### PR TITLE
Added DEBUG_PLAINTEXT_AJAX_ERROR_MESSAGES setting to customize error display

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -59,7 +59,9 @@ def technical_500_response(request, exc_type, exc_value, tb):
     the values returned from sys.exc_info() and friends.
     """
     reporter = ExceptionReporter(request, exc_type, exc_value, tb)
-    if request.is_ajax():
+
+    plaintext = request.is_ajax() and getattr(settings, 'DEBUG_PLAINTEXT_AJAX_ERROR_MESSAGES', True)
+    if plaintext:
         text = reporter.get_traceback_text()
         return HttpResponseServerError(text, mimetype='text/plain')
     else:


### PR DESCRIPTION
The plaintext error responses for AJAX requests in 1.4 drop a lot of the stack trace context that was included in the HTML responses pre-1.4.  Tools like the network response 'Preview' viewer in Chrome make it easy to navigate the HTML response to drill down into the richer context it provides.  This patch maintains the 1.4 default but enables the response to be configured to use the original behavior.
