### PR TITLE
BaseGenericInlineFormSet does not use form's save() method

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -412,12 +412,11 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
     def save_new(self, form, commit=True):
         # Avoid a circular import.
         from django.contrib.contenttypes.models import ContentType
-        kwargs = {
-            self.ct_field.get_attname(): ContentType.objects.get_for_model(self.instance).pk,
-            self.ct_fk_field.get_attname(): self.instance.pk,
-        }
-        new_obj = self.model(**kwargs)
-        return save_instance(form, new_obj, commit=commit)
+        setattr(form.instance, self.ct_field.get_attname(),
+                ContentType.objects.get_for_model(self.instance).pk)
+        setattr(form.instance, self.ct_fk_field.get_attname(),
+                self.instance.pk)
+        return form.save(commit=commit)
 
 def generic_inlineformset_factory(model, form=ModelForm,
                                   formset=BaseGenericInlineFormSet,


### PR DESCRIPTION
Saving a BaseGenericInlineFormSet through the form instead of the model directly. Same patch that attached on ticket https://code.djangoproject.com/ticket/16869
