### PR TITLE
i18n javascript_catalog Reference Error

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -125,7 +125,7 @@ LibFormatFoot = """
 function get_format(format_type) {
     var value = formats[format_type];
     if (typeof(value) == 'undefined') {
-      return msgid;
+      return format_type;
     } else {
       return value;
     }


### PR DESCRIPTION
This pull request corresponds to [Trac ticket 18232](https://code.djangoproject.com/ticket/18232)

> The get_format JavaScript function references an undefined variable (`msgid`). I believe the intent was to return the argument (`format_type`).
