### PR TITLE
Fix bullet formatting for README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,19 +5,19 @@ All documentation is in the "docs" directory and online at
 http://docs.djangoproject.com/en/dev/. If you're just getting started, here's
 how we recommend you read the docs:
 
-    * First, read docs/intro/install.txt for instructions on installing Django.
+* First, read docs/intro/install.txt for instructions on installing Django.
 
-    * Next, work through the tutorials in order (docs/intro/tutorial01.txt,
-      docs/intro/tutorial02.txt, etc.).
+* Next, work through the tutorials in order (docs/intro/tutorial01.txt,
+  docs/intro/tutorial02.txt, etc.).
 
-    * If you want to set up an actual deployment server, read
-      docs/howto/deployment/index.txt for instructions.
+* If you want to set up an actual deployment server, read
+  docs/howto/deployment/index.txt for instructions.
 
-    * You'll probably want to read through the topical guides (in docs/topics)
-      next; from there you can jump to the HOWTOs (in docs/howto) for specific
-      problems, and check out the reference (docs/ref) for gory details.
+* You'll probably want to read through the topical guides (in docs/topics)
+  next; from there you can jump to the HOWTOs (in docs/howto) for specific
+  problems, and check out the reference (docs/ref) for gory details.
 
-    * See docs/README for instructions on building an HTML version of the docs.
+* See docs/README for instructions on building an HTML version of the docs.
 
 Docs are updated rigorously. If you find any problems in the docs, or think they
 should be clarified in any way, please take 30 seconds to fill out a ticket
@@ -27,19 +27,19 @@ http://code.djangoproject.com/newticket
 
 To get more help:
 
-    * Join the #django channel on irc.freenode.net. Lots of helpful people
-      hang out there. Read the archives at http://django-irc-logs.com/.
+* Join the #django channel on irc.freenode.net. Lots of helpful people hang out
+  there. Read the archives at http://django-irc-logs.com/.
 
-    * Join the django-users mailing list, or read the archives, at
-      http://groups.google.com/group/django-users.
+* Join the django-users mailing list, or read the archives, at
+  http://groups.google.com/group/django-users.
 
 To contribute to Django:
 
-    * Check out http://www.djangoproject.com/community/ for information
-      about getting involved.
+* Check out http://www.djangoproject.com/community/ for information about
+  getting involved.
 
 To run Django's test suite:
 
-    * Follow the instructions in the "Unit tests" section of
-      docs/internals/contributing/writing-code/unit-tests.txt, published online at
-      https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#running-the-unit-tests
+* Follow the instructions in the "Unit tests" section of
+  docs/internals/contributing/writing-code/unit-tests.txt, published online at
+  https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/#running-the-unit-tests


### PR DESCRIPTION
Leading whitespace was causing the bullet lists to turn into [block quotes](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes).
