### PR TITLE
Prevent Oracle from changing field.null to True

### DIFF
--- a/django/db/backends/creation.py
+++ b/django/db/backends/creation.py
@@ -50,7 +50,13 @@ class BaseDatabaseCreation(object):
             # Make the definition (e.g. 'foo VARCHAR(30)') for this field.
             field_output = [style.SQL_FIELD(qn(f.column)),
                 style.SQL_COLTYPE(col_type)]
-            if not f.null:
+            # Oracle treats the empty string ('') as null, so coerce the null
+            # option whenever '' is a possible value.
+            null = f.null
+            if (f.empty_strings_allowed and not f.primary_key and
+                    self.connection.features.interprets_empty_strings_as_nulls):
+                null = True
+            if not null:
                 field_output.append(style.SQL_KEYWORD('NOT NULL'))
             if f.primary_key:
                 field_output.append(style.SQL_KEYWORD('PRIMARY KEY'))

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -85,11 +85,6 @@ class Field(object):
         self.primary_key = primary_key
         self.max_length, self._unique = max_length, unique
         self.blank, self.null = blank, null
-        # Oracle treats the empty string ('') as null, so coerce the null
-        # option whenever '' is a possible value.
-        if (self.empty_strings_allowed and
-            connection.features.interprets_empty_strings_as_nulls):
-            self.null = True
         self.rel = rel
         self.default = default
         self.editable = editable

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -685,11 +685,11 @@ NULL and empty strings
 
 Django generally prefers to use the empty string ('') rather than
 NULL, but Oracle treats both identically. To get around this, the
-Oracle backend coerces the ``null=True`` option on fields that have
-the empty string as a possible value. When fetching from the database,
-it is assumed that a NULL value in one of these fields really means
-the empty string, and the data is silently converted to reflect this
-assumption.
+Oracle backend ignores an explicit ``null`` option on fields that
+have the empty string as a possible value and generates DDL as if
+``null=True``. When fetching from the database, it is assumed that
+a ``NULL`` value in one of these fields really means the empty
+string, and the data is silently converted to reflect this assumption.
 
 ``TextField`` limitations
 -------------------------

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -55,9 +55,8 @@ string, not ``NULL``.
 
 .. note::
 
-    When using the Oracle database backend, the ``null=True`` option will be
-    coerced for string-based fields that have the empty string as a possible
-    value, and the value ``NULL`` will be stored to denote the empty string.
+    When using the Oracle database backend, the value ``NULL`` will be stored to
+    denote the empty string regardless of this attribute.
 
 If you want to accept :attr:`~Field.null` values with :class:`BooleanField`,
 use :class:`NullBooleanField` instead.

--- a/tests/regressiontests/queries/tests.py
+++ b/tests/regressiontests/queries/tests.py
@@ -1930,3 +1930,25 @@ class NullInExcludeTest(TestCase):
         self.assertQuerysetEqual(
             NullableName.objects.exclude(name__in=[None]),
             ['i1'], attrgetter('name'))
+
+class EmptyStringsAsNullTest(TestCase):
+    """
+    Test that filtering on non-null character fields works as expected.
+    The reason for these tests is that Oracle treats '' as NULL, and this
+    can cause problems in query construction. Refs #17957.
+    """
+
+    def setUp(self):
+        self.nc = NamedCategory.objects.create(name='')
+
+    def test_direct_exclude(self):
+        self.assertQuerysetEqual(
+            NamedCategory.objects.exclude(name__in=['nonexisting']),
+            [self.nc.pk], attrgetter('pk')
+        )
+
+    def test_joined_exclude(self):
+        self.assertQuerysetEqual(
+            DumbCategory.objects.exclude(namedcategory__name__in=['nonexisting']),
+            [self.nc.pk], attrgetter('pk')
+        )


### PR DESCRIPTION
Fixed #17957 -- when using Oracle and character fields, the fields
were set null = True to ease the handling of empty strings. This
caused problems when using multiple databases from different vendors,
or when the character field happened to be also a primary key.

The handling was changed so that NOT NULL is not emitted on Oracle
even if field.null = False, and field.null is not touched otherwise.

Thanks to bhuztez for the report, ramiro for triaging & comments and
ikelly for the patch.
