### PR TITLE
Fixed Oracle's multicolumn index introspection

### DIFF
--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -72,14 +72,14 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     FROM   user_constraints, USER_CONS_COLUMNS ca, USER_CONS_COLUMNS cb,
            user_tab_cols ta, user_tab_cols tb
     WHERE  user_constraints.table_name = %s AND
-           ta.table_name = %s AND
+           ta.table_name = user_constraints.table_name AND
            ta.column_name = ca.column_name AND
-           ca.table_name = %s AND
+           ca.table_name = ta.table_name AND
            user_constraints.constraint_name = ca.constraint_name AND
            user_constraints.r_constraint_name = cb.constraint_name AND
            cb.table_name = tb.table_name AND
            cb.column_name = tb.column_name AND
-           ca.position = cb.position""", [table_name, table_name, table_name])
+           ca.position = cb.position""", [table_name])
 
         relations = {}
         for row in cursor.fetchall():
@@ -93,30 +93,32 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             {'primary_key': boolean representing whether it's the primary key,
              'unique': boolean representing whether it's a unique index}
         """
-        # This query retrieves each index on the given table, including the
-        # first associated field name
-        # "We were in the nick of time; you were in great peril!"
-        sql = """\
-SELECT LOWER(all_tab_cols.column_name) AS column_name,
-       CASE user_constraints.constraint_type
-           WHEN 'P' THEN 1 ELSE 0
-       END AS is_primary_key,
-       CASE user_indexes.uniqueness
-           WHEN 'UNIQUE' THEN 1 ELSE 0
-       END AS is_unique
-FROM   all_tab_cols, user_cons_columns, user_constraints, user_ind_columns, user_indexes
-WHERE  all_tab_cols.column_name = user_cons_columns.column_name (+)
-  AND  all_tab_cols.table_name = user_cons_columns.table_name (+)
-  AND  user_cons_columns.constraint_name = user_constraints.constraint_name (+)
-  AND  user_constraints.constraint_type (+) = 'P'
-  AND  user_ind_columns.column_name (+) = all_tab_cols.column_name
-  AND  user_ind_columns.table_name (+) = all_tab_cols.table_name
-  AND  user_indexes.uniqueness (+) = 'UNIQUE'
-  AND  user_indexes.index_name (+) = user_ind_columns.index_name
-  AND  all_tab_cols.table_name = UPPER(%s)
+        # Note: introspect only single-column indexes. Refs #18082.
+        sql = """
+    SELECT LOWER(uic1.column_name) AS column_name,
+           CASE user_constraints.constraint_type
+               WHEN 'P' THEN 1 ELSE 0
+           END AS is_primary_key,
+           CASE user_indexes.uniqueness
+               WHEN 'UNIQUE' THEN 1 ELSE 0
+           END AS is_unique
+    FROM   user_constraints, user_indexes, user_ind_columns uic1
+    WHERE  user_constraints.constraint_type (+) = 'P'
+      AND  user_constraints.index_name (+) = uic1.index_name
+      AND  user_indexes.uniqueness (+) = 'UNIQUE'
+      AND  user_indexes.index_name (+) = uic1.index_name
+      AND  uic1.table_name = UPPER(%s)
+      AND  uic1.column_position = 1
+      AND  NOT EXISTS (
+              SELECT 1
+              FROM   user_ind_columns uic2
+              WHERE  uic2.index_name = uic1.index_name
+                AND  uic2.column_position = 2
+           )
 """
         cursor.execute(sql, [table_name])
         indexes = {}
         for row in cursor.fetchall():
-            indexes[row[0]] = {'primary_key': row[1], 'unique': row[2]}
+            indexes[row[0]] = {'primary_key': bool(row[1]),
+                               'unique': bool(row[2])}
         return indexes


### PR DESCRIPTION
Fixed #18082 -- Oracle's introspection.get_indexes() got confused
when there were multiple indexes containing the same column at
position 1. Skip all multicolumn indexes like on other databases.
