### PR TITLE
Skip model validation when models are known good.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -198,9 +198,9 @@ class BaseCommand(object):
         """
         Try to execute this command, performing model validation if
         needed (as controlled by the attribute
-        ``self.requires_model_validation``). If the command raises a
-        ``CommandError``, intercept it and print it sensibly to
-        stderr.
+        ``self.requires_model_validation``, except if force-skipped). If the
+        command raises a ``CommandError``, intercept it and print it sensibly
+        to stderr.
         """
         show_traceback = options.get('traceback', False)
 
@@ -226,7 +226,7 @@ class BaseCommand(object):
         try:
             self.stdout = options.get('stdout', sys.stdout)
             self.stderr = options.get('stderr', sys.stderr)
-            if self.requires_model_validation:
+            if self.requires_model_validation and not options.get('skip_validation'):
                 self.validate()
             output = self.handle(*args, **options)
             if output:

--- a/django/core/management/commands/syncdb.py
+++ b/django/core/management/commands/syncdb.py
@@ -160,4 +160,5 @@ class Command(NoArgsCommand):
         # Load initial_data fixtures (unless that has been disabled)
         if load_initial_data:
             from django.core.management import call_command
-            call_command('loaddata', 'initial_data', verbosity=verbosity, database=db)
+            call_command('loaddata', 'initial_data', verbosity=verbosity,
+                         database=db, skip_validation=True)

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -468,13 +468,14 @@ class TransactionTestCase(SimpleTestCase):
         else:
             databases = [DEFAULT_DB_ALIAS]
         for db in databases:
-            call_command('flush', verbosity=0, interactive=False, database=db)
+            call_command('flush', verbosity=0, interactive=False, database=db,
+                         skip_validation=True)
 
             if hasattr(self, 'fixtures'):
                 # We have to use this slightly awkward syntax due to the fact
                 # that we're using *args and **kwargs together.
                 call_command('loaddata', *self.fixtures,
-                             **{'verbosity': 0, 'database': db})
+                             **{'verbosity': 0, 'database': db, 'skip_validation': True})
 
     def _urlconf_setup(self):
         if hasattr(self, 'urls'):
@@ -826,7 +827,8 @@ class TestCase(TransactionTestCase):
                              **{
                                 'verbosity': 0,
                                 'commit': False,
-                                'database': db
+                                'database': db,
+                                 'skip_validation': True,
                              })
 
     def _fixture_teardown(self):


### PR DESCRIPTION
In some situations Django calls model validation when the models are
already known good. This is most visible in tests, which use flush
and loaddata commands. This resulted in around 10% overhead when
running tests under sqlite.
