### PR TITLE
Fixed #18182 -- Raw password echoed on authentication if no hashing used

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -16,7 +16,7 @@ PREFERRED_HASHER = None  # defaults to first item in PASSWORD_HASHERS
 
 
 def is_password_usable(encoded):
-    return (encoded is not None and encoded != UNUSABLE_PASSWORD)
+    return (encoded is not None and encoded != UNUSABLE_PASSWORD and ('$' in encoded or len(encoded) == 32))
 
 
 def check_password(password, encoded, setter=None, preferred='default'):
@@ -35,7 +35,7 @@ def check_password(password, encoded, setter=None, preferred='default'):
     password = smart_str(password)
     encoded = smart_str(encoded)
 
-    if len(encoded) == 32 and '$' not in encoded:
+    if '$' not in encoded:
         hasher = get_hasher('unsalted_md5')
     else:
         algorithm = encoded.split('$', 1)[0]

--- a/django/contrib/auth/tests/hashers.py
+++ b/django/contrib/auth/tests/hashers.py
@@ -90,6 +90,11 @@ class TestUtilsHashPass(unittest.TestCase):
             make_password('letmein', hasher='lolcat')
         self.assertRaises(ValueError, doit)
 
+    def test_bad_encoded_pasword(self):
+        encoded = 'letmeinbadencoded'
+        self.assertFalse(is_password_usable(encoded))
+
+
     def test_low_level_pkbdf2(self):
         hasher = PBKDF2PasswordHasher()
         encoded = hasher.encode('letmein', 'seasalt')


### PR DESCRIPTION
contrib.auth.hashers.is_password_usable now checks if the encoded string
contains a $ character. For backward compatibilty to unsalted md5 hashes all
encoded 32-character-long strings without a $ character are assumed to be
usable. check_password won't return True for a 32-character-long plain
password, though.
