### PR TITLE
add more warnings.simplefilter calls.

### DIFF
--- a/tests/regressiontests/logging_tests/tests.py
+++ b/tests/regressiontests/logging_tests/tests.py
@@ -43,6 +43,7 @@ class PatchLoggingConfigTest(TestCase):
         config = copy.deepcopy(OLD_LOGGING)
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             compat_patch_logging_config(config)
             self.assertEqual(len(w), 1)
 

--- a/tests/regressiontests/requests/tests.py
+++ b/tests/regressiontests/requests/tests.py
@@ -415,6 +415,7 @@ class RequestsTests(unittest.TestCase):
                                'wsgi.input': ExplodingStringIO(payload)})
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             with self.assertRaises(UnreadablePostError):
                 request.raw_post_data
             self.assertEqual(len(w), 1)

--- a/tests/regressiontests/utils/text.py
+++ b/tests/regressiontests/utils/text.py
@@ -73,6 +73,7 @@ class TestUtilsText(SimpleTestCase):
 
     def test_old_truncate_words(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.assertEqual(u'The quick brown fox jumped over the lazy dog.',
                 text.truncate_words(u'The quick brown fox jumped over the lazy dog.', 10))
             self.assertEqual(u'The quick brown fox ...',
@@ -83,6 +84,7 @@ class TestUtilsText(SimpleTestCase):
 
     def test_old_truncate_html_words(self):
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             self.assertEqual(u'<p><strong><em>The quick brown fox jumped over the lazy dog.</em></strong></p>',
                 text.truncate_html_words('<p><strong><em>The quick brown fox jumped over the lazy dog.</em></strong></p>', 10))
             self.assertEqual(u'<p><strong><em>The quick brown fox ...</em></strong></p>',


### PR DESCRIPTION
This is a follow up to 00c0d3c44ebc4e3461653ec96cd47023cc0a6e5b
which still caused 4 test failures on my machine.
