### PR TITLE
Changes Django's slice filter to be consistent with extended slice syntax

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -573,7 +573,7 @@ def slice_filter(value, arg):
                 bits.append(None)
             else:
                 bits.append(int(x))
-        return value[slice(*bits)]
+        return value[*bits]
 
     except (ValueError, TypeError):
         return value # Fail silently.


### PR DESCRIPTION
This change matches Django's slice filter to be consistent with extended slice syntax.

Before:

slice_filter(['a','b','c'], "::2") == ['a','b','c'][::2]
slice_filter(['a','b','c'], ":2") == ['a','b','c'][:2]
slice_filter(['a','b','c'], "2") != ['a','b','c'][2]

After:

slice_filter(['a','b','c'], "::2") == ['a','b','c'][::2]
slice_filter(['a','b','c'], ":2") == ['a','b','c'][:2]
slice_filter(['a','b','c'], "2") == ['a','b','c'][2]

A consequence of this change is that existing templates that make use of foobar|slice:int will no longer produce the same result, though I'd argue that the above change is closer in line with what people might expect.
