### PR TITLE
#17890: added support for extra_context in django.contrib.admin.site.password_change

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -249,7 +249,7 @@ class AdminSite(object):
     def urls(self):
         return self.get_urls(), self.app_name, self.name
 
-    def password_change(self, request):
+    def password_change(self, request, extra_context=None):
         """
         Handles the "change password" task -- both form display and validation.
         """
@@ -257,7 +257,8 @@ class AdminSite(object):
         url = reverse('admin:password_change_done', current_app=self.name)
         defaults = {
             'current_app': self.name,
-            'post_change_redirect': url
+            'post_change_redirect': url,
+            'extra_context': extra_context
         }
         if self.password_change_template is not None:
             defaults['template_name'] = self.password_change_template

--- a/tests/regressiontests/admin_views/customadmin.py
+++ b/tests/regressiontests/admin_views/customadmin.py
@@ -24,6 +24,9 @@ class Admin2(admin.AdminSite):
     def index(self, request, extra_context=None):
         return super(Admin2, self).index(request, {'foo': '*bar*'})
 
+    def password_change(self, request, extra_context={'EXTRA_CONTEXT': 'this is some extra context'}):
+        return super(Admin2, self).password_change(request, extra_context)
+
     def get_urls(self):
         return patterns('',
             (r'^my_view/$', self.admin_view(self.my_view)),

--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -763,6 +763,13 @@ class CustomModelAdminTest(AdminViewBasicTest):
         self.assertTemplateUsed(request, 'custom_admin/password_change_form.html')
         self.assertTrue('Hello from a custom password change form template' in request.content)
 
+    def testCustomAdminSitePasswordChangeWithExtraContext(self):
+        "#17890: Test support for extra_context in password_change"
+        request = self.client.get('/test_admin/admin2/password_change/')
+        self.assertIsInstance(request, TemplateResponse)
+        self.assertTemplateUsed(request, 'custom_admin/password_change_form.html')
+        self.assertTrue('this is some extra context' in request.content)
+
     def testCustomAdminSitePasswordChangeDoneTemplate(self):
         request = self.client.get('/test_admin/admin2/password_change/done/')
         self.assertIsInstance(request, TemplateResponse)

--- a/tests/templates/custom_admin/password_change_form.html
+++ b/tests/templates/custom_admin/password_change_form.html
@@ -2,5 +2,6 @@
 
 {% block content %}
 Hello from a custom password change form template
+{{ EXTRA_CONTEXT }}
 {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
Allows for extra_context to be passed in to the method password_change in django.contrib.admin.site

"python runtests.py --settings=test_sqlite" passes all tests.
