### PR TITLE
Fixed #18306 -- Deferred models should automatically issue update_fields...

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -479,6 +479,14 @@ class Model(object):
                                  "model or are m2m fields: %s"
                                  % ', '.join(non_model_fields))
 
+        elif self._meta.deferred_fields:
+            field_names = set([field.name for field in self._meta.fields 
+                                if not field.primary_key])
+            non_deferred_fields = field_names.difference(self._meta.deferred_fields)
+
+            if non_deferred_fields:
+                update_fields = frozenset(non_deferred_fields)
+
         self.save_base(using=using, force_insert=force_insert,
                        force_update=force_update, update_fields=update_fields)
     save.alters_data = True

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -17,7 +17,7 @@ get_verbose_name = lambda class_name: re.sub('(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|
 DEFAULT_NAMES = ('verbose_name', 'verbose_name_plural', 'db_table', 'ordering',
                  'unique_together', 'permissions', 'get_latest_by',
                  'order_with_respect_to', 'app_label', 'db_tablespace',
-                 'abstract', 'managed', 'proxy', 'auto_created')
+                 'abstract', 'managed', 'proxy', 'auto_created', 'deferred_fields')
 
 class Options(object):
     def __init__(self, meta, app_label=None):
@@ -53,6 +53,7 @@ class Options(object):
         self.parents = SortedDict()
         self.duplicate_targets = {}
         self.auto_created = False
+        self.deferred_fields = None
 
         # To handle various inheritance situations, we need to track where
         # managers came from (concrete or abstract base classes).

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -109,6 +109,10 @@ class DeferredAttribute(object):
         never be a database lookup involved.
         """
         instance.__dict__[self.field_name] = value
+        
+        # If attr is modified, remove this field from defererd field list.
+        if instance._meta.deferred_fields and self.field_name in instance._meta.deferred_fields:
+            instance._meta.deferred_fields.remove(self.field_name)
 
 def select_related_descend(field, restricted, requested, reverse=False):
     """
@@ -149,6 +153,7 @@ def deferred_class_factory(model, attrs):
     class Meta:
         proxy = True
         app_label = model._meta.app_label
+        deferred_fields = set(attrs)
 
     # The app_cache wants a unique name for each model, otherwise the new class
     # won't be created (we get an old one back). Therefore, we generate the

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -356,6 +356,13 @@ perform an update on all fields.
 
 Specifying ``update_fields`` will force an update.
 
+When saving a model fetched through deferred model loading :meth:`~Model.only()`  
+or :meth:`~Model.defer()` and then saving these models, ``update_fields`` 
+this automatically populated with not defered fields. 
+
+Also, if you assign or change any difered field value, this will be managed 
+properly (automatically added to the parameter update_fields).
+
 Deleting objects
 ================
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1110,6 +1110,13 @@ loading of the field that connects from the primary model to the related one
     reader, is slightly faster and consumes a little less memory in the Python
     process.
 
+.. versionadded:: 1.5
+
+.. note::
+    
+    When calling :meth:`~Model.save()` in model instances with deferred fields, 
+    by default only saves not defered fields.
+
 
 only
 ~~~~
@@ -1150,6 +1157,13 @@ logically::
 All of the cautions in the note for the :meth:`defer` documentation apply to
 ``only()`` as well. Use it cautiously and only after exhausting your other
 options.
+
+.. versionadded:: 1.5
+
+.. note::
+    
+    When calling :meth:`~Model.save()` in model instances with deferred fields, 
+    by default only saves not defered fields.
 
 using
 ~~~~~

--- a/tests/modeltests/update_only_fields/models.py
+++ b/tests/modeltests/update_only_fields/models.py
@@ -13,6 +13,7 @@ class Account(models.Model):
 class Person(models.Model):
     name = models.CharField(max_length=20)
     gender = models.CharField(max_length=1, choices=GENDER_CHOICES)
+    pid = models.IntegerField(null=True, default=None)
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/18306

Is an initial patch, run all test cases mentioned in the ticket.
I added documentation, where I felt I should be, but I'm not sure.

The only thing not clear to me, as it should behave `_state.update_fields`.
- Normal case, save all fields -> this attribute must be `None` (or all fields?)
- In all other cases, filled with the result of `update_fields`.
