### PR TITLE
Make sure these functions don't bleed into the global scope

### DIFF
--- a/django/contrib/admin/static/admin/js/actions.js
+++ b/django/contrib/admin/static/admin/js/actions.js
@@ -83,7 +83,7 @@
 		$(actionCheckboxes).click(function(event) {
 			if (!event) { event = window.event; }
 			var target = event.target ? event.target : event.srcElement;
-			if (lastChecked && $.data(lastChecked) != $.data(target) && event.shiftKey == true) {
+			if (lastChecked && $.data(lastChecked) != $.data(target) && event.shiftKey === true) {
 				var inrange = false;
 				$(lastChecked).attr("checked", target.checked)
 					.parent().parent().toggleClass(options.selectedClass, target.checked);


### PR DESCRIPTION
This makes sure that all of these functions are assigned to variables 
assigned to the current scope, rather than the global scope.  It also adds a
trailing semi-colon to make sure various linters are happy.
