### PR TITLE
Stable/1.4.x - Backport for #18135 -- Sleeping Database Connections on Startup with MySQL

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -407,11 +407,20 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def get_server_version(self):
         if not self.server_version:
+            new_connection = False
             if not self._valid_connection():
-                self.cursor()
-            m = server_version_re.match(self.connection.get_server_info())
+                # Ensure we have a connection with the DB by using a temporary
+                # cursor
+                new_connection = True
+                self.cursor().close()
+            server_info = self.connection.get_server_info()
+            if new_connection:
+                # Make sure we close the connection
+                self.connection.close()
+                self.connection = None
+            m = server_version_re.match(server_info)
             if not m:
-                raise Exception('Unable to determine MySQL version from version string %r' % self.connection.get_server_info())
+                raise Exception('Unable to determine MySQL version from version string %r' % server_info)
             self.server_version = tuple([int(x) for x in m.groups()])
         return self.server_version
 


### PR DESCRIPTION
This is a fix for #18135, which was closed before the patches were applied. I have tested and the DB connections are properly closed.
