### PR TITLE
Added a missing template tag load statement in the formtools emample wizard.

### DIFF
--- a/docs/ref/contrib/formtools/form-wizard.txt
+++ b/docs/ref/contrib/formtools/form-wizard.txt
@@ -186,6 +186,7 @@ Here's a full example template:
 .. code-block:: html+django
 
     {% extends "base.html" %}
+    {% load i18n %}
 
     {% block head %}
     {{ wizard.form.media }}


### PR DESCRIPTION
Ref [ticket #18335](https://code.djangoproject.com/ticket/18335).
