### PR TITLE
FormWizard documentation didn't load i18n

### DIFF
--- a/docs/ref/contrib/formtools/form-wizard.txt
+++ b/docs/ref/contrib/formtools/form-wizard.txt
@@ -186,6 +186,7 @@ Here's a full example template:
 .. code-block:: html+django
 
     {% extends "base.html" %}
+    {% load i18n %}
 
     {% block head %}
     {{ wizard.form.media }}


### PR DESCRIPTION
Added load i18n code to the base wizard form template documentation as it uses the trans tag.
