### PR TITLE
Fixed #18347 -- Wrapped raw identity inserts in tests.

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -876,6 +876,33 @@ class BaseDatabaseOperations(object):
         conn = ' %s ' % connector
         return conn.join(sub_expressions)
 
+    @contextmanager
+    def identity_insert_enabled(self, table):
+        enabled = self.enable_identity_insert(table)        
+        try:
+            yield
+        finally:
+            if enabled:
+                self.disable_identity_insert(table)
+
+    def enable_identity_insert(self, table):
+        """
+        Backends can implement as needed to enable inserts in to
+        the identity column.
+        
+        Should return True if identity inserts have been enabled.
+        """
+        pass
+    
+    def disable_identity_insert(self, table):
+        """
+        Backends can implement as needed to disable inserts in to
+        the identity column.
+        
+        Should return True if identity inserts have been disabled.
+        """
+        pass
+
 class BaseDatabaseIntrospection(object):
     """
     This class encapsulates all backend-specific introspection utilities

--- a/tests/regressiontests/transactions_regress/tests.py
+++ b/tests/regressiontests/transactions_regress/tests.py
@@ -24,8 +24,9 @@ class TestTransactionClosing(TransactionTestCase):
         @commit_on_success
         def raw_sql():
             "Write a record using raw sql under a commit_on_success decorator"
-            cursor = connection.cursor()
-            cursor.execute("INSERT into transactions_regress_mod (id,fld) values (17,18)")
+            with connection.ops.identity_insert_enabled('transactions_regress_mod'):
+                cursor = connection.cursor()
+                cursor.execute("INSERT into transactions_regress_mod (id,fld) values (17,18)")
 
         raw_sql()
         # Rollback so that if the decorator didn't commit, the record is unwritten
@@ -115,10 +116,11 @@ class TestTransactionClosing(TransactionTestCase):
             (reference). All this under commit_on_success, so the second insert should
             be committed.
             """
-            cursor = connection.cursor()
-            cursor.execute("INSERT into transactions_regress_mod (id,fld) values (1,2)")
-            transaction.rollback()
-            cursor.execute("INSERT into transactions_regress_mod (id,fld) values (1,2)")
+            with connection.ops.identity_insert_enabled('transactions_regress_mod'):
+                cursor = connection.cursor()
+                cursor.execute("INSERT into transactions_regress_mod (id,fld) values (1,2)")
+                transaction.rollback()
+                cursor.execute("INSERT into transactions_regress_mod (id,fld) values (1,2)")
 
         reuse_cursor_ref()
         # Rollback so that if the decorator didn't commit, the record is unwritten


### PR DESCRIPTION
Added enable_identity_insert, disable_identity_insert, and
contextmanager identity_insert_enabled to DatabaseOperations for
database backends that need to take special actions to allow
identity inserts.

All raw insert statements that set a value in to the identity field
should include these guards to allow all database backends to
function.
