### PR TITLE
Fixed #18408 -- Flatpages tests expect example.com for site 1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -566,6 +566,7 @@ answer newbie questions, and generally made Django that much better:
     Gasper Zejn <zejn@kiberpipa.org>
     Jarek Zgoda <jarek.zgoda@gmail.com>
     Cheng Zhang
+    Jens Page
 
 A big THANK YOU goes to:
 

--- a/django/contrib/flatpages/fixtures/example_site.json
+++ b/django/contrib/flatpages/fixtures/example_site.json
@@ -1,0 +1,11 @@
+[
+  {
+    "pk": 1, 
+    "model": "sites.site", 
+    "fields": {
+      "domain": "example.com", 
+      "name": "example.com"
+    }
+  }
+]
+

--- a/django/contrib/flatpages/tests/csrf.py
+++ b/django/contrib/flatpages/tests/csrf.py
@@ -18,9 +18,10 @@ from django.test.utils import override_settings
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageCSRFTests(TestCase):
-    fixtures = ['sample_flatpages']
+    fixtures = ['sample_flatpages', 'example_site']
     urls = 'django.contrib.flatpages.tests.urls'
 
     def setUp(self):

--- a/django/contrib/flatpages/tests/forms.py
+++ b/django/contrib/flatpages/tests/forms.py
@@ -5,7 +5,10 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import translation
 
+@override_settings(SITE_ID=1)
 class FlatpageAdminFormTests(TestCase):
+    fixtures = ['example_site']
+    
     def setUp(self):
         self.form_data = {
             'title': "A test page",

--- a/django/contrib/flatpages/tests/middleware.py
+++ b/django/contrib/flatpages/tests/middleware.py
@@ -19,9 +19,10 @@ from django.test.utils import override_settings
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageMiddlewareTests(TestCase):
-    fixtures = ['sample_flatpages']
+    fixtures = ['sample_flatpages', 'example_site']
     urls = 'django.contrib.flatpages.tests.urls'
 
     def test_view_flatpage(self):
@@ -75,7 +76,7 @@ class FlatpageMiddlewareTests(TestCase):
             enable_comments=False,
             registration_required=False,
         )
-        fp.sites.add(1)
+        fp.sites.add(settings.SITE_ID)
 
         response = self.client.get('/some.very_special~chars-here/')
         self.assertEqual(response.status_code, 200)
@@ -96,9 +97,10 @@ class FlatpageMiddlewareTests(TestCase):
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageMiddlewareAppendSlashTests(TestCase):
-    fixtures = ['sample_flatpages']
+    fixtures = ['sample_flatpages', 'example_site']
     urls = 'django.contrib.flatpages.tests.urls'
 
     def test_redirect_view_flatpage(self):
@@ -130,7 +132,7 @@ class FlatpageMiddlewareAppendSlashTests(TestCase):
             enable_comments=False,
             registration_required=False,
         )
-        fp.sites.add(1)
+        fp.sites.add(settings.SITE_ID)
 
         response = self.client.get('/some.very_special~chars-here')
         self.assertRedirects(response, '/some.very_special~chars-here/', status_code=301)
@@ -144,7 +146,7 @@ class FlatpageMiddlewareAppendSlashTests(TestCase):
             enable_comments=False,
             registration_required=False,
         )
-        fp.sites.add(1)
+        fp.sites.add(settings.SITE_ID)
 
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)

--- a/django/contrib/flatpages/tests/templatetags.py
+++ b/django/contrib/flatpages/tests/templatetags.py
@@ -18,6 +18,7 @@ from django.test.utils import override_settings
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageTemplateTagTests(TestCase):
     fixtures = ['sample_flatpages']

--- a/django/contrib/flatpages/tests/views.py
+++ b/django/contrib/flatpages/tests/views.py
@@ -19,9 +19,10 @@ from django.test.utils import override_settings
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageViewTests(TestCase):
-    fixtures = ['sample_flatpages']
+    fixtures = ['sample_flatpages', 'example_site']
     urls = 'django.contrib.flatpages.tests.urls'
 
     def test_view_flatpage(self):
@@ -85,9 +86,10 @@ class FlatpageViewTests(TestCase):
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
+    SITE_ID=1,
 )
 class FlatpageViewAppendSlashTests(TestCase):
-    fixtures = ['sample_flatpages']
+    fixtures = ['sample_flatpages', 'example_site']
     urls = 'django.contrib.flatpages.tests.urls'
 
     def test_redirect_view_flatpage(self):
@@ -119,7 +121,7 @@ class FlatpageViewAppendSlashTests(TestCase):
             enable_comments=False,
             registration_required=False,
         )
-        fp.sites.add(1)
+        fp.sites.add(settings.SITE_ID)
 
         response = self.client.get('/flatpage_root/some.very_special~chars-here')
         self.assertRedirects(response, '/flatpage_root/some.very_special~chars-here/', status_code=301)


### PR DESCRIPTION
Resolves a couple of issues with running Flatpages tests by...
- Creating an example_site fixture
- Overriding project SITE_ID setting to 1
- Normalizing the use of the hardcoded (1) site_id to settings.SITE_ID
