### PR TITLE
Language codes can include numbers, e.g. es-419 is Spanish for LatAm and...

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -29,7 +29,7 @@ CONTEXT_SEPARATOR = u"\x04"
 
 # Format of Accept-Language header values. From RFC 2616, section 14.4 and 3.9.
 accept_language_re = re.compile(r'''
-        ([A-Za-z]{1,8}(?:-[A-Za-z]{1,8})*|\*)         # "en", "en-au", "x-y-z", "*"
+        ([A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*|\*)         # "en", "en-au", "x-y-z", "*"
         (?:\s*;\s*q=(0(?:\.\d{,3})?|1(?:.0{,3})?))?   # Optional "q=1.00", "q=0.8"
         (?:\s*,\s*|$)                                 # Multiple accepts per header.
         ''', re.VERBOSE)


### PR DESCRIPTION
... Carribean.

Sorry I didn't add a test-case or anything else, but the test case is that 

parse_accept_lang_header('es-419') would result in (('es-419', 1.0),) or something ;)
