### PR TITLE
Fix qs.order_by() join promotion for already existing joins

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -455,6 +455,9 @@ class SQLCompiler(object):
             alias = self.query.get_initial_alias()
         field, target, opts, joins, _, _ = self.query.setup_joins(pieces,
                 opts, alias, False)
+        # We will later on need to promote those joins that were added to the
+        # query afresh above.
+        joins_to_promote = [j for j in joins if self.query.alias_refcount[j] < 2]
         alias = joins[-1]
         col = target.column
         if not field.rel:
@@ -466,8 +469,9 @@ class SQLCompiler(object):
         # Must use left outer joins for nullable fields and their relations.
         # Ordering or distinct must not affect the returned set, and INNER
         # JOINS for nullable fields could do this.
-        self.query.promote_alias_chain(joins,
-            self.query.alias_map[joins[0]].join_type == self.query.LOUTER)
+        if joins_to_promote:
+            self.query.promote_alias_chain(joins_to_promote,
+                self.query.alias_map[joins_to_promote[0]].join_type == self.query.LOUTER)
         return field, col, alias, joins, opts
 
     def _final_join_removal(self, col, alias):

--- a/tests/regressiontests/queries/models.py
+++ b/tests/regressiontests/queries/models.py
@@ -264,7 +264,7 @@ class SingleObject(models.Model):
         return self.name
 
 class RelatedObject(models.Model):
-    single = models.ForeignKey(SingleObject)
+    single = models.ForeignKey(SingleObject, null=True)
 
     class Meta:
         ordering = ['single']


### PR DESCRIPTION
When order_by causes new joins to be added to the query, the joins must
be LEFT OUTER joins for nullable relations, otherwise the order_by
could cause the results to be altered. This commit fixed the logic to
only promote new joins, previously all applicable joins were promoted.

Thanks to Bruno Desthuilliers for spotting this corner case.
