### PR TITLE
Docs correction and clarification.

### DIFF
--- a/docs/ref/class-based-views.txt
+++ b/docs/ref/class-based-views.txt
@@ -867,7 +867,7 @@ View
         Arguments passed to a view are shared between every instance of a view.
         This means that you shoudn't use a list, dictionary, or any other
         mutable object as an argument to a view. If you do and the shared object
-        is changed, the actions of one user visiting your view could have an affect
+        is changed, the actions of one user visiting your view could have an effect
         on subsequent users visiting the same view.
 
     .. method:: dispatch(request, *args, **kwargs)


### PR DESCRIPTION
Docs refers 'variable' objects instead of 'mutable' objects and thread
safety between class based views is not enough clear.

See #91 (I hope this time is correct enough).
