### PR TITLE
Fixed #18399 – Add a `for_concrete_model` kwarg to `ContentTypeManager.get_for_models?`

### DIFF
--- a/django/contrib/contenttypes/tests.py
+++ b/django/contrib/contenttypes/tests.py
@@ -9,6 +9,13 @@ from django.test import TestCase
 from django.utils.encoding import smart_str
 
 
+class ConcreteModel(models.Model):
+    name = models.CharField(max_length=10)
+
+class ProxyModel(ConcreteModel):
+    class Meta:
+        proxy = True
+
 class FooWithoutUrl(models.Model):
     """
     Fake model not defining ``get_absolute_url`` for
@@ -111,6 +118,87 @@ class ContentTypesTests(TestCase):
             ContentType: ContentType.objects.get_for_model(ContentType),
             FooWithUrl: ContentType.objects.get_for_model(FooWithUrl),
         })
+
+    def test_get_for_concrete_model(self):
+        """
+        Make sure the `for_concrete_model` kwarg correctly works
+        with concrete, proxy and deferred models
+        """
+        concrete_model_ct = ContentType.objects.get_for_model(ConcreteModel)
+
+        self.assertEqual(concrete_model_ct,
+            ContentType.objects.get_for_model(ProxyModel))
+
+        self.assertEqual(concrete_model_ct,
+            ContentType.objects.get_for_model(ConcreteModel,
+                                              for_concrete_model=False))
+
+        proxy_model_ct = ContentType.objects.get_for_model(ProxyModel,
+                                                           for_concrete_model=False)
+
+        self.assertNotEqual(concrete_model_ct, proxy_model_ct)
+
+        # Make sure deferred model are correctly handled
+        ConcreteModel.objects.create(name="Concrete")
+        DeferredConcreteModel = ConcreteModel.objects.only('pk').get().__class__
+        DeferredProxyModel = ProxyModel.objects.only('pk').get().__class__
+
+        self.assertEqual(concrete_model_ct,
+            ContentType.objects.get_for_model(DeferredConcreteModel))
+
+        self.assertEqual(concrete_model_ct,
+            ContentType.objects.get_for_model(DeferredConcreteModel,
+                                              for_concrete_model=False))
+        
+        self.assertEqual(concrete_model_ct,
+            ContentType.objects.get_for_model(DeferredProxyModel))
+
+        self.assertEqual(proxy_model_ct,
+            ContentType.objects.get_for_model(DeferredProxyModel,
+                                              for_concrete_model=False))
+        
+    def test_get_for_concrete_models(self):
+        """
+        Make sure the `for_concrete_models` kwarg correctly works
+        with concrete, proxy and deferred models.
+        """
+        concrete_model_ct = ContentType.objects.get_for_model(ConcreteModel)
+
+        cts = ContentType.objects.get_for_models(ConcreteModel, ProxyModel)
+        self.assertEqual(cts, {
+            ConcreteModel: concrete_model_ct,
+            ProxyModel: concrete_model_ct,
+        })
+
+        proxy_model_ct = ContentType.objects.get_for_model(ProxyModel,
+                                                           for_concrete_model=False)
+        cts = ContentType.objects.get_for_models(ConcreteModel, ProxyModel,
+                                                 for_concrete_models=False)
+        self.assertEqual(cts, {
+            ConcreteModel: concrete_model_ct,
+            ProxyModel: proxy_model_ct,
+        })
+
+        # Make sure deferred model are correctly handled
+        ConcreteModel.objects.create(name="Concrete")
+        DeferredConcreteModel = ConcreteModel.objects.only('pk').get().__class__
+        DeferredProxyModel = ProxyModel.objects.only('pk').get().__class__
+        
+        cts = ContentType.objects.get_for_models(DeferredConcreteModel,
+                                                 DeferredProxyModel)
+        self.assertEqual(cts, {
+            DeferredConcreteModel: concrete_model_ct,
+            DeferredProxyModel: concrete_model_ct,
+        })
+
+        cts = ContentType.objects.get_for_models(DeferredConcreteModel,
+                                                 DeferredProxyModel,
+                                                 for_concrete_models=False)
+        self.assertEqual(cts, {
+            DeferredConcreteModel: concrete_model_ct,
+            DeferredProxyModel: proxy_model_ct,
+        })
+        
 
     def test_shortcut_view(self):
         """

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -187,13 +187,13 @@ The ``ContentTypeManager``
         probably won't ever need to call this method yourself; Django will call
         it automatically when it's needed.
 
-    .. method:: get_for_model(model)
+    .. method:: get_for_model(model[, for_concrete_model=True])
 
         Takes either a model class or an instance of a model, and returns the
         :class:`~django.contrib.contenttypes.models.ContentType` instance
         representing that model.
 
-    .. method:: get_for_models(*models)
+    .. method:: get_for_models(*models[, for_concrete_models=True])
 
         Takes a variadic number of model classes, and returns a dictionary
         mapping the model classes to the
@@ -223,6 +223,19 @@ lookup::
 .. module:: django.contrib.contenttypes.generic
 
 .. _generic-relations:
+
+.. versionadded:: 1.5
+
+Prior to Django 1.5 :meth:`~ContentTypeManager.get_for_model()` and 
+:meth:`~ContentTypeManager.get_for_models()` always returned the 
+:class:`~django.contrib.contenttypes.models.ContentType` associated with the 
+concrete model of the specified one(s). That means there was no way to retreive 
+the :class:`~django.contrib.contenttypes.models.ContentType` of a proxy model 
+using those methods. As of Django 1.5 you can now pass a boolean flag – 
+respectively ``for_concrete_model`` and ``for_concrete_models`` – to specify
+wether or not you want to retreive the 
+:class:`~django.contrib.contenttypes.models.ContentType` for the concrete or 
+direct model.
 
 Generic relations
 =================

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -62,6 +62,16 @@ For one-to-one relationships, both sides can be cached. For many-to-one
 relationships, only the single side of the relationship can be cached. This
 is particularly helpful in combination with ``prefetch_related``.
 
+Retreival of ``ContentType`` instances associated with proxy models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The methods :meth:`ContentTypeManager.get_for_model() <django.contrib.contenttypes.models.ContentTypeManager.get_for_model()>` 
+and :meth:`ContentTypeManager.get_for_models() <django.contrib.contenttypes.models.ContentTypeManager.get_for_models()>` 
+have a new keyword argument – respectively ``for_concrete_model`` and ``for_concrete_models``. 
+By passing ``False`` using this argument it is now possible to retreive the
+:class:`ContentType <django.contrib.contenttypes.models.ContentType>` 
+associated with proxy models.
+
 Minor features
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Is is now possible to retrive `ContentType` instances associated with proxy models using those methods.
