### PR TITLE
Docs: "Form in a view" example doesn't use RequestContext

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -99,7 +99,7 @@ The standard pattern for processing a form in a view looks like this:
        else:
            form = ContactForm() # An unbound form
 
-       return render_to_response('contact.html', {
+       return render(request, 'contact.html', {
            'form': form,
        })
 


### PR DESCRIPTION
Used the `render` shortcut in the "using a form in a view" example to ensure that the CSRF is properly enabled.
