### PR TITLE
modified ModelFormMixin.get_success_url to check for self.object

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -95,7 +95,10 @@ class ModelFormMixin(FormMixin, SingleObjectMixin):
 
     def get_success_url(self):
         if self.success_url:
-            url = self.success_url % self.object.__dict__
+            if self.object:        
+                url = self.success_url % self.object.__dict__
+            else:
+                url = self.success_url
         else:
             try:
                 url = self.object.get_absolute_url()


### PR DESCRIPTION
I hit an error today where my view was trying to call get_success_url() on ModelFormMixin, with success_url set, but without self.object being present. This will fall back to a static url if self.object isn't available.
