### PR TITLE
GeoIPException is not imported, so use generic Exception class

### DIFF
--- a/django/contrib/gis/geoip/libgeoip.py
+++ b/django/contrib/gis/geoip/libgeoip.py
@@ -19,8 +19,8 @@ else:
 
 # Getting the path to the GeoIP library.
 if lib_name: lib_path = find_library(lib_name)
-if lib_path is None: raise GeoIPException('Could not find the GeoIP library (tried "%s"). '
-                                          'Try setting GEOIP_LIBRARY_PATH in your settings.' % lib_name)
+if lib_path is None: raise Exception('Could not find the GeoIP library (tried "%s"). '
+                                     'Try setting GEOIP_LIBRARY_PATH in your settings.' % lib_name)
 lgeoip = CDLL(lib_path)
 
 # Getting the C `free` for the platform.


### PR DESCRIPTION
When using GeoIP without defining the GeoIP library path, an exception is thrown. However, an incorrect exception class is used an the real exception is hidden.

Expected result:

```
Exception at /test/geoip/
Could not find the GeoIP library (tried "GeoIP"). Try setting GEOIP_LIBRARY_PATH in your settings.
Request Method: GET
Request URL:    http://localhost:8000/test/geoip/
Django Version: 1.4
Exception Type: Exception
Exception Value:    
Could not find the GeoIP library (tried "GeoIP"). Try setting GEOIP_LIBRARY_PATH in your settings.
```

Actual result:

```
NameError at /test/geoip/
name 'GeoIPException' is not defined
Request Method: GET
Request URL:    http://localhost:8000/test/geoip/
Django Version: 1.4
Exception Type: NameError
Exception Value:    
name 'GeoIPException' is not defined
Exception Location: /django/contrib/gis/geoip/libgeoip.py in <module>, line 22
```
