### PR TITLE
Remove the summary attribute of the table

### DIFF
--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -15,8 +15,12 @@
 {% if app_list %}
     {% for app in app_list %}
         <div class="module">
-        <table summary="{% blocktrans with name=app.name %}Models available in the {{ name }} application.{% endblocktrans %}">
-        <caption><a href="{{ app.app_url }}" class="section">{% blocktrans with name=app.name %}{{ name }}{% endblocktrans %}</a></caption>
+        <table>
+        <caption>
+            <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">
+                {% blocktrans with name=app.name %}{{ name }}{% endblocktrans %}
+            </a>
+        </caption>
         {% for model in app.models %}
             <tr>
             {% if model.admin_url %}


### PR DESCRIPTION
In the discussion here: https://code.djangoproject.com/ticket/17138
it was decided that using the caption for this previously
non-visible part of the table element was not semantic, this patch
moves that summary to the `title` attribute of the `a` tag which 
when hovered over, on most browsers, will show the text.
