### PR TITLE
Addresses #17496 and adds a no_index option to ModelAdmin

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -318,6 +318,7 @@ class ModelAdmin(BaseModelAdmin):
     search_fields = ()
     date_hierarchy = None
     save_as = False
+    no_index = False
     save_on_top = False
     paginator = Paginator
     inlines = []

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -334,6 +334,10 @@ class AdminSite(object):
         app_dict = {}
         user = request.user
         for model, model_admin in self._registry.items():
+            # skip models that do not wish to be shown on the index page
+            if model_admin.no_index:
+                continue
+
             app_label = model._meta.app_label
             has_module_perms = user.has_module_perms(app_label)
 
@@ -391,6 +395,10 @@ class AdminSite(object):
         app_dict = {}
         for model, model_admin in self._registry.items():
             if app_label == model._meta.app_label:
+                # ignore this model from the app's index if no_index
+                if model_admin.no_index:
+                    continue
+
                 if has_module_perms:
                     perms = model_admin.get_model_perms(request)
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -740,6 +740,17 @@ subclass::
     regardless of this setting if one of the ``list_display`` fields is a
     ``ForeignKey``.
 
+.. attribute:: ModelAdmin.no_index
+
+    .. versionadded:: 1.5
+
+    Set `no_index` to True to hide this Model from the admin index and the 
+    module's index. This is useful if you want the to be able to add the model 
+    via the ForeignKey's inline editing capabilities but do not wish to see it 
+    in the admin indexes.
+
+    Defaults to True.
+
 .. attribute:: ModelAdmin.ordering
 
     Set ``ordering`` to specify how lists of objects should be ordered in the

--- a/tests/regressiontests/admin_views/admin.py
+++ b/tests/regressiontests/admin_views/admin.py
@@ -27,7 +27,7 @@ from .models import (Article, Chapter, Account, Media, Child, Parent, Picture,
     Album, Question, Answer, ComplexSortedPerson, PrePopulatedPostLargeSlug,
     AdminOrderedField, AdminOrderedModelMethod, AdminOrderedAdminMethod,
     AdminOrderedCallable, Report, Color2, UnorderedObject, MainPrepopulated,
-    RelatedPrepopulated)
+    RelatedPrepopulated, Stuff, StuffBox)
 
 
 def callable_year(dt_value):
@@ -569,6 +569,12 @@ class UnorderedObjectAdmin(admin.ModelAdmin):
     list_per_page = 2
 
 
+class StuffAdmin(admin.ModelAdmin):
+    """
+    A ModelAdmin that is hidden from the app index
+    """
+    no_index = True
+
 
 site = admin.AdminSite(name="admin")
 site.register(Article, ArticleAdmin)
@@ -616,6 +622,8 @@ site.register(OtherStory, OtherStoryAdmin)
 site.register(Report, ReportAdmin)
 site.register(MainPrepopulated, MainPrepopulatedAdmin)
 site.register(UnorderedObject, UnorderedObjectAdmin)
+site.register(Stuff, StuffAdmin)
+site.register(StuffBox)
 
 # We intentionally register Promo and ChapterXtra1 but not Chapter nor ChapterXtra2.
 # That way we cover all four cases:

--- a/tests/regressiontests/admin_views/models.py
+++ b/tests/regressiontests/admin_views/models.py
@@ -606,3 +606,19 @@ class UnorderedObject(models.Model):
     """
     name = models.CharField(max_length=255)
     bool = models.BooleanField(default=True)
+
+
+class Stuff(models.Model):
+    """
+    Model to test no_index=True/False setting no_index=True on this model's
+    registered ModelAdmin will exclude it from the index but still allow it to
+    be added via the "+" button when referenced via ForeignKey
+    """
+    name = models.IntegerField(default=1)
+
+
+class StuffBox(models.Model):
+    """
+    The "+" button should show up next to `stuff` when adding a StuffBox
+    """
+    stuff = models.ForeignKey(Stuff)

--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -2840,6 +2840,38 @@ class AdminInlineTests(TestCase):
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+class NoIndexTests(TestCase):
+    urls = "regressiontests.admin_views.urls"
+    fixtures = ['admin-views-users.xml']
+
+    def setUp(self):
+        self.client.login(username='super', password='secret')
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_admin_index_no_index(self):
+        "no_index=True on model admin should exclude itself from the index"
+        response = self.client.get('/test_admin/admin/')
+        # a link to the stuff admin should not be present
+        self.assertContains(response, '<a href="/test_admin/admin/admin_views/stuffbox/">Stuff boxs</a>', html=True)
+        self.assertNotContains(response, '<a href="/test_admin/admin/admin_views/stuff/">Stuffs</a>', html=True)
+
+    def test_admin_app_index_no_index(self):
+        "no_index=True on model admin should exclude itself from its app index"
+        response = self.client.get('/test_admin/admin/admin_views/')
+        # a link to the stuff admin should not present
+        self.assertContains(response, '<a href="/test_admin/admin/admin_views/stuffbox/">Stuff boxs</a>', html=True)
+        self.assertNotContains(response, '<a href="/test_admin/admin/admin_views/stuff/">Stuffs</a>', html=True)
+
+    def test_admin_no_index_inline_available(self):
+        "no_index=True should allow inline editing capability"
+        response = self.client.get('/test_admin/admin/admin_views/stuffbox/add/')
+        # an add button should be next to the `stuff` field for the StuffBox form
+        self.assertContains(response, 'id="add_id_stuff"')
+
+
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
 class NeverCacheTests(TestCase):
     urls = "regressiontests.admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-colors.xml', 'admin-views-fabrics.xml']


### PR DESCRIPTION
Adds, documents and tests a fix for #17496 which adds a new option
to ModelAdmin called no_index, which when set to True, will exclude
that Model from being displayed in the AdminSite's indexes (both
the primary index and the app-level index).

For convenience: https://code.djangoproject.com/ticket/17498
