### PR TITLE
Database indexes for some of contrib.auth.models.User fields

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -235,14 +235,16 @@ class User(models.Model):
     email = models.EmailField(_('e-mail address'), blank=True)
     password = models.CharField(_('password'), max_length=128)
     is_staff = models.BooleanField(_('staff status'), default=False,
-        help_text=_('Designates whether the user can log into this admin '
-                    'site.'))
+        db_index=True, help_text=_('Designates whether the user can log '
+                                   'into this admin site.'))
     is_active = models.BooleanField(_('active'), default=True,
-        help_text=_('Designates whether this user should be treated as '
-                    'active. Unselect this instead of deleting accounts.'))
+        db_index=True, help_text=_('Designates whether this user should be '
+                                   'treated as active. Unselect this instead '
+                                   'of deleting accounts.'))
     is_superuser = models.BooleanField(_('superuser status'), default=False,
-        help_text=_('Designates that this user has all permissions without '
-                    'explicitly assigning them.'))
+        db_index=True, help_text=_('Designates that this user has '
+                                   'all permissions without explicitly '
+                                   'assigning them.'))
     last_login = models.DateTimeField(_('last login'), default=timezone.now)
     date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
     groups = models.ManyToManyField(Group, verbose_name=_('groups'),


### PR DESCRIPTION
It is not a very quick operation: iterate over users table with some joins within. For example, code like this will works slow, because it iterates over a whole `auth_user` table firstly (checked at MySQL):

```
permission = Permission.objects.get(…)
slow_query_is_here = User.objects.filter(Q(is_staff=True),
    Q(user_permissions=permission) | Q(groups__permissions=permission)).distinct()
```

Database indexes for fields `is_staff`, `is_active` and `is_superuser` helps here and in the similar queries.
