### PR TITLE
Fixes #17933

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -18,6 +18,17 @@ Documentation changes generally come in two forms:
 This section explains how writers can craft their documentation changes
 in the most useful and least error-prone ways.
 
+
+.. _getting-the-documentation-code:
+
+Getting the documentation code
+------------------------------
+To get started improving or writing documentation, get the development version
+of Django from the source code repository (see :ref:`installing-development-version`).
+The documentation is usually only revised in trunk, as it is frozen for
+existing releases (see :ref:`differences-between-doc-versions`).
+
+
 Getting started with Sphinx
 ---------------------------
 
@@ -311,3 +322,4 @@ look better:
   (that's a tilde) to get just the "last bit" of that path. So
   ``:class:`~django.contrib.contenttypes.models.ContentType``` will just
   display a link with the title "ContentType".
+

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -191,6 +191,8 @@ You can get a local copy of the HTML documentation following a few easy steps:
 __ http://sphinx.pocoo.org/
 __ http://www.gnu.org/software/make/
 
+.. _differences-between-doc-versions:
+
 Differences between versions
 ============================
 


### PR DESCRIPTION
added link to check out documentation to "Writing documentation" page

One can argue about placing this information on the bottom of the page to ensure that possible contributors read the docs first. One the other hand checking out the code is the first step to get started.
