### PR TITLE
Don't escape object ids when passing to the contenttypes.shortcut view.

### DIFF
--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -31,7 +31,7 @@
   <ul class="object-tools">
     {% block object-tools-items %}
     <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
-    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
+    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ original.pk }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
     {% endblock %}
   </ul>
 {% endif %}{% endif %}

--- a/tests/regressiontests/admin_views/fixtures/string-primary-key.xml
+++ b/tests/regressiontests/admin_views/fixtures/string-primary-key.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <django-objects version="1.0">
     <object pk="1" model="admin_views.modelwithstringprimarykey">
-        <field type="CharField" name="id"><![CDATA[abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 -_.!~*'() ;/?:@&=+$, <>#%" {}|\^[]`]]></field>
-    </object>    
+        <field type="CharField" name="string_pk"><![CDATA[abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 -_.!~*'() ;/?:@&=+$, <>#%" {}|\^[]`]]></field>
+    </object>
 </django-objects>

--- a/tests/regressiontests/admin_views/models.py
+++ b/tests/regressiontests/admin_views/models.py
@@ -93,10 +93,13 @@ class CustomArticle(models.Model):
 
 
 class ModelWithStringPrimaryKey(models.Model):
-    id = models.CharField(max_length=255, primary_key=True)
+    string_pk = models.CharField(max_length=255, primary_key=True)
 
     def __unicode__(self):
-        return self.id
+        return self.string_pk
+
+    def get_absolute_url(self):
+        return u'/dummy/%s/' % self.string_pk
 
 
 class Color(models.Model):

--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -1403,7 +1403,7 @@ class AdminViewStringPrimaryKeyTest(TestCase):
 
     def test_url_conflicts_with_add(self):
         "A model with a primary key that ends with add should be visible"
-        add_model = ModelWithStringPrimaryKey(id="i have something to add")
+        add_model = ModelWithStringPrimaryKey(pk="i have something to add")
         add_model.save()
         response = self.client.get('/test_admin/admin/admin_views/modelwithstringprimarykey/%s/' % quote(add_model.pk))
         should_contain = """<h1>Change model with string primary key</h1>"""
@@ -1411,7 +1411,7 @@ class AdminViewStringPrimaryKeyTest(TestCase):
 
     def test_url_conflicts_with_delete(self):
         "A model with a primary key that ends with delete should be visible"
-        delete_model = ModelWithStringPrimaryKey(id="delete")
+        delete_model = ModelWithStringPrimaryKey(pk="delete")
         delete_model.save()
         response = self.client.get('/test_admin/admin/admin_views/modelwithstringprimarykey/%s/' % quote(delete_model.pk))
         should_contain = """<h1>Change model with string primary key</h1>"""
@@ -1419,10 +1419,18 @@ class AdminViewStringPrimaryKeyTest(TestCase):
 
     def test_url_conflicts_with_history(self):
         "A model with a primary key that ends with history should be visible"
-        history_model = ModelWithStringPrimaryKey(id="history")
+        history_model = ModelWithStringPrimaryKey(pk="history")
         history_model.save()
         response = self.client.get('/test_admin/admin/admin_views/modelwithstringprimarykey/%s/' % quote(history_model.pk))
         should_contain = """<h1>Change model with string primary key</h1>"""
+        self.assertContains(response, should_contain)
+
+    def test_shortcut_view_with_escaping(self):
+        "'View on site should' work properly with char fields"
+        model = ModelWithStringPrimaryKey(pk='abc_123')
+        model.save()
+        response = self.client.get('/test_admin/admin/admin_views/modelwithstringprimarykey/%s/' % quote(model.pk))
+        should_contain = '/%s/" class="viewsitelink">' % model.pk
         self.assertContains(response, should_contain)
 
 


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/18381 for details.
