### PR TITLE
Fixed #17888 -- removed a bare except: statement

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -502,11 +502,7 @@ class CheckboxInput(Widget):
 
     def render(self, name, value, attrs=None):
         final_attrs = self.build_attrs(attrs, type='checkbox', name=name)
-        try:
-            result = self.check_test(value)
-        except: # Silently catch exceptions
-            result = False
-        if result:
+        if self.check_test(value):
             final_attrs['checked'] = 'checked'
         if not (value is True or value is False or value is None or value == ''):
             # Only add the 'value' attribute if a value is non-empty.

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -310,6 +310,10 @@ commonly used groups of widgets:
         A callable that takes the value of the CheckBoxInput and returns
         ``True`` if the checkbox should be checked for that value.
 
+        .. versionchanged:: 1.5
+            The ``check_test()`` method used to silently catch all exceptions
+            raised during its call. This is not the case anymore.
+
 ``Select``
 ~~~~~~~~~~
 

--- a/tests/regressiontests/forms/tests/widgets.py
+++ b/tests/regressiontests/forms/tests/widgets.py
@@ -213,13 +213,9 @@ class FormsWidgetTestCase(TestCase):
         self.assertHTMLEqual(w.render('greeting', 'hello there'), u'<input checked="checked" type="checkbox" name="greeting" value="hello there" />')
         self.assertHTMLEqual(w.render('greeting', 'hello & goodbye'), u'<input checked="checked" type="checkbox" name="greeting" value="hello &amp; goodbye" />')
 
-        # A subtlety: If the 'check_test' argument cannot handle a value and raises any
-        # exception during its __call__, then the exception will be swallowed and the box
-        # will not be checked. In this example, the 'check_test' assumes the value has a
-        # startswith() method, which fails for the values True, False and None.
-        self.assertHTMLEqual(w.render('greeting', True), u'<input type="checkbox" name="greeting" />')
-        self.assertHTMLEqual(w.render('greeting', False), u'<input type="checkbox" name="greeting" />')
-        self.assertHTMLEqual(w.render('greeting', None), u'<input type="checkbox" name="greeting" />')
+        # Ticket #17888: calling check_test shouldn't swallow exceptions
+        with self.assertRaises(AttributeError):
+            w.render('greeting', True)
 
         # The CheckboxInput widget will return False if the key is not found in the data
         # dictionary (because HTML form submission doesn't send any result for unchecked


### PR DESCRIPTION
CheckboxInput no longer swallows exceptions when calling check_test()

See https://code.djangoproject.com/ticket/17888

This should be a proper pull request after an attempt in #125
