### PR TITLE
Fixed #18056 - Cleared aggregations on DateQuery.add_date_select

### DIFF
--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -8,6 +8,7 @@ from django.db.models.sql.constants import *
 from django.db.models.sql.datastructures import Date
 from django.db.models.sql.query import Query
 from django.db.models.sql.where import AND, Constraint
+from django.utils.datastructures import SortedDict
 from django.utils.functional import Promise
 from django.utils.encoding import force_unicode
 
@@ -205,6 +206,7 @@ class DateQuery(Query):
         self.select = [select]
         self.select_fields = [None]
         self.select_related = False # See #7097.
+        self.aggregates = SortedDict() # See 18056.
         self.set_extra_mask([])
         self.distinct = True
         self.order_by = order == 'ASC' and [1] or [-1]

--- a/tests/modeltests/aggregation/tests.py
+++ b/tests/modeltests/aggregation/tests.py
@@ -565,3 +565,22 @@ class BaseAggregateTestCase(TestCase):
                 (Decimal('82.8'), 1),
             ]
         )
+
+    def test_dates_with_aggregation(self):
+        """
+        Test that .dates() returns a distinct set of dates when applied to a QuerySet with aggregation.
+        
+        Refs #18056. Previously, .dates() would return distinct (date_kind, aggregation) sets, 
+        in this case (year, num_authors), so 2008 would be returned twice because there are books from
+        2008 with a different number of authors.
+        """
+        dates = Book.objects.annotate(num_authors=Count("authors")).dates('pubdate', 'year')
+        self.assertQuerysetEqual(
+            dates, [
+                "datetime.datetime(1991, 1, 1, 0, 0)",
+                "datetime.datetime(1995, 1, 1, 0, 0)",
+                "datetime.datetime(2007, 1, 1, 0, 0)",
+                "datetime.datetime(2008, 1, 1, 0, 0)"
+            ]
+        )
+        


### PR DESCRIPTION
Cleared aggregations on add_date_select method so only distinct dates are returned when dealing
with a QuerySet that contained aggregations. That would cause the query set to return repeated
dates because it would look for distinct (date kind, aggregation) pairs.

Tests pass on sqllite.
