### PR TITLE
Fixed #11154 and #17904 -- Inconsistency with permissions for proxy models

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -33,8 +33,9 @@ def create_permissions(app, created_models, verbosity, **kwargs):
     searched_perms = list()
     # The codenames and ctypes that should exist.
     ctypes = set()
-    for klass in app_models:
-        ctype = ContentType.objects.get_for_model(klass)
+    ctypes_for_models = ContentType.objects.get_for_models(*app_models,
+                                                           for_concrete_models=False)
+    for klass, ctype in ctypes_for_models.iteritems():
         ctypes.add(ctype)
         for perm in _get_all_permissions(klass._meta):
             searched_perms.append((ctype, perm))

--- a/tests/modeltests/proxy_models/tests.py
+++ b/tests/modeltests/proxy_models/tests.py
@@ -173,6 +173,11 @@ class ProxyModelTests(TestCase):
             Permission.objects.get(name="May display users information")
         except Permission.DoesNotExist:
             self.fail("The permission 'May display users information' has not been created")
+        try:
+            Permission.objects.get(content_type__model='myperson',
+                                   codename='add_myperson')
+        except Permission.DoesNotExist:
+            self.fail("There's no permission 'add_myperson' associated with the MyPerson model")
 
     def test_proxy_model_signals(self):
         """


### PR DESCRIPTION
Make sure permissions are associated with the correct
`ContentType` when dealing with proxy models.
