### PR TITLE
Fixed #18110 -- Improve template cache tag documentation

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -595,7 +595,8 @@ the ``cache`` template tag. To give your template access to this tag, put
 
 The ``{% cache %}`` template tag caches the contents of the block for a given
 amount of time. It takes at least two arguments: the cache timeout, in seconds,
-and the name to give the cache fragment. For example:
+and the name to give the cache fragment. The name will be taken as is, do not
+use a variable. For example:
 
 .. code-block:: html+django
 


### PR DESCRIPTION
For me it was not clear that the fragment name cannot be a variable. I just found out by wondering about errors and having a quick look into Django's code. It should be made more clear that the second argument will not be resolved even though all the others will be (even the cache time gets resolved).

"It takes at least two arguments: the cache timeout, in seconds, and the name to give the cache fragment. For example:"

should at least be something like

"It takes at least two arguments: the cache timeout, in seconds, and the name to give the cache fragment. The name will be taken as is, do not use a variable. For example:"

 https://docs.djangoproject.com/en/dev/topics/cache/#template-fragment-caching

https://code.djangoproject.com/ticket/18110
