### PR TITLE
Changed setUp/tearDown magic in contrib.auth tests to override_settings.

### DIFF
--- a/django/contrib/auth/tests/models.py
+++ b/django/contrib/auth/tests/models.py
@@ -5,29 +5,12 @@ from django.contrib.auth.models import (Group, User,
     SiteProfileNotAvailable, UserManager)
 
 
-@override_settings(USE_TZ=False)
+@override_settings(USE_TZ=False, AUTH_PROFILE_MODULE=None)
 class ProfileTestCase(TestCase):
     fixtures = ['authtestdata.json']
 
-    def setUp(self):
-        """Backs up the AUTH_PROFILE_MODULE"""
-        self.old_AUTH_PROFILE_MODULE = getattr(settings,
-                                               'AUTH_PROFILE_MODULE', None)
-
-    def tearDown(self):
-        """Restores the AUTH_PROFILE_MODULE -- if it was not set it is deleted,
-        otherwise the old value is restored"""
-        if self.old_AUTH_PROFILE_MODULE is None and \
-                hasattr(settings, 'AUTH_PROFILE_MODULE'):
-            del settings.AUTH_PROFILE_MODULE
-
-        if self.old_AUTH_PROFILE_MODULE is not None:
-            settings.AUTH_PROFILE_MODULE = self.old_AUTH_PROFILE_MODULE
-
     def test_site_profile_not_available(self):
         # calling get_profile without AUTH_PROFILE_MODULE set
-        if hasattr(settings, 'AUTH_PROFILE_MODULE'):
-            del settings.AUTH_PROFILE_MODULE
         user = User.objects.get(username='testclient')
         self.assertRaises(SiteProfileNotAvailable, user.get_profile)
 


### PR DESCRIPTION
This fixes the following bug:

```
<apollo13> I get http://dpaste.org/KhnIK/ since django 1.4 -- the issue is that UserSettingsHolder doesn't pass del on the default_settings it stores
<apollo13> this only surfaces on 1.4 since mYk added override_settings(USE_TZ=False) which does wrap the settings in the UserSettingsHolder
```

While it's not clear how UserSettingsHolder should act in that case, Aymeric said the tests should use override_settings instead.
