### PR TITLE
Fixed GIS testsuite.

### DIFF
--- a/django/contrib/gis/gdal/__init__.py
+++ b/django/contrib/gis/gdal/__init__.py
@@ -44,18 +44,6 @@ try:
 except:
     HAS_GDAL, GEOJSON = False, False
 
-from django.contrib.gis.tests.utils import no_mysql, oracle, postgis, spatialite
-HAS_SPATIALREFSYS = True
-if oracle:
-    from django.contrib.gis.db.backends.oracle.models import SpatialRefSys
-elif postgis:
-    from django.contrib.gis.db.backends.postgis.models import SpatialRefSys
-elif spatialite:
-    from django.contrib.gis.db.backends.spatialite.models import SpatialRefSys
-else:
-    HAS_SPATIALREFSYS = False
-    SpatialRefSys = None
-
 try:
     from django.contrib.gis.gdal.envelope import Envelope
 except ImportError:

--- a/django/contrib/gis/tests/test_geoforms.py
+++ b/django/contrib/gis/tests/test_geoforms.py
@@ -1,5 +1,6 @@
 from django.forms import ValidationError
-from django.contrib.gis.gdal import HAS_GDAL, HAS_SPATIALREFSYS
+from django.contrib.gis.gdal import HAS_GDAL
+from django.contrib.gis.tests.utils import HAS_SPATIALREFSYS
 from django.utils import unittest
 
 

--- a/django/contrib/gis/tests/test_spatialrefsys.py
+++ b/django/contrib/gis/tests/test_spatialrefsys.py
@@ -1,6 +1,7 @@
 from django.db import connection
-from django.contrib.gis.gdal import HAS_GDAL, HAS_SPATIALREFSYS, SpatialRefSys
-from django.contrib.gis.tests.utils import no_mysql, oracle, postgis, spatialite
+from django.contrib.gis.gdal import HAS_GDAL
+from django.contrib.gis.tests.utils import (no_mysql, oracle, postgis,
+    spatialite, HAS_SPATIALREFSYS, SpatialRefSys)
 from django.utils import unittest
 
 

--- a/django/contrib/gis/tests/utils.py
+++ b/django/contrib/gis/tests/utils.py
@@ -24,3 +24,14 @@ oracle  = _default_db == 'oracle'
 postgis = _default_db == 'postgis'
 mysql   = _default_db == 'mysql'
 spatialite = _default_db == 'spatialite'
+
+HAS_SPATIALREFSYS = True
+if oracle:
+    from django.contrib.gis.db.backends.oracle.models import SpatialRefSys
+elif postgis:
+    from django.contrib.gis.db.backends.postgis.models import SpatialRefSys
+elif spatialite:
+    from django.contrib.gis.db.backends.spatialite.models import SpatialRefSys
+else:
+    HAS_SPATIALREFSYS = False
+    SpatialRefSys = None


### PR DESCRIPTION
Moved HAS_SPATIALREFSYS back into the tests namespace since it only operates
on the default database and isn't a global flag like HAS_GDAL.
