### PR TITLE
Fixed #18414 -- Raise assertion with exists() and sliced query

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -569,6 +569,8 @@ class QuerySet(object):
     _update.alters_data = True
 
     def exists(self):
+        assert self.query.can_filter(),\
+                "Cannot check existance once a slice has been taken."
         if self._result_cache is None:
             return self.query.has_results(using=self.db)
         return bool(self._result_cache)

--- a/tests/regressiontests/queries/tests.py
+++ b/tests/regressiontests/queries/tests.py
@@ -1580,11 +1580,20 @@ class ComparisonTests(TestCase):
 class ExistsSql(TestCase):
     def setUp(self):
         settings.DEBUG = True
+        Article.objects.create(name='one', created=datetime.datetime.now())
 
     def test_exists(self):
         self.assertFalse(Tag.objects.exists())
         # Ok - so the exist query worked - but did it include too many columns?
         self.assertTrue("id" not in connection.queries[-1]['sql'] and "name" not in connection.queries[-1]['sql'])
+
+    def test_ticket_18414(self):
+        self.assertEqual(Article.objects.all().exists(), True)
+        self.assertRaisesMessage(
+            AssertionError,
+            'Cannot check existance once a slice has been taken.',
+            Article.objects.all()[:1].exists
+        )
 
     def tearDown(self):
         settings.DEBUG = False


### PR DESCRIPTION
Assertion that query hasn't been sliced when calling exists() method.
