### PR TITLE
Fixed check for table layout in formset js

### DIFF
--- a/django/contrib/admin/static/admin/js/inlines.js
+++ b/django/contrib/admin/static/admin/js/inlines.js
@@ -41,7 +41,7 @@
 		});
 		if ($(this).length && showAddButton) {
 			var addButton;
-			if ($(this).attr("tagName") == "TR") {
+			if ($(this).is("tr")) {
 				// If forms are laid out as table rows, insert the
 				// "add" button in a new table row:
 				var numCols = this.eq(-1).children().length;


### PR DESCRIPTION
Fixed check for table layout, so that the add button is actually wrapped within a tr and td tag if appropriate.

Currently the plugin attempts to check for the tagName on the jQuery object (which will always return undefined), now it uses the jQuery "is" method.
