### PR TITLE
Update ref/templates/api.txt

### DIFF
--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -370,6 +370,7 @@ and return a dictionary of items to be merged into the context. By default,
     "django.core.context_processors.i18n",
     "django.core.context_processors.media",
     "django.core.context_processors.static",
+    "django.core.context_processors.tz",
     "django.contrib.messages.context_processors.messages")
 
 In addition to these, ``RequestContext`` always uses


### PR DESCRIPTION
`django.core.context_processors.tz` was missing from default `TEMPLATE_CONTEXT_PROCESSORS`.
