### PR TITLE
Fixed #17083 -- Allow cached based sessions to use a custom cache backend

### DIFF
--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -1,5 +1,5 @@
 from django.contrib.sessions.backends.base import SessionBase, CreateError
-from django.core.cache import cache
+from django.core.cache import get_cache, InvalidCacheBackendError, cache
 
 KEY_PREFIX = "django.contrib.sessions.cache"
 
@@ -10,6 +10,11 @@ class SessionStore(SessionBase):
     """
     def __init__(self, session_key=None):
         self._cache = cache
+        try:
+            self._cache = get_cache('sessions')
+        except InvalidCacheBackendError:
+            # Use the default backend
+            self._cache = cache
         super(SessionStore, self).__init__(session_key)
 
     @property

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -102,6 +102,10 @@ Django 1.5 also includes several smaller improvements worth noting:
 * In the localflavor for Canada, "pq" was added to the acceptable codes for
   Quebec. It's an old abbreviation.
 
+* :ref:`Cached-based sessions <cached-sessions-backend>` can now use a custom
+  cache backend. Add a ``'sessions'`` entry to the :setting:`CACHES` setting to
+  use a different backend instead of the ``'default'`` backend.
+
 Backwards incompatible changes in 1.5
 =====================================
 

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -45,6 +45,8 @@ If you want to use a database-backed session, you need to add
 Once you have configured your installation, run ``manage.py syncdb``
 to install the single database table that stores session data.
 
+.. _cached-sessions-backend:
+
 Using cached sessions
 ---------------------
 
@@ -76,6 +78,11 @@ the cache:
   write-through cache -- every write to the cache will also be written to
   the database. Session reads only use the database if the data is not
   already in the cache.
+
+.. versionchanged:: 1.5
+    Cached sessions use the ``'sessions'`` entry in the :setting:`CACHES`
+    setting, but will fall back to the ``'default'`` cache backend if this
+    doesn't exist.
 
 Both session stores are quite fast, but the simple cache is faster because it
 disregards persistence. In most cases, the ``cached_db`` backend will be fast


### PR DESCRIPTION
Django currently lacks a way of using a custom cache backend in django.contrib.sessions - it always uses the default backend.

https://code.djangoproject.com/ticket/17083

This commit will default to the "sessions" backend, but will fall back to the "default" backend, this is similar to  django.contrib.staticfiles behaviour.
