### PR TITLE
Add reST role to templates named in some view docs.

### DIFF
--- a/django/contrib/comments/views/moderation.py
+++ b/django/contrib/comments/views/moderation.py
@@ -17,7 +17,7 @@ def flag(request, comment_id, next=None):
     """
     Flags a comment. Confirmation on GET, action on POST.
 
-    Templates: `comments/flag.html`,
+    Templates: :template:`comments/flag.html`,
     Context:
         comment
             the flagged `comments.comment` object
@@ -43,7 +43,7 @@ def delete(request, comment_id, next=None):
     Deletes a comment. Confirmation on GET, action on POST. Requires the "can
     moderate comments" permission.
 
-    Templates: `comments/delete.html`,
+    Templates: :template:`comments/delete.html`,
     Context:
         comment
             the flagged `comments.comment` object
@@ -70,7 +70,7 @@ def approve(request, comment_id, next=None):
     Approve a comment (that is, mark it as public and non-removed). Confirmation
     on GET, action on POST. Requires the "can moderate comments" permission.
 
-    Templates: `comments/approve.html`,
+    Templates: :template:`comments/approve.html`,
     Context:
         comment
             the `comments.comment` object for approval

--- a/django/contrib/comments/views/utils.py
+++ b/django/contrib/comments/views/utils.py
@@ -56,7 +56,7 @@ def confirmation_view(template, doc="Display a confirmation view."):
     confirmed.__doc__ = textwrap.dedent("""\
         %s
 
-        Templates: `%s``
+        Templates: :template:`%s``
         Context:
             comment
                 The posted comment

--- a/django/contrib/flatpages/views.py
+++ b/django/contrib/flatpages/views.py
@@ -23,7 +23,7 @@ def flatpage(request, url):
 
     Models: `flatpages.flatpages`
     Templates: Uses the template defined by the ``template_name`` field,
-        or `flatpages/default.html` if template_name is not defined.
+        or :template:`flatpages/default.html` if template_name is not defined.
     Context:
         flatpage
             `flatpages.flatpages` object

--- a/django/views/defaults.py
+++ b/django/views/defaults.py
@@ -12,7 +12,7 @@ def page_not_found(request, template_name='404.html'):
     """
     Default 404 handler.
 
-    Templates: `404.html`
+    Templates: :template:`404.html`
     Context:
         request_path
             The path of the requested URL (e.g., '/app/pages/bad_page/')
@@ -26,7 +26,7 @@ def server_error(request, template_name='500.html'):
     """
     500 error handler.
 
-    Templates: `500.html`
+    Templates: :template:`500.html`
     Context: None
     """
     t = loader.get_template(template_name) # You need to create a 500.html template.
@@ -41,7 +41,7 @@ def permission_denied(request, template_name='403.html'):
     """
     Permission denied (403) handler.
 
-    Templates: `403.html`
+    Templates: :template:`403.html`
     Context: None
 
     If the template does not exist, an Http403 response containing the text


### PR DESCRIPTION
This makes the templates link up correctly in the admindocs. See Django Trac ticket [#18521](https://code.djangoproject.com/ticket/18521).
