### PR TITLE
Fixed #18574 -- Make `BaseFormSet.is_valid` call it's underlying forms'`is_valid`

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -259,7 +259,7 @@ class BaseFormSet(StrAndUnicode):
 
     def is_valid(self):
         """
-        Returns True if form.errors is empty for every form in self.forms.
+        Returns True if every form in self.forms is valid.
         """
         if not self.is_bound:
             return False
@@ -274,8 +274,7 @@ class BaseFormSet(StrAndUnicode):
                     # This form is going to be deleted so any of its errors
                     # should not cause the entire formset to be invalid.
                     continue
-            if bool(self.errors[i]):
-                forms_valid = False
+            forms_valid &= form.is_valid()
         return forms_valid and not bool(self.non_form_errors())
 
     def full_clean(self):


### PR DESCRIPTION
This should provide a more expectable behavior.
