### PR TITLE
Fix copyright holder

### DIFF
--- a/django/utils/baseconv.py
+++ b/django/utils/baseconv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010 Taurinus Collective. All rights reserved.
+# Copyright (c) 2010 Guilherme Gondim. All rights reserved.
 # Copyright (c) 2009 Simon Willison. All rights reserved.
 # Copyright (c) 2002 Drew Perttula. All rights reserved.
 #


### PR DESCRIPTION
Taurinus Collective does not exist anymore. I guess is a good idea to attribute the rights to the real owner.

This change is already made in the main repository:
https://bitbucket.org/semente/baseconv/src/e70ec732fcf9/src/baseconv.py
