### PR TITLE
Return unicode arrays instead of utf-8 encoded string arrays from the psycopg database backend

### DIFF
--- a/django/db/backends/postgresql_psycopg2/base.py
+++ b/django/db/backends/postgresql_psycopg2/base.py
@@ -28,6 +28,7 @@ DatabaseError = Database.DatabaseError
 IntegrityError = Database.IntegrityError
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
+psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
 psycopg2.extensions.register_adapter(SafeString, psycopg2.extensions.QuotedString)
 psycopg2.extensions.register_adapter(SafeUnicode, psycopg2.extensions.QuotedString)
 


### PR DESCRIPTION
When retrieving an array from the database using the psycopg2 backend, I was surprised when the query returned a utf-8 encoded string instead of a unicode string. Since django uses unicode everywhere internally, it should enable the psycopg connection setting that automatically converts database arrays into python unicode arrays.
