### PR TITLE
Update forms.fields.DateField docs to reflect current default input formats

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -399,10 +399,6 @@ For each field, we describe the default widget used if you don't specify
     If no ``input_formats`` argument is provided, the default input formats are::
 
         '%Y-%m-%d', '%m/%d/%Y', '%m/%d/%y', # '2006-10-25', '10/25/2006', '10/25/06'
-        '%b %d %Y', '%b %d, %Y',            # 'Oct 25 2006', 'Oct 25, 2006'
-        '%d %b %Y', '%d %b, %Y',            # '25 Oct 2006', '25 Oct, 2006'
-        '%B %d %Y', '%B %d, %Y',            # 'October 25 2006', 'October 25, 2006'
-        '%d %B %Y', '%d %B, %Y',            # '25 October 2006', '25 October, 2006'
 
 ``DateTimeField``
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Per: https://code.djangoproject.com/ticket/18490
