### PR TITLE
[1.4.x] Fixed #18537 -- Fixed calculation of CUIT

### DIFF
--- a/tests/regressiontests/localflavor/ar/tests.py
+++ b/tests/regressiontests/localflavor/ar/tests.py
@@ -79,12 +79,14 @@ class ARLocalFlavorTests(SimpleTestCase):
     def test_ARCUITField(self):
         error_format = [u'Enter a valid CUIT in XX-XXXXXXXX-X or XXXXXXXXXXXX format.']
         error_invalid = [u'Invalid CUIT.']
+        error_legal_type = [u'Invalid legal type. Type must be 27, 20, 23 or 30.']
         valid = {
             '20-10123456-9': '20-10123456-9',
             u'20-10123456-9': '20-10123456-9',
             '27-10345678-4': '27-10345678-4',
             '20101234569': '20-10123456-9',
             '27103456784': '27-10345678-4',
+            '30011111110': '30-01111111-0',
         }
         invalid = {
             '2-10123456-9': error_format,
@@ -94,5 +96,6 @@ class ARLocalFlavorTests(SimpleTestCase):
              '20-10123456-5': error_invalid,
              '27-10345678-1': error_invalid,
              u'27-10345678-1': error_invalid,
+            '11211111110': error_legal_type,
         }
         self.assertFieldOutput(ARCUITField, valid, invalid)


### PR DESCRIPTION
Added check for corner cases in calculation. The procdure for the
calculation this code is based on is outlined at the Spanish Wikipedia
entry for Código_Único_de_Identificación_Tributaria:

http://es.wikipedia.org/wiki/
C%C3%B3digo_%C3%9Anico_de_Identificaci%C3%B3n_Tributaria

Added check for a legal type (the first two digits of the CUIT,
according to the same Wikipedia article.

Added tests for corner cases of CUIT calculation, and for legal type
checking. The improved algorithm was added at commit:
d03b6eac56e83425ea4b02ed611e63335768710a
