### PR TITLE
Added Finnish DATETIME based on feedback from Nike@Translatewiki.

### DIFF
--- a/django/conf/locale/fi/formats.py
+++ b/django/conf/locale/fi/formats.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
 DATE_FORMAT = 'j. E Y'
 TIME_FORMAT = 'G.i.s'
-# DATETIME_FORMAT = 
+DATETIME_FORMAT = 'j. E Y \k\e\l\l\o G.i.s'
 YEAR_MONTH_FORMAT = 'F Y'
 MONTH_DAY_FORMAT = 'j. F'
 SHORT_DATE_FORMAT = 'j.n.Y'


### PR DESCRIPTION
(Native Finn, translator, and founder of Translatewiki.net) [Niklas Laxström](https://translatewiki.net/wiki/User:Nike) [has helped me](https://translatewiki.net/wiki/Thread:User_talk:Nike/DATETIME_in_Finnish) add `DATETIME` to the Finnish formats.py. I've tested the format itself with Django 1.4, and the result is a DATETIME like this: "12. joulukuuta 2011 kello 12.12.12".
