### PR TITLE
Fix typo, correct Warning message library is 'warnings'

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -1,5 +1,5 @@
 import copy
-import warning
+import warnings
 from types import GeneratorType
 
 
@@ -196,13 +196,13 @@ class SortedDict(dict):
         # This, and insert() are deprecated because they cannot be implemented
         # using collections.OrderedDict (Python 2.7 and up), which we'll
         # eventually switch to
-        warning.warn(PendingDeprecationWarning,
+        warnings.warn(PendingDeprecationWarning,
             "SortedDict.value_for_index is deprecated", stacklevel=2)
         return self[self.keyOrder[index]]
 
     def insert(self, index, key, value):
         """Inserts the key, value pair before the item with the given index."""
-        warning.warn(PendingDeprecationWarning,
+        warnings.warn(PendingDeprecationWarning,
             "SortedDict.insert is deprecated", stacklevel=2)
         if key in self.keyOrder:
             n = self.keyOrder.index(key)


### PR DESCRIPTION
[Warning messages library](http://docs.python.org/library/warnings.html) correct name is **warnings**

<pre>
favio@localhost:~/proyectos/Crowddeals$ python manage.py validate
Traceback (most recent call last):
  File "manage.py", line 9, in <module>
    execute_from_command_line(sys.argv)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_
line
    utility.execute()
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 381, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 261, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 69, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/commands/syncdb.py", line 8, in <module>
    from django.core.management.sql import custom_sql_for_model, emit_post_sync_signal
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/commands/syncdb.py", line 8, in <module>
    from django.core.management.sql import custom_sql_for_model, emit_post_sync_signal
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/core/management/sql.py", line 8, in <module>
    from django.db import models
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/db/__init__.py", line 11, in <module>
    if DEFAULT_DB_ALIAS not in settings.DATABASES:
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/utils/functional.py", line 192, in inner
    self._setup()
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/conf/__init__.py", line 43, in _setup
    self._wrapped = Settings(settings_module)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/conf/__init__.py", line 131, in __init__
    logging_config_module = importlib.import_module(logging_config_path)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/utils/log.py", line 6, in <module>
    from django.views.debug import ExceptionReporter, get_exception_reporter_filter
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/views/debug.py", line 11, in <module>
    from django.http import (HttpResponse, HttpResponseServerError,
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/http/__init__.py", line 82, in <module>
    from django.http.multipartparser import MultiPartParser
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/http/multipartparser.py", line 12, in <module>
    from django.utils.datastructures import MultiValueDict
  File "/home/favio/proyectos/Crowddeals/env/local/lib/python2.7/site-packages/django/utils/datastructures.py", line 2, in <module>
    import warning
ImportError: No module named warning
</pre>
