### PR TITLE
Common OAuth terms into debug hidden values

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -16,7 +16,7 @@ from django.utils.html import escape
 from django.utils.importlib import import_module
 from django.utils.encoding import smart_unicode, smart_str
 
-HIDDEN_SETTINGS = re.compile('API|TOKEN|KEY|SECRET|PASS|PROFANITIES_LIST|SIGNATURE')
+HIDDEN_SETTINGS = re.compile('API|TOKEN|KEY|SECRET|PASS|PROFANITIES_LIST|SIGNATURE|CONSUMER|ACCESS')
 
 CLEANSED_SUBSTITUTE = '********************'
 


### PR DESCRIPTION
Django already does a pretty nice job of protecting certain hidden values in DEBUG mode. This changes adds a few more values to sanitized based on common terminology of the OAuth protocol.
