### PR TITLE
Fixed #18634 -- Don't escape variables in the context for startproject/startapp.

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -115,7 +115,7 @@ class TemplateCommand(BaseCommand):
         context = Context(dict(options, **{
             base_name: name,
             base_directory: top_dir,
-        }))
+        }), autoescape=False)
 
         # Setup a stub settings environment for template rendering
         from django.conf import settings

--- a/tests/regressiontests/admin_scripts/custom_templates/project_template/additional_dir/extra.py
+++ b/tests/regressiontests/admin_scripts/custom_templates/project_template/additional_dir/extra.py
@@ -1,0 +1,1 @@
+# this file uses the {{ extra }} variable

--- a/tests/regressiontests/admin_scripts/management/commands/custom_startproject.py
+++ b/tests/regressiontests/admin_scripts/management/commands/custom_startproject.py
@@ -1,0 +1,11 @@
+from optparse import make_option
+
+from django.core.management.commands.startproject import Command as BaseCommand
+
+
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
+        make_option('--extra',
+                    action='store', dest='extra',
+                    help='An arbitrary extra value passed to the context'),
+        )

--- a/tests/regressiontests/admin_scripts/tests.py
+++ b/tests/regressiontests/admin_scripts/tests.py
@@ -1541,6 +1541,24 @@ class StartProject(LiveServerTestCase, AdminScriptTestCase):
             self.assertIn("project_name = 'another_project'", content)
             self.assertIn("project_directory = '%s'" % testproject_dir, content)
 
+    def test_no_escaping_of_project_variables(self):
+        "Make sure template context variables are not html escaped"
+        # We're using a custom command so we need the alternate settings
+        self.write_settings('alternate_settings.py')
+        template_path = os.path.join(test_dir, 'admin_scripts', 'custom_templates', 'project_template')
+        args = ['custom_startproject', '--template', template_path, 'another_project', 'project_dir', '--extra', '<&>', '--settings=alternate_settings']
+        testproject_dir = os.path.join(test_dir, 'project_dir')
+        os.mkdir(testproject_dir)
+        out, err = self.run_manage(args)
+        self.addCleanup(shutil.rmtree, testproject_dir)
+        self.assertNoOutput(err)
+        test_manage_py = os.path.join(testproject_dir, 'additional_dir', 'extra.py')
+        with open(test_manage_py, 'r') as fp:
+            content = fp.read()
+            self.assertIn("<&>", content)
+        # tidy up alternate settings
+        self.remove_settings('alternate_settings.py')
+
     def test_custom_project_destination_missing(self):
         """
         Make sure an exception is raised when the provided


### PR DESCRIPTION
The & symbols which can come up in the secret key were being escaped to &amp;.

I'm not sure how to test this - there's no obvious way to fix the variables so they contain bad characters as we can't pass in extra options...
