### PR TITLE
Adds interpreter option to shell command as per ticket #18639

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -2,13 +2,19 @@ import os
 from django.core.management.base import NoArgsCommand
 from optparse import make_option
 
+
 class Command(NoArgsCommand):
+    shells = ['ipython', 'bpython']
+
     option_list = NoArgsCommand.option_list + (
         make_option('--plain', action='store_true', dest='plain',
             help='Tells Django to use plain Python, not IPython or bpython.'),
+        make_option('-i', '--interface', action='store', type='choice', choices=shells,
+                    dest='interface',
+            help='Specify an interactive interpreter interface. Available options: "ipython" and "bpython"'),
+
     )
     help = "Runs a Python interactive interpreter. Tries to use IPython or bpython, if one of them is available."
-    shells = ['ipython', 'bpython']
     requires_model_validation = False
 
     def ipython(self):
@@ -31,8 +37,10 @@ class Command(NoArgsCommand):
         import bpython
         bpython.embed()
 
-    def run_shell(self):
-        for shell in self.shells:
+    def run_shell(self, shell=None):
+        available_shells = [shell] if shell else self.shells
+
+        for shell in available_shells:
             try:
                 return getattr(self, shell)()
             except ImportError:
@@ -46,19 +54,21 @@ class Command(NoArgsCommand):
         get_models()
 
         use_plain = options.get('plain', False)
+        interface = options.get('interface', None)
 
         try:
             if use_plain:
                 # Don't bother loading IPython, because the user wants plain Python.
                 raise ImportError
-            self.run_shell()
+
+            self.run_shell(shell=interface)
         except ImportError:
             import code
             # Set up a dictionary to serve as the environment for the shell, so
             # that tab completion works on objects that are imported at runtime.
             # See ticket 5082.
             imported_objects = {}
-            try: # Try activating rlcompleter, because it's handy.
+            try:  # Try activating rlcompleter, because it's handy.
                 import readline
             except ImportError:
                 pass

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -743,6 +743,24 @@ use the ``--plain`` option, like so::
 
     django-admin.py shell --plain
 
+.. versionchanged:: 1.5
+
+If you would like to specify either IPython or bpython as your interpreter if
+you have both installed you can specify an alternative interpreter interface
+with the ``-i`` or ``--interface`` options like so::
+
+IPython::
+
+    django-admin.py shell -i ipython
+    django-admin.py shell --interface ipython
+
+
+bpython::
+
+    django-admin.py shell -i bpython
+    django-admin.py shell --interface bpython
+
+
 .. _IPython: http://ipython.scipy.org/
 .. _bpython: http://bpython-interpreter.org/
 


### PR DESCRIPTION
Adds interpreter option to shell command as per ticket #18639
Specify python interpreter interface ipython or bpython with the -i,
--interface options
argument.

``` shell
python manage.py shell -i bpython
```

or

``` shell
python manage.py shell --interface bpython
```

Like all other options, defaults to default python interpreter when your
selected choice isn't available.

updated documentation where appropriate
