### PR TITLE
Fixed #18644 -- Made urlize trim trailing period followed by parenthesis

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -13,7 +13,7 @@ from django.utils.functional import allow_lazy
 from django.utils.text import normalize_newlines
 
 # Configuration for urlize() function.
-TRAILING_PUNCTUATION = ['.', ',', ':', ';']
+TRAILING_PUNCTUATION = ['.', ',', ':', ';', '.)']
 WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('&lt;', '&gt;')]
 
 # List of possible strings used for bullets in bulleted lists.

--- a/tests/regressiontests/defaultfilters/tests.py
+++ b/tests/regressiontests/defaultfilters/tests.py
@@ -297,6 +297,10 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(urlize('HTTPS://github.com/'),
             '<a href="https://github.com/" rel="nofollow">HTTPS://github.com/</a>')
 
+        # Check urlize trims trailing period when followed by parenthesis - see #18644
+        self.assertEqual(urlize('(Go to http://www.example.com/foo.)'),
+                         '(Go to <a href="http://www.example.com/foo" rel="nofollow">http://www.example.com/foo</a>.)')
+
     def test_wordcount(self):
         self.assertEqual(wordcount(''), 0)
         self.assertEqual(wordcount('oneword'), 1)


### PR DESCRIPTION
Added `'.)'` to `TRAILING_PUNCTUATION` so that a period will be stripped from URLs also when it is followed by a close parenthesis. See [Ticket #18644](https://code.djangoproject.com/ticket/18644).
