### PR TITLE
BaseCache now has a no-op close method as per ticket #18582

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -229,6 +229,7 @@ answer newbie questions, and generally made Django that much better:
     Simon Greenhill <dev@simon.net.nz>
     Owen Griffiths
     Espen Grindhaug <http://grindhaug.org/>
+    Mike Grouchy <http://mikegrouchy.com/>
     Janos Guljas
     Thomas Güttler <hv@tbz-pariv.de>
     Horst Gutmann <zerok@zerokspot.com>

--- a/django/core/cache/__init__.py
+++ b/django/core/cache/__init__.py
@@ -133,11 +133,9 @@ def get_cache(backend, **kwargs):
             "Could not find backend '%s': %s" % (backend, e))
     cache = backend_cls(location, params)
     # Some caches -- python-memcached in particular -- need to do a cleanup at the
-    # end of a request cycle. If the cache provides a close() method, wire it up
-    # here.
-    if hasattr(cache, 'close'):
-        signals.request_finished.connect(cache.close)
+    # end of a request cycle. If not implemented in a particular backend
+    # cache.close is a no-op
+    signals.request_finished.connect(cache.close)
     return cache
 
 cache = get_cache(DEFAULT_CACHE_ALIAS)
-

--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -6,14 +6,17 @@ from django.core.exceptions import ImproperlyConfigured, DjangoRuntimeWarning
 from django.utils.encoding import smart_str
 from django.utils.importlib import import_module
 
+
 class InvalidCacheBackendError(ImproperlyConfigured):
     pass
+
 
 class CacheKeyWarning(DjangoRuntimeWarning):
     pass
 
 # Memcached does not accept keys longer than this.
 MEMCACHE_MAX_KEY_LENGTH = 250
+
 
 def default_key_func(key, key_prefix, version):
     """
@@ -24,6 +27,7 @@ def default_key_func(key, key_prefix, version):
     function with custom key making behavior.
     """
     return ':'.join([key_prefix, str(version), smart_str(key)])
+
 
 def get_key_func(key_func):
     """
@@ -39,6 +43,7 @@ def get_key_func(key_func):
             key_func_module = import_module(key_func_module_path)
             return getattr(key_func_module, key_func_name)
     return default_key_func
+
 
 class BaseCache(object):
     def __init__(self, params):
@@ -221,3 +226,7 @@ class BaseCache(object):
         the new version.
         """
         return self.incr_version(key, -delta, version)
+
+    def close(self, **kwargs):
+        """Close the cache connection"""
+        pass

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -779,6 +779,16 @@ nonexistent cache key.::
     However, if the backend doesn't natively provide an increment/decrement
     operation, it will be implemented using a two-step retrieve/update.
 
+
+You can close the connection to your cache with ``close()`` if implemented by
+the cache backend.
+
+    >>> cache.close()
+
+.. note::
+
+    For caches that don't implement ``close`` methods it is a no-op.
+
 .. _cache_key_prefixing:
 
 Cache key prefixing

--- a/tests/regressiontests/cache/tests.py
+++ b/tests/regressiontests/cache/tests.py
@@ -266,6 +266,10 @@ class BaseCacheTests(object):
         self.assertEqual(self.cache.get('answer'), 32)
         self.assertRaises(ValueError, self.cache.decr, 'does_not_exist')
 
+    def test_close(self):
+        self.assertTrue(hasattr(self.cache, 'close'))
+        self.cache.close()
+
     def test_data_types(self):
         # Many different data types can be cached
         stuff = {


### PR DESCRIPTION
Also removed the hasattr check when firing request_finished signal for
caches with a 'close' method. Should be safe to call `cache.close`
everywhere now

references ticket: https://code.djangoproject.com/ticket/18482
