### PR TITLE
Fix typo in staticfiles app documentation

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -390,7 +390,7 @@ in :ref:`staticfiles-from-cdn`.
 .. versionadded:: 1.5
 
 If you'd like to retrieve a static URL without displaying it, you can use a
-slightly different call::
+slightly different call:
 
 .. code-block:: html+django
 


### PR DESCRIPTION
In the documentation for the `static` template tag, a `::` was used prior to a `code-block`. Doing so caused the `code-block` line to render as code. Changing the `::` to `:` corrects the display.
