### PR TITLE
Add missing transaction commit to cache.clear

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -179,6 +179,7 @@ class DatabaseCache(BaseDatabaseCache):
         table = connections[db].ops.quote_name(self._table)
         cursor = connections[db].cursor()
         cursor.execute('DELETE FROM %s' % table)
+        transaction.commit_unless_managed(using=db)
 
 # For backwards compatibility
 class CacheClass(DatabaseCache):


### PR DESCRIPTION
On PostgreSQL this is necessary to clear the cache table.
