### PR TITLE
Documentation fix - Change the word "brackets" to "parentheses"

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -419,7 +419,7 @@ will be interpreted like:
 
     if (athlete_list and coach_list) or cheerleader_list
 
-Use of actual brackets in the :ttag:`if` tag is invalid syntax.  If you need
+Use of actual parentheses in the :ttag:`if` tag is invalid syntax.  If you need
 them to indicate precedence, you should use nested :ttag:`if` tags.
 
 :ttag:`if` tags may also use the operators ``==``, ``!=``, ``<``, ``>``,


### PR DESCRIPTION
I want to change the word "brackets" to "parentheses" because when I think
of brackets, I think of [], and when I think of parentheses, I think of (),
and when I originally read this, I found the word confusing.

I wonder if this is a USA-centric thing.  [Wikipedia seems to think brackets and parentheses are the same thing](http://en.wikipedia.org/wiki/Bracket#Parentheses_.28_.29) but I had to pause to think to figure out what exactly this line of documentation was saying.
