### PR TITLE
No reason for CSRF tag to be wrapped in a div.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -47,7 +47,7 @@ class CsrfTokenNode(Node):
             if csrf_token == 'NOTPROVIDED':
                 return format_html("")
             else:
-                return format_html("<div><input type='hidden' name='csrfmiddlewaretoken' value='{0}' /></div>", csrf_token)
+                return format_html("<input type='hidden' name='csrfmiddlewaretoken' value='{0}' />", csrf_token)
         else:
             # It's very probable that the token is missing because of
             # misconfiguration, so we raise a warning


### PR DESCRIPTION
Unless there is a reason, this should be removed, django doesn't need to be bloating the dom if it doesn't need to.
