### PR TITLE
Improvements to Tutorial part 1

### DIFF
--- a/docs/faq/index.txt
+++ b/docs/faq/index.txt
@@ -12,3 +12,4 @@ Django FAQ
    models
    admin
    contributing
+   troubleshooting

--- a/docs/faq/troubleshooting.txt
+++ b/docs/faq/troubleshooting.txt
@@ -1,0 +1,15 @@
+===============
+Troubleshooting
+===============
+
+What if it doesn't work?  What did I not do?
+
+django-admin.py errors
+----------------------
+
+:doc:`django-admin.py </ref/django-admin>` should be on your system path if you
+installed Django via ``python setup.py``. If it's not on your path, you can find
+it in ``site-packages/django/bin``, where ``site-packages`` is a directory
+within your Python installation. Consider symlinking to :doc:`django-admin.py
+</ref/django-admin>` from some place on your path, such as
+:file:`/usr/local/bin`.

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -52,7 +52,8 @@ code, then run the following command:
 
    django-admin.py startproject mysite
 
-This will create a ``mysite`` directory in your current directory.
+This will create a ``mysite`` directory in your current directory.  If it didn't 
+work, see :doc:`Troubleshooting </faq/troubleshooting>`.
 
 .. admonition:: Script name may differ in distribution packages
 
@@ -77,13 +78,6 @@ This will create a ``mysite`` directory in your current directory.
     components. In particular, this means you should avoid using names like
     ``django`` (which will conflict with Django itself) or ``test`` (which
     conflicts with a built-in Python package).
-
-:doc:`django-admin.py </ref/django-admin>` should be on your system path if you
-installed Django via ``python setup.py``. If it's not on your path, you can find
-it in ``site-packages/django/bin``, where ``site-packages`` is a directory
-within your Python installation. Consider symlinking to :doc:`django-admin.py
-</ref/django-admin>` from some place on your path, such as
-:file:`/usr/local/bin`.
 
 .. admonition:: Where should this code live?
 


### PR DESCRIPTION
Created a new Troubleshooting page to reduce unnecessary information.  Usually people don't encounter errors about django-admin.py, but if they receive such errors they are advised to see the troubleshooting page.
