### PR TITLE
Fixed #18724: 0 bypassed IntegerField choice validation

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -179,7 +179,8 @@ class Field(object):
         if not self.editable:
             # Skip validation for non-editable fields.
             return
-        if self._choices and value:
+
+        if self._choices and value not in validators.EMPTY_VALUES:
             for option_key, option_value in self.choices:
                 if isinstance(option_value, (list, tuple)):
                     # This is an optgroup, so look inside the group for

--- a/tests/regressiontests/model_fields/tests.py
+++ b/tests/regressiontests/model_fields/tests.py
@@ -274,6 +274,10 @@ class ValidationTest(test.TestCase):
         self.assertRaises(ValidationError, f.clean, None, None)
         self.assertRaises(ValidationError, f.clean, '', None)
 
+    def test_integerfield_validates_zero_against_choices(self):
+        f = models.IntegerField(choices=((1, 1),))
+        self.assertRaises(ValidationError, f.clean, '0', None)
+
     def test_charfield_raises_error_on_empty_input(self):
         f = models.CharField(null=False)
         self.assertRaises(ValidationError, f.clean, None, None)


### PR DESCRIPTION
A stray coercion of a value to a boolean in the field validation logic was causing the value 0 to bypass checks against the choices for the field. This change instead checks the value against None and validators.EMPTY_VALUES.
