### PR TITLE
Use correct email in form validation example.

### DIFF
--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -253,7 +253,7 @@ Cleaning a specific field attribute
 
 Continuing on from the previous example, suppose that in our ``ContactForm``,
 we want to make sure that the ``recipients`` field always contains the address
-``"fred@example.com"``. This is validation that is specific to our form, so we
+``"dr.dre@example.com"``. This is validation that is specific to our form, so we
 don't want to put it into the general ``MultiEmailField`` class. Instead, we
 write a cleaning method that operates on the ``recipients`` field, like so::
 
@@ -263,8 +263,8 @@ write a cleaning method that operates on the ``recipients`` field, like so::
 
         def clean_recipients(self):
             data = self.cleaned_data['recipients']
-            if "fred@example.com" not in data:
-                raise forms.ValidationError("You have forgotten about Fred!")
+            if "dr.dre@example.com" not in data:
+                raise forms.ValidationError("You have forgotten about Dre!")
 
             # Always return the cleaned data, whether you have changed it or
             # not.


### PR DESCRIPTION
Fixes the documentation example for validating a specific form field to use the correct email address and error message.
