### PR TITLE
fix #18698. Package inputenc Error: Unicode char \u8:≥ not set up for use with LaTeX.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -219,7 +219,7 @@ latex_documents = [
 #latex_show_urls = False
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+latex_preamble = "\\DeclareUnicodeCharacter{2265}{\\ensuremath{\\ge}}"
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []


### PR DESCRIPTION
Sets the the `latex_preamble` in `docs/conf.py` to fix the error when generating docs on latex format
