### PR TITLE
[py3] Fixed model_forms_regress.tests.FileFieldTests

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -225,7 +225,7 @@ def filepath_to_uri(path):
         return path
     # I know about `os.sep` and `os.altsep` but I want to leave
     # some flexibility for hardcoding separators.
-    return quote(smart_bytes(path).replace("\\", "/"), safe=b"/~!*()'")
+    return quote(smart_bytes(path).decode('utf-8').replace("\\", "/"), safe=b"/~!*()'")
 
 # The encoding of the default system locale but falls back to the
 # given fallback encoding if the encoding is unsupported by python or could


### PR DESCRIPTION
Fixes test_clear_and_file_contradiction  and test_full_clear tests in FileFieldTests, which were failing with "TypeError: expected an object with the buffer interface"

Tested on python 3.2 and 2.7.1
