### PR TITLE
Update django/conf/locale/lt/LC_MESSAGES/django.po

### DIFF
--- a/django/conf/locale/lt/LC_MESSAGES/django.po
+++ b/django/conf/locale/lt/LC_MESSAGES/django.po
@@ -1,6 +1,7 @@
 # This file is distributed under the same license as the Django package.
 #
 # Translators:
+# Rimvydas Naktinis <naktinis@gmail.com>, 2012.
 # Jannis Leidel <jannis@leidel.info>, 2011.
 # Kostas  <tamosiunas@gmail.com>, 2011.
 # lauris <lauris@runbox.com>, 2011.
@@ -1048,57 +1049,57 @@ msgstr "Sausis"
 #: utils/dates.py:46
 msgctxt "alt. month"
 msgid "February"
-msgstr "Vasaris"
+msgstr "Vasario"
 
 #: utils/dates.py:47
 msgctxt "alt. month"
 msgid "March"
-msgstr "Kovas"
+msgstr "Kovo"
 
 #: utils/dates.py:48
 msgctxt "alt. month"
 msgid "April"
-msgstr "Balandis"
+msgstr "Balandžio"
 
 #: utils/dates.py:49
 msgctxt "alt. month"
 msgid "May"
-msgstr "Gegužė"
+msgstr "Gegužės"
 
 #: utils/dates.py:50
 msgctxt "alt. month"
 msgid "June"
-msgstr "Birželis"
+msgstr "Birželio"
 
 #: utils/dates.py:51
 msgctxt "alt. month"
 msgid "July"
-msgstr "Liepa"
+msgstr "Liepos"
 
 #: utils/dates.py:52
 msgctxt "alt. month"
 msgid "August"
-msgstr "Rugpjūtis"
+msgstr "Rugpjūčio"
 
 #: utils/dates.py:53
 msgctxt "alt. month"
 msgid "September"
-msgstr "Rugsėjis"
+msgstr "Rugsėjo"
 
 #: utils/dates.py:54
 msgctxt "alt. month"
 msgid "October"
-msgstr "Spalis"
+msgstr "Spalio"
 
 #: utils/dates.py:55
 msgctxt "alt. month"
 msgid "November"
-msgstr "Lapkritis"
+msgstr "Lapkričio"
 
 #: utils/dates.py:56
 msgctxt "alt. month"
 msgid "December"
-msgstr "Gruodis"
+msgstr "Gruodžio"
 
 #: utils/text.py:65
 #, python-format


### PR DESCRIPTION
Changed Lithuanian translation of alternative month names to the genitive case.
