### PR TITLE
Update django/conf/locale/lt/LC_MESSAGES/django.po

### DIFF
--- a/django/conf/locale/lt/LC_MESSAGES/django.po
+++ b/django/conf/locale/lt/LC_MESSAGES/django.po
@@ -1044,7 +1044,7 @@ msgstr "Grd."
 #: utils/dates.py:45
 msgctxt "alt. month"
 msgid "January"
-msgstr "Sausis"
+msgstr "Sausio"
 
 #: utils/dates.py:46
 msgctxt "alt. month"


### PR DESCRIPTION
Changed Lithuanian translation of alternative month names to the genitive case.
