### PR TITLE
[py3] Fixes WizardTests hashes

### DIFF
--- a/django/contrib/formtools/tests/__init__.py
+++ b/django/contrib/formtools/tests/__init__.py
@@ -12,7 +12,7 @@ from django.contrib.formtools import preview, utils
 from django.contrib.formtools.wizard import FormWizard
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import unittest
+from django.utils import unittest, six
 
 from django.contrib.formtools.tests.wizard import *
 from django.contrib.formtools.tests.forms import *
@@ -275,6 +275,8 @@ class WizardTests(TestCase):
                 "1-field": "test2",
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "wizard_step": "1"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
         response = self.client.post('/wizard1/', data)
         self.assertEqual(2, response.context['step0'])
 
@@ -300,6 +302,8 @@ class WizardTests(TestCase):
                 "1-field": "test2",
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "wizard_step": "1"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
         wizard(DummyRequest(POST=data))
         self.assertTrue(reached[0])
 
@@ -308,6 +312,9 @@ class WizardTests(TestCase):
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "hash_1": "1e6f6315da42e62f33a30640ec7e007ad3fbf1a1",
                 "wizard_step": "2"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
+            data['hash_1'] = "c33142ef9d01b1beae238adf22c3c6c57328f51a"
         self.assertRaises(http.Http404, wizard, DummyRequest(POST=data))
 
     def test_14498(self):
@@ -330,6 +337,8 @@ class WizardTests(TestCase):
                 "1-field": "test2",
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "wizard_step": "1"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
         wizard(DummyRequest(POST=data))
         self.assertTrue(reached[0])
 
@@ -354,6 +363,8 @@ class WizardTests(TestCase):
                 "1-field": "test2",
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "wizard_step": "1"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
         wizard(DummyRequest(POST=data))
         self.assertTrue(reached[0])
 
@@ -380,6 +391,8 @@ class WizardTests(TestCase):
                 "1-field": "test2",
                 "hash_0": "cd13b1db3e8f55174bc5745a1b1a53408d4fd1ca",
                 "wizard_step": "1"}
+        if six.PY3:
+            data['hash_0'] = "9355d5dff22d49dbad58e46189982cec649f9f5b"
         wizard(DummyRequest(POST=data))
         self.assertTrue(reached[0])
 


### PR DESCRIPTION
Apparently, the `pickle.dumps()` function does not generate the same output for Python 3 and Python 2, regardless of the used protocol.

Maybe not the best fix but it's a start.
