### PR TITLE
Fixed #18779 -- URLValidator can't validate url with ipv6.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -44,7 +44,8 @@ class URLValidator(RegexValidator):
         r'^(?:http|ftp)s?://' # http:// or https://
         r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
         r'localhost|' #localhost...
-        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|' # ...or ipv4
+        r'\[?[A-F0-9]*:[A-F0-9:]+\]?)' # ...or ipv6
         r'(?::\d+)?' # optional port
         r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 

--- a/tests/regressiontests/forms/tests/fields.py
+++ b/tests/regressiontests/forms/tests/fields.py
@@ -668,6 +668,18 @@ class FieldsTests(SimpleTestCase):
             # Valid IDN
             self.assertEqual(url, f.clean(url))
 
+    def test_urlfield_10(self):
+        """Test URLField correctly validates IPv6 (#18779)."""
+        f = URLField()
+        urls = (
+            'http://::/',
+            'http://6:21b4:92/',
+            'http://[12:34:3a53]/',
+            'http://[a34:9238::]:8080/',
+        )
+        for url in urls:
+            self.assertEqual(url, f.clean(url))
+
     def test_urlfield_not_string(self):
         f = URLField(required=False)
         self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 23)


### PR DESCRIPTION
Validation is reasonably 'soft', as for the ipv4. False positives don't 
matter too much here.
