### PR TITLE
Fixed #17228 -- params context variable is inconsistent

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -140,11 +140,11 @@ class TemplateResponseMixin(object):
 
 class TemplateView(TemplateResponseMixin, ContextMixin, View):
     """
-    A view that renders a template.  This view is different from all the others
-    insofar as it also passes ``kwargs`` as ``params`` to the template context.
+    A view that renders a template.  This view will also pass into the context
+    any keyword arguments passed by the url conf.
     """
     def get(self, request, *args, **kwargs):
-        context = self.get_context_data(params=kwargs)
+        context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 
 

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -138,6 +138,14 @@ year|date:"Y" }}``.
 ``next_year`` and ``previous_year`` were also added in the context. They are
 calculated according to ``allow_empty`` and ``allow_future``.
 
+Context in TemplateView
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For consistency with the design of the other generic views,
+:class:`~django.views.generic.base.TemplateView` no longer passes a ``params``
+dictionary into the context, instead passing the variables from the URLconf
+directly into the context.
+
 OPTIONS, PUT and DELETE requests in the test client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/regressiontests/generic_views/base.py
+++ b/tests/regressiontests/generic_views/base.py
@@ -275,7 +275,7 @@ class TemplateViewTest(TestCase):
         """
         response = self.client.get('/template/simple/bar/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['params'], {'foo': 'bar'})
+        self.assertEqual(response.context['foo'], 'bar')
 
     def test_extra_template_params(self):
         """
@@ -283,7 +283,7 @@ class TemplateViewTest(TestCase):
         """
         response = self.client.get('/template/custom/bar/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['params'], {'foo': 'bar'})
+        self.assertEqual(response.context['foo'], 'bar')
         self.assertEqual(response.context['key'], 'value')
 
     def test_cached_views(self):


### PR DESCRIPTION
Remove the params variable from the context and just put the variables
in directly.

This had not been committed previously as the original pattern was used
in the functional generic views and we wanted consistency between them,
but django.views.generic.simple.direct_to_template is now gone so we can
do it 'right'.
