### PR TITLE
Description of MEDIA_ROOT setting in docs and generated settings.py are wildly different

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1366,7 +1366,7 @@ MEDIA_ROOT
 
 Default: ``''`` (Empty string)
 
-Absolute filesystem path to the directory that will hold user-uploaded files :doc:`managing stored files </topics/files>`.
+Absolute filesystem path to the directory that will hold user-uploaded :doc:`files </topics/files>`.
 
 Example: ``"/var/www/example.com/media/"``
 


### PR DESCRIPTION
It's already confusing for newbies that the MEDIA_ROOT is NOT where you put your static media and the current description in the documentation doesn't help. 

The description in the auto-generated settings.py is spot on though, which is what I used to replace the existing description for MEDIA_ROOT in the docs.
