### PR TITLE
avoid unnecessary query for on_delete=DO_NOTHING

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -173,6 +173,8 @@ class Collector(object):
                 if related.model._meta.auto_created:
                     self.add_batch(related.model, field, new_objs)
                 else:
+                    if field.rel.on_delete == DO_NOTHING:
+                        continue
                     sub_objs = self.related_objects(related, new_objs)
                     if not sub_objs:
                         continue


### PR DESCRIPTION
When deleting objects in the admin, there is no need to run queries on related ForeignKey(on_delete=models.DO_NOTHING).
