### PR TITLE
persist a socket across reloads of the dev server

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -25,6 +25,8 @@ class Command(BaseCommand):
             help='Tells Django to NOT use threading.'),
         make_option('--noreload', action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
+        make_option('--nopersistsock', action='store_false', dest='use_persist_sock', default=True,
+            help='Tells Django to NOT use a persistent socket.'),
     )
     help = "Starts a lightweight Web server for development."
     args = '[optional port number, or ipaddr:port]'
@@ -73,6 +75,14 @@ class Command(BaseCommand):
         Runs the server, using the autoreloader if needed
         """
         use_reloader = options.get('use_reloader')
+
+        if options.get('use_persist_sock'):
+            address_family = socket.AF_INET
+            if self.use_ipv6:
+                address_family = socket.AF_INET6
+            if not os.environ.get('DJANGO_SERVER_FD'):
+                sock = socket.socket(address_family, socket.SOCK_STREAM)
+                os.environ['DJANGO_SERVER_FD'] = str(sock.fileno())
 
         if use_reloader:
             autoreload.main(self.inner_run, args, options)


### PR DESCRIPTION
Using livereload (livereload.com) with Django becomes painful when
updating a file immediately results in reloading the webpage AND
the Django dev server.  There is a short period of time when the dev
server is not listening as it is busy reloading (frequently hit
when using livereload).

This is exacerbated with larger projects as reload time is longer.

This has been an itch I've wanted to scratch for a long time.  Hopefully, this will be accepted so others can benefit from it also.  Helps plenty even with users hitting Reload manually on their browser.

(PS: I've used Django for a while, but never contributed.  I've attempted to read up on contributing on the site, but I couldn't find much about "Pull Requests" and if I should create a ticket first or not, so please be gentle)
