### PR TITLE
Define less than or equal character for latex docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,8 @@ modindex_common_prefix = ["django."]
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-    'preamble': '\\DeclareUnicodeCharacter{2265}{\\ensuremath{\\ge}}'
+    'preamble': '''\\DeclareUnicodeCharacter{2265}{\\ensuremath{\\ge}}
+\\DeclareUnicodeCharacter{2264}{\\ensuremath{\\le}}'''
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
Stops this error:

! Package inputenc Error: Unicode char \u8:≤ not set up for use with LaTeX.
