### PR TITLE
fix documentation testing of Selenium WebDriverWait 

### DIFF
--- a/docs/topics/testing.txt
+++ b/docs/topics/testing.txt
@@ -2039,7 +2039,7 @@ out the `full reference`_ for more details.
             self.selenium.find_element_by_xpath('//input[@value="Log in"]').click()
             # Wait until the response is received
             WebDriverWait(self.selenium, timeout).until(
-                lambda driver: driver.find_element_by_tag_name('body'), timeout=10)
+                lambda driver: driver.find_element_by_tag_name('body'))
 
     The tricky thing here is that there's really no such thing as a "page load,"
     especially in modern Web apps that generate HTML dynamically after the


### PR DESCRIPTION
According to the documentation of Selenium, WebDriverWait class has no timeout parameter and using the code fails.

http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/support/ui/FluentWait.html#until%28com.google.common.base.Predicate%29
