### PR TITLE
python3 docs: slicing bytestrings is good

### DIFF
--- a/docs/topics/python3.txt
+++ b/docs/topics/python3.txt
@@ -237,9 +237,9 @@ sometimes necessary::
 
     value = value.encode('ascii', 'ignore').decode('ascii')
 
-Be cautious if you have to `slice bytestrings`_.
+Be cautious if you have to take an `index of a bytestring`_.
 
-.. _slice bytestrings: http://docs.python.org/py3k/howto/pyporting.html#bytes-literals
+.. _index of a bytestring: http://docs.python.org/py3k/howto/pyporting.html#bytes-literals
 
 Exceptions
 ~~~~~~~~~~


### PR DESCRIPTION
Small technicality, not sure the best way to phrase this, but slicing bytestrings is safe and recommended.
