### PR TITLE
Clarify usage of as_view kwargs for setting arguments on class based views

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -54,8 +54,8 @@ class View(object):
                                 % (key, cls.__name__))
             if not hasattr(cls, key):
                 raise TypeError("%s() received an invalid keyword %r. as_view only "
-                                "accepts arguments that are attributes of the class"
-                                % (cls.__name__, key))
+                        "accepts arguments that are already attributes of the class"
+                        % (cls.__name__, key))
 
         def view(request, *args, **kwargs):
             self = cls(**initkwargs)

--- a/docs/ref/class-based-views/index.txt
+++ b/docs/ref/class-based-views/index.txt
@@ -39,8 +39,8 @@ A class-based view is deployed into a URL pattern using the
 Arguments passed into :meth:`~View.as_view()` will be assigned onto the
 instance that is used to service a request. Using the previous example,
 this means that every request on ``MyView`` is able to use ``self.size``.
-Arguments must correspond to attributes that can be set on the class using
-``setattr``.
+Arguments must correspond to attributes that return True on a ``hasattr`` 
+check.
 
 Base vs Generic views
 ---------------------


### PR DESCRIPTION
The current documentation could lead to a new Python developer thinking that passing a keyword argument into as_view will result in an attribute being specified and set to the correct value. The current error message doesn't provide any additional information that might help the user towards a solution.
