### PR TITLE
Small doc change: clarify day and month

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -235,14 +235,14 @@ refinements together. For example::
     ... ).exclude(
     ...     pub_date__gte=datetime.now()
     ... ).filter(
-    ...     pub_date__gte=datetime(2005, 1, 2)
+    ...     pub_date__gte=datetime(2005, 1, 30)
     ... )
 
 This takes the initial :class:`~django.db.models.query.QuerySet` of all entries
 in the database, adds a filter, then an exclusion, then another filter. The
 final result is a :class:`~django.db.models.query.QuerySet` containing all
 entries with a headline that starts with "What", that were published between
-January 2, 2005, and the current day.
+January 30, 2005, and the current day.
 
 .. _filtered-querysets-are-unique:
 


### PR DESCRIPTION
Make the day and month different numbers, so it's easy to distinguish which argument is the month and which is the day.
