### PR TITLE
Fixed #8149 -- Use universal line terminators when iterating `File` obje...

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -91,9 +91,7 @@ class File(FileProxyMixin):
         # Iterate over this file-like object by newlines
         buffer_ = None
         for chunk in self.chunks():
-            chunk_buffer = BytesIO(chunk)
-
-            for line in chunk_buffer:
+            for line in chunk.splitlines(True):
                 if buffer_:
                     line = buffer_ + line
                     buffer_ = None

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -256,10 +256,11 @@ define the following methods/attributes:
         for line in uploadedfile:
             do_something_with(line)
 
-    However, *unlike* standard Python files, :class:`UploadedFile` only
-    understands ``\n`` (also known as "Unix-style") line endings. If you know
-    that you need to handle uploaded files with different line endings, you'll
-    need to do so in your view.
+    .. versionchanged:: 1.5
+
+    In previous versions, :class:`UploadedFile` only understood ``\n`` (also
+    known as "Unix-style") line endings. Now, you can read files line-by-line
+    when they use ``\r`` line endings as well.
 
 Upload Handlers
 ===============


### PR DESCRIPTION
...cts line-by-line.
