### PR TITLE
don't make uploaded files executable by default

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -192,7 +192,7 @@ class FileSystemStorage(Storage):
                 else:
                     # This fun binary flag incantation makes os.open throw an
                     # OSError if the file already exists before we open it.
-                    fd = os.open(full_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_BINARY', 0))
+                    fd = os.open(full_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_BINARY', 0), 0666)
                     try:
                         locks.lock(fd, locks.LOCK_EX)
                         _file = None


### PR DESCRIPTION
Apparently Django creates uploaded files with the exec bit set by default, since it uses os.open() without specifying mode and Python defaults mode to 0777 (it must be specified for the open(2) syscall if O_CREAT is given). This is easily fixed by setting os.open()'s mode argument to 0666 (it will still be masked by umask, and user specified mode will be set by chmod afterwards if necessary).
