### PR TITLE
clarify clean_<field> docs, ticket #18917

### DIFF
--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -70,9 +70,8 @@ overridden:
   formfield-specific piece of validation and, possibly,
   cleaning/normalizing the data.
 
-  Just like the general field ``clean()`` method, above, this method
-  should return the cleaned data, regardless of whether it changed
-  anything or not.
+  This method should return the cleaned value obtained from cleaned_data,
+  regardless of whether it changed anything or not.
 
 * The Form subclass's ``clean()`` method. This method can perform
   any validation that requires access to multiple fields from the form at


### PR DESCRIPTION
Clarify that the "cleaned data" returned is a single value from the cleaned_data dict.
