### PR TITLE
wrap long words in field labels on admin forms, closes #18755

### DIFF
--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -65,6 +65,7 @@ form ul.inline li {
     padding: 3px 10px 0 0;
     float: left;
     width: 8em;
+    word-wrap: break-word;
 }
 
 .aligned ul label {


### PR DESCRIPTION
Otherwise, words overlap into the fields themselves, which makes the labels unreadable.
