### PR TITLE
remove unused import in decoupling URLs tutorial, closes #18915

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -517,7 +517,7 @@ URLconf by removing the leading "polls/" from each line, and removing the
 lines registering the admin site. Your ``polls/urls.py`` file should now look like
 this::
 
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import patterns, url
 
     urlpatterns = patterns('polls.views',
         url(r'^$', 'index'),


### PR DESCRIPTION
The `include` function isn't used in polls/urls.py.
