### PR TITLE
Fixed #13142 -- Added support for SSL connections in core.mail.backends....

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -176,6 +176,9 @@ EMAIL_PORT = 25
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
+EMAIL_USE_SSL = False
+EMAIL_SSL_CERTFILE = None
+EMAIL_SSL_KEYFILE = None
 
 # List of strings representing installed apps.
 INSTALLED_APPS = ()

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -14,6 +14,7 @@ class EmailBackend(BaseEmailBackend):
     A wrapper that manages the SMTP network connection.
     """
     def __init__(self, host=None, port=None, username=None, password=None,
+                 use_ssl=None, keyfile=None, certfile=None,
                  use_tls=None, fail_silently=False, **kwargs):
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
         self.host = host or settings.EMAIL_HOST
@@ -30,6 +31,18 @@ class EmailBackend(BaseEmailBackend):
             self.use_tls = settings.EMAIL_USE_TLS
         else:
             self.use_tls = use_tls
+        if use_ssl is None:
+            self.use_ssl = settings.EMAIL_USE_SSL
+        else:
+            self.use_ssl = use_ssl
+        if keyfile is None:
+            self.keyfile = settings.EMAIL_SSL_KEYFILE
+        else:
+            self.keyfile = keyfile
+        if certfile is None:
+            self.certfile = settings.EMAIL_SSL_CERTFILE
+        else:
+            self.certfile = certfile
         self.connection = None
         self._lock = threading.RLock()
 
@@ -44,8 +57,13 @@ class EmailBackend(BaseEmailBackend):
         try:
             # If local_hostname is not specified, socket.getfqdn() gets used.
             # For performance, we use the cached FQDN for local_hostname.
-            self.connection = smtplib.SMTP(self.host, self.port,
-                                           local_hostname=DNS_NAME.get_fqdn())
+            if self.use_ssl:
+                self.connection = smtplib.SMTP_SSL(self.host, self.port,
+                        keyfile=self.keyfile, certfile=self.certfile,
+                        local_hostname=DNS_NAME.get_fqdn())
+            else:
+                self.connection = smtplib.SMTP(self.host, self.port,
+                        local_hostname=DNS_NAME.get_fqdn())
             if self.use_tls:
                 self.connection.ehlo()
                 self.connection.starttls()

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -979,6 +979,49 @@ Default: ``False``
 
 Whether to use a TLS (secure) connection when talking to the SMTP server.
 
+.. setting:: EMAIL_USE_SSL 
+
+EMAIL_USE_SSL
+-------------
+ 
+.. versionadded:: 1.5
+
+Default: ``False`` 
+ 
+Whether to use a SSL (secure) connection when talking to the SMTP server.  
+ 
+.. warning:: 
+ 
+        Requirements: Python 2.6 or higher 
+
+EMAIL_SSL_CERTFILE
+------------------
+ 
+.. versionadded:: 1.5
+
+Default: ``None`` 
+ 
+If :setting:`EMAIL_USE_SSL` is ``True``, optionally specify the path to a
+PEM-formatted certificate chain file to use for the SSL connection.
+ 
+.. warning:: 
+ 
+        Requirements: Python 2.6 or higher 
+
+EMAIL_SSL_KEYFILE
+-----------------
+ 
+.. versionadded:: 1.5
+
+Default: ``None`` 
+ 
+If :setting:`EMAIL_USE_SSL` is ``True``, optionally specify the path to a
+PEM-formatted private key file to use for the SSL connection.
+ 
+.. warning:: 
+ 
+        Requirements: Python 2.6 or higher 
+
 .. setting:: FILE_CHARSET
 
 FILE_CHARSET

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -27,7 +27,7 @@ Mail is sent using the SMTP host and port specified in the
 :setting:`EMAIL_HOST` and :setting:`EMAIL_PORT` settings. The
 :setting:`EMAIL_HOST_USER` and :setting:`EMAIL_HOST_PASSWORD` settings, if
 set, are used to authenticate to the SMTP server, and the
-:setting:`EMAIL_USE_TLS` setting controls whether a secure connection is used.
+:setting:`EMAIL_USE_TLS` or :setting:`EMAIL_USE_SSL` setting controls whether a secure connection is used. 
 
 .. note::
 
@@ -413,7 +413,8 @@ SMTP backend
 This is the default backend. Email will be sent through a SMTP server.
 The server address and authentication credentials are set in the
 :setting:`EMAIL_HOST`, :setting:`EMAIL_PORT`, :setting:`EMAIL_HOST_USER`,
-:setting:`EMAIL_HOST_PASSWORD` and :setting:`EMAIL_USE_TLS` settings in your
+:setting:`EMAIL_HOST_PASSWORD`, :setting:`EMAIL_USE_TLS`, :setting:`EMAIL_USE_SSL`,
+:setting:`EMAIL_SSL_CERTFILE`, and :setting:`EMAIL_SSL_KEYFILE` settings in your
 settings file.
 
 The SMTP backend is the default configuration inherited by Django. If you


### PR DESCRIPTION
...smtp

Note: SVN-based patch originally provided by serg.partizan / partizan
and Wojciech Banaś in Trac (refer to https://code.djangoproject.com/ticket/13142).

This commit includes the work done by those previous, with the following
changes:
- If use_ssl is True, or settings.EMAIL_USE_SSL is True, but the current Python
  version is less than 2.6, use_ssl is _not_ internally changed to False.  Nor
  does the SMTP backend code raise an exception.  We don't need to, because Django 1.5
  is dropping support for Python prior to 2.6.
- This update provides the ability to configure the keyfile and certfile
  to use with SMTP_SSL.
- Documentation is updated to specify that this feature is new in 1.5.
