### PR TITLE
Patch for ticket 18887

### DIFF
--- a/django/contrib/gis/geos/base.py
+++ b/django/contrib/gis/geos/base.py
@@ -12,11 +12,15 @@ except ImportError:
         HAS_GDAL = False
     gdal = GDALInfo()
 
-# NumPy supported?
-try:
-    import numpy
-except ImportError:
+# NumPy supported or desired?
+GEOS_USE_NUMPY = getattr(settings, 'GEOS_USE_NUMPY', True)
+if not GEOS_USE_NUMPY:
     numpy = False
+else:
+    try:
+        import numpy
+    except ImportError:
+        numpy = False
 
 class GEOSBase(object):
     """

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -921,3 +921,18 @@ location (e.g., ``/home/bob/lib/libgeos_c.so``).
 
     The setting must be the *full* path to the **C** shared library; in
     other words you want to use ``libgeos_c.so``, not ``libgeos.so``.
+
+.. setting:: GEOS_USE_NUMPY
+
+GEOS_USE_NUMPY
+--------------
+
+A boolean indicating that numpy data structures should be used when available 
+and appropriate. If numpy is unavailable, or this is set to ``False``, numpy will
+not be used. The default is ``True``.
+
+.. note::
+
+    If you have numpy available and choose to use it, you will need to be
+    careful when comparing return types. Make sure to use the proper type
+    when making comparisons.


### PR DESCRIPTION
This adds a setting that lets users ignore numpy in geos even if it's available, so people can be in control of the return types from certain operations (like calling array on a LineString)
