### PR TITLE
Ticket #12836 - Added a test to assure permalink wraps method attributes

### DIFF
--- a/tests/regressiontests/model_permalink/models.py
+++ b/tests/regressiontests/model_permalink/models.py
@@ -1,6 +1,13 @@
 from django.db import models
 
 
+def set_attr(name, value):
+    def wrapper(function):
+        setattr(function, name, value)
+        return function
+    return wrapper
+
+
 class Guitarist(models.Model):
     name = models.CharField(max_length=50)
     slug = models.CharField(max_length=50)
@@ -8,4 +15,10 @@ class Guitarist(models.Model):
     @models.permalink
     def url(self):
         "Returns the URL for this guitarist."
+        return ('guitarist_detail', [self.slug])
+
+    @models.permalink
+    @set_attr('attribute', 'value')
+    def url_with_attribute(self):
+        "Returns the URL for this guitarist and holds an attribute"
         return ('guitarist_detail', [self.slug])

--- a/tests/regressiontests/model_permalink/tests.py
+++ b/tests/regressiontests/model_permalink/tests.py
@@ -16,3 +16,12 @@ class PermalinkTests(TestCase):
         "Methods using the @permalink decorator retain their docstring."
         g = Guitarist(name='Adrien Moignard', slug='adrienmoignard')
         self.assertEqual(g.url.__doc__, "Returns the URL for this guitarist.")
+
+    def test_wrapped_attribute(self):
+        """
+        Methods using the @permalink decorator can have attached attributes
+        from other decorators
+        """
+        g = Guitarist(name='Adrien Moignard', slug='adrienmoignard')
+        self.assertTrue(hasattr(g.url_with_attribute, 'attribute'))
+        self.assertEqual(g.url_with_attribute.attribute, 'value')


### PR DESCRIPTION
The fix diff at the top of the ticket was already applied: https://code.djangoproject.com/ticket/12836

The test diff provided further down was a doc test, and was not applied or was removed along with the other doc tests.

This pull request includes a test that assures the permalink decorator passes on attributes attached to the function it wraps. The test fails if the @wraps decorator is removed from permalink, and succeeds otherwise.
