### PR TITLE
Ticket 18657: Fix inconsistent DB names in router example.

### DIFF
--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -256,7 +256,7 @@ send queries for the ``auth`` app to ``auth_db``::
             """
             if model._meta.app_label == 'auth':
                 return 'auth_db'
-            return Non
+            return None
 
         def allow_relation(self, obj1, obj2, **hints):
             """


### PR DESCRIPTION
This rewrites the entire example to use the same DB names throughout,
and also is hopefully a bit more sensibly described. Additionally, the
missing import of the random module for choosing a read slave is
included in the example now.
