### PR TITLE
fixed bug#6681: RST default reference role tries docutils' default role ...

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -92,13 +92,17 @@ def create_reference_role(rolename, urlbase):
     docutils.parsers.rst.roles.register_canonical_role(rolename, _role)
 
 def default_reference_role(name, rawtext, text, lineno, inliner, options=None, content=None):
-    if options is None: options = {}
-    if content is None: content = []
-    context = inliner.document.settings.default_reference_context
-    node = docutils.nodes.reference(rawtext, text, refuri=(ROLES[context] % (inliner.document.settings.link_base, text.lower())), **options)
-    return [node], []
+    try:
+        if options is None: options = {}
+        if content is None: content = []
+        context = inliner.document.settings.default_reference_context
+        node = docutils.nodes.reference(rawtext, text, refuri=(ROLES[context] % (inliner.document.settings.link_base, text.lower())), **options)
+        return [node], []
+    except:
+        return _DOCUTILS_DEFAULT_INTERPRETED_ROLE(name, rawtext, text, lineno, inliner, options=options, content=content)
 
 if docutils_is_available:
+    _DOCUTILS_DEFAULT_INTERPRETED_ROLE = docutils.parsers.rst.roles._role_registry.get(docutils.parsers.rst.roles.DEFAULT_INTERPRETED_ROLE, None)
     docutils.parsers.rst.roles.register_canonical_role('cmsreference', default_reference_role)
     docutils.parsers.rst.roles.DEFAULT_INTERPRETED_ROLE = 'cmsreference'
 


### PR DESCRIPTION
Fixes bug#6681 as described in https://code.djangoproject.com/ticket/6681

Docutils establish a ''DEFAULT_INTERPRETED_ROLE'' which is overriden by django with **cmsreference** role.

Django's role is intended to work on admin docs, but it's not suitable for general purpose as it needs some keys in ''inliner.document.settings''.
