### PR TITLE
Fixed #18968 -- Only use separate GML regex for SpatiaLite < 3.0

### DIFF
--- a/django/contrib/gis/tests/geoapp/tests.py
+++ b/django/contrib/gis/tests/geoapp/tests.py
@@ -520,7 +520,7 @@ class GeoQuerySetTest(TestCase):
         if oracle:
             # No precision parameter for Oracle :-/
             gml_regex = re.compile(r'^<gml:Point srsName="SDO:4326" xmlns:gml="http://www.opengis.net/gml"><gml:coordinates decimal="\." cs="," ts=" ">-104.60925\d+,38.25500\d+ </gml:coordinates></gml:Point>')
-        elif spatialite:
+        elif spatialite and connection.ops.spatial_version < (3, 0, 0):
             # Spatialite has extra colon in SrsName
             gml_regex = re.compile(r'^<gml:Point SrsName="EPSG::4326"><gml:coordinates decimal="\." cs="," ts=" ">-104.609251\d+,38.255001</gml:coordinates></gml:Point>')
         else:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/18968
