### PR TITLE
Fixed #18982 -- BaseTemporalField handles TypeError from strptime

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -343,6 +343,10 @@ class BaseTemporalField(Field):
                     return self.strptime(value, format)
                 except ValueError:
                     continue
+                except TypeError:
+                    # When value contains NUL bytes, strptime raises TypeError.
+                    # Treat it as an invalid value.
+                    continue
         raise ValidationError(self.error_messages['invalid'])
 
     def strptime(self, value, format):

--- a/tests/regressiontests/forms/tests/fields.py
+++ b/tests/regressiontests/forms/tests/fields.py
@@ -356,6 +356,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(' 25 October 2006 '))
         self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '   ')
 
+    def test_nul_bytes(self):
+        f = DateField()
+        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, 'a\x00b')
+
     # TimeField ###################################################################
 
     def test_timefield_1(self):


### PR DESCRIPTION
When BaseTemporalField tries to clean a value with NUL bytes, strptime
raises a TypeError. Added an exception handler to make this a
ValidationError instead.

Ref https://code.djangoproject.com/ticket/18982
