### PR TITLE
Fix #16865 get_or_create should only set _for_write when it's actually d...

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -455,9 +455,9 @@ class QuerySet(object):
             if f.attname in lookup:
                 lookup[f.name] = lookup.pop(f.attname)
         try:
-            self._for_write = True
             return self.get(**lookup), False
         except self.model.DoesNotExist:
+            self._for_write = True
             try:
                 params = dict([(k, v) for k, v in kwargs.items() if '__' not in k])
                 params.update(defaults)


### PR DESCRIPTION
...oing a create action.

This makes sure that the initial .get() will be able to use slave databases.
If there is replication lag it will fail when it tries to create the object on the master
and will still fetch the object. This is a trait off between extra selects when there is
no replication lag and extra transactions and rollback when there is replication lag.

Specially when some form of database pinning is in place this will help to not put all
the SELECT queries on the master. When somewhere in the code get_or_create is used.
