### PR TITLE
Fixed #18985 -- Restore DeprecationWarning output

### DIFF
--- a/django/conf/project_template/manage.py
+++ b/django/conf/project_template/manage.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+
 
 if __name__ == "__main__":
+    # Python 2.7+ (and 3.2+) have silenced DeprecationWarning by default
+    # Restore the old behavior when running Django via manage.py
+    warnings.simplefilter("default", DeprecationWarning)
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
     from django.core.management import execute_from_command_line

--- a/docs/internals/release-process.txt
+++ b/docs/internals/release-process.txt
@@ -68,8 +68,11 @@ So, for example, if we decided to remove a function that existed in Django 1.0:
   by default; you need to explicitly turn on display of these warnings.
 
 * Django 1.2 will contain the backwards-compatible replica, but the warning
-  will be promoted to a full-fledged ``DeprecationWarning``. This warning is
-  *loud* by default, and will likely be quite annoying.
+  will be promoted to a full-fledged ``DeprecationWarning``. In Python 2.6 this
+  warning is *loud* by default, and will likely be quite annoying. In order to
+  restore this loudness in Python 2.7+ simply add ``warnings.simplefilter("default", DeprecationWarning)``
+  to your project. Projects created with Django 1.5 will have this in their
+  manage.py by default.
 
 * Django 1.3 will remove the feature outright.
 

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -127,6 +127,10 @@ Django 1.5 also includes several smaller improvements worth noting:
   configuration duplication. More information can be found in the
   :func:`~django.contrib.auth.decorators.login_required` documentation.
 
+* The default manage.py created by startproject will now include
+  ``warnings.simplefilter("default", DeprecationWarning)``. This is to restore
+  the DeprecationWarning output when running your project through manage.py.
+
 Backwards incompatible changes in 1.5
 =====================================
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -9,9 +9,13 @@ import warnings
 from django import contrib
 from django.utils import six
 
+# Python 2.7+ (and 3.2+) have silenced DeprecationWarning by default, restore the old behavior
+warnings.simplefilter("default", DeprecationWarning)
+
 # databrowse is deprecated, but we still want to run its tests
 warnings.filterwarnings('ignore', "The Databrowse contrib app is deprecated",
                         DeprecationWarning, 'django.contrib.databrowse')
+
 
 CONTRIB_DIR_NAME = 'django.contrib'
 MODEL_TESTS_DIR_NAME = 'modeltests'


### PR DESCRIPTION
This fixes the issue mentioned in [#18985](https://code.djangoproject.com/ticket/18985).

It will cause projects created with startproject to include a `warnings.simplefilter` to restore DeprecationWarning and documents the fact that this is required on Python 2.7+.
