### PR TITLE
Made ModelMultipleChoiceField return an EmptyQuerySet if empty.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1013,7 +1013,7 @@ class ModelMultipleChoiceField(ModelChoiceField):
         if self.required and not value:
             raise ValidationError(self.error_messages['required'])
         elif not self.required and not value:
-            return []
+            return self.queryset.none()
         if not isinstance(value, (list, tuple)):
             raise ValidationError(self.error_messages['list'])
         key = self.to_field_name or 'pk'

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -997,8 +997,8 @@ objects (in the case of ``ModelMultipleChoiceField``) into the
 .. class:: ModelMultipleChoiceField(**kwargs)
 
     * Default widget: ``SelectMultiple``
-    * Empty value: ``[]`` (an empty list)
-    * Normalizes to: A list of model instances.
+    * Empty value: An empty ``QuerySet`` (self.queryset.none())
+    * Normalizes to: A ``QuerySet`` of model instances.
     * Validates that every id in the given list of values exists in the
       queryset.
     * Error message keys: ``required``, ``list``, ``invalid_choice``,

--- a/tests/modeltests/model_forms/tests.py
+++ b/tests/modeltests/model_forms/tests.py
@@ -8,6 +8,7 @@ from django import forms
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.validators import ValidationError
 from django.db import connection
+from django.db.models.query import EmptyQuerySet
 from django.forms.models import model_to_dict
 from django.utils.unittest import skipUnless
 from django.test import TestCase
@@ -1035,8 +1036,8 @@ class OldFormForXTests(TestCase):
             f.clean([c6.id])
 
         f = forms.ModelMultipleChoiceField(Category.objects.all(), required=False)
-        self.assertEqual(f.clean([]), [])
-        self.assertEqual(f.clean(()), [])
+        self.assertIsInstance(f.clean([]), EmptyQuerySet)
+        self.assertIsInstance(f.clean(()), EmptyQuerySet)
         with self.assertRaises(ValidationError):
             f.clean(['10'])
         with self.assertRaises(ValidationError):

--- a/tests/regressiontests/forms/models.py
+++ b/tests/regressiontests/forms/models.py
@@ -62,6 +62,8 @@ class ChoiceFieldModel(models.Model):
                                           default=lambda: ChoiceOptionModel.objects.filter(name='default'))
     multi_choice_int = models.ManyToManyField(ChoiceOptionModel, blank=False, related_name='multi_choice_int',
                                               default=lambda: [1])
+    multi_choice_optional = models.ManyToManyField(ChoiceOptionModel, blank=True, null=True,
+                                                   related_name='multi_choice_optional')
 
 
 class FileModel(models.Model):

--- a/tests/regressiontests/forms/tests/models.py
+++ b/tests/regressiontests/forms/tests/models.py
@@ -35,6 +35,16 @@ class TestTicket12510(TestCase):
             self.assertEqual('a', field.clean(self.groups[0].pk).name)
 
 class ModelFormCallableModelDefault(TestCase):
+    def test_empty_queryset_return(self):
+        "If a model's ManyToManyField has blank=True and is saved with no data, a queryset is returned."
+        option = ChoiceOptionModel.objects.create(id=1, name='default')
+        form = ChoiceFieldForm({'multi_choice_optional': '', 'choice': option.id, 'choice_int': 1,
+                              'multi_choice': ['1'], 'multi_choice_int': [1]})
+        self.assertEqual(form.is_valid(), True)
+        self.assertEqual(isinstance(form.cleaned_data['multi_choice_optional'], models.query.QuerySet), True)
+        # While we're at it, test whether a QuerySet is returned if there *is* a value.
+        self.assertEqual(isinstance(form.cleaned_data['multi_choice'], models.query.QuerySet), True)
+
     def test_no_empty_option(self):
         "If a model's ForeignKey has blank=False and a default, no empty option is created (Refs #10792)."
         option = ChoiceOptionModel.objects.create(name='default')
@@ -67,7 +77,12 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="1" selected="selected">ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0" /> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>""")
+</select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0" /> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>
+<p><label for="id_multi_choice_optional">Multi choice optional:</label> <select multiple="multiple" name="multi_choice_optional" id="id_multi_choice_optional">
+<option value="1">ChoiceOption 1</option>
+<option value="2">ChoiceOption 2</option>
+<option value="3">ChoiceOption 3</option>
+</select> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>""")
 
     def test_initial_instance_value(self):
         "Initial instances for model fields may also be instances (refs #7287)"
@@ -100,7 +115,12 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="2" selected="selected">ChoiceOption 2</option>
 <option value="3" selected="selected">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-multi_choice_int" value="2" id="initial-id_multi_choice_int_0" />
-<input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1" /> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>""")
+<input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1" /> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>
+<p><label for="id_multi_choice_optional">Multi choice optional:</label> <select multiple="multiple" name="multi_choice_optional" id="id_multi_choice_optional">
+<option value="1">ChoiceOption 1</option>
+<option value="2">ChoiceOption 2</option>
+<option value="3">ChoiceOption 3</option>
+</select> <span class="helptext"> Hold down "Control", or "Command" on a Mac, to select more than one.</span></p>""")
 
 
 


### PR DESCRIPTION
Resolves [#14567](https://code.djangoproject.com/ticket/14567).

This is technically a backwards-incompatible change in some cases. For example, the test cases needed to be updated because an empty queryset isn't equal to an empty list. Is this serious enough that it needs to be mentioned in the release notes?
