### PR TITLE
Fixed #19044 -- Allow get_success_url to access self.object in DeletionMixin

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -240,8 +240,9 @@ class DeletionMixin(object):
         redirects to the success URL.
         """
         self.object = self.get_object()
+        success_url = self.get_success_url()
         self.object.delete()
-        return HttpResponseRedirect(self.get_success_url())
+        return HttpResponseRedirect(success_url)
 
     # Add support for browsers which only accept GET and POST for now.
     def post(self, *args, **kwargs):
@@ -249,7 +250,7 @@ class DeletionMixin(object):
 
     def get_success_url(self):
         if self.success_url:
-            return self.success_url
+            return self.success_url % self.object.__dict__
         else:
             raise ImproperlyConfigured(
                 "No URL to redirect to. Provide a success_url.")


### PR DESCRIPTION
generic_views tests passes
