### PR TITLE
Fixed #16479 -- Made forms use supplied error_class

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -123,7 +123,11 @@ class BaseFormSet(object):
         """
         Instantiates and returns the i-th form instance in a formset.
         """
-        defaults = {'auto_id': self.auto_id, 'prefix': self.add_prefix(i)}
+        defaults = {
+            'auto_id': self.auto_id,
+	           'prefix': self.add_prefix(i),
+	           'error_class': self.error_class,
+	       }
         if self.is_bound:
             defaults['data'] = self.data
             defaults['files'] = self.files

--- a/tests/regressiontests/forms/tests/formsets.py
+++ b/tests/regressiontests/forms/tests/formsets.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.forms import Form, CharField, IntegerField, ValidationError, DateField
 from django.forms.formsets import formset_factory, BaseFormSet
+from django.forms.util import ErrorList
 from django.test import TestCase
 
 
@@ -845,6 +846,15 @@ class FormsFormsetTestCase(TestCase):
         formset = ChoiceFormset()
         self.assertEqual(len(formset.forms), 0)
         self.assertTrue(formset)
+
+
+    def test_formset_error_class(self):
+        # Regression tests for #16479 -- formsets form use ErrorList instead of supplied error_class
+        class CustomErrorList(ErrorList):
+            pass
+
+        formset = FavoriteDrinksFormSet(error_class=CustomErrorList)
+        self.assertEqual(formset.forms[0].error_class, CustomErrorList)
 
 
 data = {


### PR DESCRIPTION
Forms generated from formsets were using ErrorList instead of supplied error_class.
Patch with tests from charettes, updated.
