### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+env:
+  - PYTHONPATH='.'
+# command to run tests
+script: tests/runtests.py --settings=test_sqlite


### PR DESCRIPTION
Travis CI is a hosted continuous integration service for the open source community. It is integrated with GitHub and offers first class support for Python, among many other languages.

The .travis.yml file provided in the PR provides the configuration for Travis, which runs the default sqlite tests against Python 2.6 and 2.7.

Travis should be activated on http://travis-ci.org
