### PR TITLE
catalog, formats should not be arrays in JS

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -73,7 +73,7 @@ function npgettext(context, singular, plural, count) { return (count == 1) ? sin
 LibHead = """
 /* gettext library */
 
-var catalog = new Array();
+var catalog = {};
 """
 
 LibFoot = """
@@ -118,7 +118,7 @@ function npgettext(context, singular, plural, count) {
 LibFormatHead = """
 /* formatting library */
 
-var formats = new Array();
+var formats = {};
 
 """
 


### PR DESCRIPTION
catalog and formats are used as dictionaries, i.e. JavaScript objects,
and using arrays when no array-specific properties are used adds
unnecessary confusion
