### PR TITLE
Added 'groups' to UserAdmin.filter_horizontal

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -57,7 +57,7 @@ class UserAdmin(admin.ModelAdmin):
     list_filter = ('is_staff', 'is_superuser', 'is_active', 'groups')
     search_fields = ('username', 'first_name', 'last_name', 'email')
     ordering = ('username',)
-    filter_horizontal = ('user_permissions',)
+    filter_horizontal = ('groups', 'user_permissions',)
 
     def get_fieldsets(self, request, obj=None):
         if not obj:


### PR DESCRIPTION
Is there some reason it's not there already? 

Our list of groups is very cumbersome to use with the standard widget.

Ticket: Yes, https://code.djangoproject.com/ticket/19105
