### PR TITLE
Remove heteronormativity from coding style doc

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -140,9 +140,9 @@ Model style
   a tuple of tuples, with an all-uppercase name, either near the top of
   the model module or just above the model class. Example::
 
-      GENDER_CHOICES = (
-          ('M', 'Male'),
-          ('F', 'Female'),
+      DIRECTION_CHOICES = (
+          ('U', 'Up'),
+          ('D', 'Down'),
       )
 
 Use of ``django.conf.settings``


### PR DESCRIPTION
I'm proposing replacing the gender example with a non-gendered example in the _Coding style_ doc. The example as written makes an exclusionary implication about gender identification which might be off-putting to potential contributors [who do not identify as male or female](http://en.wikipedia.org/wiki/Genderqueer). Moreover, choices in collecting gender data is often considerably more complicated than demonstrated. A trivial coding _style_ example is probably more clear in this case, in that it demonstrates the style, rather than substance, of expected code.
