### PR TITLE
Fixed #19112 - Reduce maximum parameter count test to 2001.

### DIFF
--- a/tests/regressiontests/queries/tests.py
+++ b/tests/regressiontests/queries/tests.py
@@ -1875,7 +1875,7 @@ class ConditionalTests(BaseQuerysetTest):
     def test_ticket14244(self):
         # Test that the "in" lookup works with lists of 1000 items or more.
         Number.objects.all().delete()
-        numbers = range(2500)
+        numbers = range(2001)
         Number.objects.bulk_create(Number(num=num) for num in numbers)
         self.assertEqual(
             Number.objects.filter(num__in=numbers[:1000]).count(),
@@ -1889,9 +1889,10 @@ class ConditionalTests(BaseQuerysetTest):
             Number.objects.filter(num__in=numbers[:2000]).count(),
             2000
         )
+        # Test a third 'IN' clause for Oracle
         self.assertEqual(
             Number.objects.filter(num__in=numbers).count(),
-            2500
+            len(numbers)
         )
 
 


### PR DESCRIPTION
Test queries.ConditionalTests.tset_ticket14244 tests the
max_in_list_size() database feature (used by Oracle) to split the SQL 'IN'
clause in to buckets. MSSQL's database driver has a limit of 2100
parameters for the entire query, which fails on this test.
