### PR TITLE
Ungettext-related issues: #19158, #19034

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -7,7 +7,7 @@ except ImportError:     # Python 2
     from urlparse import urlsplit, urlunsplit
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 from django.utils.encoding import force_text
 from django.utils.ipv6 import is_valid_ipv6_address
 from django.utils import six
@@ -183,15 +183,26 @@ class MinValueValidator(BaseValidator):
     code = 'min_value'
 
 
-class MinLengthValidator(BaseValidator):
+class MessageFunctionValidator(BaseValidator):
+    def __call__(self, value):
+        if self.message is None:
+            self.message = self.message_function(self.limit_value)
+        return super(MessageFunctionValidator, self).__call__(value)
+
+
+class MinLengthValidator(MessageFunctionValidator):
     compare = lambda self, a, b: a < b
     clean = lambda self, x: len(x)
-    message = _('Ensure this value has at least %(limit_value)d characters (it has %(show_value)d).')
+    message_function = lambda self, n: ungettext_lazy('Ensure this value has at least %(limit_value)d character (it has %(show_value)d).',
+                                                      'Ensure this value has at least %(limit_value)d characters (it has %(show_value)d).', n)
+    message = None
     code = 'min_length'
 
 
-class MaxLengthValidator(BaseValidator):
+class MaxLengthValidator(MessageFunctionValidator):
     compare = lambda self, a, b: a > b
     clean = lambda self, x: len(x)
-    message = _('Ensure this value has at most %(limit_value)d characters (it has %(show_value)d).')
+    message_function = lambda self, n: ungettext_lazy('Ensure this value has at most %(limit_value)d character (it has %(show_value)d).',
+                                                      'Ensure this value has at most %(limit_value)d characters (it has %(show_value)d).', n)
     code = 'max_length'
+    message = None

--- a/tests/modeltests/files/models.py
+++ b/tests/modeltests/files/models.py
@@ -15,6 +15,11 @@ from django.core.files.storage import FileSystemStorage
 temp_storage_location = tempfile.mkdtemp()
 temp_storage = FileSystemStorage(location=temp_storage_location)
 
+class FileFieldSubclass(models.FileField):
+    default_error_messages = {
+        'max_length': 'Filename is %(extra)d character too long.'
+    }
+
 class Storage(models.Model):
     def custom_upload_to(self, filename):
         return 'foo'
@@ -28,3 +33,4 @@ class Storage(models.Model):
     custom = models.FileField(storage=temp_storage, upload_to=custom_upload_to)
     random = models.FileField(storage=temp_storage, upload_to=random_upload_to, max_length=16)
     default = models.FileField(storage=temp_storage, upload_to='tests', default='tests/default.txt')
+    subclass = FileFieldSubclass(storage=temp_storage, upload_to=random_upload_to, max_length=16)


### PR DESCRIPTION
`ungettext` is wrapped in lambdas, because we don't know the number at the time of definition.
