### PR TITLE
Fix #19178 create_permissions method fails if the model has a single new permission

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -25,6 +25,10 @@ def _get_all_permissions(opts, ctype):
     """
     builtin = _get_builtin_permissions(opts)
     custom = list(opts.permissions)
+
+    if any(isinstance(el, basestring) for el in custom):
+        custom = [custom]
+
     _check_permission_clashing(custom, builtin, ctype)
     return builtin + custom
 


### PR DESCRIPTION
This is a draft fix for the ticket [#19178](https://code.djangoproject.com/ticket/19178#ticket)
