### PR TITLE
Remove weird and buggy try/except block

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -206,12 +206,10 @@ class QuerySet(object):
                 stop = None
             qs.query.set_limits(start, stop)
             return k.step and list(qs)[::k.step] or qs
-        try:
-            qs = self._clone()
-            qs.query.set_limits(k, k + 1)
-            return list(qs)[0]
-        except self.model.DoesNotExist as e:
-            raise IndexError(e.args)
+        
+        qs = self._clone()
+        qs.query.set_limits(k, k + 1)
+        return list(qs)[0]
 
     def __and__(self, other):
         self._merge_sanity_check(other)


### PR DESCRIPTION
This is really weird code. I don't know how it has gone unnoticed for so long.

First of all, nothing in that try block could raise `DoesNotExist`. Passing an empty `QuerySet` to `list` returns an empty list with no error. The except block I removed was never being executed. This code only happens to work and appropriately raise `IndexError` because directly indexing the empty list raises the correct error itself.

But the except code itself is bad. `e.args` is a tuple, so passing it as the first argument to `IndexError` casts it as a string and uses it as the message:

```
IndexError: ('list index out of range',)
```

What was meant was probably to to pass either `*e.args` or simply `e.message`.

Briefly exploring the commit history, the code seems to have been like this for a long, long time.

I _could_ change the code so that the message of the `IndexError` is the same as the `DoesNotExist` exception like so:

```
IndexError: <model name> matching query does not exist.
```

As that seems to be what was originally intended. I won't make that decision myself though.

For now, the functionality is unchanged but the code itself is simplified with these nonsensical parts removed.
