### PR TITLE
Small documentation patch - /ref/contrib/admin/

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -27,7 +27,7 @@ There are seven steps in activating the Django admin site:
 
 3. Add ``django.contrib.messages.context_processors.messages`` to
    :setting:`TEMPLATE_CONTEXT_PROCESSORS` and
-   ``django.contrib.messages.middleware.MessageMiddleware`` to
+   :class:`django.contrib.messages.middleware.MessageMiddleware` to
    :setting:`MIDDLEWARE_CLASSES`. (These are both active by default, so
    you only need to do this if you've manually tweaked the settings.) You
    will also need to add ``django.contrib.auth.middleware.AuthenticationMiddleware``


### PR DESCRIPTION
Small display patch to avoid users adding just 'MessageMiddleware', rather than the full string. The rest of the paragraph references the exact string that should be used, so it should be either one or the other.

Also another doc patch to avoid;
'WSGIRequest' object has no attribute 'user'
