### PR TITLE
Address #16855 - Deprecate depth kwarg on select_related.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -5,6 +5,7 @@ The main QuerySet implementation. This provides the public API for the ORM.
 import copy
 import itertools
 import sys
+import warnings
 
 from django.core import exceptions
 from django.db import connections, router, transaction, IntegrityError
@@ -698,6 +699,8 @@ class QuerySet(object):
         If fields are specified, they must be ForeignKey fields and only those
         related objects are included in the selection.
         """
+        if 'depth' in kwargs:
+            warnings.warn('The keyword argument "depth" has been deprecated. Use field names instead.', DeprecationWarning)
         depth = kwargs.pop('depth', 0)
         if kwargs:
             raise TypeError('Unexpected keyword arguments to select_related: %s'

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -298,6 +298,9 @@ these changes.
 
 * The ``daily_cleanup.py`` script will be removed.
 
+* The ``depth`` keyword argument will be removed from
+  :meth:`~django.db.models.query.QuerySet.select_related`.
+
 2.0
 ---
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -622,6 +622,11 @@ select_related
 
 .. method:: select_related()
 
+.. deprecated:: 1.5
+    The ``depth`` parameter to ``select_related()`` has been deprecated. You
+    should replace it with the use of the ``(*fields)`` format instead. See the
+    :doc:`Django 1.5 release notes</releases/1.5>` for more information.
+
 Returns a ``QuerySet`` that will automatically "follow" foreign-key
 relationships, selecting that additional related-object data when it executes
 its query. This is a performance booster which results in (sometimes much)

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -638,3 +638,10 @@ The :djadmin:`cleanup` management command has been deprecated and replaced by
 
 The undocumented ``daily_cleanup.py`` script has been deprecated. Use the
 :djadmin:`clearsessions` management command instead.
+
+``depth`` keyword argument in ``select_related``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``depth`` keyword argument in
+:meth:`~django.db.models.query.QuerySet.select_related` has been deprecated.
+You should use field names instead.


### PR DESCRIPTION
This is the start of a deprecation path for the depth kwarg on select_related. Removing this will allow us to update select_related so it chains properly and have a more similar API to prefetch_related.
