### PR TITLE
Update django/db/models/sql/compiler.py

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -569,6 +569,8 @@ class SQLCompiler(object):
                     result.append('%s.%s' % (qn(col[0]), qn(col[1])))
                 elif hasattr(col, 'as_sql'):
                     result.append(col.as_sql(qn, self.connection))
+                elif isinstance(col, unicode):
+                    result.append('(%s)' % col)
                 else:
                     result.append('(%s)' % str(col))
         return result, params


### PR DESCRIPTION
A Fix for UnicodeDecodeError that is raised if a column name contains NON-ASCII-CHARACTERS
I encounted  the error when I wrote the following code.
QuerySet.extra(select={"month":u'''extract('month' FROM "NON-ASCII-FIELD-NAME")'''})
I use Django 1.3 and PostgreSQL 9.1.
