### PR TITLE
Fixed #18949 -- Improve performance of model_to_dict with many-to-many

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -126,7 +126,7 @@ def model_to_dict(instance, fields=None, exclude=None):
                 data[f.name] = []
             else:
                 # MultipleChoiceWidget needs a list of pks, not object instances.
-                data[f.name] = [obj.pk for obj in f.value_from_object(instance)]
+                data[f.name] = list(f.value_from_object(instance).values_list('pk', flat=True))
         else:
             data[f.name] = f.value_from_object(instance)
     return data


### PR DESCRIPTION
Link to trac ticket:
https://code.djangoproject.com/ticket/18949

When calling model_to_dict, improve performance of the generated SQL by
using values_list to determine primary keys of many to many objects. Add
a specific test for this function, test_model_to_dict_many_to_many

Thanks to brian for the original report and suggested fix.
