### PR TITLE
Class-based LoginView

### DIFF
--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -3690,6 +3690,6 @@ class AdminViewLogoutTest(TestCase):
         # follow the redirect and test results.
         response = self.client.get('/test_admin/admin/logout/', follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.template_name, 'admin/login.html')
+        self.assertTemplateUsed(response, 'admin/login.html')
         self.assertEqual(response.request['PATH_INFO'], '/test_admin/admin/')
         self.assertContains(response, '<input type="hidden" name="next" value="/test_admin/admin/" />')


### PR DESCRIPTION
Here is a proposal to replace django.contrib.auth.views.login by some class-based view.

The proposed implementation contains:
- a `LoginView` class, which focuses on providing a clean class based on FormView. As an example, it uses FormView's standard "success_url" instead of former "redirect_to" argument.
- a `BackwardCompatibleLoginView` class, which focuses on backward compatibility. As an example, if "redirect_to" is provided, it uses it instead of LoginView's "success_url".
- a `login` function, which makes it possible to use `django.contrib.auth.views.login` as before. It is a pre-configured BackwardCompatibleLoginView.
- a `login_decorator` decorator, which is just a shorcut to standard decorators for login views.
