### PR TITLE
Fixed invalid ipv4 mapped ipv6 addresses in docs

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -683,7 +683,7 @@ For each field, we describe the default widget used if you don't specify
 
     .. attribute:: unpack_ipv4
 
-        Unpacks IPv4 mapped addresses like ``::ffff::192.0.2.1``.
+        Unpacks IPv4 mapped addresses like ``::ffff:192.0.2.1``.
         If this option is enabled that address would be unpacked to
         ``192.0.2.1``. Default is disabled. Can only be used
         when ``protocol`` is set to ``'both'``.

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -825,7 +825,7 @@ are converted to lowercase.
 
 .. attribute:: GenericIPAddressField.unpack_ipv4
 
-    Unpacks IPv4 mapped addresses like ``::ffff::192.0.2.1``.
+    Unpacks IPv4 mapped addresses like ``::ffff:192.0.2.1``.
     If this option is enabled that address would be unpacked to
     ``192.0.2.1``. Default is disabled. Can only be used
     when ``protocol`` is set to ``'both'``.


### PR DESCRIPTION
The Django docs mention the IPv4 mapped IPv6 address `::ffff::192.0.2.1` twice. This IP is malformed though and should be `::ffff:192.0.2.1` instead.

I copy pasted this address for testing purposes, which led to many strange database errors (because Postgres couldn't convert it to an `inet` value). Therefore it would be great if you could merge this soon, so that this "bug" doesn't happen again.
