### PR TITLE
Fixes #19262 by calling super in __getstate__

### DIFF
--- a/django/template/response.py
+++ b/django/template/response.py
@@ -40,7 +40,7 @@ class SimpleTemplateResponse(HttpResponse):
         rendered, and that the pickled state only includes rendered
         data, not the data used to construct the response.
         """
-        obj_dict = self.__dict__.copy()
+        obj_dict = super(SimpleTemplateResponse, self).__getstate__()
         if not self._is_rendered:
             raise ContentNotRenderedError('The response content must be '
                                           'rendered before it can be pickled.')

--- a/tests/regressiontests/templates/response.py
+++ b/tests/regressiontests/templates/response.py
@@ -189,6 +189,20 @@ class SimpleTemplateResponseTest(TestCase):
         unpickled_response = pickle.loads(pickled_response)
         repickled_response = pickle.dumps(unpickled_response)
 
+    def test_pickling_cookie(self):
+        response = SimpleTemplateResponse('first/test.html', {
+                'value': 123,
+                'fn': datetime.now,
+            })
+
+        response.cookies['key'] = 'value'
+
+        response.render()
+        pickled_response = pickle.dumps(response, pickle.HIGHEST_PROTOCOL)
+        unpickled_response = pickle.loads(pickled_response)
+
+        self.assertEqual(unpickled_response.cookies['key'].value, 'value')
+
 @override_settings(
     TEMPLATE_CONTEXT_PROCESSORS=[test_processor_name],
     TEMPLATE_DIRS=(os.path.join(os.path.dirname(__file__),'templates')),


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/19262

SimpleTemplateResponse does not call super so the fixed introduced in https://code.djangoproject.com/ticket/15863 does not take effect. 
