### PR TITLE
use standard IPython startup instead of embed in manage.py shell

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -19,8 +19,10 @@ class Command(NoArgsCommand):
 
     def ipython(self):
         try:
-            from IPython import embed
-            embed()
+            from IPython.frontend.terminal.ipapp import TerminalIPythonApp
+            app = TerminalIPythonApp.instance()
+            app.initialize(argv=[])
+            app.start()
         except ImportError:
             # IPython < 0.11
             # Explicitly pass an empty list as arguments, because otherwise


### PR DESCRIPTION
`IPython.embed` has different namespace/initialization behavior, probably none of which is actually intended or desirable.

This changes `manage.py shell` to start a standard IPython shell instead, and works for any IPython ≥ 0.11.

See [Ticket 17078](https://code.djangoproject.com/ticket/17078#comment:8) for reference.
