### PR TITLE
Add tests to illustrate #16572

### DIFF
--- a/tests/modeltests/select_related/models.py
+++ b/tests/modeltests/select_related/models.py
@@ -66,3 +66,27 @@ class Species(models.Model):
     genus = models.ForeignKey(Genus)
     def __str__(self):
         return self.name
+
+
+# Some classes that use model inheritence
+
+@python_2_unicode_compatible
+class Vehicle(models.Model):
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
+
+@python_2_unicode_compatible
+class Aircraft(Vehicle):
+    max_altitude_in_feet = models.IntegerField()
+
+    def __str__(self):
+        return self.name
+
+@python_2_unicode_compatible
+class FixedWingAircraft(Aircraft):
+    wingspan_in_feet = models.IntegerField()
+
+    def __str__(self):
+        return self.name

--- a/tests/modeltests/select_related/tests.py
+++ b/tests/modeltests/select_related/tests.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.test import TestCase
 
 from .models import Domain, Kingdom, Phylum, Klass, Order, Family, Genus, Species
+from .models import Vehicle, Aircraft, FixedWingAircraft
 
 
 class SelectRelatedTests(TestCase):
@@ -160,3 +161,21 @@ class SelectRelatedTests(TestCase):
             Species.objects.select_related,
             'genus__family__order', depth=4
         )
+
+
+class SelectRelatedWithModelInheritenceTests(TestCase):
+
+    def setUp(self):
+        FixedWingAircraft.objects.create(name="747-400",
+                                         max_altitude_in_feet=45100,
+                                         wingspan_in_feet=211)
+
+    def test_two_subclass_traversels(self):
+        """
+        Test traversing down twice in the hierarchy, which is the same as
+        traversing two reverse OneToOne relationships.
+        """
+        with self.assertNumQueries(1):
+            v =Vehicle.objects.select_related('aircraft__fixedwingaircraft')
+            self.assertEqual(v.get().aircraft.fixedwingaircraft.wingspan_in_feet,
+                             211)


### PR DESCRIPTION
Add tests that use select_related to traverse two reverse OneToOne
relationships.

This reproduces the bug described in [ticket 16572](https://code.djangoproject.com/ticket/16572).
