### PR TITLE
Document example.com as default site

### DIFF
--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -240,6 +240,13 @@ To do this, you can use the sites framework. A simple example::
     >>> 'http://%s%s' % (Site.objects.get_current().domain, obj.get_absolute_url())
     'http://example.com/mymodel/objects/3/'
 
+
+Default site and unit testing
+-----------------------------
+
+Django will create a default site named ``example.com`` and with the domain
+``example.com`` when it creates the test database.
+
 Caching the current ``Site`` object
 ===================================
 


### PR DESCRIPTION
Document that a default site, example.com, will get created when
the test database is created.
