### PR TITLE
Update django/contrib/flatpages/forms.py

### DIFF
--- a/django/contrib/flatpages/forms.py
+++ b/django/contrib/flatpages/forms.py
@@ -35,7 +35,7 @@ class FlatpageForm(forms.ModelForm):
             for site in sites:
                 if same_url.filter(sites=site).exists():
                     raise forms.ValidationError(
-                        _('Flatpage with url %(url)s already exists for site %(site)s' %
-                          {'url': url, 'site': site}))
+                        _('Flatpage with url %(url)s already exists for site %(site)s') %
+                          {'url': url, 'site': site})
 
         return super(FlatpageForm, self).clean()


### PR DESCRIPTION
Translate before passing in the variables (i.e. close the bracket earlier).
If you translate after passing in the variables the translated value will contain the actual values for 'url' and 'site' and will therefore not be translated.

(I'm not actually using django's flatpages, but I ran into this apparent error when doing a global grep on my own project)
