### PR TITLE
comment_will_be_sent signals sends 400 status code

### DIFF
--- a/django/contrib/comments/signals.py
+++ b/django/contrib/comments/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import Signal
 # Sent just before a comment will be posted (after it's been approved and
 # moderated; this can be used to modify the comment (in place) with posting
 # details or other such actions. If any receiver returns False the comment will be
-# discarded and a 403 (not allowed) response. This signal is sent at more or less
+# discarded and a 400 response. This signal is sent at more or less
 # the same time (just before, actually) as the Comment object's pre-save signal,
 # except that the HTTP request is sent along with this signal.
 comment_will_be_posted = Signal(providing_args=["comment", "request"])

--- a/docs/ref/contrib/comments/signals.txt
+++ b/docs/ref/contrib/comments/signals.txt
@@ -20,8 +20,8 @@ Sent just before a comment will be saved, after it's been sanity checked and
 submitted. This can be used to modify the comment (in place) with posting
 details or other such actions.
 
-If any receiver returns ``False`` the comment will be discarded and a 403 (not
-allowed) response will be returned.
+If any receiver returns ``False`` the comment will be discarded and a 400
+response will be returned.
 
 This signal is sent at more or less the same time (just before, actually) as the
 ``Comment`` object's :data:`~django.db.models.signals.pre_save` signal.


### PR DESCRIPTION
Doc cleanup for django.contrib.comments.signals.comment_will_be_sent
If a receiver returns False, an HttpResponse with status code 400
is returned. A test case already exists confirming this behavior.
Updated docs to reflect reality.
