### PR TITLE
Fix bug [#19277]: LocaleMiddleware permanent redirects

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -16,6 +16,7 @@ class LocaleMiddleware(object):
     translated to the language the user desires (if the language
     is available, of course).
     """
+    redirect_class = HttpResponseRedirect
 
     def process_request(self, request):
         check_path = self.is_language_prefix_patterns_used()
@@ -38,7 +39,7 @@ class LocaleMiddleware(object):
                 language_url = "%s://%s/%s%s" % (
                     request.is_secure() and 'https' or 'http',
                     request.get_host(), language, request.get_full_path())
-                return HttpResponseRedirect(language_url)
+                return self.redirect_class(language_url)
         translation.deactivate()
 
         patch_vary_headers(response, ('Accept-Language',))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/19277#comment:3

"We're sprinting (Stockholm) at the moment and plan to solve this bug like this:

Instead of setting a status_code attribute, we would like to use a redirect_class. The reason for this is that HttpResponseRedirectBase has built in protection against unsafe protocol redirections. If we use a HttpResponse object and let the user supply their own status code they will probably miss that security issue, which would be a shame."

Authors: @pelme and @EmilStenstrom
