### PR TITLE
Fixed #19114 - do not return a lazy object in LogEntry.__str__

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.admin.util import quote
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, ugettext
 from django.utils.encoding import smart_text
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -42,13 +42,13 @@ class LogEntry(models.Model):
 
     def __str__(self):
         if self.action_flag == ADDITION:
-            return _('Added "%(object)s".') % {'object': self.object_repr}
+            return ugettext('Added "%(object)s".') % {'object': self.object_repr}
         elif self.action_flag == CHANGE:
-            return _('Changed "%(object)s" - %(changes)s') % {'object': self.object_repr, 'changes': self.change_message}
+            return ugettext('Changed "%(object)s" - %(changes)s') % {'object': self.object_repr, 'changes': self.change_message}
         elif self.action_flag == DELETION:
-            return _('Deleted "%(object)s."') % {'object': self.object_repr}
+            return ugettext('Deleted "%(object)s."') % {'object': self.object_repr}
 
-        return _('LogEntry Object')
+        return ugettext('LogEntry Object')
 
     def is_addition(self):
         return self.action_flag == ADDITION

--- a/tests/regressiontests/admin_util/tests.py
+++ b/tests/regressiontests/admin_util/tests.py
@@ -274,6 +274,12 @@ class UtilTests(unittest.TestCase):
             six.text_type(log_entry).startswith('Deleted ')
         )
 
+        # Make sure custom action_flags works
+        log_entry.action_flag = 4
+        self.assertTrue(
+            six.text_type(log_entry).startswith('LogEntry Object')
+        )
+
     def test_safestring_in_field_label(self):
         # safestring should not be escaped
         class MyForm(forms.Form):


### PR DESCRIPTION
We are currently sprinting in Stockholm and are going to fix this bug like this:
Since `__str__` will be called at runtime we don't need to use the lazy version of ugettext. This means no artificial string formatting will need to be added. Patch is coming.
