### PR TITLE
Deleting the correct related object on cascade when deleting a class that inherits a GenericRelation

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -222,9 +222,11 @@ class GenericRelation(RelatedField, Field):
         Return all objects related to ``objs`` via this ``GenericRelation``.
 
         """
+        if not objs:
+            return []
         return self.rel.to._base_manager.db_manager(using).filter(**{
                 "%s__pk" % self.content_type_field_name:
-                    ContentType.objects.db_manager(using).get_for_model(self.model).pk,
+                    ContentType.objects.db_manager(using).get_for_model(objs[0].__class__).pk,
                 "%s__in" % self.object_id_field_name:
                     [obj.pk for obj in objs]
                 })

--- a/tests/regressiontests/generic_relations_regress/models.py
+++ b/tests/regressiontests/generic_relations_regress/models.py
@@ -8,6 +8,7 @@ __all__ = ('Link', 'Place', 'Restaurant', 'Person', 'Address',
            'CharLink', 'TextLink', 'OddRelation1', 'OddRelation2',
            'Contact', 'Organization', 'Note')
 
+
 @python_2_unicode_compatible
 class Link(models.Model):
     content_type = models.ForeignKey(ContentType)
@@ -17,6 +18,7 @@ class Link(models.Model):
     def __str__(self):
         return "Link to %s id=%s" % (self.content_type, self.object_id)
 
+
 @python_2_unicode_compatible
 class Place(models.Model):
     name = models.CharField(max_length=100)
@@ -25,10 +27,12 @@ class Place(models.Model):
     def __str__(self):
         return "Place: %s" % self.name
 
+
 @python_2_unicode_compatible
 class Restaurant(Place):
     def __str__(self):
         return "Restaurant: %s" % self.name
+
 
 @python_2_unicode_compatible
 class Address(models.Model):
@@ -43,6 +47,7 @@ class Address(models.Model):
     def __str__(self):
         return '%s %s, %s %s' % (self.street, self.city, self.state, self.zipcode)
 
+
 @python_2_unicode_compatible
 class Person(models.Model):
     account = models.IntegerField(primary_key=True)
@@ -52,23 +57,28 @@ class Person(models.Model):
     def __str__(self):
         return self.name
 
+
 class CharLink(models.Model):
     content_type = models.ForeignKey(ContentType)
     object_id = models.CharField(max_length=100)
     content_object = generic.GenericForeignKey()
+
 
 class TextLink(models.Model):
     content_type = models.ForeignKey(ContentType)
     object_id = models.TextField()
     content_object = generic.GenericForeignKey()
 
+
 class OddRelation1(models.Model):
     name = models.CharField(max_length=100)
     clinks = generic.GenericRelation(CharLink)
 
+
 class OddRelation2(models.Model):
     name = models.CharField(max_length=100)
     tlinks = generic.GenericRelation(TextLink)
+
 
 # models for test_q_object_or:
 class Note(models.Model):
@@ -77,10 +87,27 @@ class Note(models.Model):
     content_object = generic.GenericForeignKey()
     note = models.TextField()
 
+
 class Contact(models.Model):
     notes = generic.GenericRelation(Note)
+
 
 class Organization(models.Model):
     name = models.CharField(max_length=255)
     contacts = models.ManyToManyField(Contact, related_name='organizations')
 
+
+class TaggedItem(models.Model):
+    tag = models.SlugField()
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = generic.GenericForeignKey('content_type', 'object_id')
+
+
+class ParentPost(models.Model):
+    title = models.TextField(blank=True)
+    relation = generic.GenericRelation(TaggedItem)
+
+
+class Post(ParentPost):
+    description = models.TextField(blank=True)

--- a/tests/regressiontests/generic_relations_regress/tests.py
+++ b/tests/regressiontests/generic_relations_regress/tests.py
@@ -2,7 +2,8 @@ from django.db.models import Q
 from django.test import TestCase
 
 from .models import (Address, Place, Restaurant, Link, CharLink, TextLink,
-    Person, Contact, Note, Organization, OddRelation1, OddRelation2)
+    Person, Contact, Note, Organization, OddRelation1, OddRelation2,
+    TaggedItem, ParentPost, Post)
 
 
 class GenericRelationTests(TestCase):
@@ -72,5 +73,17 @@ class GenericRelationTests(TestCase):
             Q(notes__note__icontains=r'other note'))
         self.assertTrue(org_contact in qs)
 
+    def test_inherited_models_delete(self):
+        """
+        Test that when deleting a class that inherits a GenericRelation,
+        the correct related object is deleted on cascade.
+        """
 
+        p = Post.objects.create(title="This is a title",
+            description="This is a description")
+        t = TaggedItem.objects.create(content_object=p, tag="This is a tag")
 
+        self.assertEqual(list(TaggedItem.objects.all()), [t])
+        self.assertEqual(list(Post.objects.all()), [p])
+        p.delete()
+        self.assertEqual(list(TaggedItem.objects.all()), [])


### PR DESCRIPTION
a fix for https://code.djangoproject.com/ticket/19149
