### PR TITLE
Fixed #18722 -- Admin CSS fix

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -322,6 +322,10 @@ thead th.sorted {
     background: #c5c5c5 url(../img/nav-bg-selected.gif) top left repeat-x;
 }
 
+thead th.sorted .text {
+	padding-right: 42px;
+}
+
 table thead th .text span {
     padding: 2px 5px;
     display:block;

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -84,6 +84,11 @@ table thead th.sorted .sortoptions {
    float: left;
 }
 
+thead th.sorted .text {
+	padding-right: 0;
+	padding-left: 42px;
+}
+
 /* dashboard styles */
 
 .dashboard .module table td a {


### PR DESCRIPTION
Updated admin CSS to prevent sorting options in <th> to be overlapped by column name text

https://code.djangoproject.com/ticket/18722
