### PR TITLE
Fixed #18658

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -531,6 +531,7 @@ answer newbie questions, and generally made Django that much better:
     Terry Huang <terryh.tp@gmail.com>
     Travis Terry <tdterry7@gmail.com>
     thebjorn <bp@datakortet.no>
+    Lowe Thiderman <lowe.thiderman@gmail.com>
     Zach Thompson <zthompson47@gmail.com>
     Michael Thornhill <michael.thornhill@gmail.com>
     Deepak Thukral <deep.thukral@gmail.com>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -691,12 +691,29 @@ class ModelAdmin(BaseModelAdmin):
         change_message = ' '.join(change_message)
         return change_message or _('No fields changed.')
 
-    def message_user(self, request, message):
+    def message_user(self, request, message, level='info', extra_tags='',
+                     fail_silently=False):
         """
         Send a message to the user. The default implementation
         posts a message using the django.contrib.messages backend.
+
+        Exposes almost the same API as messages.add_message(), but accepts the
+        positional arguments in a different order to maintain backwards
+        compatibility. For convenience, it accepts the `level` argument as
+        a string rather than the ususal level number.
         """
-        messages.info(request, message)
+
+        levels = messages.constants.DEFAULT_TAGS.values()
+
+        if level not in levels:
+            levels_repr = ', '.join('`%s`' % l for l in levels)
+            raise KeyError('Bad message level: `%s`. Possible values are: %s' %
+                           (level, levels_repr))
+
+        # getattr the helper methods to avoid converting the strings into
+        # numbers and sending them into messages.add_message()
+        getattr(messages, level)(request, message, extra_tags=extra_tags,
+                                 fail_silently=fail_silently)
 
     def save_form(self, request, form, change):
         """

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1303,11 +1303,18 @@ templates used by the :class:`ModelAdmin` views:
                     return qs
                 return qs.filter(author=request.user)
 
-.. method:: ModelAdmin.message_user(request, message)
+.. method:: ModelAdmin.message_user(request, message, level='info', extra_tags='', fail_silently=False)
 
     Sends a message to the user. The default implementation creates a message
-    using the :mod:`django.contrib.messages` backend. See the
-    :ref:`custom ModelAdmin example <custom-admin-action>`.
+    using the :mod:`django.contrib.messages` backend.
+    See the :ref:`custom ModelAdmin example <custom-admin-action>`.
+
+    .. versionadded:: 1.5
+
+    An API similar to :func:`django.contrib.messages.add_message` was added.
+    It accepts the positional arguments in a different order to maintain
+    backwards compatibility and, for convenience, accepts the `level` argument
+    as a string rather than the ususal level number.
 
 .. method:: ModelAdmin.get_paginator(queryset, per_page, orphans=0, allow_empty_first_page=True)
 

--- a/tests/regressiontests/admin_views/admin.py
+++ b/tests/regressiontests/admin_views/admin.py
@@ -27,7 +27,7 @@ from .models import (Article, Chapter, Account, Media, Child, Parent, Picture,
     Album, Question, Answer, ComplexSortedPerson, PrePopulatedPostLargeSlug,
     AdminOrderedField, AdminOrderedModelMethod, AdminOrderedAdminMethod,
     AdminOrderedCallable, Report, Color2, UnorderedObject, MainPrepopulated,
-    RelatedPrepopulated, UndeletableObject, Simple)
+    RelatedPrepopulated, UndeletableObject, UserMessenger, Simple)
 
 
 def callable_year(dt_value):
@@ -585,6 +585,28 @@ def callable_on_unknown(obj):
 class AttributeErrorRaisingAdmin(admin.ModelAdmin):
     list_display = [callable_on_unknown, ]
 
+class MessageTestingAdmin(admin.ModelAdmin):
+    actions = ["message_debug", "message_info", "message_success",
+               "message_warning", "message_error", "message_extra_tags"]
+
+    def message_debug(self, request, selected):
+        self.message_user(request, "Test debug", level="debug")
+
+    def message_info(self, request, selected):
+        self.message_user(request, "Test info", level="info")
+
+    def message_success(self, request, selected):
+        self.message_user(request, "Test success", level="success")
+
+    def message_warning(self, request, selected):
+        self.message_user(request, "Test warning", level="warning")
+
+    def message_error(self, request, selected):
+        self.message_user(request, "Test error", level="error")
+
+    def message_extra_tags(self, request, selected):
+        self.message_user(request, "Test tags", extra_tags="extra_tag")
+
 
 site = admin.AdminSite(name="admin")
 site.register(Article, ArticleAdmin)
@@ -660,6 +682,7 @@ site.register(AdminOrderedAdminMethod, AdminOrderedAdminMethodAdmin)
 site.register(AdminOrderedCallable, AdminOrderedCallableAdmin)
 site.register(Color2, CustomTemplateFilterColorAdmin)
 site.register(Simple, AttributeErrorRaisingAdmin)
+site.register(UserMessenger, MessageTestingAdmin)
 
 # Register core models we need in our tests
 from django.contrib.auth.models import User, Group

--- a/tests/regressiontests/admin_views/models.py
+++ b/tests/regressiontests/admin_views/models.py
@@ -651,6 +651,10 @@ class UndeletableObject(models.Model):
     """
     name = models.CharField(max_length=255)
 
+class UserMessenger(models.Model):
+    """
+    Dummy class for testing message_user functions on ModelAdmin
+    """
 
 class Simple(models.Model):
     """

--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -3693,3 +3693,62 @@ class AdminViewLogoutTest(TestCase):
         self.assertEqual(response.template_name, 'admin/login.html')
         self.assertEqual(response.request['PATH_INFO'], '/test_admin/admin/')
         self.assertContains(response, '<input type="hidden" name="next" value="/test_admin/admin/" />')
+
+
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+class AdminUserMessageTest(TestCase):
+    urls = "regressiontests.admin_views.urls"
+    fixtures = ['admin-views-users.xml']
+
+    def setUp(self):
+        self.client.login(username='super', password='secret')
+
+    def tearDown(self):
+        self.client.logout()
+
+    def send_message(self, level):
+        """
+        Helper that sends a post to the dummy test methods and asserts that a
+        message with the level has appeared in the response.
+        """
+        action_data = {
+            ACTION_CHECKBOX_NAME: [1],
+            'action': 'message_%s' % level,
+            'index': 0,
+        }
+
+        response = self.client.post('/test_admin/admin/admin_views/usermessenger/',
+                                    action_data, follow=True)
+        self.assertContains(response,
+                            '<li class="%s">Test %s</li>' % (level, level),
+                            html=True)
+
+    @override_settings(MESSAGE_LEVEL=10)  # Set to DEBUG for this request
+    def test_message_debug(self):
+        self.send_message('debug')
+
+    def test_message_info(self):
+        self.send_message('info')
+
+    def test_message_success(self):
+        self.send_message('success')
+
+    def test_message_warning(self):
+        self.send_message('warning')
+
+    def test_message_error(self):
+        self.send_message('error')
+
+    def test_message_extra_tags(self):
+        action_data = {
+            ACTION_CHECKBOX_NAME: [1],
+            'action': 'message_extra_tags',
+            'index': 0,
+        }
+
+        response = self.client.post('/test_admin/admin/admin_views/usermessenger/',
+                                    action_data, follow=True)
+        self.assertContains(response,
+                            '<li class="extra_tag info">Test tags</li>',
+                            html=True)
+


### PR DESCRIPTION
Improve ModelAdmin.message_user to have an API more similar to
django.contrib.messages.add_message(), allowing setting of debug level and
using extra_tags.

Add tests.
Modify documentation.
