### PR TITLE
Fixed #19280 -- Added url template tag syntax note to NoReverseMatch

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -414,6 +414,11 @@ class URLNode(Node):
                               current_app=context.current_app)
                 except NoReverseMatch:
                     if self.asvar is None:
+                        # If no args or kwargs are set, print help text
+                        # about url tag syntax being modified in Django 1.5
+                        if not args and not kwargs:
+                            e.args = ("%s Note: url tag syntax is changed in Django 1.5 - "
+                                      "see the documentation." % e.args[0],)
                         # Re-raise the original exception, not the one with
                         # the path relative to the project. This makes a
                         # better error message.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1035,6 +1035,10 @@ This will follow the normal :ref:`namespaced URL resolution strategy
 <topics-http-reversing-url-namespaces>`, including using any hints provided
 by the context as to the current application.
 
+.. warning::
+
+    Don't forget to put quotes around the url pattern name.
+
 .. templatetag:: verbatim
 
 verbatim


### PR DESCRIPTION
Added note to NoReverseMatch to help users figure out that there is a change in the syntax for the url template tag in Django 1.5. Added warning in url template tag documentation to emphasise that the url pattern name needs a quote.
