### PR TITLE
Set args, kwargs & request on self before dispatch is called.

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -61,6 +61,9 @@ class View(object):
             self = cls(**initkwargs)
             if hasattr(self, 'get') and not hasattr(self, 'head'):
                 self.head = self.get
+            self.request = request
+            self.args = args
+            self.kwargs = kwargs
             return self.dispatch(request, *args, **kwargs)
 
         # take name and docstring from class
@@ -79,9 +82,6 @@ class View(object):
             handler = getattr(self, request.method.lower(), self.http_method_not_allowed)
         else:
             handler = self.http_method_not_allowed
-        self.request = request
-        self.args = args
-        self.kwargs = kwargs
         return handler(request, *args, **kwargs)
 
     def http_method_not_allowed(self, request, *args, **kwargs):

--- a/tests/regressiontests/generic_views/base.py
+++ b/tests/regressiontests/generic_views/base.py
@@ -216,6 +216,17 @@ class ViewTest(unittest.TestCase):
         response_allows = set(response['Allow'].split(', '))
         self.assertEqual(set(expected_methods + ('OPTIONS',)), response_allows)
 
+    def test_args_kwargs_request_on_self(self):
+        """
+        Test a view only has args, kwargs & request once `as_view`
+        has been called.
+        """
+        bare_view = InstanceView()
+        view = InstanceView.as_view()(self.rf.get('/'))
+        for attribute in ('args', 'kwargs', 'request'):
+            self.assertNotIn(attribute, dir(bare_view))
+            self.assertIn(attribute, dir(view))
+
 
 class TemplateViewTest(TestCase):
     urls = 'regressiontests.generic_views.urls'


### PR DESCRIPTION
Move the setting of args, kwargs & request on self into the nested
`view` function in `as_view` so they are set before dispatch is
called. This allows anyone wishing to put pre-dispatch code in an
overridden `dispatch` and still use the self versions of args, kwargs
and request.
