### PR TITLE
Fixed ticket #17905

### DIFF
--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -113,6 +113,13 @@ For example::
             'mymodel': MyModel.objects.get(slug=slug)
         }, context_instance=RequestContext(request))
 
+.. versionchanged:: 1.5
+
+Access to :setting:`INSTALLED_APPS` is limited according to: 
+
+.. method:: User.has_module_perms(package_name)
+
+This means that a regular user will not see any of the module documentation unless given permission.
 
 Template tags and filters reference
 ===================================


### PR DESCRIPTION
Changes to admin documentation: Added restriction to view documentation for apps. Users can only see list and direct access documentation view for apps they have permissions to. Updated documentation to reflect this.
