### PR TITLE
Fixed #17050

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -354,6 +354,7 @@ class AdminSite(object):
                     info = (app_label, model._meta.module_name)
                     model_dict = {
                         'name': capfirst(model._meta.verbose_name_plural),
+                        'object_name': model._meta.object_name,
                         'perms': perms,
                     }
                     if perms.get('change', False):

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -14,7 +14,7 @@
 
 {% if app_list %}
     {% for app in app_list %}
-        <div class="module">
+        <div id="app-{{ app.name }}" class="module">
         <table>
         <caption>
             <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">
@@ -22,7 +22,7 @@
             </a>
         </caption>
         {% for model in app.models %}
-            <tr>
+            <tr id="app-{{ app.name }}-{{ model.object_name }}">
             {% if model.admin_url %}
                 <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
             {% else %}

--- a/tests/regressiontests/admin_views/tests.py
+++ b/tests/regressiontests/admin_views/tests.py
@@ -3697,3 +3697,23 @@ class AdminViewLogoutTest(TestCase):
         self.assertEqual(response.template_name, 'admin/login.html')
         self.assertEqual(response.request['PATH_INFO'], '/test_admin/admin/')
         self.assertContains(response, '<input type="hidden" name="next" value="/test_admin/admin/" />')
+
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+class TestIndividualIds(TestCase):
+    urls = "regressiontests.admin_views.urls"
+    fixtures = ['admin-views-users.xml']
+
+    def setUp(self):
+        self.client.login(username='super', password='secret')
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_app_id_present(self):
+        response = self.client.get("/test_admin/admin/")
+        self.assertContains(response, '<div id="app-Admin_Views" class="module">')
+
+    def test_model_ids_present(self):
+        response = self.client.get("/test_admin/admin/")
+        self.assertContains(response, '<tr id="app-Admin_Views-Actor">')
+        self.assertContains(response, '<tr id="app-Admin_Views-Album">')


### PR DESCRIPTION
Add `id` attributes to apps and models on the admin dashboard.

Add tests, documentation and a misc release note.
