### PR TITLE
Coerce lookup to str in admin's SimpleListFilter.choices detection of selected choice.

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -9,7 +9,7 @@ import datetime
 
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_text, force_unicode
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.contrib.admin.util import (get_model_from_relation,
@@ -102,7 +102,7 @@ class SimpleListFilter(ListFilter):
         }
         for lookup, title in self.lookup_choices:
             yield {
-                'selected': self.value() == str(lookup),
+                'selected': self.value() == force_unicode(lookup),
                 'query_string': cl.get_query_string({
                     self.parameter_name: lookup,
                 }, []),


### PR DESCRIPTION
When a non-string value is used for the lookup tuple first element in SimpleListFilter.lookups, the comparison with SimpleListFilter.value() will fail, and the option will not be rendered as selected in the admin's changelist.
