### PR TITLE
Small admin password change form fix for pluggable user model

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -133,7 +133,7 @@ class UserAdmin(admin.ModelAdmin):
         adminForm = admin.helpers.AdminForm(form, fieldsets, {})
 
         context = {
-            'title': _('Change password: %s') % escape(user.username),
+            'title': _('Change password: %s') % escape(user.get_username()),
             'adminForm': adminForm,
             'form_url': form_url,
             'form': form,


### PR DESCRIPTION
django.contrib.auth.admin.UserAdmin produces an exception if pluggable User model has no username field:

```
Traceback:
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  116.                         response = callback(request, *callback_args, **callback_kwargs)
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  91.                     response = view_func(request, *args, **kwargs)
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  89.         response = view_func(request, *args, **kwargs)
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  202.             return view(request, *args, **kwargs)
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/views/decorators/debug.py" in sensitive_post_parameters_wrapper
  69.             return view(request, *args, **kwargs)
File "/Users/max/.virtualenvs/pluggable-user/lib/python2.7/site-packages/django/contrib/auth/admin.py" in user_change_password
  136.             'title': _('Change password: %s') % escape(user.username),

Exception Type: AttributeError at /admin/myauth/user/1/password/
Exception Value: 'User' object has no attribute 'username'
```
