### PR TITLE
Fix for ticket 19370 (date filter returns empty string for midnight)

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -704,7 +704,7 @@ def get_digit(value, arg):
 @register.filter(expects_localtime=True, is_safe=False)
 def date(value, arg=None):
     """Formats a date according to the given format."""
-    if not value:
+    if value in (None, ''):
         return ''
     if arg is None:
         arg = settings.DATE_FORMAT

--- a/tests/regressiontests/templates/filters.py
+++ b/tests/regressiontests/templates/filters.py
@@ -8,7 +8,7 @@ consistent.
 """
 from __future__ import unicode_literals
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 
 from django.test.utils import str_prefix
 from django.utils.tzinfo import LocalTimezone, FixedOffset
@@ -356,6 +356,9 @@ def get_filter_tests():
         # Timezone name
         'date06': (r'{{ d|date:"e" }}', {'d': datetime(2009, 3, 12, tzinfo=FixedOffset(30))}, '+0030'),
         'date07': (r'{{ d|date:"e" }}', {'d': datetime(2009, 3, 12)}, ''),
+        # Ticket 19370: Make sure |date doesn't blow up on a midnight time object
+        'date08': (r'{{ t|date:"H:i" }}', {'t': time(0, 1)}, '00:01'),
+        'date09': (r'{{ t|date:"H:i" }}', {'t': time(0, 0)}, '00:00'),
 
          # Tests for #11687 and #16676
          'add01': (r'{{ i|add:"5" }}', {'i': 2000}, '2005'),


### PR DESCRIPTION
Ticket 19370: https://code.djangoproject.com/ticket/19370

Python considers midnight (`datetime.time(0, 0)`) to be `False`. The date template filter stumbles over this.

When using `{{ midnight|date:"H:i" }}`, Django returns an empty string.

See ​http://bugs.python.org/issue13936 for discussion about the bug.

This is already fixed in the `|time` filter, but not in the `|date` filter which can also be used to format times.
