### PR TITLE
Fixed #19374 -- Typo in docs/ref/models/instances.txt.

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -378,7 +378,7 @@ If ``save()`` is passed a list of field names in keyword argument
 ``update_fields``, only the fields named in that list will be updated.
 This may be desirable if you want to update just one or a few fields on
 an object. There will be a slight performance benefit from preventing
-all of the model fields from being updated in the database. For example:
+all of the model fields from being updated in the database. For example::
 
     product.name = 'Name changed again'
     product.save(update_fields=['name'])


### PR DESCRIPTION
Minor typo in docs (https://code.djangoproject.com/ticket/19374).
