### PR TITLE
contrib/flatpages/tests: override CSRF_FAILURE_VIEW in case someone changed it in settings

### DIFF
--- a/django/contrib/flatpages/tests/csrf.py
+++ b/django/contrib/flatpages/tests/csrf.py
@@ -15,7 +15,7 @@ from django.test.utils import override_settings
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     ),
-    CSRF_FAILURE_VIEW = 'django.views.csrf.csrf_failure',
+    CSRF_FAILURE_VIEW='django.views.csrf.csrf_failure',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),


### PR DESCRIPTION
It is possible to change CSRF_FAILURE_VIEW in settings to a custom view, but it can possibly break a couple of tests in flatpages module. The easiest and most obvious solution would be to ensure, that flatpages tests test against correct view.
