### PR TITLE
contrib/flatpages/tests: override CSRF_FAILURE_VIEW in case someone changed it in settings

### DIFF
--- a/django/contrib/flatpages/tests/csrf.py
+++ b/django/contrib/flatpages/tests/csrf.py
@@ -16,6 +16,8 @@ class FlatpageCSRFTests(TestCase):
             settings.MIDDLEWARE_CLASSES += (csrf_middleware_class,)
         if flatpage_middleware_class not in settings.MIDDLEWARE_CLASSES:
             settings.MIDDLEWARE_CLASSES += (flatpage_middleware_class,)
+        self.old_CSRF_FAILURE_VIEW = settings.CSRF_FAILURE_VIEW
+        settings.CSRF_FAILURE_VIEW = 'django.views.csrf.csrf_failure'
         self.old_TEMPLATE_DIRS = settings.TEMPLATE_DIRS
         settings.TEMPLATE_DIRS = (
             os.path.join(
@@ -30,6 +32,8 @@ class FlatpageCSRFTests(TestCase):
         settings.MIDDLEWARE_CLASSES = self.old_MIDDLEWARE_CLASSES
         settings.TEMPLATE_DIRS = self.old_TEMPLATE_DIRS
         settings.LOGIN_URL = self.old_LOGIN_URL
+        settings.CSRF_FAILURE_VIEW = self.old_CSRF_FAILURE_VIEW
+
 
     def test_view_flatpage(self):
         "A flatpage can be served through a view, even when the middleware is in use"


### PR DESCRIPTION
It is possible to change CSRF_FAILURE_VIEW in settings to a custom view, but it can possibly break a couple of tests in flatpages module. The easiest and most obvious solution would be to ensure, that flatpages tests test against correct view.
