### PR TITLE
Fixed #19398 -- Prevented safe_join from coercing its output to unicode.

### DIFF
--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -5,7 +5,7 @@ from django.core.files.storage import default_storage, Storage, FileSystemStorag
 from django.utils.datastructures import SortedDict
 from django.utils.functional import empty, memoize, LazyObject
 from django.utils.importlib import import_module
-from django.utils._os import safe_join
+from django.utils._os import path_as_str, path_as_text, safe_join
 from django.utils import six
 
 from django.contrib.staticfiles import utils
@@ -93,7 +93,7 @@ class FileSystemFinder(BaseFinder):
             if not path.startswith(prefix):
                 return None
             path = path[len(prefix):]
-        path = safe_join(root, path)
+        path = path_as_text(safe_join(path_as_str(root), path_as_str(path)))
         if os.path.exists(path):
             return path
 

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -15,7 +15,7 @@ from django.utils.encoding import force_text, filepath_to_uri
 from django.utils.functional import LazyObject
 from django.utils.importlib import import_module
 from django.utils.text import get_valid_filename
-from django.utils._os import safe_join, abspathu
+from django.utils._os import path_as_str, path_as_text, safe_join
 
 
 __all__ = ('Storage', 'FileSystemStorage', 'DefaultStorage', 'default_storage')
@@ -150,7 +150,7 @@ class FileSystemStorage(Storage):
         if location is None:
             location = settings.MEDIA_ROOT
         self.base_location = location
-        self.location = abspathu(self.base_location)
+        self.location = path_as_text(os.path.abspath(path_as_str(self.base_location)))
         if base_url is None:
             base_url = settings.MEDIA_URL
         self.base_url = base_url
@@ -254,7 +254,7 @@ class FileSystemStorage(Storage):
 
     def path(self, name):
         try:
-            path = safe_join(self.location, name)
+            path = path_as_text(safe_join(path_as_str(self.location), path_as_str(name)))
         except ValueError:
             raise SuspiciousOperation("Attempted access to '%s' denied." % name)
         return os.path.normpath(path)

--- a/django/template/loaders/app_directories.py
+++ b/django/template/loaders/app_directories.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.template.base import TemplateDoesNotExist
 from django.template.loader import BaseLoader
-from django.utils._os import safe_join
+from django.utils._os import path_as_str, path_as_text, safe_join
 from django.utils.importlib import import_module
 from django.utils import six
 
@@ -45,9 +45,13 @@ class Loader(BaseLoader):
             template_dirs = app_template_dirs
         for template_dir in template_dirs:
             try:
-                yield safe_join(template_dir, template_name)
-            except UnicodeDecodeError:
-                # The template dir name was a bytestring that wasn't valid UTF-8.
+                # For backwards-compatibility, paths are returned as unicode strings. See #19398.
+                yield path_as_text(safe_join(path_as_str(template_dir), path_as_str(template_name)))
+            except UnicodeError:
+                # UnicodeEncodeError: the template dir name was a unicode string
+                # that can't be expressed in the filesystem's charset (extremely unlikely).
+                # UnicodeDecodeError: the template dir name was a bytestring
+                # that wasn't valid UTF-8.
                 raise
             except ValueError:
                 # The joined path was located outside of template_dir.

--- a/tests/regressiontests/utils/os_utils.py
+++ b/tests/regressiontests/utils/os_utils.py
@@ -1,3 +1,4 @@
+# No unicode_literals, filesystem paths are native strings.
 import os
 
 from django.utils import unittest
@@ -24,3 +25,8 @@ class SafeJoinTests(unittest.TestCase):
             path,
             os.path.sep,
         )
+
+    def test_safe_join_returns_native_string(self):
+        # Regression test for #19398
+        base = os.path.dirname(__file__)
+        self.assertIsInstance(safe_join(base, 'foo'), str)


### PR DESCRIPTION
Refs #9579. Reverts parts of dfa90aec and 8fb1459b.
