### PR TITLE
fixed #18160 Auth - Unknown Encoding Error when syncdb

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -139,6 +139,7 @@ def get_system_username():
         try:
             result = result.decode(default_locale)
         except (LookupError, UnicodeDecodeError):
+            # LookupError - default_locale may not a valid codec name
             # UnicodeDecodeError - preventive treatment for non-latin Windows.
             return ''
     return result

--- a/django/contrib/auth/tests/management.py
+++ b/django/contrib/auth/tests/management.py
@@ -33,8 +33,12 @@ class GetDefaultUsernameTestCase(TestCase):
 
     def test_unknown_encoding(self):
         import locale
-        locale.getdefaultlocale = lambda: ("en_US", "x-mac-simp-chinese")
-        self.assertEqual(management.get_default_username(), '')
+        try:
+            origin = locale.getdefaultlocale
+            locale.getdefaultlocale = lambda: ("en_US", "x-mac-simp-chinese")
+            self.assertEqual(management.get_default_username(), '')
+        finally:
+            locale.getdefaultlocale = origin
 
     def test_existing(self):
         models.User.objects.create(username='joe')


### PR DESCRIPTION
I mentioned this error with sqlite3 in [the original post](https://code.djangoproject.com/ticket/18160). But the other day, I re-encounter it on another Macbook with PostgreSQL. So I think we'd better fix this issue for the non-ascii locales env.
