### PR TITLE
Ticket 13629 -- Add app and model class in <body> tag

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -439,6 +439,7 @@ class AdminSite(object):
         context = {
             'title': _('%s administration') % capfirst(app_label),
             'app_list': [app_dict],
+            'app_label': app_label,
         }
         context.update(extra_context or {})
 

--- a/django/contrib/admin/templates/admin/app_index.html
+++ b/django/contrib/admin/templates/admin/app_index.html
@@ -1,6 +1,8 @@
 {% extends "admin/index.html" %}
 {% load i18n %}
 
+{% block bodyclass %}app-{{ app_label }} {{ block.super }}{% endblock %}
+
 {% if not is_popup %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -10,7 +10,7 @@
 
 {% block coltype %}colM{% endblock %}
 
-{% block bodyclass %}{{ opts.app_label }}-{{ opts.object_name.lower }} change-form{% endblock %}
+{% block bodyclass %}app-{{ opts.app_label }} model-{{ opts.object_name.lower }} change-form{% endblock %}
 
 {% if not is_popup %}
 {% block breadcrumbs %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -32,7 +32,7 @@
 {% endif %}{% endif %}
 {% endblock %}
 
-{% block bodyclass %}change-list{% endblock %}
+{% block bodyclass %}app-{{ opts.app_label }} model-{{ opts.object_name.lower }} change-list{% endblock %}
 
 {% if not is_popup %}
 {% block breadcrumbs %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -1,6 +1,8 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls %}
 
+{% block bodyclass %}app-{{ opts.app_label }} model-{{ opts.object_name.lower }} delete-confirmation{% endblock %}
+
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -1,6 +1,8 @@
 {% extends "admin/base_site.html" %}
 {% load i18n l10n admin_urls %}
 
+{% block bodyclass %}app-{{ opts.app_label }} model-{{ opts.object_name.lower }} delete-confirmation delete-selected-confirmation{% endblock %}
+
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3824,6 +3824,59 @@ class CSSTest(TestCase):
         self.assertContains(response, '<tr class="model-actor">')
         self.assertContains(response, '<tr class="model-album">')
 
+    def testAppModelInFormBodyClass(self):
+        """
+        Ensure app and model tag are correcly read by change_form template
+        """
+        response = self.client.get('/test_admin/admin/admin_views/section/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+            '<body class="app-admin_views model-section ')
+
+    def testAppModelInListBodyClass(self):
+        """
+        Ensure app and model tag are correcly read by change_list template
+        """
+        response = self.client.get('/test_admin/admin/admin_views/section/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+            '<body class="app-admin_views model-section ')
+
+    def testAppModelInDeleteConfirmationBodyClass(self):
+        """
+        Ensure app and model tag are correcly read by delete_confirmation
+        template
+        """
+        response = self.client.get(
+            '/test_admin/admin/admin_views/section/1/delete/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+            '<body class="app-admin_views model-section ')
+
+    def testAppModelInAppIndexBodyClass(self):
+        """
+        Ensure app and model tag are correcly read by app_index template
+        """
+        response = self.client.get('/test_admin/admin/admin_views/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<body class="app-admin_views ')
+        
+    def testAppModelInDeleteSelectedConfirmationBodyClass(self):
+        """
+        Ensure app and model tag are correcly read by
+        delete_selected_confirmation template
+        """
+        action_data = {
+            ACTION_CHECKBOX_NAME: [1],
+            'action': 'delete_selected',
+            'index': 0,
+        }
+        response = self.client.post('/test_admin/admin/admin_views/section/',
+            action_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+            '<body class="app-admin_views model-section ')
+
 try:
     import docutils
 except ImportError:


### PR DESCRIPTION
Here is the fix for Ticket 13629 it contains
- evolution proposed in previous pull request on this topic : ​https://github.com/django/django/pull/158.
- enhancement to handle application and model class separately in all templates concerned
- test coverage of all evolutions
