### PR TITLE
Removes poor PHP references

### DIFF
--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -257,8 +257,7 @@ lookup and function calls.
 Note ``{{ article.pub_date|date:"F j, Y" }}`` uses a Unix-style "pipe" (the "|"
 character). This is called a template filter, and it's a way to filter the value
 of a variable. In this case, the date filter formats a Python datetime object in
-the given format (as found in PHP's date function; yes, there is one good idea
-in PHP).
+the given format (as found in PHP's date function).
 
 You can chain together as many filters as you'd like. You can write custom
 filters. You can write custom template tags, which run custom Python code behind

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -81,12 +81,12 @@ work, see :doc:`Troubleshooting </faq/troubleshooting>`.
 
 .. admonition:: Where should this code live?
 
-    If your background is in PHP, you're probably used to putting code under the
-    Web server's document root (in a place such as ``/var/www``). With Django,
-    you don't do that. It's not a good idea to put any of this Python code
-    within your Web server's document root, because it risks the possibility
-    that people may be able to view your code over the Web. That's not good for
-    security.
+    If your background is in plain old PHP (with no use of modern frameworks),
+    you're probably used to putting code under the Web server's document root
+    (in a place such as ``/var/www``). With Django, you don't do that. It's
+    not a good idea to put any of this Python code within your Web server's
+    document root, because it risks the possibility that people may be able
+    to view your code over the Web. That's not good for security.
 
     Put your code in some directory **outside** of the document root, such as
     :file:`/home/mycode`.

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -235,11 +235,11 @@ be used to identify the matched pattern; and ``\d+`` is a regular expression to
 match a sequence of digits (i.e., a number).
 
 Because the URL patterns are regular expressions, there really is no limit on
-what you can do with them. And there's no need to add URL cruft such as ``.php``
--- unless you have a sick sense of humor, in which case you can do something
-like this::
+what you can do with them. And there's no need to add URL cruft such as
+``.html`` -- unless you want to, in which case you can do something like
+this::
 
-    (r'^polls/latest\.php$', 'polls.views.index'),
+    (r'^polls/latest\.html$', 'polls.views.index'),
 
 But, don't do that. It's silly.
 

--- a/docs/misc/design-philosophies.txt
+++ b/docs/misc/design-philosophies.txt
@@ -203,9 +203,6 @@ We see a template system as a tool that controls presentation and
 presentation-related logic -- and that's it. The template system shouldn't
 support functionality that goes beyond this basic goal.
 
-If we wanted to put everything in templates, we'd be using PHP. Been there,
-done that, wised up.
-
 Discourage redundancy
 ---------------------
 

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -16,9 +16,9 @@ or CheetahTemplate_, you should feel right at home with Django's templates.
 .. admonition:: Philosophy
 
     If you have a background in programming, or if you're used to languages
-    like PHP which mix programming code directly into HTML, you'll want to
-    bear in mind that the Django template system is not simply Python embedded
-    into HTML. This is by design: the template system is meant to express
+    which mix programming code directly into HTML, you'll want to bear in
+    mind that the Django template system is not simply Python embedded into
+    HTML. This is by design: the template system is meant to express
     presentation, not program logic.
 
     The Django template system provides tags which function similarly to some


### PR DESCRIPTION
The documentation and tutorials contain references to ways of coding in very old versions of PHP. The PHP ecosystem has moved on quite considerably since those days and many of the references are not best practice - or even valid any more.

This update removes these references.

I'm enjoying my dive into Django - but found the incorrect statements and 'bashing' of the language quite annoying.

This is a new pull request (the first one was #582) which was closed due to some potentially misleading alterations. This hopefully is an improvement that will keep everyone happy!

@kmtracey - If you could leave this PR open if you think any of the alterations are incorrect I can correct them with another commit without having to start over with a fresh PR.
