### PR TITLE
Fixed #19401 - Refactored "swapped" with "is_swapped", "swapped_app_labe...

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -84,7 +84,7 @@ class AdminSite(object):
 
             # Ignore the registration if the model has been
             # swapped out.
-            if not model._meta.swapped:
+            if not model._meta.is_swapped:
                 # If we got **options then dynamically construct a subclass of
                 # admin_class with those **options.
                 if options:

--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -155,7 +155,7 @@ def get_default_username(check_db=True):
     """
     # If the User model has been swapped out, we can't make any assumptions
     # about the default user name.
-    if auth_app.User._meta.swapped:
+    if auth_app.User._meta.is_swapped:
         return ''
 
     default_username = get_system_username()

--- a/django/core/management/validation.py
+++ b/django/core/management/validation.py
@@ -39,14 +39,9 @@ def get_validation_errors(outfile, app=None):
         opts = cls._meta
 
         # Check swappable attribute.
-        if opts.swapped:
-            try:
-                app_label, model_name = opts.swapped.split('.')
-            except ValueError:
-                e.add(opts, "%s is not of the form 'app_label.app_name'." % opts.swappable)
-                continue
-            if not models.get_model(app_label, model_name):
-                e.add(opts, "Model has been swapped out for '%s' which has not been installed or is abstract." % opts.swapped)
+        if opts.is_swapped:
+            if not models.get_model(opts.app_label, opts.object_name):
+                e.add(opts, "Model has been swapped out for '%s.%s' which has not been installed or is abstract." % (opts.app_label,opts.object_name) )
             # No need to perform any other validation checks on a swapped model.
             continue
 
@@ -140,7 +135,7 @@ def get_validation_errors(outfile, app=None):
                 if f.rel.to not in models.get_models():
                     # If the related model is swapped, provide a hint;
                     # otherwise, the model just hasn't been installed.
-                    if not isinstance(f.rel.to, six.string_types) and f.rel.to._meta.swapped:
+                    if not isinstance(f.rel.to, six.string_types) and f.rel.to._meta.is_swapped:
                         e.add(opts, "'%s' defines a relation with the model '%s.%s', which has been swapped out. Update the relation to point at settings.%s." % (f.name, f.rel.to._meta.app_label, f.rel.to._meta.object_name, f.rel.to._meta.swappable))
                     else:
                         e.add(opts, "'%s' has a relation with model %s, which has either not been installed or is abstract." % (f.name, f.rel.to))
@@ -187,7 +182,7 @@ def get_validation_errors(outfile, app=None):
             if f.rel.to not in models.get_models():
                 # If the related model is swapped, provide a hint;
                 # otherwise, the model just hasn't been installed.
-                if not isinstance(f.rel.to, six.string_types) and f.rel.to._meta.swapped:
+                if not isinstance(f.rel.to, six.string_types) and f.rel.to._meta.is_swapped:
                     e.add(opts, "'%s' defines a relation with the model '%s.%s', which has been swapped out. Update the relation to point at settings.%s." % (f.name, f.rel.to._meta.app_label, f.rel.to._meta.object_name, f.rel.to._meta.swappable))
                 else:
                     e.add(opts, "'%s' has an m2m relation with model %s, which has either not been installed or is abstract." % (f.name, f.rel.to))

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -1015,7 +1015,7 @@ class BaseDatabaseIntrospection(object):
             for model in models.get_models(app):
                 if not model._meta.managed:
                     continue
-                if model._meta.swapped:
+                if model._meta.is_swapped:
                     continue
                 if not router.allow_syncdb(self.connection.alias, model):
                     continue

--- a/django/db/backends/creation.py
+++ b/django/db/backends/creation.py
@@ -40,7 +40,7 @@ class BaseDatabaseCreation(object):
             (list_of_sql, pending_references_dict)
         """
         opts = model._meta
-        if not opts.managed or opts.proxy or opts.swapped:
+        if not opts.managed or opts.proxy or opts.is_swapped:
             return [], {}
         final_output = []
         table_output = []
@@ -144,7 +144,7 @@ class BaseDatabaseCreation(object):
         from django.db.backends.util import truncate_name
 
         opts = model._meta
-        if not opts.managed or opts.proxy or opts.swapped:
+        if not opts.managed or opts.proxy or opts.is_swapped:
             return []
         qn = self.connection.ops.quote_name
         final_output = []
@@ -172,7 +172,7 @@ class BaseDatabaseCreation(object):
         """
         Returns the CREATE INDEX SQL statements for a single model.
         """
-        if not model._meta.managed or model._meta.proxy or model._meta.swapped:
+        if not model._meta.managed or model._meta.proxy or model._meta.is_swapped:
             return []
         output = []
         for f in model._meta.local_fields:
@@ -224,7 +224,7 @@ class BaseDatabaseCreation(object):
         Return the DROP TABLE and restraint dropping statements for a single
         model.
         """
-        if not model._meta.managed or model._meta.proxy or model._meta.swapped:
+        if not model._meta.managed or model._meta.proxy or model._meta.is_swapped:
             return []
         # Drop the table now
         qn = self.connection.ops.quote_name
@@ -241,7 +241,7 @@ class BaseDatabaseCreation(object):
 
     def sql_remove_table_constraints(self, model, references_to_delete, style):
         from django.db.backends.util import truncate_name
-        if not model._meta.managed or model._meta.proxy or model._meta.swapped:
+        if not model._meta.managed or model._meta.proxy or model._meta.is_swapped:
             return []
         output = []
         qn = self.connection.ops.quote_name

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -110,8 +110,8 @@ class ModelBase(type):
 
         # If the model is a proxy, ensure that the base class
         # hasn't been swapped out.
-        if is_proxy and base_meta and base_meta.swapped:
-            raise TypeError("%s cannot proxy the swapped model '%s'." % (name, base_meta.swapped))
+        if is_proxy and base_meta and base_meta.is_swapped:
+            raise TypeError("%s cannot proxy the swapped model '%s.%s'." % (name, base_meta.swapped_app_label, base_meta.swapped_object_name))
 
         if getattr(new_class, '_default_manager', None):
             if not is_proxy:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1064,7 +1064,7 @@ class ForeignKey(RelatedField, Field):
     def contribute_to_related_class(self, cls, related):
         # Internal FK's - i.e., those with a related name ending with '+' -
         # and swapped models don't get a related descriptor.
-        if not self.rel.is_hidden() and not related.model._meta.swapped:
+        if not self.rel.is_hidden() and not related.model._meta.is_swapped:
             setattr(cls, related.get_accessor_name(), ForeignRelatedObjectsDescriptor(related))
             if self.rel.limit_choices_to:
                 cls._meta.related_fkey_lookups.append(self.rel.limit_choices_to)
@@ -1279,7 +1279,7 @@ class ManyToManyField(RelatedField, Field):
         #  1) There is a manually specified intermediate, or
         #  2) The class owning the m2m field is abstract.
         #  3) The class owning the m2m field has been swapped out.
-        if not self.rel.through and not cls._meta.abstract and not cls._meta.swapped:
+        if not self.rel.through and not cls._meta.abstract and not cls._meta.is_swapped:
             self.rel.through = create_many_to_many_intermediary_model(self, cls)
 
         # Add the descriptor for the m2m relation
@@ -1304,7 +1304,7 @@ class ManyToManyField(RelatedField, Field):
     def contribute_to_related_class(self, cls, related):
         # Internal M2Ms (i.e., those with a related name ending with '+')
         # and swapped models don't get a related descriptor.
-        if not self.rel.is_hidden() and not related.model._meta.swapped:
+        if not self.rel.is_hidden() and not related.model._meta.is_swapped:
             setattr(cls, related.get_accessor_name(), ManyRelatedObjectsDescriptor(related))
 
         # Set up the accessors for the column names on the m2m table

--- a/django/db/models/loading.py
+++ b/django/db/models/loading.py
@@ -213,7 +213,7 @@ class AppCache(object):
                 model for model in app.values()
                 if ((not model._deferred or include_deferred) and
                     (not model._meta.auto_created or include_auto_created) and
-                    (not model._meta.swapped or include_swapped))
+                    (not model._meta.is_swapped or include_swapped))
             )
         self._get_models_cache[cache_key] = model_list
         return model_list

--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -16,7 +16,7 @@ def ensure_default_manager(sender, **kwargs):
     if cls._meta.abstract:
         setattr(cls, 'objects', AbstractManagerDescriptor(cls))
         return
-    elif cls._meta.swapped:
+    elif cls._meta.is_swapped:
         setattr(cls, 'objects', SwappedManagerDescriptor(cls))
         return
     if not getattr(cls, '_default_manager', None):
@@ -64,10 +64,10 @@ class Manager(object):
         # Only contribute the manager if the model is concrete
         if model._meta.abstract:
             setattr(model, name, AbstractManagerDescriptor(model))
-        elif model._meta.swapped:
+        elif model._meta.is_swapped:
             setattr(model, name, SwappedManagerDescriptor(model))
         else:
-        # if not model._meta.abstract and not model._meta.swapped:
+        # if not model._meta.abstract and not model._meta.is_swapped:
             setattr(model, name, ManagerDescriptor(self))
         if not getattr(model, '_default_manager', None) or self.creation_counter < model._default_manager.creation_counter:
             model._default_manager = self
@@ -252,8 +252,8 @@ class SwappedManagerDescriptor(object):
         self.model = model
 
     def __get__(self, instance, type=None):
-        raise AttributeError("Manager isn't available; %s has been swapped for '%s'" % (
-            self.model._meta.object_name, self.model._meta.swapped
+        raise AttributeError("Manager isn't available; %s has been swapped for '%s.%s'" % (
+            self.model._meta.object_name, self.model._meta.swapped_app_label, self.model._meta.swapped_object_name
         ))
 
 


### PR DESCRIPTION
...l" and "swapped_object_name"

I've refactored the swapped check so that its checked _once_ when the options are applied to the class, and all tests for swapped-ed-ness are done against the "is_swapped", "swapped_app_label" and "swapped_object_name" attributes.

These changes cause three regression tests to fail, but  these appear to be "non issues", or perhaps even fixing a limitation of the older method. All three tests were looking for a failure condition that appears to be perfectly fine code. There's insufficient documentation to know if the test _should_ have failed by design, or was failing for a known or unknown reasons.

```
======================================================================
FAIL: test_swappable_user (django.contrib.auth.tests.basic.BasicTestCase)
The current user model can be swapped out for another
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ccogdon/dev/django-1.5x/django/test/utils.py", line 213, in inner
    return test_func(*args, **kwargs)
  File "/Users/ccogdon/dev/django-1.5x/django/contrib/auth/tests/basic.py", line 166, in test_swappable_user
    User.objects.all()
AssertionError: AttributeError not raised

======================================================================
FAIL: test_invalid_models (modeltests.invalid_models.tests.InvalidModelTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ccogdon/dev/django-1.5x/django/test/utils.py", line 213, in inner
    return test_func(*args, **kwargs)
  File "/Users/ccogdon/dev/django-1.5x/tests/modeltests/invalid_models/tests.py", line 48, in test_invalid_models
    self.fail('Unable to load invalid model module')
AssertionError: Unable to load invalid model module

======================================================================
FAIL: test_generated_data (regressiontests.swappable_models.tests.SwappableModelTests)
Permissions and content types are not created for a swapped model
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ccogdon/dev/django-1.5x/django/test/utils.py", line 213, in inner
    return test_func(*args, **kwargs)
  File "/Users/ccogdon/dev/django-1.5x/tests/regressiontests/swappable_models/tests.py", line 41, in test_generated_data
    self.assertNotIn(('swappable_models', 'article'), apps_models)
AssertionError: (u'swappable_models', u'article') unexpectedly found in [(u'admin', u'logentry'), (u'admin', u'logentry'), (u'admin', u'logentry'), (u'admin_ch...
```
