### PR TITLE
Fixed #14974 -- Allow using custom i18n backends

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -578,6 +578,10 @@ DEFAULT_EXCEPTION_REPORTER_FILTER = 'django.views.debug.SafeExceptionReporterFil
 # The name of the class to use to run the test suite
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
+# The name of the class to use as i18n backend
+I18N_BACKEND_REAL = 'django.utils.translation.I18nRealBackend'
+I18N_BACKEND_NULL = 'django.utils.translation.I18nNullBackend'
+
 ############
 # FIXTURES #
 ############

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'pgettext', 'pgettext_lazy',
     'npgettext', 'npgettext_lazy',
     'LANGUAGE_SESSION_KEY',
+    'I18nRealBackend', 'I18nNullBackend'
 ]
 
 LANGUAGE_SESSION_KEY = '_language'
@@ -37,6 +38,48 @@ class TranslatorCommentWarning(SyntaxWarning):
 # replace the functions with their real counterparts (once we do access the
 # settings).
 
+class I18nRealBackend(object):
+    """
+    i18n backend to be used when settings.USE_I18N == True.
+    This class can also be subclassed to build a custom
+    i18n real backend.
+    """
+    def __getattr__(self, real_name):
+        from django.utils.translation import trans_real
+        return getattr(trans_real, real_name)
+
+class I18nNullBackend(object):
+    """
+    i18n backend to be used when settings.USE_I18N != True.
+    This class can also be subclassed to build a custom
+    i18n null backend.
+    """
+    def __getattr__(self, real_name):
+        from django.utils.translation import trans_null
+        return getattr(trans_null, real_name)
+
+def get_i18n_backend(i18n_backend_name, settings):
+    """
+    Get i18n backend object from settings variables:
+    - I18N_BACKEND_REAL
+    - I18N_BACKEND_NULL
+
+    Args:
+        i18n_backend_name: A string, either I18N_BACKEND_REAL or
+            I18N_BACKEND_NULL
+        settings: django.conf.settings
+    Returns:
+        An i18n backend object
+    """
+    i18n_class = getattr(settings, i18n_backend_name)
+    i18n_path = i18n_class.split('.')
+    if len(i18n_path) > 1:
+        i18n_module_name = '.'.join(i18n_path[:-1])
+    else:
+        i18n_module_name = '.'
+    i18n_module = __import__(i18n_module_name, {}, {}, i18n_path[-1])
+    return getattr(i18n_module, i18n_path[-1])()
+
 class Trans(object):
     """
     The purpose of this class is to store the actual translation function upon
@@ -49,13 +92,16 @@ class Trans(object):
     performance effect, as access to the function goes the normal path,
     instead of using __getattr__.
     """
-
-    def __getattr__(self, real_name):
+    def get_trans(self):
         from django.conf import settings
         if settings.USE_I18N:
-            from django.utils.translation import trans_real as trans
+            i18n_backend_name = 'I18N_BACKEND_REAL'
         else:
-            from django.utils.translation import trans_null as trans
+            i18n_backend_name = 'I18N_BACKEND_NULL'
+        return get_i18n_backend(i18n_backend_name, settings)
+
+    def __getattr__(self, real_name):
+        trans = self.get_trans()
         setattr(self, real_name, getattr(trans, real_name))
         return getattr(trans, real_name)
 


### PR DESCRIPTION
This adds support for custom i18n backends in Django.

This https://github.com/rtnpro/django-pontoon-hook/tree/i18n_backend shows how to customise the i18n backend as necessary.

Please review it and let me know if it's OK or needs improvements.
