### PR TITLE
- fix locale middleware redirect url handling for views that do not end ...

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -31,7 +31,8 @@ class LocaleMiddleware(object):
                     and self.is_language_prefix_patterns_used()):
             urlconf = getattr(request, 'urlconf', None)
             language_path = '/%s%s' % (language, request.path_info)
-            if settings.APPEND_SLASH and not language_path.endswith('/'):
+            if (settings.APPEND_SLASH and not language_path.endswith('/') and
+                not is_valid_path(language_path, urlconf)):
                 language_path = language_path + '/'
 
             if is_valid_path(language_path, urlconf):


### PR DESCRIPTION
...with '/'

and the settings.APPEND_SLASH option is True

  example: i18n urlpattern ^sitemap.xml$ would result in something like
  language_path=u'/en/sitemap.xml/' which in turn results in 404 because that
  doesn't match the original urlpattern.
