### PR TITLE
Fixed ticket #13161

### DIFF
--- a/django/db/backends/postgresql_psycopg2/base.py
+++ b/django/db/backends/postgresql_psycopg2/base.py
@@ -29,7 +29,6 @@ except ImportError as e:
 DatabaseError = Database.DatabaseError
 IntegrityError = Database.IntegrityError
 
-psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 psycopg2.extensions.register_adapter(SafeBytes, psycopg2.extensions.QuotedString)
 psycopg2.extensions.register_adapter(SafeText, psycopg2.extensions.QuotedString)
 
@@ -211,6 +210,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             self.init_connection_state()
             connection_created.send(sender=self.__class__, connection=self)
         cursor = self.connection.cursor()
+        psycopg2.extensions.register_type(psycopg2.extensions.UNICODE, cursor)
         cursor.tzinfo_factory = utc_tzinfo_factory if settings.USE_TZ else None
         return CursorWrapper(cursor)
 


### PR DESCRIPTION
Previously, Django would register UNICODE extensions for psycopg2 at global scope, causing all other Python applications running under the same interpreter to be fed Unicode objects instead of expected strings. This would break those applications.
Now Django will register UNICODE only on per-cursor basic, so other applications will be unaffected.
