### PR TITLE
Update django/contrib/auth/locale/es_MX/LC_MESSAGES/django.po

### DIFF
--- a/django/contrib/auth/locale/es_MX/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/es_MX/LC_MESSAGES/django.po
@@ -80,7 +80,7 @@ msgid ""
 msgstr ""
 "Las contraseñas no se almacenan en texto plano, así que no hay manera de ver "
 "la contraseña del usuario, pero se puede cambiar la contraseña mediante <a "
-"href=\"password/\">este formulario</ a>."
+"href=\"password/\">este formulario</a>."
 
 #: forms.py:143
 msgid ""


### PR DESCRIPTION
Small change from "</ a>" to "</a>".

It was wrapping everything in a "<a>" tag.
