### PR TITLE
Allow X-Forwarded-Port header to override the default SERVER_PORT when reversing URLs

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -60,7 +60,7 @@ class HttpRequest(object):
         else:
             # Reconstruct the host using the algorithm from PEP 333.
             host = self.META['SERVER_NAME']
-            server_port = str(self.META['SERVER_PORT'])
+            server_port = str(self.META.get('HTTP_X_FORWARDED_PORT', self.META['SERVER_PORT']))
             if server_port != ('443' if self.is_secure() else '80'):
                 host = '%s:%s' % (host, server_port)
 

--- a/tests/regressiontests/requests/tests.py
+++ b/tests/regressiontests/requests/tests.py
@@ -119,6 +119,24 @@ class RequestsTests(unittest.TestCase):
         }
         self.assertEqual(request.get_host(), 'internal.com:8042')
 
+        # Check if HTTP_HOST isn't provided, and X-FORWARDED-PORT is set
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 8080,
+            'HTTP_X_FORWARDED_PORT': 80,
+        }
+        self.assertEqual(request.get_host(), 'internal.com')
+
+        # Check if HTTP_HOST isn't provided, and X-FORWARDED-PORT is set to non-standard port
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'internal.com',
+            'SERVER_PORT': 8080,
+            'HTTP_X_FORWARDED_PORT': 8042,
+        }
+        self.assertEqual(request.get_host(), 'internal.com:8042')
+
         # Poisoned host headers are rejected as suspicious
         legit_hosts = [
             'example.com',


### PR DESCRIPTION
Related: https://code.djangoproject.com/ticket/19517
