### PR TITLE
Updated staticfiles.views.serve to serve files from another document_root

### DIFF
--- a/django/contrib/staticfiles/views.py
+++ b/django/contrib/staticfiles/views.py
@@ -35,7 +35,10 @@ def serve(request, path, document_root=None, insecure=False, **kwargs):
                                    "debug mode or if the the --insecure "
                                    "option of 'runserver' is used")
     normalized_path = posixpath.normpath(unquote(path)).lstrip('/')
-    absolute_path = finders.find(normalized_path)
+    if document_root is None:
+        absolute_path = finders.find(normalized_path)
+    else:
+        absolute_path = os.path.join(document_root, normalized_path)
     if not absolute_path:
         if path.endswith('/') or path == '':
             raise Http404("Directory indexes are not allowed here.")


### PR DESCRIPTION
The function django.contrib.staticfiles.views.serve has the argument 'document_root'. But this argument is never read in the function.

You should either remove this argument from the function declaration, or build the final path from it.
