### PR TITLE
Clarification of collectstatic.py warning message.

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -146,7 +146,8 @@ class Command(NoArgsCommand):
         if self.clear:
             clear_display = 'This will DELETE EXISTING FILES!'
         else:
-            clear_display = 'This will overwrite existing files!'
+            clear_display = """This will overwrite any default static files
+you have modified!"""
 
         if self.interactive:
             confirm = input("""


### PR DESCRIPTION
I am not a programmer, so I may not have completed this small task perfectly (I had trouble figuring out how to break the text line so it did not extend beyond 80 chars), but it seems that the collectstatic warning message should be more clear: it will not _always_ overwrite files; it will only replace existing default files with new default files. So, it will only overwrite default files that the user has modified. This is hard to describe in one sentence, but I have attempted to do so.
