### PR TITLE
Doc Fix -- django.shortcuts.render requires a request object

### DIFF
--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -201,7 +201,7 @@ corresponding :class:`~django.db.models.FileField` when calling
                 return HttpResponseRedirect('/success/url/')
         else:
             form = ModelFormWithFileField()
-        return render('upload.html', {'form': form})
+        return render(request, 'upload.html', {'form': form})
 
 If you are constructing an object manually, you can simply assign the file
 object from :attr:`request.FILES <django.http.HttpRequest.FILES>` to the file
@@ -221,7 +221,7 @@ field in the model::
                 return HttpResponseRedirect('/success/url/')
         else:
             form = UploadFileForm()
-        return render('upload.html', {'form': form})
+        return render(request, 'upload.html', {'form': form})
 
 
 ``UploadedFile`` objects


### PR DESCRIPTION
The file upload topic guide shows `render` being called in 2 locations
without supplying a `request` object. This is fixed in this PR.
