### PR TITLE
Fixed #19445 - Fieldsets' validation doesn't call get_form

### DIFF
--- a/django/contrib/admin/validation.py
+++ b/django/contrib/admin/validation.py
@@ -6,7 +6,7 @@ from django.forms.models import (BaseModelForm, BaseModelFormSet, fields_for_mod
 from django.contrib.admin import ListFilter, FieldListFilter
 from django.contrib.admin.util import get_fields_from_path, NotRelationField
 from django.contrib.admin.options import (flatten_fieldsets, BaseModelAdmin,
-    HORIZONTAL, VERTICAL)
+    ModelAdmin, HORIZONTAL, VERTICAL)
 
 
 __all__ = ['validate']
@@ -387,7 +387,7 @@ def check_formfield(cls, model, opts, label, field):
         except KeyError:
             raise ImproperlyConfigured("'%s.%s' refers to field '%s' that "
                 "is missing from the form." % (cls.__name__, label, field))
-    else:
+    elif hasattr(cls, 'get_form') and cls.get_form.__func__ is ModelAdmin.get_form.__func__:
         fields = fields_for_model(model)
         try:
             fields[field]

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1049,6 +1049,13 @@ templates used by the :class:`ModelAdmin` views:
     changelist that will be linked to the change view, as described in the
     :attr:`ModelAdmin.list_display_links` section.
 
+.. method:: ModelAdmin.get_fieldsets(self, request, obj=None)
+
+    The ``get_fieldsets`` method is given the ``HttpRequest`` and the ``obj``
+    being edited (or ``None`` on an add form) and is expected to return a list
+    of two-tuples, in which each two-tuple represents a ``<fieldset>`` on the
+    admin form page, as described above in the :attr:`ModelAdmin.fieldsets` section.
+
 .. method:: ModelAdmin.get_list_filter(self, request)
 
     .. versionadded:: 1.5

--- a/tests/regressiontests/admin_validation/tests.py
+++ b/tests/regressiontests/admin_validation/tests.py
@@ -20,6 +20,18 @@ class InvalidFields(admin.ModelAdmin):
     form = SongForm
     fields = ['spam']
 
+class ValidFormFieldsets(admin.ModelAdmin):
+    def get_form(self, request, obj=None, **kwargs):
+        class ExtraFieldForm(SongForm):
+            name = forms.CharField(max_length=50)
+        return ExtraFieldForm
+
+    fieldsets = (
+        (None, {
+            'fields': ('name',),
+        }),
+    )
+
 class ValidationTestCase(TestCase):
 
     def test_readonly_and_editable(self):
@@ -41,6 +53,9 @@ class ValidationTestCase(TestCase):
             "'InvalidFields.fields' refers to field 'spam' that is missing from the form.",
             validate,
             InvalidFields, Song)
+
+    def test_custom_get_form_with_fieldsets(self):
+        validate(ValidFormFieldsets, Song)
 
     def test_exclude_values(self):
         """


### PR DESCRIPTION
Added documentation for ModelAdmin.get_fieldsets method as russellm
suggested. Disabled validation when get_form is defined on a subclass
of ModelAdmin.
