### PR TITLE
Fixed #18026 -- Don't return an anonymous dict if extra_data in storage is empty.

### DIFF
--- a/django/contrib/formtools/tests/wizard/storage.py
+++ b/django/contrib/formtools/tests/wizard/storage.py
@@ -75,3 +75,13 @@ class TestStorage(object):
         storage.extra_data = extra_context
         storage2 = self.get_storage()('wizard2', request, None)
         self.assertEqual(storage2.extra_data, {})
+
+    def test_extra_context_key_persistence(self):
+        request = get_request()
+        storage = self.get_storage()('wizard1', request, None)
+
+        self.assertFalse('test' in storage.extra_data)
+
+        storage.extra_data['test'] = True
+
+        self.assertTrue('test' in storage.extra_data)

--- a/django/contrib/formtools/wizard/storage/base.py
+++ b/django/contrib/formtools/wizard/storage/base.py
@@ -37,7 +37,7 @@ class BaseStorage(object):
     current_step = lazy_property(_get_current_step, _set_current_step)
 
     def _get_extra_data(self):
-        return self.data[self.extra_data_key] or {}
+        return self.data[self.extra_data_key]
 
     def _set_extra_data(self, extra_data):
         self.data[self.extra_data_key] = extra_data


### PR DESCRIPTION
Fix for https://code.djangoproject.com/ticket/18026
