### PR TITLE
Fixed #19024 -- Corrected form wizard docs for get_form_prefix.

### DIFF
--- a/docs/ref/contrib/formtools/form-wizard.txt
+++ b/docs/ref/contrib/formtools/form-wizard.txt
@@ -320,8 +320,14 @@ Advanced ``WizardView`` methods
 
 .. method:: WizardView.get_form_prefix(step, form)
 
-    Given the step and the form class which will be called with the returned
-    form prefix. By default, this simply uses the step itself.
+    Returns the prefix which will be used when calling the form for the given
+    step. ``step`` contains the step name, ``form`` the form class which will
+    be called with the returned prefix.
+
+    If no ``step`` is given, it will be determined automatically. By
+    default, this simply uses the step itself and the ``form`` parameter
+    is not used.
+
     For more, see the :ref:`form prefix documentation <form-prefix>`.
 
 .. method:: WizardView.get_form_initial(step)


### PR DESCRIPTION
Fix for https://code.djangoproject.com/ticket/19024
