### PR TITLE
Added the ability override a setter for custom model fields

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -407,6 +407,13 @@ class Model(six.with_metaclass(ModelBase)):
         super(Model, self).__init__()
         signals.post_init.send(sender=self.__class__, instance=self)
 
+    def __setattr__(self, name, value):
+        if name in self._meta.get_all_field_names():
+            field = self._meta.get_field_by_name(name)
+            if hasattr(field[0], 'setter'):
+                value = field[0].setter(value)
+        return super(Model, self).__setattr__(name, value)
+
     def __repr__(self):
         try:
             u = six.text_type(self)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -243,6 +243,12 @@ class Field(object):
     def unique(self):
         return self._unique or self.primary_key
 
+    def setter(self, value):
+        """
+        Perform some logic before actually assigning a value to the field
+        """
+        return value
+
     def set_attributes_from_name(self, name):
         if not self.name:
             self.name = name

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -508,6 +508,59 @@ unless your custom field needs a special conversion when being saved
 that is not the same as the conversion used for normal query
 parameters (which is implemented by :meth:`.get_db_prep_value`).
 
+Preprocessing values before assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. method:: Field.setter(self, value)
+
+This method is called when a value is assigned to a non-relational model field.
+The method is given the value that is attempting to be assigned, so that it
+can be validated or transformed, then the return value is what actually gets 
+assigned to the field.
+
+By default this method simply returns the value assigned to it, which means
+that it does nothing. Overriding this method means that transformation that you
+might otherwise put into :meth:`get_prep_value` can instead be run when the
+value is assigned, which can allow you to enforce some restrictions between the
+time of assignment and when the object is stored.
+
+This type of thing can also be done at the model level using ``__setattr__()``,
+but this functionality is meant to control field assignment, so the code should
+be portable along with the field itself.
+
+Consider an example where you wanted a text field in which all the contents are
+to be forced as lower case. In this type of situation if you enforced the
+casing by overriding :meth:`get_prep_value` then anything retrieved from the
+database would reliably be in lower case, however if a new object is created
+and saved and that original object is then used for an operation, the
+assumption of lower case cannot be safely made. If the conversion to lower case
+is done during assignment, then the text can be safely converted before
+anything else happens.
+
+For example::
+
+    class LowercaseTextField(models.TextField):
+    # ...
+
+        def setter(self, value):
+            value = super(LowercaseTextField, self).setter(value)
+            if isinstance(value, (str, unicode)):
+                return value.lower()
+            else:
+                return value
+
+Though it is recommended that you call the parent ``setter()`` first in order to
+maintain any changes implemented in the parent model, it is not required. 
+Transformations like this are convenient, but it's best if you leave the actual
+field validation to validators that get called during a ``save()``.
+
+.. warning::
+
+    If the ``__setattr__()`` method has been overridden on the model that owns
+    this field without including a call to 
+    ``super.(MyClass, self)__setattr__(name, value)`` then this ``getter()``
+    method will not be called.
+
 Preprocessing values before saving
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/modeltests/field_subclassing/fields.py
+++ b/tests/modeltests/field_subclassing/fields.py
@@ -72,3 +72,11 @@ class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
         if value is None:
             return None
         return json.dumps(value)
+
+class LowerTextField(six.with_metaclass(models.SubfieldBase, models.TextField)) :
+
+    description = ("A textfield that enforces that all text will be converted to lowercase")
+
+    def setter(self, value):
+        if isinstance(value, (str, unicode)) :
+            return value.lower()

--- a/tests/modeltests/field_subclassing/models.py
+++ b/tests/modeltests/field_subclassing/models.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils.encoding import force_text
 
-from .fields import SmallField, SmallerField, JSONField
+from .fields import SmallField, SmallerField, JSONField, LowerTextField
 from django.utils.encoding import python_2_unicode_compatible
 
 
@@ -24,3 +24,6 @@ class OtherModel(models.Model):
 
 class DataModel(models.Model):
     data = JSONField()
+
+class LowercaseModel(models.Model):
+    data = LowerTextField()

--- a/tests/modeltests/field_subclassing/tests.py
+++ b/tests/modeltests/field_subclassing/tests.py
@@ -4,7 +4,7 @@ from django.core import serializers
 from django.test import TestCase
 
 from .fields import Small
-from .models import DataModel, MyModel, OtherModel
+from .models import DataModel, MyModel, OtherModel, LowercaseModel
 
 
 class CustomField(TestCase):
@@ -90,3 +90,7 @@ class CustomField(TestCase):
         o = OtherModel.objects.get()
         self.assertEqual(o.data.first, "a")
         self.assertEqual(o.data.second, "b")
+
+    def test_setter_override(self):
+        o = LowercaseModel(data="SaMe TeXt")
+        self.assertEqual(o.data, "same text")


### PR DESCRIPTION
This adds a minimal **setattr**() to the base model that checks that property being set is in the field list and has a setter() method on that field. Then the value is run through the setter() method before actually assigning it. This gives the ability to actually create a setter for a custom model field that can transform or verify data as desired. See the changes that I made in the docs for full details and limitations. The unit test added demonstrates a simple example.

The main reason that I added this is because while using get_prep_value() to do the data transformations will change what's in the database, you need to refetch the object from the database to actually update the object that was originally created. This allows you to enforce changes on the value as soon as it is assigned, instead of only making changes for what is stored and retrieved.
