### PR TITLE
Fixed #18898: has_changed now works with instances

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -341,7 +341,8 @@ class BaseForm(object):
                     hidden_widget = field.hidden_widget()
                     initial_value = hidden_widget.value_from_datadict(
                         self.data, self.files, initial_prefixed_name)
-                if field.widget._has_changed(initial_value, data_value):
+                if (field.widget._has_changed(initial_value, data_value) and
+                    field.widget._has_changed(initial_value, field.to_python(data_value))):
                     self._changed_data.append(name)
         return self._changed_data
     changed_data = property(_get_changed_data)

--- a/tests/modeltests/model_formsets/tests.py
+++ b/tests/modeltests/model_formsets/tests.py
@@ -1062,6 +1062,38 @@ class ModelFormsetTest(TestCase):
         FormSet = modelformset_factory(ClassyMexicanRestaurant, fields=["tacos_are_yummy"])
         self.assertEqual(sorted(FormSet().forms[0].fields.keys()), ['restaurant', 'tacos_are_yummy'])
 
+    def test_model_formset_with_initial_model_instance(self):
+        # has_changed should compare model instance and primary key
+        # see #18898
+        FormSet = modelformset_factory(Poem)
+        john_milton = Poet(name="John Milton")
+        john_milton.save()
+        data = {
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 0,
+            'form-MAX_NUM_FORMS': '',
+            'form-0-name': '',
+            'form-0-poet': str(john_milton.id),
+        }
+        formset = FormSet(initial=[{'poet': john_milton}], data=data)
+        self.assertFalse(formset.extra_forms[0].has_changed())
+
+    def test_model_formset_with_initial_queryset(self):
+        # has_changed should work with queryset and list of pk's
+        # see #18898
+        FormSet = modelformset_factory(AuthorMeeting)
+        author = Author.objects.create(pk=1, name='Charles Baudelaire')
+        data = {
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 0,
+            'form-MAX_NUM_FORMS': '',
+            'form-0-name': '',
+            'form-0-created': '',
+            'form-0-authors': list(Author.objects.values_list('id', flat=True)),
+        }
+        formset = FormSet(initial=[{'authors': Author.objects.all()}], data=data)
+        self.assertFalse(formset.extra_forms[0].has_changed())
+
     def test_prevent_duplicates_from_with_the_same_formset(self):
         FormSet = modelformset_factory(Product, extra=2)
         data = {


### PR DESCRIPTION
Fix for [#18898](https://code.djangoproject.com/ticket/18898)

Since form initial accepts both string and python values, has_changed also needs to work with both.

I've updated ModelMultipleChoiceField to_python so that it returns the filtered queryset based on the value.
