### PR TITLE
Include .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 docs/_build/
 tests/coverage_html/
 tests/.coverage
+*.DS_Store


### PR DESCRIPTION
When browsing in Finder, OS X automatically creates .DS_Store files.
This is very annoying when using django as a submodule which
perpetually is getting dirty.

Updated the .gitignore to ignore these files.
