### PR TITLE
Remove dup_select_related method.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -755,13 +755,6 @@ class QuerySet(object):
             clone._prefetch_related_lookups.extend(lookups)
         return clone
 
-    def dup_select_related(self, other):
-        """
-        Copies the related selection status from the QuerySet 'other' to the
-        current QuerySet.
-        """
-        self.query.select_related = other.query.select_related
-
     def annotate(self, *args, **kwargs):
         """
         Return a query set in which the returned objects have been annotated


### PR DESCRIPTION
This undocumented method was used in an old version of the admin, is totally untested and hails from 2008. Although it's listed in the "public methods" section, as it's not documented or used I don't think it needs a deprecation path.

If we think it's useful I'll write some tests/docs for it instead...
