### PR TITLE
Fix #19657: sql, sqlcustom, sqlindexes and sqlall do not take allow_syncdb into account

### DIFF
--- a/django/core/management/commands/sql.py
+++ b/django/core/management/commands/sql.py
@@ -18,4 +18,4 @@ class Command(AppCommand):
     output_transaction = True
 
     def handle_app(self, app, **options):
-        return '\n'.join(sql_create(app, self.style, connections[options.get('database')]))
+        return '\n'.join(sql_create(app, self.style, connections[options.get('database')], options.get('database')))

--- a/django/core/management/commands/sqlall.py
+++ b/django/core/management/commands/sqlall.py
@@ -19,4 +19,4 @@ class Command(AppCommand):
     output_transaction = True
 
     def handle_app(self, app, **options):
-        return '\n'.join(sql_all(app, self.style, connections[options.get('database')]))
+        return '\n'.join(sql_all(app, self.style, connections[options.get('database')], options.get('database')))

--- a/django/core/management/commands/sqlcustom.py
+++ b/django/core/management/commands/sqlcustom.py
@@ -18,4 +18,4 @@ class Command(AppCommand):
     output_transaction = True
 
     def handle_app(self, app, **options):
-        return '\n'.join(sql_custom(app, self.style, connections[options.get('database')]))
+        return '\n'.join(sql_custom(app, self.style, connections[options.get('database')], options.get('database')))

--- a/django/core/management/commands/sqlindexes.py
+++ b/django/core/management/commands/sqlindexes.py
@@ -19,4 +19,4 @@ class Command(AppCommand):
     output_transaction = True
 
     def handle_app(self, app, **options):
-        return '\n'.join(sql_indexes(app, self.style, connections[options.get('database')]))
+        return '\n'.join(sql_indexes(app, self.style, connections[options.get('database')], options.get('database')))

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -6,12 +6,12 @@ import re
 
 from django.conf import settings
 from django.core.management.base import CommandError
-from django.db import models
+from django.db import models, router
 from django.db.models import get_models
 from django.utils._os import upath
 
 
-def sql_create(app, style, connection):
+def sql_create(app, style, connection, db='default'):
     "Returns a list of the CREATE TABLE SQL statements for the given app."
 
     if connection.settings_dict['ENGINE'] == 'django.db.backends.dummy':
@@ -32,6 +32,8 @@ def sql_create(app, style, connection):
     pending_references = {}
 
     for model in app_models:
+        if not router.allow_syncdb(db, model):
+            continue
         output, references = connection.creation.sql_create_model(model, style, known_models)
         final_output.extend(output)
         for refto, refs in references.items():
@@ -118,29 +120,33 @@ def sql_flush(style, connection, only_django=False, reset_sequences=True):
     return statements
 
 
-def sql_custom(app, style, connection):
+def sql_custom(app, style, connection, db='default'):
     "Returns a list of the custom table modifying SQL statements for the given app."
     output = []
 
     app_models = get_models(app)
 
     for model in app_models:
+        if not router.allow_syncdb(db, model):
+            continue
         output.extend(custom_sql_for_model(model, style, connection))
 
     return output
 
 
-def sql_indexes(app, style, connection):
+def sql_indexes(app, style, connection, db='default'):
     "Returns a list of the CREATE INDEX SQL statements for all models in the given app."
     output = []
     for model in models.get_models(app):
+        if not router.allow_syncdb(db, model):
+            continue
         output.extend(connection.creation.sql_indexes_for_model(model, style))
     return output
 
 
-def sql_all(app, style, connection):
+def sql_all(app, style, connection, db='default'):
     "Returns a list of CREATE TABLE SQL, initial-data inserts, and CREATE INDEX SQL for the given module."
-    return sql_create(app, style, connection) + sql_custom(app, style, connection) + sql_indexes(app, style, connection)
+    return sql_create(app, style, connection, db) + sql_custom(app, style, connection, db) + sql_indexes(app, style, connection, db)
 
 
 def _split_statements(content):


### PR DESCRIPTION
Simple fix for https://code.djangoproject.com/ticket/19657

Check was copied from other modules taking database routers into account.
