### PR TITLE
Note `authenticate` usage with custom user model.

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -136,6 +136,11 @@ Authenticating Users
             # the authentication system was unable to verify the username and password
             print("The username and password were incorrect.")
 
+    .. note::
+
+        When calling ``authenticate`` for a custom user model, you should use the ``username``
+        keyword as the first argument, even if ``USERNAME_FIELD`` has been set to some other field.
+
 .. _topic-authorization:
 
 Permissions and Authorization


### PR DESCRIPTION
If using a custom user model, with eg `USERNAME_FIELD='email'`,
then it is non-obvious if the correct usage is `authenticate(username=..., password=...)` or `authenticate(email=..., password=...)`

Bit of an easy stumbling point, and it won't be obvious to the developer why login is failing, so we should really note the usage here.

This was the best phrasing I could come up with, but happy to take other suggestions.
