### PR TITLE
Fix #19663, text provided to colorize() shouldn't raise exception if None

### DIFF
--- a/django/utils/termcolors.py
+++ b/django/utils/termcolors.py
@@ -52,8 +52,8 @@ def colorize(text='', opts=(), **kwargs):
         if o in opt_dict:
             code_list.append(opt_dict[o])
     if 'noreset' not in opts:
-        text = text + '\x1b[%sm' % RESET
-    return ('\x1b[%sm' % ';'.join(code_list)) + text
+        text = '%s\x1b[%sm' % (text or '', RESET)
+    return '%s%s' % (('\x1b[%sm' % ';'.join(code_list)), text or '')
 
 def make_style(opts=(), **kwargs):
     """

--- a/tests/regressiontests/utils/termcolors.py
+++ b/tests/regressiontests/utils/termcolors.py
@@ -1,5 +1,5 @@
 from django.utils import unittest
-from django.utils.termcolors import parse_color_setting, PALETTES, DEFAULT_PALETTE, LIGHT_PALETTE, DARK_PALETTE, NOCOLOR_PALETTE
+from django.utils.termcolors import parse_color_setting, PALETTES, DEFAULT_PALETTE, LIGHT_PALETTE, DARK_PALETTE, NOCOLOR_PALETTE, colorize
 
 class TermColorTests(unittest.TestCase):
 
@@ -146,3 +146,8 @@ class TermColorTests(unittest.TestCase):
         self.assertEqual(parse_color_setting('error=green,bLiNk'),
                           dict(PALETTES[NOCOLOR_PALETTE],
                             ERROR={'fg':'green', 'opts': ('blink',)}))
+
+    def test_colorize_none_text(self):
+        self.assertTrue(colorize(text=None))
+
+        self.assertTrue(colorize(text=None, opts=('noreset')))


### PR DESCRIPTION
See #670 for the initial pull request and https://code.djangoproject.com/ticket/19663 for details.
