### PR TITLE
Added a note about needing to wrap escaped JS in double quotes

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1437,10 +1437,14 @@ templates to generate JavaScript/JSON.
 
 For example::
 
-    {{ value|escapejs }}
+    "{{ value|escapejs }}"
 
 If ``value`` is ``"testing\r\njavascript \'string" <b>escaping</b>"``,
 the output will be ``"testing\\u000D\\u000Ajavascript \\u0027string\\u0022 \\u003Cb\\u003Eescaping\\u003C/b\\u003E"``.
+
+.. note::
+
+    You must use double quotes or else the slashes in the escaped value will be literally interpreted.
 
 .. templatefilter:: filesizeformat
 


### PR DESCRIPTION
I spent some time trying to debug a problem that involved using single quotes around escapejs calls so I thought others would benefit from a note in the documentation saying to use double quoted strings.
