### PR TITLE
Users with unsalted MD5 passwords unable to log in with Django 1.4

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -373,7 +373,7 @@ class UnsaltedMD5PasswordHasher(BasePasswordHasher):
 
     def verify(self, password, encoded):
         encoded_2 = self.encode(password, '')
-        return constant_time_compare(encoded, encoded_2)
+        return constant_time_compare(encoded[5:], encoded_2)
 
     def safe_summary(self, encoded):
         return SortedDict([


### PR DESCRIPTION
Details are in https://code.djangoproject.com/ticket/19687
