### PR TITLE
Fixes #19702: mysql backend not compatible with MySQL 4 ('SHOW TABLE STA...

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -177,7 +177,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             # will tell you the default table type of the created
             # table. Since all Django's test tables will have the same
             # table type, that's enough to evaluate the feature.
-            cursor.execute("SHOW TABLE STATUS WHERE Name='INTROSPECT_TEST'")
+            cursor.execute("SHOW TABLE STATUS LIKE 'INTROSPECT_TEST'")
             result = cursor.fetchone()
             cursor.execute('DROP TABLE INTROSPECT_TEST')
             self._storage_engine = result[1]


### PR DESCRIPTION
This fixes #19702 ticket.

This is only one 1-line commit that restores MySQL 4 compatibility ( Django 1.4 documentation states that it's compatible with MySQL 4).
