### PR TITLE
Fixed #19711 -- Typo in __all__ declaration in django/test/simple.py

### DIFF
--- a/django/test/simple.py
+++ b/django/test/simple.py
@@ -11,7 +11,7 @@ from django.utils import unittest
 from django.utils.importlib import import_module
 from django.utils.module_loading import module_has_submodule
 
-__all__ = ('DjangoTestSuiteRunner')
+__all__ = ('DjangoTestSuiteRunner',)
 
 # The module name for tests outside models.py
 TEST_MODULE = 'tests'


### PR DESCRIPTION
A small typo. https://code.djangoproject.com/ticket/19711
