### PR TITLE
Ensure FK is properly set with default kwargs

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -595,6 +595,9 @@ def create_many_related_manager(superclass, rel):
             Returns the correct value for this relationship's foreign key. This
             might be something else than pk value when to_field is used.
             """
+            if not self.through:
+                # Simply use the obj.pk if there isn't an explicit through
+                return obj.pk
             fk = self.through._meta.get_field(field_name)
             if fk.rel.field_name and fk.rel.field_name != fk.rel.to._meta.pk.attname:
                 attname = fk.rel.get_related_field().get_attname()


### PR DESCRIPTION
This is all internal to ManyRelatedManager, but a custom m2m field that is instantiated and passes the default `through=None` value in will cause an exception.

Currently, the work around for this is to explicitly instantiate the ManyRelatedManager with `through=self.field.rel.through` within a custom m2m field's `__get__` method.  That is backwards-incompatible with Django <= 1.4.2, however, resulting in code like [this in Armstrong](https://github.com/armstrong/armstrong.core.arm_content/commit/788aaf3fec743f36e7f540c34270b63fa43c279c).

This was a BC break that was introduced in Django 1.4.3.  It was done in an effort to fix [#18823](https://code.djangoproject.com/ticket/18823).  The specific commit was 611c4d6f1c24763e5e6e331a5dcf9b610288aaa8.
