### PR TITLE
Casting a SimpleLazyObject to an int failed

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -309,6 +309,7 @@ class SimpleLazyObject(LazyObject):
     __hash__ = new_method_proxy(hash)
     __bool__ = new_method_proxy(bool)       # Python 3
     __nonzero__ = __bool__                  # Python 2
+    __int__ = new_method_proxy(int)
 
 
 class lazy_property(property):

--- a/tests/regressiontests/utils/functional.py
+++ b/tests/regressiontests/utils/functional.py
@@ -1,5 +1,5 @@
 from django.utils import unittest
-from django.utils.functional import lazy, lazy_property
+from django.utils.functional import lazy, lazy_property, SimpleLazyObject
 
 
 class FunctionalTestCase(unittest.TestCase):
@@ -37,3 +37,9 @@ class FunctionalTestCase(unittest.TestCase):
 
         self.assertRaises(NotImplementedError, lambda: A().do)
         self.assertEqual(B().do, 'DO IT')
+
+    def test_lazy_int(self):
+        class A(object):
+            __int__ = lambda self: 1
+
+        self.assertEqual(int(SimpleLazyObject(A)), 1)


### PR DESCRIPTION
Should be pretty self explanatory. We noticed the bug when passing `request.user` into a filter like:

``` python
Model.objects.filter(user=request.user)
```

Since Django is attempting to coerce the object to an int, it fails on the SimpleLazyObject yielding:

```
TypeError: int() argument must be a string or a number, not 'SimpleLazyObject'
```

The error can be reproduced simple by doing:

``` python
class Foo(object):
  __int__ = lambda self: 1

int(SimpleLazyObject(Foo))
```
