### PR TITLE
Fixed #19543 -- implemented SimpleLazyObject.__repr__

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -302,6 +302,13 @@ class SimpleLazyObject(LazyObject):
     def __reduce__(self):
         return (self.__newobj__, (self.__class__,), self.__getstate__())
 
+    def __repr__(self):
+        if self._wrapped is empty:
+            repr_attr = self._setupfunc
+        else:
+            repr_attr = self._wrapped
+        return '<SimpleLazyObject: %r>' % repr_attr
+
     # Need to pretend to be the wrapped class, for the sake of objects that care
     # about this (especially in equality tests)
     __class__ = property(new_method_proxy(operator.attrgetter("__class__")))

--- a/tests/regressiontests/utils/simplelazyobject.py
+++ b/tests/regressiontests/utils/simplelazyobject.py
@@ -59,10 +59,17 @@ class TestUtilsSimpleLazyObject(TestCase):
                          hash(SimpleLazyObject(complex_object)))
 
     def test_repr(self):
-        # For debugging, it will really confuse things if there is no clue that
-        # SimpleLazyObject is actually a proxy object. So we don't
-        # proxy __repr__
-        self.assertTrue("SimpleLazyObject" in repr(SimpleLazyObject(complex_object)))
+        # First, for an unevaluated SimpleLazyObject
+        x = SimpleLazyObject(complex_object)
+        # __repr__ contains __repr__ of setup function and does not evaluate
+        # the SimpleLazyObject
+        self.assertEqual("<SimpleLazyObject: %r>" % complex_object, repr(x))
+        self.assertEqual(empty, x._wrapped)
+
+        # Second, for an evaluated SimpleLazyObject
+        name = x.name # evaluate
+        # __repr__ contains __repr__ of wrapped object
+        self.assertEqual("<SimpleLazyObject: %r>" % complex_object(), repr(x))
 
     def test_bytes(self):
         self.assertEqual(b"I am _ComplexObject('joe')",


### PR DESCRIPTION
[#19543](https://code.djangoproject.com/ticket/19543)  SimpleLazyObject missing **repr** proxy
