### PR TITLE
Fixed #19693 truncatewords_html closes <br/><hr/> tags

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -24,8 +24,7 @@ capfirst = allow_lazy(capfirst, six.text_type)
 
 # Set up regular expressions
 re_words = re.compile(r'&.*?;|<.*?>|(\w[\w-]*)', re.U|re.S)
-re_tag = re.compile(r'<(/)?([^ ]+?)(?: (/)| .*?)?>', re.S)
-
+re_tag = re.compile(r'<(/)?([^ ]+?)(?:(\s*/)| .*?)?>', re.S)
 
 def wrap(text, width):
     """

--- a/tests/regressiontests/utils/text.py
+++ b/tests/regressiontests/utils/text.py
@@ -70,6 +70,16 @@ class TestUtilsText(SimpleTestCase):
             'id="mylink">brown fox</a> jumped over the lazy dog.</p>')
         self.assertEqual('<p>The quick <a href="xyz.html"\n'
             'id="mylink">brown...</a></p>', truncator.words(3, '...', html=True))
+        # Test self closing tags
+        truncator = text.Truncator('<br/>The <hr />quick brown fox jumped over'
+            ' the lazy dog.')
+        self.assertEqual('<br/>The <hr />quick brown...', 
+            truncator.words(3, '...', html=True ))
+        truncator = text.Truncator('<br>The <hr/>quick <em>brown fox</em> '
+            'jumped over the lazy dog.')
+        self.assertEqual('<br>The <hr/>quick <em>brown...</em>', 
+            truncator.words(3, '...', html=True ))
+        
 
     def test_wrap(self):
         digits = '1234 67 9'


### PR DESCRIPTION
- Changed re_tag in django.utils.text to sneawo's suggestion
- Added regression tests
