### PR TITLE
Fixed #19810 -- MemcachedCache now uses pickle.HIGHEST_PROTOCOL

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -1,6 +1,7 @@
 "Memcached cache backend"
 
 import time
+import pickle
 from threading import local
 
 from django.core.cache.backends.base import BaseCache, InvalidCacheBackendError
@@ -145,6 +146,13 @@ class MemcachedCache(BaseMemcachedCache):
         super(MemcachedCache, self).__init__(server, params,
                                              library=memcache,
                                              value_not_found_exception=ValueError)
+    @property
+    def _cache(self):
+        if getattr(self, '_client', None) is None:
+            self._client = self._lib.Client(self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
+
+        return self._client
+
 
 class PyLibMCCache(BaseMemcachedCache):
     "An implementation of a cache binding using pylibmc"


### PR DESCRIPTION
For better compatibility with other cache backends

I didn't change BaseMemcachedCache._cache because I think it could be backwards incompatible with custom backends that may rely on it.
