### PR TITLE
Fixed #19819 - Handle template filter errors correctly.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -250,7 +250,11 @@ class Parser(object):
             elif token.token_type == 1: # TOKEN_VAR
                 if not token.contents:
                     self.empty_variable(token)
-                filter_expression = self.compile_filter(token.contents)
+                try:
+                    filter_expression = self.compile_filter(token.contents)
+                except TemplateSyntaxError as e:
+                    if not self.compile_filter_error(token, e):
+                        raise
                 var_node = self.create_variable_node(filter_expression)
                 self.extend_nodelist(nodelist, var_node, token)
             elif token.token_type == 2: # TOKEN_BLOCK
@@ -329,6 +333,9 @@ class Parser(object):
 
     def unclosed_block_tag(self, parse_until):
         raise self.error(None, "Unclosed tags: %s " % ', '.join(parse_until))
+
+    def compile_filter_error(self, token, e):
+        pass
 
     def compile_function_error(self, token, e):
         pass

--- a/django/template/debug.py
+++ b/django/template/debug.py
@@ -64,6 +64,10 @@ class DebugParser(Parser):
         msg = "Unclosed tag '%s'. Looking for one of: %s " % (command, ', '.join(parse_until))
         raise self.source_error(source, msg)
 
+    def compile_filter_error(self, token, e):
+        if not hasattr(e, 'django_template_source'):
+            e.django_template_source = token.source
+
     def compile_function_error(self, token, e):
         if not hasattr(e, 'django_template_source'):
             e.django_template_source = token.source


### PR DESCRIPTION
Wrap the Parser.compile_filter method call with a try/except and call the
newly added Parser.compile_filter_error(). Overwrite this method in the
DebugParser to throw the correct error.

Since this error was otherwise catched by the compile_function try/except
block the debugger highlighted the wrong line.
