### PR TITLE
Fixed #19812 - Duplicate phrase in documentation of MultiWidget

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -279,15 +279,13 @@ foundation for custom widgets.
         * A single value (e.g., a string) that is the "compressed" representation
           of a ``list`` of values.
 
-        If `value` is a list, output of :meth:`~MultiWidget.render` will be a
-        concatenation of rendered child widgets. If `value` is not a list, it
-        will be first processed by the method :meth:`~MultiWidget.decompress()`
-        to create the list and then processed as above.
+        In the first case, ``value`` is a list, output of :meth:`~MultiWidget.render` will be a
+        concatenation of rendered child widgets.
 
-        In the second case -- i.e., if the value is *not* a list --
-        ``render()`` will first decompress the value into a ``list`` before
-        rendering it. It does so by calling the ``decompress()`` method, which
-        :class:`MultiWidget`'s subclasses must implement (see above).
+        In the second case, ``value`` is *not* a list, ``render()`` will first
+	decompress the value into a ``list`` before rendering it. It does so by 
+	calling :meth:`~MultiWidget.decompress()`, which :class:`MultiWidget`'s
+	subclasses must implement.
 
         When ``render()`` executes its HTML rendering, each value in the list
         is rendered with the corresponding widget -- the first value is


### PR DESCRIPTION
Removed duplicate lines in the instructions and clarified the render(name, value, attrs=None) description.
