### PR TITLE
Fix for #18526

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -130,7 +130,7 @@ class BaseIncludeNode(Node):
         super(BaseIncludeNode, self).__init__(*args, **kwargs)
 
     def render_template(self, template, context):
-        values = dict([(name, var.resolve(context)) for name, var
+        values = dict([(name, var.resolve(context, ignore_failures=True)) for name, var
                        in six.iteritems(self.extra_context)])
         if self.isolated_context:
             return template.render(context.new(values))


### PR DESCRIPTION
This trivial change fixes #18526: {% with %} template tag shows strange behaviour if TEMPLATE_STRING_IF_INVALID is non-empty.

https://code.djangoproject.com/ticket/18526
