### PR TITLE
Added backwards compatibility with old unsalted SHA1 passwords

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -519,6 +519,7 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
+    'django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher',
     'django.contrib.auth.hashers.CryptPasswordHasher',
 )
 

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -135,6 +135,8 @@ def identify_hasher(encoded):
     if ((len(encoded) == 32 and '$' not in encoded) or
             (len(encoded) == 37 and encoded.startswith('md5$$'))):
         algorithm = 'unsalted_md5'
+    elif len(encoded) == 46 and encoded.startswith('sha1$$'):
+        algorithm = 'unsalted_sha1'
     else:
         algorithm = encoded.split('$', 1)[0]
     return get_hasher(algorithm)
@@ -384,7 +386,35 @@ class UnsaltedMD5PasswordHasher(BasePasswordHasher):
             (_('hash'), mask_hash(encoded, show=3)),
         ])
 
+class UnsaltedSHA1PasswordHasher(BasePasswordHasher):
+    """
+    I am an incredibly insecure algorithm you should *never* use;
+    stores unsalted MD5 hashes without the algorithm prefix.
 
+    This class is implemented because Django used to store passwords
+    this way. Some older Django installs still have these values
+    lingering around so we need to handle and upgrade them properly.
+    """
+    algorithm = "unsalted_sha1"
+
+    def salt(self):
+        return ''
+
+    def encode(self, password, salt):
+        return hashlib.sha1(password).hexdigest()
+
+    def verify(self, password, encoded):
+        if len(encoded) == 46 and encoded.startswith('sha1$$'):
+            encoded = encoded[6:]
+        encoded_2 = self.encode(password, '')
+        return constant_time_compare(encoded, encoded_2)
+
+    def safe_summary(self, encoded):
+        return SortedDict([
+            (_('algorithm'), self.algorithm),
+            (_('hash'), mask_hash(encoded, show=3)),
+        ])
+        
 class CryptPasswordHasher(BasePasswordHasher):
     """
     Password hashing using UNIX crypt (not recommended)

--- a/django/contrib/auth/tests/hashers.py
+++ b/django/contrib/auth/tests/hashers.py
@@ -72,6 +72,19 @@ class TestUtilsHashPass(unittest.TestCase):
         self.assertTrue(check_password('lètmein', alt_encoded))
         self.assertFalse(check_password('lètmeinz', alt_encoded))
 
+    def test_unsalted_sha1(self):
+        encoded = make_password('lètmein', 'seasalt', 'unsalted_sha1')
+        self.assertEqual(encoded, '38474bd98757137304be00938b15cef5b8ad9c98')
+        self.assertTrue(is_password_usable(encoded))
+        self.assertTrue(check_password(u'lètmein', encoded))
+        self.assertFalse(check_password('lètmeinz', encoded))
+        self.assertEqual(identify_hasher(encoded).algorithm, "unsalted_sha1")
+        # Alternate unsalted syntax
+        alt_encoded = "sha1$$%s" % encoded
+        self.assertTrue(is_password_usable(alt_encoded))
+        self.assertTrue(check_password(u'lètmein', alt_encoded))
+        self.assertFalse(check_password('lètmeinz', alt_encoded))
+
     @skipUnless(crypt, "no crypt module to generate password.")
     def test_crypt(self):
         encoded = make_password('lètmei', 'ab', 'crypt')


### PR DESCRIPTION
This is to fix ticket https://code.djangoproject.com/ticket/18144 for password stored in SHA1. It was already fixed for MD5.
