### PR TITLE
Fixes #19758 -- disables e-mail leaking through the password reset form

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_done.html
+++ b/django/contrib/admin/templates/registration/password_reset_done.html
@@ -14,6 +14,6 @@
 
 <h1>{% trans 'Password reset successful' %}</h1>
 
-<p>{% trans "We've emailed you instructions for setting your password to the email address you submitted. You should be receiving it shortly." %}</p>
+<p>{% trans "If you provided a registered e-mail address we've emailed you instructions for setting your password to the email address you submitted. You should be receiving it shortly." %}</p>
 
 {% endblock %}

--- a/django/contrib/auth/tests/forms.py
+++ b/django/contrib/auth/tests/forms.py
@@ -326,20 +326,28 @@ class PasswordResetFormTest(TestCase):
                          [force_text(EmailField.default_error_messages['invalid'])])
 
     def test_nonexistant_email(self):
-        # Test nonexistant email address
+        # Test nonexistant email address. This should not fail because it would
+        # expose information about registered users.
         data = {'email': 'foo@bar.com'}
         form = PasswordResetForm(data)
-        self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors,
-                         {'email': [force_text(form.error_messages['unknown'])]})
+        self.assertTrue(form.is_valid())
+        self.assertEquals(len(mail.outbox), 0)
 
+    @override_settings(
+        TEMPLATE_LOADERS=('django.template.loaders.filesystem.Loader',),
+        TEMPLATE_DIRS=(
+            os.path.join(os.path.dirname(upath(__file__)), 'templates'),
+        ),
+    )
     def test_cleaned_data(self):
         # Regression test
         (user, username, email) = self.create_dummy_user()
         data = {'email': email}
         form = PasswordResetForm(data)
         self.assertTrue(form.is_valid())
+        form.save(domain_override='example.com')
         self.assertEqual(form.cleaned_data['email'], email)
+        self.assertEqual(len(mail.outbox), 1)
 
     @override_settings(
         TEMPLATE_LOADERS=('django.template.loaders.filesystem.Loader',),
@@ -373,7 +381,8 @@ class PasswordResetFormTest(TestCase):
         user.is_active = False
         user.save()
         form = PasswordResetForm({'email': email})
-        self.assertFalse(form.is_valid())
+        self.assertTrue(form.is_valid())
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_unusable_password(self):
         user = User.objects.create_user('testuser', 'test@example.com', 'test')
@@ -383,9 +392,10 @@ class PasswordResetFormTest(TestCase):
         user.set_unusable_password()
         user.save()
         form = PasswordResetForm(data)
-        self.assertFalse(form.is_valid())
-        self.assertEqual(form["email"].errors,
-                         [_("The user account associated with this email address cannot reset the password.")])
+        # The form itself is valid, but no email is sent
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEquals(len(mail.outbox), 0)
 
 
 class ReadOnlyPasswordHashTest(TestCase):

--- a/django/contrib/auth/tests/views.py
+++ b/django/contrib/auth/tests/views.py
@@ -86,11 +86,12 @@ class AuthViewNamedURLTests(AuthViewsTestCase):
 class PasswordResetTest(AuthViewsTestCase):
 
     def test_email_not_found(self):
-        "Error is raised if the provided email address isn't currently registered"
+        """If the provided email is not registered, don't raise any error but
+        also don't send any email."""
         response = self.client.get('/password_reset/')
         self.assertEqual(response.status_code, 200)
         response = self.client.post('/password_reset/', {'email': 'not_a_real_email@email.com'})
-        self.assertFormError(response, PasswordResetForm.error_messages['unknown'])
+        self.assertEqual(response.status_code, 302)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_email_found(self):

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -742,11 +742,19 @@ patterns.
     Allows a user to reset their password by generating a one-time use link
     that can be used to reset the password, and sending that link to the
     user's registered email address.
+    
+    If the email provided does not exist in the system the user *will not*
+    receive any error message to prevent information leaking to potential
+    attckers. If your requirements expect an error message in this case you
+    can provide your own subclass of
+    :class:`~django.contrib.auth.forms.PasswordResetForm` that does just that.
 
     Users flagged with an unusable password (see
     :meth:`~django.contrib.auth.models.User.set_unusable_password()` aren't
     allowed to request a password reset to prevent misuse when using an
-    external authentication source like LDAP.
+    external authentication source like LDAP. Note that they won't receive
+    any error message since this would expose their account's existence but
+    no mail will be sent either.
 
     **URL name:** ``password_reset``
 


### PR DESCRIPTION
Ticket: #19758

PasswordResetForm's validation logic no longer checks if a provided email is registered in the system to prevent information leaking to attackers.

This patch includes updated unittests, docs and templates.
