### PR TITLE
Fixed tutorial02: Customizing project’s templates.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -74,11 +74,11 @@ After the previous tutorials, our project should look like this::
                     results.html
             urls.py
             views.py
-        mytemplates/
+        templates/
             admin/
                 base_site.html
 
-You created ``mysite/mytemplates`` in :doc:`Tutorial 2 </intro/tutorial02>`,
+You created ``mysite/templates`` in :doc:`Tutorial 2 </intro/tutorial02>`,
 and ``polls/templates`` in :doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps
 it is clearer why we chose to have separate template directories for the
 project and application: everything that is part of the polls application is in

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -404,7 +404,7 @@ system.
 Customizing your *project's* templates
 --------------------------------------
 
-Create a ``mytemplates`` directory in your project directory. Templates can
+Create a ``templates`` directory in your project directory. Templates can
 live anywhere on your filesystem that Django can access. (Django runs as
 whatever user your server runs.) However, keeping your templates within the
 project is a good convention to follow.
@@ -417,7 +417,7 @@ Open your settings file (``mysite/settings.py``, remember) and  add a
 :setting:`TEMPLATE_DIRS` is an iterable of filesystem directories to check when
 loading Django templates; it's a search path.
 
-Now create a directory called ``admin`` inside ``mytemplates``, and copy the
+Now create a directory called ``admin`` inside ``templates``, and copy the
 template ``admin/base_site.html`` from within the default Django admin
 template directory in the source code of Django itself
 (``django/contrib/admin/templates``) into that directory.


### PR DESCRIPTION
User should not put templates in `mysite/mytemplates/`. Instead,
templates should be in `mysite/templates/` which is a convention.

Otherwise, if we wanted to keep `mysite/mytemplates/` then the
staticfiles tutorial should use `mysite/mystatic/` and that would just
be confusing.

Other djangonauts sitting next to me at Utrecht sprint (also working on
staticfiles documentation revamp) were also in favor of this change.

Also, the docs now demonstrate the setting with a Python list instead of a
Python tuple, removing the special note about the trailing comma. The
rationnale for this is that it is out of the scope of this tutorial to learn
Python tuple usage.
