### PR TITLE
Fixed Python syntax error in staticfiles.serve

### DIFF
--- a/django/contrib/staticfiles/views.py
+++ b/django/contrib/staticfiles/views.py
@@ -17,7 +17,7 @@ from django.views import static
 
 from django.contrib.staticfiles import finders
 
-def serve(request, path insecure=False, **kwargs):
+def serve(request, path, insecure=False, **kwargs):
     """
     Serve static files below a given point in the directory structure or
     from locations inferred from the staticfiles finders.


### PR DESCRIPTION
Syntax fix against:

```
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/jpic/dj15/src/django/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/home/jpic/dj15/src/django/django/core/management/__init__.py", line 392, in execute  
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/jpic/dj15/src/django/django/core/management/__init__.py", line 272, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/home/jpic/dj15/src/django/django/core/management/__init__.py", line 77, in load_command_class 
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/home/jpic/dj15/src/django/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/home/jpic/dj15/src/django/django/contrib/staticfiles/management/commands/runserver.py", line 6, in <module>
    from django.contrib.staticfiles.handlers import StaticFilesHandler
  File "/home/jpic/dj15/src/django/django/contrib/staticfiles/handlers.py", line 13, in <module>
    from django.contrib.staticfiles.views import serve
  File "/home/jpic/dj15/src/django/django/contrib/staticfiles/views.py", line 20
    def serve(request, path insecure=False, **kwargs):
                                   ^
SyntaxError: invalid syntax
```
