### PR TITLE
Pass PostgreSQL password to psql via environment

### DIFF
--- a/django/db/backends/postgresql_psycopg2/client.py
+++ b/django/db/backends/postgresql_psycopg2/client.py
@@ -16,6 +16,7 @@ class DatabaseClient(BaseDatabaseClient):
         if settings_dict['PORT']:
             args.extend(["-p", str(settings_dict['PORT'])])
         args += [settings_dict['NAME']]
+        os.environ['PGPASSWORD'] = settings_dict['PASSWORD']
         if os.name == 'nt':
             sys.exit(os.system(" ".join(args)))
         else:


### PR DESCRIPTION
This removes a major annoyance when using PostgreSQL databases, which
require entering the password when running manage.py dbshell.

The password is passed via the environment and is accessible only to
users who have ptrace() access (at least on Linux), so it's not a
security risk.
