### PR TITLE
Fixed #19609: admin Inlines doesn't display help_text for readonly fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -590,6 +590,8 @@ answer newbie questions, and generally made Django that much better:
     ye7cakf02@sneakemail.com
     ymasuda@ethercube.com
     Jesse Young <adunar@gmail.com>
+    Marc Aymerich Gubern
+    Wiktor Kołodziej <wiktor@pykonik.org>
     Mykola Zamkovoi <nickzam@gmail.com>
     zegor
     Gasper Zejn <zejn@kiberpipa.org>

--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -224,19 +224,20 @@ class InlineAdminFormSet(object):
 
     def fields(self):
         fk = getattr(self.formset, "fk", None)
-        for i, field in enumerate(flatten_fieldsets(self.fieldsets)):
-            if fk and fk.name == field:
+        for i, field_name in enumerate(flatten_fieldsets(self.fieldsets)):
+            if fk and fk.name == field_name:
                 continue
-            if field in self.readonly_fields:
+            if field_name in self.readonly_fields:
                 yield {
-                    'label': label_for_field(field, self.opts.model, self.opts),
+                    'label': label_for_field(field_name, self.opts.model, self.opts),
                     'widget': {
                         'is_hidden': False
                     },
-                    'required': False
+                    'required': False,
+                    'help_text': help_text_for_field(field_name, self.opts.model),
                 }
             else:
-                yield self.formset.form.base_fields[field]
+                yield self.formset.form.base_fields[field_name]
 
     def _media(self):
         media = self.opts.media + self.formset.media

--- a/tests/regressiontests/admin_inlines/admin.py
+++ b/tests/regressiontests/admin_inlines/admin.py
@@ -28,6 +28,11 @@ class HolderAdmin(admin.ModelAdmin):
         js = ('my_awesome_admin_scripts.js',)
 
 
+class ReadOnlyInlineInline(admin.TabularInline):
+    model = ReadOnlyInline
+    readonly_fields = ['name']
+
+
 class InnerInline2(admin.StackedInline):
     model = Inner2
 
@@ -142,7 +147,7 @@ site.register(Novel, NovelAdmin)
 site.register(Fashionista, inlines=[InlineWeakness])
 site.register(Holder4, Holder4Admin)
 site.register(Author, AuthorAdmin)
-site.register(CapoFamiglia, inlines=[ConsigliereInline, SottoCapoInline])
+site.register(CapoFamiglia, inlines=[ConsigliereInline, SottoCapoInline, ReadOnlyInlineInline])
 site.register(ProfileCollection, inlines=[ProfileInline])
 site.register(ParentModelWithCustomPk, inlines=[ChildModel1Inline, ChildModel2Inline])
 site.register(ExtraTerrestrial, inlines=[SightingInline])

--- a/tests/regressiontests/admin_inlines/models.py
+++ b/tests/regressiontests/admin_inlines/models.py
@@ -130,7 +130,6 @@ class Novel(models.Model):
 class Chapter(models.Model):
     novel = models.ForeignKey(Novel)
 
-
 # Models for #16838
 
 class CapoFamiglia(models.Model):
@@ -138,13 +137,19 @@ class CapoFamiglia(models.Model):
 
 
 class Consigliere(models.Model):
-    name = models.CharField(max_length=100)
+    name = models.CharField(max_length=100, help_text='Help text for Consigliere')
     capo_famiglia = models.ForeignKey(CapoFamiglia, related_name='+')
 
 
 class SottoCapo(models.Model):
     name = models.CharField(max_length=100)
     capo_famiglia = models.ForeignKey(CapoFamiglia, related_name='+')
+
+
+class ReadOnlyInline(models.Model):
+    name = models.CharField(max_length=100, help_text='Help text for ReadOnlyInline')
+    capo_famiglia = models.ForeignKey(CapoFamiglia)
+
 
 # Models for #18433
 

--- a/tests/regressiontests/admin_inlines/tests.py
+++ b/tests/regressiontests/admin_inlines/tests.py
@@ -122,6 +122,10 @@ class TestInline(TestCase):
         response = self.client.get('/admin/admin_inlines/holder4/add/')
         self.assertContains(response, '<p class="help">Awesome stacked help text is awesome.</p>', 4)
         self.assertContains(response, '<img src="/static/admin/img/icon-unknown.gif" class="help help-tooltip" width="10" height="10" alt="(Awesome tabular help text is awesome.)" title="Awesome tabular help text is awesome." />', 1)
+        # ReadOnly fields
+        response = self.client.get('/admin/admin_inlines/capofamiglia/add/')
+        self.assertContains(response, '<img src="/static/admin/img/icon-unknown.gif" class="help help-tooltip" width="10" height="10" alt="(Help text for ReadOnlyInline)" title="Help text for ReadOnlyInline" />', 1)
+
 
     def test_non_related_name_inline(self):
         """


### PR DESCRIPTION
Fixed #19609: admin Inlines doesn't display help_text for readonly fields

Refactoring: field was renamed to field_name, since flatten_fieldsets returns field name, not field.

Original patch from Marc Aymerich Gubern
