### PR TITLE
docs about caching the javascript translation library

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -488,6 +488,8 @@ Cache keys also include the active :term:`language <language code>` when
 
 __ `Controlling cache: Using other headers`_
 
+.. _per-view-cache:
+
 The per-view cache
 ==================
 

--- a/docs/topics/conditional-view-processing.txt
+++ b/docs/topics/conditional-view-processing.txt
@@ -120,6 +120,8 @@ using one of these decorators::
         ...
     front_page = last_modified(latest_entry)(front_page)
 
+.. _conditional-decorators-testing-both-conditions:
+
 Use ``condition`` when testing both conditions
 ------------------------------------------------
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -887,6 +887,66 @@ directories listed in :setting:`LOCALE_PATHS` have the highest precedence with
 the ones appearing first having higher precedence than the ones appearing
 later.
 
+Note on performance
+-------------------
+
+When using ``django.views.i18n.javascript_catalog`` be aware that this view
+will generate the catalog on every request. This can lead to significant CPU loads.
+You can avoid this by caching the output of the view server-side.
+Also, you can consider to save on bandwidth by implementing client-side caching.
+
+You can achieve this by defining a function which you can cache by wrapping it using
+decorators provided by django.
+
+.. code-block:: python
+
+    from django.views.i18n import javascript_catalog
+
+    def cached_javascript_catalog(request, domain='djangojs', packages=None):
+        return javascript_catalog(request, domain, packages)
+
+* Server-side caching using the :ref:`@cache_page<per-view-cache>` decorator:
+
+.. code-block:: python
+
+    from django.views.decorators.cache import cache_page
+
+    # The get_version() function needs to be implemented to return a different
+    # value when you change translations.
+    key_prefix = 'js18n-%s' % get_version()
+    @cache_page(86400, key_prefix=key_prefix)
+        ...
+
+* Client-side caching by adding the If-Modified-Since header using the :doc:`@last_modified</topics/conditional-view-processing>` decorator:
+
+.. code-block:: python
+
+    from django.views.decorators.http import last_modified
+
+    last_modified_date = timezone.now()
+    @last_modified(lambda req, **kw: last_modified_date)
+        ...
+
+* Client-side caching by adding the Etag header using the :doc:`@etag</topics/conditional-view-processing>` decorator:
+
+.. code-block:: python
+
+    from django.views.decorators.http import etag
+
+    etag_value = 'js18n-%s' % get_version()
+    @etag(lambda req, **kw: etag_value)
+        ...
+
+You can combine the decorators but chaining the client-side decorators is not a good idea, as
+explained in the :ref:`conditional decorators<conditional-decorators-testing-both-conditions>` section.
+
+.. admonition:: Pre-generating the catalog files
+
+    Another strategy is generating the javascript catalog whenever you change translations.
+    These pre-generated files can then be served as part of your static files and thus these requests
+    will never hit your application. Be aware that these files are language specific so you will have
+    to generate them for all required languages. External projects exist which help you do this task.
+
 Using the JavaScript translation catalog
 ----------------------------------------
 


### PR DESCRIPTION
added docs about caching the javascript translation library as discussed on the django sprint 2013 in Utrecht.
ticket: https://code.djangoproject.com/ticket/6195
