### PR TITLE
Add a unit test to exercise chunking behavior

### DIFF
--- a/tests/regressiontests/builtin_server/tests.py
+++ b/tests/regressiontests/builtin_server/tests.py
@@ -53,3 +53,22 @@ class WSGIFileWrapperTests(TestCase):
         self.assertFalse(handler._used_sendfile)
         self.assertEqual(handler.stdout.getvalue().splitlines()[-1], b'Hello World!')
         self.assertEqual(handler.stderr.getvalue(), b'')
+
+#
+# tests for #18972: the logic that performs the math to break data into 32MB
+# chunks was flawed, but it didn't actually cause any problems.
+#
+
+def send_big_data_app(environ, start_response):
+    start_response(str('200 OK'), [(str('Content-Type'), str('text/plain'))])
+    # Return a blob of data that slightly exceeds chunk size
+    return [bytes('x' * (32 * 1024 * 1024 + 5))]
+
+class ServerHandlerChunksProperly(TestCase):
+    """Test that the ServerHandler chunks data properly"""
+
+    def test_chunked_data(self):
+        env = {'SERVER_PROTOCOL': 'HTTP/1.0'}
+        handler = ServerHandler(None, BytesIO(), BytesIO(), env)
+        handler.request_handler = DummyHandler()
+        handler.run(send_big_data_app)


### PR DESCRIPTION
Bug #18972 https://code.djangoproject.com/ticket/18972 reports that the math used by django.core.servers.basehttp.ServerHandler.write to break large data into chunks before writing is incorrect.This issue is valid, but since an array slice whose end exceeds the array's length automatically truncates, nothing actually breaks because of this mistake.

@doda has contributed a patch to address the problem, but no unit tests accompany it.

This commit adds a unit test that exercises the chunking code, proves that no data is currently lost, and allows for easy refactoring of the chunking code.
