### PR TITLE
Fixed #12674 -- provide a way to override admin validation

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -10,6 +10,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.admin import widgets, helpers
 from django.contrib.admin.util import (unquote, flatten_fieldsets, get_deleted_objects,
     model_format_dict, NestedObjects)
+from django.contrib.admin import validation
 from django.contrib.admin.templatetags.admin_static import static
 from django.contrib import messages
 from django.views.decorators.csrf import csrf_protect
@@ -86,6 +87,14 @@ class BaseModelAdmin(six.with_metaclass(RenameBaseModelAdminMethods)):
     formfield_overrides = {}
     readonly_fields = ()
     ordering = None
+
+    # validation
+    validator_class = validation.BaseValidator
+
+    @classmethod
+    def validate(cls, model):
+        validator = cls.validator_class()
+        validator.validate(cls, model)
 
     def __init__(self):
         overrides = FORMFIELD_FOR_DBFIELD_DEFAULTS.copy()
@@ -370,6 +379,9 @@ class ModelAdmin(BaseModelAdmin):
     actions_on_top = True
     actions_on_bottom = False
     actions_selection_counter = True
+
+    # validation
+    validator_class = validation.ModelAdminValidator
 
     def __init__(self, model, admin_site):
         self.model = model
@@ -1446,6 +1458,9 @@ class InlineModelAdmin(BaseModelAdmin):
     verbose_name = None
     verbose_name_plural = None
     can_delete = True
+
+    # validation
+    validator_class = validation.InlineValidator
 
     def __init__(self, parent_model, admin_site):
         self.admin_site = admin_site

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -66,12 +66,6 @@ class AdminSite(object):
         if not admin_class:
             admin_class = ModelAdmin
 
-        # Don't import the humongous validation code unless required
-        if admin_class and settings.DEBUG:
-            from django.contrib.admin.validation import validate
-        else:
-            validate = lambda model, adminclass: None
-
         if isinstance(model_or_iterable, ModelBase):
             model_or_iterable = [model_or_iterable]
         for model in model_or_iterable:
@@ -94,8 +88,8 @@ class AdminSite(object):
                     options['__module__'] = __name__
                     admin_class = type("%sAdmin" % model.__name__, (admin_class,), options)
 
-                # Validate (which might be a no-op)
-                validate(admin_class, model)
+                if admin_class is not ModelAdmin and settings.DEBUG:
+                    admin_class.validate(model)
 
                 # Instantiate the admin class to save in the registry
                 self._registry[model] = admin_class(model, self)

--- a/django/contrib/admin/validation.py
+++ b/django/contrib/admin/validation.py
@@ -3,358 +3,399 @@ from django.db import models
 from django.db.models.fields import FieldDoesNotExist
 from django.forms.models import (BaseModelForm, BaseModelFormSet, fields_for_model,
     _get_foreign_key)
-from django.contrib.admin import ListFilter, FieldListFilter
 from django.contrib.admin.util import get_fields_from_path, NotRelationField
-from django.contrib.admin.options import (flatten_fieldsets, BaseModelAdmin,
-    ModelAdmin, HORIZONTAL, VERTICAL)
+
+"""
+Does basic ModelAdmin option validation. Calls custom validation
+classmethod in the end if it is provided in cls. The signature of the
+custom validation classmethod should be: def validate(cls, model).
+"""
+
+__all__ = ['BaseValidator', 'InlineValidator']
 
 
-__all__ = ['validate']
+class BaseValidator(object):
+    def __init__(self):
+        # Before we can introspect models, they need to be fully loaded so that
+        # inter-relations are set up correctly. We force that here.
+        models.get_apps()
 
-def validate(cls, model):
-    """
-    Does basic ModelAdmin option validation. Calls custom validation
-    classmethod in the end if it is provided in cls. The signature of the
-    custom validation classmethod should be: def validate(cls, model).
-    """
-    # Before we can introspect models, they need to be fully loaded so that
-    # inter-relations are set up correctly. We force that here.
-    models.get_apps()
+    def validate(self, cls, model):
+        for m in dir(self):
+            if m.startswith('validate_'):
+                getattr(self, m)(cls, model)
 
-    opts = model._meta
-    validate_base(cls, model)
+    def check_field_spec(self, cls, model, flds, label):
+        """
+        Validate the fields specification in `flds` from a ModelAdmin subclass
+        `cls` for the `model` model. Use `label` for reporting problems to the user.
 
-    # list_display
-    if hasattr(cls, 'list_display'):
-        check_isseq(cls, 'list_display', cls.list_display)
-        for idx, field in enumerate(cls.list_display):
-            if not callable(field):
-                if not hasattr(cls, field):
-                    if not hasattr(model, field):
-                        try:
-                            opts.get_field(field)
-                        except models.FieldDoesNotExist:
-                            raise ImproperlyConfigured("%s.list_display[%d], %r is not a callable or an attribute of %r or found in the model %r."
-                                % (cls.__name__, idx, field, cls.__name__, model._meta.object_name))
-                    else:
-                        # getattr(model, field) could be an X_RelatedObjectsDescriptor
-                        f = fetch_attr(cls, model, opts, "list_display[%d]" % idx, field)
-                        if isinstance(f, models.ManyToManyField):
-                            raise ImproperlyConfigured("'%s.list_display[%d]', '%s' is a ManyToManyField which is not supported."
-                                % (cls.__name__, idx, field))
-
-    # list_display_links
-    if hasattr(cls, 'list_display_links'):
-        check_isseq(cls, 'list_display_links', cls.list_display_links)
-        for idx, field in enumerate(cls.list_display_links):
-            if field not in cls.list_display:
-                raise ImproperlyConfigured("'%s.list_display_links[%d]' "
-                        "refers to '%s' which is not defined in 'list_display'."
-                        % (cls.__name__, idx, field))
-
-    # list_filter
-    if hasattr(cls, 'list_filter'):
-        check_isseq(cls, 'list_filter', cls.list_filter)
-        for idx, item in enumerate(cls.list_filter):
-            # There are three options for specifying a filter:
-            #   1: 'field' - a basic field filter, possibly w/ relationships (eg, 'field__rel')
-            #   2: ('field', SomeFieldListFilter) - a field-based list filter class
-            #   3: SomeListFilter - a non-field list filter class
-            if callable(item) and not isinstance(item, models.Field):
-                # If item is option 3, it should be a ListFilter...
-                if not issubclass(item, ListFilter):
-                    raise ImproperlyConfigured("'%s.list_filter[%d]' is '%s'"
-                            " which is not a descendant of ListFilter."
-                            % (cls.__name__, idx, item.__name__))
-                # ...  but not a FieldListFilter.
-                if issubclass(item, FieldListFilter):
-                    raise ImproperlyConfigured("'%s.list_filter[%d]' is '%s'"
-                            " which is of type FieldListFilter but is not"
-                            " associated with a field name."
-                            % (cls.__name__, idx, item.__name__))
-            else:
-                if isinstance(item, (tuple, list)):
-                    # item is option #2
-                    field, list_filter_class = item
-                    if not issubclass(list_filter_class, FieldListFilter):
-                        raise ImproperlyConfigured("'%s.list_filter[%d][1]'"
-                            " is '%s' which is not of type FieldListFilter."
-                            % (cls.__name__, idx, list_filter_class.__name__))
-                else:
-                    # item is option #1
-                    field = item
-                # Validate the field string
+        The fields specification can be a ``fields`` option or a ``fields``
+        sub-option from a ``fieldsets`` option component.
+        """
+        for fields in flds:
+            # The entry in fields might be a tuple. If it is a standalone
+            # field, make it into a tuple to make processing easier.
+            if type(fields) != tuple:
+                fields = (fields,)
+            for field in fields:
+                if field in cls.readonly_fields:
+                    # Stuff can be put in fields that isn't actually a
+                    # model field if it's in readonly_fields,
+                    # readonly_fields will handle the validation of such
+                    # things.
+                    continue
                 try:
-                    get_fields_from_path(model, field)
-                except (NotRelationField, FieldDoesNotExist):
-                    raise ImproperlyConfigured("'%s.list_filter[%d]' refers to '%s'"
-                            " which does not refer to a Field."
+                    f = model._meta.get_field(field)
+                except models.FieldDoesNotExist:
+                    # If we can't find a field on the model that matches, it could be an
+                    # extra field on the form; nothing to check so move on to the next field.
+                    continue
+                if isinstance(f, models.ManyToManyField) and not f.rel.through._meta.auto_created:
+                    raise ImproperlyConfigured("'%s.%s' "
+                        "can't include the ManyToManyField field '%s' because "
+                        "'%s' manually specifies a 'through' model." % (
+                            cls.__name__, label, field, field))
+
+    def validate_raw_id_fields(self, cls, model):
+        " Validate that raw_id_fields only contains field names that are listed on the model. "
+        if hasattr(cls, 'raw_id_fields'):
+            check_isseq(cls, 'raw_id_fields', cls.raw_id_fields)
+            for idx, field in enumerate(cls.raw_id_fields):
+                f = get_field(cls, model, 'raw_id_fields', field)
+                if not isinstance(f, (models.ForeignKey, models.ManyToManyField)):
+                    raise ImproperlyConfigured("'%s.raw_id_fields[%d]', '%s' must "
+                            "be either a ForeignKey or ManyToManyField."
                             % (cls.__name__, idx, field))
 
-    # list_per_page = 100
-    if hasattr(cls, 'list_per_page') and not isinstance(cls.list_per_page, int):
-        raise ImproperlyConfigured("'%s.list_per_page' should be a integer."
-                % cls.__name__)
+    def validate_fields(self, cls, model):
+        " Validate that fields only refer to existing fields, doesn't contain duplicates. "
+        # fields
+        if cls.fields: # default value is None
+            check_isseq(cls, 'fields', cls.fields)
+            self.check_field_spec(cls, model, cls.fields, 'fields')
+            if cls.fieldsets:
+                raise ImproperlyConfigured('Both fieldsets and fields are specified in %s.' % cls.__name__)
+            if len(cls.fields) > len(set(cls.fields)):
+                raise ImproperlyConfigured('There are duplicate field(s) in %s.fields' % cls.__name__)
 
-    # list_max_show_all
-    if hasattr(cls, 'list_max_show_all') and not isinstance(cls.list_max_show_all, int):
-        raise ImproperlyConfigured("'%s.list_max_show_all' should be an integer."
-                % cls.__name__)
+    def validate_fieldsets(self, cls, model):
+        " Validate that fieldsets is properly formatted and doesn't contain duplicates. "
+        from django.contrib.admin.options import flatten_fieldsets
+        if cls.fieldsets: # default value is None
+            check_isseq(cls, 'fieldsets', cls.fieldsets)
+            for idx, fieldset in enumerate(cls.fieldsets):
+                check_isseq(cls, 'fieldsets[%d]' % idx, fieldset)
+                if len(fieldset) != 2:
+                    raise ImproperlyConfigured("'%s.fieldsets[%d]' does not "
+                            "have exactly two elements." % (cls.__name__, idx))
+                check_isdict(cls, 'fieldsets[%d][1]' % idx, fieldset[1])
+                if 'fields' not in fieldset[1]:
+                    raise ImproperlyConfigured("'fields' key is required in "
+                            "%s.fieldsets[%d][1] field options dict."
+                            % (cls.__name__, idx))
+                self.check_field_spec(cls, model, fieldset[1]['fields'], "fieldsets[%d][1]['fields']" % idx)
+            flattened_fieldsets = flatten_fieldsets(cls.fieldsets)
+            if len(flattened_fieldsets) > len(set(flattened_fieldsets)):
+                raise ImproperlyConfigured('There are duplicate field(s) in %s.fieldsets' % cls.__name__)
 
-    # list_editable
-    if hasattr(cls, 'list_editable') and cls.list_editable:
-        check_isseq(cls, 'list_editable', cls.list_editable)
-        for idx, field_name in enumerate(cls.list_editable):
-            try:
-                field = opts.get_field_by_name(field_name)[0]
-            except models.FieldDoesNotExist:
-                raise ImproperlyConfigured("'%s.list_editable[%d]' refers to a "
-                    "field, '%s', not defined on %s.%s."
-                    % (cls.__name__, idx, field_name, model._meta.app_label, model.__name__))
-            if field_name not in cls.list_display:
-                raise ImproperlyConfigured("'%s.list_editable[%d]' refers to "
-                    "'%s' which is not defined in 'list_display'."
-                    % (cls.__name__, idx, field_name))
-            if field_name in cls.list_display_links:
-                raise ImproperlyConfigured("'%s' cannot be in both '%s.list_editable'"
-                    " and '%s.list_display_links'"
-                    % (field_name, cls.__name__, cls.__name__))
-            if not cls.list_display_links and cls.list_display[0] in cls.list_editable:
-                raise ImproperlyConfigured("'%s.list_editable[%d]' refers to"
-                    " the first field in list_display, '%s', which can't be"
-                    " used unless list_display_links is set."
-                    % (cls.__name__, idx, cls.list_display[0]))
-            if not field.editable:
-                raise ImproperlyConfigured("'%s.list_editable[%d]' refers to a "
-                    "field, '%s', which isn't editable through the admin."
-                    % (cls.__name__, idx, field_name))
+    def validate_exclude(self, cls, model):
+        " Validate that exclude is a sequence without duplicates. "
+        if cls.exclude: # default value is None
+            check_isseq(cls, 'exclude', cls.exclude)
+            if len(cls.exclude) > len(set(cls.exclude)):
+                raise ImproperlyConfigured('There are duplicate field(s) in %s.exclude' % cls.__name__)
 
-    # search_fields = ()
-    if hasattr(cls, 'search_fields'):
-        check_isseq(cls, 'search_fields', cls.search_fields)
+    def validate_form(self, cls, model):
+        " Validate that form subclasses BaseModelForm. "
+        if hasattr(cls, 'form') and not issubclass(cls.form, BaseModelForm):
+            raise ImproperlyConfigured("%s.form does not inherit from "
+                    "BaseModelForm." % cls.__name__)
 
-    # date_hierarchy = None
-    if cls.date_hierarchy:
-        f = get_field(cls, model, opts, 'date_hierarchy', cls.date_hierarchy)
-        if not isinstance(f, (models.DateField, models.DateTimeField)):
-            raise ImproperlyConfigured("'%s.date_hierarchy is "
-                    "neither an instance of DateField nor DateTimeField."
-                    % cls.__name__)
+    def validate_filter_vertical(self, cls, model):
+        " Validate that filter_vertical is a sequence of field names. "
+        if hasattr(cls, 'filter_vertical'):
+            check_isseq(cls, 'filter_vertical', cls.filter_vertical)
+            for idx, field in enumerate(cls.filter_vertical):
+                f = get_field(cls, model, 'filter_vertical', field)
+                if not isinstance(f, models.ManyToManyField):
+                    raise ImproperlyConfigured("'%s.filter_vertical[%d]' must be "
+                        "a ManyToManyField." % (cls.__name__, idx))
 
-    # ordering = None
-    if cls.ordering:
-        check_isseq(cls, 'ordering', cls.ordering)
-        for idx, field in enumerate(cls.ordering):
-            if field == '?' and len(cls.ordering) != 1:
-                raise ImproperlyConfigured("'%s.ordering' has the random "
-                        "ordering marker '?', but contains other fields as "
-                        "well. Please either remove '?' or the other fields."
+    def validate_filter_horizontal(self, cls, model):
+        " Validate that filter_horizontal is a sequence of field names. "
+        if hasattr(cls, 'filter_horizontal'):
+            check_isseq(cls, 'filter_horizontal', cls.filter_horizontal)
+            for idx, field in enumerate(cls.filter_horizontal):
+                f = get_field(cls, model, 'filter_horizontal', field)
+                if not isinstance(f, models.ManyToManyField):
+                    raise ImproperlyConfigured("'%s.filter_horizontal[%d]' must be "
+                        "a ManyToManyField." % (cls.__name__, idx))
+
+    def validate_radio_fields(self, cls, model):
+        " Validate that radio_fields is a dictionary of choice or foreign key fields. "
+        from django.contrib.admin.options import HORIZONTAL, VERTICAL
+        if hasattr(cls, 'radio_fields'):
+            check_isdict(cls, 'radio_fields', cls.radio_fields)
+            for field, val in cls.radio_fields.items():
+                f = get_field(cls, model, 'radio_fields', field)
+                if not (isinstance(f, models.ForeignKey) or f.choices):
+                    raise ImproperlyConfigured("'%s.radio_fields['%s']' "
+                            "is neither an instance of ForeignKey nor does "
+                            "have choices set." % (cls.__name__, field))
+                if not val in (HORIZONTAL, VERTICAL):
+                    raise ImproperlyConfigured("'%s.radio_fields['%s']' "
+                            "is neither admin.HORIZONTAL nor admin.VERTICAL."
+                            % (cls.__name__, field))
+
+    def validate_prepopulated_fields(self, cls, model):
+        " Validate that prepopulated_fields if a dictionary  containing allowed field types. "
+        # prepopulated_fields
+        if hasattr(cls, 'prepopulated_fields'):
+            check_isdict(cls, 'prepopulated_fields', cls.prepopulated_fields)
+            for field, val in cls.prepopulated_fields.items():
+                f = get_field(cls, model, 'prepopulated_fields', field)
+                if isinstance(f, (models.DateTimeField, models.ForeignKey,
+                    models.ManyToManyField)):
+                    raise ImproperlyConfigured("'%s.prepopulated_fields['%s']' "
+                            "is either a DateTimeField, ForeignKey or "
+                            "ManyToManyField. This isn't allowed."
+                            % (cls.__name__, field))
+                check_isseq(cls, "prepopulated_fields['%s']" % field, val)
+                for idx, f in enumerate(val):
+                    get_field(cls, model, "prepopulated_fields['%s'][%d]" % (field, idx), f)
+
+    def validate_ordering(self, cls, model):
+        " Validate that ordering refers to existing fields or is random. "
+        # ordering = None
+        if cls.ordering:
+            check_isseq(cls, 'ordering', cls.ordering)
+            for idx, field in enumerate(cls.ordering):
+                if field == '?' and len(cls.ordering) != 1:
+                    raise ImproperlyConfigured("'%s.ordering' has the random "
+                            "ordering marker '?', but contains other fields as "
+                            "well. Please either remove '?' or the other fields."
+                            % cls.__name__)
+                if field == '?':
+                    continue
+                if field.startswith('-'):
+                    field = field[1:]
+                # Skip ordering in the format field1__field2 (FIXME: checking
+                # this format would be nice, but it's a little fiddly).
+                if '__' in field:
+                    continue
+                get_field(cls, model, 'ordering[%d]' % idx, field)
+
+    def validate_readonly_fields(self, cls, model):
+        " Validate that readonly_fields refers to proper attribute or field. "
+        if hasattr(cls, "readonly_fields"):
+            check_isseq(cls, "readonly_fields", cls.readonly_fields)
+            for idx, field in enumerate(cls.readonly_fields):
+                if not callable(field):
+                    if not hasattr(cls, field):
+                        if not hasattr(model, field):
+                            try:
+                                model._meta.get_field(field)
+                            except models.FieldDoesNotExist:
+                                raise ImproperlyConfigured("%s.readonly_fields[%d], %r is not a callable or an attribute of %r or found in the model %r."
+                                    % (cls.__name__, idx, field, cls.__name__, model._meta.object_name))
+
+
+class ModelAdminValidator(BaseValidator):
+    def validate_save_as(self, cls, model):
+        " Validate save_as is a boolean. "
+        check_type(cls, 'save_as', bool)
+
+    def validate_save_on_top(self, cls, model):
+        " Validate save_on_top is a boolean. "
+        check_type(cls, 'save_on_top', bool)
+
+    def validate_inlines(self, cls, model):
+        " Validate inline model admin classes. "
+        from django.contrib.admin.options import BaseModelAdmin
+        if hasattr(cls, 'inlines'):
+            check_isseq(cls, 'inlines', cls.inlines)
+            for idx, inline in enumerate(cls.inlines):
+                if not issubclass(inline, BaseModelAdmin):
+                    raise ImproperlyConfigured("'%s.inlines[%d]' does not inherit "
+                            "from BaseModelAdmin." % (cls.__name__, idx))
+                if not inline.model:
+                    raise ImproperlyConfigured("'model' is a required attribute "
+                            "of '%s.inlines[%d]'." % (cls.__name__, idx))
+                if not issubclass(inline.model, models.Model):
+                    raise ImproperlyConfigured("'%s.inlines[%d].model' does not "
+                            "inherit from models.Model." % (cls.__name__, idx))
+                inline.validate(inline.model)
+                self.check_inline(inline, model)
+
+    def check_inline(self, cls, parent_model):
+        " Validate inline class's fk field is not excluded. "
+        fk = _get_foreign_key(parent_model, cls.model, fk_name=cls.fk_name, can_fail=True)
+        if hasattr(cls, 'exclude') and cls.exclude:
+            if fk and fk.name in cls.exclude:
+                raise ImproperlyConfigured("%s cannot exclude the field "
+                        "'%s' - this is the foreign key to the parent model "
+                        "%s.%s." % (cls.__name__, fk.name, parent_model._meta.app_label, parent_model.__name__))
+
+    def validate_list_display(self, cls, model):
+        " Validate that list_display only contains fields or usable attributes. "
+        if hasattr(cls, 'list_display'):
+            check_isseq(cls, 'list_display', cls.list_display)
+            for idx, field in enumerate(cls.list_display):
+                if not callable(field):
+                    if not hasattr(cls, field):
+                        if not hasattr(model, field):
+                            try:
+                                model._meta.get_field(field)
+                            except models.FieldDoesNotExist:
+                                raise ImproperlyConfigured("%s.list_display[%d], %r is not a callable or an attribute of %r or found in the model %r."
+                                    % (cls.__name__, idx, field, cls.__name__, model._meta.object_name))
+                        else:
+                            # getattr(model, field) could be an X_RelatedObjectsDescriptor
+                            f = fetch_attr(cls, model, "list_display[%d]" % idx, field)
+                            if isinstance(f, models.ManyToManyField):
+                                raise ImproperlyConfigured("'%s.list_display[%d]', '%s' is a ManyToManyField which is not supported."
+                                    % (cls.__name__, idx, field))
+
+    def validate_list_display_links(self, cls, model):
+        " Validate that list_display_links is a unique subset of list_display. "
+        if hasattr(cls, 'list_display_links'):
+            check_isseq(cls, 'list_display_links', cls.list_display_links)
+            for idx, field in enumerate(cls.list_display_links):
+                if field not in cls.list_display:
+                    raise ImproperlyConfigured("'%s.list_display_links[%d]' "
+                            "refers to '%s' which is not defined in 'list_display'."
+                            % (cls.__name__, idx, field))
+
+    def validate_list_filter(self, cls, model):
+        """
+        Validate that list_filter is a sequence of one of three options:
+            1: 'field' - a basic field filter, possibly w/ relationships (eg, 'field__rel')
+            2: ('field', SomeFieldListFilter) - a field-based list filter class
+            3: SomeListFilter - a non-field list filter class
+        """
+        from django.contrib.admin import ListFilter, FieldListFilter
+        if hasattr(cls, 'list_filter'):
+            check_isseq(cls, 'list_filter', cls.list_filter)
+            for idx, item in enumerate(cls.list_filter):
+                if callable(item) and not isinstance(item, models.Field):
+                    # If item is option 3, it should be a ListFilter...
+                    if not issubclass(item, ListFilter):
+                        raise ImproperlyConfigured("'%s.list_filter[%d]' is '%s'"
+                                " which is not a descendant of ListFilter."
+                                % (cls.__name__, idx, item.__name__))
+                    # ...  but not a FieldListFilter.
+                    if issubclass(item, FieldListFilter):
+                        raise ImproperlyConfigured("'%s.list_filter[%d]' is '%s'"
+                                " which is of type FieldListFilter but is not"
+                                " associated with a field name."
+                                % (cls.__name__, idx, item.__name__))
+                else:
+                    if isinstance(item, (tuple, list)):
+                        # item is option #2
+                        field, list_filter_class = item
+                        if not issubclass(list_filter_class, FieldListFilter):
+                            raise ImproperlyConfigured("'%s.list_filter[%d][1]'"
+                                " is '%s' which is not of type FieldListFilter."
+                                % (cls.__name__, idx, list_filter_class.__name__))
+                    else:
+                        # item is option #1
+                        field = item
+                    # Validate the field string
+                    try:
+                        get_fields_from_path(model, field)
+                    except (NotRelationField, FieldDoesNotExist):
+                        raise ImproperlyConfigured("'%s.list_filter[%d]' refers to '%s'"
+                                " which does not refer to a Field."
+                                % (cls.__name__, idx, field))
+
+    def validate_list_select_related(self, cls, model):
+        " Validate that list_select_related is a boolean. "
+        check_type(cls, 'list_select_related', bool)
+
+    def validate_list_per_page(self, cls, model):
+        " Validate that list_per_page is an integer. "
+        check_type(cls, 'list_per_page', int)
+
+    def validate_list_max_show_all(self, cls, model):
+        " Validate that list_max_show_all is an integer. "
+        check_type(cls, 'list_max_show_all', int)
+
+    def validate_list_editable(self, cls, model):
+        """
+        Validate that list_editable is a sequence of editable fields from
+        list_display without first element.
+        """
+        if hasattr(cls, 'list_editable') and cls.list_editable:
+            check_isseq(cls, 'list_editable', cls.list_editable)
+            for idx, field_name in enumerate(cls.list_editable):
+                try:
+                    field = model._meta.get_field_by_name(field_name)[0]
+                except models.FieldDoesNotExist:
+                    raise ImproperlyConfigured("'%s.list_editable[%d]' refers to a "
+                        "field, '%s', not defined on %s.%s."
+                        % (cls.__name__, idx, field_name, model._meta.app_label, model.__name__))
+                if field_name not in cls.list_display:
+                    raise ImproperlyConfigured("'%s.list_editable[%d]' refers to "
+                        "'%s' which is not defined in 'list_display'."
+                        % (cls.__name__, idx, field_name))
+                if field_name in cls.list_display_links:
+                    raise ImproperlyConfigured("'%s' cannot be in both '%s.list_editable'"
+                        " and '%s.list_display_links'"
+                        % (field_name, cls.__name__, cls.__name__))
+                if not cls.list_display_links and cls.list_display[0] in cls.list_editable:
+                    raise ImproperlyConfigured("'%s.list_editable[%d]' refers to"
+                        " the first field in list_display, '%s', which can't be"
+                        " used unless list_display_links is set."
+                        % (cls.__name__, idx, cls.list_display[0]))
+                if not field.editable:
+                    raise ImproperlyConfigured("'%s.list_editable[%d]' refers to a "
+                        "field, '%s', which isn't editable through the admin."
+                        % (cls.__name__, idx, field_name))
+
+    def validate_search_fields(self, cls, model):
+        " Validate search_fields is a sequence. "
+        if hasattr(cls, 'search_fields'):
+            check_isseq(cls, 'search_fields', cls.search_fields)
+
+    def validate_date_hierarchy(self, cls, model):
+        " Validate that date_hierarchy refers to DateField or DateTimeField. "
+        if cls.date_hierarchy:
+            f = get_field(cls, model, 'date_hierarchy', cls.date_hierarchy)
+            if not isinstance(f, (models.DateField, models.DateTimeField)):
+                raise ImproperlyConfigured("'%s.date_hierarchy is "
+                        "neither an instance of DateField nor DateTimeField."
                         % cls.__name__)
-            if field == '?':
-                continue
-            if field.startswith('-'):
-                field = field[1:]
-            # Skip ordering in the format field1__field2 (FIXME: checking
-            # this format would be nice, but it's a little fiddly).
-            if '__' in field:
-                continue
-            get_field(cls, model, opts, 'ordering[%d]' % idx, field)
-
-    if hasattr(cls, "readonly_fields"):
-        check_readonly_fields(cls, model, opts)
-
-    # list_select_related = False
-    # save_as = False
-    # save_on_top = False
-    for attr in ('list_select_related', 'save_as', 'save_on_top'):
-        if not isinstance(getattr(cls, attr), bool):
-            raise ImproperlyConfigured("'%s.%s' should be a boolean."
-                    % (cls.__name__, attr))
 
 
-    # inlines = []
-    if hasattr(cls, 'inlines'):
-        check_isseq(cls, 'inlines', cls.inlines)
-        for idx, inline in enumerate(cls.inlines):
-            if not issubclass(inline, BaseModelAdmin):
-                raise ImproperlyConfigured("'%s.inlines[%d]' does not inherit "
-                        "from BaseModelAdmin." % (cls.__name__, idx))
-            if not inline.model:
-                raise ImproperlyConfigured("'model' is a required attribute "
-                        "of '%s.inlines[%d]'." % (cls.__name__, idx))
-            if not issubclass(inline.model, models.Model):
-                raise ImproperlyConfigured("'%s.inlines[%d].model' does not "
-                        "inherit from models.Model." % (cls.__name__, idx))
-            validate_base(inline, inline.model)
-            validate_inline(inline, cls, model)
+class InlineValidator(BaseValidator):
+    def validate_fk_name(self, cls, model):
+        " Validate that fk_name refers to a ForeignKey. "
+        if cls.fk_name: # default value is None
+            f = get_field(cls, model, 'fk_name', cls.fk_name)
+            if not isinstance(f, models.ForeignKey):
+                raise ImproperlyConfigured("'%s.fk_name is not an instance of "
+                        "models.ForeignKey." % cls.__name__)
 
-def validate_inline(cls, parent, parent_model):
+    def validate_extra(self, cls, model):
+        " Validate that extra is an integer. "
+        check_type(cls, 'extra', int)
 
-    # model is already verified to exist and be a Model
-    if cls.fk_name: # default value is None
-        f = get_field(cls, cls.model, cls.model._meta, 'fk_name', cls.fk_name)
-        if not isinstance(f, models.ForeignKey):
-            raise ImproperlyConfigured("'%s.fk_name is not an instance of "
-                    "models.ForeignKey." % cls.__name__)
+    def validate_max_num(self, cls, model):
+        " Validate that max_num is an integer. "
+        check_type(cls, 'max_num', int)
 
-    fk = _get_foreign_key(parent_model, cls.model, fk_name=cls.fk_name, can_fail=True)
+    def validate_formset(self, cls, model):
+        " Validate formset is a subclass of BaseModelFormSet. "
+        if hasattr(cls, 'formset') and not issubclass(cls.formset, BaseModelFormSet):
+            raise ImproperlyConfigured("'%s.formset' does not inherit from "
+                    "BaseModelFormSet." % cls.__name__)
 
-    # extra = 3
-    if not isinstance(cls.extra, int):
-        raise ImproperlyConfigured("'%s.extra' should be a integer."
-                % cls.__name__)
 
-    # max_num = None
-    max_num = getattr(cls, 'max_num', None)
-    if max_num is not None and not isinstance(max_num, int):
-        raise ImproperlyConfigured("'%s.max_num' should be an integer or None (default)."
-                % cls.__name__)
-
-    # formset
-    if hasattr(cls, 'formset') and not issubclass(cls.formset, BaseModelFormSet):
-        raise ImproperlyConfigured("'%s.formset' does not inherit from "
-                "BaseModelFormSet." % cls.__name__)
-
-    # exclude
-    if hasattr(cls, 'exclude') and cls.exclude:
-        if fk and fk.name in cls.exclude:
-            raise ImproperlyConfigured("%s cannot exclude the field "
-                    "'%s' - this is the foreign key to the parent model "
-                    "%s.%s." % (cls.__name__, fk.name, parent_model._meta.app_label, parent_model.__name__))
-
-    if hasattr(cls, "readonly_fields"):
-        check_readonly_fields(cls, cls.model, cls.model._meta)
-
-def validate_fields_spec(cls, model, opts, flds, label):
-    """
-    Validate the fields specification in `flds` from a ModelAdmin subclass
-    `cls` for the `model` model. `opts` is `model`'s Meta inner class.
-    Use `label` for reporting problems to the user.
-
-    The fields specification can be a ``fields`` option or a ``fields``
-    sub-option from a ``fieldsets`` option component.
-    """
-    for fields in flds:
-        # The entry in fields might be a tuple. If it is a standalone
-        # field, make it into a tuple to make processing easier.
-        if type(fields) != tuple:
-            fields = (fields,)
-        for field in fields:
-            if field in cls.readonly_fields:
-                # Stuff can be put in fields that isn't actually a
-                # model field if it's in readonly_fields,
-                # readonly_fields will handle the validation of such
-                # things.
-                continue
-            try:
-                f = opts.get_field(field)
-            except models.FieldDoesNotExist:
-                # If we can't find a field on the model that matches, it could be an
-                # extra field on the form; nothing to check so move on to the next field.
-                continue
-            if isinstance(f, models.ManyToManyField) and not f.rel.through._meta.auto_created:
-                raise ImproperlyConfigured("'%s.%s' "
-                    "can't include the ManyToManyField field '%s' because "
-                    "'%s' manually specifies a 'through' model." % (
-                        cls.__name__, label, field, field))
-
-def validate_base(cls, model):
-    opts = model._meta
-
-    # raw_id_fields
-    if hasattr(cls, 'raw_id_fields'):
-        check_isseq(cls, 'raw_id_fields', cls.raw_id_fields)
-        for idx, field in enumerate(cls.raw_id_fields):
-            f = get_field(cls, model, opts, 'raw_id_fields', field)
-            if not isinstance(f, (models.ForeignKey, models.ManyToManyField)):
-                raise ImproperlyConfigured("'%s.raw_id_fields[%d]', '%s' must "
-                        "be either a ForeignKey or ManyToManyField."
-                        % (cls.__name__, idx, field))
-
-    # fields
-    if cls.fields: # default value is None
-        check_isseq(cls, 'fields', cls.fields)
-        validate_fields_spec(cls, model, opts, cls.fields, 'fields')
-        if cls.fieldsets:
-            raise ImproperlyConfigured('Both fieldsets and fields are specified in %s.' % cls.__name__)
-        if len(cls.fields) > len(set(cls.fields)):
-            raise ImproperlyConfigured('There are duplicate field(s) in %s.fields' % cls.__name__)
-
-    # fieldsets
-    if cls.fieldsets: # default value is None
-        check_isseq(cls, 'fieldsets', cls.fieldsets)
-        for idx, fieldset in enumerate(cls.fieldsets):
-            check_isseq(cls, 'fieldsets[%d]' % idx, fieldset)
-            if len(fieldset) != 2:
-                raise ImproperlyConfigured("'%s.fieldsets[%d]' does not "
-                        "have exactly two elements." % (cls.__name__, idx))
-            check_isdict(cls, 'fieldsets[%d][1]' % idx, fieldset[1])
-            if 'fields' not in fieldset[1]:
-                raise ImproperlyConfigured("'fields' key is required in "
-                        "%s.fieldsets[%d][1] field options dict."
-                        % (cls.__name__, idx))
-            validate_fields_spec(cls, model, opts, fieldset[1]['fields'], "fieldsets[%d][1]['fields']" % idx)
-        flattened_fieldsets = flatten_fieldsets(cls.fieldsets)
-        if len(flattened_fieldsets) > len(set(flattened_fieldsets)):
-            raise ImproperlyConfigured('There are duplicate field(s) in %s.fieldsets' % cls.__name__)
-
-    # exclude
-    if cls.exclude: # default value is None
-        check_isseq(cls, 'exclude', cls.exclude)
-        if len(cls.exclude) > len(set(cls.exclude)):
-            raise ImproperlyConfigured('There are duplicate field(s) in %s.exclude' % cls.__name__)
-
-    # form
-    if hasattr(cls, 'form') and not issubclass(cls.form, BaseModelForm):
-        raise ImproperlyConfigured("%s.form does not inherit from "
-                "BaseModelForm." % cls.__name__)
-
-    # filter_vertical
-    if hasattr(cls, 'filter_vertical'):
-        check_isseq(cls, 'filter_vertical', cls.filter_vertical)
-        for idx, field in enumerate(cls.filter_vertical):
-            f = get_field(cls, model, opts, 'filter_vertical', field)
-            if not isinstance(f, models.ManyToManyField):
-                raise ImproperlyConfigured("'%s.filter_vertical[%d]' must be "
-                    "a ManyToManyField." % (cls.__name__, idx))
-
-    # filter_horizontal
-    if hasattr(cls, 'filter_horizontal'):
-        check_isseq(cls, 'filter_horizontal', cls.filter_horizontal)
-        for idx, field in enumerate(cls.filter_horizontal):
-            f = get_field(cls, model, opts, 'filter_horizontal', field)
-            if not isinstance(f, models.ManyToManyField):
-                raise ImproperlyConfigured("'%s.filter_horizontal[%d]' must be "
-                    "a ManyToManyField." % (cls.__name__, idx))
-
-    # radio_fields
-    if hasattr(cls, 'radio_fields'):
-        check_isdict(cls, 'radio_fields', cls.radio_fields)
-        for field, val in cls.radio_fields.items():
-            f = get_field(cls, model, opts, 'radio_fields', field)
-            if not (isinstance(f, models.ForeignKey) or f.choices):
-                raise ImproperlyConfigured("'%s.radio_fields['%s']' "
-                        "is neither an instance of ForeignKey nor does "
-                        "have choices set." % (cls.__name__, field))
-            if not val in (HORIZONTAL, VERTICAL):
-                raise ImproperlyConfigured("'%s.radio_fields['%s']' "
-                        "is neither admin.HORIZONTAL nor admin.VERTICAL."
-                        % (cls.__name__, field))
-
-    # prepopulated_fields
-    if hasattr(cls, 'prepopulated_fields'):
-        check_isdict(cls, 'prepopulated_fields', cls.prepopulated_fields)
-        for field, val in cls.prepopulated_fields.items():
-            f = get_field(cls, model, opts, 'prepopulated_fields', field)
-            if isinstance(f, (models.DateTimeField, models.ForeignKey,
-                models.ManyToManyField)):
-                raise ImproperlyConfigured("'%s.prepopulated_fields['%s']' "
-                        "is either a DateTimeField, ForeignKey or "
-                        "ManyToManyField. This isn't allowed."
-                        % (cls.__name__, field))
-            check_isseq(cls, "prepopulated_fields['%s']" % field, val)
-            for idx, f in enumerate(val):
-                get_field(cls, model, opts, "prepopulated_fields['%s'][%d]" % (field, idx), f)
+def check_type(cls, attr, type_):
+    if getattr(cls, attr, None) is not None and not isinstance(getattr(cls, attr), type_):
+        raise ImproperlyConfigured("'%s.%s' should be a %s."
+                % (cls.__name__, attr, type_.__name__ ))
 
 def check_isseq(cls, label, obj):
     if not isinstance(obj, (list, tuple)):
@@ -364,16 +405,16 @@ def check_isdict(cls, label, obj):
     if not isinstance(obj, dict):
         raise ImproperlyConfigured("'%s.%s' must be a dictionary." % (cls.__name__, label))
 
-def get_field(cls, model, opts, label, field):
+def get_field(cls, model, label, field):
     try:
-        return opts.get_field(field)
+        return model._meta.get_field(field)
     except models.FieldDoesNotExist:
         raise ImproperlyConfigured("'%s.%s' refers to field '%s' that is missing from model '%s.%s'."
                 % (cls.__name__, label, field, model._meta.app_label, model.__name__))
 
-def fetch_attr(cls, model, opts, label, field):
+def fetch_attr(cls, model, label, field):
     try:
-        return opts.get_field(field)
+        return model._meta.get_field(field)
     except models.FieldDoesNotExist:
         pass
     try:
@@ -381,15 +422,3 @@ def fetch_attr(cls, model, opts, label, field):
     except AttributeError:
         raise ImproperlyConfigured("'%s.%s' refers to '%s' that is neither a field, method or property of model '%s.%s'."
             % (cls.__name__, label, field, model._meta.app_label, model.__name__))
-
-def check_readonly_fields(cls, model, opts):
-    check_isseq(cls, "readonly_fields", cls.readonly_fields)
-    for idx, field in enumerate(cls.readonly_fields):
-        if not callable(field):
-            if not hasattr(cls, field):
-                if not hasattr(model, field):
-                    try:
-                        opts.get_field(field)
-                    except models.FieldDoesNotExist:
-                        raise ImproperlyConfigured("%s.readonly_fields[%d], %r is not a callable or an attribute of %r or found in the model %r."
-                            % (cls.__name__, idx, field, cls.__name__, model._meta.object_name))

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.admin.options import (ModelAdmin, TabularInline,
      HORIZONTAL, VERTICAL)
 from django.contrib.admin.sites import AdminSite
-from django.contrib.admin.validation import validate
 from django.contrib.admin.widgets import AdminDateWidget, AdminRadioSelect
 from django.contrib.admin import (SimpleListFilter,
      BooleanFieldListFilter)
@@ -523,8 +522,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.raw_id_fields' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -534,8 +532,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.raw_id_fields' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -545,15 +542,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.raw_id_fields\[0\]', 'name' must be either a ForeignKey or ManyToManyField.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             raw_id_fields = ('users',)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_fieldsets_validation(self):
 
@@ -563,8 +559,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.fieldsets' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -574,8 +569,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.fieldsets\[0\]' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -585,8 +579,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.fieldsets\[0\]' does not have exactly two elements.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -596,8 +589,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.fieldsets\[0\]\[1\]' must be a dictionary.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -607,15 +599,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'fields' key is required in ValidationTestModelAdmin.fieldsets\[0\]\[1\] field options dict.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             fieldsets = (("General", {"fields": ("name",)}),)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
         class ValidationTestModelAdmin(ModelAdmin):
             fieldsets = (("General", {"fields": ("name",)}),)
@@ -624,8 +615,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "Both fieldsets and fields are specified in ValidationTestModelAdmin.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -635,8 +625,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "There are duplicate field\(s\) in ValidationTestModelAdmin.fieldsets",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -646,8 +635,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "There are duplicate field\(s\) in ValidationTestModelAdmin.fields",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -662,8 +650,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "ValidationTestModelAdmin.form does not inherit from BaseModelForm.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -676,7 +663,7 @@ class ValidationTests(unittest.TestCase):
                 }),
             )
 
-        validate(BandAdmin, Band)
+        BandAdmin.validate(Band)
 
         class AdminBandForm(forms.ModelForm):
             delete = forms.BooleanField()
@@ -690,7 +677,7 @@ class ValidationTests(unittest.TestCase):
                 }),
             )
 
-        validate(BandAdmin, Band)
+        BandAdmin.validate(Band)
 
     def test_filter_vertical_validation(self):
 
@@ -700,8 +687,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_vertical' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -711,8 +697,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_vertical' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -722,15 +707,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_vertical\[0\]' must be a ManyToManyField.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             filter_vertical = ("users",)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_filter_horizontal_validation(self):
 
@@ -740,8 +724,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_horizontal' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -751,8 +734,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_horizontal' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -762,15 +744,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.filter_horizontal\[0\]' must be a ManyToManyField.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             filter_horizontal = ("users",)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_radio_fields_validation(self):
 
@@ -780,8 +761,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.radio_fields' must be a dictionary.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -791,8 +771,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.radio_fields' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -802,8 +781,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.radio_fields\['name'\]' is neither an instance of ForeignKey nor does have choices set.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -813,15 +791,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.radio_fields\['state'\]' is neither admin.HORIZONTAL nor admin.VERTICAL.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             radio_fields = {"state": VERTICAL}
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_prepopulated_fields_validation(self):
 
@@ -831,8 +808,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.prepopulated_fields' must be a dictionary.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -842,8 +818,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.prepopulated_fields' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -853,8 +828,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.prepopulated_fields\['slug'\]\[0\]' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -864,15 +838,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.prepopulated_fields\['users'\]' is either a DateTimeField, ForeignKey or ManyToManyField. This isn't allowed.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             prepopulated_fields = {"slug": ("name",)}
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_list_display_validation(self):
 
@@ -882,8 +855,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_display' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -893,8 +865,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             str_prefix("ValidationTestModelAdmin.list_display\[0\], %(_)s'non_existent_field' is not a callable or an attribute of 'ValidationTestModelAdmin' or found in the model 'ValidationTestModel'."),
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -904,8 +875,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_display\[0\]', 'users' is a ManyToManyField which is not supported.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -917,7 +887,7 @@ class ValidationTests(unittest.TestCase):
                 pass
             list_display = ('name', 'decade_published_in', 'a_method', a_callable)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_list_display_links_validation(self):
 
@@ -927,8 +897,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_display_links' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -938,8 +907,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_display_links\[0\]' refers to 'non_existent_field' which is not defined in 'list_display'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -949,8 +917,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_display_links\[0\]' refers to 'name' which is not defined in 'list_display'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -963,7 +930,7 @@ class ValidationTests(unittest.TestCase):
             list_display = ('name', 'decade_published_in', 'a_method', a_callable)
             list_display_links = ('name', 'decade_published_in', 'a_method', a_callable)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_list_filter_validation(self):
 
@@ -973,8 +940,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -984,8 +950,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter\[0\]' refers to 'non_existent_field' which does not refer to a Field.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -998,8 +963,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter\[0\]' is 'RandomClass' which is not a descendant of ListFilter.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1009,8 +973,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter\[0\]\[1\]' is 'RandomClass' which is not of type FieldListFilter.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1028,8 +991,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter\[0\]\[1\]' is 'AwesomeFilter' which is not of type FieldListFilter.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1039,8 +1001,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.list_filter\[0\]' is 'BooleanFieldListFilter' which is of type FieldListFilter but is not associated with a field name.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1049,7 +1010,7 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             list_filter = ('is_active', AwesomeFilter, ('is_active', BooleanFieldListFilter), 'no')
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_list_per_page_validation(self):
 
@@ -1058,16 +1019,15 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestModelAdmin.list_per_page' should be a integer.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestModelAdmin.list_per_page' should be a int.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             list_per_page = 100
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_max_show_all_allowed_validation(self):
 
@@ -1076,16 +1036,15 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestModelAdmin.list_max_show_all' should be an integer.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestModelAdmin.list_max_show_all' should be a int.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             list_max_show_all = 200
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_search_fields_validation(self):
 
@@ -1095,8 +1054,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.search_fields' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1108,8 +1066,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.date_hierarchy' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1119,15 +1076,14 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.date_hierarchy is neither an instance of DateField nor DateTimeField.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             date_hierarchy = 'pub_date'
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_ordering_validation(self):
 
@@ -1137,8 +1093,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.ordering' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1148,8 +1103,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.ordering\[0\]' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1159,25 +1113,24 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.ordering' has the random ordering marker '\?', but contains other fields as well. Please either remove '\?' or the other fields.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             ordering = ('?',)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
         class ValidationTestModelAdmin(ModelAdmin):
             ordering = ('band__name',)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
         class ValidationTestModelAdmin(ModelAdmin):
             ordering = ('name',)
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_list_select_related_validation(self):
 
@@ -1186,16 +1139,15 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestModelAdmin.list_select_related' should be a boolean.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestModelAdmin.list_select_related' should be a bool.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             list_select_related = False
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_save_as_validation(self):
 
@@ -1204,16 +1156,15 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestModelAdmin.save_as' should be a boolean.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestModelAdmin.save_as' should be a bool.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             save_as = True
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_save_on_top_validation(self):
 
@@ -1222,16 +1173,15 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestModelAdmin.save_on_top' should be a boolean.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestModelAdmin.save_on_top' should be a bool.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
         class ValidationTestModelAdmin(ModelAdmin):
             save_on_top = True
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_inlines_validation(self):
 
@@ -1241,8 +1191,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.inlines' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1255,8 +1204,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.inlines\[0\]' does not inherit from BaseModelAdmin.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1269,8 +1217,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'model' is a required attribute of 'ValidationTestModelAdmin.inlines\[0\]'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1286,8 +1233,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestModelAdmin.inlines\[0\].model' does not inherit from models.Model.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1297,7 +1243,7 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             inlines = [ValidationTestInline]
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_fields_validation(self):
 
@@ -1311,8 +1257,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestInline.fields' must be a list or tuple.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1328,8 +1273,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestInline.fk_name' refers to field 'non_existent_field' that is missing from model 'modeladmin.ValidationTestInlineModel'.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1340,7 +1284,7 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             inlines = [ValidationTestInline]
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_extra_validation(self):
 
@@ -1353,9 +1297,8 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestInline.extra' should be a integer.",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestInline.extra' should be a int.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1366,7 +1309,7 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             inlines = [ValidationTestInline]
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_max_num_validation(self):
 
@@ -1379,9 +1322,8 @@ class ValidationTests(unittest.TestCase):
 
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
-            "'ValidationTestInline.max_num' should be an integer or None \(default\).",
-            validate,
-            ValidationTestModelAdmin,
+            "'ValidationTestInline.max_num' should be a int.",
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1392,7 +1334,7 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             inlines = [ValidationTestInline]
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)
 
     def test_formset_validation(self):
 
@@ -1409,8 +1351,7 @@ class ValidationTests(unittest.TestCase):
         six.assertRaisesRegex(self,
             ImproperlyConfigured,
             "'ValidationTestInline.formset' does not inherit from BaseModelFormSet.",
-            validate,
-            ValidationTestModelAdmin,
+            ValidationTestModelAdmin.validate,
             ValidationTestModel,
         )
 
@@ -1424,4 +1365,4 @@ class ValidationTests(unittest.TestCase):
         class ValidationTestModelAdmin(ModelAdmin):
             inlines = [ValidationTestInline]
 
-        validate(ValidationTestModelAdmin, ValidationTestModel)
+        ValidationTestModelAdmin.validate(ValidationTestModel)


### PR DESCRIPTION
Moved admin validation code to classes and have those be class
attributes to the ModelAdmin classes.
