### PR TITLE
Fixed #19526

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -71,7 +71,7 @@ class CachedFilesMixin(object):
                     pattern, template = pattern
                 else:
                     template = self.default_template
-                compiled = re.compile(pattern)
+                compiled = re.compile(pattern, re.IGNORECASE)
                 self._patterns.setdefault(extension, []).append((compiled, template))
 
     def file_hash(self, name, content=None):

--- a/tests/regressiontests/staticfiles_tests/project/documents/cached/styles_insensitive.css
+++ b/tests/regressiontests/staticfiles_tests/project/documents/cached/styles_insensitive.css
@@ -1,0 +1,1 @@
+@IMporT uRL("other.css");

--- a/tests/regressiontests/staticfiles_tests/tests.py
+++ b/tests/regressiontests/staticfiles_tests/tests.py
@@ -542,6 +542,14 @@ class TestCollectionCachedStorage(BaseCollectionTestCase,
         cache_validator.validate_key(cache_key)
         self.assertEqual(cache_key, 'staticfiles:821ea71ef36f95b3922a77f7364670e7')
 
+    def test_css_import_case_insensitive(self):
+        relpath = self.cached_file_path("cached/styles_insensitive.css")
+        self.assertEqual(relpath, "cached/styles_insensitive.2f0151cca872.css")
+        with storage.staticfiles_storage.open(relpath) as relfile:
+            content = relfile.read()
+            self.assertNotIn(b"cached/other.css", content)
+            self.assertIn(b"other.d41d8cd98f00.css", content)
+
 
 # we set DEBUG to False here since the template tag wouldn't work otherwise
 @override_settings(**dict(TEST_SETTINGS,


### PR DESCRIPTION
CSS specifications governs that syntax is case insensitive.
This modifies CachedFilesMixin to support that.
