### PR TITLE
Fixed #19896 -- cache.clear() doesn't work with DB cache

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -184,6 +184,7 @@ class DatabaseCache(BaseDatabaseCache):
         table = connections[db].ops.quote_name(self._table)
         cursor = connections[db].cursor()
         cursor.execute('DELETE FROM %s' % table)
+        transaction.commit_unless_managed(using=db)
 
 # For backwards compatibility
 class CacheClass(DatabaseCache):

--- a/tests/regressiontests/cache/tests.py
+++ b/tests/regressiontests/cache/tests.py
@@ -18,7 +18,7 @@ from django.core import management
 from django.core.cache import get_cache
 from django.core.cache.backends.base import (CacheKeyWarning,
     InvalidCacheBackendError)
-from django.db import router
+from django.db import router, transaction
 from django.http import (HttpResponse, HttpRequest, StreamingHttpResponse,
     QueryDict)
 from django.middleware.cache import (FetchFromCacheMiddleware,
@@ -835,6 +835,15 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
                 verbosity=0,
                 interactive=False
             )
+
+    def test_clear(self):
+        # The cache can be emptied using clear
+        self.cache.set("key1", "spam")
+        self.cache.set("key2", "eggs")
+        self.cache.clear()
+        transaction.rollback_unless_managed()
+        self.assertEqual(self.cache.get("key1"), None)
+        self.assertEqual(self.cache.get("key2"), None)
 
 
 @override_settings(USE_TZ=True)


### PR DESCRIPTION
Currently, the SQL `delete` in `cache.clear()` gets rolled back, resulting in the DB cache never being actually cleared.

The hacky test right now tries to roll back the delete operation if it's actually not commited.
