### PR TITLE
Fixed #17943 - too many open file descriptors while using memcache

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -25,6 +25,10 @@ class BaseMemcachedCache(BaseCache):
         self._lib = library
         self._options = params.get('OPTIONS', None)
 
+    def __del__(self):
+        if getattr(self, '_client', None) is not None:
+            self._client.disconnect_all()
+
     @property
     def _cache(self):
         """

--- a/tests/regressiontests/cache/tests.py
+++ b/tests/regressiontests/cache/tests.py
@@ -984,6 +984,14 @@ class MemcachedCacheTests(unittest.TestCase, BaseCacheTests):
         # memcached limits key length to 250
         self.assertRaises(Exception, self.cache.set, 'a' * 251, 'value')
 
+    def test_close_connection_on_del(self):
+        """
+        Test for ticket #17943 -- Too many open file descriptors while using memcache.
+        """
+        self.cache.set("key", "value")
+        self.cache.__del__()
+        self.assertTrue(all([host.socket is None for host in self.cache._client.servers]))
+
 
 class FileBasedCacheTests(unittest.TestCase, BaseCacheTests):
     """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/17943
