### PR TITLE
Fixed #13546 -- Easier handling of localize field options in ModelForm

### DIFF
--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -5,7 +5,7 @@ Model Form Functions
 .. module:: django.forms.models
    :synopsis: Django's functions for building model forms and formsets.
 
-.. function:: modelform_factory(model, form=ModelForm, fields=None, exclude=None, formfield_callback=None,  widgets=None)
+.. function:: modelform_factory(model, form=ModelForm, fields=None, exclude=None, formfield_callback=None,  widgets=None, localized_fields=None)
 
     Returns a :class:`~django.forms.ModelForm` class for the given ``model``.
     You can optionally pass a ``form`` argument to use as a starting point for
@@ -20,17 +20,23 @@ Model Form Functions
 
     ``widgets`` is a dictionary of model field names mapped to a widget.
 
+    ``localized_fields`` is a list of names of fields which should be localized.
+
     ``formfield_callback`` is a callable that takes a model field and returns
     a form field.
 
     See :ref:`modelforms-factory` for example usage.
 
-.. function:: modelformset_factory(model, form=ModelForm, formfield_callback=None, formset=BaseModelFormSet, extra=1, can_delete=False, can_order=False, max_num=None, fields=None, exclude=None, widgets=None)
+    .. versionchanged:: 1.6
+
+    The ``localized_fields`` parameter was added.
+
+.. function:: modelformset_factory(model, form=ModelForm, formfield_callback=None, formset=BaseModelFormSet, extra=1, can_delete=False, can_order=False, max_num=None, fields=None, exclude=None, widgets=None, localized_fields=None)
 
     Returns a ``FormSet`` class for the given ``model`` class.
 
     Arguments ``model``, ``form``, ``fields``, ``exclude``,
-    ``formfield_callback`` and ``widgets`` are all passed through to
+    ``formfield_callback``, ``widgets`` and ``localized_fields`` are all passed through to
     :func:`~django.forms.models.modelform_factory`.
 
     Arguments ``formset``, ``extra``, ``max_num``, ``can_order``, and
@@ -41,9 +47,9 @@ Model Form Functions
 
     .. versionchanged:: 1.6
 
-    The widgets parameter was added.
+    The ``widgets`` and ``localized_fields`` parameters were added.
 
-.. function:: inlineformset_factory(parent_model, model, form=ModelForm, formset=BaseInlineFormSet, fk_name=None, fields=None, exclude=None, extra=3, can_order=False, can_delete=True, max_num=None, formfield_callback=None, widgets=None)
+.. function:: inlineformset_factory(parent_model, model, form=ModelForm, formset=BaseInlineFormSet, fk_name=None, fields=None, exclude=None, extra=3, can_order=False, can_delete=True, max_num=None, formfield_callback=None, widgets=None, localized_fields=None)
 
     Returns an ``InlineFormSet`` using :func:`modelformset_factory` with
     defaults of ``formset=BaseInlineFormSet``, ``can_delete=True``, and
@@ -56,4 +62,4 @@ Model Form Functions
 
     .. versionchanged:: 1.6
 
-    The widgets parameter was added.
+    The ``widgets`` and ``localized_fields`` parameters were added.

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -101,6 +101,10 @@ Minor features
   context through to feed templates using a new `Feed.get_context_data()`
   callback.
 
+* :doc:`ModelForm </topics/forms/modelforms/>` accepts a new
+  Meta option: ``localized_fields``. Fields included in this list will be localized
+  (by setting ``localize`` on the form field).
+
 Backwards incompatible changes in 1.6
 =====================================
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -468,6 +468,21 @@ to be rendered first, we could specify the following ``ModelForm``::
     ...         model = Book
     ...         fields = ('title', 'author')
 
+
+Enabling localization of fields
+-------------------------------
+
+.. versionadded:: 1.6
+
+By default, the fields in a ``ModelForm`` will not localize their data. To
+enable localization for fields, you can use the ``localized_fields``
+attribute on the ``Meta`` class.
+
+    >>> class AuthorForm(ModelForm):
+    ...     class Meta:
+    ...         model = Author
+    ...         localized_fields = ('birth_date',)
+
 .. _overriding-modelform-clean-method:
 
 Overriding the clean() method
@@ -566,6 +581,10 @@ You can also specify the widgets to be used for a given field::
     >>> from django.forms import Textarea
     >>> Form = modelform_factory(Book, form=BookForm, widgets={"title": Textarea()})
 
+... or enable localization for specific fields::
+
+    >>> Form = modelform_factory(Author, form=AuthorForm, localized_fields=("birth_date",))
+
 .. _model-formsets:
 
 Model formsets
@@ -657,6 +676,17 @@ class of a ``ModelForm`` works::
 
     >>> AuthorFormSet = modelformset_factory(
     ...     Author, widgets={'name': Textarea(attrs={'cols': 80, 'rows': 20})
+
+Enabling localization for fields with ``localized_fields``
+----------------------------------------------------------
+
+.. versionadded:: 1.6
+
+Using the ``localized_fields`` parameter, you can enable localization for
+fields in the form.
+
+    >>> AuthorFormSet = modelformset_factory(
+    ...     Author, localized_fields=('value',))
 
 Providing initial values
 ------------------------

--- a/tests/regressiontests/model_forms_regress/tests.py
+++ b/tests/regressiontests/model_forms_regress/tests.py
@@ -84,6 +84,22 @@ class OverrideCleanTests(TestCase):
         # by form.full_clean().
         self.assertEqual(form.instance.left, 1)
 
+
+class LocalizedTripleForm(forms.ModelForm):
+    class Meta:
+        model = Triple
+        localized_fields = ('left', 'right',)
+
+
+class LocalizedModelFormTest(TestCase):
+    def test_model_form_applies_localize_to_fields(self):
+        f = LocalizedTripleForm({'left': 10, 'middle': 10, 'right': 10})
+        self.assertTrue(f.is_valid())
+        self.assertTrue(f.fields['left'].localize)
+        self.assertFalse(f.fields['middle'].localize)
+        self.assertTrue(f.fields['right'].localize)
+
+
 # Regression test for #12960.
 # Make sure the cleaned_data returned from ModelForm.clean() is applied to the
 # model instance.

--- a/tests/regressiontests/model_formsets_regress/tests.py
+++ b/tests/regressiontests/model_formsets_regress/tests.py
@@ -272,6 +272,7 @@ class UserSiteForm(forms.ModelForm):
             'id': CustomWidget,
             'data': CustomWidget,
         }
+        localized_fields = ('data',)
 
 
 class Callback(object):
@@ -296,19 +297,23 @@ class FormfieldCallbackTests(TestCase):
         form = Formset().forms[0]
         self.assertTrue(isinstance(form['id'].field.widget, CustomWidget))
         self.assertTrue(isinstance(form['data'].field.widget, CustomWidget))
+        self.assertFalse(form.fields['id'].localize)
+        self.assertTrue(form.fields['data'].localize)
 
     def test_modelformset_factory_default(self):
         Formset = modelformset_factory(UserSite, form=UserSiteForm)
         form = Formset().forms[0]
         self.assertTrue(isinstance(form['id'].field.widget, CustomWidget))
         self.assertTrue(isinstance(form['data'].field.widget, CustomWidget))
+        self.assertFalse(form.fields['id'].localize)
+        self.assertTrue(form.fields['data'].localize)
 
     def assertCallbackCalled(self, callback):
         id_field, user_field, data_field = UserSite._meta.fields
         expected_log = [
             (id_field, {'widget': CustomWidget}),
             (user_field, {}),
-            (data_field, {'widget': CustomWidget}),
+            (data_field, {'widget': CustomWidget, 'localize': True}),
         ]
         self.assertEqual(callback.log, expected_log)
 


### PR DESCRIPTION
Added a localized_fields ModelForm Meta option which sets the localize
option on the field.
