### PR TITLE
Add column-<field_name> classes to the admin list

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -12,10 +12,9 @@ from django.db import models
 from django.utils import formats
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils import six
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
-from django.utils.encoding import smart_text, force_text
+from django.utils.encoding import force_text
 from django.template import Library
 from django.template.loader import get_template
 from django.template.context import Context
@@ -112,12 +111,13 @@ def result_headers(cl):
                 # Not sortable
                 yield {
                     "text": text,
+                    "class_attrib": format_html(' class="column-{0}"', field_name),
                     "sortable": False,
                 }
                 continue
 
         # OK, it is sortable if we got this far
-        th_classes = ['sortable']
+        th_classes = ['sortable', 'column-{0}'.format(field_name)]
         order_type = ''
         new_order_type = 'asc'
         sort_priority = 0

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -543,6 +543,13 @@ subclass::
       The above will tell Django to order by the ``first_name`` field when
       trying to sort by ``colored_first_name`` in the admin.
 
+    * .. versionadded:: 1.6
+
+      The field names in ``list_display`` will also appear as CSS classes in
+      the HTML output, in the form of ``column-<field_name>`` on each ``<th>``
+      element. This can be used to set column widths in a CSS file for example.
+
+
 .. attribute:: ModelAdmin.list_display_links
 
     Set ``list_display_links`` to control which fields in ``list_display``

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -101,6 +101,9 @@ Minor features
   context through to feed templates using a new `Feed.get_context_data()`
   callback.
 
+* The admin list columns have a ``column-<field_name>`` class in the HTML
+  so the columns header can be styled with CSS, e.g. to set a column width.
+
 Backwards incompatible changes in 1.6
 =====================================
 


### PR DESCRIPTION
This simplifies CSS styling to set column widths.

Trac ticket: https://code.djangoproject.com/ticket/19906
