### PR TITLE
Fix documentation typo (:mod: role in Syndication feed text)

### DIFF
--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -97,7 +97,7 @@ Minor features
 
 * The jQuery library embedded in the admin has been upgraded to version 1.9.1.
 
-* Syndication feeds (:module:`django.contrib.syndication`) can now pass extra
+* Syndication feeds (:mod:`django.contrib.syndication`) can now pass extra
   context through to feed templates using a new `Feed.get_context_data()`
   callback.
 


### PR DESCRIPTION
This fixes a Sphinx error in the docs of today
