### PR TITLE
Fixed #9433 - File locking broken on AFP mounts.

### DIFF
--- a/django/core/files/move.py
+++ b/django/core/files/move.py
@@ -35,7 +35,7 @@ def _samefile(src, dst):
     return (os.path.normcase(os.path.abspath(src)) ==
             os.path.normcase(os.path.abspath(dst)))
 
-def file_move_safe(old_file_name, new_file_name, chunk_size = 1024*64, allow_overwrite=False):
+def file_move_safe(old_file_name, new_file_name, chunk_size = 1024*64, allow_overwrite=False, locks=locks):
     """
     Moves a file from one location to another in the safest way possible.
 


### PR DESCRIPTION
Updated version of the original patch using Python 3 wrapper for StringIO import.

Original patch:
https://code.djangoproject.com/attachment/ticket/9433/inject_locks_Django-1.5a1.2.patch
