### PR TITLE
Make forms.Field's __init__ call super

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -118,6 +118,8 @@ class Field(object):
 
         self.validators = self.default_validators + validators
 
+        super(Field, self).__init__()
+
     def prepare_value(self, value):
         return value
 


### PR DESCRIPTION
Add a call to super in forms.Field **init** method, so that the Field
calss can be used as a Mixin.
