### PR TITLE
Docs: Make sure the README.txt is bundled with the app

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -216,6 +216,7 @@ Create a file ``django-polls/setup.py`` with the following contents::
    ``django-polls/MANIFEST.in`` with the following contents::
 
     include LICENSE
+    include README.txt
     recursive-include polls/templates *
 
 7. It's optional, but recommended, to include detailed documentation with your


### PR DESCRIPTION
In docs/intro/reusable-apps.txt the MANIFEST.in needs README.txt in order for the setup.py to work, as it reads it directly in the code.
