### PR TITLE
Python 3: make sure hashlib always gets bytes

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -6,6 +6,7 @@ to load templates from them in order, caching the result.
 import hashlib
 from django.template.base import TemplateDoesNotExist
 from django.template.loader import BaseLoader, get_template_from_string, find_template_loader, make_origin
+from django.utils.encoding import force_bytes
 
 class Loader(BaseLoader):
     is_usable = True
@@ -40,7 +41,7 @@ class Loader(BaseLoader):
         key = template_name
         if template_dirs:
             # If template directories were specified, use a hash to differentiate
-            key = '-'.join([template_name, hashlib.sha1('|'.join(template_dirs)).hexdigest()])
+            key = '-'.join([template_name, hashlib.sha1(force_bytes('|'.join(template_dirs))).hexdigest()])
 
         if key not in self.template_cache:
             template, origin = self.find_template(template_name, template_dirs)

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -181,7 +181,7 @@ def _generate_cache_key(request, method, headerlist, key_prefix):
     for header in headerlist:
         value = request.META.get(header, None)
         if value is not None:
-            ctx.update(value)
+            ctx.update(force_bytes(value))
     path = hashlib.md5(force_bytes(iri_to_uri(request.get_full_path())))
     cache_key = 'views.decorators.cache.cache_page.%s.%s.%s.%s' % (
         key_prefix, method, path.hexdigest(), ctx.hexdigest())

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -72,10 +72,10 @@ def get_random_string(length=12,
         # is better than absolute predictability.
         random.seed(
             hashlib.sha256(
-                "%s%s%s" % (
+                ("%s%s%s" % (
                     random.getstate(),
                     time.time(),
-                    settings.SECRET_KEY)
+                    settings.SECRET_KEY)).encode('utf-8')
                 ).digest())
     return ''.join([random.choice(allowed_chars) for i in range(length)])
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1327,7 +1327,7 @@ class CacheI18nTest(TestCase):
     def check_accept_language_vary(self, accept_language, vary, reference_key):
         request = self._get_request()
         request.META['HTTP_ACCEPT_LANGUAGE'] = accept_language
-        request.META['HTTP_ACCEPT_ENCODING'] = b'gzip;q=1.0, identity; q=0.5, *;q=0'
+        request.META['HTTP_ACCEPT_ENCODING'] = 'gzip;q=1.0, identity; q=0.5, *;q=0'
         response = HttpResponse()
         response['Vary'] = vary
         key = learn_cache_key(request, response)
@@ -1340,53 +1340,53 @@ class CacheI18nTest(TestCase):
         lang = translation.get_language()
         self.assertEqual(lang, 'en')
         request = self._get_request()
-        request.META['HTTP_ACCEPT_ENCODING'] = b'gzip;q=1.0, identity; q=0.5, *;q=0'
+        request.META['HTTP_ACCEPT_ENCODING'] = 'gzip;q=1.0, identity; q=0.5, *;q=0'
         response = HttpResponse()
         response['Vary'] = 'accept-encoding'
         key = learn_cache_key(request, response)
         self.assertIn(lang, key, "Cache keys should include the language name when translation is active")
         self.check_accept_language_vary(
-            b'en-us',
+            'en-us',
             'cookie, accept-language, accept-encoding',
             key
         )
         self.check_accept_language_vary(
-            b'en-US',
+            'en-US',
             'cookie, accept-encoding, accept-language',
             key
         )
         self.check_accept_language_vary(
-            b'en-US,en;q=0.8',
+            'en-US,en;q=0.8',
             'accept-encoding, accept-language, cookie',
             key
         )
         self.check_accept_language_vary(
-            b'en-US,en;q=0.8,ko;q=0.6',
+            'en-US,en;q=0.8,ko;q=0.6',
             'accept-language, cookie, accept-encoding',
             key
         )
         self.check_accept_language_vary(
-            b'ko-kr,ko;q=0.8,en-us;q=0.5,en;q=0.3 ',
+            'ko-kr,ko;q=0.8,en-us;q=0.5,en;q=0.3 ',
             'accept-encoding, cookie, accept-language',
             key
         )
         self.check_accept_language_vary(
-            b'ko-KR,ko;q=0.8,en-US;q=0.6,en;q=0.4',
+            'ko-KR,ko;q=0.8,en-US;q=0.6,en;q=0.4',
             'accept-language, accept-encoding, cookie',
             key
         )
         self.check_accept_language_vary(
-            b'ko;q=1.0,en;q=0.5',
+            'ko;q=1.0,en;q=0.5',
             'cookie, accept-language, accept-encoding',
             key
         )
         self.check_accept_language_vary(
-            b'ko, en',
+            'ko, en',
             'cookie, accept-encoding, accept-language',
             key
         )
         self.check_accept_language_vary(
-            b'ko-KR, en-US',
+            'ko-KR, en-US',
             'accept-encoding, accept-language, cookie',
             key
         )


### PR DESCRIPTION
Tests pass on 2.7 and 3.3 (double-checked this time, Carl ;-) ).

Occurrences and consequences without the patch:
- `utils.cache`: `CacheMiddleware` fails or every user
- `utils.crypto`: generating a random string on machines without a system PRNG fails
- `template.loaders.cached`: generating a cache key with template_dirs fails (although method to trigger the bug on a real application is unknown: `TEMPLATE_DIRS` are only used in `template.loaders.filesystem`)

There are tests for `utils.cache`. There are currently no tests for a PRNG-less `utils.crypto` and without mocking the `random` module there is no way of triggering this code. As for `template.loaders.cached` I could not find a path of execution that would lead to using the `template_dirs` kwarg (dead code?).

If you require tests for those two obscure latter cases, let me know.
