### PR TITLE
use the real path to fix OS X /var/folders vs /private/var/folders mismatch

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -26,7 +26,7 @@ from django.utils.six import StringIO
 from django.test import LiveServerTestCase
 
 
-test_dir = os.path.join(os.environ['DJANGO_TEST_TEMP_DIR'], 'test_project')
+test_dir = os.path.realpath(os.path.join(os.environ['DJANGO_TEST_TEMP_DIR'], 'test_project'))
 if not os.path.exists(test_dir):
     os.mkdir(test_dir)
     open(os.path.join(test_dir, '__init__.py'), 'w').close()


### PR DESCRIPTION
Two `admin_scripts` tests are failing on OS X 10.8.2 without this patch on both 2.7 and 3.3.
