### PR TITLE
Fixed #19951 -- Avoid ValueError in admin when passing a string as PK for an inherited model with an integer PK field

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -479,7 +479,7 @@ class ModelAdmin(BaseModelAdmin):
         try:
             object_id = model._meta.pk.to_python(object_id)
             return queryset.get(pk=object_id)
-        except (model.DoesNotExist, ValidationError):
+        except (model.DoesNotExist, ValidationError, ValueError):
             return None
 
     def get_changelist_form(self, request, **kwargs):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -131,6 +131,15 @@ class AdminViewBasicTest(TestCase):
         response = self.client.get('/test_admin/%s/admin_views/section/abc/' % self.urlbit)
         self.assertEqual(response.status_code, 404)
 
+    def testBasicInheritanceGetStringPK(self):
+        """
+        A smoke test to ensure GET on the change_view works on inherited
+        models (returns an HTTP 404 error, see #19951) when passing a string
+        as the PK argument for a model with an integer PK field.
+        """
+        response = self.client.get('/test_admin/%s/admin_views/supervillain/abc/' % self.urlbit)
+        self.assertEqual(response.status_code, 404)
+
     def testBasicAddPost(self):
         """
         A smoke test to ensure POST on add_view works.


### PR DESCRIPTION
Fixed #19951 -- Avoid ValueError in admin when passing a string as PK for an inherited model with an integer PK field
