### PR TITLE
Fixed #19962 -- Add note about `SESSION_EXPIRE_AT_BROWSER_CLOSE` caveat

### DIFF
--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -474,6 +474,16 @@ This setting is a global default and can be overwritten at a per-session level
 by explicitly calling the :meth:`~backends.base.SessionBase.set_expiry` method
 of ``request.session`` as described above in `using sessions in views`_.
 
+.. note::
+
+    Some browsers (Chrome, for example) provide settings that allow users to
+    continue browsing sessions after closing and re-opening the browser.  In
+    some cases, this can interfere with the
+    :setting:`SESSION_EXPIRE_AT_BROWSER_CLOSE` setting and prevent sessions
+    from expiring on browser close.  Please be aware of this while testing
+    django applications which have the
+    :setting:`SESSION_EXPIRE_AT_BROWSER_CLOSE` setting enabled.
+
 Clearing the session store
 ==========================
 


### PR DESCRIPTION
[Ticket #19962](https://code.djangoproject.com/ticket/19962)
