### PR TITLE
Ticket 18855: persist socket across runserver reloads

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -33,6 +33,8 @@ class Command(BaseCommand):
             help='Tells Django to NOT use threading.'),
         make_option('--noreload', action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
+        make_option('--nopersistsock', action='store_false', dest='use_persist_sock', default=True,
+            help='Tells Django to NOT use a persistent socket.'),
     )
     help = "Starts a lightweight Web server for development."
     args = '[optional port number, or ipaddr:port]'
@@ -86,6 +88,18 @@ class Command(BaseCommand):
         Runs the server, using the autoreloader if needed
         """
         use_reloader = options.get('use_reloader')
+
+        # test if socket.fromfd is supported on this platform as it's needed
+        # later for this code to work
+        if options.get('use_persist_sock') and getattr(socket, 'fromfd', False):
+            address_family = socket.AF_INET
+            if self.use_ipv6:
+                address_family = socket.AF_INET6
+            if not os.environ.get('DJANGO_SERVER_FD'):
+                sock = socket.socket(address_family, socket.SOCK_STREAM)
+                if getattr(sock, 'set_inheritable', None):
+                    sock.set_inheritable(sock.fileno())
+                os.environ['DJANGO_SERVER_FD'] = str(sock.fileno())
 
         if use_reloader:
             autoreload.main(self.inner_run, args, options)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -888,6 +888,16 @@ Example usage::
 The development server is multithreaded by default. Use the ``--nothreading``
 option to disable the use of threading in the development server.
 
+.. django-admin-option:: --nopersistsock
+
+.. versionadded:: 1.8
+
+The development server will persist the listening socket while reloading code
+by default.  To disable this behavior, use the ``--nopersistsock`` option.
+The caveat is that some platforms do not support the methods needed for this
+feature (``socket.fromfd``).  In particular, Python 2 on Windows will not have
+support for this, but Python 3 does.
+
 .. django-admin-option:: --ipv6, -6
 
 Use the ``--ipv6`` (or shorter ``-6``) option to tell Django to use IPv6 for

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -145,6 +145,10 @@ Management Commands
   :djadminopt:`--exclude` which allows exclusion of specific locales from
   processing.
 
+* The :djadmin:`runserver` will reuse the same socket across automatic reloads
+  which ensures that requests will not fail if the browser is reloaded too
+  quickly. For Windows, this feature is only supported with Python 3.x.
+
 Models
 ^^^^^^
 


### PR DESCRIPTION
See discussion of this ticket on the bug tracker.

Creating a new pull request as advised in the ticket after adding documentation of the feature.

The testing part of this ticket is especially tricky.  The only way I see to test the actual functionality would be to fork a new process and run "runserver" within the process (if you have other ideas, I'd love to hear them) and then interact with the new process via the opened port.  Then there is the case of the race condition that this effectively tries to solve.

Given the wide use of runserver, I think that it's relatively safe to not add tests (given the difficultly of doing so).  If you have any ideas on how to make this test-able, I'd definitely take suggestions and attempt to add tests for them.
