### PR TITLE
Fix for issue #20034; allow callback for variables successfully parsed in multipart POST upload.

### DIFF
--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -84,6 +84,12 @@ class FileUploadHandler(object):
         """
         pass
 
+    def variable_complete(self, variable_name, variable_value):
+        """
+        Signal that a new variable has been parsed from the multipart request.
+        """
+        pass
+
     def new_file(self, field_name, file_name, content_type, content_length, charset=None):
         """
         Signal that a new file has been started.

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -167,6 +167,13 @@ class MultiPartParser(object):
 
                     self._post.appendlist(field_name,
                                           force_text(data, encoding, errors='replace'))
+                    
+                    for handler in handlers:
+                        try :
+                            handler.variable_complete(field_name, force_text(data, encoding, errors='replace'))
+                        except StopFutureHandlers:
+                            break
+
                 elif item_type == FILE:
                     # This is a file, use the handler...
                     file_name = disposition.get('filename')


### PR DESCRIPTION
Modified upload handler API to be able to invoke callbacks when new fields/variables are successfully parsed from multipart POST request. Fix for #20034.
