### PR TITLE
removed unused BLANK_CHOICE_NONE

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -29,7 +29,6 @@ class NOT_PROVIDED:
 # The values to use for "blank" in SelectFields. Will be appended to the start
 # of most "choices" lists.
 BLANK_CHOICE_DASH = [("", "---------")]
-BLANK_CHOICE_NONE = [("", "None")]
 
 class FieldDoesNotExist(Exception):
     pass


### PR DESCRIPTION
BLANK_CHOICE_NONE is defined, but not used anywhere, so I presume it can be got rid of.

I tried `git rev-list --branches|xargs git grep BLANK_CHOICE_NONE | grep -v "django/db/models/fields/__init__.py"` to search through the history for it in other locations, but that seems to crash after a couple of hundred thousand matches from the first part.
