### PR TITLE
Doc: Use django.test.TestCase for first testing example

### DIFF
--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -56,12 +56,14 @@ places:
   directory that holds ``models.py``. Again, the test runner looks for any
   subclass of :class:`unittest.TestCase` in this module.
 
-Here is an example :class:`unittest.TestCase` subclass::
+Here is an example which subclasses from :class:`django.test.TestCase`,
+which is a subclass of :class:`unittest.TestCase` that flushes the database
+between tests::
 
-    from django.utils import unittest
+    from django.test import TestCase
     from myapp.models import Animal
 
-    class AnimalTestCase(unittest.TestCase):
+    class AnimalTestCase(TestCase):
         def setUp(self):
             self.lion = Animal(name="lion", sound="roar")
             self.cat = Animal(name="cat", sound="meow")
@@ -94,10 +96,17 @@ For more details about :mod:`unittest`, see the Python documentation.
     :class:`django.test.TestCase` rather than :class:`unittest.TestCase`.
 
     In the example above, we instantiate some models but do not save them to
-    the database. Using :class:`unittest.TestCase` avoids the cost of running
-    each test in a transaction and flushing the database, but for most
-    applications the scope of tests you will be able to write this way will
-    be fairly limited, so it's easiest to use :class:`django.test.TestCase`.
+    the database. This example could have used
+    :class:`unittest.TestCase` and avoided the cost of running
+    each test in a transaction and flushing the database. However, if you use
+    :class:`unittest.TestCase` and your tests do interact with
+    the database, the behavior of the tests will vary based on the order that
+    the test runner executes them. This can lead to unit tests that pass
+    when run in isolation but fail when run in a suite.
+
+    Therefore, the simplest and less error-prone approach is to always use
+    :class:`django.test.TestCase`.
+
 
 .. _running-tests:
 


### PR DESCRIPTION
This doc change switches from unittest.TestCase to django.test.TestCase
with some accompanying text changes.

Motivation: you are very likely to get journeyman "drive-by" Django
developers just looking for a simple template example of how to write
a unit test, they will find this canonical example, copy-paste it,
and then get burned because of database coupling.

These type of readers won't read the warning that appears below the
text.
