### PR TITLE
Correct typos in the 1.6 release notes

### DIFF
--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -357,7 +357,7 @@ Methods that return a ``QuerySet`` such as ``Manager.get_query_set`` or
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``shortcut`` view was moved from ``django.views.defaults`` to
-``django.contrib.contentypes.views`` shortly after the 1.0 release, but the
+``django.contrib.contenttypes.views`` shortly after the 1.0 release, but the
 old location was never deprecated. This oversight was corrected in Django 1.6
 and you should now use the new location.
 
@@ -368,4 +368,4 @@ including it in an URLconf, simply replace::
 
 with::
 
-    (r'^prefix/(?P<content_type_id>\d+)/(?P<object_id>.*)/$', 'django.contrib.contentypes.views'),
+    (r'^prefix/(?P<content_type_id>\d+)/(?P<object_id>.*)/$', 'django.contrib.contenttypes.views.shortcut'),


### PR DESCRIPTION
- `contenttypes` has two ts
- point the url at the view, not the module

cc @aaugustin
