### PR TITLE
Fix for #19938 -- Maintain Page.object_list as a list

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -121,7 +121,9 @@ class Page(collections.Sequence):
             raise TypeError
         # The object_list is converted to a list so that if it was a QuerySet
         # it won't be a database hit per __getitem__.
-        return list(self.object_list)[index]
+        if not isinstance(self.object_list, list):
+            self.object_list = list(self.object_list)
+        return self.object_list[index]
 
     def has_next(self):
         return self.number < self.paginator.num_pages

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -297,6 +297,7 @@ class ModelPaginationTests(TestCase):
         self.assertIsNone(p.object_list._result_cache)
         self.assertRaises(TypeError, lambda: p['has_previous'])
         self.assertIsNone(p.object_list._result_cache)
+        self.assertNotIsInstance(p.object_list, list)
 
         # Make sure slicing the Page object with numbers and slice objects work.
         self.assertEqual(p[0], Article.objects.get(headline='Article 1'))
@@ -305,3 +306,5 @@ class ModelPaginationTests(TestCase):
                 "<Article: Article 2>",
             ]
         )
+        # After __getitem__ is called object_list is a list
+        self.assertIsInstance(p.object_list, list)


### PR DESCRIPTION
After `__getitem__` gets called, object_list is maintained as as a list. [Associated Ticket](https://code.djangoproject.com/ticket/19938)
