### PR TITLE
Backport Cookie Pickling Fix

### DIFF
--- a/django/template/response.py
+++ b/django/template/response.py
@@ -39,7 +39,7 @@ class SimpleTemplateResponse(HttpResponse):
         rendered, and that the pickled state only includes rendered
         data, not the data used to construct the response.
         """
-        obj_dict = self.__dict__.copy()
+        obj_dict = super(SimpleTemplateResponse, self).__getstate__()
         if not self._is_rendered:
             raise ContentNotRenderedError('The response content must be '
                                           'rendered before it can be pickled.')

--- a/tests/regressiontests/templates/response.py
+++ b/tests/regressiontests/templates/response.py
@@ -215,6 +215,21 @@ class SimpleTemplateResponseTest(BaseTemplateResponseTest):
         unpickled_response = pickle.loads(pickled_response)
         repickled_response = pickle.dumps(unpickled_response)
 
+    def test_pickling_cookie(self):
+        response = SimpleTemplateResponse('first/test.html', {
+                'value': 123,
+                'fn': datetime.now,
+            })
+
+        response.cookies['key'] = 'value'
+
+        response.render()
+        pickled_response = pickle.dumps(response, pickle.HIGHEST_PROTOCOL)
+        unpickled_response = pickle.loads(pickled_response)
+
+        self.assertEqual(unpickled_response.cookies['key'].value, 'value')
+
+
 class TemplateResponseTest(BaseTemplateResponseTest):
 
     def _response(self, template='foo', *args, **kwargs):


### PR DESCRIPTION
This is a backport of 4d817b38875c900d70793acd528afc9e954bbcb7, which fixed incorrect pickling of cookies. Given that this bug can result in scrambled CSRF token cookies (discouraging their use), I think it's worth it.

The related ticket is [19262](https://code.djangoproject.com/ticket/19262).
