### PR TITLE
Fixed #20112 -- last_executed_query unicode decoding based on connection

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -269,7 +269,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         # With MySQLdb, cursor objects have an (undocumented) "_last_executed"
         # attribute where the exact query sent to the database is saved.
         # See MySQLdb/cursors.py in the source distribution.
-        return cursor._last_executed.decode('utf-8')
+        encoding = cursor.connection.unicode_literal.charset
+        return cursor._last_executed.decode(encoding)
 
     def no_limit_value(self):
         # 2**64 - 1, as recommended by the MySQL documentation

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -202,7 +202,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         # http://initd.org/psycopg/docs/cursor.html#cursor.query
         # The query attribute is a Psycopg extension to the DB API 2.0.
         if cursor.query is not None:
-            return cursor.query.decode('utf-8')
+            return cursor.query.decode(cursor.connection.encoding)
         return None
 
     def return_insert_id(self):


### PR DESCRIPTION
For mysql/postgresql backends. I guess same situation with oracle but I cant test it
