### PR TITLE
Docs: Remove ambiguity regarding LANGUAGES setting

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1265,9 +1265,9 @@ see the current list of translated languages by looking in
 
 .. _online source: https://github.com/django/django/blob/master/django/conf/global_settings.py
 
-The list is a tuple of two-tuples in the format ``(language code, language
-name)``, the ``language code`` part should be a
-:term:`language name<language code>` -- for example, ``('ja', 'Japanese')``.
+The list is a tuple of two-tuples in the format 
+(:term:`language code<language code>`, ``language name``) -- for example, 
+``('ja', 'Japanese')``. 
 This specifies which languages are available for language selection. See
 :doc:`/topics/i18n/index`.
 


### PR DESCRIPTION
The docs to the LANGUAGES setting were using both the term language code
and language name for the same thing. This tripped me up because I at first read `language code` to mean `locale code`, as after following the link it isn't exactly clear which of the two is meant.
The fix is easy enough, I just removed the (in my opinion) unnecessary bit and moved the link into the tuple.

Note: I slightly altered the double-quotes because that interfered. If that's a problem, I'll glady incorporate a fix, I just don't know how to use `:term:` next to double quotes.
