### PR TITLE
Fixed #14825 - LocaleMiddleware keeps language

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -52,6 +52,10 @@ class LocaleMiddleware(object):
                     request.get_host(), language, request.get_full_path())
                 return HttpResponseRedirect(language_url)
 
+        # Store language back into session if it is not present
+        if hasattr(request, 'session'):
+            request.session.setdefault('django_language', language)
+
         if not (self.is_language_prefix_patterns_used()
                 and language_from_path):
             patch_vary_headers(response, ('Accept-Language',))

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -181,6 +181,10 @@ Minor features
   and the undocumented limit of the higher of 1000 or ``max_num`` forms
   was changed so it is always 1000 more than ``max_num``.
 
+* The middleware :class:`~django.middleware.locale.LocaleMiddleware` now
+  stores active language in session if it is not present there. This
+  prevents loss of language settings after session flush, e.g. logout.
+
 Backwards incompatible changes in 1.6
 =====================================
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1120,3 +1120,33 @@ class LocaleMiddlewareTests(TestCase):
         self.assertContains(response, "Oui/Non")
         response = self.client.get('/en/streaming/')
         self.assertContains(response, "Yes/No")
+
+    @override_settings(
+        MIDDLEWARE_CLASSES=(
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.middleware.locale.LocaleMiddleware',
+            'django.middleware.common.CommonMiddleware',
+        ),
+    )
+    def test_session_language(self):
+        # Check that language is stored in session if missing
+
+        # Create an empty session
+        engine = import_module(settings.SESSION_ENGINE)
+        session = engine.SessionStore()
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+
+        # Clear the session data before request
+        session.save()
+        response = self.client.get('/en/simple/')
+        self.assertEqual(self.client.session['django_language'], 'en')
+
+        # Clear the session data before request
+        session.save()
+        response = self.client.get('/fr/simple/')
+        self.assertEqual(self.client.session['django_language'], 'fr')
+
+        # Check that language is not changed in session
+        response = self.client.get('/en/simple/')
+        self.assertEqual(self.client.session['django_language'], 'fr')

--- a/tests/i18n/urls.py
+++ b/tests/i18n/urls.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 
 from django.conf.urls.i18n import i18n_patterns
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.translation import ugettext_lazy as _
 
 urlpatterns = i18n_patterns('',
+    (r'^simple/$', lambda r: HttpResponse()),
     (r'^streaming/$', lambda r: StreamingHttpResponse([_("Yes"), "/", _("No")])),
 )


### PR DESCRIPTION
- LocaleMiddleware stores language into session if it is not present there.
