### PR TITLE
Store original file upload name

### DIFF
--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -37,6 +37,7 @@ class UploadedFile(File):
         return self._name
 
     def _set_name(self, name):
+        self._original_name = name
         # Sanitize the file name so that it can't be dangerous.
         if name is not None:
             # Just use the basename of the file -- anything else is dangerous.


### PR DESCRIPTION
We use this to implement folder upload logic (using WebKit's `<input type=file webkitdirectory ...>`). I thought it didn't hurt having the original file name + path as an undocumented additional attribute.
