### PR TITLE
Fixed #20146: updated removed_tags example

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -568,11 +568,11 @@ escaping HTML.
 
 .. function:: remove_tags(value, tags)
 
-    Removes a list of [X]HTML tag names from the output.
+    Removes a space separated list of [X]HTML tag names from the output.
 
     For example::
 
-        remove_tags(value, ["b", "span"])
+        remove_tags(value, "b span")
 
     If ``value`` is ``"<b>Joel</b> <button>is</button> a <span>slug</span>"`` the
     return value will be ``"Joel <button>is</button> a slug"``.


### PR DESCRIPTION
Implementation waits for a string but example was with list. Changed example according to implementation.

Example: `remove_tags(value, ["b", "p"])`
Implementation: `remove_tags(value, "b p")`
