### PR TITLE
Fixed spelling of "consistent" in admin/options.py

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -478,7 +478,7 @@ class ModelAdmin(BaseModelAdmin):
             # Take the custom ModelForm's Meta.exclude into account only if the
             # ModelAdmin doesn't define its own.
             exclude.extend(self.form._meta.exclude)
-        # if exclude is an empty list we pass None to be consistant with the
+        # if exclude is an empty list we pass None to be consistent with the
         # default on modelform_factory
         exclude = exclude or None
         defaults = {


### PR DESCRIPTION
This pull request fixes a typo in a comment in the admin/options.py file.

I checked just to make sure, http://en.wiktionary.org/wiki/consistant, consistant is listed as a common misspelling of consistent and searching for it in Google will correct it.

According to https://docs.djangoproject.com/en/1.5/internals/contributing/writing-code/submitting-patches/#typo-fixes-and-trivial-documentation-changes this does not need a ticket in Trac, but if you would like, I could make one.
