### PR TITLE
Fixed #20167 -- Preserve the traceback of ImportErrors in import_by_path

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -1,10 +1,10 @@
 import imp
 import os
 import sys
-import six
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.importlib import import_module
+from django.utils import six
 
 
 def import_by_path(dotted_path, error_prefix=''):

--- a/tests/utils_tests/module_loading.py
+++ b/tests/utils_tests/module_loading.py
@@ -124,7 +124,7 @@ class ModuleImportTestCase(unittest.TestCase):
         """Test preserving the original traceback on an ImportError."""
         try:
             import_by_path('test_module.bad_module.content')
-        except ImproperlyConfigured, e:
+        except ImproperlyConfigured:
             traceback = sys.exc_info()[2]
 
         self.assertIsNotNone(traceback.tb_next.tb_next,


### PR DESCRIPTION
Uses six.reraise to fix https://code.djangoproject.com/ticket/20167.
