### PR TITLE
Update debug.py

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -62,7 +62,7 @@ def technical_500_response(request, exc_type, exc_value, tb):
     the values returned from sys.exc_info() and friends.
     """
     reporter = ExceptionReporter(request, exc_type, exc_value, tb)
-    if request.is_ajax():
+    if request.is_ajax() and settings.NERF_DEBUG_ON_AJAX:
         text = reporter.get_traceback_text()
         return HttpResponseServerError(text, content_type='text/plain')
     else:


### PR DESCRIPTION
Interactive debug response was nerfed as of Django 1.4 when working with AJAX. The change resulted in internal errors only returning the traceback body, and not the nice interactive debug response which we know and love.

This change makes working with AJAX in >1.4 very difficult compared with <1.4. 

My proposed change makes this nerfing optional: set NERF_DEBUG_ON_AJAX to False in your settings.py to get the goodness when using AJAX.

See here: https://github.com/django/django/commit/0d9b6a5bc43c06716212bd3f847460ce985381aa
