### PR TITLE
Removed a trailing space in the template name on line 174.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -171,7 +171,7 @@ just declare the cycle, but not output the first value, you can add a
 
     {% for obj in some_list %}
         {% cycle 'row1' 'row2' as rowcolors silent %}
-        <tr class="{{ rowcolors }}">{% include "subtemplate.html " %}</tr>
+        <tr class="{{ rowcolors }}">{% include "subtemplate.html" %}</tr>
     {% endfor %}
 
 This will output a list of ``<tr>`` elements with ``class``


### PR DESCRIPTION
This trailing space may seem innocuous, but can be easily copied-and-pasted from the docs.

This can lead to bizarre File Not Found errors where the checked paths look correct, but actually aren't because the trailing space is hard to see in an error message.
