### PR TITLE
Fixed #19987 All host validation disabled when DEBUG=True.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -64,14 +64,19 @@ class HttpRequest(object):
             if server_port != ('443' if self.is_secure() else '80'):
                 host = '%s:%s' % (host, server_port)
 
-        allowed_hosts = ['*'] if settings.DEBUG else settings.ALLOWED_HOSTS
+        # There is no hostname validation when DEBUG=True
+        if settings.DEBUG:
+            return host
+
         domain, port = split_domain_port(host)
-        if domain and validate_host(domain, allowed_hosts):
+        if domain and validate_host(domain, settings.ALLOWED_HOSTS):
             return host
         else:
             msg = "Invalid HTTP_HOST header: %r." % host
             if domain:
                 msg += "You may need to add %r to ALLOWED_HOSTS." % domain
+            else:
+                msg += "The domain name provided is not valid according to RFC 1034/1035"
             raise SuspiciousOperation(msg)
 
     def get_full_path(self):


### PR DESCRIPTION
The documentation promises that host validation is disabled when
DEBUG=True, that all hostnames are accepted. Domains not compliant with
RFC 1034/1035 were however being validated, this validation has now been
removed when DEBUG=True.

Additionally, when DEBUG=False a more detailed SuspiciousOperation
exception message is provided when host validation fails because the
hostname is not RFC 1034/1035 compliant.
