### PR TITLE
Fixed #17927 - Initial values support for BaseGenericInlineFormSet

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -381,7 +381,7 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
     """
 
     def __init__(self, data=None, files=None, instance=None, save_as_new=None,
-                 prefix=None, queryset=None):
+                 prefix=None, queryset=None, **kwargs):
         opts = self.model._meta
         self.instance = instance
         self.rel_name = '-'.join((
@@ -399,7 +399,8 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
             })
         super(BaseGenericInlineFormSet, self).__init__(
             queryset=qs, data=data, files=files,
-            prefix=prefix
+            prefix=prefix,
+            **kwargs
         )
 
     @classmethod

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -240,6 +240,22 @@ class GenericRelationsTests(TestCase):
         TaggedItem.objects.create(content_object=granite, tag="countertop")
         self.assertEqual(Rock.objects.filter(tags__tag="countertop").count(), 1)
 
+    def test_generic_inline_formsets_initial(self):
+        """
+        Test for #17927 Initial values support for BaseGenericInlineFormSet.
+        """
+        quartz = Mineral.objects.create(name="Quartz", hardness=7)
+
+        GenericFormSet = generic_inlineformset_factory(TaggedItem, extra=1)
+        ctype = ContentType.objects.get_for_model(quartz)
+        initial_data = [{
+            'tag': 'lizard',
+            'content_type': ctype.pk,
+            'object_id': quartz.pk,
+        }]
+        formset = GenericFormSet(initial=initial_data)
+        self.assertEqual(formset.forms[0].initial, initial_data[0])
+
 
 class CustomWidget(forms.TextInput):
     pass


### PR DESCRIPTION
Added **kwargs to BaseGenericInlineFormSet and regression test.

https://code.djangoproject.com/ticket/17927
