### PR TITLE
remove confusing phrase from DecimalField docs

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -476,7 +476,7 @@ A fixed-precision decimal number, represented in Python by a
 .. attribute:: DecimalField.max_digits
 
     The maximum number of digits allowed in the number. Note that this number
-    must be greater than or equal to ``decimal_places``, if it exists.
+    must be greater than or equal to ``decimal_places``.
 
 .. attribute:: DecimalField.decimal_places
 


### PR DESCRIPTION
The phrase "if it exists" was used in reference to the `decimal_places`
argument to `DecimalField`, when in fact that field is required.
