### PR TITLE
Docs: add labels in cache docs

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -1,3 +1,5 @@
+.. _django-cache-framework:
+
 ========================
 Django's cache framework
 ========================
@@ -38,6 +40,8 @@ Django also works well with "upstream" caches, such as `Squid
 <http://www.squid-cache.org>`_ and browser-based caches. These are the types of
 caches that you don't directly control but to which you can provide hints (via
 HTTP headers) about which parts of your site should be cached, and how.
+
+.. _setting-up-the-cache:
 
 Setting up the cache
 ====================
@@ -151,6 +155,8 @@ Without a doubt, *none* of the Django caching backends should be used for
 permanent storage -- they're all intended to be solutions for caching, not
 storage -- but we point this out here because memory-based caching is
 particularly temporary.
+
+.. _database-caching:
 
 Database caching
 ----------------


### PR DESCRIPTION
Provide labels in cache docs in order to allow Intersphinx cross references.
