### PR TITLE
Forms - FloatField and IntegerField raise errors when a user enters space in textboxes.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -240,7 +240,8 @@ class IntegerField(Field):
         Validates that int() can be called on the input. Returns the result
         of int(). Returns None for empty values.
         """
-        value = value.strip()
+        if isinstance(value, basestring):
+            value = value.strip()
         value = super(IntegerField, self).to_python(value)
         if value in self.empty_values:
             return None
@@ -272,7 +273,8 @@ class FloatField(IntegerField):
         Validates that float() can be called on the input. Returns the result
         of float(). Returns None for empty values.
         """
-        value = value.strip()
+        if isinstance(value, basestring):
+            value = value.strip()
         value = super(IntegerField, self).to_python(value)
         if value in self.empty_values:
             return None

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -165,6 +165,7 @@ class FieldsTests(SimpleTestCase):
     def test_integerfield_2(self):
         f = IntegerField(required=False)
         self.assertEqual(None, f.clean(''))
+        self.assertEqual(None, f.clean(' '))
         self.assertEqual('None', repr(f.clean('')))
         self.assertEqual(None, f.clean(None))
         self.assertEqual('None', repr(f.clean(None)))
@@ -249,6 +250,7 @@ class FieldsTests(SimpleTestCase):
     def test_floatfield_2(self):
         f = FloatField(required=False)
         self.assertEqual(None, f.clean(''))
+        self.assertEqual(None, f.clean(' '))
         self.assertEqual(None, f.clean(None))
         self.assertEqual(1.0, f.clean('1'))
         self.assertEqual(f.max_value, None)


### PR DESCRIPTION
When a user keys in few spaces in a FloatField or IntegerField. Django fails to treat them as empty and tries to convert them to float and int respectively, leading to an unnecessary validation error. Users need to define custom fields and custom clean methods currently to overcome this issue. 

Ticket: https://code.djangoproject.com/ticket/20298
