### PR TITLE
Clearer explanation when exception has no message

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -584,7 +584,7 @@ TECHNICAL_500_TEMPLATE = """
 <body>
 <div id="summary">
   <h1>{% if exception_type %}{{ exception_type }}{% else %}Report{% endif %}{% if request %} at {{ request.path_info|escape }}{% endif %}</h1>
-  <pre class="exception_value">{% if exception_value %}{{ exception_value|force_escape }}{% else %}No exception supplied{% endif %}</pre>
+  <pre class="exception_value">{% if exception_value %}{{ exception_value|force_escape }}{% else %}No exception message supplied{% endif %}</pre>
   <table class="meta">
 {% if request %}
     <tr>
@@ -927,7 +927,7 @@ Exception Value: {{ exception_value|force_escape }}
 """
 
 TECHNICAL_500_TEXT_TEMPLATE = """{% load firstof from future %}{% firstof exception_type 'Report' %}{% if request %} at {{ request.path_info }}{% endif %}
-{% firstof exception_value 'No exception supplied' %}
+{% firstof exception_value 'No exception message supplied' %}
 {% if request %}
 Request Method: {{ request.META.REQUEST_METHOD }}
 Request URL: {{ request.build_absolute_uri }}{% endif %}

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -128,7 +128,7 @@ class ExceptionReporterTests(TestCase):
         reporter = ExceptionReporter(request, None, None, None)
         html = reporter.get_traceback_html()
         self.assertIn('<h1>Report at /test_view/</h1>', html)
-        self.assertIn('<pre class="exception_value">No exception supplied</pre>', html)
+        self.assertIn('<pre class="exception_value">No exception message supplied</pre>', html)
         self.assertIn('<th>Request Method:</th>', html)
         self.assertIn('<th>Request URL:</th>', html)
         self.assertNotIn('<th>Exception Type:</th>', html)


### PR DESCRIPTION
I always found the "No exception supplied" message on debug error page slightly misleading; actually there is an exception, but there's no message string.

Ran 5352 tests in 505.706s
OK (skipped=165, expected failures=10)
