### PR TITLE
Fixed #20340 - document required return value for disable_constraint_checking

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -390,9 +390,10 @@ class BaseDatabaseWrapper(object):
     def disable_constraint_checking(self):
         """
         Backends can implement as needed to temporarily disable foreign key
-        constraint checking.
+        constraint checking. Should return True if the constraints were 
+        disabled and will need to be reenabled.
         """
-        pass
+        return False
 
     def enable_constraint_checking(self):
         """


### PR DESCRIPTION
The docstring and base implementation of disable_constraint_checking do not indicate that a return value is expected for proper behavior.
