### PR TITLE
Fix CharField typo in legacy-databases.txt docs

### DIFF
--- a/docs/howto/legacy-databases.txt
+++ b/docs/howto/legacy-databases.txt
@@ -61,7 +61,7 @@ this generated model definition:
 
       class Person(models.Model):
           id = models.IntegerField(primary_key=True)
-          first_name = models.ChaField(max_length=70)
+          first_name = models.CharField(max_length=70)
           class Meta:
 	       **managed = False**
 	       db_table = 'CENSUS_PERSONS'


### PR DESCRIPTION
The example Person model in the legacy databases HowTo had a typo referring to ChaField instead of Charfield
