### PR TITLE
Fixed #13910 -- Added generator based rendering (streaming) of templates...

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -81,6 +81,15 @@ def instrumented_test_render(self, context):
     return self.nodelist.render(context)
 
 
+def instrumented_test_stream(self, context):
+    """
+    An instrumented Template stream method, providing a signal
+    that can be intercepted by the test system Client
+    """
+    template_rendered.send(sender=self, template=self, context=context)
+    return self.nodelist.stream(context)
+
+
 def setup_test_environment():
     """Perform any global pre-test setup. This involves:
 
@@ -90,6 +99,8 @@ def setup_test_environment():
     """
     Template._original_render = Template._render
     Template._render = instrumented_test_render
+    Template._original_stream = Template._stream
+    Template._stream = instrumented_test_stream
 
     # Storing previous values in the settings module itself is problematic.
     # Store them in arbitrary (but related) modules instead. See #20636.
@@ -114,6 +125,8 @@ def teardown_test_environment():
     """
     Template._render = Template._original_render
     del Template._original_render
+    Template._stream = Template._original_stream
+    del Template._original_stream
 
     settings.EMAIL_BACKEND = mail._original_email_backend
     del mail._original_email_backend

--- a/django/views/generic/__init__.py
+++ b/django/views/generic/__init__.py
@@ -1,4 +1,4 @@
-from django.views.generic.base import View, TemplateView, RedirectView
+from django.views.generic.base import View, TemplateView, StreamingTemplateView, RedirectView
 from django.views.generic.dates import (ArchiveIndexView, YearArchiveView, MonthArchiveView,
                                      WeekArchiveView, DayArchiveView, TodayArchiveView,
                                      DateDetailView)

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -6,7 +6,7 @@ from functools import update_wrapper
 from django import http
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.template.response import TemplateResponse
+from django.template.response import TemplateResponse, StreamingTemplateResponse
 from django.utils.decorators import classonlymethod
 from django.utils import six
 
@@ -154,6 +154,8 @@ class TemplateView(TemplateResponseMixin, ContextMixin, View):
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 
+class StreamingTemplateView(TemplateView):
+    response_class = StreamingTemplateResponse
 
 class RedirectView(View):
     """

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -1225,3 +1225,25 @@ For more examples of complex rendering, see the source code for
 :ttag:`{% if %}<if>`, :ttag:`{% for %}<for>`, :ttag:`{% ifequal %}<ifequal>`
 or :ttag:`{% ifchanged %}<ifchanged>`. They live in
 ``django/template/defaulttags.py``.
+
+
+Streaming support
+~~~~~~~~~~~~~~~~~
+
+Simple tags do not need to worry about streaming support. But if your custom
+tag is a more complex one with a "begin" and "end" tag, you want the tag to 
+be able to progressively render its contents. You can define your own 
+``stream()`` method for a custom tag. The ``stream()`` method takes the same
+arguments as ``render()`` but instead of returning string, it needs to return
+a string generator.
+
+As an example, the ``stream()`` method for the ``{% upper %}`` tag above will
+look like this::
+
+    def stream(self, context):
+        for chunk in self.nodelist.stream(context):
+            yield chunk.upper()
+
+If you define ``stream()`` in your custom template tag, you can define its
+``render()`` method as ``''.join(self.stream(context))`` to avoid duplicate
+code.

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -228,6 +228,15 @@ straight lookups. Here are some things to keep in mind:
   if your variable is not callable (allowing you to access attributes of
   the callable, for example).
 
+Getting the rendering generator
+-------------------------------
+
+As an alternative to rendering a context all-at-once, you can get the string
+generator that renders the context progressively by calling the ``Template``
+object's ``stream()`` method, passing the context as its argument. You can
+then pass the generator to :class:`~django.http.HttpResponse` to get a
+"streaming" effect on your view.
+
 .. _invalid-template-variables:
 
 How invalid variables are handled
@@ -766,6 +775,14 @@ context_instance
 See also the :func:`~django.shortcuts.render_to_response()` shortcut, which
 calls ``render_to_string`` and feeds the result into an :class:`~django.http.HttpResponse`
 suitable for returning directly from a view.
+
+The ``stream()`` shortcut
+=========================
+
+This shortcut is like :func:`render_to_string` but instead of returning
+the whole rendered text of the template, this shortcut returns a generator
+that successively renders parts of the template. See
+:func:`~django.shortcuts.stream_to_response()` for an example of its usage.
 
 Configuring the template system in standalone mode
 ==================================================

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -87,6 +87,13 @@ This example is equivalent to::
         return HttpResponse(t.render(c),
             content_type="application/xhtml+xml")
 
+``stream``
+==========
+
+.. function:: stream(request, template_name[, dictionary][, context_instance][, content_type][, status][, current_app])
+
+   This function is the same as :func:`render()`, but uses a generator in the 
+   :class:`~django.http.HttpResponse` object to progressively render text.
 
 ``render_to_response``
 ======================
@@ -158,6 +165,30 @@ This example is equivalent to::
         c = Context({'foo': 'bar'})
         return HttpResponse(t.render(c),
             content_type="application/xhtml+xml")
+
+``stream_to_response``
+======================
+
+.. function:: stream_to_response(template[, dictionary][, context_instance][, mimetype])
+
+   The ``stream_to_response`` shortcut is the same as
+   :func:`render_to_response`, except that ``stream_to_response`` returns an
+   :class:`~django.http.HttpResponse` object that gradually renders the
+   template, while ``render_to_response`` waits for the whole template to be
+   rendered before putting it into the response.
+
+   This is useful if something inside the template takes a long time to
+   render. For example, if the template contains the following code::
+
+    {% for item in warehouse %}
+        Current value: {{ item.calculate_depreciation }}
+    {% endfor %}
+
+   If there are 100 items in warehouse and ``calculate_depreciation()`` takes
+   0.5 seconds to complete, ``render_to_response`` will need 50 seconds to
+   render all items before returning a response, while ``stream_to_response``
+   will immediately return a response that renders one item every half
+   second.
 
 ``redirect``
 ============

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf.urls import patterns, url
 from django.views.decorators.cache import cache_page
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, StreamingTemplateView
 
 from . import models
 from . import views
@@ -25,6 +25,16 @@ urlpatterns = patterns('',
 
     (r'^template/cached/(?P<foo>\w+)/$',
         cache_page(2.0)(TemplateView.as_view(template_name='generic_views/about.html'))),
+
+    # StreamingTemplateView
+    (r'^template/streaming/no_template/$',
+        StreamingTemplateView.as_view()),
+    (r'^template/streaming/simple/(?P<foo>\w+)/$',
+        StreamingTemplateView.as_view(template_name='generic_views/about.html')),
+    (r'^template/streaming/custom/(?P<foo>\w+)/$',
+        views.CustomStreamingTemplateView.as_view(template_name='generic_views/about.html')),
+    (r'^template/streaming/content_type/$',
+        StreamingTemplateView.as_view(template_name='generic_views/robots.txt', content_type='text/plain')),
 
     # DetailView
     (r'^detail/obj/$',

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -19,6 +19,15 @@ class CustomTemplateView(generic.TemplateView):
         return context
 
 
+class CustomStreamingTemplateView(generic.StreamingTemplateView):
+    template_name = 'generic_views/about.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(CustomStreamingTemplateView, self).get_context_data(**kwargs)
+        context.update({'key': 'value'})
+        return context
+
+
 class ObjectDetail(generic.DetailView):
     template_name = 'generic_views/detail.html'
 

--- a/tests/template_tests/loaders.py
+++ b/tests/template_tests/loaders.py
@@ -119,6 +119,7 @@ class CachedLoader(unittest.TestCase):
 
         # The two templates should not have the same content
         self.assertNotEqual(t1.render(Context({})), t2.render(Context({})))
+        self.assertNotEqual(''.join(t1.stream(Context({}))), ''.join(t2.stream(Context({}))))
 
 class RenderToStringTest(unittest.TestCase):
 
@@ -138,6 +139,13 @@ class RenderToStringTest(unittest.TestCase):
         self.assertEqual(loader.render_to_string('test_context.html',
                                                  {'obj': 'test'}), 'obj:test')
 
+    def test_basic_stream(self):
+        self.assertEqual(list(loader.stream('test_context.html')), ['obj:', ''])
+
+    def test_basic_context_stream(self):
+        self.assertEqual(list(loader.stream('test_context.html',
+                                                 {'obj': 'test'})), ['obj:', 'test'])
+
     def test_existing_context_kept_clean(self):
         context = Context({'obj': 'before'})
         output = loader.render_to_string('test_context.html', {'obj': 'after'},
@@ -150,6 +158,17 @@ class RenderToStringTest(unittest.TestCase):
                                 'No template names provided$',
                                 loader.render_to_string, [])
 
+    def test_existing_context_kept_clean_stream(self):
+        context = Context({'obj': 'before'})
+        output = loader.stream('test_context.html', {'obj': 'after'},
+                                         context_instance=context)
+        self.assertEqual(list(output), ['obj:', 'after'])
+        self.assertEqual(context['obj'], 'before')
+
+    def test_empty_list_stream(self):
+        six.assertRaisesRegex(self, TemplateDoesNotExist,
+                                'No template names provided$',
+                                loader.stream, [])
 
     def test_select_templates_from_empty_list(self):
         six.assertRaisesRegex(self, TemplateDoesNotExist,

--- a/tests/template_tests/test_response.py
+++ b/tests/template_tests/test_response.py
@@ -9,6 +9,7 @@ from django.test import RequestFactory, TestCase
 from django.conf import settings
 from django.template import Template, Context
 from django.template.response import (TemplateResponse, SimpleTemplateResponse,
+                                      StreamingTemplateResponse, SimpleStreamingTemplateResponse,
                                       ContentNotRenderedError)
 from django.test.utils import override_settings
 from django.utils._os import upath
@@ -295,6 +296,53 @@ class TemplateResponseTest(TestCase):
         pickled_response = pickle.dumps(response)
         unpickled_response = pickle.loads(pickled_response)
         repickled_response = pickle.dumps(unpickled_response)
+
+
+@override_settings(
+    TEMPLATE_CONTEXT_PROCESSORS=[test_processor_name],
+    TEMPLATE_DIRS=(os.path.join(os.path.dirname(upath(__file__)), 'templates')),
+)
+class StreamingTemplateResponseTest(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _response(self, template='foo', *args, **kwargs):
+        return StreamingTemplateResponse(self.factory.get('/'), Template(template),
+                                *args, **kwargs)
+
+    def test_stream(self):
+        response = self._response('{{ foo }}{{ processors }}')
+        self.assertEqual(''.join(response.streaming_content), b'yes')
+
+    def test_stream_with_requestcontext(self):
+        response = self._response('{{ foo }}{{ processors }}',
+                                  {'foo': 'bar'})
+        self.assertEqual(''.join(response.streaming_content), b'baryes')
+
+    def test_stream_with_context(self):
+        response = self._response('{{ foo }}{{ processors }}',
+                                  Context({'foo': 'bar'}))
+        self.assertEqual(''.join(response.streaming_content), b'bar')
+
+    def test_kwargs(self):
+        response = self._response(content_type='application/json',
+                                  status=504)
+        self.assertEqual(response['content-type'], 'application/json')
+        self.assertEqual(response.status_code, 504)
+
+    def test_args(self):
+        response = StreamingTemplateResponse(self.factory.get('/'), '', {},
+                                    'application/json', 504)
+        self.assertEqual(response['content-type'], 'application/json')
+        self.assertEqual(response.status_code, 504)
+
+    def test_custom_app(self):
+        response = self._response('{{ foo }}', current_app="foobar")
+
+        rc = response.resolve_context(response.context_data)
+
+        self.assertEqual(rc.current_app, 'foobar')
 
 
 class CustomURLConfTest(TestCase):

--- a/tests/template_tests/test_unicode.py
+++ b/tests/template_tests/test_unicode.py
@@ -29,5 +29,6 @@ class UnicodeTests(TestCase):
         # they all render the same (and are returned as unicode objects and
         # "safe" objects as well, for auto-escaping purposes).
         self.assertEqual(t1.render(c3), t2.render(c3))
+        self.assertEqual(''.join(t1.stream(c3)), t1.render(c3))
         self.assertIsInstance(t1.render(c3), six.text_type)
         self.assertIsInstance(t1.render(c3), SafeData)


### PR DESCRIPTION
... and supporting views
- Added stream_to_response shortcut, similar to render_to_response
- Added stream shortcut, similar to render
- Added stream method to Template and Node classes
- Added stream functionality to defaulttags that would benefit from it
- Added stream function to template.loader
- Added StreamingTemplateResponse and supporting generic StreamingTemplateView
  -- Rearranged inheritance of generic.base views to support both traditional and streaming views
  -- Added StreamingTemplateResponse and SimpleStreamingTemplateResponse to complement the
  exsting non-streaming template response classes
