### PR TITLE
Ticket #20349 Don't load test suite when not needed

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -6,7 +6,6 @@ import hashlib
 
 from django.dispatch import receiver
 from django.conf import settings
-from django.test.signals import setting_changed
 from django.utils import importlib
 from django.utils.datastructures import SortedDict
 from django.utils.encoding import force_bytes, force_str
@@ -20,14 +19,6 @@ from django.utils.translation import ugettext_noop as _
 UNUSABLE_PASSWORD = '!'  # This will never be a valid encoded hash
 HASHERS = None  # lazily loaded from PASSWORD_HASHERS
 PREFERRED_HASHER = None  # defaults to first item in PASSWORD_HASHERS
-
-@receiver(setting_changed)
-def reset_hashers(**kwargs):
-    if kwargs['setting'] == 'PASSWORD_HASHERS':
-        global HASHERS, PREFERRED_HASHER
-        HASHERS = None
-        PREFERRED_HASHER = None
-
 
 def is_password_usable(encoded):
     if encoded is None or encoded == UNUSABLE_PASSWORD:

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -74,8 +74,17 @@ def language_changed(**kwargs):
         if kwargs['setting'] == 'LOCALE_PATHS':
             trans_real._translations = {}
 
+
 @receiver(setting_changed)
 def file_storage_changed(**kwargs):
     if kwargs['setting'] in ('MEDIA_ROOT', 'DEFAULT_FILE_STORAGE'):
         from django.core.files.storage import default_storage
         default_storage._wrapped = empty
+
+
+@receiver(setting_changed)
+def reset_hashers(**kwargs):
+    if kwargs['setting'] == 'PASSWORD_HASHERS':
+        global HASHERS, PREFERRED_HASHER
+        HASHERS = None
+        PREFERRED_HASHER = None


### PR DESCRIPTION
I noticed that `django/contrib/auth/hashers.py` is loading the `settings_changed` signal from the test suite. This ends up also loading the whole test suite in addition.

All of the other code that handles the `settings_changed` signal is kept inside the test suite itself. I assume this code is kept out of the test suite because of the "core shouldn't be aware of contrib" rule. Seems to me it's more important to avoid unnecessarily loading the test suite on a production website.

Yes, I realize this is picky, but we're perfectionists, right?

https://code.djangoproject.com/ticket/20349
