### PR TITLE
Fixed #20354 -- `makemessages` no longer crashes with `UnicodeDecodeErro...

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -294,7 +294,10 @@ class Command(NoArgsCommand):
             os.unlink(potfile)
 
         for f in file_list:
-            f.process(self, potfile, self.domain, self.keep_pot)
+            try:
+                f.process(self, potfile, self.domain, self.keep_pot)
+            except UnicodeDecodeError:
+                self.stdout.write("UnicodeDecodeError: skipped file %s in %s" % (f.file, f.dirpath))
         return potfile
 
     def find_files(self, root):

--- a/tests/i18n/commands/extraction.py
+++ b/tests/i18n/commands/extraction.py
@@ -126,6 +126,17 @@ class BasicExtractorTests(ExtractorTests):
         # Check that the temporary file was cleaned up
         self.assertFalse(os.path.exists('./templates/template_with_error.tpl.py'))
 
+    def test_unicode_decode_error(self):
+        os.chdir(self.test_dir)
+        shutil.copyfile('./not_utf8.sample', './not_utf8.txt')
+        stdout = StringIO()
+        management.call_command('makemessages', locale=LOCALE, stdout=stdout)
+        os.remove('./not_utf8.txt')
+        # Check that the temporary file was cleaned up
+        self.assertFalse(os.path.exists('./not_utf8.txt.py'))
+        self.assertIn("UnicodeDecodeError: skipped file not_utf8.txt in .",
+                      force_text(stdout.getvalue()))
+
     def test_extraction_warning(self):
         """test xgettext warning about multiple bare interpolation placeholders"""
         os.chdir(self.test_dir)

--- a/tests/i18n/commands/not_utf8.sample
+++ b/tests/i18n/commands/not_utf8.sample
@@ -1,0 +1,1 @@
+Copyright (c) 2009 Øyvind Sean Kinsey, oyvind@kinsey.no


### PR DESCRIPTION
...r`.

Handle the `UnicodeDecodeError` exception, send a warning to `stdout` with the
file name and location, and continue processing other files.
