### PR TITLE
Check username field label for None

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -170,7 +170,7 @@ class AuthenticationForm(forms.Form):
         # Set the label for the "username" field.
         UserModel = get_user_model()
         self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)
-        if not self.fields['username'].label:
+        if self.fields['username'].label is None:
             self.fields['username'].label = capfirst(self.username_field.verbose_name)
 
     def clean(self):

--- a/django/contrib/auth/tests/forms.py
+++ b/django/contrib/auth/tests/forms.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 import os
+
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import (UserCreationForm, AuthenticationForm,
     PasswordChangeForm, SetPasswordForm, UserChangeForm, PasswordResetForm,
@@ -13,6 +15,7 @@ from django.test.utils import override_settings
 from django.utils.encoding import force_text
 from django.utils._os import upath
 from django.utils import translation
+from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
 
@@ -145,6 +148,24 @@ class AuthenticationFormTest(TestCase):
 
         form = CustomAuthenticationForm()
         self.assertEqual(form['username'].label, "Name")
+        
+    def test_username_field_label_not_set(self):
+        
+        class CustomAuthenticationForm(AuthenticationForm):
+            username = CharField()
+
+        form = CustomAuthenticationForm()
+        UserModel = get_user_model()
+        username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)
+        self.assertEqual(form.fields['username'].label, capfirst(username_field.verbose_name))
+            
+    def test_username_field_label_empty_string(self):
+        
+        class CustomAuthenticationForm(AuthenticationForm):
+            username = CharField(label='')
+            
+        form = CustomAuthenticationForm()
+        self.assertEqual(form.fields['username'].label, "")
 
 
 @skipIfCustomUser


### PR DESCRIPTION
In line [173 of django.contrib.auth.forms](https://github.com/zhenghao1/django/blob/master/django/contrib/auth/forms.py#L173), the `if` check is too generic and covers too wide a scope.  

Anyone that wanted to deliberately set the label to an empty string like such:

```
username = CharField(label='')
```

would still get a _Username_ label being shown.  

This pull request hopes to fix that with a `None` check, since the default value for label is `None`.
