### PR TITLE
Remove outdated ForeignKey manager documentation

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1112,15 +1112,6 @@ above example code would look like this::
     >>> b.entries.filter(headline__contains='Lennon')
     >>> b.entries.count()
 
-You cannot access a reverse :class:`~django.db.models.ForeignKey`
-:class:`~django.db.models.Manager` from the class; it must be accessed from an
-instance::
-
-    >>> Blog.entry_set
-    Traceback:
-        ...
-    AttributeError: "Manager must be accessed via instance".
-
 In addition to the :class:`~django.db.models.query.QuerySet` methods defined in
 "Retrieving objects" above, the :class:`~django.db.models.ForeignKey`
 :class:`~django.db.models.Manager` has additional methods used to handle the


### PR DESCRIPTION
It appears the documentation here on accessing a related manager directly from a class is out of date. When I set up my models.py the same as in the example here, I get:

```
In [1]: from myapp.models import *

In [2]: Blog.entry_set
Out[2]: <django.db.models.fields.related.ForeignRelatedObjectsDescriptor at 0x108923a50>
```

This is what I'd expect from my reading of django.db.models.fields.related.
