### PR TITLE
Remove unnecessary check on __set__ parameters.

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -137,9 +137,6 @@ class GenericForeignKey(six.with_metaclass(RenameGenericForeignKeyMethods)):
             return rel_obj
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("%s must be accessed via instance" % self.related.opts.object_name)
-
         ct = None
         fk = None
         if value is not None:
@@ -280,9 +277,6 @@ class ReverseGenericRelatedObjectsDescriptor(object):
         return manager
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("Manager must be accessed via instance")
-
         manager = self.__get__(instance)
         manager.clear()
         for obj in value:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -206,9 +206,6 @@ class SingleRelatedObjectDescriptor(six.with_metaclass(RenameRelatedObjectDescri
             return rel_obj
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("%s must be accessed via instance" % self.related.opts.object_name)
-
         # The similarity of the code below to the code in
         # ReverseSingleRelatedObjectDescriptor is annoying, but there's a bunch
         # of small differences that would make a common base class convoluted.
@@ -312,9 +309,6 @@ class ReverseSingleRelatedObjectDescriptor(six.with_metaclass(RenameRelatedObjec
             return rel_obj
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("%s must be accessed via instance" % self.field.name)
-
         # If null=True, we can assign null here, but otherwise the value needs
         # to be an instance of the related class.
         if value is None and self.field.null == False:
@@ -384,9 +378,6 @@ class ForeignRelatedObjectsDescriptor(object):
         return self.related_manager_cls(instance)
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("Manager must be accessed via instance")
-
         manager = self.__get__(instance)
         # If the foreign key can support nulls, then completely clear the related set.
         # Otherwise, just move the named objects into the set.
@@ -767,9 +758,6 @@ class ManyRelatedObjectsDescriptor(object):
         return manager
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("Manager must be accessed via instance")
-
         if not self.related.field.rel.through._meta.auto_created:
             opts = self.related.field.rel.through._meta
             raise AttributeError("Cannot set values on a ManyToManyField which specifies an intermediary model. Use %s.%s's Manager instead." % (opts.app_label, opts.object_name))
@@ -824,9 +812,6 @@ class ReverseManyRelatedObjectsDescriptor(object):
         return manager
 
     def __set__(self, instance, value):
-        if instance is None:
-            raise AttributeError("Manager must be accessed via instance")
-
         if not self.field.rel.through._meta.auto_created:
             opts = self.field.rel.through._meta
             raise AttributeError("Cannot set values on a ManyToManyField which specifies an intermediary model.  Use %s.%s's Manager instead." % (opts.app_label, opts.object_name))


### PR DESCRIPTION
This commit removes parameter checks on the `instance` argument to the `__set__` methods for descriptors. These checks are not necessary - the [documentation on descriptors](http://docs.python.org/release/2.7.4/reference/datamodel.html#object.__set__) makes it clear that the `__set__` methods will always be called with a non-null `instance` parameter (unless you're doing something silly like `MyClass.__dict__['mydesc'].__set__(None, None)` of course) More info available via [this question on stackoverflow](http://stackoverflow.com/questions/16412672/can-a-python-descriptors-set-ever-get-called-with-instance-none).

I'm guessing this doesn't need a ticket, but if it does, let me know and I'll open one.
