### PR TITLE
Added Django version to truncatechars template tag documentation

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2086,6 +2086,8 @@ If ``value`` is ``"my first post"``, the output will be ``"My First Post"``.
 truncatechars
 ^^^^^^^^^^^^^
 
+.. versionadded:: 1.4
+
 Truncates a string if it is longer than the specified number of characters.
 Truncated strings will end with a translatable ellipsis sequence ("...").
 


### PR DESCRIPTION
The documentation of the built-in template tag truncatechars did not yet have the Django version (1.4) which can cause confusion for those using Django 1.3 and earlier.

This pull request adds that.
