### PR TITLE
BCrypt on Python3

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.test.signals import setting_changed
 from django.utils import importlib
 from django.utils.datastructures import SortedDict
-from django.utils.encoding import force_bytes, force_str
+from django.utils.encoding import force_bytes, force_str, force_text
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import (
     pbkdf2, constant_time_compare, get_random_string)
@@ -291,7 +291,7 @@ class BCryptSHA256PasswordHasher(BasePasswordHasher):
             password = force_bytes(password)
 
         data = bcrypt.hashpw(password, salt)
-        return "%s$%s" % (self.algorithm, data)
+        return "%s$%s" % (self.algorithm, force_text(data))
 
     def verify(self, password, encoded):
         algorithm, data = encoded.split('$', 1)
@@ -306,6 +306,9 @@ class BCryptSHA256PasswordHasher(BasePasswordHasher):
             password = binascii.hexlify(self.digest(force_bytes(password)).digest())
         else:
             password = force_bytes(password)
+
+        # Ensure that our data is a bytestring
+        data = force_bytes(data)
 
         return constant_time_compare(data, bcrypt.hashpw(password, data))
 


### PR DESCRIPTION
Properly use `force_bytes` and `force_str` so that the bcrypt library is always handed bytes, and the encode function always returns a proper `str`.

Tested on:
    - Python 2.7 with py-bcrypt and my new bcrypt library
    - PyPy 2.0 with py-bcrypt and my new bcrypt library
    - Python 3.2 with my new bcrypt library
