### PR TITLE
Fix #20394, parameter user_id of the custom get_user has to be the pk of User

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -95,7 +95,8 @@ An authentication backend is a class that implements two required methods:
 optional permission related :ref:`authorization methods <authorization_methods>`.
 
 The ``get_user`` method takes a ``user_id`` -- which could be a username,
-database ID or whatever -- and returns a ``User`` object.
+database ID or whatever, but has to be the primary key of your ``User`` object
+-- and returns a ``User`` object.
 
 The ``authenticate`` method takes credentials as keyword arguments. Most of
 the time, it'll just look like this::


### PR DESCRIPTION
The original statement "which could be ... or whatever" **misguides** many newbies like me.

In fact, the `login` function in `contrib.auth` stores `user.pk` in session, then `get_user` function in `contrib.auth` gets `user.pk` in session and then passes it to your custom `get_user` as `user_id`.

Which means, `user_id` parameter in your custom `get_user` has to be the primary key of `User` object, too.
