### PR TITLE
#20393 django.db.models.query.QuerySet.__repr__ should not have side-effects

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -76,7 +76,7 @@ class QuerySet(object):
         return obj_dict
 
     def __repr__(self):
-        data = list(self[:REPR_OUTPUT_SIZE + 1])
+        data = list((self._result_cache or [])[:REPR_OUTPUT_SIZE + 1])
         if len(data) > REPR_OUTPUT_SIZE:
             data[-1] = "...(remaining elements truncated)..."
         return repr(data)


### PR DESCRIPTION
Only use the result cache for **repr**
