### PR TITLE
Fixed #20398 - Added language selection code to example in documentation

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1437,7 +1437,9 @@ Here's example HTML template code:
     <select name="language">
     {% get_language_info_list for LANGUAGES as languages %}
     {% for language in languages %}
-    <option value="{{ language.code }}" {% if language.code == LANGUAGE_CODE %} selected="selected"{% endif %}>{{ language.name_local }} ({{ language.code }})</option>
+    <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected="selected"{% endif %}>
+        {{ language.name_local }} ({{ language.code }})
+    </option>
     {% endfor %}
     </select>
     <input type="submit" value="Go" />


### PR DESCRIPTION
This adds the suggestion in ticket #20398 to the documentation.
