### PR TITLE
Fixed #20397 - Cleaned up issue with quotation marks in documentation

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -328,7 +328,7 @@ Use the ``reverse()`` method to reverse the order in which a queryset's
 elements are returned. Calling ``reverse()`` a second time restores the
 ordering back to the normal direction.
 
-To retrieve the ''last'' five items in a queryset, you could do this::
+To retrieve the "last" five items in a queryset, you could do this::
 
     my_queryset.reverse()[:5]
 


### PR DESCRIPTION
The documentation tools appears to generate incorrect quotation marks in this case. This pull request resolves that.
