### PR TITLE
Recommend using the bcrypt library instead of py-bcrypt

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -263,13 +263,13 @@ class BCryptSHA256PasswordHasher(BasePasswordHasher):
     Secure password hashing using the bcrypt algorithm (recommended)
 
     This is considered by many to be the most secure algorithm but you
-    must first install the py-bcrypt library.  Please be warned that
+    must first install the bcrypt library.  Please be warned that
     this library depends on native C code and might cause portability
     issues.
     """
     algorithm = "bcrypt_sha256"
     digest = hashlib.sha256
-    library = ("py-bcrypt", "bcrypt")
+    library = ("bcrypt", "bcrypt")
     rounds = 12
 
     def salt(self):
@@ -329,7 +329,7 @@ class BCryptPasswordHasher(BCryptSHA256PasswordHasher):
     Secure password hashing using the bcrypt algorithm
 
     This is considered by many to be the most secure algorithm but you
-    must first install the py-bcrypt library.  Please be warned that
+    must first install the bcrypt library.  Please be warned that
     this library depends on native C code and might cause portability
     issues.
 

--- a/django/contrib/auth/tests/test_hashers.py
+++ b/django/contrib/auth/tests/test_hashers.py
@@ -92,7 +92,7 @@ class TestUtilsHashPass(unittest.TestCase):
         self.assertFalse(check_password('lètmeiz', encoded))
         self.assertEqual(identify_hasher(encoded).algorithm, "crypt")
 
-    @skipUnless(bcrypt, "py-bcrypt not installed")
+    @skipUnless(bcrypt, "bcrypt not installed")
     def test_bcrypt_sha256(self):
         encoded = make_password('lètmein', hasher='bcrypt_sha256')
         self.assertTrue(is_password_usable(encoded))
@@ -108,7 +108,7 @@ class TestUtilsHashPass(unittest.TestCase):
         self.assertTrue(check_password(password, encoded))
         self.assertFalse(check_password(password[:72], encoded))
 
-    @skipUnless(bcrypt, "py-bcrypt not installed")
+    @skipUnless(bcrypt, "bcrypt not installed")
     def test_bcrypt(self):
         encoded = make_password('lètmein', hasher='bcrypt')
         self.assertTrue(is_password_usable(encoded))

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -76,8 +76,8 @@ use it Django supports bcrypt with minimal effort.
 
 To use Bcrypt as your default storage algorithm, do the following:
 
-1. Install the `py-bcrypt`_ library (probably by running ``sudo pip install
-   py-bcrypt``, or downloading the library and installing it with ``python
+1. Install the `bcrypt library`_ (probably by running ``sudo pip install
+   bcrypt``, or downloading the library and installing it with ``python
    setup.py install``).
 
 2. Modify :setting:`PASSWORD_HASHERS` to list ``BCryptSHA256PasswordHasher``
@@ -185,7 +185,7 @@ mentioned algorithms won't be able to upgrade.
 .. _pbkdf2: http://en.wikipedia.org/wiki/PBKDF2
 .. _nist: http://csrc.nist.gov/publications/nistpubs/800-132/nist-sp800-132.pdf
 .. _bcrypt: http://en.wikipedia.org/wiki/Bcrypt
-.. _py-bcrypt: http://pypi.python.org/pypi/py-bcrypt/
+.. _`bcrypt library`: https://pypi.python.org/pypi/bcrypt/
 
 
 Manually managing a user's password


### PR DESCRIPTION
- py-bcrypt has not been updated in some time
- py-bcrypt does not support Python3
- py3k-bcrypt, a port of py-bcrypt to python3 is not compatible with Django
- bcrypt is supported on all versions of Python that Django supports
