### PR TITLE
Add a keys() method to ContextList.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -58,6 +58,10 @@ class ContextList(list):
         return True
 
     def keys(self):
+        """It's useful to be able to list all the (flattened) keys of a
+        ContextList, to help you (in a debugger) figure out why the
+        variable that's supposed to be there is not."""
+        
         keys = set()
         for subcontext in self:
             for dict in subcontext:

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -707,10 +707,6 @@ class ContextTests(TestCase):
             self.assertEqual(e.args[0], 'does-not-exist')
 
     def test_context_keys_method(self):
-        """It's useful to be able to list all the (flattened) keys of a
-        ContextList, to help you figure out why the variable that's supposed
-        to be there is not."""
-        
         c1 = Context()
         c1.update({'hello': 'world', 'goodbye': 'john'})
         c1.update({'hello': 'dolly', 'dolly': 'parton'})
@@ -719,6 +715,8 @@ class ContextTests(TestCase):
         c2.update({'goodbye': 'dolly'})
         
         l = ContextList([c1, c2])
+        # None, True and False are builtins of BaseContext, and present
+        # in every Context without needing to be added.
         self.assertEqual(set(['None', 'True', 'False', 'hello', 'goodbye',
             'python', 'dolly']), l.keys())
 


### PR DESCRIPTION
It's useful to be able to list all the (flattened) keys of a ContextList, to help you figure out why the variable that's supposed to be there is not. A ContextList is hard to interpret in pdb without a method like this.

All tests pass on SQLite. Not yet run on MySQL due to taking >3 hours to run the test suite.
