### PR TITLE
Restore default time zone for next requests to the same thread

### DIFF
--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -189,6 +189,10 @@ Add the following middleware to :setting:`MIDDLEWARE_CLASSES`::
             tz = request.session.get('django_timezone')
             if tz:
                 timezone.activate(tz)
+        
+        def process_response(self, request, response):
+            timezone.deactivate()
+            return response
 
 Create a view that can set the current timezone::
 


### PR DESCRIPTION
Currently the docs suggest to conditionally activate a timezone, but not to deactivate the timezone afterwards. The documentation for timezone.activate states:

> Sets the time zone for the current thread.

The expected behaviour for any request would be to use the default timezone, not that of any previous request. Therefor the timezone should be deactivated in the middleware as well.
