### PR TITLE
Make the example usage of import_by_path less confusing.

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -659,11 +659,11 @@ Functions for working with Python modules.
     wrong. For example::
 
         from django.utils.module_loading import import_by_path
-        import_by_path = import_by_path('django.utils.module_loading.import_by_path')
+        ImproperlyConfigured = import_by_path('django.core.exceptions.ImproperlyConfigured')
 
     is equivalent to::
 
-        from django.utils.module_loading import import_by_path
+        from django.core.exceptions import ImproperlyConfigured
 
 ``django.utils.safestring``
 ===========================


### PR DESCRIPTION
Using import_by_path to import import_by_path is a really odd use case and made the code example difficult to read
