### PR TITLE
Fix #20422: Fix makemessage's --ignore patterns being applied to

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -309,10 +309,9 @@ class Command(NoArgsCommand):
             """
             Check if the given path should be ignored or not.
             """
-            for pattern in ignore_patterns:
-                if fnmatch.fnmatchcase(path, pattern):
-                    return True
-            return False
+            filename = os.path.basename(path)
+            ignore = lambda pattern: fnmatch.fnmatchcase(filename, pattern)
+            return any(ignore(pattern) for pattern in ignore_patterns)
 
         dir_suffix = '%s*' % os.sep
         norm_patterns = [p[:-len(dir_suffix)] if p.endswith(dir_suffix) else p for p in self.ignore_patterns]

--- a/tests/i18n/commands/extraction.py
+++ b/tests/i18n/commands/extraction.py
@@ -279,17 +279,22 @@ class IgnoredExtractorTests(ExtractorTests):
 
     def test_ignore_option(self):
         os.chdir(self.test_dir)
-        pattern1 = os.path.join('ignore_dir', '*')
+        ignore_patterns = [
+            os.path.join('ignore_dir', '*'),
+            'xxx_*',
+        ]
         stdout = StringIO()
         management.call_command('makemessages', locale=LOCALE, verbosity=2,
-            ignore_patterns=[pattern1], stdout=stdout)
+            ignore_patterns=ignore_patterns, stdout=stdout)
         data = stdout.getvalue()
         self.assertTrue("ignoring directory ignore_dir" in data)
+        self.assertTrue("ignoring file xxx_ignored.html" in data)
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
             po_contents = fp.read()
             self.assertMsgId('This literal should be included.', po_contents)
             self.assertNotMsgId('This should be ignored.', po_contents)
+            self.assertNotMsgId('This should be ignored too.', po_contents)
 
 
 class SymlinkExtractorTests(ExtractorTests):

--- a/tests/i18n/commands/templates/xxx_ignored.html
+++ b/tests/i18n/commands/templates/xxx_ignored.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "This should be ignored too." %}


### PR DESCRIPTION
the full path instead of the file name.
Thanks to nnseva for the report and the original patch.
