### PR TITLE
Fixes #20235 - MultipleObjectMixin requires object_list in kwargs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -274,6 +274,7 @@ answer newbie questions, and generally made Django that much better:
     Eric Holscher <http://ericholscher.com>
     Ian Holsman <http://feh.holsman.net/>
     Kieran Holland <http://www.kieranholland.com>
+    Markus Holtermann <http://markusholtermann.eu>
     Sung-Jin Hong <serialx.net@gmail.com>
     Leo "hylje" Honkanen <sealage@gmail.com>
     Matt Hoskins <skaffenuk@googlemail.com>

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -105,7 +105,7 @@ class MultipleObjectMixin(ContextMixin):
         """
         Get the context for this view.
         """
-        queryset = kwargs.pop('object_list')
+        queryset = kwargs.pop('object_list', self.object_list)
         page_size = self.get_paginate_by(queryset)
         context_object_name = self.get_context_object_name(queryset)
         if page_size:
@@ -149,7 +149,7 @@ class BaseListView(MultipleObjectMixin, View):
             if is_empty:
                 raise Http404(_("Empty list and '%(class_name)s.allow_empty' is False.")
                         % {'class_name': self.__class__.__name__})
-        context = self.get_context_data(object_list=self.object_list)
+        context = self.get_context_data()
         return self.render_to_response(context)
 
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -411,3 +411,23 @@ class GetContextDataTest(unittest.TestCase):
         # test that kwarg overrides values assigned higher up
         context = test_view.get_context_data(test_name='test_value')
         self.assertEqual(context['test_name'], 'test_value')
+
+
+class UseMultipleObjectMixinTest(unittest.TestCase):
+    rf = RequestFactory()
+
+    def test_use_queryset_from_view(self):
+        test_view = views.CustomMultipleObjectMixinView()
+        test_view.get(self.rf.get('/'))
+        # Don't pass queryset as argument
+        context = test_view.get_context_data()
+        self.assertEqual(context['object_list'], test_view.queryset)
+
+    def test_overwrite_queryset(self):
+        test_view = views.CustomMultipleObjectMixinView()
+        test_view.get(self.rf.get('/'))
+        queryset = [{'name': 'Lennon'}, {'name': 'Ono'}]
+        self.assertNotEqual(test_view.queryset, queryset)
+        # Overwrite the view's queryset with queryset from kwarg
+        context = test_view.get_context_data(object_list=queryset)
+        self.assertEqual(context['object_list'], queryset)

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -201,6 +201,17 @@ class BookDetailGetObjectCustomQueryset(BookDetail):
         return super(BookDetailGetObjectCustomQueryset,self).get_object(
             queryset=Book.objects.filter(pk=2))
 
+
+class CustomMultipleObjectMixinView(generic.list.MultipleObjectMixin, generic.View):
+    queryset = [
+        {'name': 'John'},
+        {'name': 'Yoko'},
+    ]
+
+    def get(self, request):
+        self.object_list = self.get_queryset()
+
+
 class CustomContextView(generic.detail.SingleObjectMixin, generic.View):
     model = Book
     object = Book(name='dummy')


### PR DESCRIPTION
Use self.object_list if object_list not present in get_context_data kwargs.

This is so MultipleObjectMixin can be used in the same way as
SingleObjectMixin.

https://code.djangoproject.com/ticket/20235
