### PR TITLE
Fix #18998 and #20438

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -120,12 +120,14 @@ def get_user_model():
 
 
 def get_user(request):
+    from django.conf import settings
     from django.contrib.auth.models import AnonymousUser
     try:
         user_id = request.session[SESSION_KEY]
         backend_path = request.session[BACKEND_SESSION_KEY]
+        assert backend_path in settings.AUTHENTICATION_BACKENDS
         backend = load_backend(backend_path)
         user = backend.get_user(user_id) or AnonymousUser()
-    except (KeyError, ImproperlyConfigured):
+    except (AssertionError, KeyError, ImproperlyConfigured):
         user = AnonymousUser()
     return user


### PR DESCRIPTION
Fix both issues together as the code implicated is the same:

[#18998](https://code.djangoproject.com/ticket/18998?cnum_edit=10#comment:2)) If a backend is configured in `AUTHENTICATION_BACKENDS` but the module is not longer available django raises an `ImproperlyConfigured` instead of returning an `AnonymousUser`.

As @claudep said in first instance [#18998](https://code.djangoproject.com/ticket/18998?cnum_edit=10#comment:1), django should catch `ImproperlyConfigured` and return an `AnonymousUser` instead.

The solution is pretty straightforward( https://github.com/jorgebastida/django/commit/347606c7d20b89b7bd891e597d96b82b8a788c39)

As mentioned in [#18998](https://code.djangoproject.com/ticket/18998?cnum_edit=10#comment:2), [#20438](https://code.djangoproject.com/ticket/20438#ticket) is related to [#18998](https://code.djangoproject.com/ticket/18998?cnum_edit=10#comment:2) and as both use mostly the same test case, will fix both together.

[#20438](https://code.djangoproject.com/ticket/20438#ticket)) If a user logs in with backend `A` and then we remove `A` from `AUTHENTICATION_BACKENDS` the user will still be log in even if the backend is no longer available in `AUTHENTICATION_BACKENDS` but the module is.

In order to fix this bug we need to check if `backend_path` is in `settings.AUTHENTICATION_BACKENDS` before loading the backend (https://github.com/jorgebastida/django/commit/116ac198ff3aeaa0cbe08c7a89f6127fa2d0e78c)

Both changes have regression tests attached and I don't think any documentation is needed.
