### PR TITLE
Make Model.__repr__() safe

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -419,11 +419,8 @@ class Model(six.with_metaclass(ModelBase)):
         signals.post_init.send(sender=self.__class__, instance=self)
 
     def __repr__(self):
-        try:
-            u = six.text_type(self)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            u = '[Bad Unicode data]'
-        return force_str('<%s: %s>' % (self.__class__.__name__, u))
+        return force_str('%s(%s=%r)' % (
+            self.__class__.__name__, self._meta.pk.attname, self._get_pk_val()))
 
     def __str__(self):
         if not six.PY3 and hasattr(self, '__unicode__'):


### PR DESCRIPTION
`__repr__` is mainly used in the debugging context and it calling `__unicode__` can yield unwanted consequences such as executing a database query (I guess it's a common thing with translated objects).

This implementation also makes it easier to find the object in the database as it displays its primary key which is the only field we can assume to be indexed.

All tests pass.
