### PR TITLE
Don't log warnings in ensure_csrf_cookie decorator

### DIFF
--- a/django/views/decorators/csrf.py
+++ b/django/views/decorators/csrf.py
@@ -15,7 +15,7 @@ using the decorator multiple times, is harmless and efficient.
 
 class _EnsureCsrfToken(CsrfViewMiddleware):
     # We need this to behave just like the CsrfViewMiddleware, but not reject
-    # requests.
+    # requests or log warnings.
     def _reject(self, request, reason):
         return None
 


### PR DESCRIPTION
See ticket #19436.
https://code.djangoproject.com/ticket/19436
