### PR TITLE
Marked CACHE_MIDDLEWARE_ANONYMOUS_ONLY as deprecated

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -29,11 +29,6 @@ More details about how the caching works:
   of the response's "Cache-Control" header, falling back to the
   CACHE_MIDDLEWARE_SECONDS setting if the section was not found.
 
-* If CACHE_MIDDLEWARE_ANONYMOUS_ONLY is set to True, only anonymous requests
-  (i.e., those not made by a logged-in user) will be cached. This is a simple
-  and effective way of avoiding the caching of the Django admin (and any other
-  user-specific content).
-
 * This middleware expects that a HEAD request is answered with the same response
   headers exactly like the corresponding GET request.
 
@@ -47,6 +42,8 @@ More details about how the caching works:
   headers on the response object.
 
 """
+
+import warnings
 
 from django.conf import settings
 from django.core.cache import get_cache, DEFAULT_CACHE_ALIAS
@@ -199,6 +196,10 @@ class CacheMiddleware(UpdateCacheMiddleware, FetchFromCacheMiddleware):
             self.cache_anonymous_only = getattr(settings, 'CACHE_MIDDLEWARE_ANONYMOUS_ONLY', False)
         else:
             self.cache_anonymous_only = cache_anonymous_only
+
+        if self.cache_anonymous_only:
+            msg = "CACHE_MIDDLEWARE_ANONYMOUS_ONLY has been deprecated and will be removed in Django 1.8."
+            warnings.warn(msg, PendingDeprecationWarning, stacklevel=1)
 
         self.cache = get_cache(self.cache_alias, **cache_kwargs)
         self.cache_timeout = self.cache.default_timeout

--- a/docs/faq/admin.txt
+++ b/docs/faq/admin.txt
@@ -27,12 +27,6 @@ account has :attr:`~django.contrib.auth.models.User.is_active` and
 :attr:`~django.contrib.auth.models.User.is_staff` set to True. The admin site
 only allows access to users with those two fields both set to True.
 
-How can I prevent the cache middleware from caching the admin site?
--------------------------------------------------------------------
-
-Set the :setting:`CACHE_MIDDLEWARE_ANONYMOUS_ONLY` setting to ``True``. See the
-:doc:`cache documentation </topics/cache>` for more information.
-
 How do I automatically set a field's value to the user who last edited the object in the admin?
 -----------------------------------------------------------------------------------------------
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -390,6 +390,8 @@ these changes.
   ``django.test.testcases.OutputChecker`` will be removed. Instead use the
   doctest module from the Python standard library.
 
+* The ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting will be removed.
+
 2.0
 ---
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -280,14 +280,18 @@ CACHE_MIDDLEWARE_ANONYMOUS_ONLY
 
 Default: ``False``
 
+.. deprecated:: 1.6
+
+    This setting was largely ineffective because of using cookies for sessions
+    and CSRF. See the :doc:`Django 1.6 release notes</releases/1.6>` for more
+    information.
+
 If the value of this setting is ``True``, only anonymous requests (i.e., not
 those made by a logged-in user) will be cached.  Otherwise, the middleware
 caches every page that doesn't have GET or POST parameters.
 
 If you set the value of this setting to ``True``, you should make sure you've
 activated ``AuthenticationMiddleware``.
-
-See :doc:`/topics/cache`.
 
 .. setting:: CACHE_MIDDLEWARE_KEY_PREFIX
 

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -665,3 +665,23 @@ you can set set the ``form_class`` attribute to a ``ModelForm`` that explicitly
 defines the fields to be used. Defining an ``UpdateView`` or ``CreateView``
 subclass to be used with a model but without an explicit list of fields is
 deprecated.
+
+``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`~django.middleware.cache.CacheMiddleware` used to provide a way to
+cache requests if they weren't made by a logged-in user. This mechanism was
+largely ineffective because the middleware correctly takes into account the
+``Vary: Cookie`` HTTP header. This header is being set on a variety of
+occasions, such as:
+
+* accessing the session,
+
+* using a client-side library which sets cookies (like `Google Analytics`__),
+
+* or using CSRF protection, which is turned on by default.
+
+This makes the cache work on a per-session basis regardless of the
+``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting.
+
+__ http://www.google.com/analytics/

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -443,15 +443,9 @@ Then, add the following required settings to your Django settings file:
 The cache middleware caches GET and HEAD responses with status 200, where the request
 and response headers allow. Responses to requests for the same URL with different
 query parameters are considered to be unique pages and are cached separately.
-Optionally, if the :setting:`CACHE_MIDDLEWARE_ANONYMOUS_ONLY`
-setting is ``True``, only anonymous requests (i.e., not those made by a
-logged-in user) will be cached. This is a simple and effective way of disabling
-caching for any user-specific pages (including Django's admin interface). Note
-that if you use :setting:`CACHE_MIDDLEWARE_ANONYMOUS_ONLY`, you should make
-sure you've activated ``AuthenticationMiddleware``. The cache middleware
-expects that a HEAD request is answered with the same response headers as
-the corresponding GET request; in which case it can return a cached GET
-response for HEAD request.
+The cache middleware expects that a HEAD request is answered with the same
+response headers as the corresponding GET request; in which case it can return
+a cached GET response for HEAD request.
 
 Additionally, the cache middleware automatically sets a few headers in each
 :class:`~django.http.HttpResponse`:

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -28,7 +28,7 @@ from django.middleware.cache import (FetchFromCacheMiddleware,
 from django.template import Template
 from django.template.response import TemplateResponse
 from django.test import TestCase, TransactionTestCase, RequestFactory
-from django.test.utils import override_settings, six
+from django.test.utils import override_settings, six, IgnorePendingDeprecationWarningsMixin
 from django.utils import timezone, translation, unittest
 from django.utils.cache import (patch_vary_headers, get_cache_key,
     learn_cache_key, patch_cache_control, patch_response_headers)
@@ -1592,14 +1592,16 @@ def hello_world_view(request, value):
             },
         },
 )
-class CacheMiddlewareTest(TestCase):
+class CacheMiddlewareTest(IgnorePendingDeprecationWarningsMixin, TestCase):
 
     def setUp(self):
+        super(CacheMiddlewareTest, self).setUp()
         self.factory = RequestFactory()
         self.default_cache = get_cache('default')
         self.other_cache = get_cache('other')
 
     def tearDown(self):
+        super(CacheMiddlewareTest, self).tearDown()
         self.default_cache.clear()
         self.other_cache.clear()
 


### PR DESCRIPTION
Fixes #15201.
