### PR TITLE
My patch for ticket 20284

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -42,7 +42,7 @@ Configuring static files
 
     During development, this will be done automatically if you use :djadmin:`runserver`
     and :setting:`DEBUG` is set to ``True`` (see
-    :class:`django.contrib.staticfiles.views.serve`). 
+    :func:`django.contrib.staticfiles.views.serve`). 
 
     This method is **grossly inefficient** and probably **insecure**,
     so it is **unsuitable for production**. 


### PR DESCRIPTION
As described at https://code.djangoproject.com/ticket/20284, it was lacking a mention that serving static assets in production was dependent on the DEBUG settings.

So I replaced the single line of text "Now, if you use ./manage.py runserver, all static files should be served automatically at the STATIC_URL and be shown correctly." by a more complete note block (also re-stating that this was not a proper solution for production environments, and added links to relevant documentation).

Please note that I'm not a native English speaker.
