### PR TITLE
Fix NoneType error when fetching a stale ContentType with get_for_id

### DIFF
--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -118,10 +118,12 @@ class ContentTypeManager(models.Manager):
 
     def _add_to_cache(self, using, ct):
         """Insert a ContentType into the cache."""
-        model = ct.model_class()
-        key = (model._meta.app_label, model._meta.model_name)
+        # Note it's possible for ContentType objects to be stale; model_class() will return None.
+        # Hence, there is no reliance on model._meta.app_label here, just using the model fields instead.
+        key = (ct.app_label, ct.model)
         self.__class__._cache.setdefault(using, {})[key] = ct
         self.__class__._cache.setdefault(using, {})[ct.id] = ct
+
 
 @python_2_unicode_compatible
 class ContentType(models.Model):

--- a/django/contrib/contenttypes/tests.py
+++ b/django/contrib/contenttypes/tests.py
@@ -274,3 +274,10 @@ class ContentTypesTests(TestCase):
             model = 'OldModel',
         )
         self.assertEqual(six.text_type(ct), 'Old model')
+        self.assertIsNone(ct.model_class())
+
+        # Make sure stale ContentTypes can be fetched like any other object.
+        # Before Django 1.6 this caused a NoneType error in the caching mechanism.
+        # Instead, just return the ContentType object and let the app detect stale states.
+        ct_fetched = ContentType.objects.get_for_id(ct.pk)
+        self.assertIsNone(ct_fetched.model_class())


### PR DESCRIPTION
When a stale ContentType is fetched with `get_for_id()`, a `NoneType` error was raised.

The `_add_to_cache()` function didn't detect that `model_class()` returns `None` (which it does by design). However, the `app_label` + `model` fields can be used instead to as local cache key. Third party apps can detect stale models by checking whether `model_class()` returns `None`; as they'd previously had to do as well.

Ticket: https://code.djangoproject.com/ticket/20442
