### PR TITLE
Fixed #19489 - assertRedirects host parameter not in the doc

### DIFF
--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -1547,15 +1547,19 @@ your test suite.
     You can use this as a context manager in the same way as
     :meth:`~TestCase.assertTemplateUsed`.
 
-.. method:: TestCase.assertRedirects(response, expected_url, status_code=302, target_status_code=200, msg_prefix='')
+.. method:: TestCase.assertRedirects(response, expected_url, status_code=302, target_status_code=200, host=None, msg_prefix='')
 
-    Asserts that the response return a ``status_code`` redirect status, it
+    Asserts that the response returns a ``status_code`` redirect status, is
     redirected to ``expected_url`` (including any GET data), and the final
     page was received with ``target_status_code``.
 
-    If your request used the ``follow`` argument, the ``expected_url`` and
+    If your request uses the ``follow`` argument, the ``expected_url`` and
     ``target_status_code`` will be the url and status code for the final
     point of the redirect chain.
+	
+	The ``host`` argument can be used to set a default host for relative
+	``expected_url`` arguments.  Absolute ``expected_url`` will ignore the
+	``host`` argument.
 
 .. method:: TestCase.assertQuerysetEqual(qs, values, transform=repr, ordered=True)
 


### PR DESCRIPTION
Added 'host' argument to method signature and corrected grammar.
