### PR TITLE
Make sure QuerySet.get() never fetches more than two rows

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -383,6 +383,7 @@ class QuerySet(object):
         clone = self.filter(*args, **kwargs)
         if self.query.can_filter():
             clone = clone.order_by()
+        clone = clone[:2]
         num = len(clone)
         if num == 1:
             return clone._result_cache[0]
@@ -392,9 +393,8 @@ class QuerySet(object):
                 "Lookup parameters were %s" %
                 (self.model._meta.object_name, kwargs))
         raise self.model.MultipleObjectsReturned(
-            "get() returned more than one %s -- it returned %s! "
-            "Lookup parameters were %s" %
-            (self.model._meta.object_name, num, kwargs))
+            "get() returned more than one %s! Lookup parameters were %s" %
+            (self.model._meta.object_name, kwargs))
 
     def create(self, **kwargs):
         """

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -145,21 +145,21 @@ class ModelTest(TestCase):
         # lookup matches more than one object
         six.assertRaisesRegex(self,
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
+            "get\(\) returned more than one Article!",
             Article.objects.get,
             headline__startswith='Area',
         )
 
         six.assertRaisesRegex(self,
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
+            "get\(\) returned more than one Article!",
             Article.objects.get,
             pub_date__year=2005,
         )
 
         six.assertRaisesRegex(self,
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
+            "get\(\) returned more than one Article!",
             Article.objects.get,
             pub_date__year=2005,
             pub_date__month=7,


### PR DESCRIPTION
Currently if you pass incorrect parameters to get you can end up fetching a huge number of rows and possibly run out of memory for the sake of displaying the number of matched rows.
