### PR TITLE
Make Urdu (ur) recognized as RTL language. Refs #20454

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -131,7 +131,7 @@ LANGUAGES = (
 )
 
 # Languages using BiDi (right-to-left) layout
-LANGUAGES_BIDI = ("he", "ar", "fa")
+LANGUAGES_BIDI = ("he", "ar", "fa", "ur")
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.


### PR DESCRIPTION
 In #15300, Urdu was added, but not added to the list of RTL locales. But it is.

References: ​https://github.com/django/django/blob/master/django/contrib/admin/locale/ur/LC_MESSAGES/django.po shows if you select bidi text, and ​http://en.wikipedia.org/wiki/Urdu says so.

This is for https://code.djangoproject.com/ticket/20454.
