### PR TITLE
refs #20233 - Full custom user model example isn't really full

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -1075,7 +1075,6 @@ code would be required in the app's ``admin.py`` file::
             (None, {'fields': ('email', 'password')}),
             ('Personal info', {'fields': ('date_of_birth',)}),
             ('Permissions', {'fields': ('is_admin',)}),
-            ('Important dates', {'fields': ('last_login',)}),
         )
         add_fieldsets = (
             (None, {
@@ -1092,3 +1091,8 @@ code would be required in the app's ``admin.py`` file::
     # ... and, since we're not using Django's builtin permissions,
     # unregister the Group model from admin.
     admin.site.unregister(Group)
+
+Finally specify the custom model as the default user model for your project using the :setting:`AUTH_USER_MODEL` setting in your ``settings.py``::
+
+    AUTH_USER_MODEL = 'customauth.MyUser'
+    


### PR DESCRIPTION
Addition and fix for custom user model example documentation.

https://code.djangoproject.com/ticket/20233

I added the missing fragment to the docs.

I also tested the docs and found another problem with this example. 
When you use the provided code, you will get this error:

```
ImproperlyConfigured at /admin/
'MyUserAdmin.fieldsets[3][1]['fields']' refers to field 'last_login' that is missing from the form.
```

It complains that we're referring to a missing field `last_login`.
In order to correct this, you can simply remove the offending line:

```
('Important dates', {'fields': ('last_login',)}),
```

I added both changes to the docs file.
