### PR TITLE
fix for #20452

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -578,19 +578,19 @@ streaming response if (and only if) no middleware accesses the
     instantiated with an iterator. Django will consume and save the content of
     the iterator on first access.
 
-Setting headers
-~~~~~~~~~~~~~~~
+Setting header fields
+~~~~~~~~~~~~~~~~~~~~~
 
-To set or remove a header in your response, treat it like a dictionary::
+To set or remove a header field in your response, treat it like a dictionary::
 
     >>> response = HttpResponse()
     >>> response['Cache-Control'] = 'no-cache'
     >>> del response['Cache-Control']
 
-Note that unlike a dictionary, ``del`` doesn't raise ``KeyError`` if the header
+Note that unlike a dictionary, ``del`` doesn't raise ``KeyError`` if the field
 doesn't exist.
 
-HTTP headers cannot contain newlines. An attempt to set a header containing a
+HTTP header fields cannot contain newlines. An attempt to set a header field containing a
 newline character (CR or LF) will raise ``BadHeaderError``
 
 Telling the browser to treat the response as a file attachment


### PR DESCRIPTION
rename 'headers' to 'header fields'
