### PR TITLE
Integrity problems when using get_or_create through M2M

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1409,6 +1409,41 @@ has a side effect on your data. For more, see `Safe methods`_ in the HTTP spec.
 
 .. _Safe methods: http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1.1
 
+.. warning::
+
+  You can use ``get_or_create()`` through :class:`~django.db.models.ManyToManyField`
+  attributes and reverse relations. In that case you will restrict the queries
+  inside the context of that relation. That could lead you to some integrity
+  problems if you don't use it consistently.
+
+  Being the following models::
+
+      class Chapter(models.Model):
+          title = models.CharField(max_length=255, unique=True)
+
+      class Book(models.Model):
+          title = models.CharField(max_length=256)
+          chapters = models.ManyToManyField(Chapter)
+
+  You can use ``get_or_create()`` through Book's chapters field, but it only
+  fetches inside the context of that book::
+
+      >>> book = Book.objects.create(title="Ulysses")
+      >>> book.chapters.get_or_create(title="Telemachus")
+      (<Chapter: Telemachus>, True)
+      >>> book.chapters.get_or_create(title="Telemachus")
+      (<Chapter: Telemachus>, False)
+      >>> Chapter.objects.create(title="Chapter 1")
+      <Chapter: Chapter 1>
+      >>> book.chapters.get_or_create(title="Chapter 1")
+      # Raises IntegrityError
+
+  This is happening because it's trying to get or create "Chapter 1" through the
+  book "Ulysses", but it can't do any of them: the relation can't fetch that
+  chapter because it isn't related to that book, but it can't create it either
+  because ``title`` field should be unique.
+
+
 bulk_create
 ~~~~~~~~~~~
 

--- a/tests/get_or_create/models.py
+++ b/tests/get_or_create/models.py
@@ -28,3 +28,12 @@ class ManualPrimaryKeyTest(models.Model):
 
 class Profile(models.Model):
     person = models.ForeignKey(Person, primary_key=True)
+
+
+class Tag(models.Model):
+    text = models.CharField(max_length=256, unique=True)
+
+
+class Thing(models.Model):
+    name = models.CharField(max_length=256)
+    tags = models.ManyToManyField(Tag)


### PR DESCRIPTION
As described on [#18896](https://code.djangoproject.com/ticket/18896), if we use `get_or_create` through M2M fields or reverse FK, we can have integrity problems. As there's no obvious solution over here, I'm adding a note into the documentation for it. I also added a couple of tests cases for checking that bug.
