### PR TITLE
Ticket 20250

### DIFF
--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1112,6 +1112,17 @@ class Queries1Tests(BaseQuerysetTest):
             ['<Report: r1>']
         )
 
+    def test_ticket20250(self):
+        # A negated Q along with an annotated queryset used to fail in v1.4
+        qs = Author.objects.annotate(Count('item'))
+        qs = qs.filter(~Q(extra__value=0))
+
+        self.assertTrue('SELECT' in str(qs.query))
+        self.assertQuerysetEqual(
+            qs,
+            ['<Author: a1>', '<Author: a2>', '<Author: a3>', '<Author: a4>']
+        )
+
 
 class Queries2Tests(TestCase):
     def setUp(self):


### PR DESCRIPTION
A negated Q along with an annotated queryset used to fail in Django 1.4. It is no more the case in Django 1.5.

This pull request contains a regression test in order not to face the issue again.

Please see https://code.djangoproject.com/ticket/20250 for more details.
