### PR TITLE
Ticket no. 20183 - documentation note about existing data

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -102,7 +102,8 @@ Saving ``ForeignKey`` and ``ManyToManyField`` fields
 Updating a :class:`~django.db.models.ForeignKey` field works exactly the same
 way as saving a normal field -- simply assign an object of the right type to
 the field in question. This example updates the ``blog`` attribute of an
-``Entry`` instance ``entry``::
+``Entry`` instance ``entry``, assuming appropriate instances of ``Entry`` and
+``Blog`` are already saved to the database (so we can retrieve them below)::
 
     >>> from blog.models import Entry
     >>> entry = Entry.objects.get(pk=1)


### PR DESCRIPTION
This is fix for ticket no. 20183 (https://code.djangoproject.com/ticket/20183).

Generally documentation pages suggest the code should work as-is, but this breaks on one of the documentation pages. Some earlier example mentions that specific instance has already been created, but in this case there is no note, and adding full creation code would blur the examples (according to [this comment](https://code.djangoproject.com/ticket/20183#comment:6)).

The fix is simply to notify the user that the instances in question have already been saved in the database. If the fix is not enough, it is possible to rewrite the example to use models with less required fields.
