### PR TITLE
Fixed #1919 -- filter truncatewords is inefficient and destroys white space

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -85,6 +85,7 @@ class Truncator(SimpleLazyObject):
             return text
         return '%s%s' % (text, truncate)
 
+    @allow_lazy
     def chars(self, num, truncate=None, html=False):
         """
         Returns the text truncated to be no longer than the specified number
@@ -131,6 +132,7 @@ class Truncator(SimpleLazyObject):
         # Return the original string since no truncation was necessary
         return text
 
+    @allow_lazy
     def words(self, num, truncate=None, html=False):
         """
         Truncates a string after a certain number of words. Takes an optional
@@ -141,19 +143,34 @@ class Truncator(SimpleLazyObject):
         if html:
             return self._truncate_html(length, truncate, self._wrapped, length, True)
         return self._text_words(length, truncate)
-    words = allow_lazy(words)
 
-    def _text_words(self, length, truncate):
+    word_re = re.compile(r'\S+')
+
+    def _text_words(self, max_words, ellipsis):
         """
         Truncates a string after a certain number of words.
 
-        Newlines in the string will be stripped.
+        Whitespace within the string will not be modified before the
+        truncation point.
+        maximum  is reached.
         """
-        words = self._wrapped.split()
-        if len(words) > length:
-            words = words[:length]
-            return self.add_truncation_text(' '.join(words), truncate)
-        return ' '.join(words)
+        if max_words < 1:
+            return u''
+
+        word_count = 0
+        truncation_point = None
+
+        for match in self.word_re.finditer(self._wrapped):
+            word_count += 1
+            if word_count == max_words:
+                truncation_point = match.end() 
+                break
+
+        if truncation_point is None:
+            return self._wrapped
+        else:
+            return self.add_truncation_text(self._wrapped[:truncation_point],
+                ellipsis)
 
     def _truncate_html(self, length, truncate, text, truncate_len, words):
         """

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -169,7 +169,23 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(
             truncatewords('A sentence with a few words in it',
             'not a number'), 'A sentence with a few words in it')
-
+        self.assertEqual(
+            truncatewords('Double-spaced  sentence  with  a  few  words', 2),
+            'Double-spaced  sentence ...')
+        self.assertEqual(
+            truncatewords('  Two leading spaces for this sentence', 3),
+            '  Two leading spaces ...')
+        self.assertEqual(
+            truncatewords('  Text with leading and trailing whitespace  ', 10),
+            '  Text with leading and trailing whitespace  ')
+        self.assertEqual(
+            truncatewords('  Text with leading and trailing whitespace  ', 6),
+            '  Text with leading and trailing whitespace ...')
+        self.assertEqual(
+            truncatewords('  Text with leading and trailing whitespace  ', 1),
+            '  Text ...')
+        self.assertEqual(truncatewords('  Text  ', 0), '')
+        
     def test_truncatewords_html(self):
         self.assertEqual(truncatewords_html(
             '<p>one <a href="#">two - three <br>four</a> five</p>', 0), '')


### PR DESCRIPTION
Used @arien's patch and @SmileyChris' comments, integrated with current code, hopefully made even more efficient for long strings by not splitting and rejoining them.

https://code.djangoproject.com/ticket/1919
