### PR TITLE
Idiomatic Python: use lists where appropriate

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -110,7 +110,7 @@ class BaseSettings(object):
             raise ImproperlyConfigured("If set, %s must end with a slash" % name)
         elif name == "ALLOWED_INCLUDE_ROOTS" and isinstance(value, six.string_types):
             raise ValueError("The ALLOWED_INCLUDE_ROOTS setting must be set "
-                "to a tuple, not a string.")
+                "to a list, not a string.")
         object.__setattr__(self, name, value)
 
 
@@ -129,19 +129,19 @@ class Settings(BaseSettings):
         except ImportError as e:
             raise ImportError("Could not import settings '%s' (Is it on sys.path?): %s" % (self.SETTINGS_MODULE, e))
 
-        # Settings that should be converted into tuples if they're mistakenly entered
-        # as strings.
-        tuple_settings = ("INSTALLED_APPS", "TEMPLATE_DIRS")
+        # Settings that should be converted into lists if they're mistakenly
+        # entered as strings.
+        list_settings = ["INSTALLED_APPS", "TEMPLATE_DIRS"]
 
         for setting in dir(mod):
             if setting == setting.upper():
                 setting_value = getattr(mod, setting)
-                if setting in tuple_settings and \
+                if setting in list_settings and \
                         isinstance(setting_value, six.string_types):
-                    warnings.warn("The %s setting must be a tuple. Please fix your "
+                    warnings.warn("The %s setting must be a list. Please fix your "
                                   "settings, as auto-correction is now deprecated." % setting,
                                   DeprecationWarning, stacklevel=2)
-                    setting_value = (setting_value,) # In case the user forgot the comma.
+                    setting_value = [setting_value]  # In case the user forgot the comma.
                 setattr(self, setting, setting_value)
 
         if not self.SECRET_KEY:

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -21,13 +21,13 @@ DEBUG_PROPAGATE_EXCEPTIONS = False
 USE_ETAGS = False
 
 # People who get code error notifications.
-# In the format (('Full Name', 'email@example.com'), ('Full Name', 'anotheremail@example.com'))
-ADMINS = ()
+# In the format [('Full Name', 'email@example.com'), ('Full Name', 'anotheremail@example.com')]
+ADMINS = []
 
 # Tuple of IP addresses, as strings, that:
 #   * See debug comments, when DEBUG is true
 #   * Receive x-headers
-INTERNAL_IPS = ()
+INTERNAL_IPS = []
 
 # Hosts/domain names that are valid for this site.
 # "*" matches anything, ".example.com" matches example.com and all subdomains
@@ -47,7 +47,7 @@ USE_TZ = False
 LANGUAGE_CODE = 'en-us'
 
 # Languages we provide translations for, out of the box.
-LANGUAGES = (
+LANGUAGES = [
     ('af', gettext_noop('Afrikaans')),
     ('ar', gettext_noop('Arabic')),
     ('az', gettext_noop('Azerbaijani')),
@@ -127,16 +127,16 @@ LANGUAGES = (
     ('ur', gettext_noop('Urdu')),
     ('vi', gettext_noop('Vietnamese')),
     ('zh-cn', gettext_noop('Simplified Chinese')),
-    ('zh-tw', gettext_noop('Traditional Chinese')),
-)
+    ('zh-tw', gettext_noop('Traditional Chinese'))
+]
 
 # Languages using BiDi (right-to-left) layout
-LANGUAGES_BIDI = ("he", "ar", "fa", "ur")
+LANGUAGES_BIDI = ["he", "ar", "fa", "ur"]
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = True
-LOCALE_PATHS = ()
+LOCALE_PATHS = []
 LANGUAGE_COOKIE_NAME = 'django_language'
 
 # If you set this to True, Django will format dates, numbers and calendars
@@ -186,33 +186,33 @@ EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
 
 # List of strings representing installed apps.
-INSTALLED_APPS = ()
+INSTALLED_APPS = []
 
 # List of locations of the template source files, in search order.
-TEMPLATE_DIRS = ()
+TEMPLATE_DIRS = []
 
 # List of callables that know how to import templates from various sources.
 # See the comments in django/core/template/loader.py for interface
 # documentation.
-TEMPLATE_LOADERS = (
+TEMPLATE_LOADERS = [
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
+    # 'django.template.loaders.eggs.Loader',
+]
 
 # List of processors used by RequestContext to populate the context.
 # Each one should be a callable that takes the request object as its
 # only parameter and returns a dictionary to add to the context.
-TEMPLATE_CONTEXT_PROCESSORS = (
+TEMPLATE_CONTEXT_PROCESSORS = [
     'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.i18n',
     'django.core.context_processors.media',
     'django.core.context_processors.static',
     'django.core.context_processors.tz',
-#    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-)
+    # 'django.core.context_processors.request',
+    'django.contrib.messages.context_processors.messages'
+]
 
 # Output to use in template system for invalid (e.g. misspelled) variables.
 TEMPLATE_STRING_IF_INVALID = ''
@@ -244,7 +244,7 @@ FORCE_SCRIPT_NAME = None
 #         re.compile(r'^SiteSucker.*'),
 #         re.compile(r'^sohu-search')
 #     )
-DISALLOWED_USER_AGENTS = ()
+DISALLOWED_USER_AGENTS = []
 
 ABSOLUTE_URL_OVERRIDES = {}
 
@@ -255,7 +255,7 @@ ALLOWED_INCLUDE_ROOTS = ()
 # If this is a admin settings module, this should be a list of
 # settings modules (in the format 'foo.bar.baz') for which this admin
 # is an admin.
-ADMIN_FOR = ()
+ADMIN_FOR = []
 
 # List of compiled regular expression objects representing URLs that need not
 # be reported by BrokenLinkEmailsMiddleware. Here are a few examples:
@@ -267,7 +267,7 @@ ADMIN_FOR = ()
 #        re.compile(r'^/phpmyadmin/),
 #        re.compile(r'\.(cgi|php|pl)$'),
 #    )
-IGNORABLE_404_URLS = ()
+IGNORABLE_404_URLS = []
 
 # A secret key for this particular Django installation. Used in secret-key
 # hashing algorithms. Set this in your settings, or Django will complain
@@ -294,14 +294,14 @@ STATIC_ROOT = ''
 STATIC_URL = None
 
 # List of upload handler classes to be applied in order.
-FILE_UPLOAD_HANDLERS = (
+FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.MemoryFileUploadHandler',
-    'django.core.files.uploadhandler.TemporaryFileUploadHandler',
-)
+    'django.core.files.uploadhandler.TemporaryFileUploadHandler'
+]
 
 # Maximum size, in bytes, of a request before it will be streamed to the
 # file system instead of into memory.
-FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440 # i.e. 2.5 MB
+FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory
@@ -353,30 +353,30 @@ SHORT_DATETIME_FORMAT = 'm/d/Y P'
 # See all available format string here:
 # http://docs.python.org/library/datetime.html#strftime-behavior
 # * Note that these format strings are different from the ones to display dates
-DATE_INPUT_FORMATS = (
+DATE_INPUT_FORMATS = [
     '%Y-%m-%d', '%m/%d/%Y', '%m/%d/%y', # '2006-10-25', '10/25/2006', '10/25/06'
     '%b %d %Y', '%b %d, %Y',            # 'Oct 25 2006', 'Oct 25, 2006'
     '%d %b %Y', '%d %b, %Y',            # '25 Oct 2006', '25 Oct, 2006'
     '%B %d %Y', '%B %d, %Y',            # 'October 25 2006', 'October 25, 2006'
-    '%d %B %Y', '%d %B, %Y',            # '25 October 2006', '25 October, 2006'
-)
+    '%d %B %Y', '%d %B, %Y'             # '25 October 2006', '25 October, 2006'
+]
 
 # Default formats to be used when parsing times from input boxes, in order
 # See all available format string here:
 # http://docs.python.org/library/datetime.html#strftime-behavior
 # * Note that these format strings are different from the ones to display dates
-TIME_INPUT_FORMATS = (
+TIME_INPUT_FORMATS = [
     '%H:%M:%S',     # '14:30:59'
     '%H:%M:%S.%f',  # '14:30:59.000200'
-    '%H:%M',        # '14:30'
-)
+    '%H:%M'         # '14:30'
+]
 
 # Default formats to be used when parsing dates and times from input boxes,
 # in order
 # See all available format string here:
 # http://docs.python.org/library/datetime.html#strftime-behavior
 # * Note that these format strings are different from the ones to display dates
-DATETIME_INPUT_FORMATS = (
+DATETIME_INPUT_FORMATS = [
     '%Y-%m-%d %H:%M:%S',     # '2006-10-25 14:30:59'
     '%Y-%m-%d %H:%M:%S.%f',  # '2006-10-25 14:30:59.000200'
     '%Y-%m-%d %H:%M',        # '2006-10-25 14:30'
@@ -388,8 +388,8 @@ DATETIME_INPUT_FORMATS = (
     '%m/%d/%y %H:%M:%S',     # '10/25/06 14:30:59'
     '%m/%d/%y %H:%M:%S.%f',  # '10/25/06 14:30:59.000200'
     '%m/%d/%y %H:%M',        # '10/25/06 14:30'
-    '%m/%d/%y',              # '10/25/06'
-)
+    '%m/%d/%y'               # '10/25/06'
+]
 
 # First day of week, to be used on calendars
 # 0 means Sunday, 1 means Monday...
@@ -444,15 +444,15 @@ SECURE_PROXY_SSL_HEADER = None
 # List of middleware classes to use.  Order is important; in the request phase,
 # this middleware classes will be applied in the order given, and in the
 # response phase the middleware will be applied in reverse order.
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-#     'django.middleware.http.ConditionalGetMiddleware',
-#     'django.middleware.gzip.GZipMiddleware',
-)
+    # 'django.middleware.http.ConditionalGetMiddleware',
+    # 'django.middleware.gzip.GZipMiddleware',
+]
 
 ############
 # SESSIONS #
@@ -492,7 +492,7 @@ COMMENTS_ALLOW_PROFANITIES = False
 
 # The profanities that will trigger a validation error in
 # CommentDetailsForm.clean_comment. All of these should be in lowercase.
-PROFANITIES_LIST = ()
+PROFANITIES_LIST = []
 
 ##################
 # AUTHENTICATION #
@@ -500,7 +500,7 @@ PROFANITIES_LIST = ()
 
 AUTH_USER_MODEL = 'auth.User'
 
-AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend',)
+AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend']
 
 LOGIN_URL = '/accounts/login/'
 
@@ -514,7 +514,7 @@ PASSWORD_RESET_TIMEOUT_DAYS = 3
 # the first hasher in this list is the preferred algorithm.  any
 # password using different algorithms will be converted automatically
 # upon login
-PASSWORD_HASHERS = (
+PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
     'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
@@ -523,8 +523,8 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
     'django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher',
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
-    'django.contrib.auth.hashers.CryptPasswordHasher',
-)
+    'django.contrib.auth.hashers.CryptPasswordHasher'
+]
 
 ###########
 # SIGNING #
@@ -583,22 +583,22 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 ############
 
 # The list of directories to search for fixtures
-FIXTURE_DIRS = ()
+FIXTURE_DIRS = []
 
 ###############
 # STATICFILES #
 ###############
 
 # A list of locations of additional static files
-STATICFILES_DIRS = ()
+STATICFILES_DIRS = []
 
 # The default file storage backend used during the build process
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 # List of finder classes that know how to find static files in
 # various locations.
-STATICFILES_FINDERS = (
+STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
-)
+    # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
+]

--- a/django/conf/project_template/project_name/settings.py
+++ b/django/conf/project_template/project_name/settings.py
@@ -29,23 +29,23 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
-    'django.contrib.staticfiles',
-)
+    'django.contrib.staticfiles'
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+    'django.middleware.clickjacking.XFrameOptionsMiddleware'
+]
 
 ROOT_URLCONF = '{{ project_name }}.urls'
 
@@ -58,7 +58,7 @@ WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3')
     }
 }
 

--- a/django/contrib/auth/tests/test_remote_user.py
+++ b/django/contrib/auth/tests/test_remote_user.py
@@ -23,8 +23,10 @@ class RemoteUserTest(TestCase):
     def setUp(self):
         self.curr_middleware = settings.MIDDLEWARE_CLASSES
         self.curr_auth = settings.AUTHENTICATION_BACKENDS
-        settings.MIDDLEWARE_CLASSES += (self.middleware,)
-        settings.AUTHENTICATION_BACKENDS += (self.backend,)
+        settings.MIDDLEWARE_CLASSES = (list(settings.MIDDLEWARE_CLASSES) +
+                                       [self.middleware])
+        settings.AUTHENTICATION_BACKENDS = (
+            list(settings.AUTHENTICATION_BACKENDS) + [self.backend])
 
     def test_no_remote_user(self):
         """

--- a/django/contrib/flatpages/tests/test_csrf.py
+++ b/django/contrib/flatpages/tests/test_csrf.py
@@ -8,14 +8,14 @@ from django.test.utils import override_settings
 
 @override_settings(
     LOGIN_URL='/accounts/login/',
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    ),
+    ],
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),

--- a/django/contrib/flatpages/tests/test_forms.py
+++ b/django/contrib/flatpages/tests/test_forms.py
@@ -37,7 +37,7 @@ class FlatpageAdminFormTests(TestCase):
             self.assertEqual(form.errors['url'], ["URL is missing a leading slash."])
 
     @override_settings(APPEND_SLASH=True,
-            MIDDLEWARE_CLASSES=('django.middleware.common.CommonMiddleware',))
+            MIDDLEWARE_CLASSES=['django.middleware.common.CommonMiddleware'])
     def test_flatpage_requires_trailing_slash_with_append_slash(self):
         form = FlatpageForm(data=dict(url='/no_trailing_slash', **self.form_data))
         with translation.override('en'):
@@ -45,7 +45,7 @@ class FlatpageAdminFormTests(TestCase):
             self.assertEqual(form.errors['url'], ["URL is missing a trailing slash."])
 
     @override_settings(APPEND_SLASH=False,
-            MIDDLEWARE_CLASSES=('django.middleware.common.CommonMiddleware',))
+            MIDDLEWARE_CLASSES=['django.middleware.common.CommonMiddleware'])
     def test_flatpage_doesnt_requires_trailing_slash_without_append_slash(self):
         form = FlatpageForm(data=dict(url='/no_trailing_slash', **self.form_data))
         self.assertTrue(form.is_valid())

--- a/django/contrib/flatpages/tests/test_middleware.py
+++ b/django/contrib/flatpages/tests/test_middleware.py
@@ -9,17 +9,17 @@ from django.test.utils import override_settings
 
 @override_settings(
     LOGIN_URL='/accounts/login/',
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    ),
-    TEMPLATE_DIRS=(
+    ],
+    TEMPLATE_DIRS=[
         os.path.join(os.path.dirname(__file__), 'templates'),
-    ),
+    ],
     SITE_ID=1,
 )
 class FlatpageMiddlewareTests(TestCase):
@@ -89,17 +89,17 @@ class FlatpageMiddlewareTests(TestCase):
 @override_settings(
     APPEND_SLASH = True,
     LOGIN_URL='/accounts/login/',
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    ),
-    TEMPLATE_DIRS=(
+    ],
+    TEMPLATE_DIRS=[
         os.path.join(os.path.dirname(__file__), 'templates'),
-    ),
+    ],
     SITE_ID=1,
 )
 class FlatpageMiddlewareAppendSlashTests(TestCase):

--- a/django/contrib/flatpages/tests/test_templatetags.py
+++ b/django/contrib/flatpages/tests/test_templatetags.py
@@ -8,17 +8,17 @@ from django.test.utils import override_settings
 
 
 @override_settings(
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    ),
-    TEMPLATE_DIRS=(
+    ],
+    TEMPLATE_DIRS=[
         os.path.join(os.path.dirname(__file__), 'templates'),
-    ),
+    ],
     SITE_ID=1,
 )
 class FlatpageTemplateTagTests(TestCase):

--- a/django/contrib/flatpages/tests/test_views.py
+++ b/django/contrib/flatpages/tests/test_views.py
@@ -9,17 +9,17 @@ from django.test.utils import override_settings
 
 @override_settings(
     LOGIN_URL='/accounts/login/',
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         # no 'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware'
-    ),
-    TEMPLATE_DIRS=(
+    ],
+    TEMPLATE_DIRS=[
         os.path.join(os.path.dirname(__file__), 'templates'),
-    ),
+    ],
     SITE_ID=1,
 )
 class FlatpageViewTests(TestCase):
@@ -77,17 +77,17 @@ class FlatpageViewTests(TestCase):
 @override_settings(
     APPEND_SLASH = True,
     LOGIN_URL='/accounts/login/',
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE_CLASSES=[
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         # no 'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware'
-    ),
-    TEMPLATE_DIRS=(
+    ],
+    TEMPLATE_DIRS=[
         os.path.join(os.path.dirname(__file__), 'templates'),
-    ),
+    ],
     SITE_ID=1,
 )
 class FlatpageViewAppendSlashTests(TestCase):

--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -34,19 +34,19 @@ First, you must add the
 :setting:`MIDDLEWARE_CLASSES` setting **after** the
 :class:`django.contrib.auth.middleware.AuthenticationMiddleware`::
 
-    MIDDLEWARE_CLASSES = (
-        ...
+    MIDDLEWARE_CLASSES = [
+        # ...
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.auth.middleware.RemoteUserMiddleware',
-        ...
-        )
+        # ...
+        ]
 
 Next, you must replace the :class:`~django.contrib.auth.backends.ModelBackend`
 with ``RemoteUserBackend`` in the :setting:`AUTHENTICATION_BACKENDS` setting::
 
-    AUTHENTICATION_BACKENDS = (
-        'django.contrib.auth.backends.RemoteUserBackend',
-    )
+    AUTHENTICATION_BACKENDS = [
+        'django.contrib.auth.backends.RemoteUserBackend'
+    ]
 
 With this setup, ``RemoteUserMiddleware`` will detect the username in
 ``request.META['REMOTE_USER']`` and will authenticate and auto-login that user

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -146,10 +146,10 @@ this. For a small app like polls, this process isn't too difficult.
 
     1. Add "polls" to your INSTALLED_APPS setting like this::
 
-          INSTALLED_APPS = (
+          INSTALLED_APPS = [
               ...
-              'polls',
-          )
+              'polls'
+          ]
 
     2. Include the polls URLconf in your project urls.py like this::
 

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -408,15 +408,15 @@ Edit the :file:`mysite/settings.py` file again, and change the
 :setting:`INSTALLED_APPS` setting to include the string ``'polls'``. So it'll
 look like this::
 
-    INSTALLED_APPS = (
+    INSTALLED_APPS = [
         'django.contrib.admin',
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
-        'polls',
-    )
+        'polls'
+    ]
 
 Now Django knows to include the ``polls`` app. Let's run another command:
 

--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -55,11 +55,11 @@ To set the same ``X-Frame-Options`` value for all responses in your site, put
 ``'django.middleware.clickjacking.XFrameOptionsMiddleware'`` to
 :setting:`MIDDLEWARE_CLASSES`::
 
-    MIDDLEWARE_CLASSES = (
-        ...
+    MIDDLEWARE_CLASSES = [
+        # ...
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        ...
-    )
+        # ...
+    ]
 
 .. versionchanged:: 1.6
 

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -114,7 +114,7 @@ In addition, modify the :setting:`INSTALLED_APPS` setting to include
 :mod:`django.contrib.admin`, :mod:`django.contrib.gis`,
 and ``world`` (your newly created application)::
 
-    INSTALLED_APPS = (
+    INSTALLED_APPS = [
         'django.contrib.admin',
         'django.contrib.auth',
         'django.contrib.contenttypes',
@@ -123,7 +123,7 @@ and ``world`` (your newly created application)::
         'django.contrib.staticfiles',
         'django.contrib.gis',
         'world'
-    )
+    ]
 
 Geographic Data
 ===============

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -9,7 +9,7 @@ Settings
 .. warning::
 
     Be careful when you override settings, especially when the default value
-    is a non-empty tuple or dictionary, such as :setting:`MIDDLEWARE_CLASSES`
+    is a non-empty list or dictionary, such as :setting:`MIDDLEWARE_CLASSES`
     and :setting:`TEMPLATE_CONTEXT_PROCESSORS`. Make sure you keep the
     components required by the features of Django you wish to use.
 
@@ -44,14 +44,14 @@ of the case of the actual model class name.
 ADMINS
 ------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple that lists people who get code error notifications. When
-``DEBUG=False`` and a view raises an exception, Django will email these people
-with the full exception information. Each member of the tuple should be a tuple
-of (Full name, email address). Example::
+A list of people who get code error notifications. When ``DEBUG=False`` and a
+view raises an exception, Django will email these people with the full
+exception information. Each member of the tuple should be a tuple of (Full
+name, email address). Example::
 
-    (('John', 'john@example.com'), ('Mary', 'mary@example.com'))
+    [('John', 'john@example.com'), ('Mary', 'mary@example.com')]
 
 Note that Django will email *all* of these people whenever an error happens.
 See :doc:`/howto/error-reporting` for more information.
@@ -87,8 +87,8 @@ middleware; if so this middleware must be listed first in
     a subdomain wildcard::
 
         ALLOWED_HOSTS = [
-            '.example.com', # Allow domain and subdomains
-            '.example.com.', # Also allow FQDN and subdomains
+            '.example.com',  # Allow domain and subdomains
+            '.example.com.'  # Also allow FQDN and subdomains
         ]
 
 .. _`fully qualified domain name (FQDN)`: http://en.wikipedia.org/wiki/Fully_qualified_domain_name
@@ -111,9 +111,9 @@ are bypassing this security protection.
 ALLOWED_INCLUDE_ROOTS
 ---------------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple of strings representing allowed prefixes for the ``{% ssi %}`` template
+A list of strings representing allowed prefixes for the ``{% ssi %}`` template
 tag. This is a security measure, so that template authors can't access files
 that they shouldn't be accessing.
 
@@ -740,15 +740,15 @@ DATE_INPUT_FORMATS
 
 Default::
 
-    (
+    [
         '%Y-%m-%d', '%m/%d/%Y', '%m/%d/%y', # '2006-10-25', '10/25/2006', '10/25/06'
         '%b %d %Y', '%b %d, %Y',            # 'Oct 25 2006', 'Oct 25, 2006'
         '%d %b %Y', '%d %b, %Y',            # '25 Oct 2006', '25 Oct, 2006'
         '%B %d %Y', '%B %d, %Y',            # 'October 25 2006', 'October 25, 2006'
         '%d %B %Y', '%d %B, %Y',            # '25 October 2006', '25 October, 2006'
-    )
+    ]
 
-A tuple of formats that will be accepted when inputting data on a date field.
+A list of formats that will be accepted when inputting data on a date field.
 Formats will be tried in order, using the first valid one. Note that these
 format strings use Python's datetime_ module syntax, not the format strings
 from the ``date`` Django template tag.
@@ -781,7 +781,7 @@ DATETIME_INPUT_FORMATS
 
 Default::
 
-    (
+    [
         '%Y-%m-%d %H:%M:%S',     # '2006-10-25 14:30:59'
         '%Y-%m-%d %H:%M:%S.%f',  # '2006-10-25 14:30:59.000200'
         '%Y-%m-%d %H:%M',        # '2006-10-25 14:30'
@@ -794,9 +794,9 @@ Default::
         '%m/%d/%y %H:%M:%S.%f',  # '10/25/06 14:30:59.000200'
         '%m/%d/%y %H:%M',        # '10/25/06 14:30'
         '%m/%d/%y',              # '10/25/06'
-    )
+    ]
 
-A tuple of formats that will be accepted when inputting data on a datetime
+A list of formats that will be accepted when inputting data on a datetime
 field. Formats will be tried in order, using the first valid one. Note that
 these format strings use Python's datetime_ module syntax, not the format
 strings from the ``date`` Django template tag.
@@ -960,7 +960,7 @@ backend supports it (see :doc:`/topics/db/tablespaces`).
 DISALLOWED_USER_AGENTS
 ----------------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
 List of compiled regular expression objects representing User-Agent strings that
 are not allowed to visit any page, systemwide. Use this for bad robots/crawlers.
@@ -1069,10 +1069,10 @@ FILE_UPLOAD_HANDLERS
 
 Default::
 
-    ("django.core.files.uploadhandler.MemoryFileUploadHandler",
-     "django.core.files.uploadhandler.TemporaryFileUploadHandler",)
+    ["django.core.files.uploadhandler.MemoryFileUploadHandler",
+     "django.core.files.uploadhandler.TemporaryFileUploadHandler"]
 
-A tuple of handlers to use for uploading. See :doc:`/topics/files` for details.
+A list of handlers to use for uploading. See :doc:`/topics/files` for details.
 
 .. setting:: FILE_UPLOAD_MAX_MEMORY_SIZE
 
@@ -1143,7 +1143,7 @@ Monday and so on.
 FIXTURE_DIRS
 -------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
 List of directories searched for fixture files, in addition to the
 ``fixtures`` directory of each application, in search order.
@@ -1199,7 +1199,7 @@ Available formats are :setting:`DATE_FORMAT`, :setting:`TIME_FORMAT`,
 IGNORABLE_404_URLS
 ------------------
 
-Default: ``()``
+Default: ``[]`` (Empty list)
 
 List of compiled regular expression objects describing URLs that should be
 ignored when reporting HTTP 404 errors via email (see
@@ -1218,9 +1218,9 @@ This is only used if
 INSTALLED_APPS
 --------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple of strings designating all applications that are enabled in this Django
+A list of strings designating all applications that are enabled in this Django
 installation. Each string should be a full Python path to a Python package that
 contains a Django application, as created by :djadmin:`django-admin.py startapp
 <startapp>`.
@@ -1238,9 +1238,9 @@ contains a Django application, as created by :djadmin:`django-admin.py startapp
 INTERNAL_IPS
 ------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple of IP addresses, as strings, that:
+A list of IP addresses, as strings, that:
 
 * See debug comments, when :setting:`DEBUG` is ``True``
 * Receive X headers in admindocs if the ``XViewMiddleware`` is installed (see
@@ -1276,14 +1276,14 @@ you want (but should be different from :setting:`SESSION_COOKIE_NAME`). See
 LANGUAGES
 ---------
 
-Default: A tuple of all available languages. This list is continually growing
+Default: A list of all available languages. This list is continually growing
 and including a copy here would inevitably become rapidly out of date. You can
 see the current list of translated languages by looking in
 ``django/conf/global_settings.py`` (or view the `online source`_).
 
 .. _online source: https://github.com/django/django/blob/master/django/conf/global_settings.py
 
-The list is a tuple of two-tuples in the format
+The list consists of two-tuples in the format
 (:term:`language code<language code>`, ``language name``) -- for example,
 ``('ja', 'Japanese')``.
 This specifies which languages are available for language selection. See
@@ -1305,10 +1305,10 @@ settings file::
 
     gettext = lambda s: s
 
-    LANGUAGES = (
+    LANGUAGES = [
         ('de', gettext('German')),
         ('en', gettext('English')),
-    )
+    ]
 
 With this arrangement, ``django-admin.py makemessages`` will still find and
 mark these strings for translation, but the translation won't happen at
@@ -1320,17 +1320,17 @@ runtime -- so you'll have to remember to wrap the languages in the *real*
 LOCALE_PATHS
 ------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple of directories where Django looks for translation files.
+A list of directories where Django looks for translation files.
 See :ref:`how-django-discovers-translations`.
 
 Example::
 
-    LOCALE_PATHS = (
+    LOCALE_PATHS = [
         '/home/www/project/common_files/locale',
         '/var/local/translations/locale'
-    )
+    ]
 
 Django will look within each of these paths for the ``<locale_code>/LC_MESSAGES``
 directories containing the actual translation files.
@@ -1370,9 +1370,9 @@ configuration process will be skipped.
 MANAGERS
 --------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple in the same format as :setting:`ADMINS` that specifies who should get
+A list in the same format as :setting:`ADMINS` that specifies who should get
 broken link notifications when
 :class:`~django.middleware.common.BrokenLinkEmailsMiddleware` is enabled.
 
@@ -1410,13 +1410,13 @@ MIDDLEWARE_CLASSES
 
 Default::
 
-    ('django.middleware.common.CommonMiddleware',
+    ['django.middleware.common.CommonMiddleware',
      'django.contrib.sessions.middleware.SessionMiddleware',
      'django.middleware.csrf.CsrfViewMiddleware',
      'django.contrib.auth.middleware.AuthenticationMiddleware',
-     'django.contrib.messages.middleware.MessageMiddleware',)
+     'django.contrib.messages.middleware.MessageMiddleware']
 
-A tuple of middleware classes to use. See :doc:`/topics/http/middleware`.
+A list of middleware classes to use. See :doc:`/topics/http/middleware`.
 
 .. setting:: MONTH_DAY_FORMAT
 
@@ -1655,15 +1655,15 @@ TEMPLATE_CONTEXT_PROCESSORS
 
 Default::
 
-    ("django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages")
+    ["django.contrib.auth.context_processors.auth",
+     "django.core.context_processors.debug",
+     "django.core.context_processors.i18n",
+     "django.core.context_processors.media",
+     "django.core.context_processors.static",
+     "django.core.context_processors.tz",
+     "django.contrib.messages.context_processors.messages"]
 
-A tuple of callables that are used to populate the context in ``RequestContext``.
+A list of callables that are used to populate the context in ``RequestContext``.
 These callables take a request object as their argument and return a dictionary
 of items to be merged into the context.
 
@@ -1689,7 +1689,7 @@ See also :setting:`DEBUG`.
 TEMPLATE_DIRS
 -------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
 List of locations of the template source files searched by
 :class:`django.template.loaders.filesystem.Loader`, in search order.
@@ -1705,10 +1705,10 @@ TEMPLATE_LOADERS
 
 Default::
 
-     ('django.template.loaders.filesystem.Loader',
-      'django.template.loaders.app_directories.Loader')
+     ['django.template.loaders.filesystem.Loader',
+      'django.template.loaders.app_directories.Loader']
 
-A tuple of template loader classes, specified as strings. Each ``Loader`` class
+A list of template loader classes, specified as strings. Each ``Loader`` class
 knows how to import templates from a particular source. Optionally, a tuple can be
 used instead of a string. The first item in the tuple should be the ``Loader``'s
 module, subsequent items are passed to the ``Loader`` during initialization. See
@@ -1777,13 +1777,13 @@ TIME_INPUT_FORMATS
 
 Default::
 
-    (
+    [
         '%H:%M:%S',     # '14:30:59'
         '%H:%M:%S.%f',  # '14:30:59.000200'
-        '%H:%M',        # '14:30'
-    )
+        '%H:%M'         # '14:30'
+    ]
 
-A tuple of formats that will be accepted when inputting data on a time field.
+A list of formats that will be accepted when inputting data on a time field.
 Formats will be tried in order, using the first valid one. Note that these
 format strings use Python's datetime_ module syntax, not the format strings
 from the ``date`` Django template tag.
@@ -2014,9 +2014,9 @@ Settings for :mod:`django.contrib.admindocs`.
 ADMIN_FOR
 ---------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-Used for admin-site settings modules, this should be a tuple of settings
+Used for admin-site settings modules, this should be a list of settings
 modules (in the format ``'foo.bar.baz'``) for which this site is an admin.
 
 The admin site uses this in its automatically-introspected documentation of
@@ -2033,9 +2033,9 @@ Settings for :mod:`django.contrib.auth`.
 AUTHENTICATION_BACKENDS
 -----------------------
 
-Default: ``('django.contrib.auth.backends.ModelBackend',)``
+Default: ``['django.contrib.auth.backends.ModelBackend']``
 
-A tuple of authentication backend classes (as strings) to use when attempting to
+A list of authentication backend classes (as strings) to use when attempting to
 authenticate a user. See the :ref:`authentication backends documentation
 <authentication-backends>` for details.
 
@@ -2131,13 +2131,13 @@ See :ref:`auth_password_storage`.
 
 Default::
 
-    ('django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    ['django.contrib.auth.hashers.PBKDF2PasswordHasher',
      'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
      'django.contrib.auth.hashers.BCryptPasswordHasher',
      'django.contrib.auth.hashers.SHA1PasswordHasher',
      'django.contrib.auth.hashers.MD5PasswordHasher',
      'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
-     'django.contrib.auth.hashers.CryptPasswordHasher',)
+     'django.contrib.auth.hashers.CryptPasswordHasher']
 
 
 .. _settings-comments:
@@ -2180,9 +2180,9 @@ must also be listed in :setting:`INSTALLED_APPS`.
 PROFANITIES_LIST
 ----------------
 
-Default: ``()`` (Empty tuple)
+Default: ``[]`` (Empty list)
 
-A tuple of profanities, as strings, that will be forbidden in comments when
+A list of profanities, as strings, that will be forbidden in comments when
 ``COMMENTS_ALLOW_PROFANITIES`` is ``False``.
 
 
@@ -2239,10 +2239,10 @@ MESSAGE_TAGS
 Default::
 
     {messages.DEBUG: 'debug',
-    messages.INFO: 'info',
-    messages.SUCCESS: 'success',
-    messages.WARNING: 'warning',
-    messages.ERROR: 'error',}
+     messages.INFO: 'info',
+     messages.SUCCESS: 'success',
+     messages.WARNING: 'warning',
+     messages.ERROR: 'error',}
 
 This sets the mapping of message level to message tag, which is typically
 rendered as a CSS class in HTML. If you specify a value, it will extend
@@ -2496,7 +2496,7 @@ It must end in a slash if set to a non-empty value.
 STATICFILES_DIRS
 ----------------
 
-Default: ``[]``
+Default: ``[]`` (Empty list)
 
 This setting defines the additional locations the staticfiles app will traverse
 if the ``FileSystemFinder`` finder is enabled, e.g. if you use the
@@ -2506,11 +2506,11 @@ static file serving view.
 This should be set to a list or tuple of strings that contain full paths to
 your additional files directory(ies) e.g.::
 
-    STATICFILES_DIRS = (
+    STATICFILES_DIRS = [
         "/home/special.polls.com/polls/static",
         "/home/polls.com/polls/static",
-        "/opt/webfiles/common",
-    )
+        "/opt/webfiles/common"
+    ]
 
 Prefixes (optional)
 ~~~~~~~~~~~~~~~~~~~
@@ -2519,10 +2519,10 @@ In case you want to refer to files in one of the locations with an additional
 namespace, you can **optionally** provide a prefix as ``(prefix, path)``
 tuples, e.g.::
 
-    STATICFILES_DIRS = (
+    STATICFILES_DIRS = [
         # ...
         ("downloads", "/opt/webfiles/stats"),
-    )
+    ]
 
 Example:
 
@@ -2560,8 +2560,8 @@ STATICFILES_FINDERS
 
 Default::
 
-    ("django.contrib.staticfiles.finders.FileSystemFinder",
-     "django.contrib.staticfiles.finders.AppDirectoriesFinder")
+    ["django.contrib.staticfiles.finders.FileSystemFinder",
+     "django.contrib.staticfiles.finders.AppDirectoriesFinder"]
 
 The list of finder backends that know how to find static files in
 various locations.

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -662,7 +662,7 @@ class. Here are the template loaders that come with Django:
 
     For example, for this setting::
 
-        INSTALLED_APPS = ('myproject.polls', 'myproject.music')
+        INSTALLED_APPS = ['myproject.polls', 'myproject.music']
 
     ...then ``get_template('foo.html')`` will look for ``foo.html`` in these
     directories, in this order:

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -418,11 +418,11 @@ entire site. You'll need to add
 ``'django.middleware.cache.FetchFromCacheMiddleware'`` to your
 :setting:`MIDDLEWARE_CLASSES` setting, as in this example::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
         'django.middleware.cache.UpdateCacheMiddleware',
         'django.middleware.common.CommonMiddleware',
-        'django.middleware.cache.FetchFromCacheMiddleware',
-    )
+        'django.middleware.cache.FetchFromCacheMiddleware'
+    ]
 
 .. note::
 

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -70,11 +70,11 @@ For example, if the models for your application live in the module
 application by the :djadmin:`manage.py startapp <startapp>` script),
 :setting:`INSTALLED_APPS` should read, in part::
 
-    INSTALLED_APPS = (
-        #...
+    INSTALLED_APPS = [
+        # ...
         'myapp',
-        #...
-    )
+        # ...
+    ]
 
 When you add new apps to :setting:`INSTALLED_APPS`, be sure to run
 :djadmin:`manage.py syncdb <syncdb>`.

--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -27,13 +27,13 @@ a string: the full Python path to the middleware's class name. For example,
 here's the default value created by :djadmin:`django-admin.py startproject
 <startproject>`::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-    )
+        'django.contrib.messages.middleware.MessageMiddleware'
+    ]
 
 A Django installation doesn't require any middleware —
 :setting:`MIDDLEWARE_CLASSES` can be empty, if you'd like — but it's strongly

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -201,7 +201,7 @@ For example::
             'there is %(count)d object',
             'there are %(count)d objects',
         count) % {
-            'count': count,
+            'count': count
         }
         return HttpResponse(page)
 
@@ -883,11 +883,11 @@ URL. Paths listed in :setting:`LOCALE_PATHS` are also included.
 You hook it up like this::
 
     js_info_dict = {
-        'packages': ('your.app.package',),
+        'packages': ('your.app.package',)
     }
 
     urlpatterns = patterns('',
-        (r'^jsi18n/$', 'django.views.i18n.javascript_catalog', js_info_dict),
+        (r'^jsi18n/$', 'django.views.i18n.javascript_catalog', js_info_dict)
     )
 
 Each string in ``packages`` should be in Python dotted-package syntax (the
@@ -907,7 +907,7 @@ changed by altering the ``domain`` argument.
 You can make the view dynamic by putting the packages into the URL pattern::
 
     urlpatterns = patterns('',
-        (r'^jsi18n/(?P<packages>\S+?)/$', 'django.views.i18n.javascript_catalog'),
+        (r'^jsi18n/(?P<packages>\S+?)/$', 'django.views.i18n.javascript_catalog')
     )
 
 With this, you specify the packages as a list of package names delimited by '+'
@@ -1067,18 +1067,18 @@ prepend the current active language code to all url patterns defined within
     from django.conf.urls.i18n import i18n_patterns
 
     urlpatterns = patterns('',
-        url(r'^sitemap\.xml$', 'sitemap.view', name='sitemap_xml'),
+        url(r'^sitemap\.xml$', 'sitemap.view', name='sitemap_xml')
     )
 
     news_patterns = patterns('',
         url(r'^$', 'news.views.index', name='index'),
         url(r'^category/(?P<slug>[\w-]+)/$', 'news.views.category', name='category'),
-        url(r'^(?P<slug>[\w-]+)/$', 'news.views.details', name='detail'),
+        url(r'^(?P<slug>[\w-]+)/$', 'news.views.details', name='detail')
     )
 
     urlpatterns += i18n_patterns('',
         url(r'^about/$', 'about.view', name='about'),
-        url(r'^news/', include(news_patterns, namespace='news')),
+        url(r'^news/', include(news_patterns, namespace='news'))
     )
 
 
@@ -1122,18 +1122,18 @@ URL patterns can also be marked translatable using the
     from django.utils.translation import ugettext_lazy as _
 
     urlpatterns = patterns(''
-        url(r'^sitemap\.xml$', 'sitemap.view', name='sitemap_xml'),
+        url(r'^sitemap\.xml$', 'sitemap.view', name='sitemap_xml')
     )
 
     news_patterns = patterns(''
         url(r'^$', 'news.views.index', name='index'),
         url(_(r'^category/(?P<slug>[\w-]+)/$'), 'news.views.category', name='category'),
-        url(r'^(?P<slug>[\w-]+)/$', 'news.views.details', name='detail'),
+        url(r'^(?P<slug>[\w-]+)/$', 'news.views.details', name='detail')
     )
 
     urlpatterns += i18n_patterns('',
         url(_(r'^about/$'), 'about.view', name='about'),
-        url(_(r'^news/'), include(news_patterns, namespace='news')),
+        url(_(r'^news/'), include(news_patterns, namespace='news'))
     )
 
 
@@ -1436,7 +1436,7 @@ Make sure that the following item is in your
 
 Activate this view by adding the following line to your URLconf::
 
-    (r'^i18n/', include('django.conf.urls.i18n')),
+    (r'^i18n/', include('django.conf.urls.i18n'))
 
 (Note that this example makes the view available at ``/i18n/setlang/``.)
 
@@ -1579,11 +1579,11 @@ Because middleware order matters, you should follow these guidelines:
 
 For example, your :setting:`MIDDLEWARE_CLASSES` might look like this::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE_CLASSES = [
        'django.contrib.sessions.middleware.SessionMiddleware',
        'django.middleware.locale.LocaleMiddleware',
-       'django.middleware.common.CommonMiddleware',
-    )
+       'django.middleware.common.CommonMiddleware'
+    ]
 
 (For more on middleware, see the :doc:`middleware documentation
 </topics/http/middleware>`.)
@@ -1629,10 +1629,10 @@ Notes:
   languages (because your application doesn't provide all those languages),
   set :setting:`LANGUAGES` to a list of languages. For example::
 
-      LANGUAGES = (
-        ('de', _('German')),
-        ('en', _('English')),
-      )
+      LANGUAGES = [
+          ('de', _('German')),
+          ('en', _('English'))
+      ]
 
   This example restricts languages that are available for automatic
   selection to German and English (and any sublanguage, like de-ch or
@@ -1651,10 +1651,10 @@ Notes:
 
       ugettext = lambda s: s
 
-      LANGUAGES = (
+      LANGUAGES = [
           ('de', ugettext('German')),
-          ('en', ugettext('English')),
-      )
+          ('en', ugettext('English'))
+      ]
 
   With this arrangement, :djadmin:`django-admin.py makemessages <makemessages>`
   will still find and mark these strings for translation, but the translation

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -13,22 +13,22 @@ from django.utils import translation
 
 @override_settings(
     USE_I18N=True,
-    LOCALE_PATHS=(
-        os.path.join(os.path.dirname(upath(__file__)), 'locale'),
-    ),
-    TEMPLATE_DIRS=(
-        os.path.join(os.path.dirname(upath(__file__)), 'templates'),
-    ),
+    LOCALE_PATHS=[
+        os.path.join(os.path.dirname(upath(__file__)), 'locale')
+    ],
+    TEMPLATE_DIRS=[
+        os.path.join(os.path.dirname(upath(__file__)), 'templates')
+    ],
     LANGUAGE_CODE='en-us',
-    LANGUAGES=(
+    LANGUAGES=[
         ('nl', 'Dutch'),
         ('en', 'English'),
-        ('pt-br', 'Brazilian Portuguese'),
-    ),
-    MIDDLEWARE_CLASSES=(
+        ('pt-br', 'Brazilian Portuguese')
+    ],
+    MIDDLEWARE_CLASSES=[
         'django.middleware.locale.LocaleMiddleware',
-        'django.middleware.common.CommonMiddleware',
-    ),
+        'django.middleware.common.CommonMiddleware'
+    ]
 )
 class URLTestCaseBase(TestCase):
     """
@@ -183,7 +183,7 @@ class URLRedirectTests(URLTestCaseBase):
 class URLVaryAcceptLanguageTests(URLTestCaseBase):
     """
     Tests that 'Accept-Language' is not added to the Vary header when using
-    prefixed URLs. 
+    prefixed URLs.
     """
     def test_no_prefix_response(self):
         response = self.client.get('/not-prefixed/')

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -50,9 +50,9 @@ from .models import Company, TestModel
 
 
 here = os.path.dirname(os.path.abspath(upath(__file__)))
-extended_locale_paths = settings.LOCALE_PATHS + (
+extended_locale_paths = settings.LOCALE_PATHS + [
     os.path.join(here, 'other', 'locale'),
-)
+]
 
 
 class TranslationTests(TransRealMixin, TestCase):
@@ -1132,14 +1132,14 @@ class MultipleLocaleActivationTests(TransRealMixin, TestCase):
 
 @override_settings(
     USE_I18N=True,
-    LANGUAGES=(
+    LANGUAGES=[
         ('en', 'English'),
-        ('fr', 'French'),
-    ),
-    MIDDLEWARE_CLASSES=(
+        ('fr', 'French')
+    ],
+    MIDDLEWARE_CLASSES=[
         'django.middleware.locale.LocaleMiddleware',
-        'django.middleware.common.CommonMiddleware',
-    ),
+        'django.middleware.common.CommonMiddleware'
+    ]
 )
 class LocaleMiddlewareTests(TransRealMixin, TestCase):
 
@@ -1154,15 +1154,15 @@ class LocaleMiddlewareTests(TransRealMixin, TestCase):
 
 @override_settings(
     USE_I18N=True,
-    LANGUAGES=(
+    LANGUAGES=[
         ('bg', 'Bulgarian'),
         ('en-us', 'English'),
-        ('pt-br', 'Portugese (Brazil)'),
-    ),
-    MIDDLEWARE_CLASSES=(
+        ('pt-br', 'Portugese (Brazil)')
+    ],
+    MIDDLEWARE_CLASSES=[
         'django.middleware.locale.LocaleMiddleware',
-        'django.middleware.common.CommonMiddleware',
-    ),
+        'django.middleware.common.CommonMiddleware'
+    ]
 )
 class CountrySpecificLanguageTests(TransRealMixin, TestCase):
 

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -469,7 +469,8 @@ class CSRFEnabledClientTests(TestCase):
         self.old_MIDDLEWARE_CLASSES = settings.MIDDLEWARE_CLASSES
         csrf_middleware_class = 'django.middleware.csrf.CsrfViewMiddleware'
         if csrf_middleware_class not in settings.MIDDLEWARE_CLASSES:
-            settings.MIDDLEWARE_CLASSES += (csrf_middleware_class,)
+            settings.MIDDLEWARE_CLASSES = (list(settings.MIDDLEWARE_CLASSES) +
+                                           [csrf_middleware_class])
 
     def tearDown(self):
         settings.MIDDLEWARE_CLASSES = self.old_MIDDLEWARE_CLASSES

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -445,9 +445,9 @@ class RequestURLconfTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_urlconf_overridden(self):
-        settings.MIDDLEWARE_CLASSES += (
-            '%s.ChangeURLconfMiddleware' % middleware.__name__,
-        )
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
+            '%s.ChangeURLconfMiddleware' % middleware.__name__
+        ]
         response = self.client.get('/test/me/')
         self.assertEqual(response.status_code, 404)
         response = self.client.get('/inner_urlconf/second_test/')
@@ -457,9 +457,9 @@ class RequestURLconfTests(TestCase):
         self.assertEqual(response.content, b'outer:,inner:/second_test/')
 
     def test_urlconf_overridden_with_null(self):
-        settings.MIDDLEWARE_CLASSES += (
-            '%s.NullChangeURLconfMiddleware' % middleware.__name__,
-        )
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
+            '%s.NullChangeURLconfMiddleware' % middleware.__name__
+        ]
         self.assertRaises(ImproperlyConfigured, self.client.get, '/test/me/')
 
     def test_reverse_inner_in_response_middleware(self):
@@ -467,10 +467,10 @@ class RequestURLconfTests(TestCase):
         Test reversing an URL from the *overridden* URLconf from inside
         a response middleware.
         """
-        settings.MIDDLEWARE_CLASSES += (
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
             '%s.ChangeURLconfMiddleware' % middleware.__name__,
-            '%s.ReverseInnerInResponseMiddleware' % middleware.__name__,
-        )
+            '%s.ReverseInnerInResponseMiddleware' % middleware.__name__
+        ]
         response = self.client.get('/second_test/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'/second_test/')
@@ -480,10 +480,10 @@ class RequestURLconfTests(TestCase):
         Test reversing an URL from the *default* URLconf from inside
         a response middleware.
         """
-        settings.MIDDLEWARE_CLASSES += (
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
             '%s.ChangeURLconfMiddleware' % middleware.__name__,
-            '%s.ReverseOuterInResponseMiddleware' % middleware.__name__,
-        )
+            '%s.ReverseOuterInResponseMiddleware' % middleware.__name__
+        ]
         message = "Reverse for 'outer' with arguments '()' and keyword arguments '{}' not found."
         with self.assertRaisesMessage(NoReverseMatch, message):
             self.client.get('/second_test/')
@@ -493,10 +493,10 @@ class RequestURLconfTests(TestCase):
         Test reversing an URL from the *overridden* URLconf from inside
         a streaming response.
         """
-        settings.MIDDLEWARE_CLASSES += (
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
             '%s.ChangeURLconfMiddleware' % middleware.__name__,
-            '%s.ReverseInnerInStreaming' % middleware.__name__,
-        )
+            '%s.ReverseInnerInStreaming' % middleware.__name__
+        ]
         response = self.client.get('/second_test/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(b''.join(response), b'/second_test/')
@@ -506,10 +506,10 @@ class RequestURLconfTests(TestCase):
         Test reversing an URL from the *default* URLconf from inside
         a streaming response.
         """
-        settings.MIDDLEWARE_CLASSES += (
+        settings.MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + [
             '%s.ChangeURLconfMiddleware' % middleware.__name__,
-            '%s.ReverseOuterInStreaming' % middleware.__name__,
-        )
+            '%s.ReverseOuterInStreaming' % middleware.__name__
+        ]
         message = "Reverse for 'outer' with arguments '()' and keyword arguments '{}' not found."
         with self.assertRaisesMessage(NoReverseMatch, message):
             self.client.get('/second_test/')

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -167,9 +167,9 @@ class JsI18NTestsMultiPackage(TestCase):
                 self.assertContains(response, javascript_quote('este texto de app3 debe ser traducido'))
 
     def testI18NWithLocalePaths(self):
-        extended_locale_paths = settings.LOCALE_PATHS + (
+        extended_locale_paths = settings.LOCALE_PATHS + [
             path.join(path.dirname(
-                path.dirname(path.abspath(upath(__file__)))), 'app3', 'locale'),)
+                path.dirname(path.abspath(upath(__file__)))), 'app3', 'locale')]
         with self.settings(LANGUAGE_CODE='es-ar', LOCALE_PATHS=extended_locale_paths):
             with override('es-ar'):
                 response = self.client.get('/views/jsi18n/')


### PR DESCRIPTION
Tuples are not the same thing as frozen lists and should not be used as such.

This change only touches user-visible lists and should be backwards-compatible.

Ticket: https://code.djangoproject.com/ticket/20466
