### PR TITLE
Fixed #11725 -- Made possible to create widget label tag without "for"

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -524,9 +524,13 @@ class BoundField(object):
         id_ = widget.attrs.get('id') or self.auto_id
         if id_:
             attrs = flatatt(attrs) if attrs else ''
-            contents = format_html('<label for="{0}"{1}>{2}</label>',
-                                   widget.id_for_label(id_), attrs, contents
-                                   )
+            id_for_label = widget.id_for_label(id_)
+            if id_for_label:
+                contents = format_html('<label for="{0}"{1}>{2}</label>',
+                                       id_for_label, attrs, contents)
+            else:
+                contents = format_html('<label{0}>{1}</label>',
+                                       attrs, contents)
         else:
             contents = conditional_escape(contents)
         return mark_safe(contents)

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1846,3 +1846,20 @@ class FormsTestCase(TestCase):
 
         self.assertHTMLEqual(boundfield.label_tag(), 'Field')
         self.assertHTMLEqual(boundfield.label_tag('Custom&'), 'Custom&amp;')
+
+    def test_boundfield_label_tag_custom_widget_id_for_label(self):
+        class CustomIdForLabelTextInput(TextInput):
+            def id_for_label(self, id):
+                return 'custom_' + id
+
+        class EmptyIdForLabelTextInput(TextInput):
+            def id_for_label(self, id):
+                return None
+
+        class SomeForm(Form):
+            custom = CharField(widget=CustomIdForLabelTextInput)
+            empty = CharField(widget=EmptyIdForLabelTextInput)
+
+        form = SomeForm()
+        self.assertHTMLEqual(form['custom'].label_tag(), '<label for="custom_id_custom">Custom</label>')
+        self.assertHTMLEqual(form['empty'].label_tag(), '<label>Empty</label>')


### PR DESCRIPTION
Now when overriding id_for_label for a BoundField, so that it would
return None, you would get a label without "for" attribute, rather than
a label with "for" attribute equal to "None" string.
