### PR TITLE
Fix typo in redirect view docs

### DIFF
--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -208,7 +208,7 @@ RedirectView
 
         urlpatterns = patterns('',
 
-            url(r'r^(?P<pk>\d+)/$', ArticleCounterRedirectView.as_view(), name='article-counter'),
+            url(r'^(?P<pk>\d+)/$', ArticleCounterRedirectView.as_view(), name='article-counter'),
             url(r'^go-to-django/$', RedirectView.as_view(url='http://djangoproject.com'), name='go-to-django'),
         )
 


### PR DESCRIPTION
The typo appears in the dev and 1.5 docs.
