### PR TITLE
[1.5.x] Fix typo in redirect view docs

### DIFF
--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -207,7 +207,7 @@ RedirectView
 
         urlpatterns = patterns('',
 
-            url(r'r^(?P<pk>\d+)/$', ArticleCounterRedirectView.as_view(), name='article-counter'),
+            url(r'^(?P<pk>\d+)/$', ArticleCounterRedirectView.as_view(), name='article-counter'),
             url(r'^go-to-django/$', RedirectView.as_view(url='http://djangoproject.com'), name='go-to-django'),
         )
 


### PR DESCRIPTION
Backport of a936726228 from master

Thanks for merging my pull request #1184. This pull request fixes the same typo in the 1.5.x docs. I'm not certain of the etiquette for getting docs patches backported -- I hope that opening a second pull request like this is ok.
