### PR TITLE
Add for_concrete_model to GenericForeignKey

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -598,6 +598,7 @@ answer newbie questions, and generally made Django that much better:
     Milton Waddams
     Chris Wagner <cw264701@ohio.edu>
     Rick Wagner <rwagner@physics.ucsd.edu>
+    Gavin Wahl <gavinwahl@gmail.com>
     wam-djangobug@wamber.net
     Wang Chun <wangchun@exoweb.net>
     Filip Wasilewski <filip.wasilewski@gmail.com>

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -303,6 +303,15 @@ model:
        :class:`~django.contrib.contenttypes.generic.GenericForeignKey` will
        look for.
 
+    .. attribute:: GenericForeignKey.for_concrete_model
+
+       .. versionadded:: 1.6
+
+       If ``False``, the field will be able to reference proxy models. Default
+       is ``True``. This mirrors the ``for_concrete_model`` argument to
+       :meth:`~django.contrib.contenttypes.models.ContentTypeManager.get_for_model`.
+
+
 .. admonition:: Primary key type compatibility
 
    The "object_id" field doesn't have to be the same type as the
@@ -492,7 +501,7 @@ information.
     Subclasses of :class:`GenericInlineModelAdmin` with stacked and tabular
     layouts, respectively.
 
-.. function:: generic_inlineformset_factory(model, form=ModelForm, formset=BaseGenericInlineFormSet, ct_field="content_type", fk_field="object_id", fields=None, exclude=None, extra=3, can_order=False, can_delete=True, max_num=None, formfield_callback=None, validate_max=False)
+.. function:: generic_inlineformset_factory(model, form=ModelForm, formset=BaseGenericInlineFormSet, ct_field="content_type", fk_field="object_id", fields=None, exclude=None, extra=3, can_order=False, can_delete=True, max_num=None, formfield_callback=None, validate_max=False, for_concrete_model=True)
 
     Returns a ``GenericInlineFormSet`` using
     :func:`~django.forms.models.modelformset_factory`.
@@ -502,3 +511,9 @@ information.
     are similar to those documented in
     :func:`~django.forms.models.modelformset_factory` and
     :func:`~django.forms.models.inlineformset_factory`.
+
+    .. versionadded:: 1.6
+
+        The ``for_concrete_model`` argument corresponds to the
+        :class:`~django.contrib.contenttypes.generic.GenericForeignKey.for_concrete_model`
+        argument on ``GenericForeignKey``.

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -261,6 +261,11 @@ Minor features
 * :class:`~django.views.generic.base.View` and
   :class:`~django.views.generic.base.RedirectView` now support HTTP PATCH method.
 
+* :class:`GenericForeignKey <django.contrib.contenttypes.generic.GenericForeignKey>`
+  now takes an optional ``for_concrete_model`` argument, which when set to
+  ``False`` allows the field to reference proxy models. The default is ``True``
+  to retain the old behavior.
+
 Backwards incompatible changes in 1.6
 =====================================
 

--- a/tests/generic_relations/models.py
+++ b/tests/generic_relations/models.py
@@ -102,3 +102,22 @@ class Rock(Mineral):
 class ManualPK(models.Model):
     id = models.IntegerField(primary_key=True)
     tags = generic.GenericRelation(TaggedItem)
+
+
+class ForProxyModelModel(models.Model):
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    obj = generic.GenericForeignKey(for_concrete_model=False)
+    title = models.CharField(max_length=255, null=True)
+
+class ForConcreteModelModel(models.Model):
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    obj = generic.GenericForeignKey()
+
+class ConcreteRelatedModel(models.Model):
+    bases = generic.GenericRelation(ForProxyModelModel, for_concrete_model=False)
+
+class ProxyRelatedModel(ConcreteRelatedModel):
+    class Meta:
+        proxy = True

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -6,7 +6,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from .models import (TaggedItem, ValuableTaggedItem, Comparison, Animal,
-    Vegetable, Mineral, Gecko, Rock, ManualPK)
+                     Vegetable, Mineral, Gecko, Rock, ManualPK,
+                     ForProxyModelModel, ForConcreteModelModel,
+                     ProxyRelatedModel, ConcreteRelatedModel)
 
 
 class GenericRelationsTests(TestCase):
@@ -256,12 +258,120 @@ class TaggedItemForm(forms.ModelForm):
         widgets = {'tag': CustomWidget}
 
 class GenericInlineFormsetTest(TestCase):
-    """
-    Regression for #14572: Using base forms with widgets
-    defined in Meta should not raise errors.
-    """
-
     def test_generic_inlineformset_factory(self):
+        """
+        Regression for #14572: Using base forms with widgets
+        defined in Meta should not raise errors.
+        """
         Formset = generic_inlineformset_factory(TaggedItem, TaggedItemForm)
         form = Formset().forms[0]
         self.assertIsInstance(form['tag'].field.widget, CustomWidget)
+
+    def test_save_new_for_proxy(self):
+        Formset = generic_inlineformset_factory(ForProxyModelModel,
+            fields='__all__', for_concrete_model=False)
+
+        instance = ProxyRelatedModel.objects.create()
+
+        data = {
+            'form-TOTAL_FORMS': '1',
+            'form-INITIAL_FORMS': '0',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-title': 'foo',
+        }
+
+        formset = Formset(data, instance=instance, prefix='form')
+        self.assertTrue(formset.is_valid())
+
+        new_obj, = formset.save()
+        self.assertEqual(new_obj.obj, instance)
+
+    def test_save_new_for_concrete(self):
+        Formset = generic_inlineformset_factory(ForProxyModelModel,
+            fields='__all__', for_concrete_model=True)
+
+        instance = ProxyRelatedModel.objects.create()
+
+        data = {
+            'form-TOTAL_FORMS': '1',
+            'form-INITIAL_FORMS': '0',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-title': 'foo',
+        }
+
+        formset = Formset(data, instance=instance, prefix='form')
+        self.assertTrue(formset.is_valid())
+
+        new_obj, = formset.save()
+        self.assertNotIsInstance(new_obj.obj, ProxyRelatedModel)
+
+
+class ProxyRelatedModelTest(TestCase):
+    def test_default_behavior(self):
+        """
+        The default for for_concrete_model should be True
+        """
+        base = ForConcreteModelModel()
+        base.obj = rel = ProxyRelatedModel.objects.create()
+        base.save()
+
+        base = ForConcreteModelModel.objects.get(pk=base.pk)
+        rel = ConcreteRelatedModel.objects.get(pk=rel.pk)
+        self.assertEqual(base.obj, rel)
+
+    def test_works_normally(self):
+        """
+        When for_concrete_model is False, we should still be able to get
+        an instance of the concrete class.
+        """
+        base = ForProxyModelModel()
+        base.obj = rel = ConcreteRelatedModel.objects.create()
+        base.save()
+
+        base = ForProxyModelModel.objects.get(pk=base.pk)
+        self.assertEqual(base.obj, rel)
+
+    def test_proxy_is_returned(self):
+        """
+        Instances of the proxy should be returned when
+        for_concrete_model is False.
+        """
+        base = ForProxyModelModel()
+        base.obj = ProxyRelatedModel.objects.create()
+        base.save()
+
+        base = ForProxyModelModel.objects.get(pk=base.pk)
+        self.assertIsInstance(base.obj, ProxyRelatedModel)
+
+    def test_query(self):
+        base = ForProxyModelModel()
+        base.obj = rel = ConcreteRelatedModel.objects.create()
+        base.save()
+
+        self.assertEqual(rel, ConcreteRelatedModel.objects.get(bases__id=base.id))
+
+    def test_query_proxy(self):
+        base = ForProxyModelModel()
+        base.obj = rel = ProxyRelatedModel.objects.create()
+        base.save()
+
+        self.assertEqual(rel, ProxyRelatedModel.objects.get(bases__id=base.id))
+
+    def test_generic_relation(self):
+        base = ForProxyModelModel()
+        base.obj = ProxyRelatedModel.objects.create()
+        base.save()
+
+        base = ForProxyModelModel.objects.get(pk=base.pk)
+        rel = ProxyRelatedModel.objects.get(pk=base.obj.pk)
+        self.assertEqual(base, rel.bases.get())
+
+    def test_generic_relation_set(self):
+        base = ForProxyModelModel()
+        base.obj = ConcreteRelatedModel.objects.create()
+        base.save()
+        newrel = ConcreteRelatedModel.objects.create()
+
+        newrel.bases = [base]
+        newrel = ConcreteRelatedModel.objects.get(pk=newrel.pk)
+        self.assertEqual(base, newrel.bases.get())


### PR DESCRIPTION
Allows a GenericForeignKey to reference proxy models. The default for for_concrete_model is True to keep backwards compatibility.

Fixes https://code.djangoproject.com/ticket/17648
