### PR TITLE
Fixed #20472: response.content should be bytes on both Python 2 and 3

### DIFF
--- a/django/http/utils.py
+++ b/django/http/utils.py
@@ -31,13 +31,13 @@ def conditional_content_removal(request, response):
         if response.streaming:
             response.streaming_content = []
         else:
-            response.content = ''
+            response.content = b''
         response['Content-Length'] = '0'
     if request.method == 'HEAD':
         if response.streaming:
             response.streaming_content = []
         else:
-            response.content = ''
+            response.content = b''
     return response
 
 

--- a/tests/http_utils/tests.py
+++ b/tests/http_utils/tests.py
@@ -1,8 +1,19 @@
 from __future__ import unicode_literals
 
+import io
+import gzip
+
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 from django.http.utils import conditional_content_removal
 from django.test import TestCase
+
+
+# based on Python 3.3's gzip.compress
+def gzip_compress(data):
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode='wb', compresslevel=0) as f:
+        f.write(data)
+    return buf.getvalue()
 
 
 class HttpUtilTests(TestCase):
@@ -32,6 +43,19 @@ class HttpUtilTests(TestCase):
             res = StreamingHttpResponse(['abc'], status=status_code)
             conditional_content_removal(req, res)
             self.assertEqual(b''.join(res), b'')
+
+        # Issue #20472  
+        abc = gzip_compress(b'abc')
+        res = HttpResponse(abc, status=304)
+        res['Content-Encoding'] = 'gzip'
+        conditional_content_removal(req, res)
+        self.assertEqual(res.content, b'')
+
+        res = StreamingHttpResponse([abc], status=304)
+        res['Content-Encoding'] = 'gzip'
+        conditional_content_removal(req, res)
+        self.assertEqual(b''.join(res), b'')
+
 
         # Strip content for HEAD requests.
         req.method = 'HEAD'


### PR DESCRIPTION
Without the patch having `ConditionalGetMiddleware` enabled under Python 3.x results in the following exception when running `manage.py runserver`:

```
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/wsgiref/handlers.py", line 138, in run
    self.finish_response()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/wsgiref/handlers.py", line 178, in finish_response
    for data in self.result:
  File "/Users/ambv/Documents/Projekty/Python/django/django/http/response.py", line 288, in __next__
    return self.make_bytes(next(self._iterator))
  File "/Users/ambv/Documents/Projekty/Python/django/django/http/response.py", line 270, in make_bytes
    return bytes(value)
TypeError: string argument without an encoding
```
