### PR TITLE
Limit "first()" and "last()" to return only the first object

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -504,7 +504,7 @@ class QuerySet(object):
         """
         qs = self if self.ordered else self.order_by('pk')
         try:
-            return qs[0]
+            return qs[:1][0]
         except IndexError:
             return None
 
@@ -514,7 +514,7 @@ class QuerySet(object):
         """
         qs = self.reverse() if self.ordered else self.order_by('-pk')
         try:
-            return qs[0]
+            return qs[:1][0]
         except IndexError:
             return None
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1613,7 +1613,7 @@ last
 
 .. versionadded:: 1.6
 
-Works like  :meth:`first()` except the ordering is reversed.
+Works like  :meth:`first()`, but returns the last object in the queryset.
 
 aggregate
 ~~~~~~~~~


### PR DESCRIPTION
Performance improvement for `first()` and `last()`. Slightly updated docs based on @ptone 's feedback [here](https://github.com/django/django/pull/1056)
