### PR TITLE
Add predicate decorator to not match specific view (#20479)

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -98,7 +98,7 @@ class BaseHandler(object):
                     urlresolvers.set_urlconf(urlconf)
                     resolver = urlresolvers.RegexURLResolver(r'^/', urlconf)
 
-                resolver_match = resolver.resolve(request.path_info)
+                resolver_match = resolver.resolve(request.path_info, request=request)
                 callback, callback_args, callback_kwargs = resolver_match
                 request.resolver_match = resolver_match
 

--- a/django/views/decorators/predicate.py
+++ b/django/views/decorators/predicate.py
@@ -1,0 +1,47 @@
+"""
+Decorators for views based on HTTP headers.
+"""
+
+import logging
+from functools import wraps
+
+from django.utils.decorators import decorator_from_middleware, available_attrs
+from django.utils.http import http_date
+from django.middleware.http import ConditionalGetMiddleware
+
+logger = logging.getLogger('django.request')
+
+
+def url_predicates(predicates_list):
+    """
+    Decorators to make urls matchable if predicates return True
+    Usage::
+
+        url_pattern += url('/', my_view_GET)
+        url_pattern += url('/', my_view_POST)
+
+        ...
+
+        predicate_GET = lambda request: request.method == 'GET'
+        predicate_POST = lambda request: request.method == 'POST'
+
+        @url_predicates([predicate_GET])
+        def my_view_GET(request):
+            # I can assume now that only GET requests get match to the url
+            # associated to this view
+            # ...
+
+        @url_predicates([predicate_POST])
+        def my_view_POST(request):
+            # I can assume now that only POST requests get match to the url
+            # associated to this view
+            # ...
+    """
+    def decorator(func):
+        @wraps(func, assigned=available_attrs(func))
+        def inner(request, *args, **kwargs):
+            return func(request, *args, **kwargs)
+        inner.predicates = predicates_list
+        return inner
+    return decorator
+

--- a/docs/topics/http/decorators.txt
+++ b/docs/topics/http/decorators.txt
@@ -51,6 +51,42 @@ a :class:`django.http.HttpResponseNotAllowed` if the conditions are not met.
         such as link checkers, rely on HEAD requests, you might prefer
         using ``require_safe`` instead of ``require_GET``.
 
+
+Predicates url processing
+=========================
+
+The decorators in :mod:django.views.decorators.predicate can be used to restrict 
+the view selection based on a list of function result. 
+These decorators will attach a list of functions to be checked before returning 
+a match for the url. 
+If the predicates fail then the process continue the url resolving process.
+
+.. function:: view_predicates(predicate_function_list)
+
+    Decorator to require that a view only match particular request. Usage::
+
+        url_pattern += url('/', my_view_GET)
+        url_pattern += url('/', my_view_POST)
+
+        ...
+
+        predicate_GET = lambda request: request.method == 'GET'
+        predicate_POST = lambda request: request.method == 'POST'
+
+        @url_predicates([predicate_GET])
+        def my_view_GET(request):
+            # I can assume now that only GET requests get match to the url
+            # associated to this view
+            # ...
+
+        @url_predicates([predicate_POST])
+        def my_view_POST(request):
+            # I can assume now that only POST requests get match to the url
+            # associated to this view
+            # ...
+
+
+
 Conditional view processing
 ===========================
 

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -89,3 +89,15 @@ class SignalsTests(TestCase):
         self.assertEqual(self.signals, ['started'])
         self.assertEqual(b''.join(response.streaming_content), b"streaming content")
         self.assertEqual(self.signals, ['started', 'finished'])
+
+
+class PredicatesTests(TestCase):
+    urls = 'handlers.urls'
+
+    def test_request_predicates(self):
+        response = self.client.post('/predicate/')
+        self.assertEqual(response.content, b"predicate content")
+
+    def test_request_predicates_fail_return_404(self):
+        response = self.client.get('/predicate/')
+        self.assertEqual(response.status_code, 404)

--- a/tests/handlers/urls.py
+++ b/tests/handlers/urls.py
@@ -9,4 +9,5 @@ urlpatterns = patterns('',
     url(r'^streaming/$', views.streaming),
     url(r'^in_transaction/$', views.in_transaction),
     url(r'^not_in_transaction/$', views.not_in_transaction),
+    url(r'^predicate/$', views.predicate),
 )

--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.db import connection, transaction
 from django.http import HttpResponse, StreamingHttpResponse
+from django.views.decorators.predicate import url_predicates
 
 def regular(request):
     return HttpResponse(b"regular content")
@@ -15,3 +16,7 @@ def in_transaction(request):
 @transaction.non_atomic_requests
 def not_in_transaction(request):
     return HttpResponse(str(connection.in_atomic_block))
+
+@url_predicates([lambda request: request.method == 'POST',])
+def predicate(request):
+    return HttpResponse(b"predicate content")


### PR DESCRIPTION
Predicates is concept brought back from Pyramid, Pylon.
It has the goal of allowing a better organization of your function based view and get rid of redundant code as `if request.method == 'POST`

ticket : https://code.djangoproject.com/ticket/20479#ticket
