### PR TITLE
Link to active project for ODBC backend

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -803,5 +803,5 @@ the support channels provided by each 3rd party project.
 .. _IBM DB2: http://code.google.com/p/ibm-db/
 .. _Microsoft SQL Server 2005: http://code.google.com/p/django-mssql/
 .. _Firebird: http://code.google.com/p/django-firebird/
-.. _ODBC: http://code.google.com/p/django-pyodbc/
+.. _ODBC: https://github.com/aurorasoftware/django-pyodbc/
 .. _ADSDB: http://code.google.com/p/adsdb-django/


### PR DESCRIPTION
It took me quite some time to find if and where the ODBC backend was maintained.
On djangoproject.com I found:
http://code.google.com/p/django-pyodbc/ (last commit about 3 years ago)
then:
https://github.com/avidal/django-pyodbc avidal fork.
then:
https://github.com/aurorasoftware/django-pyodbc/ aurorasoftware version which has avidal improvements merged and is actively maintained and is also the version installed through PIP.

Avidals version now links to https://github.com/aurorasoftware/django-pyodbc/ 
(See https://github.com/aurorasoftware/django-pyodbc/issues/4)
