### PR TITLE
Update link to jQuery Cookie plugin site

### DIFF
--- a/docs/ref/contrib/csrf.txt
+++ b/docs/ref/contrib/csrf.txt
@@ -120,7 +120,7 @@ Acquiring the token is straightforward:
     var csrftoken = getCookie('csrftoken');
 
 The above code could be simplified by using the `jQuery cookie plugin
-<http://plugins.jquery.com/project/Cookie>`_ to replace ``getCookie``:
+<http://plugins.jquery.com/cookie/>`_ to replace ``getCookie``:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
The jQuery plugins website has been updated. This pull requests updates the link to the jQuery Cookie plugin in the Django CSRF docs.

It would be useful to update the link where it appears in 1.4.X and 1.5.X branches as well.
