### PR TITLE
Fixed #20205 - Disallowed empty string as an empty value for IntegerField

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1030,6 +1030,7 @@ class FloatField(Field):
 
 class IntegerField(Field):
     empty_strings_allowed = False
+    empty_values = [None]
     default_error_messages = {
         'invalid': _("'%s' value must be an integer."),
     }


### PR DESCRIPTION
Thanks Areski Belaid for the initial patch.
