### PR TITLE
Fixed #16137 - Removed kwargs requirement for QuerySet.get_or_create

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -363,8 +363,6 @@ class QuerySet(object):
         Returns a tuple of (object, created), where created is a boolean
         specifying whether an object was created.
         """
-        assert kwargs, \
-                'get_or_create() must be passed at least one keyword argument'
         defaults = kwargs.pop('defaults', {})
         lookup = kwargs.copy()
         for f in self.model._meta.fields:

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1343,8 +1343,12 @@ get_or_create
 
 .. method:: get_or_create(**kwargs)
 
-A convenience method for looking up an object with the given kwargs, creating
-one if necessary.
+A convenience method for looking up an object with the given kwargs (may be
+empty if your model has defaults for all fields), creating one if necessary.
+
+.. versionchanged:: 1.6
+
+    Older verions of Django required ``kwargs``.
 
 Returns a tuple of ``(object, created)``, where ``object`` is the retrieved or
 created object and ``created`` is a boolean specifying whether a new object was

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -266,6 +266,9 @@ Minor features
   ``False`` allows the field to reference proxy models. The default is ``True``
   to retain the old behavior.
 
+* The :meth:`~django.db.models.query.QuerySet.get_or_create` method no longer
+  requires at least one keyword argument.
+
 Backwards incompatible changes in 1.6
 =====================================
 

--- a/tests/get_or_create/models.py
+++ b/tests/get_or_create/models.py
@@ -21,6 +21,11 @@ class Person(models.Model):
     def __str__(self):
         return '%s %s' % (self.first_name, self.last_name)
 
+
+class DefaultPerson(models.Model):
+    first_name = models.CharField(max_length=100, default="Anonymous")
+
+
 class ManualPrimaryKeyTest(models.Model):
     id = models.IntegerField(primary_key=True)
     data = models.CharField(max_length=100)

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -7,7 +7,7 @@ import warnings
 from django.db import IntegrityError, DatabaseError
 from django.test import TestCase, TransactionTestCase
 
-from .models import Person, ManualPrimaryKeyTest, Profile, Tag, Thing
+from .models import DefaultPerson, Person, ManualPrimaryKeyTest, Profile, Tag, Thing
 
 
 class GetOrCreateTests(TestCase):
@@ -81,6 +81,13 @@ class GetOrCreateTests(TestCase):
                 first_name="Bob", last_name="Ross", birthday=date(1950, 1, 1))
         else:
             self.skipTest("This backend accepts broken utf-8.")
+
+    def test_get_or_create_empty(self):
+        try:
+            DefaultPerson.objects.get_or_create()
+        except AssertionError:
+            self.fail("If all the attributes on a model have defaults, we "
+                      "shouldn't need to pass any arguments.")
 
 
 class GetOrCreateTransactionTests(TransactionTestCase):


### PR DESCRIPTION
Thanks wilfred@, poirier, and charettes for work
on the patch.
