### PR TITLE
Fixes #20502 -- i18n test bug discovered by Travis.

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -132,6 +132,9 @@ def activate(language):
 def deactivate():
     return _trans.deactivate()
 
+def uncache(language):
+    return _trans.uncache(language)
+
 class override(object):
     def __init__(self, language, deactivate=False):
         self.language = language

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -96,6 +96,21 @@ class DjangoTranslation(gettext_module.GNUTranslations):
     def __repr__(self):
         return "<DjangoTranslation lang:%s>" % self.__language
 
+def uncache(language):
+    """
+    Deletes a translation from the cache.
+
+    This is necessary if settings.INSTALLED_APPS has changed in a way that
+    affects translations, such as adding or removing an app that comes with
+    its own translations. This happens in
+    i18n.tests.AppResolutionOrderI18NTests.test_app_translation for example,
+    which fails if the "de" catalog was loaded and cached before the test
+    modifies INSTALLED_APPS.
+    """
+    if language in _translations:
+        return _translations.pop(language)
+    return None
+
 def translation(language):
     """
     Returns a translation object.

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -30,7 +30,8 @@ from django.utils.translation import (activate, deactivate,
     ngettext, ngettext_lazy,
     ungettext, ungettext_lazy,
     pgettext, pgettext_lazy,
-    npgettext, npgettext_lazy)
+    npgettext, npgettext_lazy,
+    check_for_language, uncache)
 
 from .commands.tests import can_run_extraction_tests, can_run_compilation_tests
 if can_run_extraction_tests:
@@ -906,6 +907,9 @@ class AppResolutionOrderI18NTests(ResolutionOrderI18NTests):
     def setUp(self):
         self.old_installed_apps = settings.INSTALLED_APPS
         settings.INSTALLED_APPS = ['i18n.resolution'] + list(settings.INSTALLED_APPS)
+        uncache('de')
+        self.assertIsNone(uncache('de'), "This test will not work if "
+            "the 'de' locale is already cached")
         super(AppResolutionOrderI18NTests, self).setUp()
 
     def tearDown(self):


### PR DESCRIPTION
If the following tests are run in this order:
- defaultfilters.tests.DefaultFiltersTests.test_localized_filesizeformat
- i18n.tests.AppResolutionOrderI18NTests

then the second test will fail because the first has cached the 'de' translation before the second one changes INSTALLED_APPS to install the test app, which has its own translation.
