### PR TITLE
Fixed ticket #20500 -- Added slash inside the match parentheses

### DIFF
--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -82,7 +82,7 @@ to place the pattern at the end of the other urlpatterns::
 
     # Your other patterns here
     urlpatterns += patterns('django.contrib.flatpages.views',
-        (r'^(?P<url>.*)$', 'flatpage'),
+        (r'^(?P<url>.*/)$', 'flatpage'),
     )
 
 Another common setup is to use flat pages for a limited set of known pages and


### PR DESCRIPTION
Fixed documentation bug that omitted trailing slash inside URL match parentheses
