### PR TITLE
Fixed #2445: Allow callable values for limit_choices_to.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -224,6 +224,7 @@ answer newbie questions, and generally made Django that much better:
     Bill Fenner <fenner@gmail.com>
     Stefane Fermgier <sf@fermigier.com>
     J. Pablo Fernandez <pupeno@pupeno.com>
+    Sébastien Fievet <zyegfryed@gmail.com>
     Maciej Fijalkowski
     Leandra Finger <leandra.finger@gmail.com>
     Juan Pedro Fisanotti <fisadev@gmail.com>

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -385,6 +385,10 @@ class Model(six.with_metaclass(ModelBase)):
                         # pass in "None" for related objects if it's allowed.
                         if rel_obj is None and field.null:
                             val = None
+                        # Set the model field choices function on the field.
+                        # Refs #2445.
+                        choice_func = getattr(self, 'choices_for_%s' % field.name, None)
+                        field._queryset = choice_func
                 else:
                     try:
                         val = kwargs.pop(field.attname)

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1170,10 +1170,7 @@ class ForeignKey(ForeignObject):
             return
 
         using = router.db_for_read(model_instance.__class__, instance=model_instance)
-        qs = self.rel.to._default_manager.using(using).filter(
-                **{self.rel.field_name: value}
-             )
-        qs = qs.complex_filter(self.rel.limit_choices_to)
+        qs = self.queryset.using(using).filter(**{self.rel.field_name: value})
         if not qs.exists():
             raise exceptions.ValidationError(self.error_messages['invalid'] % {
                 'model': self.rel.to._meta.verbose_name, 'pk': value})
@@ -1228,7 +1225,7 @@ class ForeignKey(ForeignObject):
                              (self.name, self.rel.to))
         defaults = {
             'form_class': forms.ModelChoiceField,
-            'queryset': self.rel.to._default_manager.using(db).complex_filter(self.rel.limit_choices_to),
+            'queryset': self.queryset.using(db),
             'to_field_name': self.rel.field_name,
         }
         defaults.update(kwargs)

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1062,6 +1062,11 @@ define the details of how the relation works.
     will only have an effect on the choices available in the admin when the
     field is not listed in ``raw_id_fields`` in the ``ModelAdmin`` for the model.
 
+    .. seealso::
+
+        For extended filtering, use the
+        :attr:`~django.db.models.Model.choices_for_FOO` method.
+
 .. attribute:: ForeignKey.related_name
 
     The name to use for the relation from the related object back to this one.

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -679,3 +679,29 @@ described in :ref:`Field lookups <field-lookups>`.
 Note that in the case of identical date values, these methods will use the
 primary key as a tie-breaker. This guarantees that no records are skipped or
 duplicated. That also means you cannot use those methods on unsaved objects.
+
+.. method:: Model.choices_for_FOO()
+
+    .. versionadded:: 1.6
+
+    For every :class:`~django.db.models.ForeignKey` which
+    :attr:`~django.db.models.ForeignKey.limit_choices_to` is too limited, you
+    can define a ``choices_for_FOO`` method, where ``FOO`` is the name of the
+    field, that returns a queryset. It allows you to limit choices with
+    respect to ``self``. For example::
+
+        class MyModel(models.Model):
+            user = models.ForeignKey(User)
+
+            def choices_for_user(self):
+                return User.objects.filter(Q(id=self.user) | Q(is_active=True))
+
+    will make only active and currently associated users choosable.
+
+    .. note::
+
+        The ``choices_for_FOO`` method takes precedence over the
+        :attr:`~django.db.models.ForeignKey.limit_choices_to` option. So, when
+        a ``choices_for_FOO`` method is available it will always be used
+        instead of the queryset generated using
+        :attr:`~django.db.models.ForeignKey.limit_choices_to`.

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -280,6 +280,9 @@ Minor features
 * The :exc:`~django.core.exceptions.DoesNotExist` exception now includes a
   message indicating the name of the attribute used for the lookup.
 
+* Added :attr:`~django.db.models.Model.choices_for_FOO` option allowing extended
+  filtering for :class:`~django.db.models.ForeignKey`.
+
 Backwards incompatible changes in 1.6
 =====================================
 
@@ -599,6 +602,12 @@ Miscellaneous
 * The ``XViewMiddleware`` has been moved from ``django.middleware.doc`` to
   ``django.contrib.admindocs.middleware`` because it is an implementation
   detail of admindocs, proven not to be reusable in general.
+
+* The support for extended filtering on :class:`~django.db.models.ForeignKey`
+  lookups for model-defined :attr:`~django.db.models.Model.choices_for_FOO`
+  methods, where ``FOO`` is the name of a field. Be careful when upgrading that
+  you haven't already defined some method following this pattern in your
+  codebase, otherwise things might not work as expected.
 
 Features deprecated in 1.6
 ==========================

--- a/tests/choices/models.py
+++ b/tests/choices/models.py
@@ -22,6 +22,10 @@ GENDER_CHOICES = (
 class Person(models.Model):
     name = models.CharField(max_length=20)
     gender = models.CharField(max_length=1, choices=GENDER_CHOICES)
+    parent = models.ForeignKey('self', blank=True, null=True, related_name='child')
 
     def __str__(self):
         return self.name
+
+    def choices_for_parent(self):
+        return self._default_manager.exclude(id=self.id)

--- a/tests/choices/tests.py
+++ b/tests/choices/tests.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.test import TestCase
+from django.db.models.query import QuerySet
 
 from .models import Person
 
@@ -23,3 +24,17 @@ class ChoicesTests(TestCase):
         a.gender = 'U'
         self.assertEqual(a.get_gender_display(), 'U')
 
+    def test_choices_for_FOO(self):
+        a = Person.objects.create(name='Adrian', gender='M')
+        s = Person.objects.create(name='Simon', gender='M', parent=a)
+        k = Person.objects.create(name='Karen', gender='F', parent=a)
+        b = Person.objects.create(name='Brian', gender='M', parent=s)
+
+        queryset = b._meta.get_field('parent').queryset
+        self.assertIsInstance(queryset, QuerySet)
+        self.assertQuerysetEqual(
+            queryset, [
+                'Adrian',
+                'Simon',
+                'Karen'
+            ], lambda p: p.name, ordered=False)


### PR DESCRIPTION
Introduces the Model.choices_for_FOO method allowing to extend the limit_choices_to option.
