### PR TITLE
Don't hard-code class names when calling static methods

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -177,7 +177,7 @@ class UserManager(BaseUserManager):
         now = timezone.now()
         if not username:
             raise ValueError('The given username must be set')
-        email = UserManager.normalize_email(email)
+        email = self.normalize_email(email)
         user = self.model(username=username, email=email,
                           is_staff=False, is_active=True, is_superuser=False,
                           last_login=now, date_joined=now, **extra_fields)

--- a/django/contrib/auth/tests/test_custom_user.py
+++ b/django/contrib/auth/tests/test_custom_user.py
@@ -21,7 +21,7 @@ class CustomUserManager(BaseUserManager):
             raise ValueError('Users must have an email address')
 
         user = self.model(
-            email=CustomUserManager.normalize_email(email),
+            email=self.normalize_email(email),
             date_of_birth=date_of_birth,
         )
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -939,7 +939,7 @@ authentication app::
                 raise ValueError('Users must have an email address')
 
             user = self.model(
-                email=MyUserManager.normalize_email(email),
+                email=self.normalize_email(email),
                 date_of_birth=date_of_birth,
             )
 


### PR DESCRIPTION
`UserManager.normalize_email` should be called on the instance, not the class. This has the same effect normally but is more helpful to subclassers. When methods are called directly on the class, subclasses can't override them.
