### PR TITLE
Reverse password_reset_confirm view by name, not by path.

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_email.html
+++ b/django/contrib/admin/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'django.contrib.auth.views.password_reset_confirm' uidb36=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb36=uid token=token %}
 {% endblock %}
 {% trans "Your username, in case you've forgotten:" %} {{ user.get_username }}
 

--- a/django/contrib/auth/tests/test_views.py
+++ b/django/contrib/auth/tests/test_views.py
@@ -404,7 +404,7 @@ class ChangePasswordTest(AuthViewsTestCase):
 class LoginTest(AuthViewsTestCase):
 
     def test_current_site_in_context_after_login(self):
-        response = self.client.get(reverse('django.contrib.auth.views.login'))
+        response = self.client.get(reverse('login'))
         self.assertEqual(response.status_code, 200)
         if Site._meta.installed:
             site = Site.objects.get_current()
@@ -416,7 +416,7 @@ class LoginTest(AuthViewsTestCase):
                      'Login form is not an AuthenticationForm')
 
     def test_security_check(self, password='password'):
-        login_url = reverse('django.contrib.auth.views.login')
+        login_url = reverse('login')
 
         # Those URLs should not pass the security check
         for bad_url in ('http://example.com',
@@ -631,7 +631,7 @@ class LogoutTest(AuthViewsTestCase):
         self.confirm_logged_out()
 
     def test_security_check(self, password='password'):
-        logout_url = reverse('django.contrib.auth.views.logout')
+        logout_url = reverse('logout')
 
         # Those URLs should not pass the security check
         for bad_url in ('http://example.com',

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -142,7 +142,7 @@ def password_reset(request, is_admin_site=False,
                    current_app=None,
                    extra_context=None):
     if post_reset_redirect is None:
-        post_reset_redirect = reverse('django.contrib.auth.views.password_reset_done')
+        post_reset_redirect = reverse('password_reset_done')
     else:
         post_reset_redirect = resolve_url(post_reset_redirect)
     if request.method == "POST":
@@ -197,7 +197,7 @@ def password_reset_confirm(request, uidb36=None, token=None,
     UserModel = get_user_model()
     assert uidb36 is not None and token is not None  # checked by URLconf
     if post_reset_redirect is None:
-        post_reset_redirect = reverse('django.contrib.auth.views.password_reset_complete')
+        post_reset_redirect = reverse('password_reset_complete')
     else:
         post_reset_redirect = resolve_url(post_reset_redirect)
     try:
@@ -249,7 +249,7 @@ def password_change(request,
                     password_change_form=PasswordChangeForm,
                     current_app=None, extra_context=None):
     if post_change_redirect is None:
-        post_change_redirect = reverse('django.contrib.auth.views.password_change_done')
+        post_change_redirect = reverse('password_change_done')
     else:
         post_change_redirect = resolve_url(post_change_redirect)
     if request.method == "POST":


### PR DESCRIPTION
This URL should be reversed using its name, 'password_reset_email', not its location in `django.contrib.auth.views`. This allows using your own password_reset_confirm view.

ticket: https://code.djangoproject.com/ticket/20532
