### PR TITLE
Explicit exception chaining for db exceptions by setting __cause__ in py2

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -91,8 +91,7 @@ class DatabaseErrorWrapper(object):
                 except AttributeError:
                     args = (exc_value,)
                 dj_exc_value = dj_exc_type(*args)
-                if six.PY3:
-                    dj_exc_value.__cause__ = exc_value
+                dj_exc_value.__cause__ = exc_value
                 # Only set the 'errors_occurred' flag for errors that may make
                 # the connection unusable.
                 if dj_exc_type not in (DataError, IntegrityError):

--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -152,10 +152,16 @@ The Django wrappers for database exceptions behave exactly the same as
 the underlying database exceptions. See :pep:`249`, the Python Database API
 Specification v2.0, for further information.
 
+As per :pep:`3134`, a ``__cause__`` attribute is set with the original
+(underlying) database exception, allowing access to any additional
+information provided. (Note that this attribute is available under
+both Python 2 and Python 3, although :pep:`3134` normally only applies
+to Python 3.)
+
 .. versionchanged:: 1.6
 
     Previous version of Django only wrapped ``DatabaseError`` and
-    ``IntegrityError``.
+    ``IntegrityError``, and did not provide ``__cause__``.
 
 .. exception:: models.ProtectedError
 


### PR DESCRIPTION
As per [ticket 17601](https://code.djangoproject.com/ticket/17601).
