### PR TITLE
Fixed #19875 - Added notes in docs regarding DEBUG=False and empty ALLOWED HOSTS.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -40,6 +40,11 @@ class Command(BaseCommand):
         return get_internal_wsgi_application()
 
     def handle(self, addrport='', *args, **options):
+        from django.conf import settings
+
+        if not settings.DEBUG and not settings.ALLOWED_HOSTS:
+            raise CommandError('You must set settings.ALLOWED_HOSTS if DEBUG is False.')
+
         self.use_ipv6 = options.get('use_ipv6')
         if self.use_ipv6 and not socket.has_ipv6:
             raise CommandError('Your Python does not support IPv6.')

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -473,6 +473,13 @@ template for all 404 errors when :setting:`DEBUG` is set to ``False`` (in your
 settings module). If you do create the template, add at least some dummy
 content like "Page not found".
 
+.. warning::
+
+    If :setting:`DEBUG` is set to ``False``, all responses will be
+    "Bad Request (400)" unless you specify the proper :setting:`ALLOWED_HOSTS`
+    as well (something like ``['localhost', '127.0.0.1']`` for
+    local development).
+
 A couple more things to note about 404 views:
 
 * If :setting:`DEBUG` is set to ``True`` (in your settings module) then your

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -852,6 +852,10 @@ It is also important to remember that when running with :setting:`DEBUG`
 turned on, Django will remember every SQL query it executes. This is useful
 when you're debugging, but it'll rapidly consume memory on a production server.
 
+Finally, if :setting:`DEBUG` is ``False``, you also need to properly set
+the :setting:`ALLOWED_HOSTS` setting. Failing to do so will result in all
+requests being returned as "Bad Request (400)".
+
 .. _django/views/debug.py: https://github.com/django/django/blob/master/django/views/debug.py
 
 .. setting:: DEBUG_PROPAGATE_EXCEPTIONS

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -17,6 +17,11 @@ Here are a couple of example settings::
     DEFAULT_FROM_EMAIL = 'webmaster@example.com'
     TEMPLATE_DIRS = ('/home/templates/mike', '/home/templates/john')
 
+.. note::
+
+    If you set :setting:`DEBUG` to ``False``, you also need to properly set
+    the :setting:`ALLOWED_HOSTS` setting.
+
 Because a settings file is a Python module, the following apply:
 
 * It doesn't allow for Python syntax errors.

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1192,6 +1192,21 @@ class ManageRunserver(AdminScriptTestCase):
         self.cmd.handle(addrport="deadbeef:7654")
         self.assertServerSettings('deadbeef', '7654')
 
+class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):
+    def setUp(self):
+        self.write_settings('settings.py', sdict={
+            'ALLOWED_HOSTS': [],
+            'DEBUG': False,
+        })
+
+    def tearDown(self):
+        self.remove_settings('settings.py')
+
+    def test_empty_allowed_hosts_error(self):
+        out, err = self.run_manage(['runserver'])
+        self.assertNoOutput(out)
+        self.assertOutput(err, 'CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.')
+
 
 ##########################################################################
 # COMMAND PROCESSING TESTS


### PR DESCRIPTION
Also modified runserver to output an error message if
it won't serve any requests due to such a config.
