### PR TITLE
Simplifying a formset code example in the documentation

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -247,8 +247,7 @@ is where you define your own validation that works at the formset level::
     ...             # Don't bother validating the formset unless each form is valid on its own
     ...             return
     ...         titles = []
-    ...         for i in range(0, self.total_form_count()):
-    ...             form = self.forms[i]
+    ...         for form in self.forms:
     ...             title = form.cleaned_data['title']
     ...             if title in titles:
     ...                 raise forms.ValidationError("Articles in a set must have distinct titles.")


### PR DESCRIPTION
Rather than `for i in range(0, self.total_form_count())` and manually accessing `self.forms[i]`, it's clearer to just iterate over `self.forms`.

Since `FormSet` implements `__iter__`, you could even iterate over `self`, but this approach is more explicit.
