### PR TITLE
Fixed order of base classes in CBV mixin docs

### DIFF
--- a/docs/topics/class-based-views/mixins.txt
+++ b/docs/topics/class-based-views/mixins.txt
@@ -233,7 +233,7 @@ We'll demonstrate this with the publisher modelling we used in the
     from django.views.generic.detail import SingleObjectMixin
     from books.models import Author
 
-    class RecordInterest(View, SingleObjectMixin):
+    class RecordInterest(SingleObjectMixin, View):
         """Records the current user's interest in an author."""
         model = Author
 
@@ -446,7 +446,7 @@ Our new ``AuthorDetail`` looks like this::
     class AuthorInterestForm(forms.Form):
         message = forms.CharField()
 
-    class AuthorDetail(DetailView, FormMixin):
+    class AuthorDetail(FormMixin, DetailView):
         model = Author
         form_class = AuthorInterestForm
 
@@ -553,7 +553,7 @@ template as ``AuthorDisplay`` is using on ``GET``.
     from django.views.generic import FormView
     from django.views.generic.detail import SingleObjectMixin
 
-    class AuthorInterest(FormView, SingleObjectMixin):
+    class AuthorInterest(SingleObjectMixin, FormView):
         template_name = 'books/author_detail.html'
         form_class = AuthorInterestForm
         model = Author


### PR DESCRIPTION
The order of the base classes in the docs was inconsistent.

If I'm not mistaken, mixins should always be on the left of the base class.

In the changes, View, DetailView and FormView are the base classes and the mixins should go to the left (even if just for the sake of consistency).
