### PR TITLE
Fix for #17076

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -422,8 +422,11 @@ class RegexURLResolver(LocaleRegexProvider):
             lookup_view_s = "%s.%s" % (m, n)
         else:
             lookup_view_s = lookup_view
+
+        patterns = [pattern for (possibility, pattern, defaults) in possibilities]
         raise NoReverseMatch("Reverse for '%s' with arguments '%s' and keyword "
-                "arguments '%s' not found." % (lookup_view_s, args, kwargs))
+                "arguments '%s' not found. %d pattern(s) tried: %s" %
+                             (lookup_view_s, args, kwargs, len(patterns), patterns))
 
 class LocaleRegexURLResolver(RegexURLResolver):
     """

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -192,6 +192,20 @@ class URLPatternReverse(TestCase):
         self.assertEqual('/%7Eme/places/1/',
                 reverse('places', args=[1], prefix='/~me/'))
 
+    def test_patterns_reported(self):
+        # Regression for #17076
+        try:
+            # this url exists, but requires an argument
+            reverse("people", args=[])
+        except NoReverseMatch as e:
+            pattern_description = r"1 pattern(s) tried: ['people/(?P<name>\\w+)/$']"
+            self.assertIn(pattern_description, str(e))
+        else:
+            # we can't use .assertRaises, since we want to inspect the
+            # exception
+            self.fail("Expected a NoReverseMatch, but none occurred.")
+
+
 class ResolverTests(unittest.TestCase):
     def test_resolver_repr(self):
         """


### PR DESCRIPTION
When reversing a URL fails, inform the user which patterns were tried.

See https://code.djangoproject.com/ticket/17076
