### PR TITLE
doc/tutorial: use RequestContext instead of Context

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -339,14 +339,14 @@ Put the following code in that template:
 Now let's update our ``index`` view in ``polls/views.py`` to use the template::
 
     from django.http import HttpResponse
-    from django.template import Context, loader
+    from django.template import RequestContext, loader
 
     from polls.models import Poll
 
     def index(request):
         latest_poll_list = Poll.objects.order_by('-pub_date')[:5]
         template = loader.get_template('polls/index.html')
-        context = Context({
+        context = RequestContext({
             'latest_poll_list': latest_poll_list,
         })
         return HttpResponse(template.render(context))
@@ -377,7 +377,7 @@ rewritten::
         return render(request, 'polls/index.html', context)
 
 Note that once we've done this in all these views, we no longer need to import
-:mod:`~django.template.loader`, :class:`~django.template.Context` and
+:mod:`~django.template.loader`, :class:`~django.template.RequestContext` and
 :class:`~django.http.HttpResponse` (you'll want to keep ``HttpResponse`` if you
 still have the stub methods for ``detail``, ``results``, and ``vote``).
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/intro/tutorial03/#write-views-that-actually-do-something
The first real view in the tutorial is using Context which results in two problems:
- the comparison with the render shortcut is incorrect  
  render uses RequestContext which makes the verbose example not equal to the shortcut  
  the render shortcut is documented in the paragraph below the verbose example
- new django users that were enticed to use the verbose example would later have problems with static files etc.  
  I've seen a few cases of this on #django
