### PR TITLE
The max length of the email is 254

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -213,7 +213,7 @@ class AuthenticationForm(forms.Form):
 
 
 class PasswordResetForm(forms.Form):
-    email = forms.EmailField(label=_("Email"), max_length=254)
+    email = forms.EmailField(label=_("Email"))
 
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -87,7 +87,7 @@ class EmailValidator(object):
         r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"$)', # quoted-string
         re.IGNORECASE)
     domain_regex = re.compile(
-        r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?$)'  # domain
+        r'(?:[A-Z0-9](?:[A-Z0-9-]{0,252}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?$)'  # domain
         # literal form, ipv4 address (SMTP 4.1.3)
         r'|^\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$',
         re.IGNORECASE)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -986,7 +986,7 @@ class EmailField(CharField):
         # max_length should be overridden to 254 characters to be fully
         # compliant with RFCs 3696 and 5321
 
-        kwargs['max_length'] = kwargs.get('max_length', 75)
+        kwargs['max_length'] = kwargs.get('max_length', 254)
         CharField.__init__(self, *args, **kwargs)
 
     def formfield(self, **kwargs):
@@ -994,6 +994,7 @@ class EmailField(CharField):
         # twice.
         defaults = {
             'form_class': forms.EmailField,
+            'max_length': self.max_length,
         }
         defaults.update(kwargs)
         return super(EmailField, self).formfield(**defaults)

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -525,6 +525,18 @@ class EmailField(CharField):
     widget = EmailInput
     default_validators = [validators.validate_email]
 
+    def __init__(self, *args, **kwargs):
+        kwargs['max_length'] = kwargs.get('max_length', 254)
+        super(EmailField, self).__init__(*args, **kwargs)
+        if not self.has_max_length_validator():
+            self.validators.append(validators.MaxLengthValidator(self.max_length))
+
+    def has_max_length_validator(self):
+        for validator in self.validators:
+            if isinstance(validator, validators.MaxLengthValidator):
+                return True
+        return False
+
     def clean(self, value):
         value = self.to_python(value).strip()
         return super(EmailField, self).clean(value)


### PR DESCRIPTION
How you can see in the next link the max length of an email is 254 chars. Now we have only 75 chars...

http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address

Related commit:

https://github.com/django/django/commit/bfcda7781a886ab2b7b41937c0f49c088f58a3d7
