### PR TITLE
Fixed #20650 -- Fixed {% filter %} incorrectly accepting 'escape' as an ...

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -1101,6 +1101,7 @@ class Library(object):
                     # for decorators that need it e.g. stringfilter
                     if hasattr(filter_func, "_decorated_function"):
                         setattr(filter_func._decorated_function, attr, value)
+            filter_func._filter_name = name
             return filter_func
         else:
             raise InvalidTemplateLibrary("Unsupported arguments to "

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -665,8 +665,9 @@ def do_filter(parser, token):
     _, rest = token.contents.split(None, 1)
     filter_expr = parser.compile_filter("var|%s" % (rest))
     for func, unused in filter_expr.filters:
-        if getattr(func, '_decorated_function', func).__name__ in ('escape', 'safe'):
-            raise TemplateSyntaxError('"filter %s" is not permitted.  Use the "autoescape" tag instead.' % func.__name__)
+        filter_name = getattr(func, '_filter_name', None)
+        if filter_name in ('escape', 'safe'):
+            raise TemplateSyntaxError('"filter %s" is not permitted.  Use the "autoescape" tag instead.' % filter_name)
     nodelist = parser.parse(('endfilter',))
     parser.delete_first_token()
     return FilterNode(filter_expr, nodelist)

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -854,6 +854,10 @@ class TemplateTests(TransRealMixin, TestCase):
             'filter02': ('{% filter upper %}django{% endfilter %}', {}, 'DJANGO'),
             'filter03': ('{% filter upper|lower %}django{% endfilter %}', {}, 'django'),
             'filter04': ('{% filter cut:remove %}djangospam{% endfilter %}', {'remove': 'spam'}, 'django'),
+            'filter05': ('{% filter safe %}fail{% endfilter %}', {}, template.TemplateSyntaxError),
+            'filter05bis': ('{% filter upper|safe %}fail{% endfilter %}', {}, template.TemplateSyntaxError),
+            'filter06': ('{% filter escape %}fail{% endfilter %}', {}, template.TemplateSyntaxError),
+            'filter06bis': ('{% filter upper|escape %}fail{% endfilter %}', {}, template.TemplateSyntaxError),
 
             ### FIRSTOF TAG ###########################################################
             'firstof01': ('{% firstof a b c %}', {'a':0,'b':0,'c':0}, ''),


### PR DESCRIPTION
...argument

Thanks to grzesiof for the report.
