### PR TITLE
Fixed #20462 -- null/non-string regex lookups are now consistent

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -152,6 +152,7 @@ answer newbie questions, and generally made Django that much better:
     Antonis Christofides <anthony@itia.ntua.gr>
     Michal Chruszcz <troll@pld-linux.org>
     Can Burak Çilingir <canburak@cs.bilgi.edu.tr>
+    Andrew Clark <amclark7@gmail.com>
     Ian Clelland <clelland@gmail.com>
     Travis Cline <travis.cline@gmail.com>
     Russell Cloran <russell@rucus.net>
@@ -273,6 +274,7 @@ answer newbie questions, and generally made Django that much better:
     Brian Harring <ferringb@gmail.com>
     Brant Harris
     Ronny Haryanto <http://ronny.haryan.to/>
+    Axel Haustant <noirbizarre@gmail.com>
     Hawkeye
     Kent Hauser <kent@khauser.net>
     Joe Heck <http://www.rhonabwy.com/wp/>

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -69,7 +69,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
         # Cast text lookups to text to allow things like filter(x__contains=4)
         if lookup_type in ('iexact', 'contains', 'icontains', 'startswith',
-                           'istartswith', 'endswith', 'iendswith'):
+                           'istartswith', 'endswith', 'iendswith', 'regex', 'iregex'):
             lookup = "%s::text"
 
         # Use UPPER(x) for case-insensitive lookups; it's faster.

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -522,4 +522,4 @@ def _sqlite_format_dtdelta(dt, conn, days, secs, usecs):
     return str(dt)
 
 def _sqlite_regexp(re_pattern, re_string):
-    return bool(re.search(re_pattern, re_string))
+    return bool(re.search(re_pattern, str(re_string))) if re_string is not None else False

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -610,6 +610,21 @@ class LookupTests(TestCase):
         self.assertQuerysetEqual(Article.objects.filter(headline__regex=r'b(.).*b\1'),
             ['<Article: barfoobaz>', '<Article: bazbaRFOO>', '<Article: foobarbaz>'])
 
+    def test_regex_null(self):
+        """
+        Ensure that a regex lookup does not fail on null/None values
+        """
+        Season.objects.create(year=2012, gt=None)
+        self.assertQuerysetEqual(Season.objects.filter(gt__regex=r'^$'), [])
+
+    def test_regex_non_string(self):
+        """
+        Ensure that a regex lookup does not fail on non-string fields
+        """
+        Season.objects.create(year=2013, gt=444)
+        self.assertQuerysetEqual(Season.objects.filter(gt__regex=r'^444$'),
+            ['<Season: 2013>'])
+
     def test_nonfield_lookups(self):
         """
         Ensure that a lookup query containing non-fields raises the proper


### PR DESCRIPTION
Thanks to noirbizarre for the report and initial patch. (https://github.com/django/django/pull/1043)

Ticket: https://code.djangoproject.com/ticket/20462

This change addresses the following issues with regex lookups:
- failure if field value is None/null for SQLite
- failure if field type is not a string based type for SQLite and PostgreSQL
