### PR TITLE
Define the SessionStore inside __init__ instead of process_request

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -6,10 +6,13 @@ from django.utils.http import cookie_date
 from django.utils.importlib import import_module
 
 class SessionMiddleware(object):
-    def process_request(self, request):
+    def __init__(self):
         engine = import_module(settings.SESSION_ENGINE)
+        self.SessionStore = engine.SessionStore
+
+    def process_request(self, request):
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
-        request.session = engine.SessionStore(session_key)
+        request.session = self.SessionStore(session_key)
 
     def process_response(self, request, response):
         """


### PR DESCRIPTION
It's unnecessary to run this on every request, since technically, settings _should be_ immutable.

Is there some edge case that I'm missing where the engine may be different on a per request basis?
