### PR TITLE
Fixed #20693 -- Add timezone support to built-in time filter.

### DIFF
--- a/tests/template_tests/filters.py
+++ b/tests/template_tests/filters.py
@@ -360,6 +360,13 @@ def get_filter_tests():
         # Ticket 19370: Make sure |date doesn't blow up on a midnight time object
         'date08': (r'{{ t|date:"H:i" }}', {'t': time(0, 1)}, '00:01'),
         'date09': (r'{{ t|date:"H:i" }}', {'t': time(0, 0)}, '00:00'),
+        # Ticket 20693: Add timezone support to built-in time template filter
+        'time01': (r'{{ dt|time:"e:O:T:Z" }}', {'dt': now_tz_i}, '+0315:+0315:+0315:11700'),
+        'time02': (r'{{ dt|time:"e:T" }}', {'dt': now}, ':' + now_tz.tzinfo.tzname(now_tz)),
+        'time03': (r'{{ t|time:"P:e:O:T:Z" }}', {'t': time(4, 0, tzinfo=FixedOffset(30))}, '4 a.m.::::'),
+        'time04': (r'{{ t|time:"P:e:O:T:Z" }}', {'t': time(4, 0)}, '4 a.m.::::'),
+        'time05': (r'{{ d|time:"P:e:O:T:Z" }}', {'d': today}, ''),
+        'time06': (r'{{ obj|time:"P:e:O:T:Z" }}', {'obj': 'non-datetime-value'}, ''),
 
          # Tests for #11687 and #16676
          'add01': (r'{{ i|add:"5" }}', {'i': 2000}, '2005'),

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -127,10 +127,16 @@ class DateFormatTests(unittest.TestCase):
         wintertime = datetime(2005, 10, 30, 4, 00)
         timestamp = datetime(2008, 5, 19, 11, 45, 23, 123456)
 
+        # 3h30m to the west of UTC
+        tz = FixedOffset(-3*60 - 30)
+        aware_dt = datetime(2009, 5, 16, 5, 30, 30, tzinfo=tz)
+
         if self.tz_tests:
             self.assertEqual(dateformat.format(my_birthday, 'O'), '+0100')
             self.assertEqual(dateformat.format(my_birthday, 'r'), 'Sun, 8 Jul 1979 22:00:00 +0100')
             self.assertEqual(dateformat.format(my_birthday, 'T'), 'CET')
+            self.assertEqual(dateformat.format(my_birthday, 'e'), '')
+            self.assertEqual(dateformat.format(aware_dt, 'e'), '-0330')
             self.assertEqual(dateformat.format(my_birthday, 'U'), '300315600')
             self.assertEqual(dateformat.format(timestamp, 'u'), '123456')
             self.assertEqual(dateformat.format(my_birthday, 'Z'), '3600')
@@ -140,7 +146,4 @@ class DateFormatTests(unittest.TestCase):
             self.assertEqual(dateformat.format(wintertime, 'O'), '+0100')
 
         # Ticket #16924 -- We don't need timezone support to test this
-        # 3h30m to the west of UTC
-        tz = FixedOffset(-3*60 - 30)
-        dt = datetime(2009, 5, 16, 5, 30, 30, tzinfo=tz)
-        self.assertEqual(dateformat.format(dt, 'O'), '-0330')
+        self.assertEqual(dateformat.format(aware_dt, 'O'), '-0330')


### PR DESCRIPTION
Modified django.utils.dateformat module, moving **init**() method and
timezone-related format methods from DateFormat class to TimeFormat
base class. Modified timezone-related format methods to return an
empty string when timezone is inappropriate for input value.
