### PR TITLE
Added explicit quota to test user on Oracle backend

### DIFF
--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -174,6 +174,7 @@ class DatabaseCreation(BaseDatabaseCreation):
                TEMPORARY TABLESPACE %(tblspace_temp)s
             """,
             """GRANT CONNECT, RESOURCE TO %(user)s""",
+	    """ALTER USER %(user)s QUOTA UNLIMITED ON %(tblspace)s""",
         ]
         self._execute_statements(cursor, statements, parameters, verbosity)
 


### PR DESCRIPTION
'UNLIMITED TABLESPACE' privilege is no longer included in RESOURCE role Oracle 12c. Therefore django test user, who have CONNECT and RESOURCE roles only, can't load any data into tables. To fix this, created user neede explicit quota allocation. Patch tested on Oracle v10.2.0.4, v11.2.0.3 and v12.1.0.1
