### PR TITLE
Add ContextContextManager

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -12,6 +12,21 @@ class ContextPopException(Exception):
     "pop() has been called more times than push()"
     pass
 
+
+class ContextDict(dict):
+    def __init__(self, context, *args, **kwargs):
+        super(ContextDict, self).__init__(*args, **kwargs)
+
+        context.dicts.append(self)
+        self.context = context
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.context.pop()
+
+
 class BaseContext(object):
     def __init__(self, dict_=None):
         self._reset_dicts(dict_)
@@ -34,10 +49,8 @@ class BaseContext(object):
         for d in reversed(self.dicts):
             yield d
 
-    def push(self):
-        d = {}
-        self.dicts.append(d)
-        return d
+    def push(self, *args, **kwargs):
+        return ContextDict(self, *args, **kwargs)
 
     def pop(self):
         if len(self.dicts) == 1:
@@ -83,6 +96,7 @@ class BaseContext(object):
         new_context._reset_dicts(values)
         return new_context
 
+
 class Context(BaseContext):
     "A stack container for variable context"
     def __init__(self, dict_=None, autoescape=True, current_app=None,
@@ -105,6 +119,7 @@ class Context(BaseContext):
             raise TypeError('other_dict must be a mapping (dictionary-like) object.')
         self.dicts.append(other_dict)
         return other_dict
+
 
 class RenderContext(BaseContext):
     """

--- a/django/template/loader.py
+++ b/django/template/loader.py
@@ -164,11 +164,8 @@ def render_to_string(template_name, dictionary=None, context_instance=None):
         return t.render(Context(dictionary))
     # Add the dictionary to the context stack, ensuring it gets removed again
     # to keep the context_instance in the same state it started in.
-    context_instance.update(dictionary)
-    try:
+    with context_instance.push(dictionary):
         return t.render(context_instance)
-    finally:
-        context_instance.pop()
 
 def select_template(template_name_list):
     "Given a list of template names, returns the first that can be loaded."

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -47,22 +47,21 @@ class BlockNode(Node):
 
     def render(self, context):
         block_context = context.render_context.get(BLOCK_CONTEXT_KEY)
-        context.push()
-        if block_context is None:
-            context['block'] = self
-            result = self.nodelist.render(context)
-        else:
-            push = block = block_context.pop(self.name)
-            if block is None:
-                block = self
-            # Create new block so we can store context without thread-safety issues.
-            block = BlockNode(block.name, block.nodelist)
-            block.context = context
-            context['block'] = block
-            result = block.nodelist.render(context)
-            if push is not None:
-                block_context.push(self.name, push)
-        context.pop()
+        with context.push():
+            if block_context is None:
+                context['block'] = self
+                result = self.nodelist.render(context)
+            else:
+                push = block = block_context.pop(self.name)
+                if block is None:
+                    block = self
+                # Create new block so we can store context without thread-safety issues.
+                block = BlockNode(block.name, block.nodelist)
+                block.context = context
+                context['block'] = block
+                result = block.nodelist.render(context)
+                if push is not None:
+                    block_context.push(self.name, push)
         return result
 
     def super(self):
@@ -133,10 +132,9 @@ class BaseIncludeNode(Node):
                        in six.iteritems(self.extra_context)])
         if self.isolated_context:
             return template.render(context.new(values))
-        context.update(values)
-        output = template.render(context)
-        context.pop()
-        return output
+        with context.push(**values):
+            return template.render(context)
+
 
 class ConstantIncludeNode(BaseIncludeNode):
     def __init__(self, template_path, *args, **kwargs):

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -325,6 +325,29 @@ If you ``pop()`` too much, it'll raise
     ...
     django.template.ContextPopException
 
+.. versionadded:: 1.7
+
+You can also use ``push()`` as a context manager to ensure a matching ``pop()`` is called.
+
+    >>> c = Context()
+    >>> c['foo'] = 'first level'
+    >>> with c.push():
+    >>>     c['foo'] = 'second level'
+    >>>     c['foo']
+    'second level'
+    >>> c['foo']
+    'first level'
+
+All arguments passed to ``push()`` will be passed to the ``dict`` constructor used to build the new context level.
+
+    >>> c = Context()
+    >>> c['foo'] = 'first level'
+    >>> with c.push(foo='second level'):
+    >>>     c['foo']
+    'second level'
+    >>> c['foo']
+    'first level'
+
 .. method:: update(other_dict)
 
 In addition to ``push()`` and ``pop()``, the ``Context``

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -57,6 +57,13 @@ Minor features
 * The :meth:`QuerySet.update_or_create()
   <django.db.models.query.QuerySet.update_or_create>` method was added.
 
+* The :meth:`Context.push() <django.template.Context.push>` method now returns
+  a context manager which automatically calls :meth:`pop()
+  <django.template.Context.pop>` upon exiting the ``with`` statement.
+  Additionally :meth:`push() <django.template.Context.push>` now accepts
+  parameters that are passed to the ``dict`` constructor used to build the new
+  context level.
+
 Backwards incompatible changes in 1.7
 =====================================
 

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -16,3 +16,12 @@ class ContextTests(TestCase):
         self.assertEqual(c.pop(), {"a": 2})
         self.assertEqual(c["a"], 1)
         self.assertEqual(c.get("foo", 42), 42)
+
+        with c.push():
+            c['a'] = 2
+            self.assertEqual(c['a'], 2)
+        self.assertEqual(c['a'], 1)
+
+        with c.push(a=3):
+            self.assertEqual(c['a'], 3)
+        self.assertEqual(c['a'], 1)


### PR DESCRIPTION
Add Context.with method

This patch allows you to use a context with "with", so you can be certain whatever context you push on the stack is popped after.

``` python
with context.with(extra_data):
    return self.blocks.render(context)
```
