### PR TITLE
Fixed #20716 --Missing 'name_local' translation for Albanian

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -399,7 +399,7 @@ LANG_INFO = {
         'bidi': False,
         'code': 'sq',
         'name': 'Albanian',
-        'name_local': 'Albanian',
+        'name_local': 'shqip',
     },
     'sr': {
         'bidi': False,


### PR DESCRIPTION
Added 'name_local' translation for Albanian in LANG_INFO
