### PR TITLE
Remove url quoting in auth/views.py for reverse

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -249,7 +249,7 @@ def password_change(request,
                     password_change_form=PasswordChangeForm,
                     current_app=None, extra_context=None):
     if post_change_redirect is None:
-        post_change_redirect = reverse('password_change_done')
+        post_change_redirect = reverse(password_change_done)
     else:
         post_change_redirect = resolve_url(post_change_redirect)
     if request.method == "POST":


### PR DESCRIPTION
reverse(password_change_done) and others(not fixed) have quotes which has been changed in this version:

Quoting in reverse()

When reversing URLs, Django didn’t apply urlquote() to arguments before interpolating them in URL patterns. This bug is fixed in Django 1.6. If you worked around this bug by applying URL quoting before passing arguments to reverse(), this may result in double-quoting. If this happens, simply remove the URL quoting from your code.

Only reverse(password_change_done) has been changed. Similar code in this file and probably elsewhere needs to be changed and tested as well.
