### PR TITLE
Fixed #19941 -- Modified runtests.py to make running the tests easier.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -25,15 +25,25 @@ Quickstart
 ~~~~~~~~~~
 
 Running the tests requires a Django settings module that defines the
-databases to use. To make it easy to get started, Django provides a
-sample settings module that uses the SQLite database. To run the tests
-with this sample ``settings`` module:
+databases to use. To make it easy to get started, Django provides and uses a
+sample settings module that uses the SQLite database. To run the tests:
 
 .. code-block:: bash
 
     git clone git@github.com:django/django.git django-repo
     cd django-repo/tests
+    ./runtests.py
+
+.. versionchanged:: 1.7
+
+Older versions of Django required running the tests like this::
+
     PYTHONPATH=..:$PYTHONPATH python ./runtests.py --settings=test_sqlite
+
+``runtests.py`` now uses the Django package found at ``tests/../django`` (there
+isn't a need to add this on your ``PYTHONPATH``) and ``test_sqlite`` for the
+settings if settings aren't provided through either ``--settings`` or
+:envvar:`DJANGO_SETTINGS_MODULE`.
 
 .. _running-unit-tests-settings:
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -7,6 +7,21 @@ import sys
 import tempfile
 import warnings
 
+def upath(path):
+    """
+    Separate version of django.utils._os.upath. The django.utils version isn't
+    usable here, as upath is needed for RUNTESTS_DIR which is needed for the
+    try-except of import django.
+    """
+    if sys.version_info[0] != 3 and not isinstance(path, bytes):
+        fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+        return path.decode(fs_encoding)
+    return path
+
+RUNTESTS_DIR = os.path.abspath(os.path.dirname(upath(__file__)))
+sys.path.insert(0, os.path.dirname(RUNTESTS_DIR))  # 'tests/../'
+import django
+
 from django import contrib
 from django.utils._os import upath
 from django.utils import six
@@ -15,7 +30,6 @@ CONTRIB_MODULE_PATH = 'django.contrib'
 
 TEST_TEMPLATE_DIR = 'templates'
 
-RUNTESTS_DIR = os.path.abspath(os.path.dirname(upath(__file__)))
 CONTRIB_DIR = os.path.dirname(upath(contrib.__file__))
 
 TEMP_DIR = tempfile.mkdtemp(prefix='django_')
@@ -331,10 +345,9 @@ if __name__ == "__main__":
     options, args = parser.parse_args()
     if options.settings:
         os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
-    elif "DJANGO_SETTINGS_MODULE" not in os.environ:
-        parser.error("DJANGO_SETTINGS_MODULE is not set in the environment. "
-                      "Set it or use --settings.")
     else:
+        if "DJANGO_SETTINGS_MODULE" not in os.environ:
+            os.environ['DJANGO_SETTINGS_MODULE'] = 'test_sqlite'
         options.settings = os.environ['DJANGO_SETTINGS_MODULE']
 
     if options.liveserver is not None:


### PR DESCRIPTION
1. Automatically use tests/../django as the Django version.
2. If settings aren't provided through --settings or DJANGO_SETTINGS_MODULE)
   then use test_sqlite.

https://code.djangoproject.com/ticket/19941
