### PR TITLE
Fixed #14656 -- Atom1Feed should write atom:published element

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -204,6 +204,7 @@ answer newbie questions, and generally made Django that much better:
     Clint Ecker
     Nick Efford <nick@efford.org>
     Marc Egli <frog32@me.com>
+    Matt Deacalion Stevens <matt@dirtymonkey.co.uk>
     eibaan@gmail.com
     David Eklund
     Julia Elman

--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -815,6 +815,24 @@ This example illustrates all possible attributes and methods for a
 
         item_pubdate = datetime.datetime(2005, 5, 3) # Hard-coded pubdate.
 
+        # ITEM UPDATED -- It's optional to use one of these three. This is a
+        # hook that specifies how to get the updateddate for a given item.
+        # In each case, the method/attribute should return a Python
+        # datetime.datetime object.
+
+        def item_updateddate(self, item):
+            """
+            Takes an item, as returned by items(), and returns the item's
+            updateddate.
+            """
+
+        def item_updateddate(self):
+            """
+            Returns the updateddated for every item in the feed.
+            """
+
+        item_updateddate = datetime.datetime(2005, 5, 3) # Hard-coded updateddate.
+
         # ITEM CATEGORIES -- It's optional to use one of these three. This is
         # a hook that specifies how to get the list of categories for a given
         # item. In each case, the method/attribute should return an iterable
@@ -928,15 +946,21 @@ They share this interface:
     * ``categories``
     * ``item_copyright``
     * ``ttl``
+    * ``updateddate``
 
     Extra keyword arguments will be stored for `custom feed generators`_.
 
     All parameters, if given, should be Unicode objects, except:
 
     * ``pubdate`` should be a Python  :class:`~datetime.datetime` object.
+    * ``updateddate`` should be a Python  :class:`~datetime.datetime` object.
     * ``enclosure`` should be an instance of
       :class:`django.utils.feedgenerator.Enclosure`.
     * ``categories`` should be a sequence of Unicode objects.
+
+    .. versionadded:: 1.7
+
+        The optional ``updateddate`` argument was added.
 
 :meth:`.SyndicationFeed.write`
     Outputs the feed in the given encoding to outfile, which is a file-like object.

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -342,11 +342,15 @@ SyndicationFeed
         All parameters should be Unicode objects, except ``categories``, which
         should be a sequence of Unicode objects.
 
-    .. method:: add_item(title, link, description, [author_email=None, author_name=None, author_link=None, pubdate=None, comments=None, unique_id=None, enclosure=None, categories=(), item_copyright=None, ttl=None, **kwargs])
+    .. method:: add_item(title, link, description, [author_email=None, author_name=None, author_link=None, pubdate=None, comments=None, unique_id=None, enclosure=None, categories=(), item_copyright=None, ttl=None, updateddate=None, **kwargs])
 
         Adds an item to the feed. All args are expected to be Python ``unicode``
-        objects except ``pubdate``, which is a ``datetime.datetime`` object, and
-        ``enclosure``, which is an instance of the ``Enclosure`` class.
+        objects except ``pubdate`` and ``updateddate``, which are ``datetime.datetime``
+        objects, and ``enclosure``, which is an instance of the ``Enclosure`` class.
+
+        .. versionadded:: 1.7
+
+            The optional ``updateddate`` argument was added.
 
     .. method:: num_items()
 
@@ -380,8 +384,8 @@ SyndicationFeed
 
     .. method:: latest_post_date()
 
-        Returns the latest item's ``pubdate``. If none of them have a
-        ``pubdate``, this returns the current date/time.
+        Returns the latest item's ``pubdate`` or ``updateddate`` date. If no items
+        have either of these attributes this returns the current date/time.
 
 Enclosure
 ---------

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -67,6 +67,11 @@ Minor features
   parameters that are passed to the ``dict`` constructor used to build the new
   context level.
 
+* The :class:`~django.utils.feedgenerator.Atom1Feed` syndication feed's
+  ``updated`` element now utilizes `updateddate` instead of ``pubdate``,
+  allowing the ``published`` element to be included in the feed (which
+  relies on ``pubdate``).
+
 Backwards incompatible changes in 1.7
 =====================================
 

--- a/tests/syndication/feeds.py
+++ b/tests/syndication/feeds.py
@@ -33,7 +33,10 @@ class TestRss2Feed(views.Feed):
         return "Overridden description: %s" % item
 
     def item_pubdate(self, item):
-        return item.date
+        return item.published
+
+    def item_updateddate(self, item):
+        return item.updated
 
     item_author_name = 'Sally Smith'
     item_author_email = 'test@example.com'
@@ -70,6 +73,17 @@ class TestNoPubdateFeed(views.Feed):
 class TestAtomFeed(TestRss2Feed):
     feed_type = feedgenerator.Atom1Feed
     subtitle = TestRss2Feed.description
+
+
+class TestLatestFeed(TestRss2Feed):
+    """
+    A feed where the latest entry date is an `updated` element.
+    """
+    feed_type = feedgenerator.Atom1Feed
+    subtitle = TestRss2Feed.description
+
+    def items(self):
+        return Entry.objects.exclude(pk=5)
 
 
 class ArticlesFeed(TestRss2Feed):
@@ -115,7 +129,7 @@ class NaiveDatesFeed(TestAtomFeed):
     A feed with naive (non-timezone-aware) dates.
     """
     def item_pubdate(self, item):
-        return item.date
+        return item.published
 
 
 class TZAwareDatesFeed(TestAtomFeed):
@@ -126,7 +140,7 @@ class TZAwareDatesFeed(TestAtomFeed):
         # Provide a weird offset so that the test can know it's getting this
         # specific offset and not accidentally getting on from
         # settings.TIME_ZONE.
-        return item.date.replace(tzinfo=tzinfo.FixedOffset(42))
+        return item.published.replace(tzinfo=tzinfo.FixedOffset(42))
 
 
 class TestFeedUrlFeed(TestAtomFeed):

--- a/tests/syndication/fixtures/feeddata.json
+++ b/tests/syndication/fixtures/feeddata.json
@@ -4,7 +4,8 @@
     "pk": 1,
     "fields": {
       "title": "My first entry",
-      "date": "1850-01-01 12:30:00"
+      "updated": "1850-01-01 12:30:00",
+      "published": "1066-09-25 20:15:00"
     }
   },
   {
@@ -12,7 +13,8 @@
     "pk": 2,
     "fields": {
       "title": "My second entry",
-      "date": "2008-01-02 12:30:00"
+      "updated": "2008-01-02 12:30:00",
+      "published": "2006-03-17 18:00:00"
     }
   },
   {
@@ -20,7 +22,8 @@
     "pk": 3,
     "fields": {
       "title": "My third entry",
-      "date": "2008-01-02 13:30:00"
+      "updated": "2008-01-02 13:30:00",
+      "published": "2005-06-14 10:45:00"
     }
   },
   {
@@ -28,7 +31,17 @@
     "pk": 4,
     "fields": {
       "title": "A & B < C > D",
-      "date": "2008-01-03 13:30:00"
+      "updated": "2008-01-03 13:30:00",
+      "published": "2005-11-25 12:11:23"
+    }
+  },
+  {
+    "model": "syndication.entry",
+    "pk": 5,
+    "fields": {
+      "title": "My last entry",
+      "updated": "2013-01-20 00:00:00",
+      "published": "2013-03-25 20:00:00"
     }
   },
   {

--- a/tests/syndication/models.py
+++ b/tests/syndication/models.py
@@ -5,10 +5,11 @@ from django.utils.encoding import python_2_unicode_compatible
 @python_2_unicode_compatible
 class Entry(models.Model):
     title = models.CharField(max_length=200)
-    date = models.DateTimeField()
+    updated = models.DateTimeField()
+    published = models.DateTimeField()
 
     class Meta:
-        ordering = ('date',)
+        ordering = ('updated',)
 
     def __str__(self):
         return self.title

--- a/tests/syndication/urls.py
+++ b/tests/syndication/urls.py
@@ -16,6 +16,7 @@ urlpatterns = patterns(
     (r'^syndication/rss091/$', feeds.TestRss091Feed()),
     (r'^syndication/no_pubdate/$', feeds.TestNoPubdateFeed()),
     (r'^syndication/atom/$', feeds.TestAtomFeed()),
+    (r'^syndication/latest/$', feeds.TestLatestFeed()),
     (r'^syndication/custom/$', feeds.TestCustomFeed()),
     (r'^syndication/naive-dates/$', feeds.NaiveDatesFeed()),
     (r'^syndication/aware-dates/$', feeds.TZAwareDatesFeed()),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/14656

The first commit – e51e589728208e856734958e7115e0b26ab6e55d was some [housekeeping](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule) because I was in the neighbourhood… if it's cluttering the history I'll remove it. Cheers. :monkey_face: 
