### PR TITLE
Index creation fails on field.db_type() is None

### DIFF
--- a/django/db/backends/postgresql_psycopg2/creation.py
+++ b/django/db/backends/postgresql_psycopg2/creation.py
@@ -68,10 +68,10 @@ class DatabaseCreation(BaseDatabaseCreation):
             # needed when performing correct LIKE queries outside the
             # C locale. See #12234.
             db_type = f.db_type(connection=self.connection)
-            if db_type.startswith('varchar'):
+            if db_type and db_type.startswith('varchar'):
                 output.append(get_index_sql('%s_%s_like' % (db_table, f.column),
                                             ' varchar_pattern_ops'))
-            elif db_type.startswith('text'):
+            elif db_type and db_type.startswith('text'):
                 output.append(get_index_sql('%s_%s_like' % (db_table, f.column),
                                             ' text_pattern_ops'))
         return output


### PR DESCRIPTION
Sometimes field.db_type doesn't return a value what should raise an index creation error. As example the GeoDjango Point field doesn't return a value in this state.
