### PR TITLE
[1.6.X] Fixed typo in inspectdb docs

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -323,7 +323,7 @@ you need to perform on the resulting ``models.py`` file is to change the
 Python declaration of each one of these models to specify it is a
 :attr:`managed <django.db.models.Options.managed>` one.
 
-This servers as an explicit opt-in to give your nascent Django project write
+This serves as an explicit opt-in to give your nascent Django project write
 access to your precious data on a model by model basis.
 
 The :djadminopt:`--database` option may be used to specify the


### PR DESCRIPTION
Follows #1368. Backport of 1131d4191f from master
