### PR TITLE
Fixed -- broken URLs in docs

### DIFF
--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -17,7 +17,7 @@ you want to generate feeds outside of a Web context, or in some other
 lower-level way.
 
 .. _RSS: http://www.whatisrss.com/
-.. _Atom: http://www.atomenabled.org/
+.. _Atom: http://tools.ietf.org/html/rfc4287
 
 The high-level framework
 ========================

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -414,7 +414,7 @@ Atom1Feed
 
 .. class:: Atom1Feed(SyndicationFeed)
 
-    Spec: http://www.atomenabled.org/developers/syndication/atom-format-spec.php
+    Spec: http://tools.ietf.org/html/rfc4287
 
 ``django.utils.functional``
 ===========================


### PR DESCRIPTION
### Atom specification URL updated

Changed to the URL of the official RFC for Atom, since [AtomEnabled.org](http://www.atomenabled.org/) is just a holding page.
