### PR TITLE
Fix Croatia's country code in `localflavor` docs

### DIFF
--- a/docs/topics/localflavor.txt
+++ b/docs/topics/localflavor.txt
@@ -48,7 +48,7 @@ The following countries have django-localflavor- packages.
 * Chile: https://github.com/django/django-localflavor-cl
 * China: https://github.com/django/django-localflavor-cn
 * Colombia: https://github.com/django/django-localflavor-co
-* Croatia: https://github.com/django/django-localflavor-cr
+* Croatia: https://github.com/django/django-localflavor-hr
 * Czech Republic: https://github.com/django/django-localflavor-cz
 * Ecuador: https://github.com/django/django-localflavor-ec
 * Finland: https://github.com/django/django-localflavor-fi


### PR DESCRIPTION
Croatia's country code is 'HR', not 'CR'.
