### PR TITLE
Updated the `databases` documentation

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -208,8 +208,8 @@ MySQL when using the MyISAM storage engine, see the next section.
 Storage engines
 ---------------
 
-MySQL has several `storage engines`_ (previously called table types). You can
-change the default storage engine in the server configuration.
+MySQL has several `storage engines`_. You can change the default storage engine
+in the server configuration.
 
 Until MySQL 5.5.4, the default engine was MyISAM_ [#]_. The main drawbacks of
 MyISAM are that it doesn't support transactions or enforce foreign-key
@@ -232,7 +232,7 @@ running ``syncdb``::
 
 .. _storage engines: http://dev.mysql.com/doc/refman/5.5/en/storage-engines.html
 .. _MyISAM: http://dev.mysql.com/doc/refman/5.5/en/myisam-storage-engine.html
-.. _InnoDB: http://dev.mysql.com/doc/refman/5.5/en/innodb.html
+.. _InnoDB: http://dev.mysql.com/doc/refman/5.5/en/innodb-storage-engine.html
 
 .. [#] Unless this was changed by the packager of your MySQL package. We've
    had reports that the Windows Community Server installer sets up InnoDB as
@@ -718,9 +718,9 @@ as empty strings.
 Threaded option
 ----------------
 
-If you plan to run Django in a multithreaded environment (e.g. Apache in Windows
-using the default MPM module), then you **must** set the ``threaded`` option of
-your Oracle database configuration to True::
+If you plan to run Django in a multithreaded environment (e.g. Apache using the
+the default MPM module on any modern operating system), then you **must** set
+the ``threaded`` option of your Oracle database configuration to True::
 
             'OPTIONS': {
                 'threaded': True,


### PR DESCRIPTION
- Removed a reference about MySQL storage engines also being called `table types`, as this term has been deprecated for 8 years and is no longer used.
- Fixed the link to the official InnoDB storage engine docs.
- Apache (versions >= 2.4) will always choose a multi-threaded MPM module on modern operating systems (later than 2002).
