### PR TITLE
DjangoJSONEncoder returned string for Decimal, now returns float

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -99,7 +99,7 @@ class DjangoJSONEncoder(json.JSONEncoder):
                 r = r[:12]
             return r
         elif isinstance(o, decimal.Decimal):
-            return str(o)
+            return float(o)
         else:
             return super(DjangoJSONEncoder, self).default(o)
 


### PR DESCRIPTION
It's an open discussion and I want to understand why Django returns string for Decimal.
