### PR TITLE
Document changes to validate_email

### DIFF
--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -801,6 +801,9 @@ Miscellaneous
   of the admin views. You should update your custom templates if they use the
   previous parameter name.
 
+* :meth:`~django.core.validators.validate_email` now accepts email addresses
+  with ``localhost`` as the domain.
+
 Features deprecated in 1.6
 ==========================
 


### PR DESCRIPTION
4e2e8f39d19d79a59c2696b2c40cb619a54fa745 changed the way validate_email behaves for foo@localhost email addresses, but wasn't listed in the release notes.
