### PR TITLE
Make it possible to use Exception details on custom 404 handlers.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -149,6 +149,7 @@ class BaseHandler(object):
             else:
                 try:
                     callback, param_dict = resolver.resolve404()
+                    param_dict.update({'exception_404': e})
                     response = callback(request, **param_dict)
                 except:
                     signals.got_request_exception.send(sender=self.__class__, request=request)


### PR DESCRIPTION
This would be an alternative way to solve the question on SO, without using the `contrib.message` framework.
http://stackoverflow.com/questions/1621173/404-error-messages-in-django
