### PR TITLE
Update middleware documentation to close #20792

### DIFF
--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -37,7 +37,7 @@ defines. See the :doc:`cache documentation </topics/cache>`.
 Adds a few conveniences for perfectionists:
 
 * Forbids access to user agents in the :setting:`DISALLOWED_USER_AGENTS`
-  setting, which should be a list of strings.
+  setting, which should be a list of compiled regular expression objects.
 
 * Performs URL rewriting based on the :setting:`APPEND_SLASH` and
   :setting:`PREPEND_WWW` settings.


### PR DESCRIPTION
Update middleware documentation to state that DISALLOWED_USER_AGENTS is a list of compiled regex.
