### PR TITLE
Added html_message parameter to django.core.mail.send_mail() ticket #20817

### DIFF
--- a/django/core/mail/__init__.py
+++ b/django/core/mail/__init__.py
@@ -32,7 +32,7 @@ def get_connection(backend=None, fail_silently=False, **kwds):
 
 def send_mail(subject, message, from_email, recipient_list,
               fail_silently=False, auth_user=None, auth_password=None,
-              connection=None):
+              connection=None, html_message=None):
     """
     Easy wrapper for sending a single message to a recipient list. All members
     of the recipient list will see the other recipients in the 'To' field.
@@ -46,8 +46,12 @@ def send_mail(subject, message, from_email, recipient_list,
     connection = connection or get_connection(username=auth_user,
                                     password=auth_password,
                                     fail_silently=fail_silently)
-    return EmailMessage(subject, message, from_email, recipient_list,
-                        connection=connection).send()
+    mail = EmailMultiAlternatives(subject, message, from_email, recipient_list,
+                                  connection=connection)
+    if html_message:
+        mail.attach_alternative(html_message, 'text/html')
+
+    return mail.send()
 
 
 def send_mass_mail(datatuple, fail_silently=False, auth_user=None,

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -89,6 +89,9 @@ Minor features
 * The admin changelist cells now have a ``field-<field_name>`` class in the
   HTML to enable style customizations.
 
+* The :func:`~django.core.mail.send_mail` now accepts an ``html_message``
+  parameter for sending a multipart text/plain and text/html email.
+
 Backwards incompatible changes in 1.7
 =====================================
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -38,7 +38,7 @@ a secure connection is used.
 send_mail()
 ===========
 
-.. function:: send_mail(subject, message, from_email, recipient_list, fail_silently=False, auth_user=None, auth_password=None, connection=None)
+.. function:: send_mail(subject, message, from_email, recipient_list, fail_silently=False, auth_user=None, auth_password=None, connection=None, html_message=None)
 
 The simplest way to send email is using
 ``django.core.mail.send_mail()``.
@@ -66,6 +66,13 @@ are required.
   If unspecified, an instance of the default backend will be used.
   See the documentation on :ref:`Email backends <topic-email-backends>`
   for more details.
+* ``html_message``: If ``html_message`` is provided, the resulting email will be a
+  :mimetype:`multipart/alternative` email with ``message`` as the
+  :mimetype:`text/plain` content type and ``html_message`` as the
+  :mimetype:`text/html` content type.
+
+.. versionadded:: 1.7
+The html_message parameter was added
 
 send_mass_mail()
 ================

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -397,6 +397,34 @@ class BaseEmailBackendTests(object):
         self.assertEqual(message.get_payload(), "Content")
         self.assertEqual(message["from"], "=?utf-8?q?Firstname_S=C3=BCrname?= <from@example.com>")
 
+    def test_plaintext_send_mail(self):
+        """
+        Test send_mail without the html_message
+        regression test for adding html_message parameter to send_mail()
+        """
+        send_mail('Subject', 'Content', 'sender@example.com', ['nobody@example.com'])
+        message = self.get_the_message()
+
+        self.assertEqual(message.get('subject'), 'Subject')
+        self.assertEqual(message.get_all('to'), ['nobody@example.com'])
+        self.assertFalse(message.is_multipart())
+        self.assertEqual(message.get_payload(), 'Content')
+        self.assertEqual(message.get_content_type(), 'text/plain')
+
+    def test_html_send_mail(self):
+        """Test html_message argument to send_mail"""
+        send_mail('Subject', 'Content', 'sender@example.com', ['nobody@example.com'], html_message='HTML Content')
+        message = self.get_the_message()
+
+        self.assertEqual(message.get('subject'), 'Subject')
+        self.assertEqual(message.get_all('to'), ['nobody@example.com'])
+        self.assertTrue(message.is_multipart())
+        self.assertEqual(len(message.get_payload()), 2)
+        self.assertEqual(message.get_payload(0).get_payload(), 'Content')
+        self.assertEqual(message.get_payload(0).get_content_type(), 'text/plain')
+        self.assertEqual(message.get_payload(1).get_payload(), 'HTML Content')
+        self.assertEqual(message.get_payload(1).get_content_type(), 'text/html')
+
     @override_settings(MANAGERS=[('nobody', 'nobody@example.com')])
     def test_html_mail_managers(self):
         """Test html_message argument to mail_managers"""


### PR DESCRIPTION
I have added the ability to send html email through django.core.mail.send_mail() for ticket #20817 after discussion at https://groups.google.com/forum/#!topic/django-developers/_mXKP9JZzK0
