### PR TITLE
Fixed #8620 -- Allowed ModelForm.Meta.exclude to exclude explicitely declared fields.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -283,6 +283,9 @@ class ModelFormMetaclass(type):
                 raise FieldError(message)
             # Override default model fields with any custom declared ones
             # (plus, include all the other declared fields).
+            # Leave out custom declared fields mentioned in exclude
+            if opts.exclude:
+                [declared_fields.pop(f) for f in declared_fields.keys() if f in opts.exclude]
             fields.update(declared_fields)
         else:
             fields = declared_fields

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -116,6 +116,9 @@ Miscellaneous
 * Loading empty fixtures emits a ``RuntimeWarning`` rather than raising
   :class:`~django.core.management.CommandError`.
 
+* If you explicitly declare a field on a :class:`~django.forms.ModelForm` and
+  also list it in ``Meta.exclude`` it will no longer appear on the form.
+
 Features deprecated in 1.7
 ==========================
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -626,6 +626,26 @@ the ``Meta.fields`` or ``Meta.excludes`` lists::
 This adds the extra method from the ``EnhancedArticleForm`` and modifies
 the original ``ArticleForm.Meta`` to remove one field.
 
+.. versionchanged:: 1.7
+
+If you need to remove a field from the child form that was explicitly defined in
+a parent form, you can include it in the ``Meta.exclude`` list.
+
+An example::
+
+    class ArticleForm(ModelForm):
+        notes = TextField()
+
+        class Meta:
+            model = Article
+
+    class EnhancedArticleForm(ArticleForm):
+        class Meta(ArticleForm.Meta):
+            exclude = ('notes',)
+
+The ``EnhancedArticleForm`` will not include the field ``notes``, though it was
+explicitly declared on ``ArticleForm``.
+
 There are a couple of things to note, however.
 
 * Normal Python name resolution rules apply. If you have multiple base


### PR DESCRIPTION
Thanks levity for the report and marcinnowak, himonrura, and koenb
for work on the patch.

I don't see a use case where you would declare a field on a form only to exclude it, but posting a PR to give someone a chance to object.
