### PR TITLE
Introduced `BaseModelAdmin.get_fields()` and cleaned up admin fields handling.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1,6 +1,7 @@
 import copy
 import operator
 from functools import partial, reduce, update_wrapper
+import warnings
 
 from django import forms
 from django.conf import settings
@@ -238,13 +239,49 @@ class BaseModelAdmin(six.with_metaclass(RenameBaseModelAdminMethods)):
 
         return db_field.formfield(**kwargs)
 
-    def _declared_fieldsets(self):
+    @property
+    def declared_fieldsets(self):
+        warnings.warn(
+            "ModelAdmin.declared_fieldsets is deprecated and "
+            "will be removed in Django 1.9.",
+            PendingDeprecationWarning, stacklevel=2
+        )
+
         if self.fieldsets:
             return self.fieldsets
         elif self.fields:
             return [(None, {'fields': self.fields})]
         return None
-    declared_fieldsets = property(_declared_fieldsets)
+
+    def get_fields(self, request, obj=None):
+        """
+        Hook for specifying fields.
+        """
+        return self.fields
+
+    def get_fieldsets(self, request, obj=None):
+        """
+        Hook for specifying fieldsets.
+        """
+        # We access the property and check if it triggers a warning.
+        # If it does, then it's ours and we can safely ignore it, but if
+        # it doesn't then it has been overriden so we must warn about the
+        # deprecation.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            declared_fieldsets = self.declared_fieldsets
+        if len(w) != 1 or not issubclass(w[0].category, PendingDeprecationWarning):
+            warnings.warn(
+                "ModelAdmin.declared_fieldsets is deprecated and "
+                "will be removed in Django 1.9.",
+                PendingDeprecationWarning
+            )
+            if declared_fieldsets:
+                return declared_fieldsets
+
+        if self.fieldsets:
+            return self.fieldsets
+        return [(None, {'fields': self.get_fields(request, obj)})]
 
     def get_ordering(self, request):
         """
@@ -506,13 +543,11 @@ class ModelAdmin(BaseModelAdmin):
             'delete': self.has_delete_permission(request),
         }
 
-    def get_fieldsets(self, request, obj=None):
-        "Hook for specifying fieldsets for the add form."
-        if self.declared_fieldsets:
-            return self.declared_fieldsets
+    def get_fields(self, request, obj=None):
+        if self.fields:
+            return self.fields
         form = self.get_form(request, obj, fields=None)
-        fields = list(form.base_fields) + list(self.get_readonly_fields(request, obj))
-        return [(None, {'fields': fields})]
+        return list(form.base_fields) + list(self.get_readonly_fields(request, obj))
 
     def get_form(self, request, obj=None, **kwargs):
         """
@@ -1645,12 +1680,11 @@ class InlineModelAdmin(BaseModelAdmin):
 
         return inlineformset_factory(self.parent_model, self.model, **defaults)
 
-    def get_fieldsets(self, request, obj=None):
-        if self.declared_fieldsets:
-            return self.declared_fieldsets
+    def get_fields(self, request, obj=None):
+        if self.fields:
+            return self.fields
         form = self.get_formset(request, obj, fields=None).form
-        fields = list(form.base_fields) + list(self.get_readonly_fields(request, obj))
-        return [(None, {'fields': fields})]
+        return list(form.base_fields) + list(self.get_readonly_fields(request, obj))
 
     def get_queryset(self, request):
         queryset = super(InlineModelAdmin, self).get_queryset(request)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -423,6 +423,8 @@ these changes.
 * FastCGI support via the ``runfcgi`` management command will be
   removed. Please deploy your project using WSGI.
 
+* ``ModelAdmin.declared_fieldsets`` will be removed.
+
 2.0
 ---
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1218,6 +1218,14 @@ templates used by the :class:`ModelAdmin` views:
     changelist that will be linked to the change view, as described in the
     :attr:`ModelAdmin.list_display_links` section.
 
+.. method:: ModelAdmin.get_fields(self, request, obj=None)
+
+    .. versionadded:: 1.7
+
+    The ``get_fields`` method is given the ``HttpRequest`` and the ``obj``
+    being edited (or ``None`` on an add form) and is expected to return a list
+    of fields, as described above in the :attr:`ModelAdmin.fields` section.
+
 .. method:: ModelAdmin.get_fieldsets(self, request, obj=None)
 
     The ``get_fieldsets`` method is given the ``HttpRequest`` and the ``obj``

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -110,6 +110,11 @@ Minor features
   or ``None`` for the key and the custom label as the value. The default blank
   option ``"----------"`` will be omitted in this case.
 
+* The :meth:`ModelAdmin.get_fields()
+  <django.contrib.admin.ModelAdmin.get_fields>` method may be overridden to
+  customize the value of :attr:`ModelAdmin.fields
+  <django.contrib.admin.ModelAdmin.fields>`.
+
 Backwards incompatible changes in 1.7
 =====================================
 
@@ -172,3 +177,11 @@ than simply ``myapp/models.py``, Django would look for :ref:`initial SQL data
 <initial-sql>` in ``myapp/models/sql/``. This bug has been fixed so that Django
 will search ``myapp/sql/`` as documented. The old location will continue to
 work until Django 1.9.
+
+``declared_fieldsets`` attribute on ``ModelAdmin.``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ModelAdmin.declared_fieldsets`` was deprecated. Despite being a private API,
+it will go through a regular deprecation path. This attribute was mostly used
+by methods that bypassed ``ModelAdmin.get_queryset()`` but this was considered
+a bug and has been addressed.

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -51,6 +51,12 @@ class ModelAdminTests(TestCase):
         self.assertEqual(list(ma.get_form(request).base_fields),
             ['name', 'bio', 'sign_date'])
 
+        self.assertEqual(list(ma.get_fields(request)),
+            ['name', 'bio', 'sign_date'])
+
+        self.assertEqual(list(ma.get_fields(request, self.band)),
+            ['name', 'bio', 'sign_date'])
+
     def test_default_fieldsets(self):
         # fieldsets_add and fieldsets_change should return a special data structure that
         # is used in the templates. They should generate the "right thing" whether we
@@ -96,6 +102,10 @@ class ModelAdminTests(TestCase):
             fields = ['name']
 
         ma = BandAdmin(Band, self.site)
+
+        self.assertEqual(list(ma.get_fields(request)), ['name'])
+
+        self.assertEqual(list(ma.get_fields(request, self.band)), ['name'])
 
         self.assertEqual(ma.get_fieldsets(request),
             [(None, {'fields': ['name']})])


### PR DESCRIPTION
Refs #18681.
