### PR TITLE
Fixed #20819 -- Return 404 instead of 500 error when ``staticfiles`` vie...

### DIFF
--- a/django/contrib/staticfiles/views.py
+++ b/django/contrib/staticfiles/views.py
@@ -11,7 +11,6 @@ except ImportError:     # Python 2
     from urllib import unquote
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.views import static
 
@@ -31,9 +30,7 @@ def serve(request, path, insecure=False, **kwargs):
     It uses the django.views.static view to serve the found files.
     """
     if not settings.DEBUG and not insecure:
-        raise ImproperlyConfigured("The staticfiles view can only be used in "
-                                   "debug mode or if the --insecure "
-                                   "option of 'runserver' is used")
+        raise Http404
     normalized_path = posixpath.normpath(unquote(path)).lstrip('/')
     absolute_path = finders.find(normalized_path)
     if not absolute_path:

--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -350,6 +350,12 @@ This view function serves static files in development.
     **insecure**. This is only intended for local development, and should
     **never be used in production**.
 
+.. versionchanged:: 1.7
+
+    Will now raise an :exc:`~django.http.Http404` exception instead of
+    :exc:`~from django.core.exceptions.ImproperlyConfigured` when
+    :setting:`DEBUG` is ``True``.
+
 .. note::
 
     To guess the served files' content types, this view relies on the

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -122,6 +122,14 @@ Miscellaneous
 * Loading empty fixtures emits a ``RuntimeWarning`` rather than raising
   :class:`~django.core.management.CommandError`.
 
+* :view:`~django.contrib.staticfiles.views.serve` will now raise an
+  :exc:`~django.http.Http404` exception instead of
+  :exc:`~from django.core.exceptions.ImproperlyConfigured` when :setting:`DEBUG`
+  is ``True``. This change removes the need to conditionally add the view to
+  your root URLconf, which in turn makes it safe to reverse by name. It also
+  removes the ability for visitors to generate spurious HTTP 500 errors by
+  requesting static files that don't exist or haven't been collected yet.
+
 Features deprecated in 1.7
 ==========================
 

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -650,8 +650,7 @@ class TestServeDisabled(TestServeStatic):
         settings.DEBUG = False
 
     def test_disabled_serving(self):
-        six.assertRaisesRegex(self, ImproperlyConfigured, 'The staticfiles view '
-            'can only be used in debug mode ', self._response, 'test.txt')
+        self.assertFileNotFound('test.txt')
 
 
 class TestServeStaticWithDefaultURL(TestServeStatic, TestDefaults):


### PR DESCRIPTION
...w is used in production.
