### PR TITLE
#20836 to_field lost when adding via raw_id_fields

### DIFF
--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -40,6 +40,7 @@
 <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
+{% if to_field %}<input type="hidden" name="t" value="{{ to_field }}" />{% endif %}
 {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
 {% if errors %}
     <p class="errornote">

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -54,7 +54,7 @@
           {% block object-tools-items %}
             <li>
               {% url cl.opts|admin_urlname:'add' as add_url %}
-              <a href="{% add_preserved_filters add_url is_popup %}" class="addlink">
+              <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
                 {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
               </a>
             </li>

--- a/django/contrib/admin/templates/admin/popup_response.html
+++ b/django/contrib/admin/templates/admin/popup_response.html
@@ -3,7 +3,7 @@
   <head><title></title></head>
   <body>
     <script type="text/javascript">
-      opener.dismissAddAnotherPopup(window, "{{ pk_value }}", "{{ obj }}");
+      opener.dismissAddAnotherPopup(window, "{{ value }}", "{{ obj }}");
     </script>
   </body>
 </html>

--- a/django/contrib/admin/templatetags/admin_urls.py
+++ b/django/contrib/admin/templatetags/admin_urls.py
@@ -22,7 +22,7 @@ def admin_urlquote(value):
 
 
 @register.simple_tag(takes_context=True)
-def add_preserved_filters(context, url, popup=False):
+def add_preserved_filters(context, url, popup=False, to_field=None):
     opts = context.get('opts')
     preserved_filters = context.get('preserved_filters')
 
@@ -48,6 +48,9 @@ def add_preserved_filters(context, url, popup=False):
     if popup:
         from django.contrib.admin.options import IS_POPUP_VAR
         merged_qs[IS_POPUP_VAR] = 1
+    if to_field:
+        from django.contrib.admin.options import TO_FIELD_VAR
+        merged_qs[TO_FIELD_VAR] = to_field
 
     merged_qs.update(parsed_qs)
 

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -15,7 +15,7 @@ from django.utils.http import urlencode
 
 from django.contrib.admin import FieldListFilter
 from django.contrib.admin.exceptions import DisallowedModelAdminLookup
-from django.contrib.admin.options import IncorrectLookupParameters, IS_POPUP_VAR
+from django.contrib.admin.options import IncorrectLookupParameters, IS_POPUP_VAR, TO_FIELD_VAR
 from django.contrib.admin.util import (quote, get_fields_from_path,
     lookup_needs_distinct, prepare_lookup_value)
 
@@ -25,7 +25,6 @@ ORDER_VAR = 'o'
 ORDER_TYPE_VAR = 'ot'
 PAGE_VAR = 'p'
 SEARCH_VAR = 'q'
-TO_FIELD_VAR = 't'
 ERROR_FLAG = 'e'
 
 IGNORED_PARAMS = (


### PR DESCRIPTION
Sorry, it's against 1.6.x. I don't have easy access to python2.7 for master.

Basically, TO_FIELD_VAR really needs to follow IS_POPUP_VAR everywhere it goes. Whenever it's a popup, there's always the possibility that there's a to_field.

https://code.djangoproject.com/ticket/20836
