### PR TITLE
Fixed #20829 -- skip postgis geometry metadata tables with introspection

### DIFF
--- a/django/contrib/gis/db/backends/postgis/introspection.py
+++ b/django/contrib/gis/db/backends/postgis/introspection.py
@@ -9,6 +9,14 @@ class PostGISIntrospection(DatabaseIntrospection):
     # introspection is actually performed.
     postgis_types_reverse = {}
 
+    ignored_tables = DatabaseIntrospection.ignored_tables + [
+        'geography_columns',
+        'geometry_columns',
+        'raster_columns',
+        'spatial_ref_sys',
+        'raster_overviews',
+    ]
+
     def get_postgis_types(self):
         """
         Returns a dictionary with keys that are the PostgreSQL object

--- a/django/db/backends/postgresql_psycopg2/introspection.py
+++ b/django/db/backends/postgresql_psycopg2/introspection.py
@@ -26,6 +26,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         1700: 'DecimalField',
     }
 
+    ignored_tables = []
+
     def get_table_list(self, cursor):
         "Returns a list of table names in the current database."
         cursor.execute("""
@@ -35,7 +37,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             WHERE c.relkind IN ('r', 'v', '')
                 AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
                 AND pg_catalog.pg_table_is_visible(c.oid)""")
-        return [row[0] for row in cursor.fetchall()]
+        return [row[0] for row in cursor.fetchall() if row[0] not in self.ignored_tables]
 
     def get_table_description(self, cursor, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."


### PR DESCRIPTION
Using postgresql-9.2.4 and postgis-2.0.3 the inspectdb tests fail on the geometry metadata tables.

```
ERROR: test_special_column_name_introspection (inspectdb.tests.InspectDBTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/harm/dev/django/tests/inspectdb/tests.py", line 142, in test_special_column_name_introspection
    call_command('inspectdb', stdout=out)
  File "/home/harm/dev/django/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/home/harm/dev/django/django/core/management/base.py", line 289, in execute
    output = self.handle(*args, **options)
  File "/home/harm/dev/django/django/core/management/base.py", line 419, in handle
    return self.handle_noargs(**options)
  File "/home/harm/dev/django/django/core/management/commands/inspectdb.py", line 27, in handle_noargs
    for line in self.handle_inspection(options):
  File "/home/harm/dev/django/django/core/management/commands/inspectdb.py", line 99, in handle_inspection
    field_type, field_params, field_notes = self.get_field_type(connection, table_name, row)
  File "/home/harm/dev/django/django/contrib/gis/management/commands/inspectdb.py", line 13, in get_field_type
    field_type, geo_params = connection.introspection.get_geometry_type(table_name, geo_col)
  File "/home/harm/dev/django/django/contrib/gis/db/backends/postgis/introspection.py", line 78, in get_geometry_type
    (table_name, geo_col))
Exception: Could not find a geometry or geography column for "raster_columns"."extent"
```

the test fails because the geometry type lookup does not contain metadata about the metadata tables themselves.
https://github.com/django/django/blob/master/django/contrib/gis/db/backends/postgis/introspection.py#L51

postgis itself has models for those tables so a user should never need to create models for them.
https://github.com/django/django/blob/master/django/contrib/gis/db/backends/postgis/models.py
