### PR TITLE
Removed unused model option "admin"

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -41,7 +41,6 @@ class Options(object):
         self.get_latest_by = None
         self.order_with_respect_to = None
         self.db_tablespace = settings.DEFAULT_TABLESPACE
-        self.admin = None
         self.meta = meta
         self.pk = None
         self.has_auto_field, self.auto_field = False, None

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -227,9 +227,8 @@ Django quotes column and table names behind the scenes.
 .. attribute:: Options.permissions
 
     Extra permissions to enter into the permissions table when creating this object.
-    Add, delete and change permissions are automatically created for each object
-    that has ``admin`` set. This example specifies an extra permission,
-    ``can_deliver_pizzas``::
+    Add, delete and change permissions are automatically created for each
+    model. This example specifies an extra permission, ``can_deliver_pizzas``::
 
         permissions = (("can_deliver_pizzas", "Can deliver pizzas"),)
 


### PR DESCRIPTION
I guess this is an old LJ World artifact?
