### PR TITLE
Fixed #20844 -- adds formatted log entry in the body of the email ...

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -84,24 +84,22 @@ class AdminEmailHandler(logging.Handler):
                 record.getMessage()
             )
             filter = get_exception_reporter_filter(request)
-            request_repr = filter.get_request_repr(request)
+            request_repr = '\n{0}'.format(filter.get_request_repr(request))
         except Exception:
             subject = '%s: %s' % (
                 record.levelname,
                 record.getMessage()
             )
             request = None
-            request_repr = "Request repr() unavailable."
+            request_repr = "unavailable"
         subject = self.format_subject(subject)
 
         if record.exc_info:
             exc_info = record.exc_info
-            stack_trace = '\n'.join(traceback.format_exception(*record.exc_info))
         else:
             exc_info = (None, record.getMessage(), None)
-            stack_trace = 'No stack trace available'
 
-        message = "%s\n\n%s" % (stack_trace, request_repr)
+        message = "%s\n\nRequest repr(): %s" % (self.format(record), request_repr)
         reporter = ExceptionReporter(request, is_email=True, *exc_info)
         html_message = reporter.get_traceback_html() if self.include_html else None
         mail.mail_admins(subject, message, fail_silently=True,


### PR DESCRIPTION
... as per specified LOGGING handler 'formatter' setting.

Sample email subject:

`[Some Site][Development] ERROR: Refactor this to use QuerySet level solution as per ticket - https://code.djangoproject.com/ticket/20625 - Offer.objects.filter(...).active() != Offer.objects.active.filter(...)`

Sample email message:

```
ERROR django.db.models.manager 2013-08-01 11:58:03,897 manager 6516 -1244890304 /srv/www/django/development.yupi.ca/src/github-danielsokolowski-django-ticket_20625-tailored/django/db/models/manager.py@139: Refactor this to use QuerySet level solution as per ticket - https://code.djangoproject.com/ticket/20625 - Offer.objects.filter(...).active() != Offer.objects.active.filter(...)

No stack trace available

Request repr() unavailable.
```

Sample LOGGING config:

```
LOGGING = {
    'version': 1,
    'disable_existing_loggers': True,
    'filters': {
        'require_debug_false': {
            '()': 'django.utils.log.RequireDebugFalse'
        }
    },
    'formatters': {
        'verbose': {
            '()': 'djangocolors_formatter.DjangoColorsFormatter', # colored output
            'format': '%(levelname)s %(name)s %(asctime)s %(module)s %(process)d %(thread)d %(pathname)s@%(lineno)s: %(message)s'
        },
        'simple': {
            '()': 'djangocolors_formatter.DjangoColorsFormatter', # colored output
            'format': '%(levelname)s %(name)s %(filename)s@%(lineno)s: %(message)s'
        },
    },
     # omitting the handler 'level' setting so that all messages are passed and we do level filtering in 'loggers'
    'handlers': {
        'null': {
            'class':'django.utils.log.NullHandler',
        },
        'console':{
            'class':'logging.StreamHandler',
            'formatter': 'simple',
        },
        'mail_admins': {
            'filters': ['require_debug_false'],
            'class': 'django.utils.log.AdminEmailHandler',
            'formatter': 'verbose'
        }
    },
    'loggers': {
        '': { 
            'handlers': ['mail_admins', 'console'],
            'level': 'WARNING',
        },
    }
}
```
