### PR TITLE
Fix for #20855 Added documentation of current_app and extra_context params

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -561,12 +561,31 @@ Most built-in authentication views provide a URL name for easier reference. See
 patterns.
 
 
-.. function:: login(request, [template_name, redirect_field_name, authentication_form])
+.. function:: login(request, [template_name, redirect_field_name, authentication_form, current_app, extra_context])
 
     **URL name:** ``login``
 
     See :doc:`the URL documentation </topics/http/urls>` for details on using
     named URL patterns.
+
+    **Optional arguments:**
+
+    * ``template_name``: The full name of a template to display for the view
+      used to log the user in. Defaults to :file:`registration/login.html` if no argument is supplied.
+
+    * ``redirect_field_name``: The name of a ``GET`` field containing the
+      URL to redirect to after login. Overrides ``next`` if the given
+      ``GET`` parameter is passed.
+
+    * ``authentication_form``: A callable to override the default form used for authentication.
+      Defaults to :class:`~django.contrib.auth.forms.AuthenticationForm`.
+
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
 
     Here's what ``django.contrib.auth.views.login`` does:
 
@@ -657,7 +676,7 @@ patterns.
     .. _site framework docs: ../sites/
 
 
-.. function:: logout(request, [next_page, template_name, redirect_field_name])
+.. function:: logout(request, [next_page, template_name, redirect_field_name, current_app, extra_context])
 
     Logs a user out.
 
@@ -675,6 +694,13 @@ patterns.
       URL to redirect to after log out. Overrides ``next_page`` if the given
       ``GET`` parameter is passed.
 
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
     **Template context:**
 
     * ``title``: The string "Logged out", localized.
@@ -691,7 +717,14 @@ patterns.
       :attr:`request.META['SERVER_NAME'] <django.http.HttpRequest.META>`.
       For more on sites, see :doc:`/ref/contrib/sites`.
 
-.. function:: logout_then_login(request[, login_url])
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
+.. function:: logout_then_login(request[, login_url, current_app, extra_context])
 
     Logs a user out, then redirects to the login page.
 
@@ -702,7 +735,14 @@ patterns.
     * ``login_url``: The URL of the login page to redirect to.
       Defaults to :setting:`settings.LOGIN_URL <LOGIN_URL>` if not supplied.
 
-.. function:: password_change(request[, template_name, post_change_redirect, password_change_form])
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
+.. function:: password_change(request[, template_name, post_change_redirect, password_change_form, current_app, extra_context])
 
     Allows a user to change their password.
 
@@ -722,11 +762,18 @@ patterns.
       actually changing the user's password. Defaults to
       :class:`~django.contrib.auth.forms.PasswordChangeForm`.
 
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
     **Template context:**
 
     * ``form``: The password change form (see ``password_change_form`` above).
 
-.. function:: password_change_done(request[, template_name])
+.. function:: password_change_done(request[, template_name, current_app, extra_context])
 
     The page shown after a user has changed their password.
 
@@ -738,7 +785,14 @@ patterns.
       Defaults to :file:`registration/password_change_done.html` if not
       supplied.
 
-.. function:: password_reset(request[, is_admin_site, template_name, email_template_name, password_reset_form, token_generator, post_reset_redirect, from_email])
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
+.. function:: password_reset(request[, is_admin_site, template_name, email_template_name, password_reset_form, token_generator, post_reset_redirect, from_email, current_app, extra_context])
 
     Allows a user to reset their password by generating a one-time use link
     that can be used to reset the password, and sending that link to the
@@ -794,6 +848,13 @@ patterns.
     * ``from_email``: A valid email address. By default Django uses
       the :setting:`DEFAULT_FROM_EMAIL`.
 
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
     **Template context:**
 
     * ``form``: The form (see ``password_reset_form`` above) for resetting
@@ -838,7 +899,7 @@ patterns.
     single line plain text string.
 
 
-.. function:: password_reset_done(request[, template_name])
+.. function:: password_reset_done(request[, template_name, current_app, extra_context])
 
     The page shown after a user has been emailed a link to reset their
     password. This view is called by default if the :func:`password_reset` view
@@ -852,7 +913,14 @@ patterns.
       Defaults to :file:`registration/password_reset_done.html` if not
       supplied.
 
-.. function:: password_reset_confirm(request[, uidb64, token, template_name, token_generator, set_password_form, post_reset_redirect])
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
+.. function:: password_reset_confirm(request[, uidb64, token, template_name, token_generator, set_password_form, post_reset_redirect, current_app, extra_context])
 
     Presents a form for entering a new password.
 
@@ -883,6 +951,13 @@ patterns.
     * ``post_reset_redirect``: URL to redirect after the password reset
       done. Defaults to ``None``.
 
+    * ``current_app``: A hint indicating which application contains the current view. See the
+      :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+      for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the default context data
+      passed to the template.
+
     **Template context:**
 
     * ``form``: The form (see ``set_password_form`` above) for setting the
@@ -891,7 +966,7 @@ patterns.
     * ``validlink``: Boolean, True if the link (combination of ``uidb64`` and
       ``token``) is valid or unused yet.
 
-.. function:: password_reset_complete(request[,template_name])
+.. function:: password_reset_complete(request[,template_name, current_app, extra_context])
 
    Presents a view which informs the user that the password has been
    successfully changed.
@@ -902,6 +977,13 @@ patterns.
 
    * ``template_name``: The full name of a template to display the view.
      Defaults to :file:`registration/password_reset_complete.html`.
+
+   * ``current_app``: A hint indicating which application contains the current view. See the
+     :ref:`namespaced URL resolution strategy <topics-http-reversing-url-namespaces>`
+     for more information.
+
+   * ``extra_context``: A dictionary of context data that will be added to the default context data
+     passed to the template.
 
 Helper functions
 ----------------


### PR DESCRIPTION
Added documentation of current_app and extra_context params to the django.contrib.auth views.  I also touched up the optional parameters for django.contrib.auth.login to match up with the other views which made it easier to add in those two params for it.
