### PR TITLE
Added missing request argument to example in URL dispatcher docs

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -412,7 +412,7 @@ For example::
     )
 
 In this example, for a request to ``/blog/2005/``, Django will call
-``blog.views.year_archive(year='2005', foo='bar')``.
+``blog.views.year_archive(request, year='2005', foo='bar')``.
 
 This technique is used in the
 :doc:`syndication framework </ref/contrib/syndication>` to pass metadata and


### PR DESCRIPTION
Please backport this to the 1.5.X and 1.6.X branches as well.
