### PR TITLE
Fixed #16986 -- Model.clean() can report errors on individual fields.

### DIFF
--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -12,7 +12,7 @@ import os
 import tempfile
 
 from django.core import validators
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.utils import six
@@ -296,3 +296,7 @@ class CustomErrorMessage(models.Model):
     name2 = models.CharField(max_length=50,
         validators=[validators.validate_slug],
         error_messages={'invalid': 'Model custom error message.'})
+
+    def clean(self):
+        if self.name1 == 'FORBIDDEN_VALUE':
+            raise ValidationError({'name1': [ValidationError('Model.clean() error messages.')]})

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1782,6 +1782,14 @@ class OldFormForXTests(TestCase):
             '<ul class="errorlist"><li>Model custom error message.</li></ul>'
         )
 
+    def test_model_clean_error_messages(self) :
+        data = {'name1': 'FORBIDDEN_VALUE', 'name2': 'ABC'}
+        errors = CustomErrorMessageForm(data).errors
+        self.assertHTMLEqual(
+            str(errors['name1']),
+            '<ul class="errorlist"><li>Model.clean() error messages.</li></ul>'
+        )
+
 
 class M2mHelpTextTest(TestCase):
     """Tests for ticket #9321."""


### PR DESCRIPTION
This commit provides the tests for this issue but the actual problem was solved
by the ValidationError refactor in f34cfec and ee77d4b.

Refs #20199.
