### PR TITLE
12288 Added new check on INSTALL_APPS for unique values

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -107,6 +107,9 @@ class BaseSettings(object):
         elif name == "ALLOWED_INCLUDE_ROOTS" and isinstance(value, six.string_types):
             raise ValueError("The ALLOWED_INCLUDE_ROOTS setting must be set "
                 "to a tuple, not a string.")
+        elif name == "INSTALLED_APPS" and len(value) != len(set(value)):
+            raise ImproperlyConfigured("The INSTALLED_APPS setting must contain unique values.")
+
         object.__setattr__(self, name, value)
 
 

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -226,6 +226,28 @@ class TestComplexSettingOverride(TestCase):
             self.assertEqual('Overriding setting TEST_WARN can lead to unexpected behaviour.', str(w[-1].message))
 
 
+class UniqueSettngsTests(TestCase):
+    """
+    Tests for the INSTALLED_APPS setting.
+
+    Applications in INSTALLED_APPS must be unique.
+    """
+    settings_module = settings
+
+    def setUp(self):
+        self._installed_apps = self.settings_module.INSTALLED_APPS
+
+    def tearDown(self):
+        self.settings_module.INSTALLED_APPS = self._installed_apps
+
+    def test_unique(self):
+        """
+        An ImproperlyConfigured exception is raised if the INSTALLED_APPS contains
+        any duplicate strings.
+        """
+        with self.assertRaises(ImproperlyConfigured):
+            self.settings_module.INSTALLED_APPS = ("myApp1", "myApp1", "myApp2", "myApp3")
+
 class TrailingSlashURLTests(TestCase):
     """
     Tests for the MEDIA_URL and STATIC_URL settings.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/12288 Removing lines 110-111 in django/django/conf/**init**.py causes the test to fail, but putting in the lines 110-111 allow tests to succeed. I've confirmed that the test works. In addition, the full Django test suite all passed. Thanks  @timgraham @jdunck @charettes for the advice and code review. 

 I'll appreciate feedback; feel free to code review. Thanks. 
