### PR TITLE
Use `usegmt` flag in formatdate [tiny change]

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -109,8 +109,7 @@ def http_date(epoch_seconds=None):
 
     Outputs a string in the format 'Wdy, DD Mon YYYY HH:MM:SS GMT'.
     """
-    rfcdate = formatdate(epoch_seconds)
-    return '%s GMT' % rfcdate[:25]
+    return formatdate(epoch_seconds, usegmt=True)
 
 def parse_http_date(date):
     """


### PR DESCRIPTION
This is slightly cleaner and faster than string manipulation.

Assuming patch is trivial enough not to warrant a Trac ticket.

This flag has been available since Python 2.4:
http://docs.python.org/2/library/email.util.html#email.utils.formatdate
