### PR TITLE
Ticket 20870 - document @cached_property, restructure topics/cache.txt

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -449,6 +449,11 @@ Atom1Feed
 
 .. class:: cached_property(object)
 
+    ``@cached_property`` caches the result of a method with a single ``self``
+    argument as a property. It will persist as long as the instance does, so
+    when the instance is passed to the context and the function invoked, the
+    saved result will be returned.
+
     Consider a typical case, where a view might need to call a model's method
     to perform some computation, before placing the model instance into the
     context, where the template might invoke the method once more::
@@ -477,12 +482,7 @@ Atom1Feed
         def get_enemies(self):
             # expensive computation
             ...
-            return enemies
-    
-    ``@cached_property`` caches the result of a method with a single ``self``
-    argument as a property. It will persist as long as the instance does, so
-    when the instance is passed to the context and the function invoked, the
-    saved result will be returned.
+            return enemies   
     
     Note that as the method is now a property, in Python code it will need to
     be invoked appropriately::

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -19,21 +19,13 @@ That's where optimization and caching come in.
 **Optimization** can include caching, but it's the general process of
 re-configuring and re-writing code and software systems so that they work more
 efficiently - faster, and consuming fewer resources - while perfoming the same
-function.
+function. 
 
-Django offers some readily-available tools to help optimize your code.
+Django offers some readily-available tools to help optimize the performance of
+your code.
 
-To **cache** something is to save the result of an expensive calculation so that
-you don't have to perform the calculation next time. Here's some pseudocode
-explaining how this would work for a dynamically generated Web page::
-
-    given a URL, try finding that page in the cache
-    if the page is in the cache:
-        return the cached page
-    else:
-        generate the page
-        save the generated page in the cache (for next time)
-        return the generated page
+**Caching** saves the result of an expensive calculation so that you don't have
+to perform the calculation next time. 
 
 General optimization tools
 ==========================
@@ -41,7 +33,7 @@ General optimization tools
 Middleware
 ----------
 
-Django comes with a few other pieces of middleware that can help optimize your
+Django comes with a few pieces of middleware that can help optimize your
 site's performance:
 
 * :class:`django.middleware.gzip.GZipMiddleware` compresses responses for all
@@ -55,10 +47,11 @@ site's performance:
 Order of MIDDLEWARE_CLASSES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use caching middleware, it's important to put each half in the right
-place within the :setting:`MIDDLEWARE_CLASSES` setting. That's because the cache
-middleware needs to know which headers by which to vary the cache storage.
-Middleware always adds something to the ``Vary`` response header when it can.
+If you use caching middleware - see `The per-site cache`_ below - it's
+important to put each half in the right place within the
+:setting:`MIDDLEWARE_CLASSES` setting. That's because the cache middleware
+needs to know which headers by which to vary the cache storage. Middleware
+always adds something to the ``Vary`` response header when it can.
 
 ``UpdateCacheMiddleware`` runs during the response phase, where middleware is
 run in reverse order, so an item at the top of the list runs *last* during the
@@ -94,10 +87,22 @@ Django's cache framework
 ========================
 
 Django comes with a robust cache system that lets you save dynamic pages so
-they don't have to be calculated for each request. For convenience, Django
-offers different levels of cache granularity: You can cache the output of
-specific views, you can cache only the pieces that are difficult to produce,
-or you can cache your entire site.
+they don't have to be calculated for each request. 
+
+Here's some pseudocode explaining how caching would work for a dynamically
+generated Web page::
+
+    given a URL, try finding that page in the cache
+    if the page is in the cache:
+        return the cached page
+    else:
+        generate the page
+        save the generated page in the cache (for next time)
+        return the generated page
+
+In fact, Django offers different levels of cache granularity: You can cache the
+output of specific views, you can cache only the pieces that are difficult to
+produce, or you can cache your entire site.
 
 Django also works well with "upstream" caches, such as `Squid
 <http://www.squid-cache.org>`_ and browser-based caches. These are the types of
@@ -493,7 +498,7 @@ entire site. You'll need to add
 
     No, that's not a typo: the "update" middleware must be first in the list,
     and the "fetch" middleware must be last. The details are a bit obscure, but
-    see `Order of MIDDLEWARE_CLASSES`_ below if you'd like the full story.
+    see `Order of MIDDLEWARE_CLASSES`_ above if you'd like the full story.
 
 Then, add the following required settings to your Django settings file:
 


### PR DESCRIPTION
There's a fuller explanation of `@cached_property` in ref/utils.txt, and a pointer to that from topics/cache.txt.

The latter has been restructured so that general optimisation notes are not buried at the bottom of the caching framework section. Future notes on optimisation will find a place in the `General optimization tools` section.

https://code.djangoproject.com/ticket/20870
https://groups.google.com/forum/#!topic/django-developers/MytkDIgZ9kA
