### PR TITLE
added .strip() to username for AuthenticationForm .clean()

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -180,7 +180,7 @@ class AuthenticationForm(forms.Form):
             self.fields['username'].label = capfirst(self.username_field.verbose_name)
 
     def clean(self):
-        username = self.cleaned_data.get('username')
+        username = self.cleaned_data.get('username').strip()
         password = self.cleaned_data.get('password')
 
         if username and password:


### PR DESCRIPTION
The Authentication form, does not validate the username field, 
if there are extra spaces at the end or the beginning in the string. 

Which shouldnt really be the case. 
