### PR TITLE
Clarify meaning of models.User.is_authenticated()

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -114,11 +114,13 @@ Methods
         Always returns ``True`` (as opposed to
         ``AnonymousUser.is_authenticated()`` which always returns ``False``).
         This is a way to tell if the user has been authenticated. This does not
-        imply any permissions, and doesn't check if the user is active - it
-        only indicates that ``request.user`` has been populated by the
-        :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` with
-        a :class:`~django.contrib.auth.models.User` object representing the
-        currently logged-in user.
+        imply any permissions, and doesn't check if the user is active or has
+        a valid session. Even though normally you will call this method on
+        ``request.user`` to find out whether it has been populated by the
+        :class:`~django.contrib.auth.middleware.AuthenticationMiddleware`
+        (representing the currently logged-in user), you should know this method
+        returns ``True`` for any :class:`~django.contrib.auth.models.User`
+        instance.
 
     .. method:: get_full_name()
 


### PR DESCRIPTION
I think the final sentence of the current explanation of is_authenticated() is a bit confusing, giving the impression that there is actually some kind of check to determine whether request.user has been populated by AuthenticationMiddleware, whereas the reality is that this method returns True always for any User instance from your database, even if it comes from a query that has nothing to do with the current logged-in user.
