### PR TITLE
Added a missing import on Class Based View introduction example

### DIFF
--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -196,10 +196,10 @@ A basic function-based view that handles forms may look something like this::
 
 A similar class-based view might look like::
 
-    from django.views.generic.base import View
     from django.http import HttpResponseRedirect
     from django.shortcuts import render
-
+    from django.views.generic.base import View
+    
     from .forms import MyForm
 
     class MyFormView(View):


### PR DESCRIPTION
There's a missing import on the Class Based View introduction documentation example.
