### PR TITLE
Fixed #11400 Passed kwargs from AbstractUser.email_user() to send_mail()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -574,6 +574,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Swartz <http://www.aaronsw.com/>
     Ville Säävuori <http://www.unessa.net/>
     Mart Sõmermaa <http://mrts.pri.ee/>
+    Susan Tan <susan.tan.fleckerl@gmail.com>
     Christian Tanzer <tanzer@swing.co.at>
     Tyler Tarabula <tyler.tarabula@gmail.com>
     Tyson Tate <tyson@fallingbullets.com>

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -406,6 +406,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         """
         send_mail(subject, message, from_email, [self.email], **kwargs)
 
+
 class User(AbstractUser):
     """
     Users within the Django authentication system are represented by this

--- a/django/contrib/auth/tests/test_models.py
+++ b/django/contrib/auth/tests/test_models.py
@@ -95,6 +95,7 @@ class AbstractUserTestCase(TestCase):
         self.assertEqual(mail.outbox[0].body, "This is a message")
         self.assertEqual(mail.outbox[0].from_email, "from@domain.com")
 
+
 class IsActiveTestCase(TestCase):
     """
     Tests the behavior of the guaranteed is_active attribute

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -224,7 +224,6 @@ Methods
 
             Any``**kwargs`` is passed directly to :meth:`~django.core.mail.send_mail()`.
 
-
 Manager methods
 ---------------
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -141,7 +141,6 @@ Minor features
 * Any ``**kwargs`` in :meth:`~django.contrib.auth.models.AbstractUser.email_user()`
   is passed directly to :meth:`~django.core.mail.send_mail()`.
 
-
 Backwards incompatible changes in 1.7
 =====================================
 


### PR DESCRIPTION
Also, I added a test to email_user. I edited
the contrib_auth doc and 1.7.txt to reflect new changes.
Thanks Jug_ for bug report and @timgraham for code review. :thumbsup: 

https://code.djangoproject.com/ticket/11400
