### PR TITLE
#20915 -- Remove django.test.client dependency on django.contrib.auth

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -550,9 +550,6 @@ class Client(RequestFactory):
         not available.
         """
         user = self.auth_module.authenticate(**credentials)
-        if user and user.is_active \
-                and 'django.contrib.sessions' in settings.INSTALLED_APPS:
-        user = self.auth_module.authenticate(**credentials)
         if (user and user.is_active and
                 apps.is_installed('django.contrib.sessions')):
             engine = import_module(settings.SESSION_ENGINE)


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/20915

This proof of concept simply makes Client accept a module name that should implement the generic

login()
logout()
authenticate()
get_user_module()

API today provided by d.c.auth (that servers as a frontend to the auth backends extensibility).

What do you think? Too ugly/hackish?
