### PR TITLE
Fixed #20709: Allow {% widthratio %} to accept an "as"-parameter.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -570,6 +570,7 @@ answer newbie questions, and generally made Django that much better:
     Travis Swicegood <travis@domain51.com>
     Pascal Varet
     SuperJared
+    Jonathan Slenders
     Radek Švarz <http://www.svarz.cz/translate/>
     Swaroop C H <http://www.swaroopch.info>
     Aaron Swartz <http://www.aaronsw.com/>

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1108,6 +1108,14 @@ If ``this_value`` is 175, ``max_value`` is 200, and ``max_width`` is 100, the
 image in the above example will be 88 pixels wide
 (because 175/200 = .875; .875 * 100 = 87.5 which is rounded up to 88).
 
+.. versionchanged:: 1.7
+
+In some cases you might want to capture the result of widthratio in a variable.
+It can be useful for instance in a blocktrans like this::
+
+    {% widthratio this_value max_value max_width as width %}
+    {% blocktrans %}The width is: {{ width }}{% endblocktrans %}
+
 .. templatetag:: with
 
 with

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -156,6 +156,9 @@ Minor features
   :meth:`~django.contrib.auth.models.User.email_user()` are passed to the
   underlying :meth:`~django.core.mail.send_mail()` call.
 
+* The widthratio template tag now accepts an "as" parameter, to capture the
+  result in a variable.
+
 Backwards incompatible changes in 1.7
 =====================================
 

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -1575,6 +1575,13 @@ class TemplateTests(TransRealMixin, TestCase):
             # Test whitespace in filter argument
             'widthratio15': ('{% load custom %}{% widthratio a|noop:"x y" b 0 %}', {'a':50,'b':100}, '0'),
 
+            # Widthratio with variable assignment
+            'widthratio16': ('{% widthratio a b 100 as variable %}-{{ variable }}-', {'a':50,'b':100}, '-50-'),
+            'widthratio17': ('{% widthratio a b 100 as variable %}-{{ variable }}-', {'a':100,'b':100}, '-100-'),
+
+            'widthratio18': ('{% widthratio a b 100 as %}', { }, template.TemplateSyntaxError),
+            'widthratio19': ('{% widthratio a b 100 not_as variable %}', { }, template.TemplateSyntaxError),
+
             ### WITH TAG ########################################################
             'with01': ('{% with key=dict.key %}{{ key }}{% endwith %}', {'dict': {'key': 50}}, '50'),
             'legacywith01': ('{% with dict.key as key %}{{ key }}{% endwith %}', {'dict': {'key': 50}}, '50'),


### PR DESCRIPTION
Allow {% widthratio %} to accept an "as"-parameter.

https://code.djangoproject.com/ticket/20709
