### PR TITLE
Fixed #20922 -- Customizable serializers for signed_cookie sessions

### DIFF
--- a/django/contrib/sessions/backends/signed_cookies.py
+++ b/django/contrib/sessions/backends/signed_cookies.py
@@ -22,6 +22,7 @@ class PickleSerializer(object):
 
 
 class SessionStore(SessionBase):
+    serializer = PickleSerializer
 
     def load(self):
         """
@@ -31,7 +32,7 @@ class SessionStore(SessionBase):
         """
         try:
             return signing.loads(self.session_key,
-                serializer=PickleSerializer,
+                serializer=self.serializer,
                 # This doesn't handle non-default expiry dates, see #19201
                 max_age=settings.SESSION_COOKIE_AGE,
                 salt='django.contrib.sessions.backends.signed_cookies')
@@ -91,7 +92,7 @@ class SessionStore(SessionBase):
         session_cache = getattr(self, '_session_cache', {})
         return signing.dumps(session_cache, compress=True,
             salt='django.contrib.sessions.backends.signed_cookies',
-            serializer=PickleSerializer)
+            serializer=self.serializer)
 
     @classmethod
     def clear_expired(cls):


### PR DESCRIPTION
Refactor the signed cookie session backend to allow subclassers to use a different serializer implementation.

For [Ticket #20922](https://code.djangoproject.com/ticket/20922#ticket)
