### PR TITLE
Updated docs following deprecation of django.views.defaults.shortcut

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -370,8 +370,11 @@ these changes.
 * Remove the backward compatible shims introduced to rename the attributes
   ``ChangeList.root_query_set`` and ``ChangeList.query_set``.
 
-* ``django.conf.urls.shortcut`` and ``django.views.defaults.shortcut`` will be
-  removed.
+* ``django.views.defaults.shortcut`` will be removed, as part of the
+  goal of removing all ``django.contrib`` references from the core
+  Django codebase. Instead use
+  ``django.contrib.contenttypes.views.shortcut``. ``django.conf.urls.shortcut``
+  will also be removed.
 
 * Support for the Python Imaging Library (PIL) module will be removed, as it
   no longer appears to be actively maintained & does not work on Python 3.
@@ -430,12 +433,6 @@ these changes.
 
 2.0
 ---
-
-* ``django.views.defaults.shortcut()``. This function has been moved
-  to ``django.contrib.contenttypes.views.shortcut()`` as part of the
-  goal of removing all ``django.contrib`` references from the core
-  Django codebase. The old shortcut will be removed in the 2.0
-  release.
 
 * ``ssi`` and ``url`` template tags will be removed from the ``future`` template
   tag library (used during the 1.3/1.4 deprecation period).

--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -417,9 +417,10 @@ Here's how Django uses the sites framework:
   :class:`~django.contrib.sites.models.Site` name to the template as
   ``{{ site_name }}``.
 
-* The shortcut view (``django.views.defaults.shortcut``) uses the domain
-  of the current :class:`~django.contrib.sites.models.Site` object when
-  calculating an object's URL.
+* The shortcut view (``django.contrib.contenttypes.views.shortcut``)
+  uses the domain of the current
+  :class:`~django.contrib.sites.models.Site` object when calculating
+  an object's URL.
 
 * In the admin framework, the "view on site" link uses the current
   :class:`~django.contrib.sites.models.Site` to work out the domain for the


### PR DESCRIPTION
Originally the deprecation was planned for Django 2.0, but it has been brought forward in 3f2befc. This pull request updates the deprecation timeline docs, and updates one other reference to the old location of the shortcut view.
