### PR TITLE
Fix proxy instance equality

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -459,7 +459,10 @@ class Model(six.with_metaclass(ModelBase)):
         return '%s object' % self.__class__.__name__
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self._get_pk_val() == other._get_pk_val()
+        return ((isinstance(other, self.__class__) or
+                 isinstance(other, Model) and
+                 other._meta.concrete_model is self._meta.concrete_model) and
+                self._get_pk_val() == other._get_pk_val())
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -362,6 +362,28 @@ class ProxyModelTests(TestCase):
         p = MyPerson.objects.get(pk=100)
         self.assertEqual(p.name, 'Elvis Presley')
 
+    def test_proxy_eq(self):
+        bug = Bug(pk=3)
+        proxy_bug = ProxyBug(pk=3)
+        proxy_proxy_bug = ProxyProxyBug(pk=3)
+
+        self.assertEqual(bug, proxy_bug)
+        self.assertEqual(proxy_bug, bug)
+        self.assertEqual(bug, proxy_proxy_bug)
+        self.assertEqual(proxy_proxy_bug, bug)
+        self.assertEqual(proxy_bug, proxy_proxy_bug)
+        self.assertEqual(proxy_proxy_bug, proxy_bug)
+
+        proxy_bug.pk = 4
+        proxy_proxy_bug.pk = 5
+
+        self.assertNotEqual(bug, proxy_bug)
+        self.assertNotEqual(proxy_bug, bug)
+        self.assertNotEqual(bug, proxy_proxy_bug)
+        self.assertNotEqual(proxy_proxy_bug, bug)
+        self.assertNotEqual(proxy_bug, proxy_proxy_bug)
+        self.assertNotEqual(proxy_proxy_bug, proxy_bug)
+
 
 class ProxyModelAdminTests(TestCase):
     fixtures = ['myhorses']


### PR DESCRIPTION
This is a WIP patch for [#14492](https://code.djangoproject.com/ticket/14492).

It makes proxy instances equatable with model instances and other proxy instances.
