### PR TITLE
Fixed #20640 -- Avoid NoReverseMatch in get_deleted_objects

### DIFF
--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -29,7 +29,7 @@ from .models import (Article, Chapter, Account, Media, Child, Parent, Picture,
     Album, Question, Answer, ComplexSortedPerson, PluggableSearchPerson, PrePopulatedPostLargeSlug,
     AdminOrderedField, AdminOrderedModelMethod, AdminOrderedAdminMethod,
     AdminOrderedCallable, Report, Color2, UnorderedObject, MainPrepopulated,
-    RelatedPrepopulated, UndeletableObject, UserMessenger, Simple, Choice,
+    RelatedPrepopulated, UndeletableObject, UnchangeableObject, UserMessenger, Simple, Choice,
     ShortMessage, Telegram)
 
 
@@ -656,6 +656,13 @@ class UndeletableObjectAdmin(admin.ModelAdmin):
         return super(UndeletableObjectAdmin, self).change_view(*args, **kwargs)
 
 
+class UnchangeableObjectAdmin(admin.ModelAdmin):
+    def get_urls(self):
+        # Disable change_view, but leave other urls untouched
+        urlpatterns = super(UnchangeableObjectAdmin, self).get_urls()
+        return [p for p in urlpatterns if not p.name.endswith("_change")]
+
+
 def callable_on_unknown(obj):
     return obj.unknown
 
@@ -741,6 +748,7 @@ site.register(Report, ReportAdmin)
 site.register(MainPrepopulated, MainPrepopulatedAdmin)
 site.register(UnorderedObject, UnorderedObjectAdmin)
 site.register(UndeletableObject, UndeletableObjectAdmin)
+site.register(UnchangeableObject, UnchangeableObjectAdmin)
 
 # We intentionally register Promo and ChapterXtra1 but not Chapter nor ChapterXtra2.
 # That way we cover all four cases:

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -674,6 +674,12 @@ class UndeletableObject(models.Model):
     """
     name = models.CharField(max_length=255)
 
+class UnchangeableObject(models.Model):
+    """
+    Model whose change_view is disabled in admin
+    Refs #20640.
+    """
+
 class UserMessenger(models.Model):
     """
     Dummy class for testing message_user functions on ModelAdmin


### PR DESCRIPTION
The default delete action resulted in a NoReverseMatch if it were to
list any Model with a ModelAdmin with `get_urls` overridden to remove
the change url.  Catching the error and not displaying the link in that
case, as was already done for models with no registered admins.
