### PR TITLE
Fixed #20936: When logging out/ending a session, don't create a new, empty session

### DIFF
--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -140,6 +140,13 @@ class SessionBase(object):
         self.accessed = True
         self.modified = True
 
+    def is_empty(self):
+        "Returns True when there is no session_key and the session is empty"
+        try:
+            return not bool(self._session_key) and not self._session_cache
+        except AttributeError:
+            return True
+
     def _get_new_session_key(self):
         "Returns session key that isn't being used."
         while True:
@@ -266,7 +273,7 @@ class SessionBase(object):
         """
         self.clear()
         self.delete()
-        self.create()
+        self._session_key = None
 
     def cycle_key(self):
         """

--- a/django/contrib/sessions/backends/cached_db.py
+++ b/django/contrib/sessions/backends/cached_db.py
@@ -77,7 +77,7 @@ class SessionStore(DBStore):
         """
         self.clear()
         self.delete(self.session_key)
-        self.create()
+        self._session_key = ''
 
 
 # At bottom to avoid circular import

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils.cache import patch_vary_headers
 from django.utils.http import cookie_date
 
+
 class SessionMiddleware(object):
     def __init__(self):
         engine = import_module(settings.SESSION_ENGINE)
@@ -17,32 +18,39 @@ class SessionMiddleware(object):
     def process_response(self, request, response):
         """
         If request.session was modified, or if the configuration is to save the
-        session every time, save the changes and set a session cookie.
+        session every time, save the changes and set a session cookie or delete
+        the session cookie if the session has been emptied.
         """
         try:
             accessed = request.session.accessed
             modified = request.session.modified
+            empty = request.session.is_empty()
         except AttributeError:
             pass
         else:
-            if accessed:
-                patch_vary_headers(response, ('Cookie',))
-            if modified or settings.SESSION_SAVE_EVERY_REQUEST:
-                if request.session.get_expire_at_browser_close():
-                    max_age = None
-                    expires = None
-                else:
-                    max_age = request.session.get_expiry_age()
-                    expires_time = time.time() + max_age
-                    expires = cookie_date(expires_time)
-                # Save the session data and refresh the client cookie.
-                # Skip session save for 500 responses, refs #3881.
-                if response.status_code != 500:
-                    request.session.save()
-                    response.set_cookie(settings.SESSION_COOKIE_NAME,
-                            request.session.session_key, max_age=max_age,
-                            expires=expires, domain=settings.SESSION_COOKIE_DOMAIN,
-                            path=settings.SESSION_COOKIE_PATH,
-                            secure=settings.SESSION_COOKIE_SECURE or None,
-                            httponly=settings.SESSION_COOKIE_HTTPONLY or None)
+            # First check if we need to delete this cookie.
+            # The session should be deleted only if the session is entirely empty
+            if settings.SESSION_COOKIE_NAME in request.COOKIES and empty:
+                response.delete_cookie(settings.SESSION_COOKIE_NAME)
+            else:
+                if accessed:
+                    patch_vary_headers(response, ('Cookie',))
+                if modified or settings.SESSION_SAVE_EVERY_REQUEST:
+                    if request.session.get_expire_at_browser_close():
+                        max_age = None
+                        expires = None
+                    else:
+                        max_age = request.session.get_expiry_age()
+                        expires_time = time.time() + max_age
+                        expires = cookie_date(expires_time)
+                    # Save the session data and refresh the client cookie.
+                    # Skip session save for 500 responses, refs #3881.
+                    if response.status_code != 500:
+                        request.session.save()
+                        response.set_cookie(settings.SESSION_COOKIE_NAME,
+                                request.session.session_key, max_age=max_age,
+                                expires=expires, domain=settings.SESSION_COOKIE_DOMAIN,
+                                path=settings.SESSION_COOKIE_PATH,
+                                secure=settings.SESSION_COOKIE_SECURE or None,
+                                httponly=settings.SESSION_COOKIE_HTTPONLY or None)
         return response

--- a/django/contrib/sessions/tests.py
+++ b/django/contrib/sessions/tests.py
@@ -566,6 +566,27 @@ class SessionMiddlewareTests(unittest.TestCase):
         # Check that the value wasn't saved above.
         self.assertNotIn('hello', request.session.load())
 
+    def test_session_delete_on_end(self):
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
+
+        # Before deleting, there has to be an existing cookie
+        request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
+
+        # Simulate a request that ends the session
+        middleware.process_request(request)
+        request.session.flush()
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
+
+        # Check that the cookie was deleted, not recreated.
+        # A deleted cookie header looks like:
+        #  Set-Cookie: sessionid=; expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+        self.assertEqual('Set-Cookie: {0}=; expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/'.format(settings.SESSION_COOKIE_NAME),
+            str(response.cookies[settings.SESSION_COOKIE_NAME]))
+
 
 class CookieSessionTests(SessionTestsMixin, TestCase):
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -41,7 +41,7 @@ database.
 Migrations are covered in :doc:`their own documentation</topics/migrations>`,
 but a few of the key features are:
 
-* ``syncdb`` has been deprecated and replaced by ``migrate``. Don't worry - 
+* ``syncdb`` has been deprecated and replaced by ``migrate``. Don't worry -
   calls to ``syncdb`` will still work as before.
 
 * A new ``makemigrations`` command provides an easy way to autodetect changes
@@ -214,6 +214,10 @@ Minor features
 * The :ttag:`widthratio` template tag now accepts an "as" parameter to capture
   the result in a variable.
 
+* Session cookie now gets deleted after calling
+  :meth:`~django.contrib.sessions.backends.base.flush()`. Also, a new
+  session is created lazily.
+
 Backwards incompatible changes in 1.7
 =====================================
 
@@ -269,7 +273,7 @@ Miscellaneous
 * The :meth:`django.db.models.Model.__eq__` method has changed such that
   two ``Model`` instances without primary key values won't be considered
   equal (unless they are the same instance).
-  
+
 * The :meth:`django.db.models.Model.__hash__` will now raise ``TypeError``
   when called on an instance without a primary key value. This is done to
   avoid mutable ``__hash__`` values in containers.

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -222,8 +222,9 @@ You can edit it multiple times.
 
     .. method:: flush
 
-      Delete the current session data from the session and regenerate the
-      session key value that is sent back to the user in the cookie. This is
+    .. versionchanged:: 1.7
+
+      Delete the current session data from the session and deletes the session cookie entirely. This is
       used if you want to ensure that the previous session data can't be
       accessed again from the user's browser (for example, the
       :func:`django.contrib.auth.logout()` function calls it).


### PR DESCRIPTION
Previously, when logging out, the existing session is overwritten by a
new sessionid instead of deleting the session all together.

This behavior adds overhead by creating a new session record in
whichever backend being used, db, cache, etc.

This extra session is unnecessary at the time since no session data
is meant to be preserved when explicitly logging out.
