### PR TITLE
Fixed #20933 -- Allowed loaddata to load fixtures from relative paths.

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -183,7 +183,7 @@ class Command(BaseCommand):
         if self.verbosity >= 2:
             self.stdout.write("Loading '%s' fixtures..." % fixture_name)
 
-        if os.path.isabs(fixture_name):
+        if os.path.sep in fixture_name:
             fixture_dirs = [os.path.dirname(fixture_name)]
             fixture_name = os.path.basename(fixture_name)
         else:

--- a/docs/howto/initial-data.txt
+++ b/docs/howto/initial-data.txt
@@ -90,8 +90,8 @@ fixtures. You can set the :setting:`FIXTURE_DIRS` setting to a list of
 additional directories where Django should look.
 
 When running :djadmin:`manage.py loaddata <loaddata>`, you can also
-specify an absolute path to a fixture file, which overrides searching
-the usual directories.
+specify a path to a fixture file, which overrides searching the usual
+directories.
 
 .. seealso::
 

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -39,12 +39,6 @@ class Stuff(models.Model):
 class Absolute(models.Model):
     name = models.CharField(max_length=40)
 
-    load_count = 0
-
-    def __init__(self, *args, **kwargs):
-        super(Absolute, self).__init__(*args, **kwargs)
-        Absolute.load_count += 1
-
 
 class Parent(models.Model):
     name = models.CharField(max_length=10)

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -148,7 +148,22 @@ class TestFixtures(TestCase):
             load_absolute_path,
             verbosity=0,
         )
-        self.assertEqual(Absolute.load_count, 1)
+        self.assertEqual(Absolute.objects.count(), 1)
+
+    def test_relative_path(self):
+        directory = os.path.dirname(upath(__file__))
+        relative_path = os.path.join('fixtures', 'absolute.json')
+        cwd = os.getcwd()
+        try:
+            os.chdir(directory)
+            management.call_command(
+                'loaddata',
+                relative_path,
+                verbosity=0,
+            )
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(Absolute.objects.count(), 1)
 
     def test_unknown_format(self):
         """


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/20933
Needs a 1.6 backport!
