### PR TITLE
Documentation -- Noted that OneToOneField doesn't respect unique argument

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -281,8 +281,8 @@ you try to save a model with a duplicate value in a :attr:`~Field.unique`
 field, a :exc:`django.db.IntegrityError` will be raised by the model's
 :meth:`~django.db.models.Model.save` method.
 
-This option is valid on all field types except :class:`ManyToManyField` and
-:class:`FileField`.
+This option is valid on all field types except :class:`ManyToManyField`,
+:class:`OneToOneField`, and :class:`FileField`.
 
 Note that when ``unique`` is ``True``, you don't need to specify
 :attr:`~Field.db_index`, because ``unique`` implies the creation of an index.


### PR DESCRIPTION
Added `OneToOneField` to the list of model fields for which the `unique`
argument isn't valid. (`OneToOneFields` are inherently unique, and if
the user supplies a value for `unique` it is ignored / overwritten.)
