### PR TITLE
Fixed #19949 -- Cached template loader now caches TemplateDoesNotExist

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -57,9 +57,12 @@ class Loader(BaseLoader):
 
     def load_template(self, template_name, template_dirs=None):
         key = self.cache_key(template_name, template_dirs)
-        try:
-            template = self.template_cache[key]
-        except KeyError:
+        template_tuple = self.template_cache.get(key)
+        # cached a previous failure:
+        if template_tuple is TemplateDoesNotExist:
+            raise TemplateDoesNotExist
+
+        elif template_tuple is None:
             template, origin = self.find_template(template_name, template_dirs)
             if not hasattr(template, 'render'):
                 try:
@@ -69,9 +72,9 @@ class Loader(BaseLoader):
                     # back off to returning the source and display name for the template
                     # we were asked to load. This allows for correct identification (later)
                     # of the actual template that does not exist.
-                    return template, origin
-            self.template_cache[key] = template
-        return template, None
+                    self.template_cache[key] = (template, origin)
+            self.template_cache[key] = (template, None)
+        return self.template_cache[key]
 
     def reset(self):
         "Empty the template cache."

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -105,6 +105,7 @@ class EggLoaderTest(unittest.TestCase):
         egg_loader = EggLoader()
         self.assertRaises(TemplateDoesNotExist, egg_loader.load_template_source, "y.html")
 
+
 class CachedLoader(unittest.TestCase):
     def setUp(self):
         self.old_TEMPLATE_LOADERS = settings.TEMPLATE_LOADERS
@@ -126,6 +127,16 @@ class CachedLoader(unittest.TestCase):
 
         # The two templates should not have the same content
         self.assertNotEqual(t1.render(Context({})), t2.render(Context({})))
+
+    def test_missing_template_is_cached(self):
+        "Check that the missing template is cached."
+        template_loader = loader.find_template_loader(settings.TEMPLATE_LOADERS[0])
+        # Empty cache, which may be filled from previous tests.
+        template_loader.reset()
+        # Check that 'missing.html' isn't already in cache before you load template 'missing.html'
+        self.assertRaises(KeyError, lambda: template_loader.template_cache["missing.html"])
+        self.assertRaises(TemplateDoesNotExist, template_loader.load_template, "missing.html")
+
 
 class RenderToStringTest(unittest.TestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/19949 Thanks @timgraham @jdunck for the code reviews. Thanks Kronuz for the bug report and initial code patch.  :+1: 
