### PR TITLE
Documentation -- Clarified use of 'view' in test client introduction

### DIFF
--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -328,7 +328,8 @@ Some of the things you can do with the test client are:
   everything from low-level HTTP (result headers and status codes) to
   page content.
 
-* Test that the correct view is executed for a given URL.
+* See the chain of redirects (if any) and check the URL and status code at
+  each step.
 
 * Test that a given request is rendered by a given Django template, with
   a template context that contains certain values.
@@ -337,8 +338,8 @@ Note that the test client is not intended to be a replacement for Selenium_ or
 other "in-browser" frameworks. Django's test client has a different focus. In
 short:
 
-* Use Django's test client to establish that the correct view is being
-  called and that the view is collecting the correct context data.
+* Use Django's test client to establish that the correct template is being
+  rendered and that the template is passed the correct context data.
 
 * Use in-browser frameworks like Selenium_ to test *rendered* HTML and the
   *behavior* of Web pages, namely JavaScript functionality. Django also


### PR DESCRIPTION
The line "Test that the correct view is executed for a given URL"
is at best ambiguous: the test client doesn't offer any special support
for determining the view function (or class) that was called. It does
detail the templates that were rendered, but those may or may not be in
a one-to-one relationship with view functions.

There are ways to determine the view function (using `django.core.urlresolvers.resolve`,
for example) but they don't really have anything to do with the test client. (See [here](http://stackoverflow.com/q/3669345/2395796)
for an example of the confusion.)

So the language was clarified to refer specifically to templates. Since
the list of features seemed stunted with only two entries, a new one
was added.
