### PR TITLE
Allow for out-of-band xsrf tokens

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -164,7 +164,7 @@ class CsrfViewMiddleware(object):
             # Check non-cookie token for match.
             request_csrf_token = ""
             if request.method == "POST":
-                request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
+                request_csrf_token = request.REQUEST.get('csrfmiddlewaretoken', '')
 
             if request_csrf_token == "":
                 # Fall back to X-CSRFToken, to make things easier for AJAX,


### PR DESCRIPTION
There have become several situations where control for something that will inevitably come back as a callback (via POST) will not include the proper CSRF token... however the callback URI can (and should) be adorned with one.

Examples are using oneall's social login service which requires a callback for extra processing.  Decorating the CSRF requirements away does not help protect against unmanageable situations.

An unmanagable situation would be where we all assume a service will be using security reasoning when developing a project.  Oneall.com uses pseudo random UUIDs when passing an important bit of information back to a callback.  If they ever switch to incremental or predictable hashes (due to a mistake on their end or perhaps a bad decision) an exploit can occur that requiring the csrf token could help mitigate.  In this case the token would have to be passed via GET parameters.

This can be extended to OAUTH behaviors as well.

There are a lot of other services.. including mail outs.. that use callbacks for send notifications that could be adorned with a token as well.
