### PR TITLE
Correct instructions for running contrib unit tests

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -220,4 +220,4 @@ If you have URLs that need to be mapped, put them in ``tests/urls.py``.
 To run tests for just one contrib app (e.g. ``auth``), use the same
 method as above::
 
-    ./runtests.py --settings=settings auth
+    ./runtests.py django.contrib.auth


### PR DESCRIPTION
I had trouble getting unit tests running for a specific contrib app following the instructions provided.

It seemed that everything was correct, except the mention of using the fully qualified path. Not sure if things got changed or what, but this worked for me.
