### PR TITLE
Fixed bug #2818 with another side of ForeignKey. Missed condition detail in a89b156 commit

### DIFF
--- a/django/contrib/admin/util.py
+++ b/django/contrib/admin/util.py
@@ -18,6 +18,7 @@ from django.utils import six
 from django.utils.translation import ungettext
 from django.core.urlresolvers import reverse, NoReverseMatch
 
+
 def lookup_needs_distinct(opts, lookup_path):
     """
     Returns True if 'distinct()' should be used to query the given lookup path.
@@ -25,11 +26,12 @@ def lookup_needs_distinct(opts, lookup_path):
     field_name = lookup_path.split('__', 1)[0]
     field = opts.get_field_by_name(field_name)[0]
     if ((hasattr(field, 'rel') and
-         isinstance(field.rel, models.ManyToManyRel)) or
+         isinstance(field.rel, (models.ManyToManyRel, models.ManyToOneRel))) or
         (isinstance(field, models.related.RelatedObject) and
          not field.field.unique)):
          return True
     return False
+
 
 def prepare_lookup_value(key, value):
     """
@@ -45,6 +47,7 @@ def prepare_lookup_value(key, value):
         else:
             value = True
     return value
+
 
 def quote(s):
     """


### PR DESCRIPTION
As we can see, in https://code.djangoproject.com/ticket/2818 we have fixed bug in django admin behavior with joins - we should use distinct in this cases. Commit 4938c8e fixed this issue.
But, in a89b156 it was reworked as set of codelines for enhanced conditions. To check for possible joins, was created function lookup_needs_distinct. It looks for field by name(for example, in 'user__docs__name' it takes 'user') and does some checks to verify is it relation object.
As we can see, RelatedObject(any relation) and ManyToManyRel(reverse side of ManyToMany) handled. But, we also have reverse side of ForeignKey - ManyToOneRel. So yea, we have a problem here - appearance of bug #2818. So I decide to create this pull request. At least, it works perfectly for me.
FYI, I'm not checking for OneToOneRel, because there should be no duplications in this case.
