### PR TITLE
Fix in MySQL converters for one item sequences

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -96,6 +96,8 @@ django_conversions.update({
     FIELD_TYPE.NEWDECIMAL: util.typecast_decimal,
     FIELD_TYPE.DATETIME: parse_datetime_with_timezone_support,
     datetime.datetime: adapt_datetime_with_timezone_support,
+    list: util.escape_sequence,
+    tuple: util.escape_sequence,
 })
 
 # This should match the numerical portion of the version numbers (we can treat

--- a/django/db/backends/util.py
+++ b/django/db/backends/util.py
@@ -165,3 +165,18 @@ def format_number(value, max_digits, decimal_places):
         return "{0:f}".format(value.quantize(decimal.Decimal(".1") ** decimal_places, context=context))
     else:
         return "%.*f" % (decimal_places, value)
+
+
+def escape_sequence(sequence, converters):
+    """
+    MySQLdb driver fails to produce valid SQL with one item sequences. For
+    example tuple `(1,)` produces `'(1,)'`. This is reported under MySQLdb1
+    Github issue #10 and closed as wontfix.
+
+    If the sequence has one item, we escape the item itself, not the sequence
+    """
+    import MySQLdb
+    if len(sequence) == 1:
+        return '(%s)' % MySQLdb.converters.escape(sequence[0], converters)
+    else:
+        return MySQLdb.converters.escape_sequence(sequence, converters)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -11,10 +11,11 @@ from django.conf import settings
 from django.core.management.color import no_style
 from django.db import (connection, connections, DEFAULT_DB_ALIAS,
     DatabaseError, IntegrityError, transaction)
+from django.db.backends.mysql.base import django_conversions
 from django.db.backends.signals import connection_created
 from django.db.backends.sqlite3.base import DatabaseOperations
 from django.db.backends.postgresql_psycopg2 import version as pg_version
-from django.db.backends.util import format_number
+from django.db.backends.util import format_number, escape_sequence
 from django.db.models import Sum, Avg, Variance, StdDev
 from django.db.models.fields import (AutoField, DateField, DateTimeField,
     DecimalField, IntegerField, TimeField)
@@ -943,3 +944,12 @@ class BackendUtilTests(TestCase):
               '0.1')
         equal('0.1234567890', 12, 0,
               '0')
+
+    def test_escape_sequence(self):
+        """
+        Test the escape_sequence converter utility
+        """
+        self.assertEqual(escape_sequence((1,), django_conversions), '(1)')
+        self.assertEqual(escape_sequence([1,], django_conversions), '(1)')
+        self.assertEqual(escape_sequence((1, 2, 3), django_conversions), ('1','2','3'))
+        self.assertEqual(escape_sequence([1, 2, 3], django_conversions), ('1','2','3'))


### PR DESCRIPTION
MySQLdb1 currently has a bug that produces incorrect SQL when dealing with one item sequences, closed as wontfix. This bug is reported in https://github.com/farcepest/MySQLdb1/issues/10

What this means, is that in Django when executing the following query with latest MySQLdb driver:

```
cursor.execute("SELECT * FROM table WHERE id IN %(ids_param)s", (1,))
```

Produces the following SQL (watch the trailing comma):

```
SELECT * FROM table WHERE id IN (1,)
```

Which obviously is not valid SQL and fails. 

This patch adds a converter function to the MySQL backend that deals with one item sequences correctly. As the author is not fixing this behavior, I considered correctly add this workaround to Django, hopefully find more  comprehension. 

I haven't added acceptance tests for this behavior, if necessary, please point me for the right location to add them.

Thanks, cheers,
Miguel
