### PR TITLE
Fixed #20881 -- Removed contrib.auth.models.AbstractUser.get_absolute_url()

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -386,9 +386,6 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         verbose_name_plural = _('users')
         abstract = True
 
-    def get_absolute_url(self):
-        return "/users/%s/" % urlquote(self.username)
-
     def get_full_name(self):
         """
         Returns the first_name plus the last_name, with a space in between.

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -318,6 +318,13 @@ Miscellaneous
   when called on an instance without a primary key value. This is done to
   avoid mutable ``__hash__`` values in containers.
 
+* ``django.contrib.auth.models.AbstractUser`` no longer defines a
+  :meth:`~django.db.models.Model.get_absolute_url()` method. The old definition
+  returned  ``"/users/%s/" % urlquote(self.username)`` which was arbitrary
+  since applications may or may not define such a url in ``urlpatterns``.
+  Define a ``get_absolute_url()`` method on your own custom user object or use
+  :setting:`ABSOLUTE_URL_OVERRIDES` if you want a URL for your user.
+
 Features deprecated in 1.7
 ==========================
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1749,9 +1749,9 @@ class SecureViewTests(TestCase):
         """
         Only admin users should be able to use the admin shortcut view.
         """
-        user_ctype = ContentType.objects.get_for_model(User)
-        user = User.objects.get(username='super')
-        shortcut_url = "/test_admin/admin/r/%s/%s/" % (user_ctype.pk, user.pk)
+        model_ctype = ContentType.objects.get_for_model(ModelWithStringPrimaryKey)
+        obj = ModelWithStringPrimaryKey.objects.create(string_pk='foo')
+        shortcut_url = "/test_admin/admin/r/%s/%s/" % (model_ctype.pk, obj.pk)
 
         # Not logged in: we should see the login page.
         response = self.client.get(shortcut_url, follow=False)
@@ -1762,7 +1762,7 @@ class SecureViewTests(TestCase):
         response = self.client.get(shortcut_url, follow=False)
         # Can't use self.assertRedirects() because User.get_absolute_url() is silly.
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://example.com/users/super/')
+        self.assertEqual(response.url, 'http://example.com/dummy/foo/')
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))


### PR DESCRIPTION
The definition is arbitrary and creates a broken "view on site"
link in the admin if a project doesn't define such a URL.

IMO, this can be considered a bug fix and not require a deprecation. Let me know if you disagree.
