### PR TITLE
forms.widgets -- fix __all__

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -28,7 +28,7 @@ __all__ = (
     'FileInput', 'DateInput', 'DateTimeInput', 'TimeInput', 'Textarea', 'CheckboxInput',
     'Select', 'NullBooleanSelect', 'SelectMultiple', 'RadioSelect',
     'CheckboxSelectMultiple', 'MultiWidget',
-    'SplitDateTimeWidget',
+    'SplitDateTimeWidget', 'SplitHiddenDateTimeWidget'
 )
 
 MEDIA_TYPES = ('css','js')


### PR DESCRIPTION
django.forms is missing the 'SplitHiddenDateTimeWidget' property. This fixes that.
