### PR TITLE
Fixed #21029 -- schema editors abort on exception

### DIFF
--- a/django/db/backends/schema.py
+++ b/django/db/backends/schema.py
@@ -74,10 +74,7 @@ class BaseDatabaseSchemaEditor(object):
         if exc_type is None:
             for sql in self.deferred_sql:
                 self.execute(sql)
-            atomic(self.connection.alias, self.connection.features.can_rollback_ddl).__exit__(None, None, None)
-        else:
-            # Continue propagating exception
-            return None
+        return atomic(self.connection.alias, self.connection.features.can_rollback_ddl).__exit__(exc_type, exc_value, traceback)
 
     # Core utility functions
 


### PR DESCRIPTION
It's missing tests and there might be a better way to do this, see [the ticket](https://code.djangoproject.com/ticket/21029#ticket).
