### PR TITLE
django.contrib.auth - passing user to set_password_form and password_reset_confirm template

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -216,13 +216,14 @@ def password_reset_confirm(request, uidb64=None, token=None,
                 form.save()
                 return HttpResponseRedirect(post_reset_redirect)
         else:
-            form = set_password_form(None)
+            form = set_password_form(user)
     else:
         validlink = False
         form = None
         title = _('Password reset unsuccessful')
     context = {
         'form': form,
+        'user': user,
         'title': title,
         'validlink': validlink,
     }


### PR DESCRIPTION
SetPasswordForm has access to User instance but only after POST.
Wouldn't it be useful to have access for it all the time?

My client requirement is to add "security question" that user pick upon registration and needs to answer before resetting password. ATM I can't implement it using "password_reset_confirm".

cheers.
