### PR TITLE
ignore build directory, so it doesn't accidentally get committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build/
 docs/locale/
 tests/coverage_html/
 tests/.coverage
+build/


### PR DESCRIPTION
When following the install file to start working on Django the first thing I did was,

``` sh
python setup.py install
```

This created a `build/` directory.  Since the directory is not in the .gitignore it makes it appear as if I've changed part of Django before I've begun to hack.  I don't think the `build/` directory should be allowed into source control, so it should be explicitly ignored. 

This may not be desired, and possibly I should place that in my global .gitignore.  

Thoughts? 
