### PR TITLE
fixes #19988, allow html in ordinal for humanize

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -8,10 +8,12 @@ from django.conf import settings
 from django.template import defaultfilters
 from django.utils.encoding import force_text
 from django.utils.formats import number_format
+from django.utils.safestring import mark_safe
 from django.utils.translation import pgettext, ungettext, ugettext as _
 from django.utils.timezone import is_aware, utc
 
 register = template.Library()
+
 
 @register.filter(is_safe=True)
 def ordinal(value):
@@ -24,9 +26,11 @@ def ordinal(value):
     except (TypeError, ValueError):
         return value
     suffixes = (_('th'), _('st'), _('nd'), _('rd'), _('th'), _('th'), _('th'), _('th'), _('th'), _('th'))
-    if value % 100 in (11, 12, 13): # special case
-        return "%d%s" % (value, suffixes[0])
-    return "%d%s" % (value, suffixes[value % 10])
+    if value % 100 in (11, 12, 13):  # special case
+        return mark_safe("%d%s" % (value, suffixes[0]))
+    # Mark value safe so i18n does not break with <sup> or <sub> see #19988
+    return mark_safe("%d%s" % (value, suffixes[value % 10]))
+
 
 @register.filter(is_safe=True)
 def intcomma(value, use_l10n=True):
@@ -97,6 +101,7 @@ intword_converters = (
     )),
 )
 
+
 @register.filter(is_safe=False)
 def intword(value):
     """
@@ -130,6 +135,7 @@ def intword(value):
             return _check_for_i18n(new_value, *converters(new_value))
     return value
 
+
 @register.filter(is_safe=True)
 def apnumber(value):
     """
@@ -143,6 +149,7 @@ def apnumber(value):
     if not 0 < value < 10:
         return value
     return (_('one'), _('two'), _('three'), _('four'), _('five'), _('six'), _('seven'), _('eight'), _('nine'))[value-1]
+
 
 # Perform the comparison in the default time zone when USE_TZ = True
 # (unless a specific time zone has been applied with the |timezone filter).
@@ -172,6 +179,7 @@ def naturalday(value, arg=None):
         return _('yesterday')
     return defaultfilters.date(value, arg)
 
+
 # This filter doesn't require expects_localtime=True because it deals properly
 # with both naive and aware datetimes. Therefore avoid the cost of conversion.
 @register.filter
@@ -180,7 +188,7 @@ def naturaltime(value):
     For date and time values shows how many seconds, minutes or hours ago
     compared to current timestamp returns representing string.
     """
-    if not isinstance(value, date): # datetime is a subclass of date
+    if not isinstance(value, date):  # datetime is a subclass of date
         return value
 
     now = datetime.now(utc if is_aware(value) else None)


### PR DESCRIPTION
I've updated the humanize function to fix the i18n issue of not allowing html to do the `<sup>` for some languages.  In particular the french translation. 

Ticket: https://code.djangoproject.com/ticket/19988

``` pthon
(djancon-sprint)➜  tests git:(#19988-ordinal-html-i18n-fix) ./runtests.py django.contrib.humanize
Creating test database for alias 'default'...
Creating test database for alias 'other'...
.............
----------------------------------------------------------------------
Ran 13 tests in 0.102s

OK
Destroying test database for alias 'default'...
Destroying test database for alias 'other'...
```
