### PR TITLE
Fixed #21043 - resolve doesn't handle lazily evaluated reverses

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -313,7 +313,7 @@ class RegexURLResolver(LocaleRegexProvider):
     def resolve(self, path):
         # Coerce path to text
         # Needed to force reverse_lazy objects to text
-        path = six.text_type(path)
+        path = force_text(path)
         tried = []
         match = self.regex.search(path)
         if match:

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -222,9 +222,7 @@ class ResolverTests(unittest.TestCase):
     def test_reverse_lazy_object_coercion_by_resolve(self):
         """
         Verifies lazy object returned by reverse_lazy is coerced to
-        text by resolve(). Previously to 21043, this would raise a TypeError.
-
-        Regression test #21043
+        text by resolve(). Previous to #21043, this would raise a TypeError.
         """
         urls = 'urlpatterns_reverse.named_urls'
         proxy_url = reverse_lazy('named-url1', urlconf=urls)


### PR DESCRIPTION
Use force_text to coerce object returned by reverse lazy to text.

https://code.djangoproject.com/ticket/21043
