### PR TITLE
Fixed #21057: FileSystemStorage can leave temporary files around.

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -215,6 +215,7 @@ class FileSystemStorage(Storage):
                                 _file = os.fdopen(fd, mode)
                             _file.write(chunk)
                     finally:
+                        content.close()
                         locks.unlock(fd)
                         if _file is not None:
                             _file.close()


### PR DESCRIPTION
This patch makes sure that the uploaded file is always closed, ensuring that temporary files get cleaned up.
