### PR TITLE
Update test utils_tests/test_html.py for python3

### DIFF
--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -87,7 +87,7 @@ class TestUtilsHtml(TestCase):
         # Test with more lengthy content (also catching performance regressions)
         for filename in ('strip_tags1.html', 'strip_tags2.txt'):
             path = os.path.join(os.path.dirname(upath(__file__)), 'files', filename)
-            with open(path, 'r') as fp:
+            with open(path, 'rb') as fp:
                 content = force_text(fp.read())
                 start = datetime.now()
                 stripped = html.strip_tags(content)


### PR DESCRIPTION
Python3 can't read files with binary data unless opened with 'b'.
This test passes on both python3 and python2.7 after this change.
