### PR TITLE
Fixed #21049 -- Fixed autoreload for Python 3

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -57,7 +57,7 @@ _error_files = []
 def code_changed():
     global _mtimes, _win
     filenames = []
-    for m in sys.modules.values():
+    for m in list(sys.modules.values()):
         try:
             filenames.append(m.__file__)
         except AttributeError:


### PR DESCRIPTION
Changed th system module values check to return a list.
In Python 3 it returns a dict_view which could occassionally produce
a runtime error of "dictionary changed size during iteration".
