### PR TITLE
Fixed #21013 -- ModelAdmin.get_queryset considered for Admin history.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1507,7 +1507,9 @@ class ModelAdmin(BaseModelAdmin):
         from django.contrib.admin.models import LogEntry
         # First check if the user can see this history.
         model = self.model
-        obj = get_object_or_404(model, pk=unquote(object_id))
+        obj = self.get_object(request, unquote(object_id))
+        if obj is None:
+            raise Http404('No %s matches the given query.' % model._meta.object_name)
 
         if not self.has_change_permission(request, obj):
             raise PermissionDenied

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -30,7 +30,7 @@ from .models import (Article, Chapter, Account, Media, Child, Parent, Picture,
     AdminOrderedField, AdminOrderedModelMethod, AdminOrderedAdminMethod,
     AdminOrderedCallable, Report, Color2, UnorderedObject, MainPrepopulated,
     RelatedPrepopulated, UndeletableObject, UnchangeableObject, UserMessenger, Simple, Choice,
-    ShortMessage, Telegram)
+    ShortMessage, Telegram, FilteredManager)
 
 
 def callable_year(dt_value):
@@ -674,6 +674,12 @@ def callable_on_unknown(obj):
 class AttributeErrorRaisingAdmin(admin.ModelAdmin):
     list_display = [callable_on_unknown, ]
 
+
+class CustomManagerAdmin(admin.ModelAdmin):
+    def get_queryset(self, request):
+        return FilteredManager.objects
+
+
 class MessageTestingAdmin(admin.ModelAdmin):
     actions = ["message_debug", "message_info", "message_success",
                "message_warning", "message_error", "message_extra_tags"]
@@ -773,6 +779,7 @@ site.register(Question)
 site.register(Answer)
 site.register(PrePopulatedPost, PrePopulatedPostAdmin)
 site.register(ComplexSortedPerson, ComplexSortedPersonAdmin)
+site.register(FilteredManager, CustomManagerAdmin)
 site.register(PluggableSearchPerson, PluggableSearchPersonAdmin)
 site.register(PrePopulatedPostLargeSlug, PrePopulatedPostLargeSlugAdmin)
 site.register(AdminOrderedField, AdminOrderedFieldAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -693,3 +693,14 @@ class Simple(models.Model):
 class Choice(models.Model):
     choice = models.IntegerField(blank=True, null=True,
         choices=((1, 'Yes'), (0, 'No'), (None, 'No opinion')))
+
+class _Manager(models.Manager):
+    def get_queryset(self):
+        return super(_Manager, self).get_queryset().filter(pk__gt=1)
+
+class FilteredManager(models.Model):
+    def __str__(self):
+        return "PK=%d" % self.pk
+
+    pk_gt_1 = _Manager()
+    objects = models.Manager()

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -48,7 +48,7 @@ from .models import (Article, BarAccount, CustomArticle, EmptyModel, FooAccount,
     AdminOrderedModelMethod, AdminOrderedAdminMethod, AdminOrderedCallable,
     Report, MainPrepopulated, RelatedPrepopulated, UnorderedObject,
     Simple, UndeletableObject, UnchangeableObject, Choice, ShortMessage,
-    Telegram, Pizza, Topping)
+    Telegram, Pizza, Topping, FilteredManager)
 from .admin import site, site2
 
 
@@ -2656,6 +2656,12 @@ class AdminCustomQuerysetTest(TestCase):
     def setUp(self):
         self.client.login(username='super', password='secret')
         self.pks = [EmptyModel.objects.create().id for i in range(3)]
+        self.super_login = {
+            REDIRECT_FIELD_NAME: '/test_admin/admin/',
+            LOGIN_FORM_KEY: 1,
+            'username': 'super',
+            'password': 'secret',
+        }
 
     def test_changelist_view(self):
         response = self.client.get('/test_admin/admin/admin_views/emptymodel/')
@@ -2872,6 +2878,16 @@ class AdminCustomQuerysetTest(TestCase):
             '<li class="success">The paper &quot;Paper_Deferred_author object&quot; was changed successfully.</li>',
             html=True
         )
+
+    def test_history_view_custom_qs(self):
+        self.client.post('/test_admin/admin/', self.super_login)
+        FilteredManager.objects.create(pk=1)
+        FilteredManager.objects.create(pk=2)
+        response = self.client.get('/test_admin/admin/admin_views/filteredmanager/')
+        self.assertContains(response, "PK=1")
+        self.assertContains(response, "PK=2")
+        self.assertEqual(self.client.get('/test_admin/admin/admin_views/filteredmanager/1/history/').status_code, 200)
+        self.assertEqual(self.client.get('/test_admin/admin/admin_views/filteredmanager/2/history/').status_code, 200)
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))


### PR DESCRIPTION
Admin history was using get_object to fetch the model instance instead
of relaying in get_queryset.

This patch modifies that behavior fixing the bug reported in
ticket #21013.
