### PR TITLE
Fixed #20821 -- Added tooltips to Admin SelectBox widget

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectBox.js
+++ b/django/contrib/admin/static/admin/js/SelectBox.js
@@ -16,7 +16,10 @@ var SelectBox = {
         for (var i = 0, j = SelectBox.cache[id].length; i < j; i++) {
             var node = SelectBox.cache[id][i];
             if (node.displayed) {
-                box.options[box.options.length] = new Option(node.text, node.value, false, false);
+                var new_option = new Option(node.text, node.value, false, false);
+                // Shows a tooltip when hovering over the option
+                new_option.setAttribute("title", node.text);
+                box.options[box.options.length] = new_option;
             }
         }
     },

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -699,7 +699,12 @@ class HorizontalVerticalFilterSeleniumFirefoxTests(AdminSeleniumWebDriverTestCas
         self.assertActiveButtons(mode, field_name, False, False, True, False)
 
         # Choose some options ------------------------------------------------
-        self.get_select_option(from_box, str(self.lisa.id)).click()
+        from_lisa_select_option = self.get_select_option(from_box, str(self.lisa.id))
+
+        # Check the title attribute is there for tool tips: ticket #20821
+        self.assertEqual(from_lisa_select_option.get_attribute('title'), from_lisa_select_option.get_attribute('text'))
+
+        from_lisa_select_option.click()
         self.get_select_option(from_box, str(self.jason.id)).click()
         self.get_select_option(from_box, str(self.bob.id)).click()
         self.get_select_option(from_box, str(self.john.id)).click()
@@ -713,6 +718,10 @@ class HorizontalVerticalFilterSeleniumFirefoxTests(AdminSeleniumWebDriverTestCas
         self.assertSelectOptions(to_box,
                         [str(self.lisa.id), str(self.bob.id),
                          str(self.jason.id), str(self.john.id)])
+
+        # Check the tooltip is still there after moving: ticket #20821
+        to_lisa_select_option = self.get_select_option(to_box, str(self.lisa.id))
+        self.assertEqual(to_lisa_select_option.get_attribute('title'), to_lisa_select_option.get_attribute('text'))
 
         # Remove some options -------------------------------------------------
         self.get_select_option(to_box, str(self.lisa.id)).click()


### PR DESCRIPTION
The Admin widget, which can be used to filter multiple selects
can sometimes be too narrow and hide information such as
user permissions. This commit adds tooltips to the select
options so that a user can hover over and see the hidden text.
