### PR TITLE
Fixed #20347 -- Added formset_factory absolute_max kwarg

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -398,19 +398,29 @@ def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
                     can_delete=False, max_num=None, validate_max=False,
                     absolute_max=None):
     """Return a FormSet for the given form class."""
+
+    # max_num is a limit on how many empty forms are created along with initial
+    # data
+    # absolute_max is a hard limit on forms instantiated, to prevent
+    # memory-exhaustion attacks. If not explicitly set, the default is
+    # max_num + DEFAULT_MAX_NUM
+
     if max_num is None:
-        if absolute_max is not None:
-            max_num = min(absolute_max, DEFAULT_MAX_NUM)
+        max_num = DEFAULT_MAX_NUM
+        if absolute_max is None:
+            absolute_max = max_num + DEFAULT_MAX_NUM
         else:
-            max_num = DEFAULT_MAX_NUM
-
-    # hard limit on forms instantiated, to prevent memory-exhaustion attacks
-    # if not explicitly set, the default is max_num + DEFAULT_MAX_NUM
-    if absolute_max is None:
-        absolute_max = max_num + DEFAULT_MAX_NUM
-
-    if absolute_max < max_num:
-        raise ValueError("max_num must be less than or equal to absolute_max")
+            if absolute_max < DEFAULT_MAX_NUM:
+                raise ValueError(
+                    'absolute_max must be greater than the default max_num ' +
+                    '({0})'.format(DEFAULT_MAX_NUM))
+    else:
+        if absolute_max is None:
+            absolute_max = max_num + DEFAULT_MAX_NUM
+        else:
+            if absolute_max < max_num:
+                raise ValueError(
+                    'max_num must be less than or equal to absolute_max')
 
     attrs = {'form': form, 'extra': extra,
              'can_order': can_order, 'can_delete': can_delete,

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -109,9 +109,9 @@ so long as the total number of forms does not exceed ``max_num``.
 
 A ``max_num`` value of ``None`` (the default) puts a high limit on the number
 of forms displayed (1000). In practice this is equivalent to no limit. If
-``max_num`` has a value of ``None`` and ``absolute_max`` is specified,
-``max_num`` will be set to the same value as ``absolute_max``. See
-:ref:`formsets-absolute-max`.
+``max_num`` has a value of ``None`` and ``absolute_max`` is specified with a
+value lower than the default max_num (1000), a ``ValueError`` will be
+raised. See :ref:`formsets-absolute-max`.
 
 If the number of forms in the initial data exceeds ``max_num``, all initial
 data forms will be displayed regardless.  (No extra forms will be displayed.)
@@ -165,6 +165,9 @@ An ``absolute_max`` value of ``None`` (the default) results in an
 
 If both ``absolute_max`` and ``max_number`` are specified and ``absolute_max``
 is less than ``max_number``, a ``ValueError`` will be raised.
+
+If ``max_num`` has a value of ``None`` and ``absolute_max`` is specified with a
+value lower than the default max_num (1000), a ``ValueError`` will be raised.
 
 .. seealso::
     :ref:`validate_max`

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -798,53 +798,64 @@ class FormsFormsetTestCase(TestCase):
             'form-MAX_NUM_FORMS': '0',
             }
 
-        #The default absolute_max is max_num + DEFAULT_MAX_NUM (which is 2*DEFAULT_MAX_NUM if max_num isn't specified)
+        # The default absolute_max is max_num + DEFAULT_MAX_NUM (which is
+        # 2*DEFAULT_MAX_NUM if max_num isn't specified)
         formset = FavoriteDrinksFormSet(data=data)
         self.assertFalse(formset.is_valid())
-        self.validate_formset_number_of_forms(formset, 2*formsets.DEFAULT_MAX_NUM)
+        self.validate_formset_number_of_forms(formset,
+                                              2*formsets.DEFAULT_MAX_NUM)
 
     def test_explicit_absolute_max_higher_than_default(self):
-        # absolute_max can now be explicitly specified via kwarg to formset_factory
-        # This behavior was changed from absolute_max always being max_num + 1000
-        # in the patch for #20347
+        # absolute_max can now be explicitly specified via kwarg to
+        # formset_factory.
+        # This behavior was changed from absolute_max always being max_num +
+        # 1000 in the patch for #20347
         data = {
             'form-TOTAL_FORMS': '2505',
             'form-INITIAL_FORMS': '0',
             'form-MAX_NUM_FORMS': '0',
             }
 
-        #absolute_max can now be explicitly set, not being affected by max_num or DEFAULT_MAX_NUM at all
-        HigherLimitFavoriteDrinksFormSet = formset_factory(FavoriteDrinkForm, max_num=1, absolute_max=3000)
+        # absolute_max can now be explicitly set, not being affected by
+        # max_num
+        # or DEFAULT_MAX_NUM at all
+        HigherLimitFavoriteDrinksFormSet = formset_factory(
+            FavoriteDrinkForm, max_num=1, absolute_max=3000)
         formset = HigherLimitFavoriteDrinksFormSet(data=data)
         self.assertTrue(formset.is_valid())
         self.validate_formset_number_of_forms(formset, 2505)
 
-        #verify that absolute_max still does provide a hard limit
+        # verify that absolute_max still does provide a hard limit
         data['form-TOTAL_FORMS'] = '3505'
-        HigherLimitFavoriteDrinksFormSet = formset_factory(FavoriteDrinkForm, max_num=1, absolute_max=3000)
+        HigherLimitFavoriteDrinksFormSet = formset_factory(
+            FavoriteDrinkForm, max_num=1, absolute_max=3000)
         formset = HigherLimitFavoriteDrinksFormSet(data=data)
         self.assertFalse(formset.is_valid())
         self.validate_formset_number_of_forms(formset, 3000)
 
-    def test_explicit_absolute_max_lower_than_default(self):
+    def test_explicit_absolute_max_lower_than_default_with_max_num(self):
         data = {
             'form-TOTAL_FORMS': '1000',
             'form-INITIAL_FORMS': '0',
             'form-MAX_NUM_FORMS': '0',
             }
 
-        LowerLimitFavoriteDrinksFormSet = formset_factory(FavoriteDrinkForm, absolute_max=30)
+        LowerLimitFavoriteDrinksFormSet = formset_factory(FavoriteDrinkForm,
+                                                          max_num=30,
+                                                          absolute_max=30)
         formset = LowerLimitFavoriteDrinksFormSet(data=data)
         self.assertFalse(formset.is_valid())
         self.validate_formset_number_of_forms(formset, 30)
 
 
+    def test_explicit_absolute_max_lower_than_default_no_max_num(self):
+        with self.assertRaises(ValueError):
+            formset_factory(FavoriteDrinkForm, absolute_max=30)
+
+
     def test_max_num_greater_than_absolute_max(self):
-        try:
+        with self.assertRaises(ValueError):
             formset_factory(FavoriteDrinkForm, max_num=100, absolute_max=30)
-            self.fail("Expected ValueError")
-        except ValueError:
-            pass
 
 
 


### PR DESCRIPTION
Added a keyword argument named absolute_max to django.forms.formsets.formset_factory(). This allows a developer to explicitly provide the absolute maximum number of forms to accept via POST, instead of relying on the former behavior limiting this to max_num + 1000. This separates the form display logic from the form processing logic.
