### PR TITLE
Fixed failing test introduced by 87d2750b39.

### DIFF
--- a/tests/regressiontests/templates/tests.py
+++ b/tests/regressiontests/templates/tests.py
@@ -1766,6 +1766,8 @@ class RequestContextTests(BaseTemplateResponseTest):
         )
 
 
+@unittest.skipIf(' ' in __file__,
+    "The {%% ssi %%} tag in Django 1.4 doesn't support spaces in path.")
 class SSITests(unittest.TestCase):
     def setUp(self):
         self.this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
The {% ssi %} tag in Django 1.4 doesn't support spaces in its argument.
Skip the test if run from a location that contains a space.
