### PR TITLE
Remove legacy format support for template kwargs

### DIFF
--- a/django/contrib/admin/templates/admin/actions.html
+++ b/django/contrib/admin/templates/admin/actions.html
@@ -8,7 +8,7 @@
         {% if cl.result_count != cl.result_list|length %}
         <span class="all">{{ selection_note_all }}</span>
         <span class="question">
-            <a href="javascript:;" title="{% trans "Click here to select the objects across all pages" %}">{% blocktrans with cl.result_count as total_count %}Select all {{ total_count }} {{ module_name }}{% endblocktrans %}</a>
+            <a href="javascript:;" title="{% trans "Click here to select the objects across all pages" %}">{% blocktrans with total_count=cl.result_count %}Select all {{ total_count }} {{ module_name }}{% endblocktrans %}</a>
         </span>
         <span class="clear"><a href="javascript:;">{% trans "Clear selection" %}</a></span>
         {% endif %}

--- a/django/contrib/admin/templates/admin/app_index.html
+++ b/django/contrib/admin/templates/admin/app_index.html
@@ -9,7 +9,7 @@
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
 &rsaquo;
 {% for app in app_list %}
-{% blocktrans with app.name as name %}{{ name }}{% endblocktrans %}
+{% blocktrans with name=app.name %}{{ name }}{% endblocktrans %}
 {% endfor %}
 </div>
 {% endblock %}

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -55,7 +55,7 @@
             <li>
               {% url cl.opts|admin_urlname:'add' as add_url %}
               <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
-                {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
+                {% blocktrans with name=cl.opts.verbose_name %}Add {{ name }}{% endblocktrans %}
               </a>
             </li>
           {% endblock %}

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -72,7 +72,7 @@
   $("#{{ inline_admin_formset.formset.prefix }}-group .tabular.inline-related tbody tr").tabularFormset({
     prefix: "{{ inline_admin_formset.formset.prefix }}",
     adminStaticPrefix: '{% static "admin/" %}',
-    addText: "{% blocktrans with inline_admin_formset.opts.verbose_name|title as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}",
+    addText: "{% blocktrans with verbose_name=inline_admin_formset.opts.verbose_name|title %}Add another {{ verbose_name }}{% endblocktrans %}",
     deleteText: "{% trans 'Remove' %}"
   });
 })(django.jQuery);

--- a/django/contrib/admindocs/templates/admin_doc/missing_docutils.html
+++ b/django/contrib/admindocs/templates/admin_doc/missing_docutils.html
@@ -14,9 +14,9 @@
 <h1>{% trans 'Documentation' %}</h1>
 
 <div id="content-main">
-  <h3>{% blocktrans with "http://docutils.sf.net/" as link %}The admin documentation system requires Python's <a href="{{ link }}">docutils</a> library.{% endblocktrans %}</h3>
+  <h3>{% blocktrans with link="http://docutils.sf.net/" %}The admin documentation system requires Python's <a href="{{ link }}">docutils</a> library.{% endblocktrans %}</h3>
 
-  <p>{% blocktrans with "http://docutils.sf.net/" as link %}Please ask your administrators to install <a href="{{ link }}">docutils</a>.{% endblocktrans %}</p>
+  <p>{% blocktrans with link="http://docutils.sf.net/" %}Please ask your administrators to install <a href="{{ link }}">docutils</a>.{% endblocktrans %}</p>
 </div>
 
 {% endblock %}

--- a/django/contrib/admindocs/templates/admin_doc/template_detail.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_detail.html
@@ -17,7 +17,7 @@
 
 {% regroup templates|dictsort:"site_id" by site as templates_by_site %}
 {% for group in templates_by_site %}
-    <h2>{% blocktrans with group.grouper as grouper %}Search path for template "{{ name }}" on {{ grouper }}:{% endblocktrans %}</h2>
+    <h2>{% blocktrans with grouper=group.grouper %}Search path for template "{{ name }}" on {{ grouper }}:{% endblocktrans %}</h2>
     <ol>
     {% for template in group.list|dictsort:"order" %}
         <li><code>{{ template.file }}</code>{% if not template.exists %} <em>{% trans '(does not exist)' %}</em>{% endif %}</li>

--- a/django/contrib/admindocs/templates/admin_doc/view_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_index.html
@@ -32,12 +32,12 @@
 
 {% for site_views in views_by_site %}
 <div class="module">
-<h2 id="site{{ site_views.grouper.id }}">{% blocktrans with site_views.grouper.name as name %}Views by URL on {{ name }}{% endblocktrans %}</h2>
+<h2 id="site{{ site_views.grouper.id }}">{% blocktrans with name=site_views.grouper.name %}Views by URL on {{ name }}{% endblocktrans %}</h2>
 
 {% for view in site_views.list|dictsort:"url" %}
 {% ifchanged %}
 <h3><a href="{% url 'django-admindocs-views-detail' view=view.full_name %}">{{ view.url }}</a></h3>
-<p class="small quiet">{% blocktrans with view.full_name as name %}View function: {{ name }}{% endblocktrans %}</p>
+<p class="small quiet">{% blocktrans with name=view.full_name %}View function: {{ name }}{% endblocktrans %}</p>
 <p>{{ view.title }}</p>
 <hr />
 {% endifchanged %}

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -886,17 +886,13 @@ class VariableNode(Node):
 # Regex for token keyword arguments
 kwarg_re = re.compile(r"(?:(\w+)=)?(.+)")
 
-def token_kwargs(bits, parser, support_legacy=False):
+def token_kwargs(bits, parser):
     """
     A utility method for parsing token keyword arguments.
 
     :param bits: A list containing remainder of the token (split by spaces)
         that is to be checked for arguments. Valid arguments will be removed
         from this list.
-
-    :param support_legacy: If set to true ``True``, the legacy format
-        ``1 as foo`` will be accepted. Otherwise, only the standard ``foo=1``
-        format is allowed.
 
     :returns: A dictionary of the arguments retrieved from the ``bits`` token
         list.
@@ -905,34 +901,14 @@ def token_kwargs(bits, parser, support_legacy=False):
     arguments, so the dictionary will be returned as soon as an invalid
     argument format is reached.
     """
-    if not bits:
-        return {}
-    match = kwarg_re.match(bits[0])
-    kwarg_format = match and match.group(1)
-    if not kwarg_format:
-        if not support_legacy:
-            return {}
-        if len(bits) < 3 or bits[1] != 'as':
-            return {}
-
     kwargs = {}
     while bits:
-        if kwarg_format:
-            match = kwarg_re.match(bits[0])
-            if not match or not match.group(1):
-                return kwargs
-            key, value = match.groups()
-            del bits[:1]
-        else:
-            if len(bits) < 3 or bits[1] != 'as':
-                return kwargs
-            key, value = bits[2], bits[0]
-            del bits[:3]
+        match = kwarg_re.match(bits[0])
+        if not match or not match.group(1):
+            return kwargs
+        key, value = match.groups()
+        del bits[:1]
         kwargs[key] = parser.compile_filter(value)
-        if bits and not kwarg_format:
-            if bits[0] != 'and':
-                return kwargs
-            del bits[:1]
     return kwargs
 
 def parse_bits(parser, bits, params, varargs, varkw, defaults,

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -1408,12 +1408,10 @@ def do_with(parser, token):
             ...
         {% endwith %}
 
-    The legacy format of ``{% with person.some_sql_method as total %}`` is
-    still accepted.
     """
     bits = token.split_contents()
     remaining_bits = bits[1:]
-    extra_context = token_kwargs(remaining_bits, parser, support_legacy=True)
+    extra_context = token_kwargs(remaining_bits, parser)
     if not extra_context:
         raise TemplateSyntaxError("%r expected at least one variable "
                                   "assignment" % bits[0])

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -225,7 +225,7 @@ def do_include(parser, token):
             raise TemplateSyntaxError('The %r option was specified more '
                                       'than once.' % option)
         if option == 'with':
-            value = token_kwargs(remaining_bits, parser, support_legacy=False)
+            value = token_kwargs(remaining_bits, parser)
             if not value:
                 raise TemplateSyntaxError('"with" in %r tag needs at least '
                                           'one keyword argument.' % bits[0])

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -387,11 +387,6 @@ def do_block_translate(parser, token):
 
     This is much like ngettext, only in template syntax.
 
-    The "var as value" legacy format is still supported::
-
-        {% blocktrans with foo|filter as bar and baz|filter as boo %}
-        {% blocktrans count var|length as count %}
-
     Contextual translations are supported::
 
         {% blocktrans with bar=foo|filter context "greeting" %}
@@ -411,12 +406,12 @@ def do_block_translate(parser, token):
             raise TemplateSyntaxError('The %r option was specified more '
                                       'than once.' % option)
         if option == 'with':
-            value = token_kwargs(remaining_bits, parser, support_legacy=True)
+            value = token_kwargs(remaining_bits, parser)
             if not value:
                 raise TemplateSyntaxError('"with" in %r tag needs at least '
                                           'one keyword argument.' % bits[0])
         elif option == 'count':
-            value = token_kwargs(remaining_bits, parser, support_legacy=True)
+            value = token_kwargs(remaining_bits, parser)
             if len(value) != 1:
                 raise TemplateSyntaxError('"count" in %r tag expected exactly '
                                           'one keyword argument.' % bits[0])

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -620,9 +620,6 @@ You can use multiple expressions inside a single ``blocktrans`` tag::
     This is {{ book_t }} by {{ author_t }}
     {% endblocktrans %}
 
-.. note:: The previous more verbose format is still supported:
-   ``{% blocktrans with book|title as book_t and author|title as author_t %}``
-
 If resolving one of the block arguments fails, blocktrans will fall back to
 the default language by deactivating the currently active language
 temporarily with the :func:`~django.utils.translation.deactivate_all`

--- a/tests/i18n/commands/templates/test.html
+++ b/tests/i18n/commands/templates/test.html
@@ -7,7 +7,7 @@ string's meaning unveiled
 
 {# Translators: Django template comment for translators #}
 <p>{% blocktrans %}I think that 100% is more that 50% of anything.{% endblocktrans %}</p>
-{% blocktrans with 'txt' as obj %}I think that 100% is more that 50% of {{ obj }}.{% endblocktrans %}
+{% blocktrans with obj='txt' %}I think that 100% is more that 50% of {{ obj }}.{% endblocktrans %}
 
 {% comment %}Some random comment
 Some random comment

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -933,7 +933,7 @@ class MiscTests(TransRealMixin, TestCase):
     @override_settings(LOCALE_PATHS=extended_locale_paths)
     def test_percent_in_translatable_block(self):
         t_sing = Template("{% load i18n %}{% blocktrans %}The result was {{ percent }}%{% endblocktrans %}")
-        t_plur = Template("{% load i18n %}{% blocktrans count num as number %}{{ percent }}% represents {{ num }} object{% plural %}{{ percent }}% represents {{ num }} objects{% endblocktrans %}")
+        t_plur = Template("{% load i18n %}{% blocktrans count number=num %}{{ percent }}% represents {{ num }} object{% plural %}{{ percent }}% represents {{ num }} objects{% endblocktrans %}")
         with translation.override('de'):
             self.assertEqual(t_sing.render(Context({'percent': 42})), 'Das Ergebnis war 42%')
             self.assertEqual(t_plur.render(Context({'percent': 42, 'num': 1})), '42% stellt 1 Objekt dar')
@@ -946,7 +946,7 @@ class MiscTests(TransRealMixin, TestCase):
         singular or plural
         """
         t_sing = Template("{% load i18n %}{% blocktrans %}There are %(num_comments)s comments{% endblocktrans %}")
-        t_plur = Template("{% load i18n %}{% blocktrans count num as number %}%(percent)s% represents {{ num }} object{% plural %}%(percent)s% represents {{ num }} objects{% endblocktrans %}")
+        t_plur = Template("{% load i18n %}{% blocktrans count number=num %}%(percent)s% represents {{ num }} object{% plural %}%(percent)s% represents {{ num }} objects{% endblocktrans %}")
         with translation.override('de'):
             # Strings won't get translated as they don't match after escaping %
             self.assertEqual(t_sing.render(Context({'num_comments': 42})), 'There are %(num_comments)s comments')

--- a/tests/template_tests/filters.py
+++ b/tests/template_tests/filters.py
@@ -327,7 +327,7 @@ def get_filter_tests():
         'length_is03': ('{% if mystring|length_is:"4" %}Four{% endif %}', {'mystring': 'word'}, 'Four'),
         'length_is04': ('{% if mystring|length_is:"4" %}Four{% else %}Not Four{% endif %}', {'mystring': 'Python'}, 'Not Four'),
         'length_is05': ('{% if mystring|length_is:"4" %}Four{% else %}Not Four{% endif %}', {'mystring': ''}, 'Not Four'),
-        'length_is06': ('{% with var|length as my_length %}{{ my_length }}{% endwith %}', {'var': 'django'}, '6'),
+        'length_is06': ('{% with my_length=var|length %}{{ my_length }}{% endwith %}', {'var': 'django'}, '6'),
         # Boolean return value from length_is should not be coerced to a string
         'length_is07': (r'{% if "X"|length_is:0 %}Length is 0{% else %}Length not 0{% endif %}', {}, 'Length not 0'),
         'length_is08': (r'{% if "X"|length_is:1 %}Length is 1{% else %}Length not 1{% endif %}', {}, 'Length is 1'),

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -1388,7 +1388,6 @@ class TemplateTests(TransRealMixin, TestCase):
 
             # simple translation of a variable and filter
             'i18n04': ('{% load i18n %}{% blocktrans with berta=anton|lower %}{{ berta }}{% endblocktrans %}', {'anton': b'\xc3\x85'}, 'å'),
-            'legacyi18n04': ('{% load i18n %}{% blocktrans with anton|lower as berta %}{{ berta }}{% endblocktrans %}', {'anton': b'\xc3\x85'}, 'å'),
 
             # simple translation of a string with interpolation
             'i18n05': ('{% load i18n %}{% blocktrans %}xxx{{ anton }}xxx{% endblocktrans %}', {'anton': 'yyy'}, "xxxyyyxxx"),
@@ -1398,11 +1397,9 @@ class TemplateTests(TransRealMixin, TestCase):
 
             # translation of singular form
             'i18n07': ('{% load i18n %}{% blocktrans count counter=number %}singular{% plural %}{{ counter }} plural{% endblocktrans %}', {'number': 1}, "singular"),
-            'legacyi18n07': ('{% load i18n %}{% blocktrans count number as counter %}singular{% plural %}{{ counter }} plural{% endblocktrans %}', {'number': 1}, "singular"),
 
             # translation of plural form
-            'i18n08': ('{% load i18n %}{% blocktrans count number as counter %}singular{% plural %}{{ counter }} plural{% endblocktrans %}', {'number': 2}, "2 plural"),
-            'legacyi18n08': ('{% load i18n %}{% blocktrans count counter=number %}singular{% plural %}{{ counter }} plural{% endblocktrans %}', {'number': 2}, "2 plural"),
+            'i18n08': ('{% load i18n %}{% blocktrans count counter=number %}singular{% plural %}{{ counter }} plural{% endblocktrans %}', {'number': 2}, "2 plural"),
 
             # simple non-translation (only marking) of a string to german
             'i18n09': ('{% load i18n %}{% trans "Page not found" noop %}', {'LANGUAGE_CODE': 'de'}, "Page not found"),
@@ -1430,8 +1427,6 @@ class TemplateTests(TransRealMixin, TestCase):
             'i18n20': ('{% load i18n %}{% trans andrew %}', {'andrew': 'a & b'}, 'a &amp; b'),
             'i18n21': ('{% load i18n %}{% blocktrans %}{{ andrew }}{% endblocktrans %}', {'andrew': mark_safe('a & b')}, 'a & b'),
             'i18n22': ('{% load i18n %}{% trans andrew %}', {'andrew': mark_safe('a & b')}, 'a & b'),
-            'legacyi18n17': ('{% load i18n %}{% blocktrans with anton|escape as berta %}{{ berta }}{% endblocktrans %}', {'anton': 'α & β'}, 'α &amp; β'),
-            'legacyi18n18': ('{% load i18n %}{% blocktrans with anton|force_escape as berta %}{{ berta }}{% endblocktrans %}', {'anton': 'α & β'}, 'α &amp; β'),
 
             # Use filters with the {% trans %} tag, #5972
             'i18n23': ('{% load i18n %}{% trans "Page not found"|capfirst|slice:"6:" %}', {'LANGUAGE_CODE': 'de'}, 'nicht gefunden'),
@@ -1440,15 +1435,12 @@ class TemplateTests(TransRealMixin, TestCase):
 
             # translation of plural form with extra field in singular form (#13568)
             'i18n26': ('{% load i18n %}{% blocktrans with extra_field=myextra_field count counter=number %}singular {{ extra_field }}{% plural %}plural{% endblocktrans %}', {'number': 1, 'myextra_field': 'test'}, "singular test"),
-            'legacyi18n26': ('{% load i18n %}{% blocktrans with myextra_field as extra_field count number as counter %}singular {{ extra_field }}{% plural %}plural{% endblocktrans %}', {'number': 1, 'myextra_field': 'test'}, "singular test"),
 
             # translation of singular form in russian (#14126)
             'i18n27': ('{% load i18n %}{% blocktrans count counter=number %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %}', {'number': 1, 'LANGUAGE_CODE': 'ru'}, '1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442'),
-            'legacyi18n27': ('{% load i18n %}{% blocktrans count number as counter %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %}', {'number': 1, 'LANGUAGE_CODE': 'ru'}, '1 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442'),
 
             # simple translation of multiple variables
             'i18n28': ('{% load i18n %}{% blocktrans with a=anton b=berta %}{{ a }} + {{ b }}{% endblocktrans %}', {'anton': 'α', 'berta': 'β'}, 'α + β'),
-            'legacyi18n28': ('{% load i18n %}{% blocktrans with anton as a and berta as b %}{{ a }} + {{ b }}{% endblocktrans %}', {'anton': 'α', 'berta': 'β'}, 'α + β'),
 
             # retrieving language information
             'i18n28_2': ('{% load i18n %}{% get_language_info for "de" as l %}{{ l.code }}: {{ l.name }}/{{ l.name_local }} bidi={{ l.bidi }}', {}, 'de: German/Deutsch bidi=False'),
@@ -1645,10 +1637,8 @@ class TemplateTests(TransRealMixin, TestCase):
 
             ### WITH TAG ########################################################
             'with01': ('{% with key=dict.key %}{{ key }}{% endwith %}', {'dict': {'key': 50}}, '50'),
-            'legacywith01': ('{% with dict.key as key %}{{ key }}{% endwith %}', {'dict': {'key': 50}}, '50'),
 
             'with02': ('{{ key }}{% with key=dict.key %}{{ key }}-{{ dict.key }}-{{ key }}{% endwith %}{{ key }}', {'dict': {'key': 50}}, ('50-50-50', 'INVALID50-50-50INVALID')),
-            'legacywith02': ('{{ key }}{% with dict.key as key %}{{ key }}-{{ dict.key }}-{{ key }}{% endwith %}{{ key }}', {'dict': {'key': 50}}, ('50-50-50', 'INVALID50-50-50INVALID')),
 
             'with03': ('{% with a=alpha b=beta %}{{ a }}{{ b }}{% endwith %}', {'alpha': 'A', 'beta': 'B'}, 'AB'),
 


### PR DESCRIPTION
Clearly we'll need to Deprecate this, however as it's been marked "legacy" for quite some time now, can it be a "fast" deprecation cycle?
