### PR TITLE
Fixed #21097 - Added DatabaseFeature.can_introspect_autofield

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -104,8 +104,11 @@ class Command(NoArgsCommand):
 
                 # Don't output 'id = meta.AutoField(primary_key=True)', because
                 # that's assumed if it doesn't exist.
-                if att_name == 'id' and field_type == 'AutoField(' and extra_params == {'primary_key': True}:
-                    continue
+                if att_name == 'id' and extra_params == {'primary_key': True}:
+                    if field_type == 'AutoField(':
+                        continue
+                    elif field_type == 'IntegerField(' and not connection.features.can_introspect_autofield:
+                        comment_notes.append('AutoField?')
 
                 # Add 'null' and 'blank', if the 'null_ok' flag was present in the
                 # table description.

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -627,6 +627,9 @@ class BaseDatabaseFeatures(object):
     # which can't do it for MyISAM tables
     can_introspect_foreign_keys = True
 
+    # Can the backend introspect an AutoField, instead of an IntegerField?
+    can_introspect_autofield = False
+
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -42,7 +42,8 @@ class InspectDBTestCase(TestCase):
             out_def = re.search(r'^\s*%s = (models.*)$' % name, output, re.MULTILINE).groups()[0]
             self.assertEqual(definition, out_def)
 
-        assertFieldType('id', "models.IntegerField(primary_key=True)")
+        if not connection.features.can_introspect_autofield:
+            assertFieldType('id', "models.IntegerField(primary_key=True) # AutoField?")
         assertFieldType('big_int_field', "models.BigIntegerField()")
         if connection.vendor == 'mysql':
             # No native boolean type on MySQL

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -66,8 +66,9 @@ class IntrospectionTests(TestCase):
         # field type on MySQL
         self.assertEqual(
             [datatype(r[1], r) for r in desc],
-            ['IntegerField', 'CharField', 'CharField', 'CharField',
-             'BigIntegerField', 'BinaryField' if connection.vendor != 'mysql' else 'TextField']
+            ['AutoField' if connection.features.can_introspect_autofield else 'IntegerField',
+             'CharField', 'CharField', 'CharField', 'BigIntegerField',
+             'BinaryField' if connection.vendor != 'mysql' else 'TextField']
         )
 
     # The following test fails on Oracle due to #17202 (can't correctly


### PR DESCRIPTION
None of the core backends currently support can_introspect_autofield.
