### PR TITLE
Fixed #21098 -- Applied sensitive_post_parameters to MultiValueDict

### DIFF
--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -24,7 +24,8 @@ from django.views.debug import ExceptionReporter
 from .. import BrokenException, except_args
 from ..views import (sensitive_view, non_sensitive_view, paranoid_view,
     custom_exception_reporter_filter_view, sensitive_method_view,
-    sensitive_args_function_caller, sensitive_kwargs_function_caller)
+    sensitive_args_function_caller, sensitive_kwargs_function_caller,
+    multivalue_dict_key_error)
 
 
 @override_settings(DEBUG=True, TEMPLATE_DEBUG=True)
@@ -510,6 +511,19 @@ class ExceptionReporterFilterTests(TestCase, ExceptionReportTestMixin):
         with self.settings(DEBUG=False):
             self.verify_paranoid_response(paranoid_view)
             self.verify_paranoid_email(paranoid_view)
+
+    def test_multivalue_dict_key_error(self):
+        """
+        #21098 -- Ensure that sensitive POST parameters cannot be seen in the
+        error reports for if request.POST['nonexistent_key'] throws an error.
+        """
+        with self.settings(DEBUG=True):
+            self.verify_unsafe_response(multivalue_dict_key_error)
+            self.verify_unsafe_email(multivalue_dict_key_error)
+
+        with self.settings(DEBUG=False):
+            self.verify_safe_response(multivalue_dict_key_error)
+            self.verify_safe_email(multivalue_dict_key_error)
 
     def test_custom_exception_reporter_filter(self):
         """

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -289,3 +289,16 @@ class Klass(object):
 
 def sensitive_method_view(request):
     return Klass().method(request)
+
+
+@sensitive_variables('sauce')
+@sensitive_post_parameters('bacon-key', 'sausage-key')
+def multivalue_dict_key_error(request):
+    cooked_eggs = ''.join(['s', 'c', 'r', 'a', 'm', 'b', 'l', 'e', 'd'])
+    sauce = ''.join(['w', 'o', 'r', 'c', 'e', 's', 't', 'e', 'r', 's', 'h', 'i', 'r', 'e'])
+    try:
+        request.POST['bar']
+    except Exception:
+        exc_info = sys.exc_info()
+        send_log(request, exc_info)
+        return technical_500_response(request, *exc_info)


### PR DESCRIPTION
Getting an error in MultiValueDict on a POST, such as doing request.POST['foo'], will leak the POST data without any escaping by Django, i.e. the MultiValueDictKeyError contains an unescaped repr of request.POST, no matter if you've added for instance @sensitive_post_parameters("password").

https://code.djangoproject.com/ticket/21098
