### PR TITLE
Fixed #17795 -- Pass kwargs to generic views context

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -332,7 +332,8 @@ class BaseDateListView(MultipleObjectMixin, DateMixin, View):
     def get(self, request, *args, **kwargs):
         self.date_list, self.object_list, extra_context = self.get_dated_items()
         context = self.get_context_data(object_list=self.object_list,
-                                        date_list=self.date_list)
+                                        date_list=self.date_list,
+                                        **kwargs)
         context.update(extra_context)
         return self.render_to_response(context)
 

--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -112,7 +112,7 @@ class BaseDetailView(SingleObjectMixin, View):
     """
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
-        context = self.get_context_data(object=self.object)
+        context = self.get_context_data(object=self.object, **kwargs)
         return self.render_to_response(context)
 
 

--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -158,7 +158,8 @@ class ProcessFormView(View):
         """
         form_class = self.get_form_class()
         form = self.get_form(form_class)
-        return self.render_to_response(self.get_context_data(form=form))
+        return self.render_to_response(
+            self.get_context_data(form=form, **kwargs))
 
     def post(self, request, *args, **kwargs):
         """

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -157,7 +157,7 @@ class BaseListView(MultipleObjectMixin, View):
             if is_empty:
                 raise Http404(_("Empty list and '%(class_name)s.allow_empty' is False.")
                         % {'class_name': self.__class__.__name__})
-        context = self.get_context_data()
+        context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 
 

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -6,9 +6,11 @@ from unittest import skipUnless
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, skipUnlessDBFeature
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils import timezone
 
+from . import views
 from .models import Book, BookSigning
 
 TZ_SUPPORT = hasattr(time, 'tzset')
@@ -132,6 +134,12 @@ class ArchiveIndexViewTests(TestCase):
         res = self.client.get('/dates/books/')
         self.assertEqual(res.status_code, 200)
         self.assertEqual(list(res.context['date_list']), list(reversed(sorted(res.context['date_list']))))
+
+    def test_datebaselistview_regression_t17795(self):
+        factory = RequestFactory()
+        request = factory.get('/dates/books/')
+        res = views.BookArchive.as_view()(request, foo='bar')
+        self.assertEqual(res.context_data.get('foo'), 'bar')
 
 
 class YearArchiveViewTests(TestCase):

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -3,9 +3,10 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.views.generic.base import View
+from django.test.client import RequestFactory
 
 from .models import Artist, Author, Page
-
+from . import views
 
 class DetailViewTest(TestCase):
     fixtures = ['generic-views-test-data.json']
@@ -99,3 +100,9 @@ class DetailViewTest(TestCase):
         res = self.client.get('/detail/nonmodel/1/')
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.context['object'].id, "non_model_1")
+
+    def test_detailview_regression_t17795(self):
+        factory = RequestFactory()
+        request = factory.get('/detail/author/1/')
+        res = views.AuthorDetail.as_view()(request, pk='1', foo='bar')
+        self.assertEqual(res.context_data.get('foo'), 'bar')

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -173,6 +173,15 @@ class CreateViewTests(TestCase):
         # but with a warning:
         self.assertEqual(w[0].category, DeprecationWarning)
 
+    def test_createview_passes_arguments_to_context(self):
+        """
+        Regression text for #17795
+        """
+        factory = RequestFactory()
+        request = factory.get('/edit/authors/create/')
+        res = views.AuthorCreate.as_view()(request, foo='bar')
+        self.assertEqual(res.context_data.get('foo'), 'bar')
+
 
 class UpdateViewTests(TestCase):
     urls = 'generic_views.urls'

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -3,11 +3,12 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.test.client import RequestFactory
 from django.views.generic.base import View
 from django.utils.encoding import force_str
 
 from .models import Author, Artist
-
+from . import views
 
 class ListViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
@@ -215,3 +216,12 @@ class ListViewTests(TestCase):
         Author.objects.all().delete()
         for i in range(n):
             Author.objects.create(name='Author %02i' % i, slug='a%s' % i)
+
+    def test_listview_passes_arguments_to_context(self):
+        """
+        Regression test for #17795
+        """
+        factory = RequestFactory()
+        request = factory.get('/list/authors/')
+        res = views.AuthorList.as_view()(request, foo='bar')
+        self.assertEqual(res.context_data.get('foo'), 'bar')


### PR DESCRIPTION
Thanks to Ed Crewe for reporting the issue and Fandekasp for
providing the patch.

https://code.djangoproject.com/ticket/17795
