### PR TITLE
[1.5.x] Fixed #21126 - Properly align resolve_columns fields for aggregates

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -895,7 +895,7 @@ class BaseDatabaseOperations(object):
         Coerce the value returned by the database backend into a consistent type
         that is compatible with the field type.
         """
-        if value is None:
+        if value is None or field is None:
             return value
         internal_type = field.get_internal_type()
         if internal_type == 'FloatField':


### PR DESCRIPTION
The 'row' passed to resolve_columns includes aggregate values, but
'fields' did not. This resulted in backends incorrectly aligning the
fields and values. 'fields' now includes None placeholders for each
aggregate value in the row.
