### PR TITLE
Allow the field index type to be specified via the db_index argument

### DIFF
--- a/django/db/backends/postgresql_psycopg2/creation.py
+++ b/django/db/backends/postgresql_psycopg2/creation.py
@@ -47,6 +47,11 @@ class DatabaseCreation(BaseDatabaseCreation):
     def sql_indexes_for_field(self, model, f, style):
         output = []
         if f.db_index or f.unique:
+            if isinstance(f.db_index, basestring):
+                index_type = f.db_index
+            else:
+                index_type = None
+
             qn = self.connection.ops.quote_name
             db_table = model._meta.db_table
             tablespace = f.db_tablespace or model._meta.db_tablespace
@@ -62,6 +67,7 @@ class DatabaseCreation(BaseDatabaseCreation):
                         style.SQL_TABLE(qn(truncate_name(index_name, self.connection.ops.max_name_length()))) + ' ' +
                         style.SQL_KEYWORD('ON') + ' ' +
                         style.SQL_TABLE(qn(db_table)) + ' ' +
+                        (style.SQL_KEYWORD('USING %s' % (index_type,)) if index_type is not None else '') +
                         "(%s%s)" % (style.SQL_FIELD(qn(f.column)), opclass) +
                         "%s;" % tablespace_sql)
 


### PR DESCRIPTION
The major use case here is being able to specify the index type for more exotic column types, like hstore.

I don't have easy access to databases other than Postgres, so I only modified that backend to use the feature.  
