### PR TITLE
Fixed #21122 -- Improved clean up of test temp directory on Windows

### DIFF
--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -174,3 +174,6 @@ class FileMoveSafeTests(unittest.TestCase):
 
         # should allow it and continue on if allow_overwrite is True
         self.assertIsNone(file_move_safe(self.file_a, self.file_b, allow_overwrite=True))
+
+        os.close(handle_a)
+        os.close(handle_b)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import warnings
 
+
 def upath(path):
     """
     Separate version of django.utils._os.upath. The django.utils version isn't
@@ -163,8 +164,8 @@ def setup(verbosity, test_labels):
             module_found_in_labels = True
         else:
             match = lambda label: (
-                module_label == label or # exact match
-                module_label.startswith(label + '.') # ancestor match
+                module_label == label or  # exact match
+                module_label.startswith(label + '.')  # ancestor match
                 )
 
             module_found_in_labels = any(match(l) for l in test_labels_set)
@@ -179,16 +180,23 @@ def setup(verbosity, test_labels):
 
     return state
 
+
 def teardown(state):
     from django.conf import settings
-    # Removing the temporary TEMP_DIR. Ensure we pass in unicode
-    # so that it will successfully remove temp trees containing
-    # non-ASCII filenames on Windows. (We're assuming the temp dir
-    # name itself does not contain non-ASCII characters.)
-    shutil.rmtree(six.text_type(TEMP_DIR))
+
+    try:
+        # Removing the temporary TEMP_DIR. Ensure we pass in unicode
+        # so that it will successfully remove temp trees containing
+        # non-ASCII filenames on Windows. (We're assuming the temp dir
+        # name itself does not contain non-ASCII characters.)
+        shutil.rmtree(six.text_type(TEMP_DIR))
+    except OSError:
+        print('Failed to remove temp directory: %s' % TEMP_DIR)
+
     # Restore the old settings.
     for key, value in state.items():
         setattr(settings, key, value)
+
 
 def django_tests(verbosity, interactive, failfast, test_labels):
     from django.conf import settings
@@ -278,6 +286,7 @@ def bisect_tests(bisection_label, options, test_labels):
         print("***** Source of error: %s" % test_labels[0])
     teardown(state)
 
+
 def paired_tests(paired_test, options, test_labels):
     state = setup(int(options.verbosity), test_labels)
 
@@ -312,6 +321,7 @@ def paired_tests(paired_test, options, test_labels):
 
     print('***** No problem pair found')
     teardown(state)
+
 
 if __name__ == "__main__":
     from optparse import OptionParser


### PR DESCRIPTION
- Fixed test that didn't close the files it opened
- Catching and handling exception when temp directory cannot be removed
- Fixed an unrelated bug that affects `bisect_tests()` under Python 3
  (having to do with true division always returning a float)
