### PR TITLE
Fix KeyError on password field.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -150,7 +150,7 @@ class UserChangeForm(forms.ModelForm):
         # Regardless of what the user provides, return the initial value.
         # This is done here, rather than on the field, because the
         # field does not have access to the initial value
-        return self.initial["password"]
+        return self.initial.get("password")
 
 
 class AuthenticationForm(forms.Form):


### PR DESCRIPTION
When the password field is disabled in a custom contrib.auth.admin.UserAdmin class (via fieldsets), saving the form raises a KeyError.
