### PR TITLE
Fixed #21141 -- Update Sphinx URL

### DIFF
--- a/docs/README
+++ b/docs/README
@@ -14,4 +14,4 @@ To create an HTML version of the docs:
 The documentation in _build/html/index.html can then be viewed in a web browser.
 
 [1] http://docutils.sourceforge.net/rst.html
-[2] http://sphinx.pocoo.org/
+[2] http://sphinx-doc.org/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ pygments_style = 'trac'
 # branch, which is located at this URL.
 intersphinx_mapping = {
     'python': ('http://docs.python.org/2.7', None),
-    'sphinx': ('http://sphinx.pocoo.org/', None),
+    'sphinx': ('http://sphinx-doc.org/', None),
     'six': ('http://pythonhosted.org/six/', None),
     'simplejson': ('http://simplejson.readthedocs.org/en/latest/', None),
 }

--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -42,7 +42,7 @@ Django's documentation uses the Sphinx__ documentation system, which in turn
 is based on docutils__. The basic idea is that lightly-formatted plain-text
 documentation is transformed into HTML, PDF, and any other output format.
 
-__ http://sphinx.pocoo.org/
+__ http://sphinx-doc.org/
 __ http://docutils.sourceforge.net/
 
 To actually build the documentation locally, you'll currently need to install
@@ -141,7 +141,7 @@ Django-specific markup
 Besides the `Sphinx built-in markup`__, Django's docs defines some extra
 description units:
 
-__ http://sphinx.pocoo.org/markup/desc.html
+__ http://sphinx-doc.org/markup/desc.html
 
 * Settings::
 
@@ -305,7 +305,7 @@ look better:
 
 * Add `info field lists`__ where appropriate.
 
-  __ http://sphinx.pocoo.org/markup/desc.html#info-field-lists
+  __ http://sphinx-doc.org/markup/desc.html#info-field-lists
 
 * Whenever possible, use links. So, use ``:setting:`ADMIN_FOR``` instead
   of ````ADMIN_FOR````.

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -192,7 +192,7 @@ You can get a local copy of the HTML documentation following a few easy steps:
     Generation of the Django documentation will work with Sphinx version 0.6
     or newer, but we recommend going straight to Sphinx 1.0.2 or newer.
 
-__ http://sphinx.pocoo.org/
+__ http://sphinx-doc.org/
 __ http://www.gnu.org/software/make/
 
 .. _differences-between-doc-versions:

--- a/docs/releases/1.0-beta-2.txt
+++ b/docs/releases/1.0-beta-2.txt
@@ -45,7 +45,7 @@ Refactored documentation
     have Sphinx installed, build the HTML yourself from the
     documentation files bundled with Django.
 
-.. _Sphinx: http://sphinx.pocoo.org/
+.. _Sphinx: http://sphinx-doc.org/
 .. _online: https://docs.djangoproject.com/
 
 Along with these new features, the Django team has also been hard at


### PR DESCRIPTION
Updated Sphinx URL from http://sphinx.pocoo.org/ to http://sphinx-doc.org/.
