### PR TITLE
Fixed #21702 - Added nested list different bullet styles

### DIFF
--- a/docs/_theme/djangodocs/static/djangodocs.css
+++ b/docs/_theme/djangodocs/static/djangodocs.css
@@ -64,6 +64,8 @@ ul { padding-left:30px; }
 ol { padding-left:30px; }
 ol.arabic li { list-style-type: decimal; }
 ul li { list-style-type:square; margin-bottom:.4em; }
+ul ul li { list-style-type:disc; margin-bottom:.4em; }
+ul ul ul li { list-style-type:circle; margin-bottom:.4em; }
 ol li { margin-bottom: .4em; }
 ul ul { padding-left:1.2em; }
 ul ul ul { padding-left:1em; }


### PR DESCRIPTION
This creates three levels of visual indentation in the documentation with the order square > disc > circle. It should make quickly scanning through the documentation contents easier. A similiar patch will be submitted alongside to the djangoproject.com repository.
