### PR TITLE
Fixed #20364 -Added a passing test that confirms URLs in quotes followed by commas are handled correctly by Chris Piwoński's patch.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -15,8 +15,8 @@ from .html_parser import HTMLParser, HTMLParseError
 
 
 # Configuration for urlize() function.
-TRAILING_PUNCTUATION = ['.', ',', ':', ';', '.)']
-WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('[', ']'), ('&lt;', '&gt;')]
+TRAILING_PUNCTUATION = ['.', ',', ':', ';', '.)', '"', '\'']
+WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('[', ']'), ('&lt;', '&gt;'), ('"', '"'), ('\'', '\'')]
 
 # List of possible strings used for bullets in bulleted lists.
 DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -324,6 +324,24 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(urlize('http://[2001:db8:cafe::2]/api/9'),
             '<a href="http://[2001:db8:cafe::2]/api/9" rel="nofollow">http://[2001:db8:cafe::2]/api/9</a>')
 
+        # Check urlize correctly include quotation marks in links - #20364
+        self.assertEqual(urlize('before "hi@example.com" afterwards'),
+                         u'before "<a href="mailto:hi@example.com">hi@example.com</a>" afterwards')
+        self.assertEqual(urlize('before hi@example.com" afterwards'),
+                         u'before <a href="mailto:hi@example.com">hi@example.com</a>" afterwards')
+        self.assertEqual(urlize('before "hi@example.com afterwards'),
+                         u'before "<a href="mailto:hi@example.com">hi@example.com</a> afterwards')
+        self.assertEqual(urlize('before \'hi@example.com\' afterwards'),
+                         u'before \'<a href="mailto:hi@example.com">hi@example.com</a>\' afterwards')
+        self.assertEqual(urlize('before hi@example.com\' afterwards'),
+                         u'before <a href="mailto:hi@example.com">hi@example.com</a>\' afterwards')
+        self.assertEqual(urlize('before \'hi@example.com afterwards'),
+                         u'before \'<a href="mailto:hi@example.com">hi@example.com</a> afterwards')
+
+        # Check urlize copes with commas following URLs in quotes - see #20364 
+        self.assertEqual(urlize('Email us at "hi@example.com", or phone us at +xx.yy'),
+            'Email us at "<a href="mailto:hi@example.com">hi@example.com</a>", or phone us at +xx.yy')
+
     def test_wordcount(self):
         self.assertEqual(wordcount(''), 0)
         self.assertEqual(wordcount('oneword'), 1)


### PR DESCRIPTION
It has been suggested that the patch 20364.diff would not correctly handle a URL in quotes followed by a comma, but this is not the case.

https://code.djangoproject.com/ticket/20364
