### PR TITLE
Fixes #21140 -- Adds ref to Using cached sessions

### DIFF
--- a/docs/topics/performance.txt
+++ b/docs/topics/performance.txt
@@ -298,6 +298,12 @@ HTML, CSS, and JavaScript. They remove uneccessary whitespace, newlines, and
 comments, and shorten variable names, and thus reduce the size of the documents
 that your site publishes.
 
+:ref:`Using cached sessions <cached-sessions-backend>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`Using cached sessions <cached-sessions-backend>` may also be a way to
+increase performance by eliminating the need to load session data from storage
+and instead stores frequently used session data in memory.
+
 Template performance
 ====================
 


### PR DESCRIPTION
A Reference to 'Using cached sessions' added to the HTTP section of
the performance page together with a short summary.

Done during EvilDMP's sprint at PyConUK.
