### PR TITLE
Fixed #4492 - Provide tests for mixed-case column names

### DIFF
--- a/tests/backends/models.py
+++ b/tests/backends/models.py
@@ -112,16 +112,16 @@ class ObjectReference(models.Model):
         return str(self.obj_id)
 
 @python_2_unicode_compatible
-class Mixed_Case_Table(models.Model):
-    '''
+class MixedCaseTable(models.Model):
+    """
     Testing mixed case entity names, Pay attention to attribute names: 
       some characters are intentionally uppercase to see how your DB of choice handles them
-    '''
+    """
     id = models.IntegerField(primary_key=True)
     sum_Field = models.IntegerField()
 
     class Meta:
-        db_table = "Mixed_Case_Table"
+        db_table = "MixedCaseTable"
 
     def __str__(self):
         return '%d %d' % (self.id, self.sum_Field)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -965,37 +965,37 @@ class BackendUtilTests(TestCase):
               '0')
 
 class TestMixedCaseEntityNames(TestCase):
-    '''
+    """
     Test for mixed case entity names. Will test particulary PostgreSQL,
     but other RDBMSs should handle this test equally well
-    '''
+    """
 
     def _build_records(self):
-        rec = models.Mixed_Case_Table(id=1, sum_Field=2)
+        rec = models.MixedCaseTable(id=1, sum_Field=2)
         rec.save()
-        rec = models.Mixed_Case_Table(id=2, sum_Field=3)
+        rec = models.MixedCaseTable(id=2, sum_Field=3)
         rec.save()
         
     def test_mixed_case_table_create(self):
         # Note that the table is already created, so we just insert the records
-        statements = connection.creation.sql_create_model(models.Mixed_Case_Table,
+        statements = connection.creation.sql_create_model(models.MixedCaseTable,
             style=no_style())
         self._build_records()
         
     def test_mixed_case_table_select(self):
         self._build_records()
-        res = models.Mixed_Case_Table.objects.all()
+        res = models.MixedCaseTable.objects.all()
         self.assertEqual(len(res), 2)
 
     def test_mixed_case_table_select_aggregate(self):
         self._build_records()
-        res = models.Mixed_Case_Table.objects.all().aggregate(Sum('sum_Field'))
+        res = models.MixedCaseTable.objects.all().aggregate(Sum('sum_Field'))
         self.assertEqual(res.values()[0], 5)
 
     def test_mixed_case_table_select_manual(self):
-        '''Manual check because if nothing is quoted, everything works, otherwise, it all fails'''
+        # Manual check because if nothing is quoted, everything works, otherwise, it all fails
         c = connection.cursor()
-        c.execute('select "sum_Field" from "Mixed_Case_Table"')
+        c.execute('select "sum_Field" from "MixedCaseTable"')
         c.close()
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/4492
I created a model for testing mixed case entity names + a suite of 4 tests that test that. Since PostgreSQL lowercases everything not in quotes, usually only the last test would fail if this isn't implemented properly in the drivers.
Tested the unit-tests on PostgreSQL 9.2 and SQLite
