### PR TITLE
Make resolve_url support relative URLs

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -383,6 +383,10 @@ class RegexURLResolver(LocaleRegexProvider):
         text_args = [force_text(v) for v in args]
         text_kwargs = dict((k, force_text(v)) for (k, v) in kwargs.items())
 
+        if isinstance(lookup_view, six.string_types):
+            # Handle relative URLs
+            if any(lookup_view.startswith(path) for path in ('./', '../')):
+                return lookup_view
         try:
             lookup_view = get_callable(lookup_view, True)
         except (ImportError, AttributeError) as e:

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -677,6 +677,9 @@ Requests
 * The new :attr:`HttpRequest.scheme <django.http.HttpRequest.scheme>` attribute
   specifies the scheme of the request (``http`` or ``https`` normally).
 
+* The shortcut :func:`redirect() <django.shortcuts.redirect>` now supports
+  relative URLs.
+
 Tests
 ^^^^^
 

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -203,7 +203,8 @@ If you want to override the :setting:`TEMPLATE_DIRS` setting, use the
      <django.core.urlresolvers.reverse>` will be used to reverse-resolve the
      name.
 
-   * A URL, which will be used as-is for the redirect location.
+   * An absolute or relative URL, which will be used as-is for the redirect
+     location.
 
    By default issues a temporary redirect; pass ``permanent=True`` to issue a
    permanent redirect

--- a/tests/resolve_url/tests.py
+++ b/tests/resolve_url/tests.py
@@ -21,6 +21,16 @@ class ResolveUrlTests(TestCase):
         """
         self.assertEqual('/something/', resolve_url('/something/'))
 
+    def test_relative_path(self):
+        """
+        Tests that passing a relative URL path to ``resolve_url`` will result
+        in the same url.
+        """
+        self.assertEqual('../', resolve_url('../'))
+        self.assertEqual('../relative/', resolve_url('../relative/'))
+        self.assertEqual('./', resolve_url('./'))
+        self.assertEqual('./relative/', resolve_url('./relative/'))
+
     def test_full_url(self):
         """
         Tests that passing a full URL to ``resolve_url`` will result in the


### PR DESCRIPTION
This fixes redirecting to relative URLs with django.shortcuts.redirect

Supporting relatives url is kind of a controversial topic. But it seems that the choice to support relative URLs has [been made](https://code.djangoproject.com/ticket/987), and [there's code to support it](https://github.com/django/django/blob/636860fbfb4e34e08749d4576bc9571028150526/django/core/handlers/base.py#L24).
