### PR TITLE
Fixed #21126 -- QuerySet value conversion failure

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -1167,7 +1167,7 @@ class BaseDatabaseOperations(object):
         Coerce the value returned by the database backend into a consistent type
         that is compatible with the field type.
         """
-        if value is None:
+        if value is None or field is None:
             return value
         internal_type = field.get_internal_type()
         if internal_type == 'FloatField':

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -686,6 +686,10 @@ class SQLCompiler(object):
         has_aggregate_select = bool(self.query.aggregate_select)
         for rows in self.execute_sql(MULTI):
             for row in rows:
+                if has_aggregate_select:
+                    loaded_fields = self.query.get_loaded_field_names().get(self.query.model, set()) or self.query.select
+                    aggregate_start = len(self.query.extra_select) + len(loaded_fields)
+                    aggregate_end = aggregate_start + len(self.query.aggregate_select)
                 if resolve_columns:
                     if fields is None:
                         # We only set this up here because
@@ -712,12 +716,14 @@ class SQLCompiler(object):
                             db_table = self.query.get_meta().db_table
                             fields = [f for f in fields if db_table in only_load and
                                       f.column in only_load[db_table]]
+                        if has_aggregate_select:
+                            # pad None in to fields for aggregates
+                            fields = fields[:aggregate_start] + [
+                                None for x in range(0, aggregate_end - aggregate_start)
+                            ] + fields[aggregate_start:]
                     row = self.resolve_columns(row, fields)
 
                 if has_aggregate_select:
-                    loaded_fields = self.query.get_loaded_field_names().get(self.query.model, set()) or self.query.select
-                    aggregate_start = len(self.query.extra_select) + len(loaded_fields)
-                    aggregate_end = aggregate_start + len(self.query.aggregate_select)
                     row = tuple(row[:aggregate_start]) + tuple(
                         self.query.resolve_aggregate(value, aggregate, self.connection)
                         for (alias, aggregate), value

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -393,6 +393,17 @@ class AggregationTests(TestCase):
         qs = Entries.objects.annotate(clue_count=Count('clues__ID'))
         self.assertQuerysetEqual(qs, [])
 
+    def test_boolean_conversion(self):
+        # Aggregates mixed up ordering of columns for backend's convert_values
+        # method. Refs #21126.
+        e = Entries.objects.create(Entry='foo')
+        c = Clues.objects.create(EntryID=e, Clue='bar')
+        qs = Clues.objects.select_related('EntryID').annotate(Count('ID'))
+        self.assertQuerysetEqual(
+            qs, [c], lambda x: x)
+        self.assertEqual(qs[0].EntryID, e)
+        self.assertIs(qs[0].EntryID.Exclude, False)
+
     def test_empty(self):
         # Regression for #10089: Check handling of empty result sets with
         # aggregates


### PR DESCRIPTION
A .annotate().select_related() query resulted in misaligned rows vs
columns for compiler.resolve_columns() method.

Report & patch by Michael Manfre.

For master and 1.6 this seems safe enough to do.

For 1.5.x the question is will some backends (either core or 3rd party) fail for None fields in convert_values(). Here the other choices seem to be (for 1.5.x only):
- No backpatch
- Create a fake field (either plain Field() or something similar to what gis uses in django.contrib.gis.db.models.sql.conversion.py:BaseField)

I talked about this with manfre on IRC and we agreed that None is safe enough. But I have a bad feeling about this as "upgrade django, site doesn't work" situation is possible.

For core the question is if Oracle works - I am pretty sure it does, but I can't verify this as I don't currently have Oracle available.
