### PR TITLE
Fixed regression introduced by 04a2a6b.

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -335,6 +335,7 @@ def create_generic_related_manager(superclass):
                 object_id_field_name = self.object_id_field_name,
                 prefetch_cache_name = self.prefetch_cache_name,
             )
+        do_not_call_in_templates = True
 
         def get_queryset(self):
             try:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -379,6 +379,7 @@ def create_foreign_related_manager(superclass, rel_field, rel_model):
             manager = getattr(self.model, kwargs.pop('manager'))
             manager_class = create_foreign_related_manager(manager.__class__, rel_field, rel_model)
             return manager_class(self.instance)
+        do_not_call_in_templates = True
 
         def get_queryset(self):
             try:
@@ -540,6 +541,7 @@ def create_many_related_manager(superclass, rel):
                 through=self.through,
                 prefetch_cache_name=self.prefetch_cache_name,
             )
+        do_not_call_in_templates = True
 
         def get_queryset(self):
             try:

--- a/tests/managers_regress/models.py
+++ b/tests/managers_regress/models.py
@@ -3,7 +3,9 @@ Various edge-cases for model managers.
 """
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import python_2_unicode_compatible, force_text
 
 
 class OnlyFred(models.Manager):
@@ -119,3 +121,26 @@ class Child6(Child4):
 # Will not inherit default manager from parent.
 class Child7(Parent):
     pass
+
+
+# RelatedManagers
+@python_2_unicode_compatible
+class RelatedModel(models.Model):
+    test_gfk = generic.GenericRelation('RelationModel', content_type_field='gfk_ctype', object_id_field='gfk_id')
+
+    def __str__(self):
+        return force_text(self.pk)
+
+
+@python_2_unicode_compatible
+class RelationModel(models.Model):
+    fk = models.ForeignKey(RelatedModel, related_name='test_fk')
+
+    m2m = models.ManyToManyField(RelatedModel, related_name='test_m2m')
+
+    gfk_ctype = models.ForeignKey(ContentType)
+    gfk_id = models.IntegerField()
+    gfk = generic.GenericForeignKey(ct_field='gfk_ctype', fk_field='gfk_id')
+
+    def __str__(self):
+        return force_text(self.pk)


### PR DESCRIPTION
#3871 made RelatedManager a callable and when DTL picks up a callable

it tries to call it. By adding a do_not_call_in_templates=True attribute
to RelatedManager we prevent this behavior.

Thanks jbg@ for the report.

Fixed #3871
