### PR TITLE
Fixed #21203 -- resolve_columns fields misalignment

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -713,9 +713,8 @@ class SQLCompiler(object):
                         # into `resolve_columns` because it wasn't selected.
                         only_load = self.deferred_to_columns()
                         if only_load:
-                            db_table = self.query.get_meta().db_table
-                            fields = [f for f in fields if db_table in only_load and
-                                      f.column in only_load[db_table]]
+                            fields = [f for f in fields if f.model._meta.db_table not in only_load or
+                                      f.column in only_load[f.model._meta.db_table]]
                         if has_aggregate_select:
                             # pad None in to fields for aggregates
                             fields = fields[:aggregate_start] + [

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -535,3 +535,12 @@ class StaffUser(BaseUser):
 
     def __str__(self):
         return self.staff
+
+class Ticket21203Parent(models.Model):
+    parentid = models.AutoField(primary_key=True)
+    parent_bool = models.BooleanField(default=True)
+    created = models.DateTimeField(auto_now=True)
+
+class Ticket21203Child(models.Model):
+    childid = models.AutoField(primary_key=True)
+    parent = models.ForeignKey(Ticket21203Parent)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -26,7 +26,7 @@ from .models import (
     ModelA, ModelB, ModelC, ModelD, Responsibility, Job, JobResponsibilities,
     BaseA, FK1, Identifier, Program, Channel, Page, Paragraph, Chapter, Book,
     MyObject, Order, OrderItem, SharedConnection, Task, Staff, StaffUser,
-    CategoryRelationship)
+    CategoryRelationship, Ticket21203Parent, Ticket21203Child)
 
 class BaseQuerysetTest(TestCase):
     def assertValueQuerysetEqual(self, qs, values):
@@ -3071,3 +3071,11 @@ class Ticket20955Tests(TestCase):
                              task_get.creator.staffuser.staff)
             self.assertEqual(task_select_related.owner.staffuser.staff,
                              task_get.owner.staffuser.staff)
+
+class Ticket21203Tests(TestCase):
+    def test_ticket_21203(self):
+        p = Ticket21203Parent.objects.create(parent_bool=True)
+        c = Ticket21203Child.objects.create(parent=p)
+        qs = Ticket21203Child.objects.select_related('parent').defer('parent__created')
+        self.assertQuerysetEqual(qs, [c], lambda x: x)
+        self.assertIs(qs[0].parent.parent_bool, True)


### PR DESCRIPTION
In queries using .defer() together with .select_related() the values
and fields arguments didn't align properly for resolve_columns().
