### PR TITLE
Accounted for r000 string in gis version regex.

### DIFF
--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -102,7 +102,10 @@ geos_version.restype = c_char_p
 
 # Regular expression should be able to parse version strings such as
 # '3.0.0rc4-CAPI-1.3.3', '3.0.0-CAPI-1.4.1' or '3.4.0dev-CAPI-1.8.0'
-version_regex = re.compile(r'^(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<subminor>\d+))((rc(?P<release_candidate>\d+))|dev)?-CAPI-(?P<capi_version>\d+\.\d+\.\d+)$')
+version_regex = re.compile(
+    r'^(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<subminor>\d+))'
+    r'((rc(?P<release_candidate>\d+))|dev)?-CAPI-'
+    r'(?P<capi_version>\d+\.\d+\.\d+)( r\d+)?$')
 def geos_version_info():
     """
     Returns a dictionary containing the various version metadata parsed from


### PR DESCRIPTION
Proposed fix for GEOS Version Regex.  This problem occurs on Mac OSX.  Example - the version info string was "3.4.2-CAPI-1.8.2 r3921" and the regex parser was not expecting the trailing " r3921". 
