### PR TITLE
Fixed #21236: migrations should work with convenient unique_together

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1,5 +1,6 @@
 from .base import Operation
 from django.db import models, router
+from django.db.models.options import normalize_unique_together
 from django.db.migrations.state import ModelState
 
 
@@ -108,6 +109,7 @@ class AlterUniqueTogether(Operation):
 
     def __init__(self, name, unique_together):
         self.name = name
+        unique_together = normalize_unique_together(list(unique_together))
         self.unique_together = set(tuple(cons) for cons in unique_together)
 
     def state_forwards(self, app_label, state):

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -25,6 +25,11 @@ DEFAULT_NAMES = ('verbose_name', 'verbose_name_plural', 'db_table', 'ordering',
                  'index_together', 'app_cache', 'default_permissions',
                  'select_on_save')
 
+def normalize_unique_together(unique_together):
+    if unique_together and not isinstance(unique_together[0], (tuple, list)):
+        unique_together = (unique_together,)
+    return unique_together
+
 @python_2_unicode_compatible
 class Options(object):
     def __init__(self, meta, app_label=None):
@@ -112,9 +117,7 @@ class Options(object):
             # tuple of two strings. Normalize it to a tuple of tuples, so that
             # calling code can uniformly expect that.
             ut = meta_attrs.pop('unique_together', self.unique_together)
-            if ut and not isinstance(ut[0], (tuple, list)):
-                ut = (ut,)
-            self.unique_together = ut
+            self.unique_together = normalize_unique_together(ut)
 
             # verbose_name_plural is a special case because it uses a 's'
             # by default.

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -267,6 +267,10 @@ class OperationTests(MigrationTestBase):
         cursor.execute("INSERT INTO test_alunto_pony (id, pink, weight) VALUES (1, 1, 1)")
         cursor.execute("INSERT INTO test_alunto_pony (id, pink, weight) VALUES (2, 1, 1)")
         cursor.execute("DELETE FROM test_alunto_pony")
+        # Test flat unique_together
+        operation = migrations.AlterUniqueTogether("Pony", ("pink", "weight"))
+        operation.state_forwards("test_alunto", new_state)
+        self.assertEqual(len(new_state.models["test_alunto", "pony"].options.get("unique_together", set())), 1)
 
     def test_alter_index_together(self):
         """


### PR DESCRIPTION
Hi,

This is regarding #21236 [0] where migrations with unique_together fail if the meta attribute is a flat tuple (instead of nested tuple). This is currently supported by django for convenience. 

Thanks,
Javed

[0] https://code.djangoproject.com/ticket/21236
