### PR TITLE
Allow ssh URLs to pass URLValidator

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -41,7 +41,7 @@ class RegexValidator(object):
 
 class URLValidator(RegexValidator):
     regex = re.compile(
-        r'^(?:http|ftp)s?://'  # http:// or https://
+        r'^(?:(?:http|ftp)s?|ssh)://'  # http:// or https://
         r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
         r'localhost|'  # localhost...
         r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # ...or ipv4

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -145,6 +145,7 @@ TEST_DATA = (
     (URLValidator(), 'http://valid-----hyphens.com/', None),
     (URLValidator(), 'http://example.com?something=value', None),
     (URLValidator(), 'http://example.com/index.php?something=value&another=value2', None),
+    (URLValidator(), 'ssh://example.com/', None),
 
     (URLValidator(), 'foo', ValidationError),
     (URLValidator(), 'http://', ValidationError),


### PR DESCRIPTION
The generic definition of Uniform Resource Locator doesn't include any
restriction on the scheme, so Django's URLValidator should at least
accept the most common ones. This includes ssh://.

Refs #21242 -- Allow more IANA schemes in URLValidator
