### PR TITLE
Fixed #7603 -- Added a 'scheme' property to the HttpRequest object

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -38,7 +38,7 @@ def bookmarklets(request):
     admin_root = urlresolvers.reverse('admin:index')
     return render_to_response('admin_doc/bookmarklets.html', {
         'root_path': admin_root,
-        'admin_url': "%s://%s%s" % ('https' if request.is_secure() else 'http', request.get_host(), admin_root),
+        'admin_url': "%s://%s%s" % (request.scheme, request.get_host(), admin_root),
     }, context_instance=RequestContext(request))
 
 @staff_member_required

--- a/django/contrib/contenttypes/views.py
+++ b/django/contrib/contenttypes/views.py
@@ -75,7 +75,7 @@ def shortcut(request, content_type_id, object_id):
     # If all that malarkey found an object domain, use it. Otherwise, fall back
     # to whatever get_absolute_url() returned.
     if object_domain is not None:
-        protocol = 'https' if request.is_secure() else 'http'
+        protocol = request.scheme
         return http.HttpResponseRedirect('%s://%s%s'
                                          % (protocol, object_domain, absurl))
     else:

--- a/django/contrib/gis/sitemaps/views.py
+++ b/django/contrib/gis/sitemaps/views.py
@@ -21,7 +21,7 @@ def index(request, sitemaps):
     """
     current_site = get_current_site(request)
     sites = []
-    protocol = 'https' if request.is_secure() else 'http'
+    protocol = request.scheme
     for section, site in sitemaps.items():
         if callable(site):
             pages = site().paginator.num_pages

--- a/django/contrib/sitemaps/views.py
+++ b/django/contrib/sitemaps/views.py
@@ -22,7 +22,7 @@ def index(request, sitemaps,
           template_name='sitemap_index.xml', content_type='application/xml',
           sitemap_url_name='django.contrib.sitemaps.views.sitemap'):
 
-    req_protocol = 'https' if request.is_secure() else 'http'
+    req_protocol = request.scheme
     req_site = get_current_site(request)
 
     sites = []
@@ -44,7 +44,7 @@ def index(request, sitemaps,
 def sitemap(request, sitemaps, section=None,
             template_name='sitemap.xml', content_type='application/xml'):
 
-    req_protocol = 'https' if request.is_secure() else 'http'
+    req_protocol = request.scheme
     req_site = get_current_site(request)
 
     if section is not None:

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -110,8 +110,8 @@ class WSGIRequest(http.HttpRequest):
         self._read_started = False
         self.resolver_match = None
 
-    def _is_secure(self):
-        return self.environ.get('wsgi.url_scheme') == 'https'
+    def _get_scheme(self):
+        return self.environ.get('wsgi.url_scheme')
 
     def _parse_content_type(self, ctype):
         """

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -85,7 +85,7 @@ class CommonMiddleware(object):
             return
         if new_url[0]:
             newurl = "%s://%s%s" % (
-                'https' if request.is_secure() else 'http',
+                request.scheme,
                 new_url[0], urlquote(new_url[1]))
         else:
             newurl = urlquote(new_url[1])

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -51,8 +51,8 @@ class LocaleMiddleware(object):
 
             if path_valid:
                 language_url = "%s://%s/%s%s" % (
-                    'https' if request.is_secure() else 'http',
-                    request.get_host(), language, request.get_full_path())
+                    request.scheme, request.get_host(), language, 
+                    request.get_full_path())
                 return self.response_redirect_class(language_url)
 
         # Store language back into session if it is not present

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -32,6 +32,13 @@ Attributes
 All attributes should be considered read-only, unless stated otherwise below.
 ``session`` is a notable exception.
 
+.. attribute:: HttpRequest.scheme
+
+   .. versionadded:: 1.7
+
+   A string representing the scheme of the request (``http`` or ``https`` 
+   usually).
+
 .. attribute:: HttpRequest.body
 
     The raw HTTP request body as a byte string. This is useful for processing

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -367,6 +367,12 @@ Templates
   <naive_vs_aware_datetimes>` ``datetime`` instances performing the expected
   rendering.
 
+Requests
+^^^^^^^^
+
+* The new :attr:`HttpRequest.scheme <django.http.HttpRequest.scheme>` attribute
+  specifies the scheme of the request (``http`` or ``https`` normally).
+
 Tests
 ^^^^^
 


### PR DESCRIPTION
HttpRequest.scheme uses self.is_secure() to determine if scheme is
'http' or 'https' wether WSGIRequest.scheme makes use of the
'wsgi.url_scheme' WSGI environ variable.

This provides a handful method to check for current scheme in, for
example, templates. It also allows to deal with other schemes.
