### PR TITLE
Fixed #21263 -- Fixed issue with override_settings in inherited classes

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -157,6 +157,7 @@ class SimpleTestCase(unittest.TestCase):
     # The class we'll use for the test client self.client.
     # Can be overridden in derived classes.
     client_class = Client
+    _custom_settings = None
 
     def __call__(self, result=None):
         """
@@ -193,6 +194,9 @@ class SimpleTestCase(unittest.TestCase):
         * If the class has a 'urls' attribute, replace ROOT_URLCONF with it.
         * Clearing the mail test outbox.
         """
+        if self._custom_settings:
+            self._overridden = override_settings(**self._custom_settings)
+            self._overridden.enable()
         self.client = self.client_class()
         self._urlconf_setup()
         mail.outbox = []
@@ -210,6 +214,8 @@ class SimpleTestCase(unittest.TestCase):
         * Putting back the original ROOT_URLCONF if it was changed.
         """
         self._urlconf_teardown()
+        if self._custom_settings:
+            self._overridden.disable()
 
     def _urlconf_teardown(self):
         set_urlconf(None)

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -203,18 +203,11 @@ class override_settings(object):
                 raise Exception(
                     "Only subclasses of Django SimpleTestCase can be decorated "
                     "with override_settings")
-            original_pre_setup = test_func._pre_setup
-            original_post_teardown = test_func._post_teardown
-
-            def _pre_setup(innerself):
-                self.enable()
-                original_pre_setup(innerself)
-
-            def _post_teardown(innerself):
-                original_post_teardown(innerself)
-                self.disable()
-            test_func._pre_setup = _pre_setup
-            test_func._post_teardown = _post_teardown
+            if test_func._custom_settings:
+                test_func._custom_settings = dict(
+                    test_func._custom_settings, **self.options)
+            else:
+                test_func._custom_settings = self.options
             return test_func
         else:
             @wraps(test_func)

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -73,6 +73,16 @@ class ClassDecoratedTestCase(ClassDecoratedTestCaseSuper):
             self.fail()
 
 
+@override_settings(TEST='override-parent')
+class ParentDecoratedTestCase(TestCase):
+    pass
+
+@override_settings(TEST='override-child')
+class ChildDecoratedTestCase(ParentDecoratedTestCase):
+    def test_override_settings_inheritance(self):
+        self.assertEqual(settings.TEST, 'override-child')
+
+
 class SettingsTests(TestCase):
     def setUp(self):
         self.testvalue = None


### PR DESCRIPTION
When both parent and child classes are decorated with override_settings,
child class settings should take precedence.
Thanks Sephi for the report.
