### PR TITLE
Fixed #18866 -- added validation error for verbose_name longer than 39 characters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -463,6 +463,7 @@ answer newbie questions, and generally made Django that much better:
     Neal Norwitz <nnorwitz@google.com>
     Todd O'Bryan <toddobryan@mac.com>
     Alex Ogier <alex.ogier@gmail.com>
+    Joao Oliveira <joaoxsouls@gmail.com>
     Selwin Ong <selwin@ui.co.id>
     Gerardo Orozco <gerardo.orozco.mosqueda@gmail.com>
     Christian Oudard <christian.oudard@gmail.com>

--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -99,6 +99,12 @@ def create_permissions(app, created_models, verbosity, db=DEFAULT_DB_ALIAS, **kw
         for ctype, (codename, name) in searched_perms
         if (ctype.pk, codename) not in all_perms
     ]
+    # Validate the permissions before bulk_creation to avoid cryptic
+    # database error when the verbose_name is longer than 50 characters
+    for perm in perms:
+        if len(perm.name) > 50:
+            raise exceptions.ValidationError(
+                "The verbose_name of %s is longer than 39 characters" % perm.content_type)
     auth_app.Permission.objects.using(db).bulk_create(perms)
     if verbosity >= 2:
         for perm in perms:


### PR DESCRIPTION
Added a validation error check when creating the permissions for model, to avoid
cryptic database error when the verbose_name is longer than 39 characters
thanks elena for reporting it
