### PR TITLE
Fixed #21210: Document when runserver doesn't auto restart

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -181,6 +181,13 @@ It worked!
     Full docs for the development server can be found in the
     :djadmin:`runserver` reference.
 
+.. admonition:: Automatically reloading
+
+    The development server automatically reloads Python code for each request,
+    as needed. You don't need to restart the server for code changes to take
+    effect. However adding files or compiling translation files don't trigger
+    a restart, so you would have to restart the development server manually.
+
 Database setup
 --------------
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -791,6 +791,8 @@ Django.)
 
 The development server automatically reloads Python code for each request, as
 needed. You don't need to restart the server for code changes to take effect.
+However adding files or compiling translation files don't trigger a restart, so
+you would have to restart the development server manually.
 
 When you start the server, and each time you change Python code while the
 server is running, the server will validate all of your installed models. (See


### PR DESCRIPTION
See [ticket 21210](https://code.djangoproject.com/ticket/21210).
