### PR TITLE
Add noop_key_func

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -35,6 +35,13 @@ def default_key_func(key, key_prefix, version):
     return '%s:%s:%s' % (key_prefix, version, key)
 
 
+def noop_key_func(key, key_prefix, version):
+    """
+    Function to generate keys that ignores `key_prefix` and `version`.
+    """
+    return key
+
+
 def get_key_func(key_func):
     """
     Function to decide which key function to use.


### PR DESCRIPTION
This feels like a common enough case that I feel should belong in core alongside `default_key_func`. Many times, when dealing with caches that are shared between systems, I just need to set a more predictable key name and not worry about version or prefixes being added.
