### PR TITLE
Fixed #21255 -- close connection in BaseCommand

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -303,6 +303,7 @@ class BaseCommand(object):
         finally:
             if saved_locale is not None:
                 translation.activate(saved_locale)
+            django.db.close_old_connections()
 
     def validate(self, app=None, display_num_errors=False):
         """

--- a/tests/user_commands/management/commands/enter_transaction.py
+++ b/tests/user_commands/management/commands/enter_transaction.py
@@ -1,0 +1,10 @@
+from django.db import transaction
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Enter a transaction"
+    args = ''
+
+    def handle(self, *args, **options):
+        transaction.enter_transaction_management()

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -1,5 +1,6 @@
 import sys
 
+from django import db
 from django.core import management
 from django.core.management import CommandError
 from django.core.management.utils import popen_wrapper
@@ -60,6 +61,10 @@ class CommandTests(SimpleTestCase):
             management.call_command('leave_locale_alone_true', stdout=out)
             self.assertEqual(out.getvalue(), "pl\n")
 
+    def test_close_connection(self):
+        management.call_command('enter_transaction')
+        for connection in db.connections.all():
+            self.assertEqual(connection.transaction_state, [])
 
 class UtilsTests(SimpleTestCase):
 


### PR DESCRIPTION
Hi,

This is related to #21255 [0] where `BaseCommand` needs to close database connections after executing.

Added a call to `django.db.close_old_connections` in `execute`. Added a test case that reproduces the problem.

Thanks,
Javed

[0] https://code.djangoproject.com/ticket/21255
