### PR TITLE
Fixed #21006 -- added example code for overriding methods on an InlineFormSet

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -1053,12 +1053,30 @@ a particular author, you could do this::
 
     :ref:`Manually rendered can_delete and can_order <manually-rendered-can-delete-and-can-order>`.
 
-Overriding ``clean()`` on an ``InlineFormSet``
-----------------------------------------------
-
-See :ref:`model-formsets-overriding-clean`, but subclass
+Overriding methods on an ``InlineFormSet``
+------------------------------------------
+When overriding methods for ``InlineFormSet``, you should subclass
 :class:`~models.BaseInlineFormSet` rather than
 :class:`~models.BaseModelFormSet`.
+
+For example, If you want to override ``clean()``::
+
+   class MyModelFormSet(BaseInlineFormSet):
+    def clean(self):
+        super(MyModelFormSet, self).clean()
+        # example custom validation across forms in the formset:
+        for form in self.forms:
+            # your custom formset validation
+
+Also see :ref:`model-formsets-overriding-clean`.
+
+Then when you create your inline formset, pass in the optional argument ``formset``::
+
+    >>> from django.forms.models import inlineformset_factory
+    >>> BookFormSet = inlineformset_factory(Author, Book, formset=MyModelFormSet)
+    >>> author = Author.objects.get(name=u'Mike Royko')
+    >>> formset = BookFormSet(instance=author)
+
 
 More than one foreign key to the same model
 -------------------------------------------


### PR DESCRIPTION
Filed from Pycon13 Ireland Django sprint. Fix for ticket https://code.djangoproject.com/ticket/21006 
