### PR TITLE
Add configurable SMTP timeout.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -180,6 +180,9 @@ EMAIL_HOST = 'localhost'
 # Port for sending email.
 EMAIL_PORT = 25
 
+# Timeout while sending email.
+EMAIL_TIMEOUT = 60
+
 # Optional SMTP authentication information for EMAIL_HOST.
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -15,10 +15,12 @@ class EmailBackend(BaseEmailBackend):
     A wrapper that manages the SMTP network connection.
     """
     def __init__(self, host=None, port=None, username=None, password=None,
-                 use_tls=None, fail_silently=False, use_ssl=None, **kwargs):
+                 use_tls=None, fail_silently=False, use_ssl=None,
+                 timeout=None, **kwargs):
         super(EmailBackend, self).__init__(fail_silently=fail_silently)
         self.host = host or settings.EMAIL_HOST
         self.port = port or settings.EMAIL_PORT
+        self.timeout = timeout or settings.EMAIL_TIMEOUT
         self.username = settings.EMAIL_HOST_USER if username is None else username
         self.password = settings.EMAIL_HOST_PASSWORD if password is None else password
         self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
@@ -43,10 +45,12 @@ class EmailBackend(BaseEmailBackend):
             # For performance, we use the cached FQDN for local_hostname.
             if self.use_ssl:
                 self.connection = smtplib.SMTP_SSL(self.host, self.port,
-                                           local_hostname=DNS_NAME.get_fqdn())
+                                           local_hostname=DNS_NAME.get_fqdn(),
+                                           timeout=self.timeout)
             else:
                 self.connection = smtplib.SMTP(self.host, self.port,
-                                           local_hostname=DNS_NAME.get_fqdn())
+                                           local_hostname=DNS_NAME.get_fqdn(),
+                                           timeout=self.timeout)
                 # TLS/SSL are mutually exclusive, so only attempt TLS over
                 # non-secure connections.
                 if self.use_tls:


### PR DESCRIPTION
This is related to https://code.djangoproject.com/ticket/21271

"When EmailBackend initializes SMTP objects it does not provide a timeout, and the default timeout is object() (no timeout). It would be sensible to provide some configurable timeout.
I've got bitten by this when using the AdminEmailHandler. My database went down, a lot of exceptions were generated and Django was trying to send emails. The SMTP server started not responding and the requests started blocking, until all my workers were used up. By then Django stopped serving requests. Basically, I was DoSed by my own SMTP server."
