### PR TITLE
Make sure to set cookie before returning response

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -186,9 +186,6 @@ class CsrfViewMiddleware(object):
         if request.META.get("CSRF_COOKIE") is None:
             return response
 
-        if not request.META.get("CSRF_COOKIE_USED", False):
-            return response
-
         # Set the CSRF cookie even if it's already set, so we renew
         # the expiry timer.
         response.set_cookie(settings.CSRF_COOKIE_NAME,
@@ -199,6 +196,10 @@ class CsrfViewMiddleware(object):
                             secure=settings.CSRF_COOKIE_SECURE,
                             httponly=settings.CSRF_COOKIE_HTTPONLY
                             )
+
+        if not request.META.get("CSRF_COOKIE_USED", False):
+            return response
+
         # Content varies with the CSRF cookie, so set the Vary header.
         patch_vary_headers(response, ('Cookie',))
         response.csrf_processing_done = True


### PR DESCRIPTION
Ran into an issue with a security review; our CSRF tokens weren't getting rotated, even after we upgraded to 1.5.4.

It seemed that it was getting set in the request.META, but not actually making it to the response headers.

This logic fixes the problem for us -- it's undoubtedly flawed. Let me know if this makes sense.
