### PR TITLE
#21271 Django's usage of smtplib.SMTP should have a timeout

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -180,9 +180,6 @@ EMAIL_HOST = 'localhost'
 # Port for sending email.
 EMAIL_PORT = 25
 
-# Timeout while sending email.
-EMAIL_TIMEOUT = 60
-
 # Optional SMTP authentication information for EMAIL_HOST.
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -239,6 +239,8 @@ Email
 
 * :func:`~django.core.mail.send_mail` now accepts an ``html_message``
   parameter for sending a multipart ``text/plain`` and ``text/html`` email.
+* :func:`~django.core.mail.backends.smtp.EmailBackend` now accepts a
+  configurable ``timeout`` parameter.
 
 File Uploads
 ^^^^^^^^^^^^

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -430,6 +430,16 @@ The server address and authentication credentials are set in the
 :setting:`EMAIL_HOST_PASSWORD`, :setting:`EMAIL_USE_TLS` and
 :setting:`EMAIL_USE_SSL` settings in your settings file.
 
+.. versionadded:: 1.7
+
+This backend contains a configurable `timeout` parameter, which can be overwritten
+with the following sample code::
+
+    class MyEmailBackend(smtp.EmailBackend):
+      def __init__(self, *args, **kwargs):
+      kwargs.setdefault('timeout', 42)
+      super(MyEmailBackend, self).__init__(self, *args, **kwargs)
+
 The SMTP backend is the default configuration inherited by Django. If you
 want to specify it explicitly, put the following in your settings::
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -278,6 +278,20 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         email = EmailMessage('Subject', 'Content', 'bounce@example.com', ['to@example.com'], headers={'From': 'from@example.com'})
         self.assertEqual(connection.send_messages([email, email, email]), 3)
 
+    def test_connection_timeout_value(self):
+        """ Test that the connection's timeout value is initially None. Test that timeout can be overwritten."""
+        connection = mail.get_connection('django.core.mail.backends.smtp.EmailBackend')
+        self.assertEqual(connection.timeout, None)
+
+        # Test a sample use case. Timeout value can get overwritten by using the __init__ attribute.
+        class MyEmailBackend(smtp.EmailBackend):
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault('timeout', 42)
+                super(MyEmailBackend, self).__init__(self, *args, **kwargs)
+
+        myemailbackend = MyEmailBackend()
+        self.assertEqual(myemailbackend.timeout, 42)
+
     def test_arbitrary_keyword(self):
         """
         Make sure that get_connection() accepts arbitrary keyword that might be


### PR DESCRIPTION
https://code.djangoproject.com/ticket/21271 

Tests pass. I added a short doc to 1.7 release notes and to https://docs.djangoproject.com/en/dev/topics/email/#smtp-backend. Do feel free to review. 
