### PR TITLE
Fixed #21242 -- Allow more IANA schemes in URLValidator

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -49,6 +49,12 @@ class URLValidator(RegexValidator):
         r'(?::\d+)?'  # optional port
         r'(?:/?|[/?]\S+)$', re.IGNORECASE)
     message = _('Enter a valid URL.')
+    schemes = None
+
+    def __init__(self, schemes=None):
+        super(URLValidator, self).__init__()
+        if schemes is not None:
+            self.schemes = schemes
 
     def __call__(self, value):
         try:
@@ -62,6 +68,12 @@ class URLValidator(RegexValidator):
                     netloc = netloc.encode('idna').decode('ascii')  # IDN -> ACE
                 except UnicodeError:  # invalid domain part
                     raise e
+                # Try for different URL schemes if configured to:
+                if self.schemes:
+                    if scheme in self.schemes:
+                        scheme = 'http'  # scheme is valid, use default to pass basic URL regex
+                    else:
+                        raise e
                 url = urlunsplit((scheme, netloc, path, query, fragment))
                 super(URLValidator, self).__call__(url)
             else:

--- a/django/utils/uri.py
+++ b/django/utils/uri.py
@@ -1,0 +1,18 @@
+"""URI utilities"""
+
+# The IANA URI scheme lists have been produced with the following code:
+#
+#   import lxml.html, urllib
+#   text = "".join(urllib.urlopen("https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml").readlines())
+#   root = lxml.html.fromstring(text)
+#   permanent_uri_schemes = [e.text for e in root.xpath("//table[@id='table-uri-schemes-1']//tbody//tr/*[1]")]
+#   provisional_uri_schemes = [e.text for e in root.xpath("//table[@id='table-uri-schemes-2']//tbody//tr/*[1]")]
+#   historical_uri_schemes = [e.text for e in root.xpath("//table[@id='table-uri-schemes-3']//tbody//tr/*[1]")]
+#
+# Last updated 2013-10-16:
+
+IANA_PERMANENT_URI_SCHEMES = ['aaa', 'aaas', 'about', 'acap', 'acct', 'cap', 'cid', 'coap', 'coaps', 'crid', 'data', 'dav', 'dict', 'dns', 'file', 'ftp', 'geo', 'go', 'gopher', 'h323', 'http', 'https', 'iax', 'icap', 'im', 'imap', 'info', 'ipp', 'iris', 'iris.beep', 'iris.xpc', 'iris.xpcs', 'iris.lwz', 'jabber', 'ldap', 'mailto', 'mid', 'msrp', 'msrps', 'mtqp', 'mupdate', 'news', 'nfs', 'ni', 'nih', 'nntp', 'opaquelocktoken', 'pop', 'pres', 'reload', 'rtsp', 'service', 'session', 'shttp', 'sieve', 'sip', 'sips', 'sms', 'snmp', 'soap.beep', 'soap.beeps', 'stun', 'stuns', 'tag', 'tel', 'telnet', 'tftp', 'thismessage', 'tn3270', 'tip', 'turn', 'turns', 'tv', 'urn', 'vemmi', 'ws', 'wss', 'xcon', 'xcon-userid', 'xmlrpc.beep', 'xmlrpc.beeps', 'xmpp', 'z39.50r', 'z39.50s']
+IANA_PROVISIONAL_URI_SCHEMES = ['adiumxtra', 'afp', 'afs', 'aim', 'apt', 'attachment', 'aw', 'beshare', 'bitcoin', 'bolo', 'callto', 'chrome', 'chrome-extension', 'com-eventbrite-attendee', 'content', 'cvs', 'dlna-playsingle', 'dlna-playcontainer', 'dtn', 'dvb', 'ed2k', 'facetime', 'feed', 'feedready', 'finger', 'fish', 'gg', 'git', 'gizmoproject', 'gtalk', 'hcp', 'icon', 'ipn', 'irc', 'irc6', 'ircs', 'itms', 'jar', 'jms', 'keyparc', 'lastfm', 'ldaps', 'magnet', 'maps', 'market', 'message', 'mms', 'ms-help', 'ms-settings-power', 'msnim', 'mumble', 'mvn', 'notes', 'oid', 'palm', 'paparazzi', 'pkcs11', 'platform', 'proxy', 'psyc', 'query', 'res', 'resource', 'rmi', 'rsync', 'rtmp', 'secondlife', 'sftp', 'sgn', 'skype', 'smb', 'soldat', 'spotify', 'ssh', 'steam', 'svn', 'teamspeak', 'things', 'udp', 'unreal', 'ut2004', 'ventrilo', 'view-source', 'webcal', 'wtai', 'wyciwyg', 'xfire', 'xri', 'ymsgr']
+IANA_HISTORICAL_URI_SCHEMES = ['fax', 'mailserver', 'modem', 'pack', 'prospero', 'snews', 'videotex', 'wais', 'z39.50']
+
+IANA_URI_SCHEMES = IANA_PERMANENT_URI_SCHEMES + IANA_PROVISIONAL_URI_SCHEMES + IANA_HISTORICAL_URI_SCHEMES

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -87,10 +87,20 @@ to, or in lieu of custom ``field.clean()`` methods.
 
 ``URLValidator``
 ----------------
-.. class:: URLValidator()
+.. class:: URLValidator([schemes=None])
 
     A :class:`RegexValidator` that ensures a value looks like a URL, and raises
     an error code of ``'invalid'`` if it doesn't.
+
+    :param schemes: If not ``None``, overrides :attr:`schemes`.
+
+    .. attribute:: schemes
+
+        Additional URL / URI scheme list to validate against should the
+        validation fails against the default list (i.e. ftp(s) or http(s)). The
+        :mod:`django.utils.uri` module contains various IANA scheme lists which
+        can be used here. Defaults to ``None``.
+
 
 ``validate_email``
 ------------------

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -9,6 +9,7 @@ from unittest import TestCase
 from django.core.exceptions import ValidationError
 from django.core.validators import *
 from django.test.utils import str_prefix
+from django.utils.uri import IANA_URI_SCHEMES
 
 
 NOW = datetime.now()
@@ -158,6 +159,15 @@ TEST_DATA = (
     (URLValidator(), 'http://-invalid.com', ValidationError),
     (URLValidator(), 'http://inv-.alid-.com', ValidationError),
     (URLValidator(), 'http://inv-.-alid.com', ValidationError),
+    (URLValidator(), 'file://localhost/path', ValidationError),
+    (URLValidator(), 'git://example.com/', ValidationError),
+    (URLValidator(), 'rsync://example.com/', ValidationError),
+    (URLValidator(), 'ssh://example.com/', ValidationError),
+
+    (URLValidator(IANA_URI_SCHEMES), 'file://localhost/path/', None),
+    (URLValidator(IANA_URI_SCHEMES), 'git://example.com/', None),
+    (URLValidator(IANA_URI_SCHEMES), 'rsync://example.com/', None),
+    (URLValidator(IANA_URI_SCHEMES), 'ssh://example.com/', None),
 
     (BaseValidator(True), True, None),
     (BaseValidator(True), False, ValidationError),


### PR DESCRIPTION
Add an optional "schemes" parameter to the URLValidator constructor
that allows to pass additional URL/URI schemes to validate against
should the validation fail against the default schemes (as part of the
generic URL regex, i.e. http(s) or ftp(s)). Also add an "uri" utility
module that provides constants with all currently registered IANA
schemes as listed on
https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
