### PR TITLE
Fix #20346: cache middleware should vary on full URL

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -191,25 +191,25 @@ def _generate_cache_key(request, method, headerlist, key_prefix):
         value = request.META.get(header, None)
         if value is not None:
             ctx.update(force_bytes(value))
-    path = hashlib.md5(force_bytes(iri_to_uri(request.get_full_path())))
+    url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())))
     cache_key = 'views.decorators.cache.cache_page.%s.%s.%s.%s' % (
-        key_prefix, method, path.hexdigest(), ctx.hexdigest())
+        key_prefix, method, url.hexdigest(), ctx.hexdigest())
     return _i18n_cache_key_suffix(request, cache_key)
 
 
 def _generate_cache_header_key(key_prefix, request):
     """Returns a cache key for the header cache."""
-    path = hashlib.md5(force_bytes(iri_to_uri(request.get_full_path())))
+    url = hashlib.md5(force_bytes(iri_to_uri(request.build_absolute_uri())))
     cache_key = 'views.decorators.cache.cache_header.%s.%s' % (
-        key_prefix, path.hexdigest())
+        key_prefix, url.hexdigest())
     return _i18n_cache_key_suffix(request, cache_key)
 
 
 def get_cache_key(request, key_prefix=None, method='GET', cache=None):
     """
-    Returns a cache key based on the request path and query. It can be used
+    Returns a cache key based on the request URL and query. It can be used
     in the request phase because it pulls the list of headers to take into
-    account from the global path registry and uses those to build a cache key
+    account from the global URL registry and uses those to build a cache key
     to check against.
 
     If there is no headerlist stored, the page needs to be rebuilt, so this
@@ -229,9 +229,9 @@ def get_cache_key(request, key_prefix=None, method='GET', cache=None):
 
 def learn_cache_key(request, response, cache_timeout=None, key_prefix=None, cache=None):
     """
-    Learns what headers to take into account for some request path from the
-    response object. It stores those headers in a global path registry so that
-    later access to that path will know what headers to take into account
+    Learns what headers to take into account for some request URL from the
+    response object. It stores those headers in a global URL registry so that
+    later access to that URL will know what headers to take into account
     without building the response object itself. The headers are named in the
     Vary header of the response, but we want to prevent response generation.
 
@@ -264,7 +264,7 @@ def learn_cache_key(request, response, cache_timeout=None, key_prefix=None, cach
         return _generate_cache_key(request, request.method, headerlist, key_prefix)
     else:
         # if there is no Vary header, we still need a cache key
-        # for the request.get_full_path()
+        # for the request.build_absolute_uri()
         cache.set(cache_key, [], cache_timeout)
         return _generate_cache_key(request, request.method, [], key_prefix)
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -578,6 +578,20 @@ Backwards incompatible changes in 1.7
     deprecation timeline for a given feature, its removal may appear as a
     backwards incompatible change.
 
+Cache keys are now generated from the request's absolute URL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previous versions of Django generated cache keys using, among other attributes
+such as locale, a `Vary` header, or a specified `key_prefix`, a request's
+path and query string, but not the scheme or host. If one Django application
+was serving multiple subdomains or domains, cache keys could collide. In
+Django 1.7, cache keys therefore vary by the absolute URL of the request,
+including scheme, host, path, and query string. For example, the URL portion
+of a cache key is now generated from `http://www.example.com/path/to/?key=val`
+rather than `/path/to/?key=val`. Migration from 1.6 to 1.7 will make existing
+cache keys unreachable, and cause the first request to any previously-cached
+URL to be a cache miss.
+
 allow_syncdb/allow_migrate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -1046,12 +1046,18 @@ the contents of a Web page depend on a user's language preference, the page is
 said to "vary on language."
 
 By default, Django's cache system creates its cache keys using the requested
-path and query -- e.g., ``"/stories/2005/?order_by=author"``. This means every
+fully-qualified URL -- e.g.,
+``"http://www.example.com/stories/2005/?order_by=author"``. This means every
 request to that URL will use the same cached version, regardless of user-agent
 differences such as cookies or language preferences. However, if this page
 produces different content based on some difference in request headers -- such
 as a cookie, or a language, or a user-agent -- you'll need to use the ``Vary``
 header to tell caching mechanisms that the page output depends on those things.
+
+    .. versionchanged:: 1.7
+
+        Cache keys use the request's fully-qualified URL rather than path
+        and query string.
 
 To do this in Django, use the convenient
 :func:`django.views.decorators.vary.vary_on_headers` view decorator, like so::


### PR DESCRIPTION
This pull request changes the generation of cache keys from using the path of a request (`request.get_full_path()`) to the more-standard fully-qualified URL (`request.build_absolute_uri()`.

Tracked at https://code.djangoproject.com/ticket/20346.
