### PR TITLE
Fixed #21280 -- Don't generate empty migration files

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -82,5 +82,6 @@ class Command(BaseCommand):
                         open(init_path, "w").close()
                     # We just do this once per app
                     directory_created[app_label] = True
+                migration_string = writer.as_string()
                 with open(writer.path, "wb") as fh:
-                    fh.write(writer.as_string())
+                    fh.write(migration_string)


### PR DESCRIPTION
Hi,

A simple fix to avoid empty migration file in case of an error in generating the migration content.

Thanks,
Javed
