### PR TITLE
#5789 -- Django LocaleMiddleware django_language should be _language

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -56,8 +56,14 @@ class LocaleMiddleware(object):
                 return self.response_redirect_class(language_url)
 
         # Store language back into session if it is not present
-        if hasattr(request, 'session'):
-            request.session.setdefault('django_language', language)
+        if hasattr(request, 'session') and '_language' not in request.session:
+            # Backwards compatibility check on django_language (remove in 1.8);
+            # revert to: `request.session.setdefault('_language', language)`.
+            if 'django_language' in request.session:
+                request.session['_language'] = request.session['django_language']
+                del request.session['django_language']
+            else:
+                request.session['_language'] = language
 
         if not (self.is_language_prefix_patterns_used()
                 and language_from_path):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -426,7 +426,9 @@ def get_language_from_request(request, check_path=False):
             return lang_code
 
     if hasattr(request, 'session'):
-        lang_code = request.session.get('django_language', None)
+        # for backwards compatibility (1.7) django_language is also checked
+        lang_code = request.session.get('_language',
+                                        request.session.get('django_language'))
         if lang_code in supported and lang_code is not None and check_for_language(lang_code):
             return lang_code
 

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -34,7 +34,7 @@ def set_language(request):
         lang_code = request.POST.get('language', None)
         if lang_code and check_for_language(lang_code):
             if hasattr(request, 'session'):
-                request.session['django_language'] = lang_code
+                request.session['_language'] = lang_code
             else:
                 response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang_code)
     return response

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -410,6 +410,9 @@ these changes.
 * The ``Model._meta.get_(add|change|delete)_permission`` methods will
   be removed.
 
+* The session key ``django_language`` will no longer be read for backwards
+  compatibility.
+
 1.9
 ---
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -302,6 +302,12 @@ Internationalization
 * The :attr:`django.middleware.locale.LocaleMiddleware.response_redirect_class`
   attribute allows you to customize the redirects issued by the middleware.
 
+* The user's selected language is now stored with the key ``_language`` in the
+  session. Previously it was stored with the key ``django_language``, but keys
+  reserved for Django should start with an underscore. For backwards
+  compatibility ``django_language`` is still read from in 1.7. Sessions will be
+  migrated to the new ``_language`` key as they are written.
+
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1594,8 +1594,13 @@ following this algorithm:
   root URLconf. See :ref:`url-internationalization` for more information
   about the language prefix and how to internationalize URL patterns.
 
-* Failing that, it looks for a ``django_language`` key in the current
-  user's session.
+* Failing that, it looks for a ``_language`` key in the current user's session.
+
+  .. versionchanged:: 1.7
+
+      In previous versions the key was named ``django_language`` but was
+      renamed to start with an underscore to denote a Django reserved session
+      key.
 
 * Failing that, it looks for a cookie.
 

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -34,7 +34,7 @@ class I18NTests(TestCase):
             post_data = dict(language=lang_code, next='/views/')
             response = self.client.post('/views/i18n/setlang/', data=post_data)
             self.assertRedirects(response, 'http://testserver/views/')
-            self.assertEqual(self.client.session['django_language'], lang_code)
+            self.assertEqual(self.client.session['_language'], lang_code)
 
     def test_setlang_unsafe_next(self):
         """
@@ -45,7 +45,7 @@ class I18NTests(TestCase):
         post_data = dict(language=lang_code, next='//unsafe/redirection/')
         response = self.client.post('/views/i18n/setlang/', data=post_data)
         self.assertEqual(response.url, 'http://testserver/')
-        self.assertEqual(self.client.session['django_language'], lang_code)
+        self.assertEqual(self.client.session['_language'], lang_code)
 
     def test_setlang_reversal(self):
         self.assertEqual(reverse('set_language'), '/views/i18n/setlang/')


### PR DESCRIPTION
See [ticket 5789](https://code.djangoproject.com/ticket/5789) for discussion. There has also been talk about migrating old session keys, but no decision so far.
