### PR TITLE
Fixed #21238 -- Ensured ImageFieldFile from cache can use its url attrib...

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -331,6 +331,10 @@ class ImageFileDescriptor(FileDescriptor):
 
 
 class ImageFieldFile(ImageFile, FieldFile):
+
+    def __getstate__(self):
+        return self.__dict__
+
     def delete(self, save=True):
         # Clear the image dimensions cache
         if hasattr(self, '_dimensions_cache'):

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -164,11 +164,12 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
 
     def test_pickle(self):
         """
-        Tests that ImageField can be pickled, unpickled, and that the
-        image of the unpickled version is the same as the original.
+        Tests that ImageField and ImageFieldFile can be pickled, unpickled,
+        and that the image of the unpickled version is the same as the original.
         """
         import pickle
 
+        # Pickle the person (ImageField)
         p = Person(name="Joe")
         p.mugshot.save("mug", self.file1)
         dump = pickle.dumps(p)
@@ -178,6 +179,11 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
 
         loaded_p = pickle.loads(dump)
         self.assertEqual(p.mugshot, loaded_p.mugshot)
+
+        # Pickle the mugshot (ImageFieldFile)
+        dump = pickle.dumps(p.mugshot)
+        loaded_mugshot = pickle.loads(dump)
+        self.assertEqual(p.mugshot.url, loaded_mugshot.url)
 
 
 @skipIf(Image is None, "PIL is required to test ImageField")


### PR DESCRIPTION
...ute.
