### PR TITLE
Fixed test that reads a migration file from disk.

### DIFF
--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import copy
+import io
 import os
 import shutil
 
@@ -143,8 +144,8 @@ class MakeMigrationsTests(MigrationTestBase):
         # Check for existing 0001_initial.py file in migration folder
         self.assertTrue(os.path.exists(initial_file))
 
-        with open(initial_file, 'r') as fp:
-            content = force_text(fp.read())
+        with io.open(initial_file, 'r', encoding='utf-8') as fp:
+            content = fp.read()
             self.assertTrue('# encoding: utf8' in content)
             self.assertTrue('migrations.CreateModel' in content)
 


### PR DESCRIPTION
We need to make sure content read from ther file is Unicode and decoded
from UTF-8 right from the start so Python doesn't try to use another
encoding (read: ASCII/CP1252 Under Windows.)
