### PR TITLE
Fix #21296: docs: postgresql can use host as alternative directory for unix sockets

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -506,8 +506,10 @@ this value is assumed to be the host.
 
 If you're using PostgreSQL, by default (empty :setting:`HOST`), the connection
 to the database is done through UNIX domain sockets ('local' lines in
-``pg_hba.conf``). If you want to connect through TCP sockets, set
-:setting:`HOST` to 'localhost' or '127.0.0.1' ('host' lines in ``pg_hba.conf``).
+``pg_hba.conf``). If your UNIX domain socket is not in the standard location
+use the same value of ``unix_socket_directory``from ``postgresql.conf``.
+If you want to connect through TCP sockets, set :setting:`HOST` to 'localhost'
+or '127.0.0.1' ('host' lines in ``pg_hba.conf``).
 On Windows, you should always define :setting:`HOST`, as UNIX domain sockets
 are not available.
 


### PR DESCRIPTION
If you have installed postgres not on the default path and want
to connect via unix domain socket clarify that adding the dir
path as HOST value is enough.

Fixes #21296.
