### PR TITLE
Fix indentation of example

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -218,15 +218,15 @@ aren't commonly used:
 .. snippet::
     :filename: polls/admin.py
 
-        from django.contrib import admin
-        from polls.models import Question
+    from django.contrib import admin
+    from polls.models import Question
 
 
-        class QuestionAdmin(admin.ModelAdmin):
-            fieldsets = [
-                (None,               {'fields': ['question_text']}),
-                ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
-            ]
+    class QuestionAdmin(admin.ModelAdmin):
+        fieldsets = [
+            (None,               {'fields': ['question_text']}),
+            ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
+        ]
 
 .. image:: _images/admin09.png
    :alt: Fieldset is initially collapsed


### PR DESCRIPTION
For easy copy+paste I've fixed the indentation of one of the examples.
