### PR TITLE
Allow custom link text for urlize filter

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -321,9 +321,10 @@ def urlencode(value, safe=None):
 
 @register.filter(is_safe=True, needs_autoescape=True)
 @stringfilter
-def urlize(value, autoescape=None):
+def urlize(value, link_text=None, autoescape=None):
     """Converts URLs in plain text into clickable links."""
-    return mark_safe(urlize_impl(value, nofollow=True, autoescape=autoescape))
+    return mark_safe(urlize_impl(value, link_text=link_text, nofollow=True,
+                            autoescape=autoescape))
 
 @register.filter(is_safe=True, needs_autoescape=True)
 @stringfilter

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -186,7 +186,7 @@ def smart_urlquote(url):
 
     return force_text(url)
 
-def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
+def urlize(text, link_text=None, trim_url_limit=None, nofollow=False, autoescape=False):
     """
     Converts any URLs in text into clickable links.
 
@@ -194,6 +194,8 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
     the original seven gTLDs (.com, .edu, .gov, .int, .mil, .net, and .org).
     Links can have trailing punctuation (periods, commas, close-parens) and
     leading punctuation (opening parens) and it'll still do the right thing.
+
+    If link_text is not None, the link text will be set to the specified value.
 
     If trim_url_limit is not None, the URLs in link text longer than this limit
     will truncated to trim_url_limit-3 characters and appended with an elipsis.
@@ -245,11 +247,11 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
 
             # Make link.
             if url:
-                trimmed = trim_url(middle)
+                tag_text = link_text or trim_url(middle)
                 if autoescape and not safe_input:
                     lead, trail = escape(lead), escape(trail)
-                    url, trimmed = escape(url), escape(trimmed)
-                middle = '<a href="%s"%s>%s</a>' % (url, nofollow_attr, trimmed)
+                    url, tag_text = escape(url), escape(tag_text)
+                middle = '<a href="%s"%s>%s</a>' % (url, nofollow_attr, tag_text)
                 words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
             else:
                 if safe_input:

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -255,6 +255,16 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(urlize('info@djangoproject.org'),
             '<a href="mailto:info@djangoproject.org">info@djangoproject.org</a>')
 
+        # Check custom link text
+        self.assertEqual(urlize('http://google.com', 'Google'),
+                '<a href="http://google.com" rel="nofollow">Google</a>')
+        self.assertEqual(urlize('www.google.com', 'Another Google'),
+            '<a href="http://www.google.com" rel="nofollow">Another Google</a>')
+
+        # Check that custom link text is excaped automatically
+        self.assertEqual(urlize('http://google.com', '<blink>Google</blink>', autoescape=True),
+                '<a href="http://google.com" rel="nofollow">&lt;blink&gt;Google&lt;/blink&gt;</a>')
+
         # Check urlize with https addresses
         self.assertEqual(urlize('https://google.com'),
             '<a href="https://google.com" rel="nofollow">https://google.com</a>')


### PR DESCRIPTION
My templates usually contain a lot of the following pattern:

```
<a href="{{ object.url }}">{{ object.name }}</a>
```

This commit adds an optional `link_text` argument to the urlize filter:

```
{{ object.url|urlize:object.name }}
```

The pull request contains the implementation and tests. If you want to include this in Django, I'll add a commit to this pull request that updates the documentation.
