### PR TITLE
Fixed #8116 -- raise an exception if a included template doesn't exist

### DIFF
--- a/django/template/__init__.py
+++ b/django/template/__init__.py
@@ -58,9 +58,9 @@ from django.template.base import (ALLOWED_VARIABLE_CHARS, BLOCK_TAG_END,  # NOQA
     VARIABLE_TAG_END, VARIABLE_TAG_START, filter_re, tag_re)
 
 # Exceptions
-from django.template.base import (ContextPopException, InvalidTemplateLibrary,  # NOQA
-    TemplateDoesNotExist, TemplateEncodingError, TemplateSyntaxError,
-    VariableDoesNotExist)
+from django.template.base import (ContextPopException, InvalidTemplateLibrary,  #NOQA
+    TemplateDoesNotExist, IncludedTemplateDoesNotExist, TemplateEncodingError,
+    TemplateSyntaxError, VariableDoesNotExist)
 
 # Template parts
 from django.template.base import (Context, FilterExpression, Lexer, Node,  # NOQA

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -80,6 +80,10 @@ class TemplateDoesNotExist(Exception):
     pass
 
 
+class IncludedTemplateDoesNotExist(TemplateDoesNotExist):
+    pass
+
+
 class TemplateEncodingError(Exception):
     pass
 

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.template.base import TemplateSyntaxError, Library, Node, TextNode,\
-    token_kwargs, Variable
+    token_kwargs, Variable, TemplateDoesNotExist, IncludedTemplateDoesNotExist
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 from django.utils import six
@@ -139,7 +139,10 @@ class IncludeNode(Node):
             # Does this quack like a Template?
             if not callable(getattr(template, 'render', None)):
                 # If not, we'll try get_template
-                template = get_template(template)
+                try:
+                    template = get_template(template)
+                except TemplateDoesNotExist as exp:
+                    raise IncludedTemplateDoesNotExist(*exp.args)
             values = {
                 name: var.resolve(context)
                 for name, var in six.iteritems(self.extra_context)

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -686,8 +686,9 @@ the ``!=`` operator.
 include
 ^^^^^^^
 
-Loads a template and renders it with the current context. This is a way of
-"including" other templates within a template.
+Loads a template and renders it with the current context raising a
+``django.template.IncludedTemplateNotFound`` if the included template isn't
+found. This is a way of "including" other templates within a template.
 
 The template name can either be a variable or a hard-coded (quoted) string,
 in either single or double quotes.

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -397,6 +397,9 @@ Templates
   arguments will be looked up using
   :func:`~django.template.loader.get_template` as always.
 
+* The :ttag:`include` will raise a ``IncludedTemplateDoesNotExist`` error if the
+  included template doesn't exist.
+
 * It is now possible to :ttag:`include` templates recursively.
 
 * Template objects now have an origin attribute set when

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -282,12 +282,10 @@ class TemplateLoaderTests(TestCase):
 
             load_name = 'test_include_error.html'
             r = None
-            try:
+            with self.assertRaises(template.IncludedTemplateDoesNotExist) as e:
                 tmpl = loader.select_template([load_name])
                 r = tmpl.render(template.Context({}))
-            except template.TemplateDoesNotExist as e:
-                self.assertEqual(e.args[0], 'missing.html')
-            self.assertEqual(r, None, 'Template rendering unexpectedly succeeded, produced: ->%r<-' % r)
+            self.assertEqual(e.exception.args[0], 'missing.html')
         finally:
             loader.template_source_loaders = old_loaders
 
@@ -312,11 +310,9 @@ class TemplateLoaderTests(TestCase):
             load_name = 'test_extends_error.html'
             tmpl = loader.get_template(load_name)
             r = None
-            try:
+            with self.assertRaises(template.IncludedTemplateDoesNotExist) as e:
                 r = tmpl.render(template.Context({}))
-            except template.TemplateDoesNotExist as e:
-                self.assertEqual(e.args[0], 'missing.html')
-            self.assertEqual(r, None, 'Template rendering unexpectedly succeeded, produced: ->%r<-' % r)
+            self.assertEqual(e.exception.args[0], 'missing.html')
         finally:
             loader.template_source_loaders = old_loaders
 
@@ -337,20 +333,16 @@ class TemplateLoaderTests(TestCase):
             load_name = 'test_extends_error.html'
             tmpl = loader.get_template(load_name)
             r = None
-            try:
+            with self.assertRaises(template.IncludedTemplateDoesNotExist) as e:
                 r = tmpl.render(template.Context({}))
-            except template.TemplateDoesNotExist as e:
-                self.assertEqual(e.args[0], 'missing.html')
-            self.assertEqual(r, None, 'Template rendering unexpectedly succeeded, produced: ->%r<-' % r)
+            self.assertEqual(e.exception.args[0], 'missing.html')
 
             # For the cached loader, repeat the test, to ensure the first attempt did not cache a
             # result that behaves incorrectly on subsequent attempts.
             tmpl = loader.get_template(load_name)
-            try:
+            with self.assertRaises(template.IncludedTemplateDoesNotExist) as e:
                 tmpl.render(template.Context({}))
-            except template.TemplateDoesNotExist as e:
-                self.assertEqual(e.args[0], 'missing.html')
-            self.assertEqual(r, None, 'Template rendering unexpectedly succeeded, produced: ->%r<-' % r)
+            self.assertEqual(e.exception.args[0], 'missing.html')
         finally:
             loader.template_source_loaders = old_loaders
 
@@ -1220,7 +1212,7 @@ class TemplateTests(TransRealMixin, TestCase):
             'include01': ('{% include "basic-syntax01" %}', {}, "something cool"),
             'include02': ('{% include "basic-syntax02" %}', {'headline': 'Included'}, "Included"),
             'include03': ('{% include template_name %}', {'template_name': 'basic-syntax02', 'headline': 'Included'}, "Included"),
-            'include04': ('a{% include "nonexistent" %}b', {}, ("ab", "ab", template.TemplateDoesNotExist)),
+            'include04': ('a{% include "nonexistent" %}b', {}, ("ab", "ab", template.IncludedTemplateDoesNotExist)),
             'include 05': ('template with a space', {}, 'template with a space'),
             'include06': ('{% include "include 05"%}', {}, 'template with a space'),
 


### PR DESCRIPTION
`django.template.IncludedTemplateDoesNotExist` exception is raised by the
`include` tag if the included template hasn't been found.
