### PR TITLE
Fixed #21227 -- Added workaround for selenium test failures

### DIFF
--- a/django/contrib/admin/tests.py
+++ b/django/contrib/admin/tests.py
@@ -32,6 +32,7 @@ class AdminSeleniumWebDriverTestCase(StaticLiveServerCase):
     @classmethod
     def _tearDownClassInternal(cls):
         if hasattr(cls, 'selenium'):
+            cls.selenium.refresh()  # see ticket #21227
             cls.selenium.quit()
         super(AdminSeleniumWebDriverTestCase, cls)._tearDownClassInternal()
 

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -189,6 +189,7 @@ class JavascriptI18nTests(LiveServerTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.selenium.refresh()  # see ticket #21227
         cls.selenium.quit()
         super(JavascriptI18nTests, cls).tearDownClass()
 


### PR DESCRIPTION
Added a refresh() before quit() in the selenium tests, since this
solves the problem of spurious test failures in some environments.
