### PR TITLE
Fixed #21201 -- Enable customization of ClearableFileInput

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -341,11 +341,9 @@ class ClearableFileInput(FileInput):
     input_text = ugettext_lazy('Change')
     clear_checkbox_label = ugettext_lazy('Clear')
 
-    template_with_initial = '%(initial_text)s: %(initial)s %(clear_template)s<br />%(input_text)s: %(input)s'
+    template_with_initial = '%(initial_text)s: <a href="%(initial_url)s">%(initial)s</a> %(clear_template)s<br />%(input_text)s: %(input)s'
 
     template_with_clear = '%(clear)s <label for="%(clear_checkbox_id)s">%(clear_checkbox_label)s</label>'
-
-    url_markup_template = '<a href="{0}">{1}</a>'
 
     def clear_checkbox_name(self, name):
         """
@@ -360,6 +358,21 @@ class ClearableFileInput(FileInput):
         """
         return name + '_id'
 
+    def is_initial(self, value):
+        """
+        Returns whether value is considered to be initial value.
+        """
+        return bool(value and hasattr(value, 'url'))
+
+    def get_template_substitution_values(self, value):
+        """
+        Returns value-related substitutions.
+        """
+        return  {
+            'initial': conditional_escape(value),
+            'initial_url': conditional_escape(value.url)
+        }
+
     def render(self, name, value, attrs=None):
         substitutions = {
             'initial_text': self.initial_text,
@@ -370,11 +383,9 @@ class ClearableFileInput(FileInput):
         template = '%(input)s'
         substitutions['input'] = super(ClearableFileInput, self).render(name, value, attrs)
 
-        if value and hasattr(value, "url"):
+        if self.is_initial(value):
             template = self.template_with_initial
-            substitutions['initial'] = format_html(self.url_markup_template,
-                                                   value.url,
-                                                   force_text(value))
+            substitutions.update(self.get_template_substitution_values(value))
             if not self.is_required:
                 checkbox_name = self.clear_checkbox_name(name)
                 checkbox_id = self.clear_checkbox_id(checkbox_name)

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -189,6 +189,11 @@ Forms
   will also update ``UploadedFile.content_type`` with the image's content type
   as determined by Pillow.
 
+* The widget :class:`~django.forms.ClearableFileInput` allows
+  more customization of templates and data rendered. Attribute
+  ``url_markup_template`` was removed in favor of attribute
+  ``template_with_initial``.
+
 Generic Views
 ^^^^^^^^^^^^^
 

--- a/tests/forms_tests/tests/test_widgets.py
+++ b/tests/forms_tests/tests/test_widgets.py
@@ -1249,3 +1249,12 @@ class ClearableFileInputTests(TestCase):
             data={'myfile-clear': True},
             files={'myfile': f},
             name='myfile'), f)
+
+    def test_render_custom_template(self):
+        widget = ClearableFileInput()
+        widget.template_with_initial = '%(initial_text)s: <img src="%(initial_url)s" alt="%(initial)s" /> ' \
+                                       '%(clear_template)s<br />%(input_text)s: %(input)s'
+        result = 'Currently: <img src="something" alt="something" /> ' \
+                 '<input type="checkbox" name="myfile-clear" id="myfile-clear_id" /> '\
+                 '<label for="myfile-clear_id">Clear</label><br />Change: <input type="file" name="myfile" />'
+        self.assertHTMLEqual(widget.render('myfile', FakeFieldFile()), result)


### PR DESCRIPTION
Adding extra methods into ClearableFileInput widget to enable
easier customization of the widget.
