### PR TITLE
Fixed #21321

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -94,9 +94,11 @@ class File(FileProxyMixin):
         # Iterate over this file-like object by newlines
         buffer_ = None
         for chunk in self.chunks():
-            chunk_buffer = BytesIO(chunk)
+            chunk_buffer = BytesIO(force_bytes(chunk))
 
             for line in chunk_buffer:
+                line = line.decode() if isinstance(line, bytes) else line
+
                 if buffer_:
                     line = buffer_ + line
                     buffer_ = None

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -172,6 +172,16 @@ class FileTests(unittest.TestCase):
         self.assertFalse(hasattr(file, 'mode'))
         gzip.GzipFile(fileobj=file)
 
+    def test_file_iteration(self):
+        orig_file = tempfile.TemporaryFile()
+        orig_file.write(b"some content")
+        base_file = File(orig_file)
+        with base_file as f:
+            for line in f:
+                self.assertEqual(line, "some content")
+        self.assertTrue(f.closed)
+        self.assertTrue(orig_file.closed)
+
 
 class FileMoveSafeTests(unittest.TestCase):
     def test_file_move_overwrite(self):


### PR DESCRIPTION
Fixed #21321 and added test case about file iteration.
`TypeError: 'str' does not support the buffer interface`
When iterating raw file wrapped by `File` obj in python3 has been fixed.
Thanks.
