### PR TITLE
Check res for possible None value.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -142,7 +142,7 @@ def translation(language):
         # doesn't affect en-gb), even though they will both use the core "en"
         # translation. So we have to subvert Python's internal gettext caching.
         base_lang = lambda x: x.split('-', 1)[0]
-        if base_lang(lang) in [base_lang(trans) for trans in list(_translations)]:
+        if res and base_lang(lang) in [base_lang(trans) for trans in list(_translations)]:
             res._info = res._info.copy()
             res._catalog = res._catalog.copy()
 


### PR DESCRIPTION
_translation can in some situations return None, and code introduced in
https://github.com/django/django/commit/72544950e198c08ac49ba9d878ea7440313b13a7
assumes that there should be a Translations instance.
