### PR TITLE
Try importing _imaging from PIL namespace first.

### DIFF
--- a/django/utils/image.py
+++ b/django/utils/image.py
@@ -121,12 +121,15 @@ def _detect_image_library():
             # produce a fully-working PIL & will create a ``_imaging`` module,
             # we'll attempt to import it to verify their kit works.
             try:
-                import _imaging as PIL_imaging
-            except ImportError as err:
-                raise ImproperlyConfigured(
-                    _("The '_imaging' module for the PIL could not be "
-                      "imported: %s") % err
-                )
+                from PIL import _imaging as PIL_imaging
+            except ImportError:
+                try:
+                    import _imaging as PIL_imaging
+                except ImportError as err:
+                    raise ImproperlyConfigured(
+                        _("The '_imaging' module for the PIL could not be "
+                          "imported: %s") % err
+                    )
 
     # Try to import ImageFile as well.
     try:


### PR DESCRIPTION
On an OS X system with a Homebrew version of Python/PIL installed, the `django/utils/image` module encounters a hash collision error when trying to import `_imaging`, as described in https://code.djangoproject.com/ticket/20964. Although that ticket was closed for not being a problem with Django, the referenced ticket in the Homebrew (https://github.com/mxcl/homebrew/issues/22135) only resulted in removing PIL from the core Homebrew libraries without actually fixing the import issue. Everyone agrees that pillow should be used in place of PIL, but because Django isn't officially removing support for PIL until 1.8, I believe that this problem deserves to be fixed in time for 1.6.

In this PR, I import `_imaging` from the `PIL` namespace first, which prevents the hash collision error because the `_imaging` module will imported using the same path as when imported through the earlier `from PIL import Image` statement. This allows PIL to be properly imported in my setup (OS X 10.8, Homebrew Python/PIL) and should still be compatible with environments in which the PIL namespace isn't available.
