### PR TITLE
#14170 -- Reset i18n cache when settings changed

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -427,7 +427,6 @@ class TransRealMixin(object):
         trans_real._translations = {}
         trans_real._active = local()
         trans_real._default = None
-        trans_real._accepted = {}
         trans_real._checked_languages = {}
 
     def tearDown(self):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -11,6 +11,8 @@ from importlib import import_module
 from threading import local
 import warnings
 
+from django.dispatch import receiver
+from django.test.signals import setting_changed
 from django.utils.encoding import force_str, force_text
 from django.utils.functional import memoize
 from django.utils._os import upath
@@ -45,6 +47,17 @@ accept_language_re = re.compile(r'''
         ''', re.VERBOSE)
 
 language_code_prefix_re = re.compile(r'^/([\w-]+)(/|$)')
+
+
+@receiver(setting_changed)
+def reset_cache(**kwargs):
+    """
+    Reset global state when LANGUAGES setting has been changed, as some
+    languages should no longer be accepted.
+    """
+    if kwargs['setting'] == 'LANGUAGES':
+        global _accepted
+        _accepted = {}
 
 
 def to_locale(language, to_lower=False):

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -15,7 +15,7 @@ from django.http import (Http404, HttpResponse, HttpResponseRedirect,
 from django.template import loader, Template, Context, TemplateDoesNotExist
 from django.utils.http import http_date, parse_http_date
 from django.utils.six.moves.urllib.parse import unquote
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 def serve(request, path, document_root=None, show_indexes=False):
     """
@@ -93,7 +93,7 @@ DEFAULT_DIRECTORY_INDEX_TEMPLATE = """
   </body>
 </html>
 """
-template_translatable = ugettext_noop("Index of %(directory)s")
+template_translatable = ugettext_lazy("Index of %(directory)s")
 
 def directory_index(path, fullpath):
     try:

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -940,6 +940,19 @@ class MiscTests(TransRealMixin, TestCase):
             self.assertEqual(t_plur.render(Context({'percent': 42, 'num': 1})), '%(percent)s% represents 1 object')
             self.assertEqual(t_plur.render(Context({'percent': 42, 'num': 4})), '%(percent)s% represents 4 objects')
 
+    def test_cache_resetting(self):
+        """
+        #14170 after setting LANGUAGE, cache should be cleared and languages
+        previously valid should not be used.
+        """
+        g = get_language_from_request
+        r = self.rf.get('/')
+        r.COOKIES = {}
+        r.META = {'HTTP_ACCEPT_LANGUAGE': 'pt-br'}
+        self.assertEqual('pt-br', g(r))
+        with self.settings(LANGUAGES=(('en', 'English'),)):
+            self.assertNotEqual('pt-br', g(r))
+
 
 class ResolutionOrderI18NTests(TransRealMixin, TestCase):
 


### PR DESCRIPTION
See [ticket 14170](https://code.djangoproject.com/ticket/14170). The global state `_accepted` is now reset when `LANGUAGES` setting has been changed.

I needed to change `static.py` to work around circular import issues.
