### PR TITLE
Fixed #15179 -- test client's login request is not run through middleware

### DIFF
--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -496,6 +496,11 @@ Tests
   :class:`~django.test.Client`. If ``True``, the request will be made
   through HTTPS.
 
+* Requests made with :meth:`Client.login() <django.test.Client.login>` and
+  :meth:`Client.logout() <django.test.Client.logout>` respect defaults defined
+  in :class:`~django.test.Client` instantiation and are processed through
+  middleware.
+
 Backwards incompatible changes in 1.7
 =====================================
 

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -663,6 +663,13 @@ Use the ``django.test.Client`` class to make requests.
         :meth:`~django.contrib.auth.models.UserManager.create_user` helper
         method to create a new user with a correctly hashed password.
 
+        .. versionadded:: 1.7
+
+            Requests made with :meth:`~django.test.Client.login` go through the
+            request middleware. If you need to control de environment, you can
+            do so at :class:`~django.test.Client` instantiation or with the
+            `Client.defaults` attribute.
+
     .. method:: Client.logout()
 
         If your site uses Django's :doc:`authentication system</topics/auth/index>`,
@@ -672,6 +679,13 @@ Use the ``django.test.Client`` class to make requests.
         After you call this method, the test client will have all the cookies
         and session data cleared to defaults. Subsequent requests will appear
         to come from an :class:`~django.contrib.auth.models.AnonymousUser`.
+
+        .. versionadded:: 1.7
+
+            Requests made with :meth:`~django.test.Client.logout` go through the
+            request middleware. If you need to control de environment, you can
+            do so at :class:`~django.test.Client` instantiation or with the
+            `Client.defaults` attribute.
 
 Testing responses
 ~~~~~~~~~~~~~~~~~

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import os
 import itertools
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.template import (TemplateSyntaxError,
     Context, Template, loader)
@@ -760,6 +761,9 @@ class AssertFormsetErrorTests(TestCase):
                                     'addresses.',
                                     **kwargs)
 
+class ProcessedMiddleware(object):
+    def process_request(self, request):
+        request.has_been_processed = True
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
 class LoginTests(TestCase):
@@ -780,6 +784,23 @@ class LoginTests(TestCase):
         # Check that assertRedirects uses the original client, not the
         # default client.
         self.assertRedirects(response, "http://testserver/test_client_regress/get_view/")
+
+    @override_settings(MIDDLEWARE_CLASSES=list(settings.MIDDLEWARE_CLASSES) + [
+            'test_client_regress.tests.ProcessedMiddleware'])
+    def test_request_middleware(self):
+        "Check that the request middleware is executed on login request"
+
+        def listener(sender, signal, **kwargs):
+            request = kwargs['request']
+            self.assertTrue(hasattr(request, 'has_been_processed'))
+
+        # Unlike other Client request performing methods, login and logout don't
+        # return the response, therefore we must use signals to get it
+        user_logged_in.connect(listener)
+        try:
+            self.client.login(username='testclient', password='password')
+        finally:
+            user_logged_in.disconnect(listener)
 
 
 @override_settings(
@@ -1260,11 +1281,31 @@ class UploadedFileEncodingTest(TestCase):
 
 
 class RequestHeadersTest(TestCase):
+    fixtures = ['testdata']
+
     def test_client_headers(self):
         "A test client can receive custom headers"
         response = self.client.get("/test_client_regress/check_headers/", HTTP_X_ARG_CHECK='Testing 123')
         self.assertEqual(response.content, b"HTTP_X_ARG_CHECK: Testing 123")
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+    def test_client_login_headers(self):
+        "Test client headers are used in login"
+
+        client = Client(HTTP_HOST='different')
+
+        def listener(sender, signal, **kwargs):
+            request = kwargs['request']
+            self.assertEqual(request.get_host(), 'different')
+
+        # Unlike other Client request performing methods, login and logout don't
+        # return the response, therefore we must use signals to get it
+        user_logged_in.connect(listener)
+        try:
+            client.login(username='testclient', password='password')
+        finally:
+            user_logged_in.disconnect(listener)
 
     def test_client_headers_redirect(self):
         "Test client headers are preserved through redirects"


### PR DESCRIPTION
Requests made with `django.test.Client.login` and
`django.test.Client.logout` respect defaults defined in `django.test.Client`
instantiation and are processed through middleware now.
