### PR TITLE
Fixed #16245 -- include traceback in ``send_robust()``s response

### DIFF
--- a/django/dispatch/dispatcher.py
+++ b/django/dispatch/dispatcher.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 import threading
 
@@ -207,7 +208,8 @@ class Signal(object):
 
         If any receiver raises an error (specifically any subclass of
         Exception), the error instance is returned as the result for that
-        receiver.
+        receiver. The traceback is always attached to the error at
+        ``__traceback__``.
         """
         responses = []
         if not self.receivers or self.sender_receivers_cache.get(sender) is NO_RECEIVERS:
@@ -219,6 +221,8 @@ class Signal(object):
             try:
                 response = receiver(signal=self, sender=sender, **named)
             except Exception as err:
+                if not hasattr(err, '__traceback__'):
+                    err.__traceback__ = sys.exc_info()[2]
                 responses.append((receiver, err))
             else:
                 responses.append((receiver, response))

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -488,6 +488,10 @@ Signals
   ``'app_label.ModelName'`` form – just like related fields – to lazily
   reference their senders.
 
+* Exceptions from the (receiver, exception) tuples returned by
+  :meth:`Signal.send_robust() <django.dispatch.Signal.send_robust>` now have
+  always their traceback attached as their ``__traceback__`` argument.
+
 Templates
 ^^^^^^^^^
 

--- a/docs/topics/signals.txt
+++ b/docs/topics/signals.txt
@@ -261,6 +261,11 @@ be notified of a signal in the face of an error.
 and ensures all receivers are notified of the signal. If an error occurs, the
 error instance is returned in the tuple pair for the receiver that raised the error.
 
+.. versionadded:: 1.7
+
+    The tracebacks are now always returned as the ``__traceback__`` attributes
+    of the errors returned when calling ``send_robust()``.
+
 Disconnecting signals
 =====================
 

--- a/tests/dispatch/tests/test_dispatcher.py
+++ b/tests/dispatch/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ import sys
 import time
 import unittest
 import weakref
+from types import TracebackType
 
 from django.dispatch import Signal, receiver
 
@@ -133,6 +134,8 @@ class DispatcherTests(unittest.TestCase):
         err = result[0][1]
         self.assertIsInstance(err, ValueError)
         self.assertEqual(err.args, ('this',))
+        self.assertTrue(hasattr(err, '__traceback__'))
+        self.assertTrue(isinstance(err.__traceback__, TracebackType))
         a_signal.disconnect(fails)
         self._testIsClean(a_signal)
 


### PR DESCRIPTION
Exceptions from the (receiver, exception) tuples returned by
`send_robust()` now have always their traceback attached as their
`__traceback__` argument.
