### PR TITLE
Fix for #21357.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -393,6 +393,11 @@ class Client(RequestFactory):
             cookie = self.cookies.get(settings.SESSION_COOKIE_NAME, None)
             if cookie:
                 return engine.SessionStore(cookie.value)
+            else:
+                s = engine.SessionStore()
+                s.save()
+                self.cookies[settings.SESSION_COOKIE_NAME] = s.session_key
+                return s
         return {}
     session = property(_session)
 

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1048,6 +1048,14 @@ class SessionTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'YES')
 
+    def test_session_initiated(self):
+        session = self.client.session
+        session['session_var'] = 'foo'
+        session.save()
+
+        response = self.client.get('/check_session/')
+        self.assertEqual(response.content, 'foo')
+
     def test_logout(self):
         """Logout should work whether the user is logged in or not (#9978)."""
         self.client.logout()


### PR DESCRIPTION
Initiate the session object if it hasn't been created already.
