### PR TITLE
Fixed #21363 - TimestampSigner.unsign accepts a timedelta

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -36,8 +36,10 @@ These functions make use of all of them.
 from __future__ import unicode_literals
 
 import base64
+import datetime
 import json
 import time
+import warnings
 import zlib
 
 from django.conf import settings
@@ -191,9 +193,13 @@ class TimestampSigner(Signer):
         value, timestamp = result.rsplit(self.sep, 1)
         timestamp = baseconv.base62.decode(timestamp)
         if max_age is not None:
+            if not isinstance(max_age, datetime.timedelta):
+                warnings.warn("Using a number of seconds for `max_age` is deprecated, "
+                              "use a timedelta instead.", PendingDeprecationWarning, 2)
+                max_age = datetime.timedelta(seconds=max_age)
             # Check timestamp is not older than max_age
-            age = time.time() - timestamp
+            age = datetime.datetime.fromtimestamp(time.time()) - datetime.datetime.fromtimestamp(timestamp)
             if age > max_age:
                 raise SignatureExpired(
-                    'Signature age %s > %s seconds' % (age, max_age))
+                    'Signature age %s > %s' % (age, max_age))
         return value

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -476,6 +476,10 @@ these changes.
 
 * The class ``django.utils.datastructures.MergeDict`` will be removed.
 
+* The ``max_age`` parameter of
+  :meth:`django.core.signing.TimestampSigner.unsign` will no longer accept a
+  number of seconds.
+
 2.0
 ---
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -690,3 +690,9 @@ deprecated and will be removed in Django 1.9.
 arguments into a ``REQUEST`` property on ``WSGIRequest``. To merge
 dictionaries, use ``dict.update()`` instead. The class ``MergeDict`` is
 deprecated and will be removed in Django 1.9.
+
+Change to the ``max_age`` parameter of :meth:`TimestampSigner.unsign<django.core.signing.TimestampSigner.unsign>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing a number of seconds to ``unsign`` as the ``max_age`` has been
+deprecated. Use a :class:`datetime.timedelta<python:datetime.timedelta>`
+instead.

--- a/docs/topics/signing.txt
+++ b/docs/topics/signing.txt
@@ -114,6 +114,7 @@ Verifying timestamped values
 timestamp to the value. This allows you to confirm that a signed value was
 created within a specified period of time::
 
+    >>> from datetime import timedelta
     >>> from django.core.signing import TimestampSigner
     >>> signer = TimestampSigner()
     >>> value = signer.sign('hello')
@@ -121,10 +122,10 @@ created within a specified period of time::
     'hello:1NMg5H:oPVuCqlJWmChm1rA2lyTUtelC-c'
     >>> signer.unsign(value)
     u'hello'
-    >>> signer.unsign(value, max_age=10)
+    >>> signer.unsign(value, max_age=timedelta(seconds=10))
     ...
-    SignatureExpired: Signature age 15.5289158821 > 10 seconds
-    >>> signer.unsign(value, max_age=20)
+    SignatureExpired: Signature age 0:00:15.978808 > 0:00:10
+    >>> signer.unsign(value, max_age=timedelta(seconds=20))
     u'hello'
 
 .. class:: TimestampSigner(key=None, sep=':', salt=None)
@@ -135,8 +136,10 @@ created within a specified period of time::
 
     .. method:: unsign(value, max_age=None)
 
-        Checks if ``value`` was signed less than ``max_age`` seconds ago,
-        otherwise raises ``SignatureExpired``.
+        Checks if ``value`` was signed less than ``max_age`` ago, otherwise
+        raises ``django.core.signing.SignatureExpired``. The ``max_age``
+        parameter should be a
+        :class:`datetime.timedelta<python:datetime.timedelta>` object.
 
 Protecting complex data structures
 ----------------------------------


### PR DESCRIPTION
Patch for https://code.djangoproject.com/ticket/21363
