### PR TITLE
Fixed #13725 -- take url scheme into account in assertRedirects

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -246,6 +246,8 @@ class SimpleTestCase(unittest.TestCase):
         if msg_prefix:
             msg_prefix += ": "
 
+        e_scheme, e_netloc, e_path, e_query, e_fragment = urlsplit(expected_url)
+
         if hasattr(response, 'redirect_chain'):
             # The request was a followed redirect
             self.assertTrue(len(response.redirect_chain) > 0,
@@ -259,6 +261,7 @@ class SimpleTestCase(unittest.TestCase):
                     (response.redirect_chain[0][1], status_code))
 
             url, status_code = response.redirect_chain[-1]
+            scheme, netloc, path, query, fragment = urlsplit(url)
 
             self.assertEqual(response.status_code, target_status_code,
                 msg_prefix + "Response didn't redirect as expected: Final"
@@ -276,7 +279,8 @@ class SimpleTestCase(unittest.TestCase):
             scheme, netloc, path, query, fragment = urlsplit(url)
 
             if fetch_redirect_response:
-                redirect_response = response.client.get(path, QueryDict(query))
+                redirect_response = response.client.get(path, QueryDict(query),
+                                                        secure=(scheme == 'https'))
 
                 # Get the redirection page, using the same client that was used
                 # to obtain the original response.
@@ -285,10 +289,10 @@ class SimpleTestCase(unittest.TestCase):
                     " response code was %d (expected %d)" %
                         (path, redirect_response.status_code, target_status_code))
 
-        e_scheme, e_netloc, e_path, e_query, e_fragment = urlsplit(expected_url)
-        if not (e_scheme or e_netloc):
-            expected_url = urlunsplit(('http', host or 'testserver', e_path,
-                e_query, e_fragment))
+        e_scheme = e_scheme if e_scheme else scheme or 'http'
+        e_netloc = e_netloc if e_netloc else host or 'testserver'
+        expected_url = urlunsplit((e_scheme, e_netloc, e_path, e_query,
+            e_fragment))
 
         self.assertEqual(url, expected_url,
             msg_prefix + "Response redirected to '%s', expected '%s'" %

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -444,6 +444,9 @@ Tests
   client can't fetch externals URLs, this allows you to use ``assertRedirects``
   with redirects that aren't part of your Django app.
 
+* Correct handling of scheme when making comparisons in
+  :meth:`~django.test.SimpleTestCase.assertRedirects`.
+
 * The ``secure`` argument was added to all the request methods of
   :class:`~django.test.Client`. If ``True``, the request will be made
   through HTTPS.

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -1576,6 +1576,13 @@ your test suite.
     loaded. Since the test client can't fetch externals URLs, this is
     particularly useful if ``expected_url`` isn't part of your Django app.
 
+    .. versionadded:: 1.7
+
+    Scheme is handled correctly when making comparisons between two URLs. If
+    there isn't any scheme specified in the location where we are redirected to,
+    the original request's scheme is used. If present, the scheme in
+    ``expected_url`` is the one used to make the comparisons to.
+
 .. method:: SimpleTestCase.assertHTMLEqual(html1, html2, msg=None)
 
     Asserts that the strings ``html1`` and ``html2`` are equal. The comparison


### PR DESCRIPTION
Scheme is handled correctly when making comparisons between two URLs. If
there isn't any scheme specified in the location where we are redirected to,
the original request's scheme is used. If present, the scheme in
`expected_url` is the one used to make the comparations to.
