### PR TITLE
Fixed #17529 -- get_template_from_string default arguments break

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -121,8 +121,7 @@ class StringOrigin(Origin):
 
 
 class Template(object):
-    def __init__(self, template_string, origin=None,
-                 name='<Unknown Template>'):
+    def __init__(self, template_string, origin=None, name=None):
         try:
             template_string = force_text(template_string)
         except UnicodeDecodeError:

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -502,7 +502,8 @@ class SimpleTestCase(unittest.TestCase):
             # use this template with context manager
             return template_name, None, msg_prefix
 
-        template_names = [t.name for t in response.templates]
+        template_names = [t.name for t in response.templates if t.name is not
+                          None]
         return None, template_names, msg_prefix
 
     def assertTemplateUsed(self, response=None, template_name=None, msg_prefix=''):

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -214,6 +214,8 @@ class AssertNumQueriesContextManagerTests(TestCase):
 
 
 class AssertTemplateUsedContextManagerTests(TestCase):
+    urls = 'test_utils.urls'
+
     def test_usage(self):
         with self.assertTemplateUsed('template_used/base.html'):
             render_to_string('template_used/base.html')
@@ -269,6 +271,11 @@ class AssertTemplateUsedContextManagerTests(TestCase):
         with six.assertRaisesRegex(self, AssertionError, r'^template_used/base\.html.*template_used/alternative\.html$'):
             with self.assertTemplateUsed('template_used/base.html'):
                 render_to_string('template_used/alternative.html')
+
+        with self.assertRaises(AssertionError) as cm:
+            response = self.client.get('/test_utils/no_template_used/')
+            self.assertTemplateUsed(response, 'template_used/base.html')
+        self.assertEqual(cm.exception.args[0], "No templates used to render the response")
 
     def test_failure(self):
         with self.assertRaises(TypeError):

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -5,4 +5,5 @@ from . import views
 
 urlpatterns = patterns('',
     (r'^test_utils/get_person/(\d+)/$', views.get_person),
+    (r'^test_utils/no_template_used/$', views.no_template_used),
 )

--- a/tests/test_utils/views.py
+++ b/tests/test_utils/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.template import loader, Context
 
 from .models import Person
 
@@ -7,3 +8,7 @@ from .models import Person
 def get_person(request, pk):
     person = get_object_or_404(Person, pk=pk)
     return HttpResponse(person.name)
+
+def no_template_used(request):
+    template = loader.get_template_from_string("This is a string-based template")
+    return HttpResponse(template.render(Context({})))


### PR DESCRIPTION
`get_template_from_string` default arguments were breaking
`assertTemplateUsed`. The solution has been to return only the names of the
templates with a `name` attribute distinct of `None`. The default `name`
kwarg of `Template` has been changed to `None`, more pythonic than `'<Unknown
Template>'`.
