### PR TITLE
Improved documentation about zh-* deprecation and upgrade path

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -476,8 +476,8 @@ these changes.
 
 * The class ``django.utils.datastructures.MergeDict`` will be removed.
 
-* The ``zh_CN`` and ``zh_TW`` language codes will be removed and have been
-  replaced by the ``zh_Hans`` and ``zh_Hant`` language code respectively.
+* The ``zh-cn`` and ``zh-tw`` language codes will be removed and have been
+  replaced by the ``zh-hans`` and ``zh-hant`` language code respectively.
 
 2.0
 ---

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -707,10 +707,12 @@ arguments into a ``REQUEST`` property on ``WSGIRequest``. To merge
 dictionaries, use ``dict.update()`` instead. The class ``MergeDict`` is
 deprecated and will be removed in Django 1.9.
 
-Language codes ``zh_CN`` and ``zh_TW``
+Language codes ``zh-cn`` and ``zh-tw``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The currently used language codes for Simplified Chinese ``zh_CN`` and
-Traditional Chinese ``zh_TW`` are deprecated and should be replaced by the
-recently introduced language codes ``zh_Hans`` and ``zh_Hant`` respectively.
-The deprecated language codes will be removed in Django 1.9.
+The currently used language codes for Simplified Chinese ``zh-cn`` and
+Traditional Chinese ``zh-tw`` are deprecated and should be replaced by the
+recently introduced language codes ``zh-hans`` and ``zh-hant`` respectively.
+If you use these language codes, you should rename the locale directories
+and update your settings to reflect these changes. The deprecated language
+codes will be removed in Django 1.9.


### PR DESCRIPTION
> <+bmispelon>   bouke: in my mind, the purpose of the release notes is twofold: 1) allow you to tell if you're affected by a change in django 2) help you go through an upgrade
>  <+bmispelon>  the current release note is good for 1), but I think we can do better for 2)
