### PR TITLE
Removed no longer relevant word

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -47,7 +47,7 @@ Specifying authentication backends
 Behind the scenes, Django maintains a list of "authentication backends" that it
 checks for authentication. When somebody calls
 :func:`django.contrib.auth.authenticate()` -- as described in :ref:`How to log
-a user in <how-to-log-a-user-in>` above -- Django tries authenticating across
+a user in <how-to-log-a-user-in>` -- Django tries authenticating across
 all of its authentication backends. If the first authentication method fails,
 Django tries the second one, and so on, until all backends have been attempted.
 


### PR DESCRIPTION
The word "above" is no longer relevant, since the "How to log a user in" section is now on a different page, since the refactoring (https://github.com/django/django/commit/11ded967c443087487f3872aafd86842608b4c64).
