### PR TITLE
Fixed missing admindocs' site_header

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -5,6 +5,7 @@ import re
 
 from django import template
 from django.conf import settings
+from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
@@ -36,11 +37,12 @@ class BaseAdminDocsView(TemplateView):
         if not utils.docutils_is_available:
             # Display an error message for people without docutils
             self.template_name = 'admin_doc/missing_docutils.html'
-            return self.render_to_response({})
+            return self.render_to_response(admin.site.each_context())
         return super(BaseAdminDocsView, self).dispatch(*args, **kwargs)
 
     def get_context_data(self, **kwargs):
         kwargs.update({'root_path': urlresolvers.reverse('admin:index')})
+        kwargs.update(admin.site.each_context())
         return super(BaseAdminDocsView, self).get_context_data(**kwargs)
 
 

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -25,6 +25,9 @@ class AdminDocViewTests(TestCase):
         self.client.login(username='super', password='secret')
         response = self.client.get(reverse('django-admindocs-docroot'))
         self.assertContains(response, '<h1>Documentation</h1>', html=True)
+        self.assertContains(response,
+                            '<h1 id="site-name"><a href="/admin/">Django '
+                            'administration</a></h1>')
 
     def test_bookmarklets(self):
         response = self.client.get(reverse('django-admindocs-bookmarklets'))
@@ -80,6 +83,9 @@ class AdminDocViewTests(TestCase):
                 '<h3>The admin documentation system requires Python\'s '
                 '<a href="http://docutils.sf.net/">docutils</a> library.</h3>',
                 html=True)
+            self.assertContains(response,
+                                '<h1 id="site-name"><a href="/admin/">Django '
+                                'administration</a></h1>')
         finally:
             utils.docutils_is_available = True
 


### PR DESCRIPTION
The same problem as in [ticket 21293](https://code.djangoproject.com/ticket/21293), making the site's header disappear and user tools (logout) unfindable.
