### PR TITLE
Fixed #2259 -- Made primary keys readonly by default in admin

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -21,7 +21,8 @@ from django.core.urlresolvers import reverse
 from django.db import models, transaction, router
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.related import RelatedObject
-from django.db.models.fields import BLANK_CHOICE_DASH, FieldDoesNotExist
+from django.db.models.fields import (BLANK_CHOICE_DASH, FieldDoesNotExist,
+                                     AutoField)
 from django.db.models.sql.constants import QUERY_TERMS
 from django.forms.formsets import all_valid, DELETION_FIELD_NAME
 from django.forms.models import (modelform_factory, modelformset_factory,
@@ -96,6 +97,7 @@ class BaseModelAdmin(six.with_metaclass(RenameBaseModelAdminMethods)):
     radio_fields = {}
     prepopulated_fields = {}
     formfield_overrides = {}
+    auto_pk_readonly_field = True
     readonly_fields = ()
     ordering = None
     view_on_site = True
@@ -311,7 +313,11 @@ class BaseModelAdmin(six.with_metaclass(RenameBaseModelAdminMethods)):
         """
         Hook for specifying custom readonly fields.
         """
-        return self.readonly_fields
+        if (self.auto_pk_readonly_field and obj is not None
+                and not isinstance(self.opts.pk, AutoField)):
+            return self.readonly_fields + (self.opts.pk.attname,)
+        else:
+            return self.readonly_fields
 
     def get_prepopulated_fields(self, request, obj=None):
         """

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -159,6 +159,15 @@ subclass::
     By default, the admin changelist will display it
     (``actions_selection_counter = True``).
 
+.. attribute:: ModelAdmin.auto_pk_readonly_field
+
+    .. versionadded:: 1.7
+
+        If the primary key is not an ``AutoField``, this controls whether the
+        primary key field is made read-only for existing objects. If set to
+        ``False``, the change form reverts to pre-1.7 behaviour and the primary
+        key field will remain editable.
+
 .. attribute:: ModelAdmin.date_hierarchy
 
     Set ``date_hierarchy`` to the name of a ``DateField`` or ``DateTimeField``

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -172,6 +172,11 @@ Minor features
   <django.contrib.admin.ModelAdmin.view_on_site>` to control whether or not to
   display the "View on site" link.
 
+* Primary key fields will now be read-only for change forms by default, but
+  can be made editable again by setting
+  :attr:`ModelAdmin.auto_pk_readonly_field<django.contrib.admin.ModelAdmin.auto_pk_readonly_field>`
+  to ``False``.
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Refs [ticket 2259](https://code.djangoproject.com/ticket/2259).
