### PR TITLE
Fixed warning due to unicode characters in cookies

### DIFF
--- a/django/http/cookie.py
+++ b/django/http/cookie.py
@@ -71,7 +71,7 @@ else:
 
 
 def parse_cookie(cookie):
-    if cookie == '':
+    if not cookie:
         return {}
     if not isinstance(cookie, http_cookies.BaseCookie):
         try:


### PR DESCRIPTION
Simple request:
curl 'http://127.0.0.1:8000/' -H $'Cookie: ТЕСТ'
Causes "Unicode equal comparison failed" in server's console
