### PR TITLE
Expose level_tag property on messages.

### DIFF
--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -40,17 +40,19 @@ class Message(object):
         return force_text(self.message)
 
     def _get_tags(self):
-        label_tag = force_text(LEVEL_TAGS.get(self.level, ''),
-                                  strings_only=True)
         extra_tags = force_text(self.extra_tags, strings_only=True)
-        if extra_tags and label_tag:
-            return ' '.join([extra_tags, label_tag])
+        if extra_tags and self.level_tag:
+            return ' '.join([extra_tags, self.level_tag])
         elif extra_tags:
             return extra_tags
-        elif label_tag:
-            return label_tag
+        elif self.level_tag:
+            return self.level_tag
         return ''
     tags = property(_get_tags)
+
+    @property
+    def level_tag(self):
+        return force_text(LEVEL_TAGS.get(self.level, ''), strings_only=True)
 
 
 class BaseStorage(object):

--- a/django/contrib/messages/tests/base.py
+++ b/django/contrib/messages/tests/base.py
@@ -361,6 +361,15 @@ class BaseTests(object):
                          ['info', '', 'extra-tag debug', 'warning', 'error',
                           'success'])
 
+    def test_level_tag(self):
+        storage = self.get_storage()
+        storage.level = 0
+        add_level_messages(storage)
+        tags = [msg.level_tag for msg in storage]
+        self.assertEqual(tags,
+                         ['info', '', 'debug', 'warning', 'error',
+                          'success'])
+
     @override_settings_tags(MESSAGE_TAGS={
         constants.INFO: 'info',
         constants.DEBUG: '',

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -122,13 +122,16 @@ than this will be ignored.
 Message tags
 ------------
 
-Message tags are a string representation of the message level plus any
-extra tags that were added directly in the view (see
-`Adding extra message tags`_ below for more details). Tags are stored in a
-string and are separated by spaces. Typically, message tags
-are used as CSS classes to customize message style based on message type. By
-default, each level has a single tag that's a lowercase version of its own
-constant:
+Each message has at least one tag which is the string representation of the
+message level. The ``level_tag`` property contains a string with only the
+name of the level. Additionally, you can add extra tags by supplying the
+``extra_tags`` argument (see `Adding extra message tags`_ below for more
+details). The ``tags`` property of a message contains a string with
+both the ``extra_tags`` and the ``level_tag`` separated by spaces.
+
+These tags are typically used as CSS classes to customize message style based
+on message type. By default, each level has a single tag that's a lowercase
+version of its own constant:
 
 ==============  ===========
 Level Constant  Tag

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -221,6 +221,9 @@ Minor features
 * The :ref:`messages context processor <message-displaying>` now adds a
   dictionary of default levels under the name ``DEFAULT_MESSAGE_LEVELS``.
 
+* Message objects now have a ``level_tag`` attribute that contains the string
+  representation of the message level.
+
 :mod:`django.contrib.redirects`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Exposing the level name (e.g. "info") makes it possible to prepend
something to the class name. For example, Twitter Bootstrap has
an alert-info class. This class can now be added to the message
using `class="alert-{{ message.level_tag }}"`.
Because the level_tag was on the end of the `tags` property, it
could not be used in this fashion when extra_tags were given.
