### PR TITLE
Fixed docs for EmailMessage extra_headers attribute

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -267,7 +267,7 @@ All parameters are optional and can be set at any time prior to calling the
 * ``headers``: A dictionary of extra headers to put on the message. The
   keys are the header name, values are the header values. It's up to the
   caller to ensure header names and values are in the correct format for
-  an email message.
+  an email message. The corresponding attribute is ``extra_headers``.
 
 * ``cc``: A list or tuple of recipient addresses used in the "Cc" header
   when sending the email.


### PR DESCRIPTION
The EmailMessage documentation describes the initialization parameters
and states they 'can be set at any time prior to calling the send()
method.'.
However, the 'headers' parameter has a corresponding attribute named
differently as 'extra_headers' - this documents that.

The EmailMessage class could be altered to correct this, but as my first Django patch I'm leaning towards a simple doc fix.
