### PR TITLE
Fixed #14800 -- Suppressed WSGIRequestHandler message filtering

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -19,7 +19,6 @@ from wsgiref.util import FileWrapper   # NOQA: for backwards compatibility
 from django.core.management.color import color_style
 from django.core.wsgi import get_wsgi_application
 from django.utils.module_loading import import_by_path
-from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.six.moves import socketserver
 
 __all__ = ('WSGIServer', 'WSGIRequestHandler', 'MAX_SOCKET_CHUNK_SIZE')
@@ -116,11 +115,6 @@ class WSGIServer(simple_server.WSGIServer, object):
 class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
 
     def __init__(self, *args, **kwargs):
-        from django.conf import settings
-        self.admin_static_prefix = urljoin(settings.STATIC_URL, 'admin/')
-        # We set self.path to avoid crashes in log_message() on unsupported
-        # requests (like "OPTIONS").
-        self.path = ''
         self.style = color_style()
         super(WSGIRequestHandler, self).__init__(*args, **kwargs)
 
@@ -129,11 +123,6 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
         return self.client_address[0]
 
     def log_message(self, format, *args):
-        # Don't bother logging requests for admin images or the favicon.
-        if (self.path.startswith(self.admin_static_prefix)
-                or self.path == '/favicon.ico'):
-            return
-
         msg = "[%s] %s\n" % (self.log_date_time_string(), format % args)
 
         # Utilize terminal colors, if available

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -783,6 +783,11 @@ are reserved for the superuser (root).
 This server uses the WSGI application object specified by the
 :setting:`WSGI_APPLICATION` setting.
 
+.. versionchanged:: 1.7
+
+    All requests are logged to the console. There are no more filtering on
+    static file or ``favicon.ico`` requests.
+
 DO NOT USE THIS SERVER IN A PRODUCTION SETTING. It has not gone through
 security audits or performance tests. (And that's how it's gonna stay. We're in
 the business of making Web frameworks, not Web servers, so improving this

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -383,6 +383,9 @@ Management Commands
     translation file is updated, i.e. after running
     :djadmin:`compilemessages`.
 
+  * Console logging of requests doesn't filter out requests for static files or
+    for ``favicon.ico`` like it used to.
+
 Models
 ^^^^^^
 


### PR DESCRIPTION
Filtering out static file requests in runserver has been judged
arbitrary and can hide some debugging-related activity.
Thanks Roy Smith for the report.
