### PR TITLE
BASE_DIR gets project's absolute path

### DIFF
--- a/django/conf/project_template/project_name/settings.py
+++ b/django/conf/project_template/project_name/settings.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
Don't you mean something like this here? With the current BASE_DIR variable set to `os.path.dirname(os.path.dirname(__file__))`, I was getting an error while trying to include a default template located in _project_folder/templates_.

```
TemplateDoesNotExist at /
```

I noticed this when I upgraded to 1.6, so it should probably be merged there too.
