### PR TITLE
Fixed #21428 -- editable GenericRelation regression

### DIFF
--- a/django/contrib/contenttypes/generic.py
+++ b/django/contrib/contenttypes/generic.py
@@ -39,6 +39,7 @@ class GenericForeignKey(six.with_metaclass(RenameGenericForeignKeyMethods)):
         self.ct_field = ct_field
         self.fk_field = fk_field
         self.for_concrete_model = for_concrete_model
+        self.editable = False
 
     def contribute_to_class(self, cls, name):
         self.name = name

--- a/docs/releases/1.6.1.txt
+++ b/docs/releases/1.6.1.txt
@@ -15,3 +15,4 @@ Bug fixes
 * Fixed a regression that prevented a ``ForeignKey`` with a hidden reverse
   manager (``related_name`` ending with '+') from being used as a lookup for
   ``prefetch_related`` (#21410).
+* Made editable ``GenericRelation`` subclasses to work again in ``ModelForms``.

--- a/tests/generic_relations_regress/models.py
+++ b/tests/generic_relations_regress/models.py
@@ -143,8 +143,18 @@ class Board(models.Model):
     name = models.CharField(primary_key=True, max_length=15)
 
 
+class SpecialGenericRelation(generic.GenericRelation):
+    def __init__(self, *args, **kwargs):
+        super(SpecialGenericRelation, self).__init__(*args, **kwargs)
+        self.editable = True
+        self.save_form_data_calls = 0
+
+    def save_form_data(self, *args, **kwargs):
+        self.save_form_data_calls += 1
+
+
 class HasLinks(models.Model):
-    links = generic.GenericRelation(Link)
+    links = SpecialGenericRelation(Link)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
The GenericRelation refactoring removed GenericRelations from
model._meta.many_to_many. This had the side effect of disallowing
editable GenericRelations in ModelForms. Editable GenericRelations
aren't officially supported, but if we don't fix this we don't offer any
upgrade path for those who used the ability to set editable=True
in GenericRelation subclass.

Thanks to Trac alias joshcartme for the report and stephencmd and Loic
for working on this issue.
