### PR TITLE
Fixed #21175 -- Abstract base model class fires class_prepared signal

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -265,6 +265,7 @@ class ModelBase(type):
             # little differently from normal models.
             attr_meta.abstract = False
             new_class.Meta = attr_meta
+            signals.class_prepared.send(sender=new_class)
             return new_class
 
         new_class._prepare()

--- a/tests/signals_regress/models.py
+++ b/tests/signals_regress/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-
+from django.dispatch import receiver
 
 @python_2_unicode_compatible
 class Author(models.Model):
@@ -17,3 +17,21 @@ class Book(models.Model):
 
     def __str__(self):
         return self.name
+
+@receiver(models.signals.class_prepared)
+# exists because tests.SignalsRegressTests.setUp() connects *after* signal sends
+def class_prepared_receiver(sender, **kwargs):
+    sender._meta.class_prepared_signal_fired = True
+
+@python_2_unicode_compatible
+class SomethingAbstract(models.Model):
+    name = models.CharField(max_length=20)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        abstract = True
+
+class NotAbstract(SomethingAbstract):
+    pass

--- a/tests/signals_regress/tests.py
+++ b/tests/signals_regress/tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.test import TestCase
 
-from .models import Author, Book
+from .models import Author, Book, SomethingAbstract, NotAbstract
 
 
 class SignalsRegressTests(TestCase):
@@ -93,3 +93,7 @@ class SignalsRegressTests(TestCase):
         self.get_signal_output(a1.save)
         self.assertEqual(self.get_signal_output(setattr, b1, 'authors', [a1]), [])
         self.assertEqual(self.get_signal_output(setattr, b1, 'authors', []), [])
+
+    def test_class_prepared_signal(self):
+        self.assertTrue(SomethingAbstract._meta.class_prepared_signal_fired)
+        self.assertTrue(NotAbstract._meta.class_prepared_signal_fired)


### PR DESCRIPTION
Created test for class_prepared signal and reconditioned abstract
base model class to send class_prepared signal.
