### PR TITLE
context_data instead of context in shell

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -381,7 +381,7 @@ With that ready, we can ask the client to do some work for us::
     >>> response = client.get('/polls/')
     >>> response.content
     '\n\n\n    <ul>\n    \n        <li><a href="/polls/1/">Who is your favorite Beatle?</a></li>\n    \n    </ul>\n\n'
-    >>> response.context['latest_question_list']
+    >>> response.context_data['latest_question_list']
     [<Question: Who is your favorite Beatle?>]
 
 Improving our view


### PR DESCRIPTION
For some reason, `context` was an empty property in my shell, whereas the `context_data` property contained the dictionary. Running Django 1.6 and IPython.
