### PR TITLE
Speed up BCrypt and PBKDF2 password hashing.

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -195,6 +195,34 @@ mentioned algorithms won't be able to upgrade.
 .. _bcrypt: http://en.wikipedia.org/wiki/Bcrypt
 .. _`bcrypt library`: https://pypi.python.org/pypi/bcrypt/
 
+.. _password-hash-caching:
+
+Password Hash Caching
+---------------------
+
+Modern algorithms like BCrypt_ and PBKDF2_ derive their strength from
+artificially increasing CPU load. Their iteration-based hashing deliberately
+slows down the hashing process to make brute force hash attacks infeasible.
+
+However this works both ways and it can make these algorithms less suitable
+for high-volume services that rely on Basic HTTP Auth.
+
+In these cases it can be desirable to cache the result of a BCrypt_ or PBKDF2_
+hash between page views so that you don't need to calculate them over and over
+again.
+
+Django offers the following alternative hashers if your service needs hash
+caching::
+
+          django.contrib.auth.hashers.CachingPBKDF2PasswordHasher
+          django.contrib.auth.hashers.CachingPBKDF2SHA1PasswordHasher
+          django.contrib.auth.hashers.CachingBCryptPasswordHasher
+          django.contrib.auth.hashers.CachingBCryptSHA256PasswordHasher
+
+Note that these use Django's default cache. It caches the result of the
+hasher's ``verify`` method, using the SHA1 of the password and raw encoded
+string as the cache key. If your service uses something like Memcached, be
+aware that this information will leave your webserver process' boundaries.
 
 Manually managing a user's password
 ===================================


### PR DESCRIPTION
Iteration-based password hashing algorithms can be prohibitively expensive for high volume sites that rely on Basic HTTP Auth.

This change adds caching versions of the BCrypt and PBKDF2 hashers.

The motivation for this came from us trying to upgrade Bitbucket to BCrypt and DOSing ourselves in the process.
