### PR TITLE
added missing argument for selector_div

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -36,7 +36,7 @@ window.SelectFilter = {
         }
 
         // <div class="selector"> or <div class="selector stacked">
-        var selector_div = quickElement('div', from_box.parentNode);
+        var selector_div = quickElement('div', from_box.parentNode, '');
         selector_div.className = is_stacked ? 'selector stacked' : 'selector';
 
         // <div class="selector-available">


### PR DESCRIPTION
I added the missing third argument within `quickElement('div', from_box.parentNode, '')` which is constructing `selector_div`
