### PR TITLE
Fixed the base class note in the Date Views docs

### DIFF
--- a/docs/ref/class-based-views/generic-date-based.txt
+++ b/docs/ref/class-based-views/generic-date-based.txt
@@ -612,7 +612,10 @@ DateDetailView
 
     All of the generic views listed above have matching ``Base`` views that
     only differ in that they do not include the
-    :class:`~django.views.generic.detail.SingleObjectTemplateResponseMixin`:
+    :class:`~django.views.generic.list.MultipleObjectTemplateResponseMixin`
+    for the archive views and
+    :class:`~django.views.generic.detail.SingleObjectTemplateResponseMixin` for
+    the :class:`DateDetailView`:
 
     .. class:: BaseArchiveIndexView
 


### PR DESCRIPTION
The note near [this](https://docs.djangoproject.com/en/dev/ref/class-based-views/generic-date-based/#django.views.generic.dates.BaseArchiveIndexView) made it seem like all of the Archive Views inherited from SingleObjectTemplateResponseMixin when most of them really inherit from MultipleObjectTemplateResponseMixin.
