### PR TITLE
Fixed #19879 -- Have 'findstatic' says on which directories it searched ...

### DIFF
--- a/django/contrib/staticfiles/management/commands/findstatic.py
+++ b/django/contrib/staticfiles/management/commands/findstatic.py
@@ -21,15 +21,23 @@ class Command(LabelCommand):
         verbosity = int(options.get('verbosity', 1))
         result = finders.find(path, all=options['all'])
         path = force_text(path)
+        if verbosity >= 2:
+            searched_locations = finders.get_searched_locations()
+            searched_locations_message = "\nLooking in the following locations:\n  " +\
+                    "\n  ".join(force_text(location) for location in searched_locations)
+        else:
+            searched_locations_message = ""
         if result:
             if not isinstance(result, (list, tuple)):
                 result = [result]
             result = (force_text(os.path.realpath(path)) for path in result)
             if verbosity >= 1:
                 output = '\n  '.join(result)
-                return "Found '%s' here:\n  %s" % (path, output)
+                return "Found '%s' here:\n  %s" % (path, output) +\
+                        searched_locations_message
             else:
-                return '\n'.join(result)
+                return '\n'.join(result) + searched_locations_message
         else:
             if verbosity >= 1:
-                self.stderr.write("No matching file found for '%s'." % path)
+                self.stderr.write("No matching file found for '%s'." % path +\
+                        searched_locations_message)

--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -158,6 +158,25 @@ output and just get the path names::
    /home/special.polls.com/core/static/css/base.css
    /home/polls.com/core/static/css/base.css
 
+On the other hand, by setting the :djadminopt:`--verbosity` flag to 2, you can
+get all the directories on which it searched the relative paths::
+
+   $ python manage.py findstatic css/base.css --verbosity 2
+   Found 'css/base.css' here:
+     /home/special.polls.com/core/static/css/base.css
+     /home/polls.com/core/static/css/base.css
+   Looking in the following locations:
+     /home/special.polls.com/core/static
+     /home/polls.com/core/static
+     /opt/project/site_media/media
+     /opt/project/site_media/static
+
+.. versionadded:: 1.7
+
+   The additional message of on which directories it searched the relative
+   paths is new in Django 1.7.
+
+
 .. _staticfiles-runserver:
 
 runserver
@@ -345,6 +364,24 @@ files:
   :ttag:`get_static_prefix` but uses :setting:`MEDIA_URL`.
 
 .. _staticfiles-development-view:
+
+Finders Module
+==============
+
+``staticfiles`` finders has ``get_searched_locations`` function which returns
+a list of directories on which the ``staticfiles`` finders searched the
+relative paths. Example usage::
+
+    from django.contrib.staticfiles import finders
+
+    result = finders.find('css/base.css')
+    searched_locations = finders.get_searched_locations()
+
+.. versionadded:: 1.7
+
+The ``get_searched_locations`` function is new in Django 1.7. Previously, we
+have to check the locations of our :setting:`STATICFILES_FINDERS` manually
+one by one.
 
 Static file development view
 ----------------------------

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -631,6 +631,10 @@ Miscellaneous
   ``select_related('foo').select_related('bar')``. Previously the latter would
   have been equivalent to ``select_related('bar')``.
 
+* :djadmin:`findstatic` now accepts verbosity flag level 2, meaning it will
+  show the directories on which it searched the relative paths. See
+  :djadmin:`findstatic` for example output.
+
 Features deprecated in 1.7
 ==========================
 

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -224,6 +224,35 @@ class TestFindStatic(CollectionTestCase, TestDefaults):
         self.assertIn('project', force_text(lines[0]))
         self.assertIn('apps', force_text(lines[1]))
 
+    def test_all_files_more_verbose(self):
+        """
+        Test that findstatic returns all candidate files if run without --first and -v2.
+        Also, test that findstatic returns the searched locations with -v2.
+        """
+        out = six.StringIO()
+        call_command('findstatic', 'test/file.txt', verbosity=2, stdout=out)
+        out.seek(0)
+        lines = [l.strip() for l in out.readlines()]
+        self.assertIn('project', force_text(lines[1]))
+        self.assertIn('apps', force_text(lines[2]))
+        self.assertIn("Looking in the following locations:", force_text(lines[3]))
+        searched_locations = ', '.join(lines[4:])
+        #AppDirectoriesFinder searched locations
+        self.assertIn(os.path.join('staticfiles_tests', 'apps', 'test', 'static'),
+                      searched_locations)
+        self.assertIn(os.path.join('staticfiles_tests', 'apps', 'no_label', 'static'),
+                      searched_locations)
+        self.assertIn(os.path.join('django', 'contrib', 'admin', 'static'),
+                      searched_locations)
+        self.assertIn(os.path.join('django', 'tests', 'servers', 'another_app', 'static'),
+                      searched_locations)
+        #FileSystemFinder searched locations
+        self.assertIn(TEST_SETTINGS['STATICFILES_DIRS'][1][1], searched_locations)
+        self.assertIn(TEST_SETTINGS['STATICFILES_DIRS'][0], searched_locations)
+        #DefaultStorageFinder searched locations
+        self.assertIn(os.path.join('staticfiles_tests', 'project', 'site_media', 'media'),
+                      searched_locations)
+
 
 class TestCollection(CollectionTestCase, TestDefaults):
     """
@@ -739,6 +768,9 @@ class TestDefaultStorageFinder(StaticFilesTestCase, FinderTestCase):
         self.find_all = ('media-file.txt', [test_file_path])
 
 
+@override_settings(STATICFILES_FINDERS=
+                   ('django.contrib.staticfiles.finders.FileSystemFinder',),
+                   STATICFILES_DIRS=[os.path.join(TEST_ROOT, 'project', 'documents')])
 class TestMiscFinder(TestCase):
     """
     A few misc finder tests.
@@ -764,6 +796,11 @@ class TestMiscFinder(TestCase):
         cache_info = finders.get_finder.cache_info()
         self.assertEqual(cache_info.hits, 9)
         self.assertEqual(cache_info.currsize, 1)
+
+    def test_get_searched_locations(self):
+        finders.find('spam')
+        self.assertEqual(finders.get_searched_locations(),
+                         {os.path.join(TEST_ROOT, 'project', 'documents')})
 
     @override_settings(STATICFILES_DIRS='a string')
     def test_non_tuple_raises_exception(self):


### PR DESCRIPTION
...the relative paths.

Added get_searched_locations in finders module. Added verbosity flag level 2 on 'findstatic'
command that will output the directories on which it searched the relative paths.

Reported by ccurvey. Initial patch by Jonas Svensson.
