### PR TITLE
Fixed E125 pep8 warnings

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -613,7 +613,7 @@ class ModelAdmin(BaseModelAdmin):
         }
         defaults.update(kwargs)
         if (defaults.get('fields') is None
-            and not modelform_defines_fields(defaults.get('form'))):
+                and not modelform_defines_fields(defaults.get('form'))):
             defaults['fields'] = forms.ALL_FIELDS
 
         return modelform_factory(self.model, **defaults)

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -169,7 +169,7 @@ class AdminSite(object):
             raise ImproperlyConfigured("Put 'django.contrib.contenttypes' in "
                 "your INSTALLED_APPS setting in order to use the admin application.")
         if not ('django.contrib.auth.context_processors.auth' in settings.TEMPLATE_CONTEXT_PROCESSORS or
-            'django.core.context_processors.auth' in settings.TEMPLATE_CONTEXT_PROCESSORS):
+                'django.core.context_processors.auth' in settings.TEMPLATE_CONTEXT_PROCESSORS):
             raise ImproperlyConfigured("Put 'django.contrib.auth.context_processors.auth' "
                 "in your TEMPLATE_CONTEXT_PROCESSORS setting in order to use the admin application.")
 

--- a/django/contrib/admin/validation.py
+++ b/django/contrib/admin/validation.py
@@ -155,7 +155,7 @@ class BaseValidator(object):
             for field, val in cls.prepopulated_fields.items():
                 f = get_field(cls, model, 'prepopulated_fields', field)
                 if isinstance(f, (models.DateTimeField, models.ForeignKey,
-                    models.ManyToManyField)):
+                        models.ManyToManyField)):
                     raise ImproperlyConfigured("'%s.prepopulated_fields['%s']' "
                             "is either a DateTimeField, ForeignKey or "
                             "ManyToManyField. This isn't allowed."

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -29,7 +29,7 @@ def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIE
             login_scheme, login_netloc = urlparse(resolved_login_url)[:2]
             current_scheme, current_netloc = urlparse(path)[:2]
             if ((not login_scheme or login_scheme == current_scheme) and
-                (not login_netloc or login_netloc == current_netloc)):
+                    (not login_netloc or login_netloc == current_netloc)):
                 path = request.get_full_path()
             from django.contrib.auth.views import redirect_to_login
             return redirect_to_login(

--- a/django/contrib/flatpages/forms.py
+++ b/django/contrib/flatpages/forms.py
@@ -23,8 +23,8 @@ class FlatpageForm(forms.ModelForm):
                 code='missing_leading_slash',
             )
         if (settings.APPEND_SLASH and
-            'django.middleware.common.CommonMiddleware' in settings.MIDDLEWARE_CLASSES and
-            not url.endswith('/')):
+                'django.middleware.common.CommonMiddleware' in settings.MIDDLEWARE_CLASSES and
+                not url.endswith('/')):
             raise forms.ValidationError(
                 ugettext("URL is missing a trailing slash."),
                 code='missing_trailing_slash',

--- a/django/contrib/formtools/wizard/views.py
+++ b/django/contrib/formtools/wizard/views.py
@@ -123,7 +123,7 @@ class WizardView(TemplateView):
 
     @classmethod
     def get_initkwargs(cls, form_list=None, initial_dict=None,
-        instance_dict=None, condition_dict=None, *args, **kwargs):
+            instance_dict=None, condition_dict=None, *args, **kwargs):
         """
         Creates a dict with all needed parameters for the form wizard instances.
 

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -369,7 +369,7 @@ class PostGISOperations(DatabaseOperations, BaseSpatialOperations):
             dist_param = value
 
         if (not geography and geodetic and lookup_type != 'dwithin'
-            and option == 'spheroid'):
+                and option == 'spheroid'):
             # using distance_spheroid requires the spheroid of the field as
             # a parameter.
             return [f._spheroid, dist_param]
@@ -467,7 +467,7 @@ class PostGISOperations(DatabaseOperations, BaseSpatialOperations):
         def two_to_three(np):
             return np >= 2 and np <= 3
         if (lookup_type in self.distance_functions and
-            lookup_type != 'dwithin'):
+                lookup_type != 'dwithin'):
             return two_to_three(num_param)
         else:
             return exactly_two(num_param)

--- a/django/contrib/gis/db/models/sql/where.py
+++ b/django/contrib/gis/db/models/sql/where.py
@@ -39,7 +39,7 @@ class GeoWhereNode(WhereNode):
         if isinstance(data, (list, tuple)):
             obj, lookup_type, value = data
             if (isinstance(obj, Constraint) and
-                isinstance(obj.field, GeometryField)):
+                    isinstance(obj.field, GeometryField)):
                 data = (GeoConstraint(obj), lookup_type, value)
         return super(GeoWhereNode, self)._prepare_data(data)
 

--- a/django/contrib/gis/models.py
+++ b/django/contrib/gis/models.py
@@ -1,7 +1,7 @@
 from django.db import connection
 
 if (hasattr(connection.ops, 'spatial_version') and
-    not connection.ops.mysql):
+        not connection.ops.mysql):
     # Getting the `SpatialRefSys` and `GeometryColumns`
     # models for the default spatial backend.  These
     # aliases are provided for backwards-compatibility.

--- a/django/contrib/gis/utils/layermapping.py
+++ b/django/contrib/gis/utils/layermapping.py
@@ -339,7 +339,7 @@ class LayerMapping(object):
         otherwise the proper exception is raised.
         """
         if (isinstance(ogr_field, OFTString) and
-            isinstance(model_field, (models.CharField, models.TextField))):
+                isinstance(model_field, (models.CharField, models.TextField))):
             if self.encoding:
                 # The encoding for OGR data sources may be specified here
                 # (e.g., 'cp437' for Census Bureau boundary files).

--- a/django/contrib/sessions/tests.py
+++ b/django/contrib/sessions/tests.py
@@ -141,7 +141,7 @@ class SessionTestsMixin(object):
 
     def test_save(self):
         if (hasattr(self.session, '_cache') and 'DummyCache' in
-            settings.CACHES[settings.SESSION_CACHE_ALIAS]['BACKEND']):
+                settings.CACHES[settings.SESSION_CACHE_ALIAS]['BACKEND']):
             raise unittest.SkipTest("Session saving tests require a real cache backend")
         self.session.save()
         self.assertTrue(self.session.exists(self.session.session_key))

--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -94,7 +94,7 @@ class Sitemap(object):
             if all_items_lastmod:
                 all_items_lastmod = lastmod is not None
                 if (all_items_lastmod and
-                    (latest_lastmod is None or lastmod > latest_lastmod)):
+                        (latest_lastmod is None or lastmod > latest_lastmod)):
                     latest_lastmod = lastmod
             url_info = {
                 'item': item,

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -153,7 +153,7 @@ class BaseDatabaseWrapper(object):
         """
         self.validate_thread_sharing()
         if (self.use_debug_cursor or
-            (self.use_debug_cursor is None and settings.DEBUG)):
+                (self.use_debug_cursor is None and settings.DEBUG)):
             cursor = self.make_debug_cursor(self._cursor())
         else:
             cursor = utils.CursorWrapper(self._cursor(), self)

--- a/django/db/backends/mysql/compiler.py
+++ b/django/db/backends/mysql/compiler.py
@@ -8,7 +8,7 @@ class SQLCompiler(compiler.SQLCompiler):
         index_extra_select = len(self.query.extra_select)
         for value, field in zip_longest(row[index_extra_select:], fields):
             if (field and field.get_internal_type() in ("BooleanField", "NullBooleanField") and
-                value in (0, 1)):
+                    value in (0, 1)):
                 value = bool(value)
             values.append(value)
         return row[:index_extra_select] + tuple(values)

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -135,7 +135,7 @@ class Collector(object):
         # Foreign keys pointing to this model, both from m2m and other
         # models.
         for related in opts.get_all_related_objects(
-            include_hidden=True, include_proxy_eq=True):
+                include_hidden=True, include_proxy_eq=True):
             if related.field.rel.on_delete is not DO_NOTHING:
                 return False
         # GFK deletes
@@ -145,7 +145,7 @@ class Collector(object):
         return True
 
     def collect(self, objs, source=None, nullable=False, collect_related=True,
-        source_attr=None, reverse_dependency=False):
+            source_attr=None, reverse_dependency=False):
         """
         Adds 'objs' to the collection of objects to be deleted as well as all
         parent instances.  'objs' must be a homogenous iterable collection of

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1281,7 +1281,7 @@ class IntegerField(Field):
 
     def get_prep_lookup(self, lookup_type, value):
         if ((lookup_type == 'gte' or lookup_type == 'lt')
-            and isinstance(value, float)):
+                and isinstance(value, float)):
             value = math.ceil(value)
         return super(IntegerField, self).get_prep_lookup(lookup_type, value)
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -392,7 +392,7 @@ class QuerySet(object):
         fields = self.model._meta.local_fields
         with transaction.commit_on_success_unless_managed(using=self.db):
             if (connection.features.can_combine_inserts_with_and_without_auto_increment_pk
-                and self.model._meta.has_auto_field):
+                    and self.model._meta.has_auto_field):
                 self._batched_insert(objs, fields, batch_size)
             else:
                 objs_with_pk, objs_without_pk = partition(lambda o: o.pk is None, objs)
@@ -1486,7 +1486,7 @@ class RawQuerySet(object):
     annotated model instances.
     """
     def __init__(self, raw_query, model=None, query=None, params=None,
-        translations=None, using=None, hints=None):
+            translations=None, using=None, hints=None):
         self.raw_query = raw_query
         self.model = model
         self._db = using

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -991,9 +991,9 @@ class Query(object):
                 raise FieldError("Cannot compute %s('%s'): '%s' is an aggregate" % (
                     aggregate.name, field_name, field_name))
         elif ((len(field_list) > 1) or
-            (field_list[0] not in [i.name for i in opts.fields]) or
-            self.group_by is None or
-            not is_summary):
+                (field_list[0] not in [i.name for i in opts.fields]) or
+                self.group_by is None or
+                not is_summary):
             # If:
             #   - the field descriptor has more than one part (foo__bar), or
             #   - the field descriptor is referencing an m2m/m2o field, or
@@ -1903,7 +1903,7 @@ class Query(object):
         # is_nullable() is needed to the compiler stage, but that is not easy
         # to do currently.
         if ((connections[DEFAULT_DB_ALIAS].features.interprets_empty_strings_as_nulls)
-            and field.empty_strings_allowed):
+                and field.empty_strings_allowed):
             return True
         else:
             return field.null

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -61,7 +61,7 @@ class DeleteQuery(Query):
         innerq_used_tables = [t for t in innerq.tables
                               if innerq.alias_refcount[t]]
         if ((not innerq_used_tables or innerq_used_tables == self.tables)
-            and not len(innerq.having)):
+                and not len(innerq.having)):
             # There is only the base table in use in the query, and there is
             # no aggregate filtering going on.
             self.where = innerq.where

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -69,7 +69,7 @@ class WhereNode(tree.Node):
         # and empty values need special handling. Other types could be used
         # here in the future (using Python types is suggested for consistency).
         if (isinstance(value, datetime.datetime)
-            or (isinstance(obj.field, DateTimeField) and lookup_type != 'isnull')):
+                or (isinstance(obj.field, DateTimeField) and lookup_type != 'isnull')):
             value_annotation = datetime.datetime
         elif hasattr(value, 'value_annotation'):
             value_annotation = value.value_annotation
@@ -207,7 +207,7 @@ class WhereNode(tree.Node):
         params = field_params + params
 
         if (len(params) == 1 and params[0] == '' and lookup_type == 'exact'
-            and connection.features.interprets_empty_strings_as_nulls):
+                and connection.features.interprets_empty_strings_as_nulls):
             lookup_type = 'isnull'
             value_annotation = True
 

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1102,8 +1102,8 @@ class FilePathField(ChoiceField):
                         continue
                     full_file = os.path.join(self.path, f)
                     if (((self.allow_files and os.path.isfile(full_file)) or
-                        (self.allow_folders and os.path.isdir(full_file))) and
-                        (self.match is None or self.match_re.search(f))):
+                            (self.allow_folders and os.path.isdir(full_file))) and
+                            (self.match is None or self.match_re.search(f))):
                         self.choices.append((full_file, f))
             except OSError:
                 pass

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -325,15 +325,15 @@ class BaseFormSet(object):
             self._errors.append(form.errors)
         try:
             if (self.validate_max and
-                self.total_form_count() - len(self.deleted_forms) > self.max_num) or \
-                self.management_form.cleaned_data[TOTAL_FORM_COUNT] > self.absolute_max:
+                    self.total_form_count() - len(self.deleted_forms) > self.max_num) or \
+                    self.management_form.cleaned_data[TOTAL_FORM_COUNT] > self.absolute_max:
                 raise ValidationError(ungettext(
                     "Please submit %d or fewer forms.",
                     "Please submit %d or fewer forms.", self.max_num) % self.max_num,
                     code='too_many_forms',
                 )
             if (self.validate_min and
-                self.total_form_count() - len(self.deleted_forms) < self.min_num):
+                    self.total_form_count() - len(self.deleted_forms) < self.min_num):
                 raise ValidationError(ungettext(
                     "Please submit %d or more forms.",
                     "Please submit %d or more forms.", self.min_num) % self.min_num,

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -524,7 +524,7 @@ def modelform_factory(model, form=ModelForm, fields=None, exclude=None,
     # be difficult to debug for code that needs updating, so we produce the
     # warning here too.
     if (getattr(Meta, 'fields', None) is None and
-        getattr(Meta, 'exclude', None) is None):
+            getattr(Meta, 'exclude', None) is None):
         warnings.warn("Calling modelform_factory without defining 'fields' or "
                       "'exclude' explicitly is deprecated",
                       DeprecationWarning, stacklevel=2)
@@ -675,7 +675,7 @@ class BaseModelFormSet(BaseFormSet):
             for form in valid_forms:
                 # see if we have data for both fields
                 if (form.cleaned_data and form.cleaned_data[field] is not None
-                    and form.cleaned_data[unique_for] is not None):
+                        and form.cleaned_data[unique_for] is not None):
                     # if it's a date lookup we need to get the data for all the fields
                     if lookup == 'date':
                         date = form.cleaned_data[unique_for]
@@ -815,7 +815,7 @@ def modelformset_factory(model, form=ModelForm, formfield_callback=None,
     if meta is None:
         meta = type(str('Meta'), (object,), {})
     if (getattr(meta, 'fields', fields) is None and
-        getattr(meta, 'exclude', exclude) is None):
+            getattr(meta, 'exclude', exclude) is None):
         warnings.warn("Calling modelformset_factory without defining 'fields' or "
                       "'exclude' explicitly is deprecated",
                       DeprecationWarning, stacklevel=2)

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -66,7 +66,7 @@ class HttpRequest(object):
         """Returns the HTTP host using the environment or request headers."""
         # We try three options, in order of decreasing preference.
         if settings.USE_X_FORWARDED_HOST and (
-            'HTTP_X_FORWARDED_HOST' in self.META):
+                'HTTP_X_FORWARDED_HOST' in self.META):
             host = self.META['HTTP_X_FORWARDED_HOST']
         elif 'HTTP_HOST' in self.META:
             host = self.META['HTTP_HOST']

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -122,7 +122,7 @@ class CommonMiddleware(object):
                 etag = '"%s"' % hashlib.md5(response.content).hexdigest()
             if etag is not None:
                 if (200 <= response.status_code < 300
-                    and request.META.get('HTTP_IF_NONE_MATCH') == etag):
+                        and request.META.get('HTTP_IF_NONE_MATCH') == etag):
                     cookies = response.cookies
                     response = http.HttpResponseNotModified()
                     response.cookies = cookies

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -40,7 +40,7 @@ def stringfilter(func):
             args = list(args)
             args[0] = force_text(args[0])
             if (isinstance(args[0], SafeData) and
-                getattr(_dec._decorated_function, 'is_safe', False)):
+                    getattr(_dec._decorated_function, 'is_safe', False)):
                 return mark_safe(func(*args, **kwargs))
         return func(*args, **kwargs)
 

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -70,7 +70,7 @@ class BlockNode(Node):
     def super(self):
         render_context = self.context.render_context
         if (BLOCK_CONTEXT_KEY in render_context and
-            render_context[BLOCK_CONTEXT_KEY].get_block(self.name) is not None):
+                render_context[BLOCK_CONTEXT_KEY].get_block(self.name) is not None):
             return mark_safe(self.render(self.context))
         return ''
 

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -272,7 +272,7 @@ def setup_databases(verbosity, interactive, **kwargs):
     mirrors = []
 
     for signature, (db_name, aliases) in dependency_ordered(
-        test_databases.items(), dependencies):
+            test_databases.items(), dependencies):
         test_db_name = None
         # Actually create the database for the first connection
         for alias in aliases:

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -298,7 +298,7 @@ class SimpleTestCase(unittest.TestCase):
         # If the response supports deferred rendering and hasn't been rendered
         # yet, then ensure that it does get rendered before proceeding further.
         if (hasattr(response, 'render') and callable(response.render)
-            and not response.is_rendered):
+                and not response.is_rendered):
             response.render()
 
         if msg_prefix:
@@ -1043,7 +1043,7 @@ class LiveServerThread(threading.Thread):
                         (self.host, port), QuietWSGIRequestHandler)
                 except socket.error as e:
                     if (index + 1 < len(self.possible_ports) and
-                        e.errno == errno.EADDRINUSE):
+                            e.errno == errno.EADDRINUSE):
                         # This port is already in use, so we go on and try with
                         # the next one in the list.
                         continue
@@ -1097,7 +1097,7 @@ class LiveServerTestCase(TransactionTestCase):
             # If using in-memory sqlite databases, pass the connections to
             # the server thread.
             if (conn.vendor == 'sqlite'
-                and conn.settings_dict['NAME'] == ':memory:'):
+                    and conn.settings_dict['NAME'] == ':memory:'):
                 # Explicitly enable thread-shareability for this connection
                 conn.allow_thread_sharing = True
                 connections_override[conn.alias] = conn
@@ -1154,7 +1154,7 @@ class LiveServerTestCase(TransactionTestCase):
         # Restore sqlite connections' non-sharability
         for conn in connections.all():
             if (conn.vendor == 'sqlite'
-                and conn.settings_dict['NAME'] == ':memory:'):
+                    and conn.settings_dict['NAME'] == ':memory:'):
                 conn.allow_thread_sharing = False
 
     @classmethod

--- a/django/utils/_os.py
+++ b/django/utils/_os.py
@@ -74,8 +74,8 @@ def safe_join(base, *paths):
     #  b) The final path must be the same as the base path.
     #  c) The base path must be the most root path (meaning either "/" or "C:\\")
     if (not normcase(final_path).startswith(normcase(base_path + sep)) and
-        normcase(final_path) != normcase(base_path) and
-        dirname(normcase(base_path)) != normcase(base_path)):
+            normcase(final_path) != normcase(base_path) and
+            dirname(normcase(base_path)) != normcase(base_path)):
         raise ValueError('The joined path (%s) is located outside of the base '
                          'path component (%s)' % (final_path, base_path))
     return final_path

--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -113,9 +113,9 @@ class SyndicationFeed(object):
         self.items = []
 
     def add_item(self, title, link, description, author_email=None,
-        author_name=None, author_link=None, pubdate=None, comments=None,
-        unique_id=None, unique_id_is_permalink=None, enclosure=None,
-        categories=(), item_copyright=None, ttl=None, updateddate=None, **kwargs):
+            author_name=None, author_link=None, pubdate=None, comments=None,
+            unique_id=None, unique_id_is_permalink=None, enclosure=None,
+            categories=(), item_copyright=None, ttl=None, updateddate=None, **kwargs):
         """
         Adds an item to the feed. All args are expected to be Python Unicode
         objects except pubdate and updateddate, which are datetime.datetime

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -238,7 +238,7 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
                     lead = lead + opening
                 # Keep parentheses at the end only if they're balanced.
                 if (middle.endswith(closing)
-                    and middle.count(closing) == middle.count(opening) + 1):
+                        and middle.count(closing) == middle.count(opening) + 1):
                     middle = middle[:-len(closing)]
                     trail = closing + trail
 

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -189,7 +189,7 @@ class SafeExceptionReporterFilter(ExceptionReporterFilter):
         sensitive_variables = None
         while current_frame is not None:
             if (current_frame.f_code.co_name == 'sensitive_variables_wrapper'
-                and 'sensitive_variables_wrapper' in current_frame.f_locals):
+                    and 'sensitive_variables_wrapper' in current_frame.f_locals):
                 # The sensitive_variables decorator was used, so we take note
                 # of the sensitive variables' names.
                 wrapper = current_frame.f_locals['sensitive_variables_wrapper']
@@ -218,7 +218,7 @@ class SafeExceptionReporterFilter(ExceptionReporterFilter):
                 cleansed[name] = self.cleanse_special_types(request, value)
 
         if (tb_frame.f_code.co_name == 'sensitive_variables_wrapper'
-            and 'sensitive_variables_wrapper' in tb_frame.f_locals):
+                and 'sensitive_variables_wrapper' in tb_frame.f_locals):
             # For good measure, obfuscate the decorated function's arguments in
             # the sensitive_variables decorator's frame, in case the variables
             # associated with those arguments were meant to be obfuscated from
@@ -287,7 +287,7 @@ class ExceptionReporter(object):
                     'templates': template_list,
                 })
         if (settings.TEMPLATE_DEBUG and
-            hasattr(self.exc_value, 'django_template_source')):
+                hasattr(self.exc_value, 'django_template_source')):
             self.get_template_exception_info()
 
         frames = self.get_traceback_frames()

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -150,7 +150,7 @@ class BaseListView(MultipleObjectMixin, View):
             # it's better to do a cheap query than to load the unpaginated
             # queryset in memory.
             if (self.get_paginate_by(self.object_list) is not None
-                and hasattr(self.object_list, 'exists')):
+                    and hasattr(self.object_list, 'exists')):
                 is_empty = not self.object_list.exists()
             else:
                 is_empty = len(self.object_list) == 0

--- a/extras/csrf_migration_helper.py
+++ b/extras/csrf_migration_helper.py
@@ -145,11 +145,11 @@ def get_template_dirs():
     from django.conf import settings
     dirs = set()
     if ('django.template.loaders.filesystem.load_template_source' in settings.TEMPLATE_LOADERS
-        or 'django.template.loaders.filesystem.Loader' in settings.TEMPLATE_LOADERS):
+            or 'django.template.loaders.filesystem.Loader' in settings.TEMPLATE_LOADERS):
         dirs.update(map(unicode, settings.TEMPLATE_DIRS))
 
     if ('django.template.loaders.app_directories.load_template_source' in settings.TEMPLATE_LOADERS
-        or 'django.template.loaders.app_directories.Loader' in settings.TEMPLATE_LOADERS):
+            or 'django.template.loaders.app_directories.Loader' in settings.TEMPLATE_LOADERS):
         from django.template.loaders.app_directories import app_template_dirs
         dirs.update(app_template_dirs)
     return dirs

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -11,7 +11,7 @@ class DeferTests(TestCase):
         count = 0
         for field in obj._meta.fields:
             if isinstance(obj.__class__.__dict__.get(field.attname),
-                DeferredAttribute):
+                    DeferredAttribute):
                 count += 1
         self.assertEqual(count, num)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -69,11 +69,11 @@ def get_test_modules():
     for modpath, dirpath in discovery_paths:
         for f in os.listdir(dirpath):
             if ('.' in f or
-                # Python 3 byte code dirs (PEP 3147)
-                f == '__pycache__' or
-                f.startswith('sql') or
-                os.path.basename(f) in SUBDIRS_TO_SKIP or
-                os.path.isfile(f)):
+                    # Python 3 byte code dirs (PEP 3147)
+                    f == '__pycache__' or
+                    f.startswith('sql') or
+                    os.path.basename(f) in SUBDIRS_TO_SKIP or
+                    os.path.isfile(f)):
                 continue
             modules.append((modpath, f))
     return modules

--- a/tests/wsgi/tests.py
+++ b/tests/wsgi/tests.py
@@ -93,15 +93,15 @@ class GetInternalWSGIApplicationTest(unittest.TestCase):
     @override_settings(WSGI_APPLICATION="wsgi.noexist.app")
     def test_bad_module(self):
         with six.assertRaisesRegex(self,
-            ImproperlyConfigured,
-            r"^WSGI application 'wsgi.noexist.app' could not be loaded; Error importing.*"):
+                ImproperlyConfigured,
+                r"^WSGI application 'wsgi.noexist.app' could not be loaded; Error importing.*"):
 
             get_internal_wsgi_application()
 
     @override_settings(WSGI_APPLICATION="wsgi.wsgi.noexist")
     def test_bad_name(self):
         with six.assertRaisesRegex(self,
-            ImproperlyConfigured,
-            r"^WSGI application 'wsgi.wsgi.noexist' could not be loaded; Module.*"):
+                ImproperlyConfigured,
+                r"^WSGI application 'wsgi.wsgi.noexist' could not be loaded; Module.*"):
 
             get_internal_wsgi_application()


### PR DESCRIPTION
You can reproduce this patch by typing:

```
autopep8 -i --select=E125 `find . -name "*.py"`
```

You need the master version of `autopep8` -- there is a new patch for reindentation.
