### PR TITLE
Fixed #15619 – Added CSRF protection in logout view.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -49,6 +49,7 @@ class AdminSite(object):
     app_index_template = None
     login_template = None
     logout_template = None
+    logout_confirmation_template = None
     password_change_template = None
     password_change_done_template = None
 
@@ -322,6 +323,9 @@ class AdminSite(object):
         }
         if self.logout_template is not None:
             defaults['template_name'] = self.logout_template
+        if self.logout_confirmation_template is not None:
+            defaults['confirmation_template_name'] = self.logout_confirmation_template
+
         return logout(request, **defaults)
 
     @never_cache

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -788,12 +788,25 @@ table#change-history tbody th {
     overflow: hidden;
 }
 
-#header a:link, #header a:visited {
+#header form{
+    display: inline;
+}
+
+#header a:link, #header a:visited, #header input[type="submit"] {
     color: #fff;
 }
 
-#header a:hover {
+#header a:hover, #header input[type="submit"]:hover{
     text-decoration: underline;
+    cursor: pointer;
+}
+
+#header input[type="submit"] {
+    background: none;
+    border: none;
+    font-family: inherit;
+    margin: 0;
+    padding: 0;
 }
 
 #branding h1 {

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -38,7 +38,10 @@
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
                 {% endif %}
-                <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+                <form action="{% url 'admin:logout' %}" method="post">
+                    {% csrf_token %}
+                    <input type="submit" value="{% trans 'Log out' %}">
+                </form>
             {% endblock %}
         </div>
         {% endif %}

--- a/django/contrib/admin/templates/registration/logout_confirmation.html
+++ b/django/contrib/admin/templates/registration/logout_confirmation.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="../">{% trans "Home" %}</a> &rsaquo;
+    </div>
+{% endblock %}
+
+{% block content %}
+    <p>{% trans "Are you sure you want to log out?" %}</p>
+    <form action="" method="post">
+        {% csrf_token %}
+        <div>
+            <input type="submit" value="{% trans 'Yes, I’m sure' %}">
+        </div>
+    </form>
+{% endblock %}

--- a/django/contrib/admin/templates/registration/password_change_done.html
+++ b/django/contrib/admin/templates/registration/password_change_done.html
@@ -1,6 +1,15 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% trans 'Documentation' %}</a> / {% endif %}{% trans 'Change password' %} / <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>{% endblock %}
+{% block userlinks %}
+    {% url 'django-admindocs-docroot' as docsroot %}
+    {% if docsroot %}
+        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+    {% endif %}
+    {% trans 'Change password' %} /
+    <form action="{% url 'admin:logout' %}" method="post">
+        <input type="submit" value="{% trans 'Log out' %}">
+    </form>
+{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,7 +1,16 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% trans 'Documentation' %}</a> / {% endif %} {% trans 'Change password' %} / <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>{% endblock %}
+{% block userlinks %}
+    {% url 'django-admindocs-docroot' as docsroot %}
+    {% if docsroot %}
+        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+    {% endif %}
+    {% trans 'Change password' %} /
+    <form action="{% url 'admin:logout' %}" method="post">
+        <input type="submit" value="{% trans 'Log out' %}">
+    </form>
+{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/django/contrib/auth/tests/templates/registration/logout_confirmation.html
+++ b/django/contrib/auth/tests/templates/registration/logout_confirmation.html
@@ -1,0 +1,7 @@
+<p>Are you sure you want to log out?</p>
+<form action="" method="post">
+    {% csrf_token %}
+    <div>
+        <input type="submit" value="Yes, I’m sure">
+    </div>
+</form>

--- a/django/contrib/auth/tests/test_signals.py
+++ b/django/contrib/auth/tests/test_signals.py
@@ -56,13 +56,13 @@ class SignalTestCase(TestCase):
     def test_logout_anonymous(self):
         # The log_out function will still trigger the signal for anonymous
         # users.
-        self.client.get('/logout/next_page/')
+        self.client.post('/logout/next_page/')
         self.assertEqual(len(self.logged_out), 1)
         self.assertEqual(self.logged_out[0], None)
 
     def test_logout(self):
         self.client.login(username='testclient', password='password')
-        self.client.get('/logout/next_page/')
+        self.client.post('/logout/next_page/')
         self.assertEqual(len(self.logged_out), 1)
         self.assertEqual(self.logged_out[0].username, 'testclient')
 

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -60,13 +60,19 @@ def login(request, template_name='registration/login.html',
                             current_app=current_app)
 
 
+@csrf_protect
 def logout(request, next_page=None,
            template_name='registration/logged_out.html',
+           confirmation_template_name='registration/logout_confirmation.html',
            redirect_field_name=REDIRECT_FIELD_NAME,
            current_app=None, extra_context=None):
     """
     Logs out the user and displays 'You are logged out' message.
     """
+    if request.method != 'POST':
+        return TemplateResponse(request, confirmation_template_name, extra_context,
+            current_app=current_app)
+
     auth_logout(request)
 
     if next_page is not None:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2278,8 +2278,9 @@ Root and login templates
 
 If you wish to change the index, login or logout templates, you are better off
 creating your own ``AdminSite`` instance (see below), and changing the
-:attr:`AdminSite.index_template` , :attr:`AdminSite.login_template` or
-:attr:`AdminSite.logout_template` properties.
+:attr:`AdminSite.index_template` , :attr:`AdminSite.login_template`,
+:attr:`AdminSite.logout_template` or
+:attr:`AdminSite.logout_confirmation_template` properties.
 
 ``AdminSite`` objects
 =====================
@@ -2352,6 +2353,11 @@ Templates can override or extend base admin templates as described in
 .. attribute:: AdminSite.logout_template
 
     Path to a custom template that will be used by the admin site logout view.
+
+.. attribute:: AdminSite.logout_confirmation_template
+
+    Path to a custom confirmation template that will be used by the admin site
+    logout view when it is called via ``GET``.
 
 .. attribute:: AdminSite.password_change_template
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -710,6 +710,10 @@ Miscellaneous
   ``select_related('foo').select_related('bar')``. Previously the latter would
   have been equivalent to ``select_related('bar')``.
 
+* :func:`~django.contrib.auth.views.logout` is now CSRF protected and should be
+  called via ``POST``. If called via ``GET``, a confirmation page containing
+  a logout form is displayed.
+
 Features deprecated in 1.7
 ==========================
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -602,7 +602,7 @@ patterns.
       defaults to ``/accounts/profile/``). If login isn't successful, it
       redisplays the login form.
 
-    It's your responsibility to provide the html for the login template
+    It's your responsibility to provide the HTML for the login template
     , called ``registration/login.html`` by default. This template gets passed
     four template context variables:
 
@@ -679,9 +679,9 @@ patterns.
     .. _site framework docs: ../sites/
 
 
-.. function:: logout(request, [next_page, template_name, redirect_field_name, current_app, extra_context])
+.. function:: logout(request, [next_page, template_name, confirmation_template_name, redirect_field_name, current_app, extra_context])
 
-    Logs a user out.
+    Logs a user out when called via ``POST``, displays a logout form otherwise.
 
     **URL name:** ``logout``
 
@@ -693,9 +693,13 @@ patterns.
       logging the user out. Defaults to
       :file:`registration/logged_out.html` if no argument is supplied.
 
-    * ``redirect_field_name``: The name of a ``GET`` field containing the
-      URL to redirect to after log out. Defaults to ``next``. Overrides the
-      ``next_page`` URL if the given ``GET`` parameter is passed.
+    * ``confirmation_template_name``: The full name of a template to display
+      when the view is called via ``GET``. Defaults to
+      :file:`registration/logout_confirmation.html` if no argument is supplied.
+
+    * ``redirect_field_name``: The name of a ``GET`` or ``POST`` field
+      containing the URL to redirect to after log out. Defaults to ``next``.
+      Overrides the ``next_page`` URL if the given parameter is passed.
 
     * ``current_app``: A hint indicating which application contains the current
       view. See the :ref:`namespaced URL resolution strategy

--- a/tests/admin_views/customadmin.py
+++ b/tests/admin_views/customadmin.py
@@ -17,6 +17,7 @@ class Admin2(admin.AdminSite):
     login_form = forms.CustomAdminAuthenticationForm
     login_template = 'custom_admin/login.html'
     logout_template = 'custom_admin/logout.html'
+    logout_confirmation_template = 'custom_admin/logout_confirmation.html'
     index_template = ['custom_admin/index.html']  # a list, to test fix for #18697
     password_change_template = 'custom_admin/password_change_form.html'
     password_change_done_template = 'custom_admin/password_change_done.html'

--- a/tests/templates/custom_admin/logout_confirmation.html
+++ b/tests/templates/custom_admin/logout_confirmation.html
@@ -1,0 +1,6 @@
+{% extends "registration/logout_confirmation.html" %}
+
+{% block content %}
+    Hello from a custom logout confirmation template.
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Logout is now performed only for POST requests.
GET requests return confirmation page.

Based on patches from ashchristopher and vzima.

https://code.djangoproject.com/ticket/15619
