### PR TITLE
Fix ticket 21460

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -420,6 +420,7 @@ answer newbie questions, and generally made Django that much better:
     mark@junklight.com
     Orestis Markou <orestis@orestis.gr>
     Andrés Torres Marroquín <andres.torres.marroquin@gmail.com>
+    Pablo Martín <goinnn@gmail.com>
     Takashi Matsuo <matsuo.takashi@gmail.com>
     Zlatko Mašek <zlatko.masek@gmail.com>
     Yasushi Masuda <whosaysni@gmail.com>

--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -53,6 +53,7 @@ class Loader(BaseLoader):
                     pass
                 else:
                     result = (template, make_origin(display_name, loader, name, dirs))
+                    break
         self.find_template_cache[key] = result
         if result:
             return result

--- a/tests/template_tests/templates/priority/foo.html
+++ b/tests/template_tests/templates/priority/foo.html
@@ -1,0 +1,1 @@
+no priority

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -189,3 +189,29 @@ class TemplateDirsOverrideTest(unittest.TestCase):
         for dirs in self.dirs_iter:
             template = loader.select_template(['test_dirs.html'], dirs=dirs)
             self.assertEqual(template.render(Context({})), 'spam eggs\n')
+
+
+@override_settings(
+    TEMPLATE_LOADERS=(
+        ('django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        )),
+    )
+)
+class PriorityCacheLoader(TestCase):
+    def test_basic(self):
+        "Check that the order of template loader works. Refs #21460"
+        t1, name = loader.find_template('priority/foo.html')
+        self.assertEqual(t1.render(Context({})), 'priority\n')
+
+
+@override_settings(
+    TEMPLATE_LOADERS=('django.template.loaders.filesystem.Loader',
+                      'django.template.loaders.app_directories.Loader',),
+)
+class PriorityLoader(TestCase):
+    def test_basic(self):
+        "Check that the order of template loader works. Refs #21460"
+        t1, name = loader.find_template('priority/foo.html')
+        self.assertEqual(t1.render(Context({})), 'priority\n')

--- a/tests/templates/priority/foo.html
+++ b/tests/templates/priority/foo.html
@@ -1,0 +1,1 @@
+priority


### PR DESCRIPTION
Now if you use cache template loader this will return the same template that if you does not use it.

Ticket in [django project](https://code.djangoproject.com/ticket/21460)
