### PR TITLE
Notes that localmem is the default cache.

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -289,9 +289,9 @@ user ``apache``.
 Local-memory caching
 --------------------
 
-This is the default cache if none other is defined. If you want the speed 
-advantages of in-memory caching but don't have the capability of running 
-Memcached, consider the local-memory cache backend. This cache is 
+This is the default cache if no other is specified in your settings file. If you 
+want the speed advantages of in-memory caching but don't have the capability 
+of running Memcached, consider the local-memory cache backend. This cache is 
 multi-process and thread-safe. To use it, set :setting:`BACKEND <CACHES-BACKEND>`
 to ``"django.core.cache.backends.locmem.LocMemCache"``. For example::
 


### PR DESCRIPTION
I read the whole page trying to figure out the default settings, and assuming it'd be explained...it never was, so I figured I should add it.
