### PR TITLE
Issue #15619 - Protect logout against CSRF

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -49,6 +49,7 @@ class AdminSite(object):
     app_index_template = None
     login_template = None
     logout_template = None
+    logout_confirmation_template = None
     password_change_template = None
     password_change_done_template = None
 
@@ -322,6 +323,9 @@ class AdminSite(object):
         }
         if self.logout_template is not None:
             defaults['template_name'] = self.logout_template
+        if self.logout_confirmation_template is not None:
+            defaults['confirmation_template_name'] = self.logout_confirmation_template
+
         return logout(request, **defaults)
 
     @never_cache

--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -828,6 +828,23 @@ table#change-history tbody th {
     text-align: right;
 }
 
+#user-tools .logout {
+    display: inline-block;
+}
+
+#user-tools .logout input {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+}
+
+#user-tools .logout input:hover {
+    text-decoration: underline;
+}
+
 /* SIDEBAR */
 
 #content-related h3 {

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -38,7 +38,10 @@
                 {% if user.has_usable_password %}
                 <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
                 {% endif %}
-                <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+                <form action="{% url 'admin:logout' %}" method="post" class="logout">
+                    {% csrf_token %}
+                    <input type="submit" value="{% trans 'Log out' %}" />
+                </form>
             {% endblock %}
         </div>
         {% endif %}

--- a/django/contrib/admin/templates/registration/logout_confirmation.html
+++ b/django/contrib/admin/templates/registration/logout_confirmation.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="../">{% trans "Home" %}</a> &rsaquo;
+    </div>
+{% endblock %}
+
+
+{% block content %}
+    <p>{% blocktrans %}Are you sure you want to logout?{% endblocktrans %}</p>
+    <form action="" method="post">
+        {% csrf_token %}
+        <div>
+            <input type="hidden" name="post" value="yes" />
+            <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+        </div>
+    </form>
+{% endblock %}

--- a/django/contrib/admin/templates/registration/password_change_done.html
+++ b/django/contrib/admin/templates/registration/password_change_done.html
@@ -1,6 +1,16 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% trans 'Documentation' %}</a> / {% endif %}{% trans 'Change password' %} / <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>{% endblock %}
+{% block userlinks %}
+    {% url 'django-admindocs-docroot' as docsroot %}
+    {% if docsroot %}
+        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+    {% endif %}
+    {% trans 'Change password' %} /
+    <form action="{% url 'admin:logout' %}" method="post" class="logout">
+        {% csrf_token %}
+        <input type="submit" value="{% trans 'Log out' %}" />
+    </form>
+{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,7 +1,17 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
-{% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% trans 'Documentation' %}</a> / {% endif %} {% trans 'Change password' %} / <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>{% endblock %}
+{% block userlinks %}
+    {% url 'django-admindocs-docroot' as docsroot %}
+    {% if docsroot %}
+        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+    {% endif %}
+    {% trans 'Change password' %} /
+    <form action="{% url 'admin:logout' %}" method="post" class="logout">
+        {% csrf_token %}
+        <input type="submit" value="{% trans 'Log out' %}" />
+    </form>
+{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>

--- a/django/contrib/auth/tests/templates/registration/logout_confirmation.html
+++ b/django/contrib/auth/tests/templates/registration/logout_confirmation.html
@@ -1,0 +1,8 @@
+<p>Are you sure you want to logout?</p>
+<form action="" method="post">
+    {% csrf_token %}
+    <div>
+        <input type="hidden" name="post" value="yes" />
+        <input type="submit" value="Yes, I'm sure" />
+    </div>
+</form>

--- a/django/contrib/auth/tests/test_signals.py
+++ b/django/contrib/auth/tests/test_signals.py
@@ -56,13 +56,13 @@ class SignalTestCase(TestCase):
     def test_logout_anonymous(self):
         # The log_out function will still trigger the signal for anonymous
         # users.
-        self.client.get('/logout/next_page/')
+        self.client.post('/logout/next_page/')
         self.assertEqual(len(self.logged_out), 1)
         self.assertEqual(self.logged_out[0], None)
 
     def test_logout(self):
         self.client.login(username='testclient', password='password')
-        self.client.get('/logout/next_page/')
+        self.client.post('/logout/next_page/')
         self.assertEqual(len(self.logged_out), 1)
         self.assertEqual(self.logged_out[0].username, 'testclient')
 

--- a/django/contrib/auth/tests/test_views.py
+++ b/django/contrib/auth/tests/test_views.py
@@ -53,7 +53,7 @@ class AuthViewsTestCase(TestCase):
         return response
 
     def logout(self):
-        response = self.client.get('/admin/logout/')
+        response = self.client.post('/admin/logout/')
         self.assertEqual(response.status_code, 200)
         self.assertTrue(SESSION_KEY not in self.client.session)
 
@@ -361,7 +361,7 @@ class ChangePasswordTest(AuthViewsTestCase):
         })
 
     def logout(self):
-        self.client.get('/logout/')
+        self.client.post('/logout/')
 
     def test_password_change_fails_with_invalid_old_password(self):
         self.login()
@@ -606,6 +606,8 @@ class LoginRedirectUrlTest(AuthViewsTestCase):
 
 @skipIfCustomUser
 class LogoutTest(AuthViewsTestCase):
+    def confirm_logged_in(self):
+        self.assertTrue(SESSION_KEY in self.client.session)
 
     def confirm_logged_out(self):
         self.assertTrue(SESSION_KEY not in self.client.session)
@@ -613,24 +615,29 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_default(self):
         "Logout without next_page option renders the default template"
         self.login()
+
         response = self.client.get('/logout/')
+        self.assertContains(response, 'Are you sure you want to logout?')
+        self.confirm_logged_in()
+
+        response = self.client.post('/logout/')
         self.assertContains(response, 'Logged out')
         self.confirm_logged_out()
 
     def test_14377(self):
         # Bug 14377
         self.login()
-        response = self.client.get('/logout/')
+        response = self.client.post('/logout/')
         self.assertTrue('site' in response.context)
 
     def test_logout_with_overridden_redirect_url(self):
         # Bug 11223
         self.login()
-        response = self.client.get('/logout/next_page/')
+        response = self.client.post('/logout/next_page/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/somewhere/')
 
-        response = self.client.get('/logout/next_page/?next=/login/')
+        response = self.client.post('/logout/next_page/?next=/login/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/login/')
 
@@ -639,7 +646,7 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_with_next_page_specified(self):
         "Logout with next_page option given redirects to specified resource"
         self.login()
-        response = self.client.get('/logout/next_page/')
+        response = self.client.post('/logout/next_page/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/somewhere/')
         self.confirm_logged_out()
@@ -647,7 +654,7 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_with_redirect_argument(self):
         "Logout with query string redirects to specified resource"
         self.login()
-        response = self.client.get('/logout/?next=/login/')
+        response = self.client.post('/logout/?next=/login/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/login/')
         self.confirm_logged_out()
@@ -655,7 +662,7 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_with_custom_redirect_argument(self):
         "Logout with custom query string redirects to specified resource"
         self.login()
-        response = self.client.get('/logout/custom_query/?follow=/somewhere/')
+        response = self.client.post('/logout/custom_query/?follow=/somewhere/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/somewhere/')
         self.confirm_logged_out()
@@ -663,7 +670,7 @@ class LogoutTest(AuthViewsTestCase):
     def test_logout_with_named_redirect(self):
         "Logout resolves names or URLs passed as next_page."
         self.login()
-        response = self.client.get('/logout/next_page/named/')
+        response = self.client.post('/logout/next_page/named/')
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/password_reset/')
         self.confirm_logged_out()
@@ -683,7 +690,7 @@ class LogoutTest(AuthViewsTestCase):
                 'bad_url': urlquote(bad_url),
             }
             self.login()
-            response = self.client.get(nasty_url)
+            response = self.client.post(nasty_url)
             self.assertEqual(response.status_code, 302)
             self.assertFalse(bad_url in response.url,
                              "%s should be blocked" % bad_url)
@@ -704,7 +711,7 @@ class LogoutTest(AuthViewsTestCase):
                 'good_url': urlquote(good_url),
             }
             self.login()
-            response = self.client.get(safe_url)
+            response = self.client.post(safe_url)
             self.assertEqual(response.status_code, 302)
             self.assertTrue(good_url in response.url,
                             "%s should be allowed" % good_url)

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -60,13 +60,24 @@ def login(request, template_name='registration/login.html',
                             current_app=current_app)
 
 
+@csrf_protect
 def logout(request, next_page=None,
            template_name='registration/logged_out.html',
            redirect_field_name=REDIRECT_FIELD_NAME,
+           confirmation_template_name='registration/logout_confirmation.html',
            current_app=None, extra_context=None):
     """
     Logs out the user and displays 'You are logged out' message.
     """
+    if request.method != 'POST':
+        context = {
+            'title' : _('Are you sure?'),
+        }
+        if extra_context is not None:
+            context.update(extra_context)
+        return TemplateResponse(request, confirmation_template_name, context,
+            current_app=current_app)
+
     auth_logout(request)
 
     if next_page is not None:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2272,8 +2272,9 @@ Root and login templates
 
 If you wish to change the index, login or logout templates, you are better off
 creating your own ``AdminSite`` instance (see below), and changing the
-:attr:`AdminSite.index_template` , :attr:`AdminSite.login_template` or
-:attr:`AdminSite.logout_template` properties.
+:attr:`AdminSite.index_template` , :attr:`AdminSite.login_template`,
+:attr:`AdminSite.logout_template` or :attr:`AdminSite.logout_confirmation_template`
+properties.
 
 ``AdminSite`` objects
 =====================
@@ -2346,6 +2347,12 @@ Templates can override or extend base admin templates as described in
 .. attribute:: AdminSite.logout_template
 
     Path to a custom template that will be used by the admin site logout view.
+
+.. attribute:: AdminSite.logout_confirmation_template
+
+    .. versionadded:: 1.7
+
+    Path to a custom template that will be used by the admin site logout confirmation view.
 
 .. attribute:: AdminSite.password_change_template
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -548,6 +548,18 @@ zone-related date formats or :mod:`django.contrib.syndication`.
 
 .. _pytz: https://pypi.python.org/pypi/pytz/
 
+Logout protected against CSRF
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+User log out is now protected against cross-site attacks. For this reason
+``POST`` request are required to actually log out user. Function
+:func:`~django.contrib.auth.views.logout` may not log user out and can
+return a confirmation page instead. The function also have new ``confirmation_template_name``
+argument. Also new attribute
+:attr:`~django.contrib.admin.sites.AdminSite.logout_confirmation_template` was
+added for customization of administration.
+
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -679,9 +679,9 @@ patterns.
     .. _site framework docs: ../sites/
 
 
-.. function:: logout(request, [next_page, template_name, redirect_field_name, current_app, extra_context])
+.. function:: logout(request, [next_page, template_name, redirect_field_name, confirmation_template_name, current_app, extra_context])
 
-    Logs a user out.
+    Logs a user out or displays a confirmation page.
 
     **URL name:** ``logout``
 
@@ -697,12 +697,20 @@ patterns.
       URL to redirect to after log out. Defaults to ``next``. Overrides the
       ``next_page`` URL if the given ``GET`` parameter is passed.
 
+    * ``confirmation_template_name``: The full name of a template to display if the
+      user's confirmation is required. Defaults to
+      :file:`registration/logged_confirmation.html` if no argument is supplied.
+
     * ``current_app``: A hint indicating which application contains the current
       view. See the :ref:`namespaced URL resolution strategy
       <topics-http-reversing-url-namespaces>` for more information.
 
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
+
+    .. versionchanged:: 1.7
+
+        The view can return the confirmation page. The argument ``confirmation_template_name`` was added.
 
     **Template context:**
 

--- a/tests/admin_views/customadmin.py
+++ b/tests/admin_views/customadmin.py
@@ -17,6 +17,7 @@ class Admin2(admin.AdminSite):
     login_form = forms.CustomAdminAuthenticationForm
     login_template = 'custom_admin/login.html'
     logout_template = 'custom_admin/logout.html'
+    logout_confirmation_template = 'custom_admin/logout_confirmation.html'
     index_template = ['custom_admin/index.html']  # a list, to test fix for #18697
     password_change_template = 'custom_admin/password_change_form.html'
     password_change_done_template = 'custom_admin/password_change_done.html'

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -470,7 +470,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
 
     def testLogoutAndPasswordChangeURLs(self):
         response = self.client.get('/test_admin/%s/admin_views/article/' % self.urlbit)
-        self.assertContains(response, '<a href="/test_admin/%s/logout/">' % self.urlbit)
+        self.assertContains(response, '<form action="/test_admin/%s/logout/" method="post" class="logout">' % self.urlbit)
         self.assertContains(response, '<a href="/test_admin/%s/password_change/">' % self.urlbit)
 
     def testNamedGroupFieldChoicesChangeList(self):
@@ -782,8 +782,14 @@ class CustomModelAdminTest(AdminViewBasicTestCase):
         self.assertTemplateUsed(response, 'custom_admin/login.html')
         self.assertContains(response, 'Hello from a custom login template')
 
-    def testCustomAdminSiteLogoutTemplate(self):
+    def testCustomAdminSiteLogoutConfirmationTemplate(self):
         response = self.client.get('/test_admin/admin2/logout/')
+        self.assertIsInstance(response, TemplateResponse)
+        self.assertTemplateUsed(response, 'custom_admin/logout_confirmation.html')
+        self.assertContains(response, 'Hello from a custom logout confirmation template')
+
+    def testCustomAdminSiteLogoutTemplate(self):
+        response = self.client.post('/test_admin/admin2/logout/')
         self.assertIsInstance(response, TemplateResponse)
         self.assertTemplateUsed(response, 'custom_admin/logout.html')
         self.assertContains(response, 'Hello from a custom logout template')
@@ -932,7 +938,7 @@ class AdminViewPermissionsTest(TestCase):
         login = self.client.post('/test_admin/admin/', self.super_login)
         self.assertRedirects(login, '/test_admin/admin/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Test if user enters email address
         response = self.client.get('/test_admin/admin/')
@@ -954,7 +960,7 @@ class AdminViewPermissionsTest(TestCase):
         login = self.client.post('/test_admin/admin/', self.adduser_login)
         self.assertRedirects(login, '/test_admin/admin/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Change User
         response = self.client.get('/test_admin/admin/')
@@ -962,7 +968,7 @@ class AdminViewPermissionsTest(TestCase):
         login = self.client.post('/test_admin/admin/', self.changeuser_login)
         self.assertRedirects(login, '/test_admin/admin/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Delete User
         response = self.client.get('/test_admin/admin/')
@@ -970,7 +976,7 @@ class AdminViewPermissionsTest(TestCase):
         login = self.client.post('/test_admin/admin/', self.deleteuser_login)
         self.assertRedirects(login, '/test_admin/admin/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Regular User should not be able to login.
         response = self.client.get('/test_admin/admin/')
@@ -1041,7 +1047,7 @@ class AdminViewPermissionsTest(TestCase):
         post = self.client.post('/test_admin/admin/admin_views/article/add/', add_dict)
         self.assertEqual(post.status_code, 403)
         self.assertEqual(Article.objects.all().count(), 3)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Add user may login and POST to add view, then redirect to admin root
         self.client.get('/test_admin/admin/')
@@ -1055,7 +1061,7 @@ class AdminViewPermissionsTest(TestCase):
         self.assertEqual(Article.objects.all().count(), 4)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, 'Greetings from a created object')
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Super can add too, but is redirected to the change list view
         self.client.get('/test_admin/admin/')
@@ -1066,7 +1072,7 @@ class AdminViewPermissionsTest(TestCase):
         post = self.client.post('/test_admin/admin/admin_views/article/add/', add_dict)
         self.assertRedirects(post, '/test_admin/admin/admin_views/article/')
         self.assertEqual(Article.objects.all().count(), 5)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # 8509 - if a normal user is already logged in, it is possible
         # to change user into the superuser without error
@@ -1094,7 +1100,7 @@ class AdminViewPermissionsTest(TestCase):
         self.assertEqual(response.status_code, 403)
         post = self.client.post('/test_admin/admin/admin_views/article/1/', change_dict)
         self.assertEqual(post.status_code, 403)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # change user can view all items and edit them
         self.client.get('/test_admin/admin/')
@@ -1117,7 +1123,7 @@ class AdminViewPermissionsTest(TestCase):
         post = self.client.post('/test_admin/admin/admin_views/article/1/', change_dict)
         self.assertContains(post, 'Please correct the errors below.',
             msg_prefix='Plural error message not found in response to post with multiple errors')
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Test redirection when using row-level change permissions. Refs #11513.
         RowLevelChangePermissionModel.objects.create(id=1, name="odd id")
@@ -1134,7 +1140,7 @@ class AdminViewPermissionsTest(TestCase):
             response = self.client.post('/test_admin/admin/admin_views/rowlevelchangepermissionmodel/2/', {'name': 'changed'})
             self.assertEqual(RowLevelChangePermissionModel.objects.get(id=2).name, 'changed')
             self.assertRedirects(response, '/test_admin/admin/')
-            self.client.get('/test_admin/admin/logout/')
+            self.client.post('/test_admin/admin/logout/')
         for login_dict in [self.joepublic_login, self.no_username_login]:
             self.client.post('/test_admin/admin/', login_dict)
             response = self.client.get('/test_admin/admin/admin_views/rowlevelchangepermissionmodel/1/')
@@ -1151,7 +1157,7 @@ class AdminViewPermissionsTest(TestCase):
             self.assertEqual(RowLevelChangePermissionModel.objects.get(id=2).name, 'changed')
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, 'login-form')
-            self.client.get('/test_admin/admin/logout/')
+            self.client.post('/test_admin/admin/logout/')
 
     def testHistoryView(self):
         """History view should restrict access."""
@@ -1161,7 +1167,7 @@ class AdminViewPermissionsTest(TestCase):
         self.client.post('/test_admin/admin/', self.adduser_login)
         response = self.client.get('/test_admin/admin/admin_views/article/1/history/')
         self.assertEqual(response.status_code, 403)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # change user can view all items and edit them
         self.client.get('/test_admin/admin/')
@@ -1180,7 +1186,7 @@ class AdminViewPermissionsTest(TestCase):
             response = self.client.get('/test_admin/admin/admin_views/rowlevelchangepermissionmodel/2/history/')
             self.assertEqual(response.status_code, 200)
 
-            self.client.get('/test_admin/admin/logout/')
+            self.client.post('/test_admin/admin/logout/')
 
         for login_dict in [self.joepublic_login, self.no_username_login]:
             self.client.post('/test_admin/admin/', login_dict)
@@ -1191,7 +1197,7 @@ class AdminViewPermissionsTest(TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, 'login-form')
 
-            self.client.get('/test_admin/admin/logout/')
+            self.client.post('/test_admin/admin/logout/')
 
     def testConditionallyShowAddSectionLink(self):
         """
@@ -1253,7 +1259,7 @@ class AdminViewPermissionsTest(TestCase):
         response = self.client.get('/test_admin/admin/admin_views/customarticle/%d/history/' % article_pk)
         self.assertTemplateUsed(response, 'custom_admin/object_history.html')
 
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
     def testDeleteView(self):
         """Delete view should restrict access and actually delete items."""
@@ -1268,7 +1274,7 @@ class AdminViewPermissionsTest(TestCase):
         post = self.client.post('/test_admin/admin/admin_views/article/1/delete/', delete_dict)
         self.assertEqual(post.status_code, 403)
         self.assertEqual(Article.objects.all().count(), 3)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Delete user can delete
         self.client.get('/test_admin/admin/')
@@ -1287,7 +1293,7 @@ class AdminViewPermissionsTest(TestCase):
         article_ct = ContentType.objects.get_for_model(Article)
         logged = LogEntry.objects.get(content_type=article_ct, action_flag=DELETION)
         self.assertEqual(logged.object_id, '1')
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
     def testDisabledPermissionsWhenLoggedIn(self):
         self.client.login(username='super', password='secret')
@@ -1366,7 +1372,7 @@ class AdminViewsNoUrlTest(TestCase):
         r = self.client.get('/test_admin/admin/')
         # we shouldn' get an 500 error caused by a NoReverseMatch
         self.assertEqual(r.status_code, 200)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
@@ -1702,7 +1708,7 @@ class SecureViewTests(TestCase):
         login = self.client.post('/test_admin/admin/secure-view/', self.super_login)
         self.assertRedirects(login, '/test_admin/admin/secure-view/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
         # make sure the view removes test cookie
         self.assertEqual(self.client.session.test_cookie_worked(), False)
 
@@ -1726,7 +1732,7 @@ class SecureViewTests(TestCase):
         login = self.client.post('/test_admin/admin/secure-view/', self.adduser_login)
         self.assertRedirects(login, '/test_admin/admin/secure-view/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Change User
         response = self.client.get('/test_admin/admin/secure-view/')
@@ -1734,7 +1740,7 @@ class SecureViewTests(TestCase):
         login = self.client.post('/test_admin/admin/secure-view/', self.changeuser_login)
         self.assertRedirects(login, '/test_admin/admin/secure-view/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Delete User
         response = self.client.get('/test_admin/admin/secure-view/')
@@ -1742,7 +1748,7 @@ class SecureViewTests(TestCase):
         login = self.client.post('/test_admin/admin/secure-view/', self.deleteuser_login)
         self.assertRedirects(login, '/test_admin/admin/secure-view/')
         self.assertFalse(login.context)
-        self.client.get('/test_admin/admin/logout/')
+        self.client.post('/test_admin/admin/logout/')
 
         # Regular User should not be able to login.
         response = self.client.get('/test_admin/admin/secure-view/')
@@ -1872,8 +1878,9 @@ class AdminViewListEditable(TestCase):
         # search field and search submit button = 2
         # CSRF field = 1
         # field to track 'select all' across paginated views = 1
-        # 6 + 4 + 4 + 1 + 2 + 1 + 1 = 19 inputs
-        self.assertContains(response, "<input", count=19)
+        # Logout form = 2
+        # 6 + 4 + 4 + 1 + 2 + 1 + 1 + 2 = 21 inputs
+        self.assertContains(response, "<input", count=21)
         # 1 select per object = 3 selects
         self.assertContains(response, "<select", count=4)
 
@@ -3616,7 +3623,8 @@ class ReadonlyTest(TestCase):
         self.assertNotContains(response, 'name="posted"')
         # 3 fields + 2 submit buttons + 5 inline management form fields, + 2
         # hidden fields for inlines + 1 field for the inline + 2 empty form
-        self.assertContains(response, "<input", count=15)
+        # + 2 inputs for logout form
+        self.assertContains(response, "<input", count=17)
         self.assertContains(response, formats.localize(datetime.date.today()))
         self.assertContains(response,
             "<label>Awesomeness level:</label>")
@@ -4317,7 +4325,7 @@ class AdminViewLogoutTest(TestCase):
         self.client.logout()
 
     def test_client_logout_url_can_be_used_to_login(self):
-        response = self.client.get('/test_admin/admin/logout/')
+        response = self.client.post('/test_admin/admin/logout/')
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'registration/logged_out.html')
         self.assertEqual(response.request['PATH_INFO'], '/test_admin/admin/logout/')
@@ -4332,6 +4340,21 @@ class AdminViewLogoutTest(TestCase):
         self.assertTemplateUsed(response, 'admin/login.html')
         self.assertEqual(response.request['PATH_INFO'], '/test_admin/admin/')
         self.assertContains(response, '<input type="hidden" name="next" value="/test_admin/admin/" />')
+
+    def test_logout_attempt_using_get(self):
+        response = self.client.get('/test_admin/admin/logout/')
+        self.assertEqual(response.status_code, 200)
+        # since we are issuing a GET request we should be rendering
+        # the confirmation template
+        self.assertTemplateUsed(response, 'registration/logout_confirmation.html')
+
+    def test_logout_attempt_using_post(self):
+        # 15619 - you must POST to the logout view to actually logout.
+        response = self.client.post('/test_admin/admin/logout/')
+        self.assertEqual(response.status_code, 200)
+        # since we are issuing a POST request we should be logging out the
+        # user immediately.
+        self.assertTemplateUsed(response, 'registration/logged_out.html')
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))

--- a/tests/templates/custom_admin/logout_confirmation.html
+++ b/tests/templates/custom_admin/logout_confirmation.html
@@ -1,0 +1,6 @@
+{% extends "registration/logout_confirmation.html" %}
+
+{% block content %}
+Hello from a custom logout confirmation template
+{{ block.super }}
+{% endblock %}


### PR DESCRIPTION
- Logout only performed on POST requests. GET requests returns
  confirmation page.
- Logout link in administration replaced by logout form without change
  of appearance.

Based on patch from ashchristopher.
