### PR TITLE
Fixed #21491 -- Removed documented workaround for a known issue.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1230,13 +1230,6 @@ that control how the relationship functions.
 
     Same as :attr:`ForeignKey.related_name`.
 
-    If you have more than one ``ManyToManyField`` pointing to the same model
-    and want to suppress the backwards relations, set each ``related_name``
-    to a unique value ending with ``'+'``::
-
-        users = models.ManyToManyField(User, related_name='u+')
-        referents = models.ManyToManyField(User, related_name='ref+')
-
 .. attribute:: ForeignKey.related_query_name
 
     .. versionadded:: 1.6


### PR DESCRIPTION
The issue was that two M2M hidden reverse managers
(related_name ending with a '+') could clash with each other.

Refs #21375 and #15932. Thanks Baptiste.
