### PR TITLE
Don't crash if GeometryField widget doesn't know srid

### DIFF
--- a/django/contrib/gis/forms/fields.py
+++ b/django/contrib/gis/forms/fields.py
@@ -45,9 +45,24 @@ class GeometryField(forms.Field):
             try:
                 value = GEOSGeometry(value)
                 if not value.srid:
-                    value.srid = self.widget.map_srid
+                    try:
+                        value.srid = self.widget.map_srid
+                    except AttributeError:
+                        pass
             except (GEOSException, ValueError, TypeError):
                 raise forms.ValidationError(self.error_messages['invalid_geom'], code='invalid_geom')
+
+        # Transforming the geometry if the SRID was set.
+        if self.srid:
+            if not value.srid:
+                # Should match that of the field if not given.
+                value.srid = self.srid
+            elif self.srid != -1 and self.srid != value.srid:
+                try:
+                    value.transform(self.srid)
+                except GEOSException:
+                    raise forms.ValidationError(self.error_messages['transform_error'], code='transform_error')
+
         return value
 
     def clean(self, value):
@@ -64,17 +79,6 @@ class GeometryField(forms.Field):
         # using the OGC string label).
         if str(geom.geom_type).upper() != self.geom_type and not self.geom_type == 'GEOMETRY':
             raise forms.ValidationError(self.error_messages['invalid_geom_type'], code='invalid_geom_type')
-
-        # Transforming the geometry if the SRID was set.
-        if self.srid:
-            if not geom.srid:
-                # Should match that of the field if not given.
-                geom.srid = self.srid
-            elif self.srid != -1 and self.srid != geom.srid:
-                try:
-                    geom.transform(self.srid)
-                except GEOSException:
-                    raise forms.ValidationError(self.error_messages['transform_error'], code='transform_error')
 
         return geom
 

--- a/django/contrib/gis/tests/test_geoforms.py
+++ b/django/contrib/gis/tests/test_geoforms.py
@@ -1,6 +1,6 @@
 from unittest import skipUnless
 
-from django.forms import ValidationError
+from django.forms import widgets, ValidationError
 from django.contrib.gis.gdal import HAS_GDAL
 from django.contrib.gis.tests.utils import HAS_SPATIALREFSYS
 from django.test import SimpleTestCase
@@ -25,7 +25,7 @@ class GeometryFieldTest(SimpleTestCase):
         "Testing GeometryField with a SRID set."
         # Input that doesn't specify the SRID is assumed to be in the SRID
         # of the input field.
-        fld = forms.GeometryField(srid=4326)
+        fld = forms.GeometryField(srid=4326, widget=widgets.TextInput)
         geom = fld.clean('POINT(5 23)')
         self.assertEqual(4326, geom.srid)
         # Making the field in a different SRID from that of the geometry, and


### PR DESCRIPTION
Also, it seems inappropriate for srid transformation to be done within the `clean` function, rather than `to_python`.

The `_has_changed` wont' see the transformation, for example.
