### PR TITLE
fixes #21412 -- messages framework add_message should check request arg

### DIFF
--- a/django/contrib/messages/api.py
+++ b/django/contrib/messages/api.py
@@ -1,10 +1,12 @@
 from django.contrib.messages import constants
 from django.contrib.messages.storage import default_storage
+from django.http import HttpRequest
 
 __all__ = (
     'add_message', 'get_messages',
     'get_level', 'set_level',
     'debug', 'info', 'success', 'warning', 'error',
+    'MessageFailure',
 )
 
 
@@ -16,6 +18,9 @@ def add_message(request, level, message, extra_tags='', fail_silently=False):
     """
     Attempts to add a message to the request using the 'messages' app.
     """
+    if not isinstance(request, HttpRequest):
+        raise TypeError("add_message() argument must be an HttpRequest object, "
+                        "not '%s'." % request.__class__.__name__)
     if hasattr(request, '_messages'):
         return request._messages.add(level, message, extra_tags)
     if not fail_silently:

--- a/django/contrib/messages/tests/test_api.py
+++ b/django/contrib/messages/tests/test_api.py
@@ -1,0 +1,55 @@
+from django.test import TestCase, RequestFactory
+
+from django.contrib import messages
+
+
+class DummyStorage(object):
+    """
+    dummy message-store to test the api methods
+    """
+
+    def __init__(self):
+        self.store = []
+
+    def add(self, level, message, extra_tags=''):
+        self.store.append(message)
+
+
+class APITest(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+        self.request = self.rf.request()
+        self.storage = DummyStorage()
+
+    def test_ok(self):
+        msg = 'some message'
+
+        self.request._messages = self.storage
+        messages.add_message(self.request, messages.DEBUG, msg)
+        self.assertIn(msg, self.storage.store)
+
+    def test_request_is_none(self):
+        msg = 'some message'
+
+        self.request._messages = self.storage
+
+        with self.assertRaises(TypeError):
+            messages.add_message(None, messages.DEBUG, msg)
+
+        self.assertEqual([], self.storage.store)
+
+    def test_middleware_missing(self):
+        msg = 'some message'
+
+        with self.assertRaises(messages.MessageFailure):
+            messages.add_message(self.request, messages.DEBUG, msg)
+
+        self.assertEqual([], self.storage.store)
+
+    def test_middleware_missing_silently(self):
+        msg = 'some message'
+
+        messages.add_message(self.request, messages.DEBUG, msg,
+                             fail_silently=True)
+
+        self.assertEqual([], self.storage.store)


### PR DESCRIPTION
problem were users calling messages.debug/info/\* with a wrong argument
and getting the error "You cannot add messages without installing
MessageMiddleware"

https://code.djangoproject.com/ticket/21412
