### PR TITLE
Fixed #21477 -- Renamed pre/post_migrate argument 'db' to 'using'.

### DIFF
--- a/django/contrib/contenttypes/management.py
+++ b/django/contrib/contenttypes/management.py
@@ -6,7 +6,7 @@ from django.utils import six
 from django.utils.six.moves import input
 
 
-def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, **kwargs):
+def update_contenttypes(app, created_models, verbosity=2, using=DEFAULT_DB_ALIAS, **kwargs):
     """
     Creates content types for models in the given app, removing any model
     entries that no longer have a matching model class.
@@ -16,7 +16,7 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
     except UnavailableApp:
         return
 
-    if not router.allow_migrate(db, ContentType):
+    if not router.allow_migrate(using, ContentType):
         return
 
     ContentType.objects.clear_cache()
@@ -33,7 +33,7 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
     # Get all the content types
     content_types = dict(
         (ct.model, ct)
-        for ct in ContentType.objects.using(db).filter(app_label=app_label)
+        for ct in ContentType.objects.using(using).filter(app_label=app_label)
     )
     to_remove = [
         ct
@@ -50,7 +50,7 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
         for (model_name, model) in six.iteritems(app_models)
         if model_name not in content_types
     ]
-    ContentType.objects.using(db).bulk_create(cts)
+    ContentType.objects.using(using).bulk_create(cts)
     if verbosity >= 2:
         for ct in cts:
             print("Adding content type '%s | %s'" % (ct.app_label, ct.model))

--- a/django/contrib/sites/management.py
+++ b/django/contrib/sites/management.py
@@ -10,9 +10,9 @@ from django.contrib.sites import models as site_app
 from django.core.management.color import no_style
 
 
-def create_default_site(app, created_models, verbosity, db, **kwargs):
+def create_default_site(app, created_models, verbosity, using, **kwargs):
     # Only create the default sites in databases where Django created the table
-    if Site in created_models and router.allow_migrate(db, Site):
+    if Site in created_models and router.allow_migrate(using, Site):
         # The default settings set SITE_ID = 1, and some tests in Django's test
         # suite rely on this value. However, if database sequences are reused
         # (e.g. in the test suite after flush/syncdb), it isn't guaranteed that
@@ -20,15 +20,15 @@ def create_default_site(app, created_models, verbosity, db, **kwargs):
         # can also crop up outside of tests - see #15346.
         if verbosity >= 2:
             print("Creating example.com Site object")
-        Site(pk=1, domain="example.com", name="example.com").save(using=db)
+        Site(pk=1, domain="example.com", name="example.com").save(using=using)
 
         # We set an explicit pk instead of relying on auto-incrementation,
         # so we need to reset the database sequence. See #17415.
-        sequence_sql = connections[db].ops.sequence_reset_sql(no_style(), [Site])
+        sequence_sql = connections[using].ops.sequence_reset_sql(no_style(), [Site])
         if sequence_sql:
             if verbosity >= 2:
                 print("Resetting sequence")
-            cursor = connections[db].cursor()
+            cursor = connections[using].cursor()
             for command in sequence_sql:
                 cursor.execute(command)
 

--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -211,10 +211,15 @@ def emit_pre_migrate_signal(create_models, verbosity, interactive, db):
         if verbosity >= 2:
             print("Running pre-migrate handlers for application %s" % app_name)
         models.signals.pre_migrate.send(sender=app, app=app,
+                                        create_models=create_models,
+                                        verbosity=verbosity,
+                                        interactive=interactive, using=db)
+
+        # PendingDeprecationWarning
+        models.signals.pre_syncdb.send(sender=app, app=app,
                                        create_models=create_models,
                                        verbosity=verbosity,
-                                       interactive=interactive,
-                                       db=db)
+                                       interactive=interactive, db=db)
 
 
 def emit_post_migrate_signal(created_models, verbosity, interactive, db):
@@ -224,5 +229,11 @@ def emit_post_migrate_signal(created_models, verbosity, interactive, db):
         if verbosity >= 2:
             print("Running post-migrate handlers for application %s" % app_name)
         models.signals.post_migrate.send(sender=app, app=app,
-            created_models=created_models, verbosity=verbosity,
-            interactive=interactive, db=db)
+                                         created_models=created_models,
+                                         verbosity=verbosity,
+                                         interactive=interactive, using=db)
+        # PendingDeprecationWarning
+        models.signals.post_syncdb.send(sender=app, app=app,
+                                        created_models=created_models,
+                                        verbosity=verbosity,
+                                        interactive=interactive, db=db)

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.dispatch import Signal
 
 class_prepared = Signal(providing_args=["class"])
@@ -12,9 +14,30 @@ post_save = Signal(providing_args=["instance", "raw", "created", "using", "updat
 pre_delete = Signal(providing_args=["instance", "using"], use_caching=True)
 post_delete = Signal(providing_args=["instance", "using"], use_caching=True)
 
-pre_migrate = Signal(providing_args=["app", "create_models", "verbosity", "interactive", "db"])
-pre_syncdb = pre_migrate
-post_migrate = Signal(providing_args=["class", "app", "created_models", "verbosity", "interactive", "db"])
-post_syncdb = post_migrate
+pre_migrate = Signal(providing_args=["app", "create_models", "verbosity", "interactive", "using"])
+post_migrate = Signal(providing_args=["class", "app", "created_models", "verbosity", "interactive", "using"])
+
+
+class DeprecatedSignal(Signal):
+    def __init__(self, *args, **kwargs):
+        self.deprecation = kwargs.pop('deprecation')
+        super(DeprecatedSignal, self).__init__(*args, **kwargs)
+
+    def connect(self, *args, **kwargs):
+        warnings.warn(
+            "%s signal is deprecated and will be removed in Django 1.9, "
+            "use %s instead." % self.deprecation,
+            PendingDeprecationWarning, stacklevel=2
+        )
+        super(DeprecatedSignal, self).connect(*args, **kwargs)
+
+
+pre_syncdb = DeprecatedSignal(
+    providing_args=["app", "create_models", "verbosity", "interactive", "db"],
+    deprecation=('pre_syncdb', 'pre_migrate'))
+
+post_syncdb = DeprecatedSignal(
+    providing_args=["class", "app", "created_models", "verbosity", "interactive", "db"],
+    deprecation=('post_syncdb', 'post_migrate'))
 
 m2m_changed = Signal(providing_args=["action", "instance", "reverse", "model", "pk_set", "using"], use_caching=True)

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -396,7 +396,7 @@ Arguments sent with this signal:
     For example, the :mod:`django.contrib.auth` app only prompts to create a
     superuser when ``interactive`` is ``True``.
 
-``db``
+``using``
     The alias of database on which a command will operate.
 
 pre_syncdb
@@ -407,14 +407,19 @@ pre_syncdb
 
 .. deprecated:: 1.7
 
-    This signal has been renamed to :data:`~django.db.models.signals.pre_migrate`.
+    This signal has been replaced by :data:`~django.db.models.signals.pre_migrate`
+    and will be removed in Django 1.9.
 
-Alias of :data:`django.db.models.signals.pre_migrate`. As long as this alias
-is present, for backwards-compatibility this signal has an extra argument it sends:
+Handlers for this signal receives the same arguments as
+:data:`~django.db.models.signals.pre_migrate` with the following exceptions:
 
 ``create_models``
     A list of the model classes from any app which :djadmin:`migrate` is
     going to create, **only if the app has no migrations**.
+
+``db``
+    The database alias used for synchronization. Defaults to the ``default``
+    database. Renamed to ``using`` in :data:`~django.db.models.signals.pre_migrate`.
 
 post_migrate
 ------------
@@ -458,7 +463,7 @@ Arguments sent with this signal:
     For example, the :mod:`django.contrib.auth` app only prompts to create a
     superuser when ``interactive`` is ``True``.
 
-``db``
+``using``
     The database alias used for synchronization. Defaults to the ``default``
     database.
 
@@ -481,14 +486,19 @@ post_syncdb
 
 .. deprecated:: 1.7
 
-    This signal has been renamed to :data:`~django.db.models.signals.post_migrate`.
+    This signal has been replaced by :data:`~django.db.models.signals.post_migrate`
+    and will be removed in Django 1.9.
 
-Alias of :data:`django.db.models.signals.post_migrate`. As long as this alias
-is present, for backwards-compatibility this signal has an extra argument it sends:
+Handlers for this signal receives the same arguments as
+:data:`~django.db.models.signals.post_migrate` with the following exceptions:
 
 ``created_models``
     A list of the model classes from any app which :djadmin:`migrate` has
     created, **only if the app has no migrations**.
+
+``db``
+    The database alias used for synchronization. Defaults to the ``default``
+    database. Renamed to ``using`` in :data:`~django.db.models.signals.post_migrate`.
 
 Request/response signals
 ========================

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -48,10 +48,10 @@ but a few of the key features are:
   to your models and make migrations for them.
 
 * :data:`~django.db.models.signals.pre_syncdb` and
-  :data:`~django.db.models.signals.post_syncdb` have been renamed to
+  :data:`~django.db.models.signals.post_syncdb` have been replaced by
   :data:`~django.db.models.signals.pre_migrate` and
-  :data:`~django.db.models.signals.post_migrate` respectively. The
-  ``create_models``/``created_models`` argument has also been deprecated.
+  :data:`~django.db.models.signals.post_migrate` respectively. See their
+  respective documentations for more details.
 
 * The ``allow_syncdb`` method on database routers is now called ``allow_migrate``,
   but still performs the same function. Routers with ``allow_syncdb`` methods

--- a/tests/migrate_signals/tests.py
+++ b/tests/migrate_signals/tests.py
@@ -1,3 +1,4 @@
+import warnings
 from django.db.models import signals
 from django.test import TestCase
 from django.core import management
@@ -6,13 +7,12 @@ from django.utils import six
 from . import models
 
 
-PRE_MIGRATE_ARGS = ['app', 'create_models', 'verbosity', 'interactive', 'db']
 MIGRATE_DATABASE = 'default'
 MIGRATE_VERBOSITY = 1
 MIGRATE_INTERACTIVE = False
 
 
-class PreMigrateReceiver(object):
+class Receiver(object):
     def __init__(self):
         self.call_counter = 0
         self.call_args = None
@@ -28,18 +28,23 @@ class OneTimeReceiver(object):
     several databases and several times for some of them.
     """
 
-    def __init__(self):
+    def __init__(self, signal, db_kwarg):
+        self.signal = signal
+        self.db_kwarg = db_kwarg
         self.call_counter = 0
         self.call_args = None
+
+        with warnings.catch_warnings(record=True) as recorded:
+            self.signal.connect(self, sender=models)
 
     def __call__(self, signal, sender, **kwargs):
         # Although test runner calls migrate for several databases,
         # testing for only one of them is quite sufficient.
-        if kwargs['db'] == MIGRATE_DATABASE:
+        if kwargs[self.db_kwarg] == MIGRATE_DATABASE:
             self.call_counter = self.call_counter + 1
             self.call_args = kwargs
             # we need to test only one call of migrate
-            signals.pre_migrate.disconnect(pre_migrate_receiver, sender=models)
+            self.signal.disconnect(self, sender=models)
 
 
 # We connect receiver here and not in unit test code because we need to
@@ -50,8 +55,10 @@ class OneTimeReceiver(object):
 #   2. We connect receiver.
 #   3. Test runner calls migrate for create default database.
 #   4. Test runner execute our unit test code.
-pre_migrate_receiver = OneTimeReceiver()
-signals.pre_migrate.connect(pre_migrate_receiver, sender=models)
+pre_migrate_receiver = OneTimeReceiver(signals.pre_migrate, db_kwarg='using')
+pre_syncdb_receiver = OneTimeReceiver(signals.pre_syncdb, db_kwarg='db')
+post_migrate_receiver = OneTimeReceiver(signals.post_migrate, db_kwarg='using')
+post_syncdb_receiver = OneTimeReceiver(signals.post_syncdb, db_kwarg='db')
 
 
 class MigrateSignalTests(TestCase):
@@ -60,20 +67,90 @@ class MigrateSignalTests(TestCase):
         'migrate_signals',
     ]
 
-    def test_pre_migrate_call_time(self):
+    @staticmethod
+    def _call_migrate():
+        management.call_command('migrate', database=MIGRATE_DATABASE,
+                                verbosity=MIGRATE_VERBOSITY,
+                                interactive=MIGRATE_INTERACTIVE,
+                                load_initial_data=False, stdout=six.StringIO())
+
+    def test_migrate_call_times(self):
         self.assertEqual(pre_migrate_receiver.call_counter, 1)
+        self.assertEqual(pre_syncdb_receiver.call_counter, 1)
+        self.assertEqual(post_migrate_receiver.call_counter, 1)
+        self.assertEqual(post_syncdb_receiver.call_counter, 1)
 
     def test_pre_migrate_args(self):
-        r = PreMigrateReceiver()
+        r = Receiver()
         signals.pre_migrate.connect(r, sender=models)
-        management.call_command('migrate', database=MIGRATE_DATABASE,
-            verbosity=MIGRATE_VERBOSITY, interactive=MIGRATE_INTERACTIVE,
-            load_initial_data=False, stdout=six.StringIO())
+
+        self._call_migrate()
 
         args = r.call_args
         self.assertEqual(r.call_counter, 1)
-        self.assertEqual(set(args), set(PRE_MIGRATE_ARGS))
+        self.assertEqual(set(args), {"app", "create_models", "verbosity",
+                                     "interactive", "using"})
         self.assertEqual(args['app'], models)
         self.assertEqual(args['verbosity'], MIGRATE_VERBOSITY)
         self.assertEqual(args['interactive'], MIGRATE_INTERACTIVE)
-        self.assertEqual(args['db'], 'default')
+        self.assertEqual(args['using'], 'default')
+
+    def test_pre_syncdb_args(self):
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as recorded:
+            r = Receiver()
+            signals.pre_syncdb.connect(r, sender=models)
+            self._call_migrate()
+
+            args = r.call_args
+            self.assertEqual(r.call_counter, 1)
+            self.assertEqual(set(args), {"app", "create_models", "verbosity",
+                                         "interactive", "db"})
+            self.assertEqual(args['app'], models)
+            self.assertEqual(args['verbosity'], MIGRATE_VERBOSITY)
+            self.assertEqual(args['interactive'], MIGRATE_INTERACTIVE)
+            self.assertEqual(args['db'], 'default')
+
+            msgs = [str(warning.message) for warning in recorded]
+            self.assertEqual(msgs, [
+                "pre_syncdb signal is deprecated and will be removed in "
+                "Django 1.9, use pre_migrate instead."
+            ])
+
+    def test_post_migrate_args(self):
+        r = Receiver()
+        signals.post_migrate.connect(r, sender=models)
+        self._call_migrate()
+
+        args = r.call_args
+        self.assertEqual(r.call_counter, 1)
+        self.assertEqual(set(args), {"app", "created_models", "verbosity",
+                                     "interactive", "using"})
+        self.assertEqual(args['app'], models)
+        self.assertEqual(args['verbosity'], MIGRATE_VERBOSITY)
+        self.assertEqual(args['interactive'], MIGRATE_INTERACTIVE)
+        self.assertEqual(args['using'], 'default')
+
+    def test_post_syncdb_args(self):
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as recorded:
+            r = Receiver()
+            signals.post_syncdb.connect(r, sender=models)
+            self._call_migrate()
+
+            args = r.call_args
+            self.assertEqual(r.call_counter, 1)
+            self.assertEqual(set(args), {"app", "created_models", "verbosity",
+                                         "interactive", "db"})
+            self.assertEqual(args['app'], models)
+            self.assertEqual(args['verbosity'], MIGRATE_VERBOSITY)
+            self.assertEqual(args['interactive'], MIGRATE_INTERACTIVE)
+            self.assertEqual(args['db'], 'default')
+
+            msgs = [str(warning.message) for warning in recorded]
+            self.assertEqual(msgs, [
+                "post_syncdb signal is deprecated and will be removed in "
+                "Django 1.9, use post_migrate instead."
+            ])


### PR DESCRIPTION
This commit also reintroduces pre/post_syncdb as their own signals
(rather than being aliases to pre/post_migrate) to offer a proper
deprecation cycle with warnings.
