### PR TITLE
Fixed #17713 -- Renamed allows_primary_key_0 to allows_auto_pk_0.

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -610,8 +610,8 @@ class BaseDatabaseFeatures(object):
     # Is there a 1000 item limit on query parameters?
     supports_1000_query_parameters = True
 
-    # Can an object have a primary key of 0? MySQL says No.
-    allows_primary_key_0 = True
+    # Can an object have an autoincrement primary key of 0? MySQL says No.
+    allows_auto_pk_0 = True
 
     # Do we need to NULL a ForeignKey out, or can the constraint check be
     # deferred

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -169,7 +169,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_date_lookup_using_string = False
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
-    allows_primary_key_0 = False
+    allows_auto_pk_0 = False
     uses_savepoints = True
     atomic_transactions = False
     supports_check_constraints = False

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -908,10 +908,9 @@ class ThreadTests(TestCase):
 class MySQLPKZeroTests(TestCase):
     """
     Zero as id for AutoField should raise exception in MySQL, because MySQL
-    does not allow zero for automatic primary key.
+    does not allow zero for autoincrement primary key.
     """
-
-    @skipIfDBFeature('allows_primary_key_0')
+    @skipIfDBFeature('allows_auto_pk_0')
     def test_zero_as_autoval(self):
         with self.assertRaises(ValueError):
             models.Square.objects.create(id=0, root=0, square=1)

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -70,13 +70,12 @@ class BulkCreateTests(TestCase):
             "CA", "IL", "ME", "NY",
         ], attrgetter("two_letter_code"))
 
-    @skipIfDBFeature('allows_primary_key_0')
+    @skipIfDBFeature('allows_auto_pk_0')
     def test_zero_as_autoval(self):
         """
         Zero as id for AutoField should raise exception in MySQL, because MySQL
         does not allow zero for automatic primary key.
         """
-
         valid_country = Country(name='Germany', iso_two_letter='DE')
         invalid_country = Country(id=0, name='Poland', iso_two_letter='PL')
         with self.assertRaises(ValueError):

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -158,7 +158,7 @@ class InlineFormsetFactoryTest(TestCase):
             Parent, Child, exclude=('school',), fk_name='mother'
         )
 
-    @skipUnlessDBFeature('allows_primary_key_0')
+    @skipUnlessDBFeature('allows_auto_pk_0')
     def test_zero_primary_key(self):
         # Regression test for #21472
         poet = Poet.objects.create(id=0, name='test')

--- a/tests/serializers_regress/tests.py
+++ b/tests/serializers_regress/tests.py
@@ -389,10 +389,10 @@ if connection.features.interprets_empty_strings_as_nulls:
                          data[2]._meta.get_field('data').empty_strings_allowed and
                          data[3] is None)]
 
-# Regression test for #8651 -- a FK to an object iwth PK of 0
+# Regression test for #8651 -- a FK to an object with PK of 0
 # This won't work on MySQL since it won't let you create an object
-# with a primary key of 0,
-if connection.features.allows_primary_key_0:
+# with an autoincrement primary key of 0,
+if connection.features.allows_auto_pk_0:
     test_data.extend([
         (data_obj, 0, Anchor, "Anchor 0"),
         (fk_obj, 465, FKData, 0),


### PR DESCRIPTION
MySQL does allow primary key with value 0. It only forbids autoincrement
primary key with value 0.
