### PR TITLE
Fixed #21473 in 1.6.x branch - language is preserved after logout

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -101,7 +101,14 @@ def logout(request):
         user = None
     user_logged_out.send(sender=user.__class__, request=request, user=user)
 
+    # remember language choice saved to session
+    language = request.session.get('django_language')
+
     request.session.flush()
+
+    if language is not None:
+        request.session['django_language'] = language
+
     if hasattr(request, 'user'):
         from django.contrib.auth.models import AnonymousUser
         request.user = AnonymousUser()

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -53,10 +53,6 @@ class LocaleMiddleware(object):
                     request.get_host(), language, request.get_full_path())
                 return HttpResponseRedirect(language_url)
 
-        # Store language back into session if it is not present
-        if hasattr(request, 'session'):
-            request.session.setdefault('django_language', language)
-
         if not (self.is_language_prefix_patterns_used()
                 and language_from_path):
             patch_vary_headers(response, ('Accept-Language',))

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1191,29 +1191,12 @@ class LocaleMiddlewareTests(TransRealMixin, TestCase):
             'django.middleware.common.CommonMiddleware',
         ),
     )
-    def test_session_language(self):
-        """
-        Check that language is stored in session if missing.
-        """
-        # Create an empty session
-        engine = import_module(settings.SESSION_ENGINE)
-        session = engine.SessionStore()
-        session.save()
-        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
-
-        # Clear the session data before request
-        session.save()
-        response = self.client.get('/en/simple/')
-        self.assertEqual(self.client.session['django_language'], 'en')
-
-        # Clear the session data before request
-        session.save()
-        response = self.client.get('/fr/simple/')
-        self.assertEqual(self.client.session['django_language'], 'fr')
-
-        # Check that language is not changed in session
-        response = self.client.get('/en/simple/')
-        self.assertEqual(self.client.session['django_language'], 'fr')
+    def test_language_not_saved_to_session(self):
+        """Checks that current language is not automatically saved to
+        session on every request."""
+        # Regression test for #21473
+        self.client.get('/fr/simple/')
+        self.assertNotIn('django_language', self.client.session)
 
 
 @override_settings(


### PR DESCRIPTION
Current language is no longer saved to session by LocaleMiddleware
on  every response (the behavior introduced in #14825).
Instead language stored in session is reintroduced into new session
after logout.
