### PR TITLE
Fixed #21509 – Removed dead exception catching code.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -175,8 +175,6 @@ class SimpleTestCase(unittest.TestCase):
         if not skipped:
             try:
                 self._pre_setup()
-            except (KeyboardInterrupt, SystemExit):
-                raise
             except Exception:
                 result.addError(self, sys.exc_info())
                 return
@@ -184,8 +182,6 @@ class SimpleTestCase(unittest.TestCase):
         if not skipped:
             try:
                 self._post_teardown()
-            except (KeyboardInterrupt, SystemExit):
-                raise
             except Exception:
                 result.addError(self, sys.exc_info())
                 return


### PR DESCRIPTION
Since Python 2.5, KeyboardInterrupt and SystemExit are not subclasses of
Exception, so explicitly reraising them before the “except Exception” clause
is not necessary anymore.

https://code.djangoproject.com/ticket/21509
