### PR TITLE
Fixed #18456 -- escape path returned by `HttpRequest.get_full_path()`

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -15,7 +15,8 @@ from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser, MultiPartParserError
 from django.utils import six
 from django.utils.datastructures import MultiValueDict, ImmutableList
-from django.utils.encoding import force_bytes, force_text, force_str, iri_to_uri
+from django.utils.encoding import (force_bytes, force_text, force_str,
+                                   iri_to_uri, escape_uri_path)
 from django.utils.six.moves.urllib.parse import parse_qsl, urlencode, quote, urljoin, urlsplit
 
 
@@ -97,7 +98,9 @@ class HttpRequest(object):
     def get_full_path(self):
         # RFC 3986 requires query string arguments to be in the ASCII range.
         # Rather than crash if this doesn't happen, we encode defensively.
-        return '%s%s' % (self.path, ('?' + iri_to_uri(self.META.get('QUERY_STRING', ''))) if self.META.get('QUERY_STRING', '') else '')
+        return '%s%s' % (escape_uri_path(self.path),
+                         ('?' + iri_to_uri(self.META.get('QUERY_STRING', '')))
+                         if self.META.get('QUERY_STRING', '') else '')
 
     def get_signed_cookie(self, key, default=RAISE_ERROR, salt='', max_age=None):
         """

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -203,6 +203,21 @@ def iri_to_uri(iri):
         return iri
     return quote(force_bytes(iri), safe=b"/#%[]=:;$&()+,!?*@'~")
 
+def escape_uri_path(path):
+    """
+    Escape the unsafe characters from the path portion of a Uniform Resource
+    Identifier (URI).
+    """
+    # This are the "reserved" and "unreserved" characters specified in sections
+    # 2.2 and 2.3 of RFC 2396:
+    #   reserved    = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
+    #   unreserved  = alphanum | mark
+    #   mark        = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
+    # The list of safe characters here is constructed substracting ";", "=", and
+    # "?" according to the section 3.3 of RFC 2396.
+    # The reason of not subtracting and escaping "/" is that we are escaping
+    # the entire path, not a path segment.
+    return quote(force_bytes(path), safe=b"/:@&+$,-_.!~*'()")
 
 def filepath_to_uri(path):
     """Convert a file system path to a URI portion that is suitable for

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -273,6 +273,13 @@ The functions defined in this module share the following properties:
 
     Returns an ASCII string containing the encoded result.
 
+.. function:: escape_uri_path(path)
+
+    .. versionadded:: 1.7
+
+    Escape the unsafe characters from the path portion of a Uniform Resource
+    Identifier (URI).
+
 .. function:: filepath_to_uri(path)
 
     Convert a file system path to a URI portion that is suitable for inclusion

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -35,6 +35,13 @@ class RequestsTests(SimpleTestCase):
         # and FILES should be MultiValueDict
         self.assertEqual(request.FILES.getlist('foo'), [])
 
+    def test_httprequest_full_path(self):
+        request = HttpRequest()
+        request.path = request.path_info = '/;some/?awful/=path/foo:bar/'
+        request.META['QUERY_STRING'] = ';some=query&+query=string'
+        expected = '/%3Bsome/%3Fawful/%3Dpath/foo:bar/?;some=query&+query=string'
+        self.assertEqual(request.get_full_path(), expected)
+
     def test_httprequest_repr(self):
         request = HttpRequest()
         request.path = '/somepath/'

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -6,7 +6,7 @@ import datetime
 
 from django.utils import six
 from django.utils.encoding import (force_bytes, force_text, filepath_to_uri,
-        python_2_unicode_compatible)
+        escape_uri_path, python_2_unicode_compatible)
 
 
 class TestEncodingUtils(unittest.TestCase):
@@ -44,6 +44,11 @@ class TestEncodingUtils(unittest.TestCase):
             'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
         self.assertEqual(filepath_to_uri('upload\\чубака.mp4'.encode('utf-8')),
             'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
+
+    def test_uri_escape_path(self):
+        path = '/;some/=awful/?path/:with/@lots/&of/+awful/chars'
+        escaped_path = '/%3Bsome/%3Dawful/%3Fpath/:with/@lots/&of/+awful/chars'
+        self.assertEqual(escape_path(path), escaped_path)
 
     @unittest.skipIf(six.PY3, "tests a class not defining __str__ under Python 2")
     def test_decorated_class_without_str(self):


### PR DESCRIPTION
The path part of `HttpRequest.get_full_path()` is now escaped according to RFC
2396.
