### PR TITLE
Set zip_safe to false to avoid a ton of debug messages during install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    zip_safe = False,
 )
 
 if overlay_warning:


### PR DESCRIPTION
During install, it's pretty annoying to see a list of every single time that Django uses `__file__`. By specifying `zip_false` in the call to `setup`, these messages aren't output and Django is simply unpacked into a directory, as it isn't zip compatible anyway:

```
Getting distribution for 'django==1.6.0'.
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[co]' found under directory '*'
zip_safe flag not set; analyzing archive contents...
django.conf.project_template.project_name.settings: module references __file__
django.contrib.admin.bin.compress: module references __file__
django.contrib.admindocs.views: module references __file__
django.contrib.auth.tests.test_context_processors: module references __file__
django.contrib.auth.tests.test_forms: module references __file__
django.contrib.auth.tests.test_views: module references __file__
django.contrib.flatpages.tests.test_csrf: module references __file__
django.contrib.flatpages.tests.test_middleware: module references __file__
django.contrib.flatpages.tests.test_templatetags: module references __file__
django.contrib.flatpages.tests.test_views: module references __file__
django.contrib.formtools.tests.tests: module references __file__
django.contrib.formtools.tests.wizard.namedwizardtests.tests: module references __file__
django.contrib.formtools.tests.wizard.wizardtests.tests: module references __file__
django.contrib.gis.geometry.test_data: module references __file__
django.contrib.gis.tests.geo3d.tests: module references __file__
django.contrib.gis.tests.geogapp.tests: module references __file__
django.contrib.gis.tests.layermap.tests: module references __file__
django.contrib.sitemaps.tests.test_http: module references __file__
django.contrib.staticfiles.storage: module references __file__
django.core.management.__init__: module references __path__
django.core.management.sql: module references __file__
django.core.management.templates: module references __path__
django.core.management.commands.makemessages: module references __file__
django.db.utils: module references __file__
django.db.models.loading: module references __file__
django.db.models.loading: module references __path__
django.template.loaders.app_directories: module references __file__
django.test._doctest: module references __file__
django.test._doctest: module MAY be using inspect.getsourcefile
django.utils.autoreload: module references __file__
django.utils.module_loading: module references __path__
django.utils.version: module references __file__
django.utils.translation.trans_real: module references __file__
django.utils.unittest.collector: module references __file__
django.utils.unittest.loader: module references __file__
django.views.i18n: module references __file__
Got Django 1.6.
```
