### PR TITLE
[1.5.x] Fixed #21523 — added additional parsing to DateField.to_python()

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -693,6 +693,10 @@ class DateField(Field):
         if isinstance(value, datetime.date):
             return value
 
+        # handle objects that are neither dates nor strings, but which
+        # return a parseable date string, e.g. a mock date class.
+        value = smart_text(value)
+
         try:
             parsed = parse_date(value)
             if parsed is not None:
@@ -783,6 +787,11 @@ class DateTimeField(DateField):
                 default_timezone = timezone.get_default_timezone()
                 value = timezone.make_aware(value, default_timezone)
             return value
+
+
+        # handle objects that are neither dates nor strings, but which
+        # return a parseable date string, e.g. a mock date class.
+        value = smart_text(value)
 
         try:
             parsed = parse_datetime(value)

--- a/tests/regressiontests/model_fields/tests.py
+++ b/tests/regressiontests/model_fields/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 import datetime
 from decimal import Decimal
 
@@ -127,7 +128,14 @@ class ForeignKeyTests(test.TestCase):
         b = Bar.objects.create(b="bcd")
         self.assertEqual(b.a, a)
 
+from datetime import date as real_date # used to test mocking dates.
 class DateTimeFieldTests(unittest.TestCase):
+    
+    class FakeDate(real_date):
+        "An object that is *not* a date, but which could be parsed as such."
+        def __new__(cls, *args, **kwargs):
+            return real_date.__new__(real_date, *args, **kwargs)
+
     def test_datetimefield_to_python_usecs(self):
         """DateTimeField.to_python should support usecs"""
         f = models.DateTimeField()
@@ -143,6 +151,13 @@ class DateTimeFieldTests(unittest.TestCase):
                          datetime.time(1, 2, 3, 4))
         self.assertEqual(f.to_python('01:02:03.999999'),
                          datetime.time(1, 2, 3, 999999))
+
+    @mock.patch('datetime.date', FakeDate)
+    def test_datefield_to_python_can_be_mocked(self):
+        """DateField.to_python should support mock dates."""
+        self.assertEqual(models.DateField().to_python(
+                DateTimeFieldTests.FakeDate.today()),
+            datetime.date.today())
 
 class BooleanFieldTests(unittest.TestCase):
     def _test_get_db_prep_lookup(self, f):


### PR DESCRIPTION
The to_python method attempts to convert a DateField value to a python
datetime.date object instance. It checks for datetime.date, datetime.
datetime instances, and if neither of those it then attempts to parse
the value as a string. This can fail if the value is an object that is
not a date, but is being used to represent one - i.e. a mock object.

Previously there was a call to django.utils.encoding.smart_str before
the call to parse_date, which essentially converted the value to its
unicode representation. This was removed when the smart_str method was
removed (in favour of smart_text). I have put a call to smart_text back
in.
