### PR TITLE
Fixing URL bug to allow users to have only one URL rule.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -479,11 +479,7 @@ def technical_404_response(request, exception):
     except (IndexError, TypeError, KeyError):
         tried = []
     else:
-        if (not tried                           # empty URLconf
-            or (request.path == '/'
-                and len(tried) == 1             # default URLconf
-                and len(tried[0]) == 1
-                and tried[0][0].app_name == tried[0][0].namespace == 'admin')):
+        if not tried:
             return default_urlconf(request)
 
     urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)


### PR DESCRIPTION
Currently Django 1.6 does not allow developers to specify only one URL within the urls.py file. The app_name and namespace attributes don't exist and an exception is thrown if urls.py only contains one URL.
# 

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Users/dmyerscough/nagios-api-env/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 67, in **call**
    return self.application(environ, start_response)
  File "/Users/dmyerscough/nagios-api-env/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 206, in **call**
    response = self.get_response(request)
  File "/Users/dmyerscough/nagios-api-env/lib/python2.7/site-packages/django/core/handlers/base.py", line 148, in get_response
    response = debug.technical_404_response(request, e)
  File "/Users/dmyerscough/nagios-api-env/lib/python2.7/site-packages/django/views/debug.py", line 471, in technical_404_response
    and tried[0][0].app_name == tried[0][0].namespace == 'admin')):
AttributeError: 'RegexURLPattern' object has no attribute 'app_name'
# 

Steps to reproduce this:-

1 - Edit the urls.py file and include only one URL rule

urlpatterns = patterns('',
    url(r'^test/', 'nagios_api.views.comments', name='home'),

2 - Connect to the Django web server and the error above will be reproduced.
