### PR TITLE
Fix for #21530

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -483,7 +483,7 @@ def technical_404_response(request, exception):
             or (request.path == '/'
                 and len(tried) == 1             # default URLconf
                 and len(tried[0]) == 1
-                and tried[0][0].app_name == tried[0][0].namespace == 'admin')):
+                and getattr(tried[0][0], 'app_name', '') == getattr(tried[0][0], 'namespace', '') == 'admin')):
             return default_urlconf(request)
 
     urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)


### PR DESCRIPTION
Correct AttributeError exception that occurs when one URL is specified in the urls.py.
