### PR TITLE
Fixed #21539 -- Added example of modelformset_factory's form argument

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -760,6 +760,30 @@ instances of the model, you can specify an empty QuerySet::
 
    >>> AuthorFormSet(queryset=Author.objects.none())
 
+Changing the ``form``
+---------------------
+
+By default, when you use ``modelformset_factory``, a model form will
+be created using :func:`~django.forms.models.modelform_factory`.
+Often, it can be useful to specify a custom model form. For example,
+you can create a custom model form that has custom validation::
+
+    class AuthorForm(forms.ModelForm):
+        class Meta:
+            model = Author
+            fields = ('name', 'title')
+
+        def clean_name(self):
+            # custom validation for the name field
+            ...
+
+Then, pass your model form to the factory function::
+
+    AuthorFormSet = modelformset_factory(Author, form=AuthorForm)
+
+It is not always necessary to define a custom model form. The
+``modelformset_factory`` function has several arguments which are
+passed through to ``modelform_factory``, which are described below.
 
 .. _controlling-fields-with-fields-and-exclude:
 


### PR DESCRIPTION
Initial attempt at adding an example of the modelformset_factory's form argument. Feedback welcome.

I tried to write the example so that it could easily be backported to 1.5.X and 1.6.X, for example I don't refer to the new widgets or localized_fields options in 1.6.

I couldn't think of a good example to go in the clean method. The only inspiration I got from the current docs was to ensure that the name starts with 'O'.
