### PR TITLE
Fixed #20495 -- Added login failure events to security logger

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
@@ -63,9 +64,13 @@ def authenticate(**credentials):
         user.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
         return user
 
-    # The credentials supplied are invalid to all backends, fire signal
-    user_login_failed.send(sender=__name__,
-            credentials=_clean_credentials(credentials))
+    # The credentials supplied are invalid to all backends, fire signal and log error 
+    credentials=_clean_credentials(credentials)
+    credentials.setdefault('username', None)
+    user_login_failed.send(sender=__name__, credentials=credentials)
+
+    logger = logging.getLogger('django.security.FailedLogin')    
+    logger.warning("user login failed", extra=credentials)
 
 
 def login(request, user):

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -400,15 +400,17 @@ class IgnoreAllDeprecationWarningsMixin(IgnoreDeprecationWarningsMixin):
 
 
 @contextmanager
-def patch_logger(logger_name, log_level):
+def patch_logger(logger_name, log_level, formatstr=''):
     """
-    Context manager that takes a named logger and the logging level
-    and provides a simple mock-like list of messages received
+    Context manager that takes a named logger, the logging level, and
+    a format string for the logger, and provides a simple mock-like list 
+    of messages received
     """
     calls = []
 
     def replacement(msg, *args, **kwargs):
-        calls.append(msg % args)
+        extra = kwargs.get('extra',{})
+        calls.append((formatstr % extra) + (msg % args))
     logger = logging.getLogger(logger_name)
     orig = getattr(logger, log_level)
     setattr(logger, log_level, replacement)

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -400,6 +400,11 @@ can be used for notification when a user logs in or out.
         authentication backend. Credentials matching a set of 'sensitive' patterns,
         (including password) will not be sent in the clear as part of the signal.
 
+     .. versionadded:: 1.7
+     
+     It should be noted that the failure is also logged as a warning to ``django.
+     security.FailedLogin``
+
 .. _authentication-backends-reference:
 
 Authentication backends

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -457,6 +457,13 @@ specific logger following this example::
                 'propagate': False,
             },
 
+.. versionadded:: 1.7
+
+Invalid username/passwords will be logged to ``django.security.FailedLogin`` as
+a warning. This logger will have the following extra context:
+
+* ``username``: the provided username which failed.
+
 Handlers
 --------
 

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -356,7 +356,9 @@ class SettingsConfigureLogging(TestCase):
 
 @override_settings(DEBUG=True)
 class SecurityLoggerTest(TestCase):
-
+    """
+    Test that security messages are being logged
+    """
     urls = 'logging_tests.urls'
 
     def test_suspicious_operation_creates_log_message(self):
@@ -379,3 +381,17 @@ class SecurityLoggerTest(TestCase):
         self.client.get('/suspicious/')
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('path:/suspicious/,', mail.outbox[0].body)
+
+    def test_user_login_failed_creates_log_message(self):
+        with self.settings(DEBUG=True):
+            with patch_logger('django.security.FailedLogin', 'warning', "%(username)s : ") as calls:
+                self.client.login(username='testclient', password='bad') 
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0], "testclient : user login failed")
+
+    def test_no_user_login_failed_creates_log_message(self):
+        with self.settings(DEBUG=True):
+            with patch_logger('django.security.FailedLogin', 'warning', "%(username)s : ") as calls:
+                self.client.login() 
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0], "None : user login failed")


### PR DESCRIPTION
When a user login attempt fails, it will be logged using
the logger django.security.FailedLogin, at warning level.
