### PR TITLE
Fixed #19869 -- active language change inside ``LiveTestServerCase``

### DIFF
--- a/django/utils/_threading.py
+++ b/django/utils/_threading.py
@@ -1,0 +1,23 @@
+import threading
+
+
+def from_local(local=None):
+    static = type('static', (object,), {})
+    if local is None:
+        return static
+    for attr in dir(local):
+        if not attr.startswith('__'):
+            value = getattr(local, attr)
+            setattr(static, attr, value)
+    return static
+
+
+def to_local(static=None):
+    local = threading.local()
+    if static is None:
+        return local
+    for attr in dir(static):
+        if not attr.startswith('__'):
+            value = getattr(static, attr)
+            setattr(local, attr, value)
+    return local

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -13,6 +13,7 @@ from django.test.utils import override_settings
 from django.utils.http import urlencode
 from django.utils.six.moves.urllib.error import HTTPError
 from django.utils.six.moves.urllib.request import urlopen
+from django.utils import translation
 from django.utils._os import upath
 
 from .models import Person
@@ -161,6 +162,17 @@ class LiveServerViews(LiveServerBase):
     def test_environ(self):
         f = self.urlopen('/environ_view/?%s' % urlencode({'q': 'тест'}))
         self.assertIn(b"QUERY_STRING: 'q=%D1%82%D0%B5%D1%81%D1%82'", f.read())
+
+    def test_active_language(self):
+        original = translation.get_language()
+        alternative = 'eu'
+        with translation.override(alternative):
+            self.assertEqual(translation.get_language(), alternative)
+            f = self.urlopen('/active_language_view/')
+            self.assertEqual(f.read(), alternative)
+        self.assertEqual(translation.get_language(), original)
+        f = self.urlopen('/active_language_view/')
+        self.assertEqual(f.read(), original)
 
 
 class LiveServerDatabase(LiveServerBase):

--- a/tests/servers/urls.py
+++ b/tests/servers/urls.py
@@ -8,4 +8,5 @@ urlpatterns = patterns('',
     url(r'^model_view/$', views.model_view),
     url(r'^create_model_instance/$', views.create_model_instance),
     url(r'^environ_view/$', views.environ_view),
+    url(r'^active_language_view/$', views.active_language_view),
 )

--- a/tests/servers/views.py
+++ b/tests/servers/views.py
@@ -1,4 +1,6 @@
 from django.http import HttpResponse
+from django.utils import translation
+
 from .models import Person
 
 
@@ -19,3 +21,7 @@ def create_model_instance(request):
 
 def environ_view(request):
     return HttpResponse("\n".join("%s: %r" % (k, v) for k, v in request.environ.items()))
+
+
+def active_language_view(request):
+    return HttpResponse(translation.get_language())


### PR DESCRIPTION
It's now possible to change the active language of the live test server from
within the tests. This is achieved by converting the active language thread local
into a thread nonlocal.
