### PR TITLE
New Note for filter_horizontal and non-ASCII characters in verbose_name

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -42,7 +42,7 @@ For reference, here are the requirements:
 4. Determine which of your application's models should be editable in the
    admin interface.
 
-5. For each of those models, optionally create a ``ModelAdmin`` class that
+5. For each of those models, optionally create a ``ModelAdmin`` class thatfilter_horizontal
    encapsulates the customized admin functionality and options for that
    particular model.
 
@@ -353,6 +353,24 @@ subclass::
     within the options. The unselected and selected options appear in two boxes
     side by side. See :attr:`~ModelAdmin.filter_vertical` to use a vertical
     interface.
+
+    .. admonition:: Note
+
+        If :attr:`~django.db.models.Field.verbose_name` contains non-ASCII
+        characters :attr:`~ModelAdmin.filter_horizontal` and
+        :attr:`~ModelAdmin.filter_vertical` widgets does not work in the
+        :doc:`Admin site <ref/contrib/admin/index>`.
+
+        Make :attr:`~django.db.models.Field.verbose_name` a unicode string and
+        give your ``models.py`` file a (:pep:`263`) encoding::
+
+            # -*- coding: utf-8 -*-
+            
+            from django.db import models
+
+            class Person(models.Model):
+                parents = models.ManyToManyField(
+                    "self", verbose_name=u'Paternità')
 
 .. attribute:: ModelAdmin.filter_vertical
 


### PR DESCRIPTION
If verbose_name contains non-ASCII characters filter_horizontal and filter_vertical widgets does not work in the Admin site.
