### PR TITLE
[1.5.x] Fixed #21523 - support for mock dates in DateField.to_python()

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -692,6 +692,9 @@ class DateField(Field):
             return value.date()
         if isinstance(value, datetime.date):
             return value
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_date(value)
@@ -771,7 +774,17 @@ class DateTimeField(DateField):
         if isinstance(value, datetime.datetime):
             return value
         if isinstance(value, datetime.date):
-            value = datetime.datetime(value.year, value.month, value.day)
+            # edge case - if we are mocking out datetime.datetime, and manage
+            # to pass a 'real' datetime into this method, then it will return
+            # True to isinstance(value,  datetime.date), but should really be
+            # treated as a datetime.
+            try:
+                value = datetime.datetime(value.year, value.month, value.day,
+                    value.hour, value.minute, value.second, value.microsecond)
+            except AttributeError:
+                # looks like it is a date, and not a datetime.
+                value = datetime.datetime(value.year, value.month, value.day)
+
             if settings.USE_TZ:
                 # For backwards compatibility, interpret naive datetimes in
                 # local time. This won't work during DST change, but we can't
@@ -783,6 +796,9 @@ class DateTimeField(DateField):
                 default_timezone = timezone.get_default_timezone()
                 value = timezone.make_aware(value, default_timezone)
             return value
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_datetime(value)
@@ -1231,6 +1247,9 @@ class TimeField(Field):
             # information), but this can be a side-effect of interacting with a
             # database backend (e.g. Oracle), so we'll be accommodating.
             return value.time()
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_time(value)

--- a/tests/regressiontests/model_fields/tests.py
+++ b/tests/regressiontests/model_fields/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 import datetime
 from decimal import Decimal
 
@@ -143,6 +144,53 @@ class DateTimeFieldTests(unittest.TestCase):
                          datetime.time(1, 2, 3, 4))
         self.assertEqual(f.to_python('01:02:03.999999'),
                          datetime.time(1, 2, 3, 999999))
+
+    def test_datefield_to_python_issue_21523(self):
+        """DateField.to_python should handle mock dates. (see #21523)"""
+
+        class FakeDate(datetime.date):
+            """Mock date class."""
+            pass
+
+        with mock.patch('datetime.date', FakeDate):
+            # this will create a mock date
+            today = datetime.date.today()
+            # this will force the creation of a 'real' date (i.e. not the mock)
+            tomorrow = today + datetime.timedelta(days=1)
+            # to_python does an isinstance(value, datetime.date) check -
+            # when we are mocking out datetime.date with our FakeDate class
+            # then this test will FAIL if value is a real date object, which
+            # is the case with issue #21523.
+            # 
+            # NB use of assertTrue and isinstance rather than assertIsInstance
+            # is deliberate, to make it as close as possible to the case we
+            # are testing for. Pls do not revert.
+            self.assertTrue(isinstance(today, datetime.date))
+            self.assertFalse(isinstance(tomorrow, datetime.date))
+            # if #21523 is not fixed, a call to to_python with a real date,
+            # e.g. the 'tomorrow' value, will raise a TypeError.
+            # What we want is for both FakeDate and real datetime.date objects
+            # to pass through unchanged.
+            f = models.DateField()
+            self.assertEqual(f.to_python(today), today)
+            self.assertEqual(f.to_python(tomorrow), tomorrow)
+
+    def test_datetimefield_to_python_issue_21523(self):
+        """DateTimeField.to_python should handle mock dates. (see #21523)"""
+
+        class FakeDateTime(datetime.datetime):
+            """Mock datetime class."""
+            pass
+
+        with mock.patch('datetime.datetime', FakeDateTime):
+            now = datetime.datetime.now()  # this is a mock datetime
+            then = now + datetime.timedelta(hours=-1)  # this is a real datetime
+            self.assertTrue(isinstance(now, datetime.datetime))
+            self.assertFalse(isinstance(then, datetime.datetime))
+            f = models.DateTimeField()
+            self.assertEqual(f.to_python(now), now)
+            self.assertEqual(f.to_python(then), then)
+
 
 class BooleanFieldTests(unittest.TestCase):
     def _test_get_db_prep_lookup(self, f):


### PR DESCRIPTION
In cases where the value passed in to the DateField.to_python() method
is a real date, and datetime.date is being mocked out, the method would
raise an error attempting to call parse_date on the mock object (as the
parsing requires a string input). I’ve added in a duck-type check for
objects before the parse_date call - if the object has a ‘isoformat()’
method, then call this, and pass it into the parse_date function - which
should return an identical object.
