### PR TITLE
Fixed #21523 - Added support for mock dates in Date/TimeField.to_python()

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1200,6 +1200,9 @@ class DateField(DateTimeCheckMixin, Field):
             return value.date()
         if isinstance(value, datetime.date):
             return value
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_date(value)
@@ -1333,7 +1336,17 @@ class DateTimeField(DateField):
         if isinstance(value, datetime.datetime):
             return value
         if isinstance(value, datetime.date):
-            value = datetime.datetime(value.year, value.month, value.day)
+            # edge case - if we are mocking out datetime.datetime, and manage
+            # to pass a 'real' datetime into this method, then it will return
+            # True to isinstance(value,  datetime.date), but should really be
+            # treated as a datetime.
+            try:
+                value = datetime.datetime(value.year, value.month, value.day,
+                    value.hour, value.minute, value.second, value.microsecond)
+            except AttributeError:
+                # looks like it is a date, and not a datetime.
+                value = datetime.datetime(value.year, value.month, value.day)
+
             if settings.USE_TZ:
                 # For backwards compatibility, interpret naive datetimes in
                 # local time. This won't work during DST change, but we can't
@@ -1346,6 +1359,9 @@ class DateTimeField(DateField):
                 default_timezone = timezone.get_default_timezone()
                 value = timezone.make_aware(value, default_timezone)
             return value
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_datetime(value)
@@ -2173,6 +2189,9 @@ class TimeField(DateTimeCheckMixin, Field):
             # information), but this can be a side-effect of interacting with a
             # database backend (e.g. Oracle), so we'll be accommodating.
             return value.time()
+        # duck-type check for objects that may be mocks - issue #21523
+        if hasattr(value, 'isoformat'):
+            value = value.isoformat()
 
         try:
             parsed = parse_time(value)


### PR DESCRIPTION
In cases where the value passed in to the DateField.to_python() method
is a real date, and datetime.date is being mocked out, the method would
raise an error attempting to call parse_date on the mock object (as the
parsing requires a string input). I’ve added in a duck-type check for
objects before the parse_date call - if the object has a ‘isoformat()’
method, then call this, and pass it into the parse_date function - which
should return an identical object.