### PR TITLE
List 1.6.x releases in descending order

### DIFF
--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -29,8 +29,8 @@ Final releases
 .. toctree::
    :maxdepth: 1
 
-   1.6
    1.6.1
+   1.6
 
 1.5 release
 -----------


### PR DESCRIPTION
to be consistent with the other releases.
