### PR TITLE
Fixing manager documentation inaccuracy

### DIFF
--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -219,7 +219,7 @@ custom ``QuerySet`` if you also implement them on the ``Manager``::
 
     class PersonManager(models.Manager):
         def get_queryset(self):
-            return PersonQuerySet()
+            return PersonQuerySet(self.model, using=self._db)
 
         def male(self):
             return self.get_queryset().male()


### PR DESCRIPTION
Current docs cause the methods to fail with a relatively obscure error of: 

AttributeError: 'NoneType' object has no attribute '_meta'

Because self.model isn't being passed in.  I ran into this today and spent quite a bit of time sorting it out and I'm sure others have or will. 
