### PR TITLE
Fixed #21551 -- Reenabled loading fixtures from subdirectory

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -178,11 +178,15 @@ class Command(BaseCommand):
         if self.verbosity >= 2:
             self.stdout.write("Loading '%s' fixtures..." % fixture_name)
 
-        if os.path.sep in fixture_name:
+        if os.path.isabs(fixture_name):
             fixture_dirs = [os.path.dirname(fixture_name)]
             fixture_name = os.path.basename(fixture_name)
         else:
             fixture_dirs = self.fixture_dirs
+            if os.path.sep in fixture_name:
+                fixture_dirs = [os.path.join(dir_, os.path.dirname(fixture_name))
+                                for dir_ in fixture_dirs]
+                fixture_name = os.path.basename(fixture_name)
 
         suffixes = ('.'.join(ext for ext in combo if ext)
                 for combo in product(databases, ser_fmts, cmp_fmts))

--- a/tests/fixtures_regress/fixtures_1/inner/absolute.json
+++ b/tests/fixtures_regress/fixtures_1/inner/absolute.json
@@ -1,0 +1,9 @@
+[
+    {
+        "pk": "1",
+        "model": "fixtures_regress.absolute",
+        "fields": {
+            "name": "Load Absolute Path Test"
+        }
+    }
+]


### PR DESCRIPTION
This was a regression in Django 1.6 that was only partially
restored in 839940f27f.
Thanks Jonas Haag for the report.
