### PR TITLE
Fix to use concrete_fields instead of local_fields.  Fixes issue with ForeignObject bulk creation.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -389,7 +389,7 @@ class QuerySet(object):
             return objs
         self._for_write = True
         connection = connections[self.db]
-        fields = self.model._meta.local_fields
+        fields = self.model._meta.local_concrete_fields
         with transaction.commit_on_success_unless_managed(using=self.db):
             if (connection.features.can_combine_inserts_with_and_without_auto_increment_pk
                     and self.model._meta.has_auto_field):

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from .models import (
     Country, Person, Group, Membership, Friendship, Article,
     ArticleTranslation, ArticleTag, ArticleIdea, NewsArticle)
-from django.test import TestCase
+from django.test import TestCase, skipUnlessDBFeature
 from django.utils.translation import activate
 from django.core.exceptions import FieldError
 from django import forms
@@ -379,6 +379,12 @@ class MultiColumnFKTests(TestCase):
                 NewsArticle.objects.select_related(
                     'active_translation')[0].active_translation.title,
                 "foo")
+
+    @skipUnlessDBFeature('has_bulk_insert')
+    def test_batch_create_foreign_object(self):
+        """ See: https://code.djangoproject.com/ticket/21566 """
+        objs = [Person(name="abcd_%s" % i, person_country=self.usa) for i in range(0, 5)]
+        Person.objects.bulk_create(objs, 10)
 
 
 class FormsTests(TestCase):


### PR DESCRIPTION
Ticket filed at https://code.djangoproject.com/ticket/21566
