### PR TITLE
Trigger AttributeError in ValidationError.message_dict when error_dict is missing.

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -123,6 +123,10 @@ class ValidationError(Exception):
 
     @property
     def message_dict(self):
+        # Trigger an AttributeError if this ValidationError
+        # doesn't have an error_dict.
+        getattr(self, 'error_dict')
+
         return dict(self)
 
     @property


### PR DESCRIPTION
The goal of this change is twofold; firstly, matching the behavior of Django 1.6
and secondly, an AttributeError is more informative than an obscure ValueError
about mismatching sequence lengths.

Refs #20867.
