### PR TITLE
Fixed #21560 -- missing 'slug' field in example code

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -528,7 +528,7 @@ field, you could do the following::
 
         class Meta:
             model = Article
-            fields = ['pub_date', 'headline', 'content', 'reporter']
+            fields = ['pub_date', 'headline', 'content', 'reporter', 'slug']
 
 
 If you want to specify a field's validators, you can do so by defining


### PR DESCRIPTION
I updated the documentation, that the modelform now includes the 'slug' field.
