### PR TITLE
Fix #21594 -- Add note about model formsets deleting objects

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -836,6 +836,12 @@ to the database. If your formset contains a ``ManyToManyField``, you'll also
 need to call ``formset.save_m2m()`` to ensure the many-to-many relationships
 are saved properly.
 
+.. note::
+
+    While calling ``formset.save(commit=False)`` does not save new or changed
+    objects to the database, it *does* delete objects that have been marked for
+    deletion. This behavior will be corrected in Django 1.7.
+
 .. _model-formsets-max-num:
 
 Limiting the number of editable objects


### PR DESCRIPTION
Some users may interpret `formset.save(commit=False)` to mean that no changes are committed to the database, when deletions actually are. (This behavior is fixed in ticket [#10284](https://code.djangoproject.com/ticket/10284) / commit 65e03a424e82e157.)

See Track ticket [#21594](https://code.djangoproject.com/ticket/21594).
