### PR TITLE
Fixed #21598 -- cleanup template loader overrides in tests

### DIFF
--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -17,8 +17,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 from django.template.base import TemplateDoesNotExist
 from django.test import TestCase, RequestFactory, override_settings
-from django.test.utils import (
-    setup_test_template_loader, restore_template_loaders)
+from django.test.utils import override_with_test_loader
 from django.utils.encoding import force_text, force_bytes
 from django.utils import six
 from django.views.debug import ExceptionReporter
@@ -47,23 +46,16 @@ class DebugViewTests(TestCase):
 
     def test_403(self):
         # Ensure no 403.html template exists to test the default case.
-        setup_test_template_loader({})
-        try:
+        with override_with_test_loader({}):
             response = self.client.get('/raises403/')
             self.assertContains(response, '<h1>403 Forbidden</h1>', status_code=403)
-        finally:
-            restore_template_loaders()
 
     def test_403_template(self):
         # Set up a test 403.html template.
-        setup_test_template_loader(
-            {'403.html': 'This is a test template for a 403 Forbidden error.'}
-        )
-        try:
+        with override_with_test_loader({'403.html': 'This is a test template '
+                                        'for a 403 Forbidden error.'}):
             response = self.client.get('/raises403/')
             self.assertContains(response, 'test template', status_code=403)
-        finally:
-            restore_template_loaders()
 
     def test_404(self):
         response = self.client.get('/raises404/')

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.test.utils import (setup_test_template_loader,
-    restore_template_loaders, override_settings)
+from django.test.utils import override_settings, override_with_test_loader
 
 from ..models import UrlArticle
 
@@ -41,17 +40,13 @@ class DefaultsTests(TestCase):
         Test that 404.html and 500.html templates are picked by their respective
         handler.
         """
-        setup_test_template_loader(
-            {'404.html': 'This is a test template for a 404 error.',
-             '500.html': 'This is a test template for a 500 error.'}
-        )
-        try:
+        with override_with_test_loader({
+            '404.html': 'This is a test template for a 404 error.',
+            '500.html': 'This is a test template for a 500 error.'}):
             for code, url in ((404, '/non_existing_url/'), (500, '/server_error/')):
                 response = self.client.get(url)
                 self.assertContains(response, "test template for a %d error" % code,
                     status_code=code)
-        finally:
-            restore_template_loaders()
 
     def test_get_absolute_url_attributes(self):
         "A model can set attributes on the get_absolute_url method"


### PR DESCRIPTION
- Template loader overriding is managed with contexts.
- The test loader is a class (function based loaders entered deprecation timeline
  in 1.4).
- Template loader overrider that overrides with test loader added.
