### PR TITLE
Trivial doc fix: text for link to "Testing in Django" section

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -677,7 +677,7 @@ a piece of code, it usually means that code should be refactored or removed.
 Coverage will help to identify dead code. See
 :ref:`topics-testing-code-coverage` for details.
 
-:doc:`Testing Django applications </topics/testing/index>` has comprehensive
+:doc:`Testing in Django </topics/testing/index>` has comprehensive
 information about testing.
 
 .. _Selenium: http://seleniumhq.org/


### PR DESCRIPTION
The bottom of the [Further testing](https://docs.djangoproject.com/en/dev/intro/tutorial05/#further-testing) section of the documentation has a link to "Testing in Django" with the wrong link text.  "Testing Django applications" is a sub-section of ["Testing in Django"](https://docs.djangoproject.com/en/dev/topics/testing/) and is not the name of the testing section as a whole.
