### PR TITLE
Fixed #21614 -- improved development section of email docs

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -600,8 +600,8 @@ manually open the connection, you can control when it is closed. For example::
     connection.close()
 
 
-Testing email sending
-=====================
+Configuring email for development
+=================================
 
 There are times when you do not want Django to send emails at
 all. For example, while developing a Web site, you probably don't want
@@ -609,11 +609,13 @@ to send out thousands of emails -- but you may want to validate that
 emails will be sent to the right people under the right conditions,
 and that those emails will contain the correct content.
 
-The easiest way to test your project's use of email is to use the ``console``
+The easiest way to configure email in your project for local development
+is to use the :ref:`console <topic-email-console-backend>`
 email backend. This backend redirects all email to stdout, allowing you to
 inspect the content of mail.
 
-The ``file`` email backend can also be useful during development -- this backend
+The :ref:`file <topic-email-file-backend>` email backend can also be useful
+during development -- this backend
 dumps the contents of every SMTP connection to a file that can be inspected
 at your leisure.
 
@@ -626,7 +628,10 @@ anything. Python has a built-in way to accomplish this with a single command::
 This command will start a simple SMTP server listening on port 1025 of
 localhost. This server simply prints to standard output all email headers and
 the email body. You then only need to set the :setting:`EMAIL_HOST` and
-:setting:`EMAIL_PORT` accordingly, and you are set.
+:setting:`EMAIL_PORT` accordingly, and you are set. For a more detailed
+discussion of SMTP server options, see the Python documentation for the
+:mod:`smtpd` module.
 
-For a more detailed discussion of testing and processing of emails locally,
-see the Python documentation for the :mod:`smtpd` module.
+For information about unit-testing the sending of emails in your
+application, see the :ref:`topics-testing-email` section of :doc:`Testing
+Django applications </topics/testing/overview>`.


### PR DESCRIPTION
This patch improves the section of the email docs about [configuring email for development](https://docs.djangoproject.com/en/dev/topics/email/#testing-email-sending). It clarifies that the section is not so much about testing email as it is about configuring email for development. It also makes other minor improvements like adding a link to the section on unit-testing the sending of email, which is not covered in this section at all. See [ticket #21614](https://code.djangoproject.com/ticket/21614).
