### PR TITLE
Catch the more specific subclass of ObjectDoesNotExist in SingleObjectMixin

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.http import Http404
 from django.utils.translation import ugettext as _

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -1,5 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.db import models
+from django.db.models import QuerySet
+from django.db.models.manager import BaseManager
 from django.utils.encoding import python_2_unicode_compatible
 
 
@@ -31,6 +33,13 @@ class Author(models.Model):
         return self.name
 
 
+class DoesNotExistQuerySet(QuerySet):
+    def get(self, *args, **kwargs):
+        raise Author.DoesNotExist
+
+DoesNotExistBookManager = BaseManager.from_queryset(DoesNotExistQuerySet)
+
+
 @python_2_unicode_compatible
 class Book(models.Model):
     name = models.CharField(max_length=300)
@@ -38,6 +47,9 @@ class Book(models.Model):
     pages = models.IntegerField()
     authors = models.ManyToManyField(Author)
     pubdate = models.DateField()
+
+    objects = models.Manager()
+    does_not_exist = DoesNotExistBookManager()
 
     class Meta:
         ordering = ['-pubdate']

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
-from django.core.exceptions import ImproperlyConfigured
-from django.http import Http404
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.test import TestCase
 from django.views.generic.base import View
 
@@ -29,6 +28,9 @@ class DetailViewTest(TestCase):
     def test_detail_missing_object(self):
         res = self.client.get('/detail/author/500/')
         self.assertEqual(res.status_code, 404)
+
+    def test_detail_object_does_not_exist(self):
+        self.assertRaises(ObjectDoesNotExist, self.client.get, '/detail/doesnotexist/1/')
 
     def test_detail_by_custom_pk(self):
         res = self.client.get('/detail/author/bycustompk/1/')

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -55,7 +55,8 @@ urlpatterns = patterns('',
         views.AuthorDetail.as_view(queryset=None)),
     (r'^detail/nonmodel/1/$',
         views.NonModelDetail.as_view()),
-
+    (r'^detail/doesnotexist/(?P<pk>\d+)/$',
+        views.ObjectDoesNotExistDetail.as_view()),
     # FormView
     (r'^contact/$',
         views.ContactView.as_view()),

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -300,3 +300,8 @@ class NonModelDetail(generic.DetailView):
 
     def get_object(self, queryset=None):
         return NonModel()
+
+
+class ObjectDoesNotExistDetail(generic.DetailView):
+    def get_queryset(self):
+        return Book.does_not_exist.all()


### PR DESCRIPTION
Fixes #21619

I'm not sure if this test is sufficient - I couldn't see an easy way to write a test that would have actually failed previously.
