### PR TITLE
Fixed #21564 -- Use local request object when possible in generic views.

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -90,7 +90,7 @@ class View(object):
         logger.warning('Method Not Allowed (%s): %s', request.method, request.path,
             extra={
                 'status_code': 405,
-                'request': self.request
+                'request': request
             }
         )
         return http.HttpResponseNotAllowed(self._allowed_methods())
@@ -193,10 +193,10 @@ class RedirectView(View):
             else:
                 return http.HttpResponseRedirect(url)
         else:
-            logger.warning('Gone: %s', self.request.path,
+            logger.warning('Gone: %s', request.path,
                         extra={
                             'status_code': 410,
-                            'request': self.request
+                            'request': request
                         })
             return http.HttpResponseGone()
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -228,6 +228,15 @@ class ViewTest(unittest.TestCase):
             self.assertNotIn(attribute, dir(bare_view))
             self.assertIn(attribute, dir(view))
 
+    def test_direct_instantiation(self):
+        """
+        It should be possible to use the view by directly instantiating it
+        without going through .as_view() (#21564).
+        """
+        view = PostOnlyView()
+        response = view.dispatch(self.rf.head('/'))
+        self.assertEqual(response.status_code, 405)
+
 
 class TemplateViewTest(TestCase):
     urls = 'generic_views.urls'
@@ -420,6 +429,15 @@ class RedirectViewTest(TestCase):
         # we can't use self.rf.get because it always sets QUERY_STRING
         response = RedirectView.as_view(url='/bar/')(self.rf.request(PATH_INFO='/foo/'))
         self.assertEqual(response.status_code, 301)
+
+    def test_direct_instantiation(self):
+        """
+        It should be possible to use the view without going through .as_view()
+        (#21564).
+        """
+        view = RedirectView()
+        response = view.dispatch(self.rf.head('/foo/'))
+        self.assertEqual(response.status_code, 410)
 
 
 class GetContextDataTest(unittest.TestCase):


### PR DESCRIPTION
Thanks to trac user adepue for the report and original patch.
