### PR TITLE
make EmailField return e-mail addresses in canonical form

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -536,7 +536,7 @@ class EmailField(CharField):
         # strip blanks and make canonical by lower-casing the domain part
         value = self.to_python(value).strip()
         value = super(EmailField, self).clean(value)
-        usr, dom = value.split('@', 1)
+        usr, dom = value.rsplit('@', 1)
         return "%s@%s" % (usr, dom.lower())
 
 


### PR DESCRIPTION
The domain part in email addresses is case-insensitive by RFC, so x@foo.com is indistinguishable from x@fOo.cOm . This makes EmailField normalise the email representation by lower-casing the domain part. This fixes an issue with UNIQUE constraints on the model, where the constraint is not enforced if the user enters the same e-mail with different case representations.
