### PR TITLE
Override __getitem__ in RenderContext (#21639)

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -146,7 +146,7 @@ class RenderContext(BaseContext):
 
     def get(self, key, otherwise=None):
         return self.dicts[-1].get(key, otherwise)
-    
+
     def __getitem__(self, key):
         return self.dicts[-1][key]
 

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -3,6 +3,7 @@
 from unittest import TestCase
 
 from django.template import Context, Variable, VariableDoesNotExist
+from django.template.context import RenderContext
 
 
 class ContextTests(TestCase):
@@ -34,3 +35,18 @@ class ContextTests(TestCase):
         self.assertRaises(VariableDoesNotExist,
                 Variable('new').resolve, empty_context)
         self.assertEqual(Variable('new').resolve(Context({'new': 'foo'})), 'foo')
+
+    def test_render_context(self):
+        test_context = RenderContext({'fruit': 'papaya'})
+
+        # Test that push() limits access to the topmost dict
+        test_context.push()
+
+        test_context['vegetable'] = 'artichoke'
+        self.assertEqual(list(test_context), ['vegetable'])
+
+        self.assertNotIn('fruit', test_context)
+        with self.assertRaises(KeyError):
+            _ = test_context['fruit']
+        self.assertIsNone(test_context.get('fruit'))
+


### PR DESCRIPTION
Fix inconsistent access to items in RenderContext.

See https://code.djangoproject.com/ticket/21639
