### PR TITLE
Removed requires_literal_default DatabaseFeature.

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -665,9 +665,6 @@ class BaseDatabaseFeatures(object):
     # supported by the Python driver
     supports_paramstyle_pyformat = True
 
-    # Does the backend require literal defaults, rather than parameterised ones?
-    requires_literal_defaults = False
-
     # Does the backend require a connection reset after each material schema change?
     connection_persists_old_columns = False
 
@@ -971,15 +968,6 @@ class BaseDatabaseOperations(object):
         not quote the given name if it's already been quoted.
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a quote_name() method')
-
-    def quote_parameter(self, value):
-        """
-        Returns a quoted version of the value so it's safe to use in an SQL
-        string. This should NOT be used to prepare SQL statements to send to
-        the database; it is meant for outputting SQL statements to a file
-        or the console for later execution by a developer/DBA.
-        """
-        raise NotImplementedError()
 
     def random_function_sql(self):
         """

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -303,11 +303,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             return name  # Quoting once is enough.
         return "`%s`" % name
 
-    def quote_parameter(self, value):
-        # Inner import to allow module to fail to load gracefully
-        import MySQLdb.converters
-        return MySQLdb.escape(value, MySQLdb.converters.conversions)
-
     def random_function_sql(self):
         return 'RAND()'
 

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -24,3 +24,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_create_pk = "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s)"
     sql_delete_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
+
+    def _quote_parameter(self, value):
+        # Inner import to allow module to fail to load gracefully
+        import MySQLdb.converters
+        return MySQLdb.escape(value, MySQLdb.converters.conversions)
+

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -101,7 +101,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_combined_alters = False
     max_index_name_length = 30
     nulls_order_largest = True
-    requires_literal_defaults = True
     connection_persists_old_columns = True
     nulls_order_largest = True
     closed_cursor_error_class = InterfaceError
@@ -327,16 +326,6 @@ WHEN (new.%(col_name)s IS NULL)
         # that stage so we aren't really making the name longer here.
         name = name.replace('%', '%%')
         return name.upper()
-
-    def quote_parameter(self, value):
-        if isinstance(value, (datetime.date, datetime.time, datetime.datetime)):
-            return "'%s'" % value
-        elif isinstance(value, six.string_types):
-            return repr(value)
-        elif isinstance(value, bool):
-            return "1" if value else "0"
-        else:
-            return str(value)
 
     def random_function_sql(self):
         return "DBMS_RANDOM.RANDOM"

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -1,7 +1,8 @@
 import copy
+import datetime
 
 from django.db.backends.schema import BaseDatabaseSchemaEditor
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError, six
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -92,4 +93,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         return self.normalize_name(for_name + "_" + suffix)
 
     def prepare_default(self, value):
-        return self.connection.ops.quote_parameter(value)
+        return "%s" % self._quote_parameter(value), []
+
+    def _quote_parameter(self, value):
+        if isinstance(value, (datetime.date, datetime.time, datetime.datetime)):
+            return "'%s'" % value
+        elif isinstance(value, six.string_types):
+            return "'%s" % value
+        elif isinstance(value, bool):
+            return "1" if value else "0"
+        else:
+            return str(value)
+

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -98,11 +98,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             return name  # Quoting once is enough.
         return '"%s"' % name
 
-    def quote_parameter(self, value):
-        # Inner import so backend fails nicely if it's not present
-        import psycopg2
-        return psycopg2.extensions.adapt(value)
-
     def set_time_zone_sql(self):
         return "SET TIME ZONE %s"
 

--- a/django/db/backends/postgresql_psycopg2/schema.py
+++ b/django/db/backends/postgresql_psycopg2/schema.py
@@ -56,3 +56,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
         else:
             return super(DatabaseSchemaEditor, self)._alter_column_type_sql(table, column, type)
+
+    def _quote_parameter(self, value):
+        # Inner import so backend fails nicely if it's not present
+        import psycopg2
+        return psycopg2.extensions.adapt(value)
+

--- a/django/db/backends/schema.py
+++ b/django/db/backends/schema.py
@@ -90,7 +90,7 @@ class BaseDatabaseSchemaEditor(object):
         # Log the command we're running, then run it
         logger.debug("%s; (params %r)" % (sql, params))
         if self.collect_sql:
-            self.collected_sql.append((sql % tuple(map(self.connection.ops.quote_parameter, params))) + ";")
+            self.collected_sql.append((sql % tuple(map(self._quote_parameter, params))) + ";")
         else:
             cursor.execute(sql, params)
 
@@ -116,14 +116,9 @@ class BaseDatabaseSchemaEditor(object):
         # If we were told to include a default value, do so
         default_value = self.effective_default(field)
         if include_default and default_value is not None:
-            if self.connection.features.requires_literal_defaults:
-                # Some databases can't take defaults as a parameter (oracle)
-                # If this is the case, the individual schema backend should
-                # implement prepare_default
-                sql += " DEFAULT %s" % self.prepare_default(default_value)
-            else:
-                sql += " DEFAULT %s"
-                params += [default_value]
+            default_sql, default_params = self.prepare_default(default_value)
+            sql += " DEFAULT %s" % default_sql
+            params += default_params
         # Oracle treats the empty string ('') as null, so coerce the null
         # option whenever '' is a possible value.
         if (field.empty_strings_allowed and not field.primary_key and
@@ -147,9 +142,11 @@ class BaseDatabaseSchemaEditor(object):
 
     def prepare_default(self, value):
         """
-        Only used for backends which have requires_literal_defaults feature
+        Return a tuple containing the default's value SQL and params. Any 
+        database that doesn't support literal strings or params in ALTER TABLE 
+        statements should override this.
         """
-        raise NotImplementedError('subclasses of BaseDatabaseSchemaEditor for backends which have requires_literal_defaults must provide a prepare_default() method')
+        return "%s", [value]
 
     def effective_default(self, field):
         """
@@ -554,25 +551,14 @@ class BaseDatabaseSchemaEditor(object):
                     [],
                 ))
             else:
-                if self.connection.features.requires_literal_defaults:
-                    # Some databases can't take defaults as a parameter (oracle)
-                    # If this is the case, the individual schema backend should
-                    # implement prepare_default
-                    actions.append((
-                        self.sql_alter_column_default % {
-                            "column": self.quote_name(new_field.column),
-                            "default": self.prepare_default(new_default),
-                        },
-                        [],
-                    ))
-                else:
-                    actions.append((
-                        self.sql_alter_column_default % {
-                            "column": self.quote_name(new_field.column),
-                            "default": "%s",
-                        },
-                        [new_default],
-                    ))
+                default_sql, default_params = self.prepare_default(new_default)
+                actions.append((
+                    self.sql_alter_column_default % {
+                        "column": self.quote_name(new_field.column),
+                        "default": default_sql,
+                    },
+                    default_params,
+                ))
         # Nullability change?
         if old_field.null != new_field.null:
             if new_field.null:
@@ -796,3 +782,13 @@ class BaseDatabaseSchemaEditor(object):
                     continue
                 result.append(name)
         return result
+
+    def _quote_parameter(self, value):
+        """
+        Returns a quoted version of the value so it's safe to use in an SQL
+        string. This should NOT be used to prepare SQL statements to send to
+        the database; it is meant for outputting SQL statements to a file
+        or the console for later execution by a developer/DBA.
+        """
+        raise NotImplementedError()
+

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -215,25 +215,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             return name  # Quoting once is enough.
         return '"%s"' % name
 
-    def quote_parameter(self, value):
-        # Inner import to allow nice failure for backend if not present
-        import _sqlite3
-        try:
-            value = _sqlite3.adapt(value)
-        except _sqlite3.ProgrammingError:
-            pass
-        # Manual emulation of SQLite parameter quoting
-        if isinstance(value, six.integer_types):
-            return str(value)
-        elif isinstance(value, six.string_types):
-            return six.text_type(value)
-        elif isinstance(value, type(True)):
-            return str(int(value))
-        elif value is None:
-            return "NULL"
-        else:
-            raise ValueError("Cannot quote parameter value %r" % value)
-
     def no_limit_value(self):
         return -1
 

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -1,6 +1,7 @@
 from django.core.apps.cache import AppCache
 from django.db.backends.schema import BaseDatabaseSchemaEditor
 from django.db.models.fields.related import ManyToManyField
+from django.utils import six
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -153,3 +154,22 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         ))
         # Delete the old through table
         self.delete_model(old_field.rel.through)
+
+    def _quote_parameter(self, value):
+        # Inner import to allow nice failure for backend if not present
+        import _sqlite3
+        try:
+            value = _sqlite3.adapt(value)
+        except _sqlite3.ProgrammingError:
+            pass
+        # Manual emulation of SQLite parameter quoting
+        if isinstance(value, six.integer_types):
+            return str(value)
+        elif isinstance(value, six.string_types):
+            return six.text_type(value)
+        elif isinstance(value, type(True)):
+            return str(int(value))
+        elif value is None:
+            return "NULL"
+        else:
+            raise ValueError("Cannot quote parameter value %r" % value)


### PR DESCRIPTION
Any database that needs to control how the default value is rendered will
need to override prepare_default.

DatabaseOperations.quote_parameter has been relocated to SchemaEditor and
prefixed with an underscore to discourage usage by others. It's possible
to use _quote_parameter in such a way as to open the possibility of an SQL
injection attack.
