### PR TITLE
Fixed #21651 -- Made django.utils.text.recapitalize handles more than on...

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -25,6 +25,7 @@ capfirst = allow_lazy(capfirst, six.text_type)
 re_words = re.compile(r'<.*?>|((?:\w[-\w]*|&.*?;)+)', re.U | re.S)
 re_tag = re.compile(r'<(/)?([^ ]+?)(?:(\s*/)| .*?)?>', re.S)
 re_newlines = re.compile(r'\r\n|\r')  # Used in normalize_newlines
+re_caps = re.compile(r'(?:^|(?<=[\.\?\!]))(^\s*|\s+)([a-z])')
 
 
 def wrap(text, width):
@@ -259,8 +260,7 @@ normalize_newlines = allow_lazy(normalize_newlines, six.text_type)
 def recapitalize(text):
     """Recapitalizes text, placing caps after end-of-sentence punctuation."""
     text = force_text(text).lower()
-    capsRE = re.compile(r'(?:^|(?<=[\.\?\!] ))([a-z])')
-    text = capsRE.sub(lambda x: x.group(1).upper(), text)
+    text = re_caps.sub(lambda x: x.group(1) + x.group(2).upper(), text)
     return text
 recapitalize = allow_lazy(recapitalize)
 

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -120,6 +120,20 @@ class TestUtilsText(SimpleTestCase):
         self.assertEqual(normalized, "abc\ndef\nghi\n")
         self.assertIsInstance(normalized, six.text_type)
 
+    def test_recapitalize(self):
+        self.assertEqual(text.recapitalize(
+                         "first sentence. SECOND SENTENCE? tHiRd SeNtEnCe, "
+                         "and it is still third sentence! FOURTH sentence."),
+                         "First sentence. Second sentence? Third sentence, "
+                         "and it is still third sentence! Fourth sentence.")
+        self.assertEqual(text.recapitalize(
+                         "\r\nfirst sentence.  second.sentence?\n"
+                         "tHiRd;SeNtEnCe, and it is still third sentence!"
+                         "\tFOURTH sentence."),
+                         "\r\nFirst sentence.  Second.sentence?\n"
+                         "Third;sentence, and it is still third sentence!"
+                         "\tFourth sentence.")
+
     def test_slugify(self):
         items = (
             ('Hello, World!', 'hello-world'),


### PR DESCRIPTION
...e space, newlines, and tabs.
