### PR TITLE
Fixed #21627 -- Non-ASCII characters from changepassword command

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import getpass
 from optparse import make_option
 

--- a/django/contrib/auth/tests/test_management.py
+++ b/django/contrib/auth/tests/test_management.py
@@ -83,6 +83,20 @@ class ChangepasswordManagementCommandTestCase(TestCase):
         with self.assertRaises(CommandError):
             command.execute("joe", stdout=self.stdout, stderr=self.stderr)
 
+    def test_that_changepassword_command_works_with_nonascii_output(self):
+        """
+        Executing the changepassword management command should allow non-ASCII
+        characters from the User object representation.
+
+        Regression test for ticket #21627
+        """
+        # 'Julia' with accented 'u':
+        models.User.objects.create_user(username='J\xfalia', password='qwerty')
+
+        command = changepassword.Command()
+        command._get_pass = lambda *args: 'not qwerty'
+
+        command.execute("J\xfalia", stdout=self.stdout)
 
 @skipIfCustomUser
 class CreatesuperuserManagementCommandTestCase(TestCase):

--- a/docs/releases/1.6.2.txt
+++ b/docs/releases/1.6.2.txt
@@ -9,4 +9,7 @@ This is Django 1.6.2, a bugfix release for Django 1.6.
 Bug fixes
 =========
 
+* Fixed a crash when executing ``changepassword`` command when the user object
+  representation contained non-ASCII characters (#21627).
+
 ...


### PR DESCRIPTION
Fixed a crash when executing changepassword command when the user object
representation contained non-ASCII characters.
