### PR TITLE
To allow subclassing of BlockNode tags

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -59,7 +59,7 @@ class BlockNode(Node):
                 if block is None:
                     block = self
                 # Create new block so we can store context without thread-safety issues.
-                block = BlockNode(block.name, block.nodelist)
+                block = type(self)(block.name, block.nodelist)
                 block.context = context
                 context['block'] = block
                 result = block.nodelist.render(context)


### PR DESCRIPTION
Current code prevents object-oriented programming when using custom block nodes. Now render code has to be copied and this is against DRY principle.
