### PR TITLE
Fixed #21750 -- Fixed regression introduced by 4befb30.

### DIFF
--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -57,7 +57,7 @@ class FileSystemFinder(BaseFinder):
                 prefix, root = root
             else:
                 prefix = ''
-            if os.path.abspath(settings.STATIC_ROOT) == os.path.abspath(root):
+            if settings.STATIC_ROOT and os.path.abspath(settings.STATIC_ROOT) == os.path.abspath(root):
                 raise ImproperlyConfigured(
                     "The STATICFILES_DIRS setting should "
                     "not contain the STATIC_ROOT setting")

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -32,14 +32,21 @@ class StaticFilesStorage(FileSystemStorage):
             location = settings.STATIC_ROOT
         if base_url is None:
             base_url = settings.STATIC_URL
-        if not location:
-            raise ImproperlyConfigured("You're using the staticfiles app "
-                                       "without having set the STATIC_ROOT "
-                                       "setting to a filesystem path.")
         check_settings(base_url)
         super(StaticFilesStorage, self).__init__(location, base_url,
                                                  *args, **kwargs)
+        # FileSystemStorage fallbacks to MEDIA_ROOT when location
+        # is empty, so we restore the empty value.
+        if not location:
+            self.base_location = None
+            self.location = None
 
+    def path(self, name):
+        if not self.location:
+            raise ImproperlyConfigured("You're using the staticfiles app "
+                                       "without having set the STATIC_ROOT "
+                                       "setting to a filesystem path.")
+        return super(StaticFilesStorage, self).path(name)
 
 class CachedFilesMixin(object):
     default_template = """url("%s")"""


### PR DESCRIPTION
Validating STATIC_ROOT in StaticFilesStorage.**init** turned out to be
problematic - especially with tests - because the storage refuses to work even
if there are no actual interactions with the file system, which is backward
incompatible.

Originally the validation happened in the StaticFilesStorage.path method, but
that didn't work as expected because the call to FileSystemStorage.**init**
replaced the empty value by a valid path. The new approach is to move back the
check to the StaticFilesStorage.path method, but ensure that the location
attribute remains None after the call to super.

Refs #21581.
