### PR TITLE
MonthArchiveView & BaseMonthArchiveView docstrings

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -482,7 +482,7 @@ class YearArchiveView(MultipleObjectTemplateResponseMixin, BaseYearArchiveView):
 
 class BaseMonthArchiveView(YearMixin, MonthMixin, BaseDateListView):
     """
-    List of objects published in a given year.
+    List of objects published in a given month.
     """
     date_list_period = 'day'
 
@@ -516,7 +516,7 @@ class BaseMonthArchiveView(YearMixin, MonthMixin, BaseDateListView):
 
 class MonthArchiveView(MultipleObjectTemplateResponseMixin, BaseMonthArchiveView):
     """
-    List of objects published in a given year.
+    List of objects published in a given month.
     """
     template_name_suffix = '_archive_month'
 


### PR DESCRIPTION
MonthArchiveView & BaseMonthArchiveView docstrings now reference "month" rather than "year".

Thanks to @sztosz for [the report](https://github.com/refreshoxford/django-cbv-inspector/issues/87).
