### PR TITLE
Fix typo `content_type__id__exact` in `history_view`

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1620,7 +1620,7 @@ class ModelAdmin(BaseModelAdmin):
         app_label = opts.app_label
         action_list = LogEntry.objects.filter(
             object_id=unquote(object_id),
-            content_type__id__exact=ContentType.objects.get_for_model(model).id
+            content_type_id__exact=ContentType.objects.get_for_model(model).id
         ).select_related().order_by('action_time')
 
         context = dict(self.admin_site.each_context(),


### PR DESCRIPTION
In the admin interface the `history_view` method does a filter using `content_type__id__exact=...`, while it appears this should be `content_type_id__exact=...`.
