### PR TITLE
Adjust inspectdb management command to yield output following the Django Coding Style

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -50,12 +50,13 @@ class Command(NoArgsCommand):
         yield "from __future__ import unicode_literals"
         yield ''
         yield 'from %s import models' % self.db_module
-        yield ''
         known_models = []
         for table_name in connection.introspection.table_names(cursor):
             if table_name_filter is not None and callable(table_name_filter):
                 if not table_name_filter(table_name):
                     continue
+            yield ''
+            yield ''
             yield 'class %s(models.Model):' % table2model(table_name)
             known_models.append(table2model(table_name))
             try:
@@ -134,7 +135,7 @@ class Command(NoArgsCommand):
                         for k, v in extra_params.items()])
                 field_desc += ')'
                 if comment_notes:
-                    field_desc += ' # ' + ' '.join(comment_notes)
+                    field_desc += '  # ' + ' '.join(comment_notes)
                 yield '    %s' % field_desc
             for meta_line in self.get_meta(table_name):
                 yield meta_line
@@ -239,7 +240,7 @@ class Command(NoArgsCommand):
         to construct the inner Meta class for the model corresponding
         to the given database table name.
         """
-        return ["    class Meta:",
+        return ["",
+                "    class Meta:",
                 "        managed = False",
-                "        db_table = '%s'" % table_name,
-                ""]
+                "        db_table = '%s'" % table_name]

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -45,7 +45,7 @@ class InspectDBTestCase(TestCase):
             self.assertEqual(definition, out_def)
 
         if not connection.features.can_introspect_autofield:
-            assertFieldType('id', "models.IntegerField(primary_key=True) # AutoField?")
+            assertFieldType('id', "models.IntegerField(primary_key=True)  # AutoField?")
         assertFieldType('big_int_field', "models.BigIntegerField()")
         if connection.vendor == 'mysql':
             # No native boolean type on MySQL
@@ -60,7 +60,7 @@ class InspectDBTestCase(TestCase):
         assertFieldType('date_time_field', "models.DateTimeField()")
         if connection.vendor == 'sqlite':
             # Guessed arguments, see #5014
-            assertFieldType('decimal_field', "models.DecimalField(max_digits=10, decimal_places=5) "
+            assertFieldType('decimal_field', "models.DecimalField(max_digits=10, decimal_places=5)  "
                 "# max_digits and decimal_places have been guessed, as this database handles decimal fields as float")
         else:
             assertFieldType('decimal_field', "models.DecimalField(max_digits=6, decimal_places=1)")


### PR DESCRIPTION
With this change, the successful output of running the `inspectdb` command complies with style guidelines set forth in /docs/internals/contributing/writing-code/coding-style.txt. While that document refers to the best practices when coding for The Django Project, and not a developer's own project, I feel that consistency with internal practices is good.

I've added a test that checks for this behavior using the 3rd-party _pep8_ Python library ~~(included)~~.
