### PR TITLE
Allow .pyc management commands

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -27,8 +27,8 @@ def find_commands(management_dir):
     """
     command_dir = os.path.join(management_dir, 'commands')
     try:
-        return [f[:-3] for f in os.listdir(command_dir)
-                if not f.startswith('_') and f.endswith('.py')]
+        return set("".join(f.split('.')[:-1]) for f in os.listdir(command_dir)
+                if not f.startswith('_') and (f.endswith('.py') or f.endswith('.pyc')))
     except OSError:
         return []
 

--- a/tests/user_commands/management/commands/dummy.pyc
+++ b/tests/user_commands/management/commands/dummy.pyc
@@ -1,0 +1,1 @@
+# Dummy file to test detection of .pyc command files

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -60,6 +60,11 @@ class CommandTests(SimpleTestCase):
             management.call_command('leave_locale_alone_true', stdout=out)
             self.assertEqual(out.getvalue(), "pl\n")
 
+    def test_detect_pyc(self):
+        """ Tests that a file with a .pyc extension can
+            be recognized as a management command.
+        """
+        self.assertIn('dummy',management.get_commands())
 
 class UtilsTests(SimpleTestCase):
 


### PR DESCRIPTION
This allows for discovery of .pyc management commands. This can be useful if
you don't wish to deploy unobfuscated source code on your servers, but need
to retain the ability to run custom management commands. The dummy.pyc file
is a placeholder for the test case and is not actual compiled python code.
