### PR TITLE
Static UserModel prevented extending builtin users

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -677,6 +677,7 @@ answer newbie questions, and generally made Django that much better:
     Gasper Zejn <zejn@kiberpipa.org>
     Jarek Zgoda <jarek.zgoda@gmail.com>
     Cheng Zhang
+    Ole Bergmann <ole@ole.im>
 
 A big THANK YOU goes to:
 

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -90,16 +90,19 @@ class UserCreationForm(forms.ModelForm):
         help_text=_("Enter the same password as above, for verification."))
 
     class Meta:
-        model = User
+        model = get_user_model()
         fields = ("username",)
 
     def clean_username(self):
         # Since User.username is unique, this check is redundant,
         # but it sets a nicer error message than the ORM. See #13147.
         username = self.cleaned_data["username"]
+
+        UserModel = get_user_model()
+
         try:
-            User._default_manager.get(username=username)
-        except User.DoesNotExist:
+            UserModel._default_manager.get(username=username)
+        except UserModel.DoesNotExist:
             return username
         raise forms.ValidationError(
             self.error_messages['duplicate_username'],
@@ -138,7 +141,7 @@ class UserChangeForm(forms.ModelForm):
                     "using <a href=\"password/\">this form</a>."))
 
     class Meta:
-        model = User
+        model = get_user_model()
         fields = '__all__'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The way that these were defined prevented directly extending `django.contrib.auth.models.AbstractUser` and using `django.contrib.auth.admin.UserAdmin` layout to render the `AbstractUser` model in the admin site.
