### PR TITLE
Avoid "'NoneType' object is not iterable" Exception in Python 2.7.5

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -744,10 +744,10 @@ class ModelAdminChecks(BaseModelAdminChecks):
         if not isinstance(cls.list_editable, (list, tuple)):
             return must_be('a list or tuple', option='list_editable', obj=cls, id='admin.E121')
         else:
-            return list(chain(*[
+            return list(chain(*filter(None, [
                 self._check_list_editable_item(cls, model, item, "list_editable[%d]" % index)
                 for index, item in enumerate(cls.list_editable)
-            ]))
+            ])))
 
     def _check_list_editable_item(self, cls, model, field_name, label):
         try:

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -463,3 +463,17 @@ class SystemChecksTestCase(TestCase):
                 )
             ]
             self.assertEqual(errors, expected)
+
+    def test_check_list_editable(self):
+        """
+        Regression to avoid TypeError in Python 2.7 introduced by #2181
+        """
+        class EditableFieldsOnFormAdmin(admin.ModelAdmin):
+            form = SongForm
+
+            list_display = ('title', 'album', )
+            list_display_links = ('album', )
+            list_editable = ('title', )
+
+        errors = EditableFieldsOnFormAdmin.check(model=Song)
+        self.assertEqual(errors, [])


### PR DESCRIPTION
This bug was introduced by #2181
