### PR TITLE
Fixed Manager.__module__ to properly return 'django.db.models.manager'.

### DIFF
--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -190,7 +190,9 @@ class BaseManager(six.with_metaclass(RenameManagerMethods)):
         # understanding of how this comes into play.
         return self.get_queryset()
 
-Manager = BaseManager.from_queryset(QuerySet, class_name='Manager')
+
+class Manager(BaseManager.from_queryset(QuerySet)):
+    pass
 
 
 class ManagerDescriptor(object):

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -50,6 +50,9 @@ class PickleabilityTestCase(TestCase):
         self.assertEqual(original.__class__, unpickled.__class__)
         self.assertEqual(original.args, unpickled.args)
 
+    def test_manager_pickle(self):
+        pickle.loads(pickle.dumps(Happening.objects))
+
     def test_model_pickle(self):
         """
         Test that a model not defined on module level is pickleable.


### PR DESCRIPTION
The combination of BaseManager.from_queryset() and RenameMethodsBase results in
Manager.**module** having the wrong value. This can be an issue when trying to
pickle the Manager class.
