### PR TITLE
added reverse order for admin_order_field

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -293,7 +293,11 @@ class ChangeList(six.with_metaclass(RenameChangeListMethods)):
                     order_field = self.get_ordering_field(field_name)
                     if not order_field:
                         continue  # No 'admin_order_field', skip it
-                    ordering.append(pfx + order_field)
+                    # reverse order if order_field has already "-" as prefix
+                    if order_field.startswith('-') and pfx == "-":
+                        ordering.append(order_field[1:])
+                    else:
+                        ordering.append(pfx + order_field)
                 except (IndexError, ValueError):
                     continue  # Invalid ordering specified, skip it.
 


### PR DESCRIPTION
after adding this you can setup something like this:

```
def age_in_years(self):
    return # age calculated via DateField self.date_of_birth
age_in_years.admin_order_field = '-date_of_birth'
```

the '-' at the beginning of '-date_of_birth' indicates the reverse order in the changelist.
