### PR TITLE
Fix and test for Bug #18255 Inconsistent data type for BigIntegerField a...

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1578,6 +1578,12 @@ class BigIntegerField(IntegerField):
     def get_internal_type(self):
         return "BigIntegerField"
 
+    def to_python(self, value):
+        # Get the type before calling the super
+        # This prevents a long from being casted to an int for stability
+        initial_type = type(value)
+        return initial_type(super(BigIntegerField, self).to_python(value))
+
     def formfield(self, **kwargs):
         defaults = {'min_value': -BigIntegerField.MAX_BIGINT - 1,
                     'max_value': BigIntegerField.MAX_BIGINT}

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -419,6 +419,16 @@ class BigIntegerFieldTests(test.TestCase):
         b = BigInt.objects.get(value='10')
         self.assertEqual(b.value, 10)
 
+    def test_type_stability_int(self):
+        b = BigInt(value=10)
+        b.full_clean()
+        self.assertIsInstance(b.value, int)
+
+    @unittest.skipIf(six.PY3, 'This test only runs in python2 as long does not exist in python3')
+    def test_type_stability_long(self):
+        b = BigInt(value=long(10))
+        b.full_clean()
+        self.assertIsInstance(b.value, long)
 
 class TypeCoercionTests(test.TestCase):
     """


### PR DESCRIPTION
...fter calling full_clean()
