### PR TITLE
#21862: Fix TypeError in Python 3.3 when module path returns NamespacePath

### DIFF
--- a/django/apps/base.py
+++ b/django/apps/base.py
@@ -40,6 +40,10 @@ class AppConfig(object):
         if not hasattr(self, 'path'):
             try:
                 self.path = upath(app_module.__path__[0])
+            except TypeError:
+                # Starting with Python 3.3 the NamespacePath object doesn't
+                # support indexing so it has to be converted into a list
+                self.path = upath(list(app_module.__path__)[0])
             except AttributeError:
                 self.path = None
 


### PR DESCRIPTION
This fixes the issue described in ticket [#21862](https://code.djangoproject.com/ticket/21862) where loading a custom app fails using Django 1.7a1 and Python 3.3. The issue is caused by the `NamespacePath` returned by `app_module.__path__` which is not indexable and has to be convert to a list first.

A similar solution has been applied in py.test: https://bitbucket.org/hpk42/pytest/commits/dac4900b78f2

I hope this makes sense. Let me know if there's anything that needs to be improved or added.
