### PR TITLE
Fixed #21867 -- Removed AppStaticStorage; app paths are now AppConfig's job.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from collections import OrderedDict
 import hashlib
-from importlib import import_module
 import os
 import posixpath
 import re
@@ -16,7 +15,6 @@ from django.core.files.storage import FileSystemStorage, get_storage_class
 from django.utils.encoding import force_bytes, force_text
 from django.utils.functional import LazyObject
 from django.utils.six.moves.urllib.parse import unquote, urlsplit, urlunsplit, urldefrag
-from django.utils._os import upath
 
 from django.contrib.staticfiles.utils import check_settings, matches_patterns
 
@@ -381,25 +379,6 @@ class ManifestStaticFilesStorage(ManifestFilesMixin, StaticFilesStorage):
     hashed copies of the files it saves.
     """
     pass
-
-
-class AppStaticStorage(FileSystemStorage):
-    """
-    A file system storage backend that takes an app module and works
-    for the ``static`` directory of it.
-    """
-    prefix = None
-    source_dir = 'static'
-
-    def __init__(self, app, *args, **kwargs):
-        """
-        Returns a static file storage if available in the given app.
-        """
-        # app is the actual app module
-        mod = import_module(app)
-        mod_path = os.path.dirname(upath(mod.__file__))
-        location = os.path.join(mod_path, self.source_dir)
-        super(AppStaticStorage, self).__init__(location, *args, **kwargs)
 
 
 class ConfiguredStorage(LazyObject):

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -824,37 +824,6 @@ class TestTemplateTag(StaticFilesTestCase):
         self.assertStaticRenders("testfile.txt", "/static/testfile.txt")
 
 
-class TestAppStaticStorage(TestCase):
-    def setUp(self):
-        # Creates a python module foo_module in a directory with non ascii
-        # characters
-        self.search_path = 'search_path_\xc3\xbc'
-        os.mkdir(self.search_path)
-        module_path = os.path.join(self.search_path, 'foo_module')
-        os.mkdir(module_path)
-        self.init_file = open(os.path.join(module_path, '__init__.py'), 'w')
-        sys.path.append(os.path.abspath(self.search_path))
-
-    def tearDown(self):
-        self.init_file.close()
-        sys.path.remove(os.path.abspath(self.search_path))
-        shutil.rmtree(self.search_path)
-
-    def test_app_with_non_ascii_characters_in_path(self):
-        """
-        Regression test for #18404 - Tests AppStaticStorage with a module that
-        has non ascii characters in path and a non utf8 file system encoding
-        """
-        # set file system encoding to a non unicode encoding
-        old_enc_func = sys.getfilesystemencoding
-        sys.getfilesystemencoding = lambda: 'ISO-8859-1'
-        try:
-            st = storage.AppStaticStorage('foo_module')
-            st.path('bar')
-        finally:
-            sys.getfilesystemencoding = old_enc_func
-
-
 class CustomStaticFilesStorage(storage.StaticFilesStorage):
     """
     Used in TestStaticFilePermissions


### PR DESCRIPTION
AppStaticStorage only provided one thing over FileSystemStorage, which was
taking an app name (import path) and translating it into a filesystem
path. This is now something that should be done via app_config.path instead,
leaving AppStaticStorage with no reason for existence. It should be safe to
remove, as it was undocumented internal API.

There was some kind of feature in the AppDirectoriesFinder code related to a
"prefix" attribute on the storage class used by AppDirectoriesFinder. Since
this feature was undocumented, untested, and of unclear purpose, I removed it
as well.
