### PR TITLE
url resolving with script prefix defined

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -314,6 +314,9 @@ class RegexURLResolver(LocaleRegexProvider):
 
     def resolve(self, path):
         path = force_text(path)  # path may be a reverse_lazy object
+        prefix = get_script_prefix()
+        if path.startswith(prefix):
+           path = path[len(prefix)-1:]
         tried = []
         match = self.regex.search(path)
         if match:


### PR DESCRIPTION
This patch fixes problem when deploying django using wsgi and apache (possibly other servers too) on sub-url.
What it does is check if resolved path is prefixed with script name (common solution when depolying on sub urls) and if so it strips it. There might be better solution but it worked in my project when everything else failed.
