### PR TITLE
Fix pep8 violation in migration template.

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -279,7 +279,7 @@ from django.db import models, migrations
 %(imports)s
 
 class Migration(migrations.Migration):
-    %(replaces_str)s
+%(replaces_str)s
     dependencies = [
 %(dependencies)s\
     ]


### PR DESCRIPTION
This resulted in a whitespace only line. As the other value for `replaces_str` starts with `\n` it should be fine in both cases.
