### PR TITLE
Made Oracle introspect FloatFields correctly

### DIFF
--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -33,16 +33,18 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_field_type(self, data_type, description):
         # If it's a NUMBER with scale == 0, consider it an IntegerField
-        if data_type == cx_Oracle.NUMBER and description[5] == 0:
-            if description[4] > 11:
-                return 'BigIntegerField'
-            elif description[4]==1:
-                return 'BooleanField'
-            else:
-                return 'IntegerField'
-        else:
-            return super(DatabaseIntrospection, self).get_field_type(
-                data_type, description)
+        if data_type == cx_Oracle.NUMBER:
+            if description[5] == 0:
+                if description[4] > 11:
+                    return 'BigIntegerField'
+                elif description[4]==1:
+                    return 'BooleanField'
+                else:
+                    return 'IntegerField'
+            elif description[5] == -127:
+                return 'FloatField'
+
+        return super(DatabaseIntrospection, self).get_field_type(data_type, description)
 
     def get_table_list(self, cursor):
         "Returns a list of table names in the current database."


### PR DESCRIPTION
Broke InspectDBTestCase.test_field_types in two:
- a test_number_field_types, which now passes on Oracle too
- a test_field_types, for all non-numeric fields, which is still expected to fail

Also made some pep8 fixes in the tests file. Refs #19884
