### PR TITLE
In the docs, point View layer / Reference / Built-in Views to class-base...

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -104,7 +104,8 @@ to know about views via the links below:
   :doc:`Decorators <topics/http/decorators>`
 
 * **Reference:**
-  :doc:`Built-in Views <ref/views>` |
+  :doc:`Built-in Views <ref/class-based-views/index>` |
+  :doc:`Serving files in development <ref/static-development>` |
   :doc:`Request/response objects <ref/request-response>` |
   :doc:`TemplateResponse objects <ref/template-response>`
 

--- a/docs/ref/static-development.txt
+++ b/docs/ref/static-development.txt
@@ -1,15 +1,6 @@
-==============
-Built-in Views
-==============
-
-.. module:: django.views
-   :synopsis: Django's built-in views.
-
-Several of Django's built-in views are documented in
-:doc:`/topics/http/views` as well as elsewhere in the documentation.
-
+============================
 Serving files in development
-----------------------------
+============================
 
 .. function:: static.serve(request, path, document_root, show_indexes=False)
 


### PR DESCRIPTION
Go to https://docs.djangoproject.com/en/1.6/ and click on "Built-in views" under "The view layer".  The resulting page is not useful.  This pull request fixes that.
