### PR TITLE
Fixed 16192 -- Made unique error messages in ModelForm customizable.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -105,6 +105,8 @@ class Field(RegisterLookupMixin):
         'blank': _('This field cannot be blank.'),
         'unique': _('%(model_name)s with this %(field_label)s '
                     'already exists.'),
+        'unique_for_date': _("%(field_label)s must be unique for "
+                             "%(date_field_label)s %(lookup_type)s."),
     }
     class_lookups = default_lookups.copy()
 

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import copy
 import warnings
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
 from django.forms.fields import Field, FileField
 from django.forms.utils import flatatt, ErrorDict, ErrorList
 from django.forms.widgets import Media, MediaDefiningClass, TextInput, Textarea
@@ -20,8 +20,6 @@ from django.utils import six
 
 
 __all__ = ('BaseForm', 'Form')
-
-NON_FIELD_ERRORS = '__all__'
 
 
 def pretty_name(name):

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -373,15 +373,21 @@ class BaseModelForm(BaseForm):
 
     def _update_errors(self, errors):
         # Override any validation error messages defined at the model level
-        # with those defined on the form fields.
+        # with those defined at the form level.
+        opts = self._meta
         for field, messages in errors.error_dict.items():
-            if field not in self.fields:
+            if (field == NON_FIELD_ERRORS and opts.error_messages and
+                    NON_FIELD_ERRORS in opts.error_messages):
+                error_messages = opts.error_messages[NON_FIELD_ERRORS]
+            elif field in self.fields:
+                error_messages = self.fields[field].error_messages
+            else:
                 continue
-            field = self.fields[field]
+
             for message in messages:
                 if (isinstance(message, ValidationError) and
-                        message.code in field.error_messages):
-                    message.message = field.error_messages[message.code]
+                        message.code in error_messages):
+                    message.message = error_messages[message.code]
 
         self.add_error(None, errors)
 

--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -124,6 +124,15 @@ ValidationError
     :ref:`Model Field Validation <validating-objects>` and the
     :doc:`Validator Reference </ref/validators>`.
 
+NON_FIELD_ERRORS
+~~~~~~~~~~~~~~~~
+.. data:: NON_FIELD_ERRORS
+
+``ValidationError``\s that don't belong to a particular field in a form
+or model are classified as ``NON_FIELD_ERRORS``. This constant is used
+as a key in dictonaries that otherwise map fields to their respective
+list of errors.
+
 .. currentmodule:: django.core.urlresolvers
 
 URL Resolver exceptions

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -233,8 +233,12 @@ field will raise. Pass in a dictionary with keys matching the error messages you
 want to override.
 
 Error message keys include ``null``, ``blank``, ``invalid``, ``invalid_choice``,
-and ``unique``. Additional error message keys are specified for each field in
-the `Field types`_ section below.
+``unique``. Additional error message keys are specified for each field in the
+`Field types`_ section below.
+
+.. versionadded:: 1.7
+
+The ``unique_for_date`` error message key was added.
 
 ``help_text``
 -------------

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -151,8 +151,8 @@ access to more than a single field::
 
 Any :exc:`~django.core.exceptions.ValidationError` exceptions raised by
 ``Model.clean()`` will be stored in a special key error dictionary key,
-``NON_FIELD_ERRORS``, that is used for errors that are tied to the entire model
-instead of to a specific field::
+:data:`~django.core.exceptions.NON_FIELD_ERRORS`, that is used for errors
+that are tied to the entire model instead of to a specific field::
 
     from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
     try:

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -321,6 +321,11 @@ Django quotes column and table names behind the scenes.
     :class:`~django.db.models.ManyToManyField`, try using a signal or
     an explicit :attr:`through <ManyToManyField.through>` model.
 
+    .. versionchanged:: 1.7
+
+    The ``ValidationError`` raised during model validation when the
+    constraint is violated has the ``unique_together`` error code.
+
 ``index_together``
 ------------------
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -484,6 +484,14 @@ Forms
   that maps fields to their original errors, complete with all metadata
   (error code and params), the latter returns the errors serialized as json.
 
+* It's now possible to customize the error messages for ``ModelForm``’s
+  ``unique``, ``unique_for_date``, and ``unique_together``.
+  In order to support ``unique_together`` or any other ``NON_FIELD_ERROR``,
+  ``ModelForm`` now looks for the ``NON_FIELD_ERROR`` key in the
+  ``error_messages`` dictionary of the ``ModelForm``’s inner ``Meta`` class.
+  See :ref:`considerations regarding model's error_messages
+  <considerations-regarding-model-errormessages>` for more details.
+
 Internationalization
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -259,7 +259,9 @@ The model's ``clean()`` method will be called before any uniqueness checks are
 made. See :ref:`Validating objects <validating-objects>` for more information
 on the model's ``clean()`` hook.
 
-Considerations regarding fields' ``error_messages``
+.. _considerations-regarding-model-errormessages:
+
+Considerations regarding model's ``error_messages``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Error messages defined at the
@@ -267,11 +269,26 @@ Error messages defined at the
 :ref:`form Meta <modelforms-overriding-default-fields>` level always take
 precedence over the error messages defined at the
 :attr:`model field <django.db.models.Field.error_messages>` level.
+
 Error messages  defined on :attr:`model fields
 <django.db.models.Field.error_messages>` are only used when the
 ``ValidationError`` is raised during the :ref:`model validation
 <validating-objects>` step and no corresponding error messages are defined at
 the form level.
+
+.. versionadded:: 1.7
+
+You can override the error messages from ``NON_FIELD_ERRORS`` raised by model
+validation by adding the :data:`~django.core.exceptions.NON_FIELD_ERRORS` key
+to the ``error_messages`` dictionary of the ``ModelForm``’s inner ``Meta`` class::
+
+    class ArticleForm(ModelForm):
+        class Meta:
+            error_messages = {
+                NON_FIELD_ERRORS: {
+                    'unique_together': "%(model_name)s's %(field_labels)s are not unique.",
+                }
+            }
 
 The ``save()`` method
 ---------------------


### PR DESCRIPTION
Overriding the error messages now works for both unique fields, unique_together
and unique_for_date.

This patch changed the overriding logic to allow customizing NON_FIELD_ERRORS
since previously only fields' errors were customizable.

Refs #20199.
