### PR TITLE
Fixed #14760 - Admin inlines with file/image field fails to save_as

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 import warnings
 
 from django.core.exceptions import ValidationError, NON_FIELD_ERRORS, FieldError
-from django.forms.fields import Field, ChoiceField
+from django.forms.fields import Field, ChoiceField, FileField
 from django.forms.forms import DeclarativeFieldsMetaclass, BaseForm
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.forms.utils import ErrorList
@@ -857,6 +857,20 @@ class BaseInlineFormSet(BaseModelFormSet):
     def _construct_form(self, i, **kwargs):
         form = super(BaseInlineFormSet, self)._construct_form(i, **kwargs)
         if self.save_as_new:
+            # Set initial values for filetype fields
+            pk_key = "%s-%s" % (self.add_prefix(i), self.model._meta.pk.name)
+            pk_value = self.data[pk_key]
+            if pk_value:
+                original = None
+                for field_name, field in form.fields.items():
+                    if field_name in form.initial:
+                        continue
+                    if not isinstance(field, FileField):
+                        continue
+                    if not original:
+                        original = self.model.objects.get(pk=pk_value)
+                    form.initial[field_name] = getattr(original, field_name)
+
             # Remove the primary key from the form's data, we are only
             # creating new instances
             form.data[form.add_prefix(self._pk_field.name)] = None

--- a/tests/inline_formsets/models.py
+++ b/tests/inline_formsets/models.py
@@ -30,6 +30,7 @@ class Poet(models.Model):
 class Poem(models.Model):
     poet = models.ForeignKey(Poet)
     name = models.CharField(max_length=100)
+    testfile = models.FileField(upload_to='test_upload', blank=True)
 
     def __str__(self):
         return self.name

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.models import inlineformset_factory
 from django.test import TestCase, skipUnlessDBFeature
 from django.utils import six
@@ -170,3 +171,61 @@ class InlineFormsetFactoryTest(TestCase):
         PoemFormSet = inlineformset_factory(Poet, Poem, fields="__all__", extra=0)
         formset = PoemFormSet(None, instance=poet)
         self.assertEqual(len(formset.forms), 1)
+
+
+class InlineSaveAsNewTest(TestCase):
+
+    def setUp(self):
+        self.poet = Poet.objects.create(name='test')
+        self.poem = self.poet.poem_set.create(name='test poem',
+                testfile="poem.mp3")
+
+        self.poet_copy = self.poet
+        self.poet_copy.id = None
+        self.poet_copy.save()
+
+        self.PoemFormSet = inlineformset_factory(Poet, Poem)
+
+    def test_filefield_copy(self):
+        data = {
+            'poem_set-TOTAL_FORMS': '1',
+            'poem_set-INITIAL_FORMS': '1',
+            'poem_set-MAX_NUM_FORMS': '0',
+            'poem_set-0-id': str(self.poem.pk),
+            'poem_set-0-poet': str(self.poet_copy.pk),
+            'poem_set-0-name': 'test',
+        }
+        files = {
+            'poem_set-0-testfile': '',
+            }
+        formset = self.PoemFormSet(data, files=files,
+                instance=self.poet, save_as_new=True)
+        self.assertTrue(formset.is_valid())
+        formset.save()
+        self.assertEqual(self.poet_copy.poem_set.count(), 1)
+        poem_copy = self.poet_copy.poem_set.all()[0]
+        self.assertEqual(poem_copy.testfile, self.poem.testfile)
+
+    def test_override_fields(self):
+        uploaded_file = SimpleUploadedFile('test1.txt', b'hello world')
+        data = {
+            'poem_set-TOTAL_FORMS': '1',
+            'poem_set-INITIAL_FORMS': '1',
+            'poem_set-MAX_NUM_FORMS': '0',
+            'poem_set-0-id': str(self.poem.pk),
+            'poem_set-0-poet': str(self.poet_copy.pk),
+            'poem_set-0-name': 'foo',
+        }
+        files = {
+            'poem_set-0-testfile': uploaded_file,
+            }
+        formset = self.PoemFormSet(data, files=files,
+                instance=self.poet, save_as_new=True)
+        self.assertTrue(formset.is_valid())
+        formset.save()
+        self.assertEqual(self.poet_copy.poem_set.count(), 1)
+        poem_copy = self.poet_copy.poem_set.all()[0]
+        self.assertEqual(poem_copy.name, 'foo')
+        self.assertNotEqual(poem_copy.testfile, self.poem.testfile)
+        self.assertEqual(poem_copy.testfile.name, 'test_upload/test1.txt')
+        poem_copy.testfile.delete(save=False)


### PR DESCRIPTION
https://github.com/django/django/pull/697 reworked for master.

Refactored BaseInlineFormSet and ModelAdmin to copy initial
values (file name) for fields of FileField or it's subclasses.

'physical' file do not get duplicated.