### PR TITLE
Fixed #16617 - Indicate the value for MinLengthValidator and MaxLengthValidator in the exception message

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -212,7 +212,7 @@ class BaseValidator(object):
 
     def __call__(self, value):
         cleaned = self.clean(value)
-        params = {'limit_value': self.limit_value, 'show_value': cleaned}
+        params = {'limit_value': self.limit_value, 'show_value': cleaned, 'value': value}
         if self.compare(cleaned, self.limit_value):
             raise ValidationError(self.message, code=self.code, params=params)
 
@@ -239,8 +239,8 @@ class MinLengthValidator(BaseValidator):
     compare = lambda self, a, b: a < b
     clean = lambda self, x: len(x)
     message = ungettext_lazy(
-        'Ensure this value has at least %(limit_value)d character (it has %(show_value)d).',
-        'Ensure this value has at least %(limit_value)d characters (it has %(show_value)d).',
+        'Ensure this value has at least %(limit_value)d character ("%(value)s" has %(show_value)d).',
+        'Ensure this value has at least %(limit_value)d characters ("%(value)s" has %(show_value)d).',
         'limit_value')
     code = 'min_length'
 
@@ -250,7 +250,7 @@ class MaxLengthValidator(BaseValidator):
     compare = lambda self, a, b: a > b
     clean = lambda self, x: len(x)
     message = ungettext_lazy(
-        'Ensure this value has at most %(limit_value)d character (it has %(show_value)d).',
-        'Ensure this value has at most %(limit_value)d characters (it has %(show_value)d).',
+        'Ensure this value has at most %(limit_value)d character ("%(value)s" has %(show_value)d).',
+        'Ensure this value has at most %(limit_value)d characters ("%(value)s" has %(show_value)d).',
         'limit_value')
     code = 'max_length'

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -109,14 +109,14 @@ class FieldsTests(SimpleTestCase):
         f = CharField(max_length=10, required=False)
         self.assertEqual('12345', f.clean('12345'))
         self.assertEqual('1234567890', f.clean('1234567890'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (it has 11).'", f.clean, '1234567890a')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (\"1234567890a\" has 11).'", f.clean, '1234567890a')
         self.assertEqual(f.max_length, 10)
         self.assertEqual(f.min_length, None)
 
     def test_charfield_4(self):
         f = CharField(min_length=10, required=False)
         self.assertEqual('', f.clean(''))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 5).'", f.clean, '12345')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (\"12345\" has 5).'", f.clean, '12345')
         self.assertEqual('1234567890', f.clean('1234567890'))
         self.assertEqual('1234567890a', f.clean('1234567890a'))
         self.assertEqual(f.max_length, None)
@@ -125,7 +125,7 @@ class FieldsTests(SimpleTestCase):
     def test_charfield_5(self):
         f = CharField(min_length=10, required=True)
         self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 5).'", f.clean, '12345')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (\"12345\" has 5).'", f.clean, '12345')
         self.assertEqual('1234567890', f.clean('1234567890'))
         self.assertEqual('1234567890a', f.clean('1234567890a'))
         self.assertEqual(f.max_length, None)
@@ -620,11 +620,11 @@ class FieldsTests(SimpleTestCase):
 
     def test_regexfield_5(self):
         f = RegexField('^\d+$', min_length=5, max_length=10)
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 5 characters (it has 3).'", f.clean, '123')
-        six.assertRaisesRegex(self, ValidationError, "'Ensure this value has at least 5 characters \(it has 3\)\.', u?'Enter a valid value\.'", f.clean, 'abc')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 5 characters (\"123\" has 3).'", f.clean, '123')
+        six.assertRaisesRegex(self, ValidationError, "'Ensure this value has at least 5 characters \(\"abc\" has 3\)\.', u?'Enter a valid value\.'", f.clean, 'abc')
         self.assertEqual('12345', f.clean('12345'))
         self.assertEqual('1234567890', f.clean('1234567890'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (it has 11).'", f.clean, '12345678901')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (\"12345678901\" has 11).'", f.clean, '12345678901')
         self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '12345a')
 
     def test_regexfield_6(self):
@@ -672,9 +672,9 @@ class FieldsTests(SimpleTestCase):
     def test_emailfield_min_max_length(self):
         f = EmailField(min_length=10, max_length=15)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="email" name="f" maxlength="15" />')
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 9).'", f.clean, 'a@foo.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (\"a@foo.com\" has 9).'", f.clean, 'a@foo.com')
         self.assertEqual('alf@foo.com', f.clean('alf@foo.com'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 15 characters (it has 20).'", f.clean, 'alf123456788@foo.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 15 characters (\"alf123456788@foo.com\" has 20).'", f.clean, 'alf123456788@foo.com')
 
     # FileField ##################################################################
 
@@ -785,11 +785,12 @@ class FieldsTests(SimpleTestCase):
         self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://.com')
 
     def test_urlfield_5(self):
+        # ticket #16617
         f = URLField(min_length=15, max_length=20)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" />')
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 15 characters (it has 13).'", f.clean, 'http://f.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 15 characters (\"http://f.com/\" has 13).'", f.clean, 'http://f.com')
         self.assertEqual('http://example.com/', f.clean('http://example.com'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 38).'", f.clean, 'http://abcdefghijklmnopqrstuvwxyz.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (\"http://abcdefghijklmnopqrstuvwxyz.com/\" has 38).'", f.clean, 'http://abcdefghijklmnopqrstuvwxyz.com')
 
     def test_urlfield_6(self):
         f = URLField(required=False)
@@ -1154,7 +1155,7 @@ class FieldsTests(SimpleTestCase):
     def test_combofield_1(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()])
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'", f.clean, 'longemailaddress@example.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (\"longemailaddress@example.com\" has 28).'", f.clean, 'longemailaddress@example.com')
         self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'not an email')
         self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
         self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
@@ -1162,7 +1163,7 @@ class FieldsTests(SimpleTestCase):
     def test_combofield_2(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()], required=False)
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'", f.clean, 'longemailaddress@example.com')
+        self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (\"longemailaddress@example.com\" has 28).'", f.clean, 'longemailaddress@example.com')
         self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'not an email')
         self.assertEqual('', f.clean(''))
         self.assertEqual('', f.clean(None))

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1574,7 +1574,7 @@ class FormsTestCase(TestCase):
         self.assertHTMLEqual(my_function('POST', {'username': 'this-is-a-long-username', 'password1': 'foo', 'password2': 'bar'}), """<form action="" method="post">
 <table>
 <tr><td colspan="2"><ul class="errorlist"><li>Please make sure your passwords match.</li></ul></td></tr>
-<tr><th>Username:</th><td><ul class="errorlist"><li>Ensure this value has at most 10 characters (it has 23).</li></ul><input type="text" name="username" value="this-is-a-long-username" maxlength="10" /></td></tr>
+<tr><th>Username:</th><td><ul class="errorlist"><li>Ensure this value has at most 10 characters (&quot;this-is-a-long-username&quot; has 23).</li></ul><input type="text" name="username" value="this-is-a-long-username" maxlength="10" /></td></tr>
 <tr><th>Password1:</th><td><input type="password" name="password1" /></td></tr>
 <tr><th>Password2:</th><td><input type="password" name="password2" /></td></tr>
 </table>
@@ -1839,8 +1839,8 @@ class FormsTestCase(TestCase):
         self.assertEqual(form.errors, {'name': ['bad value not allowed']})
         form = NameForm(data={'name': ['should be overly', 'long for the field names']})
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors, {'name': ['Ensure this value has at most 10 characters (it has 16).',
-                                                'Ensure this value has at most 10 characters (it has 24).']})
+        self.assertEqual(form.errors, {'name': ['Ensure this value has at most 10 characters ("should be overly" has 16).',
+                                                'Ensure this value has at most 10 characters ("long for the field names" has 24).']})
         form = NameForm(data={'name': ['fname', 'lname']})
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data, {'name': 'fname lname'})


### PR DESCRIPTION
This simple patch makes the original value available to BaseValidator types allowing the value to be used in MinLengthValidator and MaxLengthValidator.
