### PR TITLE
Fix dumpdata for listing app followed by app.model [track ticket #22025]

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -102,8 +102,13 @@ class Command(BaseCommand):
                         raise CommandError("Unknown model: %s.%s" % (app_label, model_label))
 
                     app_list_value = app_list.setdefault(app_config, [])
-                    if model not in app_list_value:
-                        app_list_value.append(model)
+
+                    # We may have previously seen a "all-models" request for
+                    # this app (no model qualifier was given). In this case
+                    # there is no need adding specific models to the list.
+                    if app_list_value is not None:
+                        if model not in app_list_value:
+                            app_list_value.append(model)
                 except ValueError:
                     if primary_keys:
                         raise CommandError("You can only use --pks option with one model")

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -93,6 +93,10 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
         # Specify a dump that specifies Article both explicitly and implicitly
         self._dumpdata_assert(['fixtures.Article', 'fixtures'], '[{"pk": 1, "model": "fixtures.category", "fields": {"description": "Latest news stories", "title": "News Stories"}}, {"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", "pub_date": "2006-06-16T12:00:00"}}, {"pk": 3, "model": "fixtures.article", "fields": {"headline": "Time to reform copyright", "pub_date": "2006-06-16T13:00:00"}}, {"pk": 10, "model": "fixtures.book", "fields": {"name": "Achieving self-awareness of Python programs", "authors": []}}]')
 
+        # Specify a dump that specifies Article both explicitly and implicitly,
+        # but lists the app first (#22025).
+        self._dumpdata_assert(['fixtures', 'fixtures.Article'], '[{"pk": 1, "model": "fixtures.category", "fields": {"description": "Latest news stories", "title": "News Stories"}}, {"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", "pub_date": "2006-06-16T12:00:00"}}, {"pk": 3, "model": "fixtures.article", "fields": {"headline": "Time to reform copyright", "pub_date": "2006-06-16T13:00:00"}}, {"pk": 10, "model": "fixtures.book", "fields": {"name": "Achieving self-awareness of Python programs", "authors": []}}]')
+
         # Same again, but specify in the reverse order
         self._dumpdata_assert(['fixtures'], '[{"pk": 1, "model": "fixtures.category", "fields": {"description": "Latest news stories", "title": "News Stories"}}, {"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", "pub_date": "2006-06-16T12:00:00"}}, {"pk": 3, "model": "fixtures.article", "fields": {"headline": "Time to reform copyright", "pub_date": "2006-06-16T13:00:00"}}, {"pk": 10, "model": "fixtures.book", "fields": {"name": "Achieving self-awareness of Python programs", "authors": []}}]')
 


### PR DESCRIPTION
Prior to this fix, a command such as this:

```
$ python manage.py dumpdata blogapp blogapp.Tag
```

Would fail with an exception because app_list_value is not iterable. While
the usage case isn't very sensical, it may appear in programmatic / scripting
approaches, and handling it more gracefully is a good idea.

Since 'blogapp' implies all models in the app, subsequent specific models within
the same app can simply be ignored.
