### PR TITLE
TestClient: Allow params with empty values in POST

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -157,16 +157,24 @@ def encode_multipart(boundary, data):
         if is_file(value):
             lines.extend(encode_file(boundary, key, value))
         elif not isinstance(value, six.string_types) and is_iterable(value):
-            for item in value:
-                if is_file(item):
-                    lines.extend(encode_file(boundary, key, item))
-                else:
-                    lines.extend([to_bytes(val) for val in [
-                        '--%s' % boundary,
-                        'Content-Disposition: form-data; name="%s"' % key,
-                        '',
-                        item
-                    ]])
+            if len(value):
+                for item in value:
+                    if is_file(item):
+                        lines.extend(encode_file(boundary, key, item))
+                    else:
+                        lines.extend([to_bytes(val) for val in [
+                            '--%s' % boundary,
+                            'Content-Disposition: form-data; name="%s"' % key,
+                            '',
+                            item
+                        ]])
+            else:
+                lines.extend([to_bytes(val) for val in [
+                    '--%s' % boundary,
+                    'Content-Disposition: form-data; name="%s"' % key,
+                    '',
+                    ''
+                ]])
         else:
             lines.extend([to_bytes(val) for val in [
                 '--%s' % boundary,

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -79,6 +79,19 @@ class ClientTest(TestCase):
         self.assertEqual(response.templates[0].name, 'POST Template')
         self.assertContains(response, 'Data received')
 
+    def test_post_should_not_strip_empty_list(self):
+        "POST some data to a view"
+        post_data = {
+            'value': [],
+        }
+        response = self.client.post('/post_view/', post_data)
+
+        # Check some response details
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['data'], '')
+        self.assertEqual(response.templates[0].name, 'POST Template')
+        self.assertContains(response, 'Data received')
+
     def test_response_headers(self):
         "Check the value of HTTP headers returned in a response"
         response = self.client.get("/header_view/")


### PR DESCRIPTION
The test HTTP client allows us to send query params where the value is
empty when using GET. When using POST on the other hand, sending the
empty list as the value will remove the key/value pair entirely.
Make this behaviour symmetrical and allow keys with empty values also
for POST.
