### PR TITLE
Update django.po

### DIFF
--- a/django/conf/locale/uk/LC_MESSAGES/django.po
+++ b/django/conf/locale/uk/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgstr ""
 
 #: conf/global_settings.py:48
 msgid "Afrikaans"
-msgstr "Африканська"
+msgstr "Африкаанс"
 
 #: conf/global_settings.py:49
 msgid "Arabic"


### PR DESCRIPTION
Afrikaans was translated as "African", it should be spelt as Afrikaans but in Cyrillic.
Proof link http://uk.wikipedia.org/wiki/%D0%90%D1%84%D1%80%D0%B8%D0%BA%D0%B0%D0%B0%D0%BD%D1%81
