### PR TITLE
Remove _actions_icnt declaration from local scope

### DIFF
--- a/django/contrib/admin/static/admin/js/actions.js
+++ b/django/contrib/admin/static/admin/js/actions.js
@@ -1,5 +1,5 @@
 (function($) {
-	var _actions_icnt, lastChecked;
+	var lastChecked;
 
 	$.fn.actions = function(opts) {
 		var options = $.extend({}, $.fn.actions.defaults, opts);


### PR DESCRIPTION
Commit 4523fcd60101124a307bd4026296337087b66884 introduces `_actions_icnt` to the local scope, which overrides the value set in the HTML.

The admin will show selected rows in a change list as "1 of undefined selected".
