### PR TITLE
Fixed #22046 -- Unhelpful queryset handling for model formsets with data...

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -593,9 +593,29 @@ class BaseModelFormSet(BaseFormSet):
                 pass
         return super(BaseModelFormSet, self)._construct_form(i, **kwargs)
 
+    def _get_data_pks(self):
+        """Returns a list of all the pks in the form data."""
+        pks = []
+        pk_field = self.model._meta.pk
+        to_python = self._get_to_python(pk_field)
+        for i in range(self.initial_form_count()):
+            pk_key = "%s-%s" % (self.add_prefix(i), pk_field.name)
+            pk = self.data[pk_key]
+            pks.append(to_python(pk))
+        return pks
+
     def get_queryset(self):
         if not hasattr(self, '_queryset'):
-            if self.queryset is not None:
+            if self.is_bound:
+                # Bound forms must only deal with the instances
+                # specified by the data. Allowing any other filters
+                # could cause the data specified instances to not be
+                # found.
+                qs = self.model._default_manager.get_queryset()
+                qs = qs.filter(**{
+                    self.model._meta.pk.name+'__in': self._get_data_pks(),
+                })
+            elif self.queryset is not None:
                 qs = self.queryset
             else:
                 qs = self.model._default_manager.get_queryset()

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1183,6 +1183,47 @@ class ModelFormsetTest(TestCase):
         formset = FormSet(initial=[{'authors': Author.objects.all()}], data=data)
         self.assertFalse(formset.extra_forms[0].has_changed())
 
+    def test_model_formset_with_mismatched_queryset(self):
+        FormSet = modelformset_factory(Author, fields=('name', ))
+        Author.objects.create(pk=10, name='Charles Baudelaire')
+        Author.objects.create(pk=20, name='Arthur Rimbaud')
+        data = {
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 1,
+            'form-MAX_NUM_FORMS': 1,
+            'form-0-id': '20',
+            'form-0-name': 'A. Rimbaud',
+        }
+        formset = FormSet(data=data, queryset=Author.objects.filter(pk=10))
+        formset.save()
+
+        self.assertEqual(
+            set(Author.objects.values_list('pk', 'name')),
+            set([
+                (10, 'Charles Baudelaire'),
+                (20, 'A. Rimbaud'),
+            ]),
+        )
+
+    def test_model_formset_limits_queryset_to_data(self):
+        FormSet = modelformset_factory(Author, fields=('name', ))
+        Author.objects.create(pk=10, name='Charles Baudelaire')
+        Author.objects.create(pk=20, name='Arthur Rimbaud')
+        data = {
+            'form-TOTAL_FORMS': 1,
+            'form-INITIAL_FORMS': 1,
+            'form-MAX_NUM_FORMS': 1,
+            'form-0-id': '20',
+            'form-0-name': 'A. Rimbaud',
+        }
+        formset = FormSet(data=data, queryset=Author.objects.filter(pk=10))
+        self.assertEqual(
+            set(formset.get_queryset().values_list('pk', 'name')),
+            set([
+                (20, 'Arthur Rimbaud'),
+            ]),
+        )
+
     def test_prevent_duplicates_from_with_the_same_formset(self):
         FormSet = modelformset_factory(Product, fields="__all__", extra=2)
         data = {


### PR DESCRIPTION
....

BaseModelFormSet now overrides the queryset if it is bound.
It pulls in the instances specified in the data.

Two unit tests showing the previous problems are included.
