### PR TITLE
Fixed #21183 -- Filter block on the right covers information in admin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -614,6 +614,7 @@ answer newbie questions, and generally made Django that much better:
     Terry Huang <terryh.tp@gmail.com>
     Travis Terry <tdterry7@gmail.com>
     thebjorn <bp@datakortet.no>
+    Michał Czuba <michal.czuba@deployed.pl>
     Lowe Thiderman <lowe.thiderman@gmail.com>
     Zach Thompson <zthompson47@gmail.com>
     Michael Thornhill <michael.thornhill@gmail.com>

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -19,12 +19,7 @@
     min-height: 400px;
 }
 
-.change-list .filtered {
-    background: white url(../img/changelist-bg.gif) top right repeat-y !important;
-}
-
 .change-list .filtered .results, .change-list .filtered .paginator, .filtered #toolbar, .filtered div.xfull {
-    margin-right: 160px !important;
     width: auto !important;
 }
 
@@ -50,6 +45,12 @@
 
 .change-list .filtered .paginator {
     border-right: 1px solid #ddd;
+}
+
+.hidden_state {
+  display: inline-block;
+  margin-left: 4px;
+  line-height: 24px;
 }
 
 /* CHANGELIST TABLES */
@@ -113,6 +114,7 @@
     z-index: 1000;
     width: 160px;
     border-left: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
     background: #efefef;
     margin: 0;
 }
@@ -233,7 +235,6 @@
 /* ACTIONS */
 
 .filtered .actions {
-    margin-right: 160px !important;
     border-right: 1px solid #ddd;
 }
 

--- a/django/contrib/admin/static/admin/js/hidefilters.js
+++ b/django/contrib/admin/static/admin/js/hidefilters.js
@@ -1,0 +1,70 @@
+(function ($) {
+    var setCookie = function (cname, cvalue, exdays) {
+        var d = new Date();
+        d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+        var expires = "expires=" + d.toGMTString();
+        document.cookie = cname + "=" + cvalue + "; " + expires;
+    };
+
+    var getCookie = function (cname) {
+        var name = cname + "=";
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i].trim();
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return "";
+    };
+
+    var toggleFilter = function (hideMsg, showMsg, expireDays) {
+        var $filtersBox, $filtersHeader, $hiddenState, $filterResult;
+        hideMsg = ' (' + hideMsg + ')';
+        showMsg = ' (' + showMsg + ')';
+        $filterResult = $('#changelist-form .results');
+        $filtersBox = $('#changelist-filter');
+        $filtersHeader = $filtersBox.find('h2:first');
+        $filterResult.css('margin-right', $filtersBox.width());
+        $hiddenState = $('<span class="hidden_state"> ' +
+            showMsg + '</span>').appendTo($filtersHeader);
+        $filtersBox.css(
+                'overflow',
+                'hidden'
+            ).data(
+                'visible-height',
+                $filtersBox.height()
+            ).data(
+                'hidden-height',
+                $filtersHeader.innerHeight()
+            );
+        $filtersHeader.css({
+            cursor: 'pointer'
+        }).click(function () {
+            if ($(this).data('is-hidden')) {
+                $filterResult.css('margin-right', $filtersBox.width());
+
+                $filtersBox.animate({
+                    height: $filtersBox.data('visible-height')
+                }, 'fast', function () {
+                    return $hiddenState.text(showMsg);
+                });
+                $(this).data('is-hidden', false);
+                return setCookie('admin-filter-is-hidden', '', expireDays);
+            } else {
+                $filterResult.css('margin-right', '0px');
+                $filtersBox.animate({
+                    height: $filtersBox.data('hidden-height')
+                }, 'fast', function () {
+                    return $hiddenState.text(hideMsg);
+                });
+                $(this).data('is-hidden', true);
+                return setCookie('admin-filter-is-hidden', true, expireDays);
+            }
+        });
+        if (getCookie('admin-filter-is-hidden')) {
+            return $filtersHeader.click();
+        }
+    };
+    window.toggleFilter = toggleFilter;
+})(django.jQuery);

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -7,7 +7,7 @@
   {% if cl.formset %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />
   {% endif %}
-  {% if cl.formset or action_form %}
+  {% if cl.formset or action_form or cl.has_filters %}
     <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
   {% endif %}
   {{ media.css }}
@@ -30,6 +30,16 @@
 })(django.jQuery);
 </script>
 {% endif %}{% endif %}
+
+{% if cl.has_filters %}
+<script type="text/javascript" src="{% static 'admin/js/hidefilters.js' %}"></script>
+<script type="text/javascript">
+    django.jQuery(document).ready(function() {
+        toggleFilter(gettext("show"), gettext("hide"), 7);
+    });
+</script>
+{% endif %}
+
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}


### PR DESCRIPTION
Added filter toggle functionality to admin.
Collapse/expand state is remebered thanks to cookies.

Thanks Tuttle for the report.