### PR TITLE
Fixed #22056 -- Empty directories shouldn't be included to test modules

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -74,7 +74,9 @@ def get_test_modules():
                     f == '__pycache__' or
                     f.startswith('sql') or
                     os.path.basename(f) in SUBDIRS_TO_SKIP or
-                    os.path.isfile(f)):
+                    os.path.isfile(f) or
+                    (os.path.isdir(f) and
+                     not os.path.exists(os.path.join(f, '__init__.py')))):
                 continue
             modules.append((modpath, f))
     return modules


### PR DESCRIPTION
Additional check if module is valid by if '**init**.py' inside module.
