### PR TITLE
Fixed #21884 -- Improved reference docs on querysets

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1997,6 +1997,9 @@ For an introduction, see :ref:`models and database queries documentation
 Django's inbuilt lookups are listed below. It is also possible to write
 :doc:`custom lookups </ref/models/custom-lookups>` for model fields.
 
+As a convenience when no lookup type is provided (like in
+``Entry.objects.get(id=14)``) the lookup type is assumed to be :lookup:`exact`.
+
 .. fieldlookup:: exact
 
 exact


### PR DESCRIPTION
This change adds information that 'exact' lookup type is used when no lookup
type is provided.
