### PR TITLE
Improved fix for #18373 -- backward compatibility

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -69,11 +69,8 @@ class ResolverMatch(object):
 
 
 class Resolver404(Http404):
+    pass
 
-    def __init__(self, path, tried=None):
-        super(Resolver404, self).__init__()
-        self.path = path
-        self.tried = tried
 
 
 class NoReverseMatch(Exception):
@@ -326,7 +323,7 @@ class RegexURLResolver(LocaleRegexProvider):
                 try:
                     sub_match = pattern.resolve(new_path)
                 except Resolver404 as e:
-                    sub_tried = e.tried
+                    sub_tried = e.args[0].get('tried')
                     if sub_tried is not None:
                         tried.extend([pattern] + t for t in sub_tried)
                     else:
@@ -337,8 +334,8 @@ class RegexURLResolver(LocaleRegexProvider):
                         sub_match_dict.update(sub_match.kwargs)
                         return ResolverMatch(sub_match.func, sub_match.args, sub_match_dict, sub_match.url_name, self.app_name or sub_match.app_name, [self.namespace] + sub_match.namespaces)
                     tried.append([pattern])
-            raise Resolver404(new_path, tried=tried)
-        raise Resolver404(path)
+            raise Resolver404({'tried': tried, 'path': new_path})
+        raise Resolver404({'path': path})
 
     @property
     def urlconf_module(self):

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -475,11 +475,14 @@ class ExceptionReporter(object):
 def technical_404_response(request, exception):
     "Create a technical 404 error response. The exception should be the Http404."
     try:
-        tried = exception.tried
-        error_url = exception.path
-    except AttributeError:
+        error_url = exception.args[0]['path']
+    except (IndexError, TypeError, KeyError):
+        error_url = request.path_info[1:] # Trim leading slash
+
+    try:
+        tried = exception.args[0]['tried']
+    except (IndexError, TypeError, KeyError):
         tried = []
-        error_url = request.path_info[1:]  # Trim leading slash
     else:
         if (not tried                           # empty URLconf
             or (request.path == '/'

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -272,10 +272,10 @@ class ResolverTests(unittest.TestCase):
             self.fail('resolve did not raise a 404')
         except Resolver404 as e:
             # make sure we at least matched the root ('/') url resolver:
-            self.assertTrue(hasattr(e, 'tried'))
-            tried = e.tried
-            self.assertEqual(len(tried), len(url_types_names), 'Wrong number of tried URLs returned.  Expected %s, got %s.' % (len(url_types_names), len(tried)))
-            for tried, expected in zip(tried, url_types_names):
+            self.assertTrue('tried' in e.args[0])
+            tried = e.args[0]['tried']
+            self.assertEqual(len(e.args[0]['tried']), len(url_types_names), 'Wrong number of tried URLs returned.  Expected %s, got %s.' % (len(url_types_names), len(e.args[0]['tried'])))
+            for tried, expected in zip(e.args[0]['tried'], url_types_names):
                 for t, e in zip(tried, expected):
                     self.assertIsInstance(t, e['type']), str('%s is not an instance of %s') % (t, e['type'])
                     if 'name' in e:


### PR DESCRIPTION
Commit 79558c78 cleaned up the (undocumented) interface of Resolver404
exception, which breaks compatibility with code messing with .args[0]
directly. Revert the cleanup part and simply leave the fix itself.
