### PR TITLE
Fixed #22023 -- .values() followed by defer() or only() results invalid ...

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1060,6 +1060,12 @@ class ValuesQuerySet(QuerySet):
         # QuerySet.clone() will also set up the _fields attribute with the
         # names of the model fields to select.
 
+    def only(self, *fields):
+        raise NotImplementedError("ValuesQuerySet does not implement `only()`")
+
+    def defer(self, *fields):
+        raise NotImplementedError("ValuesQuerySet does not implement `defer()`")
+
     def iterator(self):
         # Purge any extra columns that haven't been explicitly asked for
         extra_names = list(self.query.extra_select)

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -502,14 +502,18 @@ A few subtleties that are worth mentioning:
   made after a ``values()`` call will have its extra selected fields
   ignored.
 
+* Calling :meth:`only()` and :meth:`defer()` on a ``ValuesQuerySet`` doesn't make sense so it will
+  raise a ``NotImplementedError``.
+
 A ``ValuesQuerySet`` is useful when you know you're only going to need values
 from a small number of the available fields and you won't need the
 functionality of a model instance object. It's more efficient to select only
 the fields you need to use.
 
-Finally, note a ``ValuesQuerySet`` is a subclass of ``QuerySet``, so it has all
-methods of ``QuerySet``. You can call ``filter()`` on it, or ``order_by()``, or
-whatever. Yes, that means these two calls are identical::
+Finally, note that a ``ValuesQuerySet`` is a subclass of ``QuerySet`` and it implements most
+of the same methods. You can call ``filter()`` on it, ``order_by()``, etc.
+That means that these two calls are identical::
+
 
     Blog.objects.values().order_by('id')
     Blog.objects.order_by('id').values()

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -616,6 +616,12 @@ Models
   :attr:`~django.db.models.ForeignKey.limit_choices_to` when defining a
   ``ForeignKey`` or ``ManyToManyField``.
 
+* Calling :meth:`only() <django.db.models.query.QuerySet.only>` and
+  :meth:`defer() <django.db.models.query.QuerySet.defer>` on the result of
+  :meth:`QuerySet.values() <django.db.models.query.QuerySet.values>` now raises
+  an error (before that, it would either result in a database error or
+  incorrect data).
+
 Signals
 ^^^^^^^
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1275,6 +1275,10 @@ class Queries3Tests(BaseQuerysetTest):
             Item.objects.datetimes, 'name', 'month'
         )
 
+    def test_ticket22023(self):
+        self.assertRaises(NotImplementedError, Valid.objects.values().only)
+        self.assertRaises(NotImplementedError, Valid.objects.values().defer)
+
 
 class Queries4Tests(BaseQuerysetTest):
     def setUp(self):


### PR DESCRIPTION
...data or crash

defer() and only() implementation for ValuesQuerySet

Signed-off-by: Karol Jochelson karol.jochelson@gmail.com
Signed-off-by: Jakub Nowak jakubnowakc@gmail.com
