### PR TITLE
Fixed #19980: Signer broken for binary keys (with non-ASCII chars).

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -76,7 +76,8 @@ def base64_hmac(salt, value, key):
 
 def get_cookie_signer(salt='django.core.signing.get_cookie_signer'):
     Signer = import_string(settings.SIGNING_BACKEND)
-    return Signer('django.http.cookies' + settings.SECRET_KEY, salt=salt)
+    key = force_bytes(settings.SECRET_KEY)
+    return Signer(b'django.http.cookies' + key, salt=salt)
 
 
 class JSONSerializer(object):
@@ -148,9 +149,9 @@ class Signer(object):
 
     def __init__(self, key=None, sep=':', salt=None):
         # Use of native strings in all versions of Python
-        self.sep = str(sep)
-        self.key = str(key or settings.SECRET_KEY)
-        self.salt = str(salt or
+        self.sep = force_str(sep)
+        self.key = key or settings.SECRET_KEY
+        self.salt = force_str(salt or
             '%s.%s' % (self.__class__.__module__, self.__class__.__name__))
 
     def signature(self, value):

--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -36,10 +36,13 @@ def salted_hmac(key_salt, value, secret=None):
     if secret is None:
         secret = settings.SECRET_KEY
 
+    key_salt = force_bytes(key_salt)
+    secret = force_bytes(secret)
+
     # We need to generate a derived key from our base key.  We can do this by
     # passing the key_salt and our base key through a pseudo-random function and
     # SHA1 works nicely.
-    key = hashlib.sha1((key_salt + secret).encode('utf-8')).digest()
+    key = hashlib.sha1(key_salt + secret).digest()
 
     # If len(key_salt + secret) > sha_constructor().block_size, the above
     # line is redundant and could be replaced by key = key_salt + secret, since

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -105,6 +105,12 @@ class TestSigner(TestCase):
             self.assertRaises(
                 signing.BadSignature, signing.loads, transform(encoded))
 
+    def test_works_with_non_ascii_keys(self):
+        binary_key = b'\xe7'  # Set some binary (non-ASCII key)
+
+        s = signing.Signer(binary_key)
+        self.assertEquals('foo:6NB0fssLW5RQvZ3Y-MTerq2rX7w', s.sign('foo'))
+
 
 class TestTimestampSigner(TestCase):
 


### PR DESCRIPTION
With this pull request, request #878 should considered closed.

Thanks to nvie for the patch.
