### PR TITLE
Removed Django 1.5 upgrade hints for {% url %} tag.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -434,10 +434,6 @@ class URLNode(Node):
 
         view_name = self.view_name.resolve(context)
 
-        if not view_name:
-            raise NoReverseMatch("'url' requires a non-empty first argument. "
-                "The syntax changed in Django 1.5, see the docs.")
-
         # Try to look up the URL twice: once given the view name, and again
         # relative to what we guess is the "main" app. If they both fail,
         # re-raise the NoReverseMatch unless we're using the
@@ -1345,12 +1341,7 @@ def url(parser, token):
     if len(bits) < 2:
         raise TemplateSyntaxError("'%s' takes at least one argument"
                                   " (path to a view)" % bits[0])
-    try:
-        viewname = parser.compile_filter(bits[1])
-    except TemplateSyntaxError as exc:
-        exc.args = (exc.args[0] + ". "
-                "The syntax of 'url' changed in Django 1.5, see the docs."),
-        raise
+    viewname = parser.compile_filter(bits[1])
     args = []
     kwargs = {}
     asvar = None

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -431,20 +431,6 @@ class TemplateRegressionTests(TestCase):
             self.assertTrue(depth > 5,
                 "The traceback context was lost when reraising the traceback. See #19827")
 
-    def test_url_explicit_exception_for_old_syntax_at_run_time(self):
-        # Regression test for #19280
-        t = Template('{% url path.to.view %}')      # not quoted = old syntax
-        c = Context()
-        with six.assertRaisesRegex(self, urlresolvers.NoReverseMatch,
-                "The syntax changed in Django 1.5, see the docs."):
-            t.render(c)
-
-    def test_url_explicit_exception_for_old_syntax_at_compile_time(self):
-        # Regression test for #19392
-        with six.assertRaisesRegex(self, template.TemplateSyntaxError,
-                "The syntax of 'url' changed in Django 1.5, see the docs."):
-            Template('{% url my-view %}')      # not a variable = old syntax
-
     @override_settings(DEBUG=True, TEMPLATE_DEBUG=True)
     def test_no_wrapped_exception(self):
         """


### PR DESCRIPTION
Refs #19280 and Refs #19392.

Any objections? The only downside I see is if someone is trying to upgrade directly from 1.4 to 1.7+, but I don't think trying to upgrade over multiple versions like that is a good idea.
