### PR TITLE
Update uploadedfile.py

### DIFF
--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -60,7 +60,7 @@ class TemporaryUploadedFile(UploadedFile):
     """
     A file uploaded to a temporary location (i.e. stream-to-disk).
     """
-    def __init__(self, name, content_type, size, charset, content_type_extra):
+    def __init__(self, name, content_type, size, charset, content_type_extra=None):
         if settings.FILE_UPLOAD_TEMP_DIR:
             file = tempfile.NamedTemporaryFile(suffix='.upload',
                 dir=settings.FILE_UPLOAD_TEMP_DIR)
@@ -89,7 +89,7 @@ class InMemoryUploadedFile(UploadedFile):
     """
     A file uploaded into memory (i.e. stream-to-memory).
     """
-    def __init__(self, file, field_name, name, content_type, size, charset, content_type_extra):
+    def __init__(self, file, field_name, name, content_type, size, charset, content_type_extra=None):
         super(InMemoryUploadedFile, self).__init__(file, name, content_type, size, charset, content_type_extra)
         self.field_name = field_name
 


### PR DESCRIPTION
I see no reason for content_type_extra to be required in TemporaryUploadedFile and InMemoryUploadedFile. As it breaks old code that creates InMemoryUploadedFile manually.
In my case i generate and image and wrap it in InMemoryUploadedFile and i think it is more rational not to require content_type_extra, than to pass None in most cases.
