### PR TITLE
Fixed #22087 - ModelForm Meta overrides are ignored by AdminReadonlyField

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -136,7 +136,6 @@ class AdminField(object):
 
 class AdminReadonlyField(object):
     def __init__(self, form, field, is_first, model_admin=None):
-        label = label_for_field(field, form._meta.model, model_admin)
         # Make self.field look a little bit like a field. This means that
         # {{ field.name }} must be a useful class name to identify the field.
         # For convenience, store other field-related data here too.
@@ -144,11 +143,22 @@ class AdminReadonlyField(object):
             class_name = field.__name__ if field.__name__ != '<lambda>' else ''
         else:
             class_name = field
+
+        if form._meta.labels and class_name in form._meta.labels:
+            label = form._meta.labels[class_name]
+        else:
+            label = label_for_field(field, form._meta.model, model_admin)
+
+        if form._meta.help_texts and class_name in form._meta.help_texts:
+            help_text = form._meta.help_texts[class_name]
+        else:
+            help_text = help_text_for_field(class_name, form._meta.model)
+
         self.field = {
             'name': class_name,
             'label': label,
-            'field': field,
-            'help_text': help_text_for_field(class_name, form._meta.model)
+            'help_text': help_text,
+            'field': field
         }
         self.form = form
         self.model_admin = model_admin

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -34,7 +34,7 @@ from .models import (Article, Chapter, Child, Parent, Picture, Widget,
     UnchangeableObject, UserMessenger, Simple, Choice, ShortMessage, Telegram,
     FilteredManager, EmptyModelHidden, EmptyModelVisible, EmptyModelMixin,
     State, City, Restaurant, Worker, ParentWithDependentChildren,
-    DependentChild, StumpJoke)
+    DependentChild, StumpJoke, FieldOverridePost)
 
 
 def callable_year(dt_value):
@@ -428,6 +428,22 @@ class PostAdmin(admin.ModelAdmin):
         return "Multiline\ntest\nstring"
 
     value.short_description = 'Value in $US'
+
+
+class FieldOverridePostForm(forms.ModelForm):
+    model = FieldOverridePost
+
+    class Meta:
+        help_texts = {
+            'posted': 'Overridden help text for the date'
+        }
+        labels = {
+            'public': 'Overridden public label'
+        }
+
+
+class FieldOverridePostAdmin(PostAdmin):
+    form = FieldOverridePostForm
 
 
 class CustomChangeList(ChangeList):
@@ -824,6 +840,7 @@ site.register(Recommender)
 site.register(Collector, CollectorAdmin)
 site.register(Category, CategoryAdmin)
 site.register(Post, PostAdmin)
+site.register(FieldOverridePost, FieldOverridePostAdmin)
 site.register(Gadget, GadgetAdmin)
 site.register(Villain)
 site.register(SuperVillain)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -438,6 +438,12 @@ class Post(models.Model):
         return "Very awesome."
 
 
+# Proxy model to test overridden fields attrs on Post model so as not to
+# interfere with other tests.
+class FieldOverridePost(Post):
+    class Meta:
+        proxy = True
+
 @python_2_unicode_compatible
 class Gadget(models.Model):
     name = models.CharField(max_length=100)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -52,7 +52,7 @@ from .models import (Article, BarAccount, CustomArticle, EmptyModel, FooAccount,
     Report, MainPrepopulated, RelatedPrepopulated, UnorderedObject,
     Simple, UndeletableObject, UnchangeableObject, Choice, ShortMessage,
     Telegram, Pizza, Topping, FilteredManager, City, Restaurant, Worker,
-    ParentWithDependentChildren, Character)
+    ParentWithDependentChildren, Character, FieldOverridePost)
 from .admin import site, site2, CityAdmin
 
 
@@ -3678,6 +3678,18 @@ class ReadonlyTest(TestCase):
         pizza.toppings.add(topping)
         response = self.client.get('/test_admin/admin/admin_views/topping/add/')
         self.assertEqual(response.status_code, 200)
+
+    def test_readonly_field_overrides(self):
+        """
+        Regression test for #22087 - ModelForm Meta overrides are ignored by
+        AdminReadonlyField
+        """
+        p = FieldOverridePost.objects.create(title="Test Post", content="Test Content")
+        response = self.client.get('/test_admin/admin/admin_views/fieldoverridepost/%d/' % p.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<p class="help">Overridden help text for the date</p>')
+        self.assertContains(response, '<label for="id_public">Overridden public label:</label>', html=True)
+        self.assertNotContains(response, "Some help text for the date (with unicode ŠĐĆŽćžšđ)")
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/22087
