### PR TITLE
Remove conflicting statement from docstring

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -546,8 +546,6 @@ class FilterExpression(object):
         >>> fe.var
         <Variable: 'variable'>
 
-    This class should never be instantiated outside of the
-    get_filters_from_token helper function.
     """
     def __init__(self, token, parser):
         self.token = token


### PR DESCRIPTION
The statement:

> This class should never be instantiated outside of the get_filters_from_token helper function.

is invalid since:
- There is no helper function `get_filters_from_token`
- The class is instantiated in the `compile_filter` helper function

It confused me just now for a while. I only did a `grep -r 'get_filters_from_token' ./*` in the Django project, but I couldn't find a reference to it.
