### PR TITLE
Fixed #22095 -- Enabled backward migrations for RunPython operation

### DIFF
--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -103,7 +103,6 @@ class RunPython(Operation):
     """
 
     reduces_to_sql = False
-    reversible = False
 
     def __init__(self, code, reverse_code=None):
         # Forwards code
@@ -117,6 +116,10 @@ class RunPython(Operation):
             if not callable(reverse_code):
                 raise ValueError("RunPython must be supplied with callable arguments")
             self.reverse_code = reverse_code
+
+    @property
+    def reversible(self):
+        return self.reverse_code is not None
 
     def state_forwards(self, app_label, state):
         # RunPython objects have no state effect. To add some, combine this


### PR DESCRIPTION
Added reversible property to RunPython so that migrations will not
refuse to reverse migrations including RunPython operations, so long as
reverse_code is set in the RunPython constructor. Included tests to
check the reversible property on RunPython and the similar RunSQL.

See https://code.djangoproject.com/ticket/22095
