### PR TITLE
Fixed #22101 -- Querysets using timedelta expression nodes can again be ...

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -185,6 +185,7 @@ class DateModifierNode(ExpressionNode):
             raise TypeError('Second child must be a timedelta.')
         if connector not in (self.ADD, self.SUB):
             raise TypeError('Connector must be + or -, not %s' % connector)
+        self.timedelta = children.pop()
         super(DateModifierNode, self).__init__(children, connector, negated)
 
     def evaluate(self, evaluator, qn, connection):

--- a/django/db/models/sql/expressions.py
+++ b/django/db/models/sql/expressions.py
@@ -109,11 +109,7 @@ class SQLEvaluator(object):
             return '%s.%s' % (qn(col[0]), qn(col[1])), []
 
     def evaluate_date_modifier_node(self, node, qn, connection):
-        timedelta = node.children.pop()
         sql, params = self.evaluate_node(node, qn, connection)
-        node.children.append(timedelta)
-
-        if (timedelta.days == timedelta.seconds == timedelta.microseconds == 0):
+        if (node.timedelta.days == node.timedelta.seconds == node.timedelta.microseconds == 0):
             return sql, params
-
-        return connection.ops.date_interval_sql(sql, node.connector, timedelta), params
+        return connection.ops.date_interval_sql(sql, node.connector, node.timedelta), params

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2730,6 +2730,15 @@ class IteratorExceptionsTest(TestCase):
         self.assertRaises(FieldError, list, qs)
 
 
+class DateModifierNodeCloneTest(TestCase):
+    def test_ticket_22101(self):
+        qs = Article.objects.filter(
+            created__gte=F('created')-datetime.timedelta(minutes=1))
+        qs2 = qs.all()
+        list(qs)
+        list(qs2)
+
+
 class NullJoinPromotionOrTest(TestCase):
     def setUp(self):
         self.d1 = ModelD.objects.create(name='foo')


### PR DESCRIPTION
...cloned.
