### PR TITLE
Patch 3

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1561,6 +1561,7 @@ class IntegerField(Field):
         'invalid': _("'%(value)s' value must be an integer."),
     }
     description = _("Integer")
+    MAX_SAFE_VALUE = 2147483647
 
     def get_prep_value(self, value):
         value = super(IntegerField, self).get_prep_value(value)
@@ -1590,22 +1591,26 @@ class IntegerField(Field):
             )
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': forms.IntegerField}
+        defaults = {
+            'form_class': forms.IntegerField,
+            'min_value': -IntegerField.MAX_SAFE_VALUE - 1,
+            'max_value': IntegerField.MAX_SAFE_VALUE,
+        }
         defaults.update(kwargs)
         return super(IntegerField, self).formfield(**defaults)
 
 
 class BigIntegerField(IntegerField):
     description = _("Big (8 byte) integer")
-    MAX_BIGINT = 9223372036854775807
+    MAX_SAFE_VALUE = 9223372036854775807
 
     def get_internal_type(self):
         return "BigIntegerField"
 
     def formfield(self, **kwargs):
         defaults = {
-            'min_value': -BigIntegerField.MAX_BIGINT - 1,
-            'max_value': BigIntegerField.MAX_BIGINT,
+            'min_value': -BigIntegerField.MAX_SAFE_VALUE - 1,
+            'max_value': BigIntegerField.MAX_SAFE_VALUE,
         }
         defaults.update(kwargs)
         return super(BigIntegerField, self).formfield(**defaults)
@@ -1782,22 +1787,25 @@ class PositiveIntegerField(IntegerField):
         return "PositiveIntegerField"
 
     def formfield(self, **kwargs):
-        defaults = {'min_value': 0}
+        defaults = {
+            'min_value': 0,
+            'max_value': IntegerField.MAX_SAFE_VALUE,
+        }
         defaults.update(kwargs)
         return super(PositiveIntegerField, self).formfield(**defaults)
 
 
 class SmallIntegerField(IntegerField):
     description = _("Small integer")
-    MAX_SMALLINT = 32767
+    MAX_SAFE_VALUE = 32767
 
     def get_internal_type(self):
         return "SmallIntegerField"
 
     def formfield(self, **kwargs):
         defaults = {
-            'min_value': -SmallIntegerField.MAX_SMALLINT - 1,
-            'max_value': SmallIntegerField.MAX_SMALLINT,
+            'min_value': -SmallIntegerField.MAX_SAFE_VALUE - 1,
+            'max_value': SmallIntegerField.MAX_SAFE_VALUE,
         }
         defaults.update(kwargs)
         return super(SmallIntegerField, self).formfield(**defaults)
@@ -1811,9 +1819,9 @@ class PositiveSmallIntegerField(IntegerField):
 
     def formfield(self, **kwargs):
         defaults = {
-            'min_value': 0,
-            'max_value': SmallIntegerField.MAX_SMALLINT,
-        }
+             'min_value': 0,
+             'max_value': SmallIntegerField.MAX_SAFE_VALUE,
+         }
         defaults.update(kwargs)
         return super(PositiveSmallIntegerField, self).formfield(**defaults)
 


### PR DESCRIPTION
Removed empty_strings_allowed = False in BigIntegerField, because it is already specified in its base class IntegerField.
Added safe default limits to the formfields of SmallIntegerField and PositiveSmallIntegerField according to https://docs.djangoproject.com/en/dev/ref/models/fields/#positivesmallintegerfield and https://docs.djangoproject.com/en/dev/ref/models/fields/#smallintegerfield
The reason is that when I create ModelForm from a model that contains small integers, it is vulnerable by default. You can input large integer and get an exception DataError: smallint out of range. I propose to stay on the safe side and for those backends whose small integers have greater capacity, user must provide his own limits.
