### PR TITLE
Fixed #22112 -- Added RedirectView.pattern_name to CBV flattened index

### DIFF
--- a/docs/ref/class-based-views/flattened-index.txt
+++ b/docs/ref/class-based-views/flattened-index.txt
@@ -54,9 +54,10 @@ RedirectView
 **Attributes** (with optional accessor):
 
 * :attr:`~django.views.generic.base.View.http_method_names`
+* :attr:`~django.views.generic.base.RedirectView.pattern_name`
 * :attr:`~django.views.generic.base.RedirectView.permanent`
 * :attr:`~django.views.generic.base.RedirectView.query_string`
-* :attr:`~django.views.generic.base.RedirectView.url`
+* :attr:`~django.views.generic.base.RedirectView.url` [:meth:`~django.views.generic.base.RedirectView.get_redirect_url`]
 
 **Methods**
 
@@ -64,7 +65,6 @@ RedirectView
 * ``delete()``
 * :meth:`~django.views.generic.base.View.dispatch`
 * ``get()``
-* :meth:`~django.views.generic.base.RedirectView.get_redirect_url`
 * ``head()``
 * :meth:`~django.views.generic.base.View.http_method_not_allowed`
 * ``options()``


### PR DESCRIPTION
Thanks nikunj.sg for the report

pattern_name was introduced in Django 1.6, so we could backport this to 1.6.X as well.
