### PR TITLE
Fixed #12670 -- Added note in documentation

### DIFF
--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -173,6 +173,11 @@ There are a few settings which control Django's file upload behavior:
 
         **Always prefix the mode with a 0.**
 
+    .. note::
+
+        For security reasons, these permissions aren't applied to the
+        temporary files that are stored in `FILE_UPLOAD_TEMP_DIR`.
+
 :setting:`FILE_UPLOAD_DIRECTORY_PERMISSIONS`
     The numeric mode to apply to directories created in the process of
     uploading files. This value mirrors the functionality and caveats of


### PR DESCRIPTION
The file permissions given in the `FILE_UPLOAD_PERMISSIONS` setting
aren't applied to temporary files stored in `FILE_UPLOAD_TEMP_DIR` for
security reasons. This created confusion for some people. A note is
added to the documentation to make it clear.
