### PR TITLE
Fixed #21948 -- Added mention of TEMPLATE_LOADERS to documentation

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1866,7 +1866,10 @@ directory.
 
 In order to override one or more of them, first create an ``admin`` directory
 in your project's ``templates`` directory. This can be any of the directories
-you specified in :setting:`TEMPLATE_DIRS`.
+you specified in :setting:`TEMPLATE_DIRS`. Also ensure
+``django.template.loaders.filesystem.Loader`` is specified before
+``django.template.loaders.app_directories.Loader`` in
+:setting:`TEMPLATE_LOADERS`, which is the default.
 
 Within this ``admin`` directory, create sub-directories named after your app.
 Within these app subdirectories create sub-directories named after your models.


### PR DESCRIPTION
Expanded upon which loaders should be used when overriding the
admin templates, in case the reader has deviated from the default
TEMPLATE_LOADERS setting.
