### PR TITLE
Fixed #22135 -- Implement ModelAdmin.get_changeform_initial_data

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1709,6 +1709,22 @@ templates used by the :class:`ModelAdmin` views:
     ``obj_display`` is a string with the name of the deleted
     object.
 
+.. method:: ModelAdmin.get_changeform_initial_data(request)
+
+    .. versionadded:: 1.7
+
+    A hook for the initial data on admin change forms.
+    By default, fields can be given an initial value from GET parameters.
+    For instance, ``?name=initial_value`` will set the ``name`` field's initial
+    value to be ``initial_value``.
+
+    This method should return a dictionary in the form: ``fieldname: fieldval``.
+
+    .. code-block:: python
+
+        def get_changeform_initial_data(self, request):
+            return {'name': 'custom_initial_value'}
+
 Other methods
 ~~~~~~~~~~~~~
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -308,6 +308,10 @@ Minor features
   <django.contrib.admin.ModelAdmin.list_display>` value by prefixing the
   ``admin_order_field`` value with a hyphen.
 
+* The :meth:`ModelAdmin.get_changeform_initial_data()
+  <django.contrib.admin.ModelAdmin.get_changeform_initial_data>` method may be overridden
+  to define custom behavior for setting initial changeform data.
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -796,6 +796,10 @@ class RestaurantAdmin(admin.ModelAdmin):
     inlines = [WorkerInlineAdmin]
     view_on_site = False
 
+    def get_changeform_initial_data(self, request):
+        return {'name': 'overridden_value'}
+
+
 site = admin.AdminSite(name="admin")
 site.register(Article, ArticleAdmin)
 site.register(CustomArticle, CustomArticleAdmin)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -765,6 +765,19 @@ class AdminViewFormUrlTest(TestCase):
         self.assertTrue('form_url' in response.context, msg='form_url not present in response.context')
         self.assertEqual(response.context['form_url'], 'pony')
 
+    def testInitialDataCanBeOverridden(self):
+        """
+        Tests that the behavior for setting initial
+        form data can be overridden in the ModelAdmin class.
+
+        Usually, the initial value is set via the GET params.
+        """
+        response = self.client.get('/test_admin/%s/admin_views/restaurant/add/' % self.urlbit, {'name': 'test_value'})
+        # this would be the usual behaviour
+        self.assertNotContains(response, 'value="test_value"')
+        # this is the overridden behaviour
+        self.assertContains(response, 'value="overridden_value"')
+
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
 class AdminJavaScriptTest(TestCase):


### PR DESCRIPTION
Allows custom behaviour for setting initial form data in
ModelAdmin to be defined. By default, initial data is
set via GET params. ModelAdmin.get_initial_data allows this
behaviour to be overridden.
