### PR TITLE
Fixed #22172 -- index_together now can be used with a single list

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -1,5 +1,5 @@
 from django.db import models, router
-from django.db.models.options import normalize_unique_together
+from django.db.models.options import normalize_together
 from django.db.migrations.state import ModelState
 from django.db.migrations.operations.base import Operation
 from django.utils import six
@@ -183,7 +183,7 @@ class AlterUniqueTogether(Operation):
 
     def __init__(self, name, unique_together):
         self.name = name
-        unique_together = normalize_unique_together(unique_together)
+        unique_together = normalize_together(unique_together)
         self.unique_together = set(tuple(cons) for cons in unique_together)
 
     def state_forwards(self, app_label, state):
@@ -220,6 +220,7 @@ class AlterIndexTogether(Operation):
 
     def __init__(self, name, index_together):
         self.name = name
+        index_together = normalize_together(index_together)
         self.index_together = set(tuple(cons) for cons in index_together)
 
     def state_forwards(self, app_label, state):

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.apps.registry import Apps
 from django.db import models
-from django.db.models.options import DEFAULT_NAMES, normalize_unique_together
+from django.db.models.options import DEFAULT_NAMES, normalize_together
 from django.utils import six
 from django.utils.module_loading import import_string
 
@@ -145,7 +145,10 @@ class ModelState(object):
             elif name in model._meta.original_attrs:
                 if name == "unique_together":
                     ut = model._meta.original_attrs["unique_together"]
-                    options[name] = set(normalize_unique_together(ut))
+                    options[name] = set(normalize_together(ut))
+                elif name == "index_together":
+                    it = model._meta.original_attrs["index_together"]
+                    options[name] = set(normalize_together(it))
                 else:
                     options[name] = model._meta.original_attrs[name]
         # Make our record

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -24,24 +24,26 @@ DEFAULT_NAMES = ('verbose_name', 'verbose_name_plural', 'db_table', 'ordering',
                  'select_on_save')
 
 
-def normalize_unique_together(unique_together):
+def normalize_together(option_together):
     """
-    unique_together can be either a tuple of tuples, or a single
+    option_together can be either a tuple of tuples, or a single
     tuple of two strings. Normalize it to a tuple of tuples, so that
     calling code can uniformly expect that.
     """
     try:
-        if not unique_together:
+        if not option_together:
             return ()
-        first_element = next(iter(unique_together))
+        if not isinstance(option_together, (tuple, list)):
+            raise TypeError
+        first_element = next(iter(option_together))
         if not isinstance(first_element, (tuple, list)):
-            unique_together = (unique_together,)
+            option_together = (option_together,)
         # Normalize everything to tuples
-        return tuple(tuple(ut) for ut in unique_together)
+        return tuple(tuple(ot) for ot in option_together)
     except TypeError:
-        # If the value of unique_together isn't valid, return it
+        # If the value of option_together isn't valid, return it
         # verbatim; this will be picked up by the check framework later.
-        return unique_together
+        return option_together
 
 
 @python_2_unicode_compatible
@@ -140,7 +142,10 @@ class Options(object):
                     self.original_attrs[attr_name] = getattr(self, attr_name)
 
             ut = meta_attrs.pop('unique_together', self.unique_together)
-            self.unique_together = normalize_unique_together(ut)
+            self.unique_together = normalize_together(ut)
+
+            it = meta_attrs.pop('index_together', self.index_together)
+            self.index_together = normalize_together(it)
 
             # verbose_name_plural is a special case because it uses a 's'
             # by default.

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -340,6 +340,13 @@ Django quotes column and table names behind the scenes.
     This list of fields will be indexed together (i.e. the appropriate
     ``CREATE INDEX`` statement will be issued.)
 
+    .. versionchanged:: 1.7
+
+    For convenience, ``index_together`` can be a single list when dealing with a single
+    set of fields::
+    
+        index_together = ["pub_date", "deadline"]
+
 ``verbose_name``
 ----------------
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -642,6 +642,9 @@ Models
   an error (before that, it would either result in a database error or
   incorrect data).
 
+* You can use a single list for ``index_together`` (rather than a list of lists) 
+  when specifying a single set of fields.
+
 Signals
 ^^^^^^^
 

--- a/tests/indexes/models.py
+++ b/tests/indexes/models.py
@@ -11,6 +11,13 @@ class Article(models.Model):
             ["headline", "pub_date"],
         ]
 
+# Model for index_together being used only with single list
+class IndexTogetherSingleList(models.Model):
+    headline = models.CharField(max_length=100)
+    pub_date = models.DateTimeField()
+
+    class Meta:
+        index_together = ["headline", "pub_date"]
 
 # Indexing a TextField on Oracle or MySQL results in index creation error.
 if connection.vendor == 'postgresql':

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -4,13 +4,19 @@ from django.core.management.color import no_style
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.test import TestCase
 
-from .models import Article
+from .models import Article, IndexTogetherSingleList
 
 
 class IndexesTests(TestCase):
     def test_index_together(self):
         connection = connections[DEFAULT_DB_ALIAS]
         index_sql = connection.creation.sql_indexes_for_model(Article, no_style())
+        self.assertEqual(len(index_sql), 1)
+
+    # Test for using index_together with a single list
+    def test_index_together_single_list(self):
+        connection = connections[DEFAULT_DB_ALIAS]
+        index_sql = connection.creation.sql_indexes_for_model(IndexTogetherSingleList, no_style())
         self.assertEqual(len(index_sql), 1)
 
     @skipUnless(connections[DEFAULT_DB_ALIAS].vendor == 'postgresql',

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -45,10 +45,7 @@ class IndexTogetherTests(IsolatedModelsTestCase):
     def test_list_containing_non_iterable(self):
         class Model(models.Model):
             class Meta:
-                index_together = [
-                    'non-iterable',
-                    'second-non-iterable',
-                ]
+                index_together = [('a', 'b'), 42]
 
         errors = Model.check()
         expected = [
@@ -135,6 +132,22 @@ class UniqueTogetherTests(IsolatedModelsTestCase):
                 hint=None,
                 obj=Model,
                 id='E009',
+            ),
+        ]
+        self.assertEqual(errors, expected)
+
+    def test_non_list(self):
+        class Model(models.Model):
+            class Meta:
+                unique_together = 'not-a-list'
+
+        errors = Model.check()
+        expected = [
+            Error(
+                '"unique_together" must be a list or tuple.',
+                hint=None,
+                obj=Model,
+                id='E008',
             ),
         ]
         self.assertEqual(errors, expected)

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -25,6 +25,7 @@ class StateTests(TestCase):
                 app_label = "migrations"
                 apps = new_apps
                 unique_together = ["name", "bio"]
+                index_together = ["bio", "age"]
 
         class AuthorProxy(Author):
             class Meta:
@@ -63,7 +64,7 @@ class StateTests(TestCase):
         self.assertEqual(author_state.fields[1][1].max_length, 255)
         self.assertEqual(author_state.fields[2][1].null, False)
         self.assertEqual(author_state.fields[3][1].null, True)
-        self.assertEqual(author_state.options, {"unique_together": set([("name", "bio")])})
+        self.assertEqual(author_state.options, {"unique_together": set([("name", "bio")]), "index_together": set([("bio", "age")])})
         self.assertEqual(author_state.bases, (models.Model, ))
 
         self.assertEqual(book_state.app_label, "migrations")


### PR DESCRIPTION
"For convenience, unique_together can be a single tuple when dealing with a single set of fields"
This convenience is missing in index_together

I think this should be there, as using double tuples/lists is not suitable.
Also changing this does not affects the behavior so much, though convenience is bettered.
I have also written the test for it.
Therefore I have opened this PR, please review it.
If it is approved, I will add the changes in the docs as well.

https://code.djangoproject.com/ticket/22172
