### PR TITLE
Fixed #22185 -- Added settings.CSRF_COOKIE_AGE

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -558,6 +558,7 @@ CSRF_FAILURE_VIEW = 'django.views.csrf.csrf_failure'
 
 # Settings for CSRF cookie.
 CSRF_COOKIE_NAME = 'csrftoken'
+CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
 CSRF_COOKIE_DOMAIN = None
 CSRF_COOKIE_PATH = '/'
 CSRF_COOKIE_SECURE = False

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -196,7 +196,7 @@ class CsrfViewMiddleware(object):
         # the expiry timer.
         response.set_cookie(settings.CSRF_COOKIE_NAME,
                             request.META["CSRF_COOKIE"],
-                            max_age=60 * 60 * 24 * 7 * 52,
+                            max_age=settings.CSRF_COOKIE_AGE,
                             domain=settings.CSRF_COOKIE_DOMAIN,
                             path=settings.CSRF_COOKIE_PATH,
                             secure=settings.CSRF_COOKIE_SECURE,

--- a/docs/ref/contrib/csrf.txt
+++ b/docs/ref/contrib/csrf.txt
@@ -491,6 +491,7 @@ Settings
 
 A number of settings can be used to control Django's CSRF behavior:
 
+* :setting:`CSRF_COOKIE_AGE`
 * :setting:`CSRF_COOKIE_DOMAIN`
 * :setting:`CSRF_COOKIE_HTTPONLY`
 * :setting:`CSRF_COOKIE_NAME`

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -320,6 +320,29 @@ See :doc:`/topics/cache`.
 
 .. _settings-csrf:
 
+.. setting:: CSRF_COOKIE_AGE
+
+CSRF_COOKIE_AGE
+---------------
+
+.. versionadded:: 1.7
+
+Default: ``31449600`` (1 year, in seconds)
+
+The age of CSRF cookies, in seconds.
+
+The reason for setting a long-lived expiration time has been to avoid the case if a
+user closed a browser or bookmarked a page and loaded that page from a browser
+cache.  In this case, the form submission would fail so the current behavior is
+to use persistent cookies with an expiry date one year in the future.
+
+Some browsers (specifically Internet Explorer) can disallow the use of
+persistent cookies or can have the indexes to the cookie jar corrupted on disk,
+thereby causing CSRF protection checks to fail (and sometimes intermittently).
+This setting can be changed to be None so that session-based CSRF cookies can be
+configured, which rely on keeping the cookies in-memory instead of persistent
+storage.
+
 .. setting:: CSRF_COOKIE_DOMAIN
 
 CSRF_COOKIE_DOMAIN

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -384,3 +384,48 @@ class CsrfViewMiddlewareTest(TestCase):
         finally:
             logger.removeHandler(test_handler)
             logger.setLevel(old_log_level)
+
+    def test_csrf_cookie_age(self):
+        """
+        Test to verify CSRF cookie age and therefore uses persistent-based cookies.
+        """
+        req = self._get_GET_no_csrf_cookie_request()
+
+        MAX_AGE = 123
+        # Put tests for CSRF_COOKIE_* settings here
+        with self.settings(CSRF_COOKIE_NAME='csrfcookie',
+                           CSRF_COOKIE_DOMAIN='.example.com',
+                           CSRF_COOKIE_AGE=MAX_AGE,
+                           CSRF_COOKIE_PATH='/test/',
+                           CSRF_COOKIE_SECURE=True,
+                           CSRF_COOKIE_HTTPONLY=True):
+            # token_view calls get_token() indirectly
+            CsrfViewMiddleware().process_view(req, token_view, (), {})
+            resp = token_view(req)
+
+            resp2 = CsrfViewMiddleware().process_response(req, resp)
+            max_age = resp2.cookies.get('csrfcookie').get('max-age')
+            self.assertEqual(max_age, MAX_AGE)
+
+    def test_csrf_cookie_age_none(self):
+        """
+        Test to verify CSRF cookie age does not have max age set and therefore uses session-based cookies.
+        """
+        req = self._get_GET_no_csrf_cookie_request()
+
+        MAX_AGE = None
+        # Put tests for CSRF_COOKIE_* settings here
+        with self.settings(CSRF_COOKIE_NAME='csrfcookie',
+                           CSRF_COOKIE_DOMAIN='.example.com',
+                           CSRF_COOKIE_AGE=MAX_AGE,
+                           CSRF_COOKIE_PATH='/test/',
+                           CSRF_COOKIE_SECURE=True,
+                           CSRF_COOKIE_HTTPONLY=True):
+            # token_view calls get_token() indirectly
+            CsrfViewMiddleware().process_view(req, token_view, (), {})
+            resp = token_view(req)
+
+            resp2 = CsrfViewMiddleware().process_response(req, resp)
+            max_age = resp2.cookies.get('csrfcookie').get('max-age')
+            self.assertEqual(max_age, '')
+


### PR DESCRIPTION
Internet Explorer has the ability to block/disable persistent cookies, and corruption of the index.dat cache
(i.e. to disk errors) can cause Django sites to authenticate correctly but fail to do FORM POST's.  To
avoid this behavior, provide the option to configure the CSRF cookie age and set it to be None to be session-based.

Test added and documentation updated.

https://code.djangoproject.com/ticket/22185
