### PR TITLE
Fixed hardcoded call of User model in UserCreationForm

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -96,10 +96,11 @@ class UserCreationForm(forms.ModelForm):
     def clean_username(self):
         # Since User.username is unique, this check is redundant,
         # but it sets a nicer error message than the ORM. See #13147.
+        model = self.Meta.model
         username = self.cleaned_data["username"]
         try:
-            User._default_manager.get(username=username)
-        except User.DoesNotExist:
+            model._default_manager.get(username=username)
+        except model.DoesNotExist:
             return username
         raise forms.ValidationError(
             self.error_messages['duplicate_username'],


### PR DESCRIPTION
When we implement a custom User model based on AbstractUser, we necessarily
have to write a custom UserCreationForm. If username/password behaviors are
not altered, it seems interesting to simply inerhits from UserCreationForm
with model property of Meta class.

But there was a hardcoded call to User model in clean_username() method
that was forbidding this simple inheritance.

Or did I miss something ?

Example :

----- models.py ------
from django.contrib.auth.models import AbstractUser

class CustomUser(AbstractUser):
    # ....

----- admin.py -----
from django.contrib.auth.admin import UserAdmin
from django.contrib.auth.forms import UserCreationForm

class CustomUserCreationForm(UserCreationForm): 
    class Meta:
        model = CustomUser

class CustomUserAdmin(UserAdmin):
    add_form = CustomUserCreationForm
