### PR TITLE
Fixed #21179 -- Added a small section in the "Outputting CSV with Django" about the StreamingHttpResponse

### DIFF
--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -75,6 +75,42 @@ For more information, see the Python documentation of the :mod:`csv` module.
 .. _`csv module's examples section`: http://docs.python.org/library/csv.html#examples
 .. _`python-unicodecsv module`: https://github.com/jdunck/python-unicodecsv
 
+Streaming large files
+~~~~~~~~~~~~~~~~~~~~~
+
+When dealing with views that generate very big responses, you might want to consider using Django's
+:class:`django.http.StreamingHttpResponse` objects instead.
+
+In this example, we want to make full use of Python generators to efficiently
+handle the assembly and transmission of a large CSV file::
+
+    import csv
+    
+    from django.utils.six.moves import range
+    from django.http import StreamingHttpResponse
+
+    class Echo(object):
+        """An object that implements just the write method of the file-like
+        interface.
+        """
+        def write(self, value):
+            """Write the value by returning it, instead of storing in a buffer."""
+            return value
+
+    def some_streaming_csv_view(request):
+        """A view that streams a large CSV file."""
+        # Generate a sequence of rows. The range is based on the maximum number of
+        # rows that can be handled by a single sheet in most spreadsheet
+        # applications.
+        rows = (["Row {0}".format(idx), str(idx)] for idx in range(65536))
+        pseudo_buffer = Echo()
+        writer = csv.writer(pseudo_buffer)
+        response = StreamingHttpResponse((writer.writerow(row) for row in rows),
+                                         content_type="text/csv")
+        response['Content-Disposition'] = 'attachment; filename="somefilename.csv"'
+        return response
+
+
 Using the template system
 =========================
 


### PR DESCRIPTION
This is my attempt to fix #21179.

The example shows how generators can be used with the csv.writer class stream large CSV files.

I have added a few comments on this example on the ticket's page: https://code.djangoproject.com/ticket/21179

This supersedes pull request https://github.com/django/django/pull/2358
