### PR TITLE
Pass --previous to msgmerge

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -389,7 +389,7 @@ class Command(NoArgsCommand):
         pofile = os.path.join(basedir, '%s.po' % str(self.domain))
 
         if os.path.exists(pofile):
-            args = ['msgmerge', '-q']
+            args = ['msgmerge', '-q', '--previous']
             if self.wrap:
                 args.append(self.wrap)
             if self.location:


### PR DESCRIPTION
This allows translators to see what has changed in case string becomes
fuzzy. See ticket #20566
