### PR TITLE
Fix unnecessary escaping of path chars in reverse().

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -418,7 +418,8 @@ class RegexURLResolver(LocaleRegexProvider):
                 # arguments in order to return a properly encoded URL.
                 candidate_pat = prefix_norm.replace('%', '%%') + result
                 if re.search('^%s%s' % (prefix_norm, pattern), candidate_pat % candidate_subs, re.UNICODE):
-                    candidate_subs = dict((k, urlquote(v)) for (k, v) in candidate_subs.items())
+                    candidate_subs = dict((k, urlquote(v, safe='/:@&=+$,')) for
+                                          (k, v) in candidate_subs.items())
                     return candidate_pat % candidate_subs
         # lookup_view can be URL label, or dotted path, or callable, Any of
         # these can be passed in at the top, but callables are not friendly in


### PR DESCRIPTION
The path segments concatenated by reverse() only need to get characters
quoted that are reserved as per section 3.3 of RFC-3986.

Unreserved characters that Django currently quotes as part of the work done
on #13260 are: ":@&=+$,"

Quoting unreserved characters leads to issues in situations where client and
server require unambigious URL representation, like creating a signature base
string in OAuth 1. Here the client produces a digest of a URL with quoted
chars, while the server ends up with a digest of the unquoted chars, leading
to different signatures (see
https://groups.google.com/forum/#!msg/django-developers/ZLGk7T4mJuw/4RqfgbZ-jOQJ).

To address this change still applies urlquote, but excluded the unreserved
path characters.
