### PR TITLE
Fixed #21231 -- Limited request data upload sizes for extra safety.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -303,6 +303,11 @@ FILE_UPLOAD_HANDLERS = (
 # file system instead of into memory.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440 # i.e. 2.5 MB
 
+# Maximum size in bytes of request data before a SuspiciousOperation will
+# be raised.  This applies to accessing request.body, and also to any
+# data in form data requests, excluding file uploads.
+DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440 # i.e. 2.5 MB
+
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory
 # (i.e. "/tmp" on *nix systems).

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -708,6 +708,20 @@ not provided, Django will use ``'test_' + NAME + '_temp'``.
 
 .. setting:: DATABASE_ROUTERS
 
+DATA_UPLOAD_MAX_MEMORY_SIZE
+---------------------------
+
+Default: ``2621440`` (i.e. 2.5 MB).
+
+The maximum size (in bytes) that a request body may contain before raising a
+``SuspiciousOperation`` error.  This value is applied when accessing
+``request.body`` or ``request.POST``, and is calculated against the total
+request size excluding any file upload data.
+
+See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`
+
+.. setting:: DATA_UPLOAD_MAX_MEMORY_SIZE
+
 DATABASE_ROUTERS
 ----------------
 
@@ -1083,6 +1097,8 @@ Default: ``2621440`` (i.e. 2.5 MB).
 
 The maximum size (in bytes) that an upload will be before it gets streamed to
 the file system. See :doc:`/topics/files` for details.
+
+See also :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE`
 
 .. setting:: FILE_UPLOAD_PERMISSIONS
 


### PR DESCRIPTION
Includes `DATA_UPLOAD_MAX_MEMORY_SIZE`, similar to the existing
`FILE_UPLOAD_MAX_MEMORY_SIZE`, and raises `SuspiciousOperation` on
requests that exceed it.

Refs https://code.djangoproject.com/ticket/21231
