### PR TITLE
Fixed #22070 -- Changed verbose_name to use title case

### DIFF
--- a/django/contrib/admin/apps.py
+++ b/django/contrib/admin/apps.py
@@ -8,7 +8,7 @@ class SimpleAdminConfig(AppConfig):
     """Simple AppConfig which does not do automatic discovery."""
 
     name = 'django.contrib.admin'
-    verbose_name = _("administration")
+    verbose_name = _("Administration")
 
     def ready(self):
         checks.register('admin')(check_admin_app)

--- a/django/contrib/admindocs/apps.py
+++ b/django/contrib/admindocs/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class AdminDocsConfig(AppConfig):
     name = 'django.contrib.admindocs'
-    verbose_name = _("administrative documentation")
+    verbose_name = _("Administrative Documentation")

--- a/django/contrib/auth/apps.py
+++ b/django/contrib/auth/apps.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class AuthConfig(AppConfig):
     name = 'django.contrib.auth'
-    verbose_name = _("authentication and authorization")
+    verbose_name = _("Authentication And Authorization")
 
     def ready(self):
         checks.register('models')(check_user_model)

--- a/django/contrib/comments/apps.py
+++ b/django/contrib/comments/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class CommentsConfig(AppConfig):
     name = 'django.contrib.comments'
-    verbose_name = _("comments")
+    verbose_name = _("Comments")

--- a/django/contrib/contenttypes/apps.py
+++ b/django/contrib/contenttypes/apps.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class ContentTypesConfig(AppConfig):
     name = 'django.contrib.contenttypes'
-    verbose_name = _("content types")
+    verbose_name = _("Content Types")
 
     def ready(self):
         checks.register('models')(check_generic_foreign_keys)

--- a/django/contrib/flatpages/apps.py
+++ b/django/contrib/flatpages/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class FlatPagesConfig(AppConfig):
     name = 'django.contrib.flatpages'
-    verbose_name = _("flat pages")
+    verbose_name = _("Flat Pages")

--- a/django/contrib/formtools/apps.py
+++ b/django/contrib/formtools/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class FormToolsConfig(AppConfig):
     name = 'django.contrib.formtools'
-    verbose_name = _("form tools")
+    verbose_name = _("Form Tools")

--- a/django/contrib/humanize/apps.py
+++ b/django/contrib/humanize/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class HumanizeConfig(AppConfig):
     name = 'django.contrib.humanize'
-    verbose_name = _("humanize")
+    verbose_name = _("Humanize")

--- a/django/contrib/messages/apps.py
+++ b/django/contrib/messages/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class MessagesConfig(AppConfig):
     name = 'django.contrib.messages'
-    verbose_name = _("messages")
+    verbose_name = _("Messages")

--- a/django/contrib/redirects/apps.py
+++ b/django/contrib/redirects/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class RedirectsConfig(AppConfig):
     name = 'django.contrib.redirects'
-    verbose_name = _("redirects")
+    verbose_name = _("Redirects")

--- a/django/contrib/sessions/apps.py
+++ b/django/contrib/sessions/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class SessionsConfig(AppConfig):
     name = 'django.contrib.sessions'
-    verbose_name = _("sessions")
+    verbose_name = _("Sessions")

--- a/django/contrib/sitemaps/apps.py
+++ b/django/contrib/sitemaps/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class SiteMapsConfig(AppConfig):
     name = 'django.contrib.sitemaps'
-    verbose_name = _("site maps")
+    verbose_name = _("Site Maps")

--- a/django/contrib/sites/apps.py
+++ b/django/contrib/sites/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class SitesConfig(AppConfig):
     name = 'django.contrib.sites'
-    verbose_name = _("sites")
+    verbose_name = _("Sites")

--- a/django/contrib/staticfiles/apps.py
+++ b/django/contrib/staticfiles/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class StaticFilesConfig(AppConfig):
     name = 'django.contrib.staticfiles'
-    verbose_name = _("static files")
+    verbose_name = _("Static Files")

--- a/django/contrib/syndication/apps.py
+++ b/django/contrib/syndication/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class SyndicationConfig(AppConfig):
     name = 'django.contrib.syndication'
-    verbose_name = _("syndication")
+    verbose_name = _("Syndication")

--- a/django/contrib/webdesign/apps.py
+++ b/django/contrib/webdesign/apps.py
@@ -5,4 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class WebDesignConfig(AppConfig):
     name = 'django.contrib.webdesign'
-    verbose_name = _("web design")
+    verbose_name = _("Web Design")


### PR DESCRIPTION
Changed verbose_name in each apps.py under django.contrib to match title casing used in AppConfig.
