### PR TITLE
Fix unnecessary escaping of path chars in reverse() (#22223)

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -418,7 +418,8 @@ class RegexURLResolver(LocaleRegexProvider):
                 # arguments in order to return a properly encoded URL.
                 candidate_pat = prefix_norm.replace('%', '%%') + result
                 if re.search('^%s%s' % (prefix_norm, pattern), candidate_pat % candidate_subs, re.UNICODE):
-                    candidate_subs = dict((k, urlquote(v)) for (k, v) in candidate_subs.items())
+                    candidate_subs = dict((k, urlquote(v, safe='/:@&=+$,')) for
+                                          (k, v) in candidate_subs.items())
                     return candidate_pat % candidate_subs
         # lookup_view can be URL label, or dotted path, or callable, Any of
         # these can be passed in at the top, but callables are not friendly in

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -1704,15 +1704,16 @@ class TemplateTests(TestCase):
             'url08': ('{% url "метка_оператора" v %}', {'v': 'Ω'}, '/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4/%CE%A9/'),
             'url09': ('{% url "метка_оператора_2" tag=v %}', {'v': 'Ω'}, '/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4/%CE%A9/'),
             'url10': ('{% url "template_tests.views.client_action" id=client.id action="two words" %}', {'client': {'id': 1}}, '/client/1/two%20words/'),
-            'url11': ('{% url "template_tests.views.client_action" id=client.id action="==" %}', {'client': {'id': 1}}, '/client/1/%3D%3D/'),
-            'url12': ('{% url "template_tests.views.client_action" id=client.id action="," %}', {'client': {'id': 1}}, '/client/1/%2C/'),
+            'url11': ('{% url "template_tests.views.client_action" id=client.id action="==" %}', {'client': {'id': 1}}, '/client/1/==/'),
+            'url12': ('{% url "template_tests.views.client_action" id=client.id action="," %}', {'client': {'id': 1}}, '/client/1/,/'),
             'url13': ('{% url "template_tests.views.client_action" id=client.id action=arg|join:"-" %}', {'client': {'id': 1}, 'arg': ['a', 'b']}, '/client/1/a-b/'),
             'url14': ('{% url "template_tests.views.client_action" client.id arg|join:"-" %}', {'client': {'id': 1}, 'arg': ['a', 'b']}, '/client/1/a-b/'),
             'url15': ('{% url "template_tests.views.client_action" 12 "test" %}', {}, '/client/12/test/'),
-            'url18': ('{% url "template_tests.views.client" "1,2" %}', {}, '/client/1%2C2/'),
+            'url18': ('{% url "template_tests.views.client" "1,2" %}', {}, '/client/1,2/'),
 
             'url19': ('{% url named_url client.id %}', {'named_url': 'template_tests.views.client', 'client': {'id': 1}}, '/client/1/'),
             'url20': ('{% url url_name_in_var client.id %}', {'url_name_in_var': 'named.client', 'client': {'id': 1}}, '/named-client/1/'),
+            'url21': ('{% url "unreserved.client" ":@&=+$," %}', {}, '/unreserved-client/:@&=+$,'),
 
             # Failures
             'url-fail01': ('{% url %}', {}, template.TemplateSyntaxError),

--- a/tests/template_tests/urls.py
+++ b/tests/template_tests/urls.py
@@ -13,6 +13,7 @@ urlpatterns = patterns('',
     (r'^client/(?P<id>\d+)/(?P<action>[^/]+)/$', views.client_action),
     (r'^client/(?P<client_id>\d+)/(?P<action>[^/]+)/$', views.client_action),
     url(r'^named-client/(\d+)/$', views.client2, name="named.client"),
+    url(r'^unreserved-client/(.+)$', views.client2, name="unreserved.client"),
 
     # Unicode strings are permitted everywhere.
     url(r'^Юникод/(\w+)/$', views.client2, name="метка_оператора"),


### PR DESCRIPTION
The path segments concatenated by reverse() only need to get characters
quoted that are reserved as per section 3.3 of RFC-3986.

Unreserved characters that Django currently quotes as part of the work done
on #13260 are: ":@&=+$,"

Quoting unreserved characters leads to issues in situations where client and
server require unambigious URL representation, like creating a signature base
string in OAuth 1. Here the client produces a digest of a URL with quoted
chars, while the server ends up with a digest of the unquoted chars, leading
to different signatures (see
https://groups.google.com/forum/#!msg/django-developers/ZLGk7T4mJuw/4RqfgbZ-jOQJ).

To address this change still applies urlquote, but excludes the unreserved
path characters.
