### PR TITLE
Fixed #22224 -- Non-nullable empty string based fields handling of `None`

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -19,7 +19,7 @@ from django import forms
 from django.core import exceptions, validators, checks
 from django.utils.datastructures import DictWrapper
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
-from django.utils.functional import curry, total_ordering, Promise
+from django.utils.functional import cached_property, curry, total_ordering, Promise
 from django.utils.text import capfirst
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -91,7 +91,12 @@ class Field(RegisterLookupMixin):
     # Designates whether empty strings fundamentally are allowed at the
     # database level.
     empty_strings_allowed = True
-    empty_values = list(validators.EMPTY_VALUES)
+
+    def _empty_values(self):
+        if self.empty_strings_allowed and not self.null:
+            return ['']
+        return [None, '']
+    empty_values = cached_property(_empty_values)
 
     # These track each time a Field instance is created. Used to retain order.
     # The auto_creation_counter is used for fields that Django implicitly

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -67,6 +67,10 @@ class NullBooleanModel(models.Model):
     nbfield = models.NullBooleanField()
 
 
+class NotNullEmptyStringBasedModel(models.Model):
+    field = models.CharField(max_length=100, blank=True)
+
+
 class BooleanModel(models.Model):
     bfield = models.BooleanField(default=None)
     string = models.CharField(max_length=10, default='abc')

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -23,7 +23,7 @@ from django.utils.functional import lazy
 from .models import (
     Foo, Bar, Whiz, BigD, BigS, BigInt, Post, NullBooleanModel,
     BooleanModel, PrimaryKeyCharModel, DataModel, Document, RenamedField,
-    VerboseNameField, FksToBooleans, FkToChar)
+    VerboseNameField, FksToBooleans, FkToChar, NotNullEmptyStringBasedModel)
 
 
 class BasicFieldTests(test.TestCase):
@@ -51,6 +51,11 @@ class BasicFieldTests(test.TestCase):
             nullboolean.full_clean()
         except ValidationError as e:
             self.fail("NullBooleanField failed validation with value of None: %s" % e.messages)
+
+    def test_not_null_blank_string_based_field(self):
+        stringbased = NotNullEmptyStringBasedModel(field=None)
+        with self.assertRaises(ValidationError):
+            stringbased.full_clean()
 
     def test_field_repr(self):
         """


### PR DESCRIPTION
Those fields shouldn't consider `None` as an empty value.
