### PR TITLE
Fix for ticket #22234

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -1,5 +1,4 @@
-import os
-import sys
+import subprocess
 
 from django.db.backends import BaseDatabaseClient
 
@@ -34,7 +33,4 @@ class DatabaseClient(BaseDatabaseClient):
         if db:
             args += [db]
 
-        if os.name == 'nt':
-            sys.exit(os.system(" ".join(args)))
-        else:
-            os.execvp(self.executable_name, args)
+        subprocess.call(args)

--- a/django/db/backends/oracle/client.py
+++ b/django/db/backends/oracle/client.py
@@ -1,5 +1,4 @@
-import os
-import sys
+import subprocess
 
 from django.db.backends import BaseDatabaseClient
 
@@ -10,7 +9,4 @@ class DatabaseClient(BaseDatabaseClient):
     def runshell(self):
         conn_string = self.connection._connect_string()
         args = [self.executable_name, "-L", conn_string]
-        if os.name == 'nt':
-            sys.exit(os.system(" ".join(args)))
-        else:
-            os.execvp(self.executable_name, args)
+        subprocess.call(args)

--- a/django/db/backends/postgresql_psycopg2/client.py
+++ b/django/db/backends/postgresql_psycopg2/client.py
@@ -1,5 +1,4 @@
-import os
-import sys
+import subprocess
 
 from django.db.backends import BaseDatabaseClient
 
@@ -17,7 +16,4 @@ class DatabaseClient(BaseDatabaseClient):
         if settings_dict['PORT']:
             args.extend(["-p", str(settings_dict['PORT'])])
         args += [settings_dict['NAME']]
-        if os.name == 'nt':
-            sys.exit(os.system(" ".join(args)))
-        else:
-            os.execvp(self.executable_name, args)
+        subprocess.call(args)

--- a/django/db/backends/sqlite3/client.py
+++ b/django/db/backends/sqlite3/client.py
@@ -1,5 +1,4 @@
-import os
-import sys
+import subprocess
 
 from django.db.backends import BaseDatabaseClient
 
@@ -10,7 +9,4 @@ class DatabaseClient(BaseDatabaseClient):
     def runshell(self):
         args = [self.executable_name,
                 self.connection.settings_dict['NAME']]
-        if os.name == 'nt':
-            sys.exit(os.system(" ".join(args)))
-        else:
-            os.execvp(self.executable_name, args)
+        subprocess.call(args)


### PR DESCRIPTION
On Windows platforms, `os.system` is used to invoke the dbshell command, but special characters in parameters (e.g. in the password) are not escaped in any way. `subprocess.call` takes care of stringification of argument lists on Windows platforms.
