### PR TITLE
Incorrect description of startproject command

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1225,7 +1225,7 @@ through the template engine: the files whose extensions match the
 with the ``--name`` option. The :class:`template context
 <django.template.Context>` used is:
 
-- Any option passed to the startapp command (among the command's supported
+- Any option passed to the startproject command (among the command's supported
   options)
 - ``project_name`` -- the project name as passed to the command
 - ``project_directory`` -- the full path of the newly created project


### PR DESCRIPTION
The startproject command said that any option passed to "startapp" (instead of "startproject") would be passed in the template context. Although this seems like an obvious mistake, it made me initially wonder if the startproject command also took a startapp argument
