### PR TITLE
Typo in the PATH fallback

### DIFF
--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -57,7 +57,7 @@ def handle_extensions(extensions=('html',), ignored=('py',)):
 
 def find_command(cmd, path=None, pathext=None):
     if path is None:
-        path = os.environ.get('PATH', []).split(os.pathsep)
+        path = os.environ.get('PATH', '').split(os.pathsep)
     if isinstance(path, six.string_types):
         path = [path]
     # check if there are funny path extensions for executables, e.g. Windows

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -1,8 +1,9 @@
 import sys
+import os
 
 from django.core import management
 from django.core.management import CommandError
-from django.core.management.utils import popen_wrapper
+from django.core.management.utils import popen_wrapper, find_command
 from django.test import SimpleTestCase
 from django.utils import translation
 from django.utils.six import StringIO
@@ -59,6 +60,19 @@ class CommandTests(SimpleTestCase):
         with translation.override('pl'):
             management.call_command('leave_locale_alone_true', stdout=out)
             self.assertEqual(out.getvalue(), "pl\n")
+
+    def test_find_command_without_PATH(self):
+        """
+        find_command should still work when the PATH environment variable
+        doesn't exist (#22256).
+        """
+        current_path = os.environ.pop('PATH', None)
+
+        try:
+            self.assertIs(None, find_command('_missing_'))
+        finally:
+            if current_path is not None:
+                os.environ['PATH'] = current_path
 
 
 class UtilsTests(SimpleTestCase):


### PR DESCRIPTION
The fallback for PATH was [], but that leads to "'list' object has no attribute 'split'"

This corrects that fallback to ''

Includes a unit test to prevent regression.
