### PR TITLE
Fix KeyError in _rel_agnostic_fields_ref for uncommon `rel.to` setup

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -71,7 +71,11 @@ class MigrationAutodetector(object):
             for name, field in fields:
                 deconstruction = field.deconstruct()[1:]
                 if field.rel and field.rel.to:
-                    del deconstruction[2]['to']
+                    try:
+                        del deconstruction[2]['to']
+                    except KeyError:
+                        # `rel.to` does not have to come from kwargs.
+                        pass
                 fields_def.append(deconstruction)
             return fields_def
 


### PR DESCRIPTION
NOTE: I am not sure, if this is a bug with django-taggit instead, which should have returned `to` in its deconstruction.

django-taggit manually sets up `rel.to` and therefore there is no "to" kwarg.

Fixes https://code.djangoproject.com/ticket/22263
Ref: https://github.com/alex/django-taggit/issues/206
