### PR TITLE
Fix for #22232

### DIFF
--- a/django/template/__init__.py
+++ b/django/template/__init__.py
@@ -60,7 +60,7 @@ from django.template.base import (ALLOWED_VARIABLE_CHARS, BLOCK_TAG_END,  # NOQA
 # Exceptions
 from django.template.base import (ContextPopException, InvalidTemplateLibrary,  # NOQA
     TemplateDoesNotExist, TemplateEncodingError, TemplateSyntaxError,
-    VariableDoesNotExist)
+    VariableDoesNotExist, TemplateRecursionError)
 
 # Template parts
 from django.template.base import (Context, FilterExpression, Lexer, Node,  # NOQA

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -77,6 +77,10 @@ class TemplateSyntaxError(Exception):
     pass
 
 
+class TemplateRecursionError(Exception):
+    pass
+
+
 class TemplateDoesNotExist(Exception):
     pass
 

--- a/tests/template_tests/templates/recursive_extends_child.html
+++ b/tests/template_tests/templates/recursive_extends_child.html
@@ -1,0 +1,1 @@
+{% extends "recursive_extends_parent.html" %}

--- a/tests/template_tests/templates/recursive_extends_parent.html
+++ b/tests/template_tests/templates/recursive_extends_parent.html
@@ -1,0 +1,1 @@
+{% extends "recursive_extends_child.html" %}

--- a/tests/template_tests/templates/recursive_extends_self.html
+++ b/tests/template_tests/templates/recursive_extends_self.html
@@ -1,0 +1,1 @@
+{% extends "recursive_extends_self.html" %}

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -12,7 +12,7 @@ from django import template
 from django.conf import settings
 from django.core import urlresolvers
 from django.template import (base as template_base, loader, Context,
-    RequestContext, Template, TemplateSyntaxError)
+    RequestContext, Template, TemplateSyntaxError, TemplateRecursionError)
 from django.template.loaders import app_directories, filesystem, cached
 from django.test import RequestFactory, TestCase
 from django.test.utils import (setup_test_template_loader,
@@ -392,6 +392,18 @@ class TemplateLoaderTests(TestCase):
             "Recursion!  A1  Recursion!  B1   B2   B3  Recursion!  C1",
             t.render(Context({'comments': comments})).replace(' ', '').replace('\n', ' ').strip(),
         )
+
+    def test_extends_recursive(self):
+        """
+        Tests for #22232 preventing RuntimeError Maximum Recursion Depth Exceeded when a circular extension is detected.
+        """
+        with self.assertRaises(TemplateRecursionError):
+            t = loader.get_template('recursive_extends_self.html')
+            t.render(Context({}))
+        
+        with self.assertRaises(TemplateRecursionError):
+            t = loader.get_template('recursive_extends_child.html')
+            t.render(Context({}))
 
 
 class TemplateRegressionTests(TestCase):


### PR DESCRIPTION
Fix for #22232 preventing RuntimeError Maximum Recursion Depth Exceeded when a template extends itself.
https://code.djangoproject.com/ticket/22232
