### PR TITLE
Fixed #22184 -- Isolated template_tests.tests

### DIFF
--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -641,6 +641,7 @@ class TemplateTests(TestCase):
     def get_template_tests(self):
         # SYNTAX --
         # 'template_name': ('template contents', 'context dict', 'expected string output' or Exception class)
+        from .templatetags import custom
         basedir = os.path.dirname(os.path.abspath(upath(__file__)))
         tests = {
             ### BASIC SYNTAX ################################################


### PR DESCRIPTION
import was missing in `get_template_tests` which i used in creation of `cache_loader`
