### PR TITLE
Fixed return image dimensions

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -66,7 +66,7 @@ def get_image_dimensions(file_or_path, close=False):
             if p.image:
                 return p.image.size
             chunk_size *= 2
-        return None
+        return None, None
     finally:
         if close:
             file.close()


### PR DESCRIPTION
Return tuple of None if image is not valid

I use ImageField for get image and other files.
If I get other files then Django return exception `TypeError: 'NoneType' object has no attribute '__getitem__'`
