### PR TITLE
Fixed failing test in gis app

### DIFF
--- a/django/contrib/gis/tests/gis_migrations/migrations/0001_initial.py
+++ b/django/contrib/gis/tests/gis_migrations/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
             name='Neighborhood',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.TextField(unique=True)),
+                ('name', models.CharField(max_length=100, unique=True)),
                 ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=4326, null=True)),
             ],
             options={
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('neighborhood', models.ForeignKey(to='gis.Neighborhood', to_field='id', null=True)),
-                ('address', models.TextField()),
+                ('address', models.CharField(max_length=100)),
                 ('zip_code', models.IntegerField(null=True, blank=True)),
                 ('geom', django.contrib.gis.db.models.fields.PointField(srid=4326, null=True, geography=True)),
             ],


### PR DESCRIPTION
The migrations test in the `contrib.gis` app was failing on MySQL due to an incompatible field definition.  This PR fixes that.

http://ci.djangoproject.com/job/Django/database=mysql_gis,python=python2.7/4198/testReport/junit/django.contrib.gis.tests.gis_migrations.test_commands/MigrateTests/test_migrate_gis/
