### PR TITLE
Fixed #16735 - Queryset values should be aliasable

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -617,8 +617,10 @@ class QuerySet(object):
                 params=params, translations=translations,
                 using=using)
 
-    def values(self, *fields):
-        return self._clone(klass=ValuesQuerySet, setup=True, _fields=fields)
+    def values(self, *fields, **aliased_fields):
+        cls = self._clone(klass=ValuesQuerySet, setup=True, _fields=fields,
+                           _aliased_fields=aliased_fields)
+        return cls
 
     def values_list(self, *fields, **kwargs):
         flat = kwargs.pop('flat', False)
@@ -1094,21 +1096,31 @@ class ValuesQuerySet(QuerySet):
         self.query.clear_deferred_loading()
         self.query.clear_select_fields()
 
-        if self._fields:
+        aliased_fields = getattr(self, '_aliased_fields', {})
+        all_fields = None
+
+        if self._fields or aliased_fields:
             self.extra_names = []
             self.aggregate_names = []
+            all_fields = list(self._fields) + aliased_fields.keys()
             if not self.query._extra and not self.query._aggregates:
                 # Short cut - if there are no extra or aggregates, then
                 # the values() clause must be just field names.
-                self.field_names = list(self._fields)
+                self.field_names = all_fields
             else:
                 self.query.default_cols = False
                 self.field_names = []
-                for f in self._fields:
+                for f in all_fields:
                     # we inspect the full extra_select list since we might
                     # be adding back an extra select item that we hadn't
                     # had selected previously.
-                    if self.query._extra and f in self.query._extra:
+                    real_f = f
+                    if f in aliased_fields:
+                        real_f = aliased_fields[f]
+                    if self.query._extra and real_f in self.query._extra:
+                        if f in aliased_fields:
+                            self.query._extra[f] = self.query._extra[real_f]
+                            del self.query._extra[real_f]
                         self.extra_names.append(f)
                     elif f in self.query.aggregate_select:
                         self.aggregate_names.append(f)
@@ -1121,6 +1133,8 @@ class ValuesQuerySet(QuerySet):
             self.aggregate_names = None
 
         self.query.select = []
+        if hasattr(self, '_aliased_fields'):
+            self.query.aliased_fields = self._aliased_fields
         if self.extra_names is not None:
             self.query.set_extra_mask(self.extra_names)
         self.query.add_fields(self.field_names, True)
@@ -1136,9 +1150,11 @@ class ValuesQuerySet(QuerySet):
             # Only clone self._fields if _fields wasn't passed into the cloning
             # call directly.
             c._fields = self._fields[:]
-        c.field_names = self.field_names
-        c.extra_names = self.extra_names
-        c.aggregate_names = self.aggregate_names
+        if not hasattr(c, '_aliased_fields') and hasattr(self, '_aliased_fields'):
+            c._aliased_fields = self._aliased_fields
+        c.field_names = None if self.field_names is None else self.field_names[:]
+        c.extra_names = None if self.extra_names is None else self.extra_names[:]
+        c.aggregate_names = None if self.aggregate_names is None else self.aggregate_names[:]
         if setup and hasattr(c, '_setup_query'):
             c._setup_query()
         return c
@@ -1171,8 +1187,10 @@ class ValuesQuerySet(QuerySet):
         returned). This differs from QuerySet.as_sql(), where the column to
         select is set up by Django.
         """
-        if ((self._fields and len(self._fields) > 1) or
-                (not self._fields and len(self.model._meta.fields) > 1)):
+        aliased_fields = getattr(self, '_aliased_fields', {})
+        all_fields = list(self._fields) + aliased_fields.values()
+        if ((all_fields and len(all_fields) > 1) or
+                (not all_fields and len(self.model._meta.fields) > 1)):
             raise TypeError('Cannot use a multi-field %s as a filter value.'
                     % self.__class__.__name__)
 
@@ -1186,8 +1204,10 @@ class ValuesQuerySet(QuerySet):
         Validates that we aren't trying to do a query like
         value__in=qs.values('value1', 'value2'), which isn't valid.
         """
-        if ((self._fields and len(self._fields) > 1) or
-                (not self._fields and len(self.model._meta.fields) > 1)):
+        aliased_fields = getattr(self, '_aliased_fields', {})
+        all_fields = list(self._fields) + aliased_fields.values()
+        if ((all_fields and len(all_fields) > 1) or
+                (not all_fields and len(self.model._meta.fields) > 1)):
             raise TypeError('Cannot use a multi-field %s as a filter value.'
                     % self.__class__.__name__)
         return self

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -206,27 +206,27 @@ class SQLCompiler(object):
             col_aliases = set()
         if self.query.select:
             only_load = self.deferred_to_columns()
-            for col, _ in self.query.select:
+            for col, _, column_alias in self.query.select:
                 if isinstance(col, (list, tuple)):
                     alias, column = col
                     table = self.query.alias_map[alias].table_name
                     if table in only_load and column not in only_load[table]:
                         continue
                     r = '%s.%s' % (qn(alias), qn(column))
-                    if with_aliases:
-                        if col[1] in col_aliases:
+                    a = r
+                    c = column
+                    if column_alias or with_aliases:
+                        if column_alias in col_aliases or (not column_alias and column in col_aliases):
                             c_alias = 'Col%d' % len(col_aliases)
-                            result.append('%s AS %s' % (r, c_alias))
-                            aliases.add(c_alias)
-                            col_aliases.add(c_alias)
+                            a = c_alias
                         else:
-                            result.append('%s AS %s' % (r, qn2(col[1])))
-                            aliases.add(r)
-                            col_aliases.add(col[1])
-                    else:
-                        result.append(r)
-                        aliases.add(r)
-                        col_aliases.add(col[1])
+                            c_alias = column_alias or column
+                            a = column_alias or a
+                        r = '%s AS %s' % (r, qn2(c_alias))
+                        c = c_alias
+                    result.append(r)
+                    aliases.add(a)
+                    col_aliases.add(c)
                 else:
                     col_sql, col_params = self.compile(col)
                     result.append(col_sql)
@@ -251,7 +251,7 @@ class SQLCompiler(object):
                 result.append('%s AS %s' % (agg_sql, qn(truncate_name(alias, max_name_length))))
             params.extend(agg_params)
 
-        for (table, col), _ in self.query.related_select_cols:
+        for (table, col), _, _ in self.query.related_select_cols:
             r = '%s.%s' % (qn(table), qn(col))
             if with_aliases and col in col_aliases:
                 c_alias = 'Col%d' % len(col_aliases)
@@ -404,7 +404,8 @@ class SQLCompiler(object):
                 group_by.append((str(field), []))
                 continue
             col, order = get_order_dir(field, asc)
-            if col in self.query.aggregate_select:
+            if (col in self.query.aggregate_select or
+                col in (a for _,_,a in self.query.select if a)):
                 result.append('%s %s' % (qn(col), order))
                 continue
             if '.' in field:
@@ -642,7 +643,7 @@ class SQLCompiler(object):
             columns, _ = self.get_default_columns(start_alias=alias,
                     opts=f.rel.to._meta, as_pairs=True)
             self.query.related_select_cols.extend(
-                SelectInfo((col[0], col[1].column), col[1]) for col in columns)
+                SelectInfo((col[0], col[1].column), col[1], None) for col in columns)
             if restricted:
                 next = requested.get(f.name, {})
             else:
@@ -669,7 +670,7 @@ class SQLCompiler(object):
                 columns, _ = self.get_default_columns(start_alias=alias,
                     opts=model._meta, as_pairs=True, from_parent=from_parent)
                 self.query.related_select_cols.extend(
-                    SelectInfo((col[0], col[1].column), col[1]) for col in columns)
+                    SelectInfo((col[0], col[1].column), col[1], None) for col in columns)
                 next = requested.get(f.related_query_name(), {})
                 self.fill_related_selections(model._meta, alias, cur_depth + 1,
                                              next, restricted)

--- a/django/db/models/sql/constants.py
+++ b/django/db/models/sql/constants.py
@@ -28,7 +28,7 @@ JoinInfo = namedtuple('JoinInfo',
                       'join_cols nullable join_field')
 
 # Pairs of column clauses to select, and (possibly None) field for the clause.
-SelectInfo = namedtuple('SelectInfo', 'col field')
+SelectInfo = namedtuple('SelectInfo', 'col field alias')
 
 # How many results to expect from a cursor.execute call
 MULTI = 'multi'

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -77,7 +77,7 @@ class DeleteQuery(Query):
             else:
                 innerq.clear_select_clause()
                 innerq.select = [
-                    SelectInfo((self.get_initial_alias(), pk.column), None)
+                    SelectInfo((self.get_initial_alias(), pk.column), None, None)
                 ]
                 values = innerq
             self.where = self.where_class()
@@ -229,7 +229,7 @@ class DateQuery(Query):
         alias = result[3][-1]
         select = self._get_select((alias, field.column), lookup_type)
         self.clear_select_clause()
-        self.select = [SelectInfo(select, None)]
+        self.select = [SelectInfo(select, None, None)]
         self.distinct = True
         self.order_by = [1] if order == 'ASC' else [-1]
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -438,7 +438,7 @@ Examples (those after the first will only work on PostgreSQL)::
 values
 ~~~~~~
 
-.. method:: values(*fields)
+.. method:: values(*fields, **aliased_fields)
 
 Returns a ``ValuesQuerySet`` — a ``QuerySet`` subclass that returns
 dictionaries when used as an iterable, rather than model-instance objects.
@@ -469,6 +469,16 @@ Example::
     [{'id': 1, 'name': 'Beatles Blog', 'tagline': 'All the latest Beatles news.'}],
     >>> Blog.objects.values('id', 'name')
     [{'id': 1, 'name': 'Beatles Blog'}]
+
+Additionally, the ``values()`` method takes optional keyword arguments,
+``**aliased_fields``, which give aliases under which the ``SELECT`` etrieves the
+fields.  If used, the returned dictionary will contain the values of the ields
+under the corresponding alias provided.
+
+Example::
+
+    >>> Blog.objects.values('id', blog_name='name')
+    [{'id': 1, 'blog_name': 'Beatles Blog'}]
 
 A few subtleties that are worth mentioning:
 


### PR DESCRIPTION
Adds the ability to provide aliased field names on .values() querysets.  See https://code.djangoproject.com/ticket/16735 for discussion.
