### PR TITLE
Fix _alter_many_to_many to not rename the table to itself

### DIFF
--- a/django/db/backends/schema.py
+++ b/django/db/backends/schema.py
@@ -762,7 +762,8 @@ class BaseDatabaseSchemaEditor(object):
         Alters M2Ms to repoint their to= endpoints.
         """
         # Rename the through table
-        self.alter_db_table(old_field.rel.through, old_field.rel.through._meta.db_table, new_field.rel.through._meta.db_table)
+        if old_field.rel.through._meta.db_table != new_field.rel.through._meta.db_table:
+            self.alter_db_table(old_field.rel.through, old_field.rel.through._meta.db_table, new_field.rel.through._meta.db_table)
         # Repoint the FK to the other side
         self.alter_field(
             new_field.rel.through,

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -161,6 +161,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         """
         Alters M2Ms to repoint their to= endpoints.
         """
+        if old_field.rel.through == new_field.rel.through:
+            return
+
         # Make a new through table
         self.create_model(new_field.rel.through)
         # Copy the data across

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -347,6 +347,15 @@ class SchemaTests(TransactionTestCase):
             # Ensure there is now an m2m table there
             columns = self.column_classes(new_field.rel.through)
             self.assertEqual(columns['tagm2mtest_id'][0], "IntegerField")
+
+            # "Alter" the field. This should not rename the DB table to itself.
+            with connection.schema_editor() as editor:
+                editor.alter_field(
+                    Author,
+                    new_field,
+                    new_field
+                )
+
             # Remove the M2M table again
             with connection.schema_editor() as editor:
                 editor.remove_field(


### PR DESCRIPTION
Fixes #22293.

https://code.djangoproject.com/ticket/22293
