### PR TITLE
Fixed #12030 -- Validate integer field range at the model level.

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -617,6 +617,16 @@ class BaseDatabaseOperations(object):
     """
     compiler_module = "django.db.models.sql.compiler"
 
+    # Integer field safe ranges by `internal_type` as documented
+    # in docs/ref/models/fields.txt.
+    integer_field_ranges = {
+        'SmallIntegerField': (-32768, 32767),
+        'IntegerField': (-2147483648, 2147483647),
+        'BigIntegerField': (-9223372036854775808, 9223372036854775807),
+        'PositiveSmallIntegerField': (0, 32767),
+        'PositiveIntegerField': (0, 2147483647),
+    }
+
     def __init__(self, connection):
         self.connection = connection
         self._cache = None
@@ -1100,6 +1110,14 @@ class BaseDatabaseOperations(object):
         backend due to #10888.
         """
         return params
+
+    def integer_field_range(self, internal_type):
+        """
+        Given an integer field internal type (e.g. 'PositiveIntegerField'),
+        returns a tuple of the (min_value, max_value) form representing the
+        range of the column type bound to the field.
+        """
+        return self.integer_field_ranges[internal_type]
 
 
 # Structure returned by the DB-API cursor.description interface (PEP 249)

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -223,6 +223,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = "django.db.backends.mysql.compiler"
 
+    # MySQL stores positive fields as UNSIGNED ints.
+    integer_field_ranges = dict(BaseDatabaseOperations.integer_field_ranges,
+        PositiveSmallIntegerField=(0, 4294967295),
+        PositiveIntegerField=(0, 18446744073709551615),
+    )
+
     def date_extract_sql(self, lookup_type, field_name):
         # http://dev.mysql.com/doc/mysql/en/date-and-time-functions.html
         if lookup_type == 'week_day':

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -121,6 +121,15 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = "django.db.backends.oracle.compiler"
 
+    # Oracle uses NUMBER(11) and NUMBER(19) for integer fields.
+    integer_field_ranges = {
+        'SmallIntegerField': (-99999999999, 99999999999),
+        'IntegerField': (-99999999999, 99999999999),
+        'BigIntegerField': (-9999999999999999999, 9999999999999999999),
+        'PositiveSmallIntegerField': (0, 99999999999),
+        'PositiveIntegerField': (0, 99999999999),
+    }
+
     def autoinc_sql(self, table, column):
         # To simulate auto-incrementing primary keys in Oracle, we have to
         # create a sequence and a trigger.

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -292,6 +292,10 @@ class DatabaseOperations(BaseDatabaseOperations):
             return 'django_power(%s)' % ','.join(sub_expressions)
         return super(DatabaseOperations, self).combine_expression(connector, sub_expressions)
 
+    def integer_field_range(self, internal_type):
+        # SQLite doesn't enforce any integer constraints
+        return (None, None)
+
 
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = 'sqlite'

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1561,6 +1561,16 @@ class IntegerField(Field):
     }
     description = _("Integer")
 
+    def __init__(self, *args, **kwargs):
+        field_validators = kwargs.setdefault('validators', [])
+        internal_type = self.get_internal_type()
+        min_value, max_value = connection.ops.integer_field_range(internal_type)
+        if min_value is not None:
+            field_validators.append(validators.MinValueValidator(min_value))
+        if max_value is not None:
+            field_validators.append(validators.MaxValueValidator(max_value))
+        super(IntegerField, self).__init__(*args, **kwargs)
+
     def get_prep_value(self, value):
         value = super(IntegerField, self).get_prep_value(value)
         if value is None:

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -678,6 +678,11 @@ Models
   Previously this used to work if the field accepted integers as input as it
   took the primary key.
 
+* Integer fields are now validated against database backend specific min and
+  max values based on their :meth:`internal_type <django.db.models.Field.get_internal_type>`.
+  Previously model field validation didn't prevent values out of their associated
+  column data type range from being saved resulting in an integrity error.
+
 Signals
 ^^^^^^^
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -55,9 +55,25 @@ class BigS(models.Model):
     s = models.SlugField(max_length=255)
 
 
-class BigInt(models.Model):
+class SmallIntegerModel(models.Model):
+    value = models.SmallIntegerField()
+
+
+class IntegerModel(models.Model):
+    value = models.IntegerField()
+
+
+class BigIntegerModel(models.Model):
     value = models.BigIntegerField()
     null_value = models.BigIntegerField(null=True, blank=True)
+
+
+class PositiveSmallIntegerModel(models.Model):
+    value = models.PositiveSmallIntegerField()
+
+
+class PositiveIntegerModel(models.Model):
+    value = models.PositiveIntegerField()
 
 
 class Post(models.Model):


### PR DESCRIPTION
Locally tested against (Py2, Py3) X (SQLite3, PostgreSQL, MySQL) (only missing Oracle).

It's missing a release note since we might want to backport this bugfix to the 1.7.x branch?
