### PR TITLE
Fixed #22257 -- Added file output option to dumpdata command.

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -36,6 +36,8 @@ class Command(BaseCommand):
             help="Only dump objects with given primary keys. "
                  "Accepts a comma separated list of keys. "
                  "This option will only work when you specify one model."),
+        make_option('-o' ,'--output', default=None, dest='output',
+            help='Specifies file to which the output is written.'),
     )
     help = ("Output the contents of the database as a fixture of the given "
             "format (using each model's default manager unless --all is "
@@ -47,6 +49,7 @@ class Command(BaseCommand):
         indent = options.get('indent')
         using = options.get('database')
         excludes = options.get('exclude')
+        output = options.get('output')
         show_traceback = options.get('traceback')
         use_natural_keys = options.get('use_natural_keys')
         if use_natural_keys:
@@ -155,7 +158,7 @@ class Command(BaseCommand):
             serializers.serialize(format, get_objects(), indent=indent,
                     use_natural_foreign_keys=use_natural_foreign_keys,
                     use_natural_primary_keys=use_natural_primary_keys,
-                    stream=self.stdout)
+                    stream=open(output, 'w') if output else self.stdout)
         except Exception as e:
             if show_traceback:
                 raise

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -287,6 +287,13 @@ you can use the ``--pks`` option to specify a comma separated list of
 primary keys on which to filter.  This is only available when dumping
 one model.
 
+.. versionadded:: 1.8
+
+.. django-admin-option:: --output
+
+By default ``dumpdata`` will output all the serialized data to standard output.
+This options allows to specify the file to which the data is to be written.
+
 flush
 -----
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -124,7 +124,8 @@ Internationalization
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 
-* ...
+* :djadmin:`dumpdata` now has the option ``--output`` which allows to specify the
+file to which the serialized data is to be written.
 
 Models
 ^^^^^^


### PR DESCRIPTION
Added `-o` or `--output` to dumpdata for specifying filename to which the data would be written.
default still `stdout`.
People may prefer this on case of small databases.
Also its backwards compatible

Refs.
- https://code.djangoproject.com/ticket/22257
- https://code.djangoproject.com/ticket/22251
