### PR TITLE
Turn *EmailBackend into contextmanager

### DIFF
--- a/django/core/mail/backends/base.py
+++ b/django/core/mail/backends/base.py
@@ -6,6 +6,13 @@ class BaseEmailBackend(object):
     Base class for email backend implementations.
 
     Subclasses must at least overwrite send_messages().
+
+   open() and close() can be called indirectly by using a backend object as a
+   context manager:
+
+       with backend as connection:
+           # do something with connection
+           pass
     """
     def __init__(self, fail_silently=False, **kwargs):
         self.fail_silently = fail_silently
@@ -31,6 +38,13 @@ class BaseEmailBackend(object):
     def close(self):
         """Close a network connection."""
         pass
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
     def send_messages(self, email_messages):
         """

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -91,7 +91,8 @@ Cache
 Email
 ^^^^^
 
-* ...
+* Email backends now support the context manager protocol for opening and
+  closing connections.
 
 File Storage
 ^^^^^^^^^^^^

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -393,6 +393,21 @@ The email backend class has the following methods:
   connection afterwards. If the connection is already open, it will be
   left open after mail has been sent.
 
+It can also be used as a context manager, calling ``open()`` and ``close()``
+as needed as an alternative to ``send_messages(email_messages)``::
+
+    from django.core import mail
+
+    with mail.get_connection() as connection:
+        mail.EmailMessage(subject1, body1, from1, [to1],
+                          connection=connection).send()
+        mail.EmailMessage(subject2, body2, from2, [to2],
+                          connection=connection).send()
+
+.. versionadded:: 1.8
+
+    The context manager protocol was added.
+
 Obtaining an instance of an email backend
 -----------------------------------------
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -638,6 +638,27 @@ class BaseEmailBackendTests(HeadersCheckMixin, object):
         except Exception as e:
             self.fail("close() unexpectedly raised an exception: %s" % e)
 
+    def test_use_as_contextmanager(self):
+        """
+        Test that the connection can be used as a contextmanager.
+        """
+        opened = [False]
+        closed = [False]
+        conn = mail.get_connection(username='', password='')
+
+        def open():
+            opened[0] = True
+        conn.open = open
+
+        def close():
+            closed[0] = True
+        conn.close = close
+        with conn as same_conn:
+            self.assertTrue(opened[0])
+            self.assertIs(same_conn, conn)
+            self.assertFalse(closed[0])
+        self.assertTrue(closed[0])
+
 
 class LocmemBackendTests(BaseEmailBackendTests, SimpleTestCase):
     email_backend = 'django.core.mail.backends.locmem.EmailBackend'


### PR DESCRIPTION
This pull request turns `django.core.mail.backends.BaseEmailBackend` into a contextmanager that can be used in a with statement. This is useful, if you are sending multiple messages as described in [https://docs.djangoproject.com/en/dev/topics/email/#sending-multiple-emails]. The example mentioned there basically turns into

```
with mail.get_connection() as conn:
    # ...
    mail.EmailMessage(..., connection=conn).send()
    # ...
```

which makes it less likely to forget the calls to `.open()` and `.close()`.

I've added a test but no documentation, yet. For documentation I considered adding a `.. versionadded:: ...` directive but I was unsure on which version to use and would appreciate any pointers you could give me regarding that problem.
