### PR TITLE
Fix #22265: The text was too strong in its assertion

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -55,9 +55,9 @@ staging machines, and eventually your production machines.
     It is possible to override the name of the package which contains the
     migrations on a per-app basis by modifying the :setting:`MIGRATION_MODULES` setting.
 
-Migrations will run the same way every time and produce consistent results,
-meaning that what you see in development and staging is exactly what will
-happen in production - no unexpected surprises.
+Migrations will run the same way on the same dataset and produce consistent results,
+meaning that what you see in development and staging is, under the same circumstances,
+exactly what will happen in production - no unexpected surprises.
 
 Backend Support
 ---------------


### PR DESCRIPTION
The text was too strong in its assertion of the consistency of migrations across development and production servers.
