### PR TITLE
Improve error message in django.contrib.sitemaps

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -117,7 +117,7 @@ class Sitemap(object):
 class FlatPageSitemap(Sitemap):
     def items(self):
         if not django_apps.is_installed('django.contrib.sites'):
-            raise ImproperlyConfigured("ping_google requires django.contrib.sites, which isn't installed.")
+            raise ImproperlyConfigured("FlatPageSitemap requires django.contrib.sites, which isn't installed.")
         Site = django_apps.get_model('sites.Site')
         current_site = Site.objects.get_current()
         return current_site.flatpage_set.filter(registration_required=False)


### PR DESCRIPTION
Using FlatPageSitemap without django.contrib.sites installed raises a slightly confusing exception which 
looks like a copy'n'paste error to me: 

> ping_google() requires django.contrib.sites

should say

> FlatPageSitemap requires django.contrib.sites
