### PR TITLE
Clarified the documentation of the kwargs param to django.conf.urls.url()

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -76,6 +76,9 @@ This function takes five arguments, most of which are optional::
 
     url(regex, view, kwargs=None, name=None, prefix='')
 
+The ``kwargs`` parameter allows you to pass additional arguments to the view
+function or method. See :ref:`views-extra-options` for an example.
+
 See :ref:`Naming URL patterns <naming-url-patterns>` for why the ``name``
 parameter is useful.
 

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -51,11 +51,17 @@ algorithm the system follows to determine which Python code to execute:
 3. Django runs through each URL pattern, in order, and stops at the first
    one that matches the requested URL.
 
-4. Once one of the regexes matches, Django imports and calls the given
-   view, which is a simple Python function (or a :doc:`class based view
-   </topics/class-based-views/index>`). The view gets passed an
-   :class:`~django.http.HttpRequest` as its first argument and any values
-   captured in the regex as remaining arguments.
+4. Once one of the regexes matches, Django imports and calls the given view,
+   which is a simple Python function (or a :doc:`class based view
+   </topics/class-based-views/index>`). The view gets passed the following
+   arguments:
+
+   * An instance of :class:`~django.http.HttpRequest`.
+   * If the matched regular expression returned no named groups, then the
+     matches from the regular expression are provided as positional arguments.
+   * The keyword arguments are made up of any named groups matched by the
+     regular expression, overridden by any arguments specified in the optional
+     ``kwargs`` argument to :func:`django.conf.urls.url`.
 
 5. If no regex matches, or if an exception is raised during any
    point in this process, Django invokes an appropriate


### PR DESCRIPTION
The reference documentation for the url() function now links to the example
elsewhere in the documentation.

The explanation of URL processing explains how the kwargs parameter is
combined with the results of the regexp match
