### PR TITLE
Fixed the PostGIS circular imports caused by 1506c71a95.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -20,7 +20,7 @@ from django.core import exceptions, validators, checks
 from django.utils.datastructures import DictWrapper
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.deprecation import RemovedInDjango19Warning
-from django.utils.functional import curry, total_ordering, Promise
+from django.utils.functional import cached_property, curry, total_ordering, Promise
 from django.utils.text import capfirst
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -157,7 +157,6 @@ class Field(RegisterLookupMixin):
             Field.creation_counter += 1
 
         self._validators = validators  # Store for deconstruction later
-        self.validators = self.default_validators + validators
 
         messages = {}
         for c in reversed(self.__class__.__mro__):
@@ -446,6 +445,12 @@ class Field(RegisterLookupMixin):
         Returns the converted value. Subclasses should override this.
         """
         return value
+
+    @cached_property
+    def validators(self):
+        # Some validators can't be created at field initialization time.
+        # This method provides a way to delay their creation until required.
+        return self.default_validators + self._validators
 
     def run_validators(self, value):
         if value in self.empty_values:
@@ -1561,16 +1566,18 @@ class IntegerField(Field):
     }
     description = _("Integer")
 
-    def __init__(self, *args, **kwargs):
-        default_validators = self.default_validators[:]
+    @cached_property
+    def validators(self):
+        # These validators can't be added at field initialization time since
+        # they're based on values retrieved from `connection`.
+        range_validators = []
         internal_type = self.get_internal_type()
         min_value, max_value = connection.ops.integer_field_range(internal_type)
         if min_value is not None:
-            default_validators.append(validators.MinValueValidator(min_value))
+            range_validators.append(validators.MinValueValidator(min_value))
         if max_value is not None:
-            default_validators.append(validators.MaxValueValidator(max_value))
-        self.default_validators = default_validators
-        super(IntegerField, self).__init__(*args, **kwargs)
+            range_validators.append(validators.MaxValueValidator(max_value))
+        return super(IntegerField, self).validators + range_validators
 
     def get_prep_value(self, value):
         value = super(IntegerField, self).get_prep_value(value)


### PR DESCRIPTION
refs #12030.

Hopefully this will be the latest fix for #12030.
1. We can't access `connection` at `IntegerField` creation time (module import time) since the PostGIS backend defines models with `IntegerField` and it triggers a circular import. Thus we must delay access to `connection`, hence the cached property.
2. We can't simply append those validators to `self.validators` to avoid polluting migration with database backend specific validators. Hence the `range_validators` property. See ff874f363ce6556577f03909b15c71c051d5b617.
3. We want to make sure `range_validators` behave just like normal validators in regard to their aggregation logic in `run_validators` while keeping the code DRY. Hence the `extra_validators` kwarg of `Field.run_validators()`.
