### PR TITLE
Skipped a test that errors rather than marked it as an expectedFailure.

### DIFF
--- a/tests/serializers_regress/tests.py
+++ b/tests/serializers_regress/tests.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 import datetime
 import decimal
-from unittest import expectedFailure, skipUnless
+from unittest import skip, skipUnless
 import warnings
 
 try:
@@ -482,8 +482,7 @@ def serializerTest(format, self):
         self.assertEqual(count, klass.objects.count())
 
 if connection.vendor == 'mysql' and six.PY3:
-    # Existing MySQL DB-API drivers fail on binary data.
-    serializerTest = expectedFailure(serializerTest)
+    serializerTest = skip("Existing MySQL DB-API drivers fail on binary data.")(serializerTest)
 
 
 def naturalKeySerializerTest(format, self):


### PR DESCRIPTION
The test throws an error which Python 3.4 doesn't seem to catch as an
expectedFailure.

refs 7476d96f83a004d674244aeb7a66289035427396
