### PR TITLE
Add Python 3.4 to classifiers in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Internet :: WWW/HTTP :: WSGI',


### PR DESCRIPTION
I've ran the test suite with Python 3.4.0:

```
$ python3.4 -m venv venv34
$ . venv34/bin/activate
$ pip install -e .
$ cd tests/
$ ./runtests.py
...
Ran 6783 tests in 313.773s

OK (skipped=540, expected failures=7)
```
