### PR TITLE
Fixed #22350 -- Consistently serialize bytes and text in migrations.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -227,7 +227,7 @@ class ModelState(object):
         body['__module__'] = "__fake__"
         # Then, make a Model object
         return type(
-            self.name,
+            str(self.name),
             bases,
             body,
         )

--- a/tests/migrations/test_migrations/0001_initial.py
+++ b/tests/migrations/test_migrations/0001_initial.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations/0002_second.py
+++ b/tests/migrations/test_migrations/0002_second.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_2/0001_initial.py
+++ b/tests/migrations/test_migrations_2/0001_initial.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_conflict/0001_initial.py
+++ b/tests/migrations/test_migrations_conflict/0001_initial.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_conflict/0002_conflicting_second.py
+++ b/tests/migrations/test_migrations_conflict/0002_conflicting_second.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_conflict/0002_second.py
+++ b/tests/migrations/test_migrations_conflict/0002_second.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_squashed/0001_initial.py
+++ b/tests/migrations/test_migrations_squashed/0001_initial.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_squashed/0001_squashed_0002.py
+++ b/tests/migrations/test_migrations_squashed/0001_squashed_0002.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_squashed/0002_second.py
+++ b/tests/migrations/test_migrations_squashed/0002_second.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 

--- a/tests/migrations/test_migrations_unmigdep/0001_initial.py
+++ b/tests/migrations/test_migrations_unmigdep/0001_initial.py
@@ -1,3 +1,6 @@
+# encoding: utf8
+from __future__ import unicode_literals
+
 from django.db import migrations, models
 
 


### PR DESCRIPTION
Thanks to treyhunner for the report and Loïc for the initial patch.
