### PR TITLE
Fixed #22380 -- Missing SECRET_KEY variable in sample settings file for ...

### DIFF
--- a/docs/ref/contrib/gis/testing.txt
+++ b/docs/ref/contrib/gis/testing.txt
@@ -169,6 +169,8 @@ in :mod:`django.contrib.gis`::
        }
     }
 
+    SECRET_KEY = 'django_tests_secret_key'
+
 Assuming the settings above were in a ``postgis.py`` file in the same
 directory as ``runtests.py``, then all Django and GeoDjango tests would
 be performed when executing the command::


### PR DESCRIPTION
Missing SECRET_KEY variable caused runtests.py to throw an error. Added variable to example settings file.
