### PR TITLE
Fixed #21977 -- Deprecated SimpleTestCase.urls in favour of override_settings

### DIFF
--- a/django/contrib/auth/tests/test_context_processors.py
+++ b/django/contrib/auth/tests/test_context_processors.py
@@ -66,6 +66,7 @@ class PermWrapperTests(TestCase):
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(upath(__file__)), 'templates'),
     ),
+    ROOT_URLCONF='django.contrib.auth.tests.urls',
     USE_TZ=False,                           # required for loading the fixture
     PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
 )
@@ -73,7 +74,6 @@ class AuthContextProcessorTests(TestCase):
     """
     Tests for the ``django.contrib.auth.context_processors.auth`` processor
     """
-    urls = 'django.contrib.auth.tests.urls'
     fixtures = ['context-processors-users.xml']
 
     @override_settings(

--- a/django/contrib/auth/tests/test_decorators.py
+++ b/django/contrib/auth/tests/test_decorators.py
@@ -5,16 +5,16 @@ from django.contrib.auth.tests.test_views import AuthViewsTestCase
 from django.contrib.auth.tests.utils import skipIfCustomUser
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.auth.tests.urls')
 class LoginRequiredTestCase(AuthViewsTestCase):
     """
     Tests the login_required decorators
     """
-    urls = 'django.contrib.auth.tests.urls'
 
     def testCallable(self):
         """

--- a/django/contrib/auth/tests/test_remote_user.py
+++ b/django/contrib/auth/tests/test_remote_user.py
@@ -6,14 +6,14 @@ from django.contrib.auth.backends import RemoteUserBackend
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.contrib.auth.models import User
 from django.contrib.auth.tests.utils import skipIfCustomUser
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.auth.tests.urls')
 class RemoteUserTest(TestCase):
 
-    urls = 'django.contrib.auth.tests.urls'
     middleware = 'django.contrib.auth.middleware.RemoteUserMiddleware'
     backend = 'django.contrib.auth.backends.RemoteUserBackend'
     header = 'REMOTE_USER'

--- a/django/contrib/auth/tests/test_signals.py
+++ b/django/contrib/auth/tests/test_signals.py
@@ -7,9 +7,10 @@ from django.test import override_settings
 
 
 @skipIfCustomUser
-@override_settings(USE_TZ=False, PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(USE_TZ=False,
+    PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='django.contrib.auth.tests.urls')
 class SignalTestCase(TestCase):
-    urls = 'django.contrib.auth.tests.urls'
     fixtures = ['authtestdata.json']
 
     def listener_login(self, user, **kwargs):

--- a/django/contrib/auth/tests/test_templates.py
+++ b/django/contrib/auth/tests/test_templates.py
@@ -15,9 +15,9 @@ from django.utils.http import urlsafe_base64_encode
 @skipIfCustomUser
 @override_settings(
     PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='django.contrib.auth.tests.urls',
 )
 class AuthTemplateTests(TestCase):
-    urls = 'django.contrib.auth.tests.urls'
 
     def test_titles(self):
         rf = RequestFactory()

--- a/django/contrib/auth/tests/test_views.py
+++ b/django/contrib/auth/tests/test_views.py
@@ -41,13 +41,13 @@ from django.contrib.auth.views import login as login_view
     ),
     USE_TZ=False,
     PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='django.contrib.auth.tests.urls',
 )
 class AuthViewsTestCase(TestCase):
     """
     Helper base class for all the follow test cases.
     """
     fixtures = ['authtestdata.json']
-    urls = 'django.contrib.auth.tests.urls'
 
     def login(self, password='password'):
         response = self.client.post('/login/', {
@@ -86,8 +86,8 @@ class AuthViewsTestCase(TestCase):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.auth.urls')
 class AuthViewNamedURLTests(AuthViewsTestCase):
-    urls = 'django.contrib.auth.urls'
 
     def test_named_urls(self):
         "Named URLs should be reversible"
@@ -732,9 +732,9 @@ class LogoutTest(AuthViewsTestCase):
 @skipIfCustomUser
 @override_settings(
     PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='django.contrib.auth.tests.urls_admin',
 )
 class ChangelistTests(AuthViewsTestCase):
-    urls = 'django.contrib.auth.tests.urls_admin'
 
     def setUp(self):
         # Make me a superuser before logging in.

--- a/django/contrib/flatpages/tests/test_csrf.py
+++ b/django/contrib/flatpages/tests/test_csrf.py
@@ -15,6 +15,7 @@ from django.test import override_settings
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     CSRF_FAILURE_VIEW='django.views.csrf.csrf_failure',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
@@ -23,7 +24,6 @@ from django.test import override_settings
 )
 class FlatpageCSRFTests(TestCase):
     fixtures = ['sample_flatpages', 'example_site']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def setUp(self):
         self.client = Client(enforce_csrf_checks=True)

--- a/django/contrib/flatpages/tests/test_middleware.py
+++ b/django/contrib/flatpages/tests/test_middleware.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
@@ -23,7 +24,6 @@ from django.test import TestCase, override_settings
 )
 class FlatpageMiddlewareTests(TestCase):
     fixtures = ['sample_flatpages', 'example_site']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def test_view_flatpage(self):
         "A flatpage can be served through a view, even when the middleware is in use"
@@ -96,6 +96,7 @@ class FlatpageMiddlewareTests(TestCase):
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
@@ -103,7 +104,6 @@ class FlatpageMiddlewareTests(TestCase):
 )
 class FlatpageMiddlewareAppendSlashTests(TestCase):
     fixtures = ['sample_flatpages', 'example_site']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def test_redirect_view_flatpage(self):
         "A flatpage can be served through a view and should add a slash"

--- a/django/contrib/flatpages/tests/test_templatetags.py
+++ b/django/contrib/flatpages/tests/test_templatetags.py
@@ -14,6 +14,7 @@ from django.test import TestCase, override_settings
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
@@ -21,7 +22,6 @@ from django.test import TestCase, override_settings
 )
 class FlatpageTemplateTagTests(TestCase):
     fixtures = ['sample_flatpages']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def test_get_flatpages_tag(self):
         "The flatpage template tag retrives unregistered prefixed flatpages by default"

--- a/django/contrib/flatpages/tests/test_views.py
+++ b/django/contrib/flatpages/tests/test_views.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
         'django.contrib.messages.middleware.MessageMiddleware',
         # no 'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware'
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
@@ -23,7 +24,6 @@ from django.test import TestCase, override_settings
 )
 class FlatpageViewTests(TestCase):
     fixtures = ['sample_flatpages', 'example_site']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def test_view_flatpage(self):
         "A flatpage can be served through a view"
@@ -84,6 +84,7 @@ class FlatpageViewTests(TestCase):
         'django.contrib.messages.middleware.MessageMiddleware',
         # no 'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware'
     ),
+    ROOT_URLCONF='django.contrib.flatpages.tests.urls',
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(__file__), 'templates'),
     ),
@@ -91,7 +92,6 @@ class FlatpageViewTests(TestCase):
 )
 class FlatpageViewAppendSlashTests(TestCase):
     fixtures = ['sample_flatpages', 'example_site']
-    urls = 'django.contrib.flatpages.tests.urls'
 
     def test_redirect_view_flatpage(self):
         "A flatpage can be served through a view and should add a slash"

--- a/django/contrib/formtools/tests/tests.py
+++ b/django/contrib/formtools/tests/tests.py
@@ -36,9 +36,9 @@ class TestFormPreview(preview.FormPreview):
     TEMPLATE_DIRS=(
         os.path.join(os.path.dirname(upath(__file__)), 'templates'),
     ),
+    ROOT_URLCONF='django.contrib.formtools.tests.urls',
 )
 class PreviewTests(TestCase):
-    urls = 'django.contrib.formtools.tests.urls'
 
     def setUp(self):
         super(PreviewTests, self).setUp()

--- a/django/contrib/formtools/tests/wizard/namedwizardtests/tests.py
+++ b/django/contrib/formtools/tests/wizard/namedwizardtests/tests.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django.contrib.auth.models import User
 from django.contrib.auth.tests.utils import skipIfCustomUser
@@ -13,7 +13,6 @@ from django.contrib.formtools.tests.wizard.test_forms import get_request, Step1,
 
 
 class NamedWizardTests(object):
-    urls = 'django.contrib.formtools.tests.wizard.namedwizardtests.urls'
 
     def setUp(self):
         self.testuser, created = User.objects.get_or_create(username='testuser1')
@@ -283,6 +282,7 @@ class NamedWizardTests(object):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.namedwizardtests.urls')
 class NamedSessionWizardTests(NamedWizardTests, TestCase):
     wizard_urlname = 'nwiz_session'
     wizard_step_1_data = {
@@ -315,6 +315,7 @@ class NamedSessionWizardTests(NamedWizardTests, TestCase):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.namedwizardtests.urls')
 class NamedCookieWizardTests(NamedWizardTests, TestCase):
     wizard_urlname = 'nwiz_cookie'
     wizard_step_1_data = {
@@ -347,7 +348,6 @@ class NamedCookieWizardTests(NamedWizardTests, TestCase):
 
 
 class NamedFormTests(object):
-    urls = 'django.contrib.formtools.tests.wizard.namedwizardtests.urls'
 
     def test_revalidation(self):
         request = get_request()
@@ -376,12 +376,14 @@ class TestNamedUrlCookieWizardView(NamedUrlCookieWizardView):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.namedwizardtests.urls')
 class NamedSessionFormTests(NamedFormTests, TestCase):
     formwizard_class = TestNamedUrlSessionWizardView
     wizard_urlname = 'nwiz_session'
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.namedwizardtests.urls')
 class NamedCookieFormTests(NamedFormTests, TestCase):
     formwizard_class = TestNamedUrlCookieWizardView
     wizard_urlname = 'nwiz_cookie'

--- a/django/contrib/formtools/tests/wizard/wizardtests/tests.py
+++ b/django/contrib/formtools/tests/wizard/wizardtests/tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import os
 
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -24,7 +24,6 @@ PoemFormSet = forms.models.inlineformset_factory(Poet, Poem, fields="__all__")
 
 
 class WizardTests(object):
-    urls = 'django.contrib.formtools.tests.wizard.wizardtests.urls'
 
     def setUp(self):
         self.testuser, created = User.objects.get_or_create(username='testuser1')
@@ -208,6 +207,7 @@ class WizardTests(object):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.wizardtests.urls')
 class SessionWizardTests(WizardTests, TestCase):
     wizard_url = '/wiz_session/'
     wizard_step_1_data = {
@@ -240,6 +240,7 @@ class SessionWizardTests(WizardTests, TestCase):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.wizardtests.urls')
 class CookieWizardTests(WizardTests, TestCase):
     wizard_url = '/wiz_cookie/'
     wizard_step_1_data = {
@@ -272,6 +273,7 @@ class CookieWizardTests(WizardTests, TestCase):
 
 
 @skipIfCustomUser
+@override_settings(ROOT_URLCONF='django.contrib.formtools.tests.wizard.wizardtests.urls')
 class WizardTestKwargs(TestCase):
     wizard_url = '/wiz_other_template/'
     wizard_step_1_data = {
@@ -301,7 +303,6 @@ class WizardTestKwargs(TestCase):
             'cookie_contact_wizard-current_step': 'form4',
         }
     )
-    urls = 'django.contrib.formtools.tests.wizard.wizardtests.urls'
 
     def setUp(self):
         self.testuser, created = User.objects.get_or_create(username='testuser1')

--- a/django/contrib/gis/tests/geoadmin/tests.py
+++ b/django/contrib/gis/tests/geoadmin/tests.py
@@ -4,7 +4,7 @@ from unittest import skipUnless
 
 from django.contrib.gis.geos import HAS_GEOS
 from django.contrib.gis.tests.utils import HAS_SPATIAL_DB
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 if HAS_GEOS and HAS_SPATIAL_DB:
     from django.contrib.gis import admin
@@ -14,8 +14,8 @@ if HAS_GEOS and HAS_SPATIAL_DB:
 
 
 @skipUnless(HAS_GEOS and HAS_SPATIAL_DB, "Geos and spatial db are required.")
+@override_settings(ROOT_URLCONF='django.contrib.gis.tests.geoadmin.urls')
 class GeoAdminTest(TestCase):
-    urls = 'django.contrib.gis.tests.geoadmin.urls'
 
     def test_ensure_geographic_media(self):
         geoadmin = admin.site._registry[City]

--- a/django/contrib/gis/tests/geoapp/test_feeds.py
+++ b/django/contrib/gis/tests/geoapp/test_feeds.py
@@ -7,17 +7,16 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.contrib.gis.geos import HAS_GEOS
 from django.contrib.gis.tests.utils import HAS_SPATIAL_DB
-from django.test import TestCase, modify_settings
+from django.test import TestCase, modify_settings, override_settings
 
 if HAS_GEOS:
     from .models import City
 
 
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sites'})
+@override_settings(ROOT_URLCONF='django.contrib.gis.tests.geoapp.urls')
 @skipUnless(HAS_GEOS and HAS_SPATIAL_DB, "Geos and spatial db are required.")
 class GeoFeedTest(TestCase):
-
-    urls = 'django.contrib.gis.tests.geoapp.urls'
 
     def setUp(self):
         Site(id=settings.SITE_ID, domain="example.com", name="example.com").save()

--- a/django/contrib/gis/tests/geoapp/test_sitemaps.py
+++ b/django/contrib/gis/tests/geoapp/test_sitemaps.py
@@ -9,17 +9,16 @@ from django.conf import settings
 from django.contrib.gis.geos import HAS_GEOS
 from django.contrib.gis.tests.utils import HAS_SPATIAL_DB
 from django.contrib.sites.models import Site
-from django.test import TestCase, modify_settings
+from django.test import TestCase, modify_settings, override_settings
 
 if HAS_GEOS:
     from .models import City, Country
 
 
 @modify_settings(INSTALLED_APPS={'append': ['django.contrib.sites', 'django.contrib.sitemaps']})
+@override_settings(ROOT_URLCONF='django.contrib.gis.tests.geoapp.urls')
 @skipUnless(HAS_GEOS and HAS_SPATIAL_DB, "Geos and spatial db are required.")
 class GeoSitemapTest(TestCase):
-
-    urls = 'django.contrib.gis.tests.geoapp.urls'
 
     def setUp(self):
         super(GeoSitemapTest, self).setUp()

--- a/django/contrib/messages/tests/base.py
+++ b/django/contrib/messages/tests/base.py
@@ -48,7 +48,6 @@ class override_settings_tags(override_settings):
 
 class BaseTests(object):
     storage_class = default_storage
-    urls = 'django.contrib.messages.tests.urls'
     levels = {
         'debug': constants.DEBUG,
         'info': constants.INFO,
@@ -61,6 +60,7 @@ class BaseTests(object):
         self.settings_override = override_settings_tags(
             TEMPLATE_DIRS=(),
             TEMPLATE_CONTEXT_PROCESSORS=global_settings.TEMPLATE_CONTEXT_PROCESSORS,
+            ROOT_URLCONF='django.contrib.messages.tests.urls',
             MESSAGE_TAGS='',
             MESSAGE_STORAGE='%s.%s' % (self.storage_class.__module__,
                                        self.storage_class.__name__),

--- a/django/contrib/messages/tests/test_mixins.py
+++ b/django/contrib/messages/tests/test_mixins.py
@@ -1,10 +1,10 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.contrib.messages.tests.urls import ContactFormViewWithMsg
 from django.core.urlresolvers import reverse
 
 
+@override_settings(ROOT_URLCONF='django.contrib.messages.tests.urls')
 class SuccessMessageMixinTests(TestCase):
-    urls = 'django.contrib.messages.tests.urls'
 
     def test_set_messages_success(self):
         author = {'name': 'John Doe',

--- a/django/contrib/sitemaps/tests/base.py
+++ b/django/contrib/sitemaps/tests/base.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.core.cache import cache
 from django.db import models
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class TestModel(models.Model):
@@ -17,11 +17,11 @@ class TestModel(models.Model):
         return '/testmodel/%s/' % self.id
 
 
+@override_settings(ROOT_URLCONF='django.contrib.sitemaps.tests.urls.http')
 class SitemapTestsBase(TestCase):
     protocol = 'http'
     sites_installed = apps.is_installed('django.contrib.sites')
     domain = 'example.com' if sites_installed else 'testserver'
-    urls = 'django.contrib.sitemaps.tests.urls.http'
 
     def setUp(self):
         self.base_url = '%s://%s' % (self.protocol, self.domain)

--- a/django/contrib/sitemaps/tests/test_https.py
+++ b/django/contrib/sitemaps/tests/test_https.py
@@ -7,9 +7,9 @@ from django.test import override_settings
 from .base import SitemapTestsBase
 
 
+@override_settings(ROOT_URLCONF='django.contrib.sitemaps.tests.urls.https')
 class HTTPSSitemapTests(SitemapTestsBase):
     protocol = 'https'
-    urls = 'django.contrib.sitemaps.tests.urls.https'
 
     def test_secure_sitemap_index(self):
         "A secure sitemap index can be rendered"

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -12,6 +12,7 @@ import socket
 import sys
 import threading
 import unittest
+import warnings
 from unittest import skipIf         # NOQA: Imported here for backward compatibility
 from unittest.util import safe_repr
 
@@ -33,6 +34,7 @@ from django.test.html import HTMLParseError, parse_html
 from django.test.signals import setting_changed, template_rendered
 from django.test.utils import (CaptureQueriesContext, ContextList,
     override_settings, modify_settings, compare_xml)
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 from django.utils import six
 from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit, urlparse, unquote
@@ -202,6 +204,11 @@ class SimpleTestCase(unittest.TestCase):
     def _urlconf_setup(self):
         set_urlconf(None)
         if hasattr(self, 'urls'):
+            warnings.warn(
+                "SimpleTestCase.urls is deprecated and will be removed in"
+                "Django 2.0. Use @override_settings(ROOT_URLCONF=...)"
+                "in %s instead." % str(self.__class__.__name__),
+                RemovedInDjango20Warning, stacklevel=2)
             self._old_root_urlconf = settings.ROOT_URLCONF
             settings.ROOT_URLCONF = self.urls
             clear_url_caches()

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -20,6 +20,8 @@ about each item can often be found in the release notes of two versions prior.
 * Support for the ``prefix`` argument to
   ``django.conf.urls.i18n.i18n_patterns()`` will be removed.
 
+* ``SimpleTestCase.urls`` will be removed.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -256,6 +256,15 @@ Updating your code is as simple as ensuring that ``urlpatterns`` is a list of
         url('^other/$', views.otherview),
     ]
 
+``django.test.SimpleTestCase.urls``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The attribute :attr:`SimpleTestCase.urls <django.test.SimpleTestCase.urls>`
+for specifying URLconf configuration in tests has now been deprecated in
+favor of :func:`~django.test.override_settings`. Use
+``@override_settings(ROOT_URLCONF=...)``. The attribute will be removed in
+Django 2.0.
+
 ``prefix`` argument to :func:`~django.conf.urls.i18n.i18n_patterns`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -961,6 +961,11 @@ URLconf configuration
 
 .. attribute:: SimpleTestCase.urls
 
+.. deprecated:: 1.8
+
+    Use ``@override_settings(ROOT_URLCONF=...)`` instead for URLconf
+    configuration.
+
 If your application provides views, you may want to include tests that use the
 test client to exercise those views. However, an end user is free to deploy the
 views in your application at any URL of their choosing. This means that your

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -26,8 +26,8 @@ from .models import (Event, Child, Parent, Genre, Band, Musician, Group,
     UnorderedObject, OrderedObject, CustomIdUser)
 
 
+@override_settings(ROOT_URLCONF="admin_changelist.urls")
 class ChangeListTests(TestCase):
-    urls = "admin_changelist.urls"
 
     def setUp(self):
         self.factory = RequestFactory()
@@ -664,12 +664,12 @@ class AdminLogNodeTestCase(TestCase):
         self.assertEqual(template.render(context), '')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_changelist.urls")
 class SeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['admin_changelist'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['users.json']
-    urls = "admin_changelist.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_add_row_selection(self):

--- a/tests/admin_custom_urls/tests.py
+++ b/tests/admin_custom_urls/tests.py
@@ -8,7 +8,8 @@ from django.test import TestCase, override_settings
 from .models import Action, Person, Car
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='admin_custom_urls.urls',)
 class AdminCustomUrlsTest(TestCase):
     """
     Remember that:
@@ -16,7 +17,6 @@ class AdminCustomUrlsTest(TestCase):
     * The ModelAdmin for Action customizes the add_view URL, it's
       '<app name>/<model name>/!add/'
     """
-    urls = 'admin_custom_urls.urls'
     fixtures = ['users.json', 'actions.json']
 
     def setUp(self):
@@ -83,9 +83,9 @@ class AdminCustomUrlsTest(TestCase):
         self.assertContains(response, 'value="path/to/html/document.html"')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='admin_custom_urls.urls',)
 class CustomRedirects(TestCase):
-    urls = 'admin_custom_urls.urls'
     fixtures = ['users.json', 'actions.json']
 
     def setUp(self):

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -11,8 +11,8 @@ from django.test import TestCase, modify_settings, override_settings
 from .models import Person, Company
 
 
+@override_settings(ROOT_URLCONF='admin_docs.urls')
 class MiscTests(TestCase):
-    urls = 'admin_docs.urls'
 
     def setUp(self):
         User.objects.create_superuser('super', None, 'secret')
@@ -30,11 +30,11 @@ class MiscTests(TestCase):
         self.client.get('/admindocs/views/')  # should not raise
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='admin_docs.urls')
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
 class AdminDocViewTests(TestCase):
     fixtures = ['data.xml']
-    urls = 'admin_docs.urls'
 
     def setUp(self):
         self.client.login(username='super', password='secret')
@@ -104,10 +104,10 @@ class AdminDocViewTests(TestCase):
             utils.docutils_is_available = True
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_docs.urls')
 class XViewMiddlewareTest(TestCase):
     fixtures = ['data.xml']
-    urls = 'admin_docs.urls'
 
     def test_xview_func(self):
         user = User.objects.get(username='super')
@@ -147,8 +147,8 @@ class XViewMiddlewareTest(TestCase):
 
 
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
+@override_settings(ROOT_URLCONF='admin_docs.urls')
 class DefaultRoleTest(TestCase):
-    urls = 'admin_docs.urls'
 
     def test_parse_rst(self):
         """
@@ -183,7 +183,8 @@ class DefaultRoleTest(TestCase):
         self.assertEqual(parts['fragment'], markup)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_docs.urls')
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
 class TestModelDetailView(TestCase):
     """
@@ -191,7 +192,6 @@ class TestModelDetailView(TestCase):
     """
 
     fixtures = ['data.xml']
-    urls = 'admin_docs.urls'
 
     def setUp(self):
         self.client.login(username='super', password='secret')

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -15,9 +15,9 @@ from .models import (Holder, Inner, Holder2, Inner2, Holder3, Inner3, Person,
     SomeChildModel)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_inlines.urls")
 class TestInline(TestCase):
-    urls = "admin_inlines.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -255,9 +255,9 @@ class TestInline(TestCase):
         )
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_inlines.urls")
 class TestInlineMedia(TestCase):
-    urls = "admin_inlines.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -294,8 +294,8 @@ class TestInlineMedia(TestCase):
         self.assertContains(response, 'my_awesome_inline_scripts.js')
 
 
+@override_settings(ROOT_URLCONF="admin_inlines.urls")
 class TestInlineAdminForm(TestCase):
-    urls = "admin_inlines.urls"
 
     def test_immutable_content_type(self):
         """Regression for #9362
@@ -313,9 +313,9 @@ class TestInlineAdminForm(TestCase):
         self.assertEqual(iaf.original.content_type, parent_ct)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_inlines.urls")
 class TestInlineProtectedOnDelete(TestCase):
-    urls = "admin_inlines.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -350,13 +350,13 @@ class TestInlineProtectedOnDelete(TestCase):
                             % (chapter, foot_note))
 
 
+@override_settings(ROOT_URLCONF="admin_inlines.urls")
 class TestInlinePermissions(TestCase):
     """
     Make sure the admin respects permissions for objects that are edited
     inline. Refs #8060.
 
     """
-    urls = "admin_inlines.urls"
 
     def setUp(self):
         self.user = User(username='admin')
@@ -546,12 +546,12 @@ class TestInlinePermissions(TestCase):
         self.assertContains(response, 'id="id_inner2_set-0-DELETE"')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_inlines.urls")
 class SeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['admin_inlines'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-views-users.xml']
-    urls = "admin_inlines.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_add_stackeds(self):

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -26,7 +26,7 @@ from django.db import connection
 from django.utils.encoding import force_text
 from django.utils._os import npath, upath
 from django.utils.six import StringIO
-from django.test import LiveServerTestCase, TestCase
+from django.test import LiveServerTestCase, TestCase, override_settings
 from django.test.runner import DiscoverRunner
 from django.test.utils import str_prefix
 
@@ -1631,9 +1631,9 @@ class ArgumentOrder(AdminScriptTestCase):
         self.assertOutput(out, str_prefix("EXECUTE:BaseCommand labels=('testlabel',), options=[('no_color', False), ('option_a', 'x'), ('option_b', %%s), ('option_c', '3'), ('pythonpath', None), ('settings', 'alternate_settings'), ('traceback', None), ('verbosity', %(_)s'1')]") % option_b)
 
 
+@override_settings(ROOT_URLCONF='admin_scripts.urls')
 class StartProject(LiveServerTestCase, AdminScriptTestCase):
 
-    urls = 'admin_scripts.urls'
     available_apps = [
         'admin_scripts',
         'django.contrib.auth',

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -64,6 +64,7 @@ ADMIN_VIEW_TEMPLATES_DIR = settings.TEMPLATE_DIRS + (os.path.join(os.path.dirnam
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_views.urls",
                    USE_I18N=True, USE_L10N=False, LANGUAGE_CODE='en')
 class AdminViewBasicTestCase(TestCase):
     fixtures = ['admin-views-users.xml', 'admin-views-colors.xml',
@@ -73,8 +74,6 @@ class AdminViewBasicTestCase(TestCase):
     # variable. That way we can test a second AdminSite just by subclassing
     # this test case and changing urlbit.
     urlbit = 'admin'
-
-    urls = "admin_views.urls"
 
     def setUp(self):
         self.client.login(username='super', password='secret')
@@ -747,9 +746,9 @@ class AdminCustomTemplateTests(AdminViewBasicTestCase):
         self.assertTemplateUsed(response, 'custom_filter_template.html')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_views.urls")
 class AdminViewFormUrlTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ["admin-views-users.xml"]
     urlbit = "admin3"
 
@@ -781,11 +780,10 @@ class AdminViewFormUrlTest(TestCase):
         self.assertContains(response, 'value="overridden_value"')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_views.urls")
 class AdminJavaScriptTest(TestCase):
     fixtures = ['admin-views-users.xml']
-
-    urls = "admin_views.urls"
 
     def setUp(self):
         self.client.login(username='super', password='secret')
@@ -827,9 +825,9 @@ class AdminJavaScriptTest(TestCase):
             self.assertNotContains(response, 'inlines.min.js')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class SaveAsTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-person.xml']
 
     def setUp(self):
@@ -858,8 +856,8 @@ class SaveAsTests(TestCase):
         self.assertEqual(response.context['form_url'], '/test_admin/admin/admin_views/person/add/')
 
 
+@override_settings(ROOT_URLCONF="admin_views.urls")
 class CustomModelAdminTest(AdminViewBasicTestCase):
-    urls = "admin_views.urls"
     urlbit = "admin2"
 
     def testCustomAdminSiteLoginForm(self):
@@ -937,11 +935,11 @@ def get_perm(Model, perm):
     return Permission.objects.get(content_type=ct, codename=perm)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewPermissionsTest(TestCase):
     """Tests for Admin Views Permissions."""
 
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -1465,11 +1463,11 @@ class AdminViewPermissionsTest(TestCase):
         self.assertEqual(response.url, 'http://example.com/dummy/foo/')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewsNoUrlTest(TestCase):
     """Regression test for #17333"""
 
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -1496,9 +1494,9 @@ class AdminViewsNoUrlTest(TestCase):
         self.client.get('/test_admin/admin/logout/')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewDeletedObjectsTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'deleted-objects.xml']
 
     def setUp(self):
@@ -1614,9 +1612,9 @@ class AdminViewDeletedObjectsTest(TestCase):
         self.assertContains(response, should_contain)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewStringPrimaryKeyTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'string-primary-key.xml']
 
     def __init__(self, *args):
@@ -1748,12 +1746,12 @@ class AdminViewStringPrimaryKeyTest(TestCase):
         self.assertContains(response, '<a href="%s" class="historylink"' % expected_link)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class SecureViewTests(TestCase):
     """
     Test behavior of a view protected by the staff_member_required decorator.
     """
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def tearDown(self):
@@ -1771,9 +1769,9 @@ class SecureViewTests(TestCase):
         self.assertEqual(response.context[REDIRECT_FIELD_NAME], secure_url)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewUnicodeTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-unicode.xml']
 
     def setUp(self):
@@ -1826,9 +1824,9 @@ class AdminViewUnicodeTest(TestCase):
         self.assertRedirects(response, '/test_admin/admin/admin_views/book/')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewListEditable(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-person.xml']
 
     def setUp(self):
@@ -2203,9 +2201,9 @@ class AdminViewListEditable(TestCase):
         self.assertContains(response, '<th class="field-id"><a href="%s">%d</a></th>' % (link2, story2.id), 1)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminSearchTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users', 'multiple-child-classes',
                 'admin-views-person']
 
@@ -2274,9 +2272,9 @@ class AdminSearchTest(TestCase):
             html=True)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminInheritedInlinesTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -2362,9 +2360,9 @@ class AdminInheritedInlinesTest(TestCase):
         self.assertEqual(Persona.objects.all()[0].accounts.count(), 2)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminActionsTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-actions.xml']
 
     def setUp(self):
@@ -2631,9 +2629,9 @@ action)</option>
         self.assertEqual(response.template_name, 'admin/popup_response.html')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class TestCustomChangeList(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
     urlbit = 'admin'
 
@@ -2660,9 +2658,9 @@ class TestCustomChangeList(TestCase):
         self.assertNotContains(response, 'First Gadget')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class TestInlineNotEditable(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -2680,9 +2678,9 @@ class TestInlineNotEditable(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminCustomQuerysetTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -2925,9 +2923,9 @@ class AdminCustomQuerysetTest(TestCase):
         self.assertEqual(self.client.get('/test_admin/admin/admin_views/filteredmanager/2/history/').status_code, 200)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminInlineFileUploadTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-actions.xml']
     urlbit = 'admin'
 
@@ -2972,9 +2970,9 @@ class AdminInlineFileUploadTest(TestCase):
         self.assertContains(response, b"Currently")
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminInlineTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3291,9 +3289,9 @@ class AdminInlineTests(TestCase):
         self.assertEqual(Category.objects.get(id=4).order, 0)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class NeverCacheTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-colors.xml', 'admin-views-fabrics.xml']
 
     def setUp(self):
@@ -3365,9 +3363,9 @@ class NeverCacheTests(TestCase):
         self.assertEqual(get_max_age(response), None)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class PrePopulatedTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3401,12 +3399,12 @@ class PrePopulatedTest(TestCase):
         self.assertContains(response, "maxLength: 1000")  # instead of 1,000
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class SeleniumAdminViewsFirefoxTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['admin_views'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-views-users.xml']
-    urls = "admin_views.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_prepopulated_fields(self):
@@ -3597,9 +3595,9 @@ class SeleniumAdminViewsIETests(SeleniumAdminViewsFirefoxTests):
     webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class ReadonlyTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3708,9 +3706,9 @@ class ReadonlyTest(TestCase):
         self.assertNotContains(response, "Some help text for the date (with unicode ŠĐĆŽćžšđ)")
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class LimitChoicesToInAdminTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3735,9 +3733,9 @@ class LimitChoicesToInAdminTest(TestCase):
         self.assertNotContains(response, marley.username)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class RawIdFieldsTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3815,12 +3813,12 @@ class RawIdFieldsTest(TestCase):
         self.assertContains(response2, "Palin")
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class UserAdminTest(TestCase):
     """
     Tests user CRUD functionality.
     """
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3922,12 +3920,12 @@ class UserAdminTest(TestCase):
         self.assertEqual(response.context['form_url'], 'pony')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class GroupAdminTest(TestCase):
     """
     Tests group CRUD functionality.
     """
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -3959,9 +3957,9 @@ class GroupAdminTest(TestCase):
             self.assertEqual(response.status_code, 200)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class CSSTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4084,9 +4082,9 @@ except ImportError:
 
 
 @unittest.skipUnless(docutils, "no docutils installed.")
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminDocsTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4127,9 +4125,9 @@ class AdminDocsTest(TestCase):
         self.assertContains(response, '<li><a href="#built_in-add">add</a></li>', html=True)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class ValidXHTMLTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
     urlbit = 'admin'
 
@@ -4152,9 +4150,9 @@ class ValidXHTMLTests(TestCase):
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="admin_views.urls",
                    USE_THOUSAND_SEPARATOR=True, USE_L10N=True)
 class DateHierarchyTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4274,13 +4272,13 @@ class DateHierarchyTests(TestCase):
             self.assert_non_localized_year(response, 2005)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminCustomSaveRelatedTests(TestCase):
     """
     Ensure that one can easily customize the way related objects are saved.
     Refs #16115.
     """
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4343,9 +4341,9 @@ class AdminCustomSaveRelatedTests(TestCase):
         self.assertEqual(['Catherine Stone', 'Paul Stone'], children_names)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewLogoutTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4372,9 +4370,9 @@ class AdminViewLogoutTest(TestCase):
         self.assertContains(response, '<input type="hidden" name="next" value="/test_admin/admin/" />')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminUserMessageTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4430,9 +4428,9 @@ class AdminUserMessageTest(TestCase):
                             html=True)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminKeepChangeListFiltersTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
     admin_site = site
 
@@ -4716,11 +4714,11 @@ class NamespacedAdminKeepChangeListFiltersTests(AdminKeepChangeListFiltersTests)
     admin_site = site2
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class TestLabelVisibility(TestCase):
     """ #11277 -Labels of hidden fields in admin were not hidden. """
 
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml']
 
     def setUp(self):
@@ -4757,9 +4755,9 @@ class TestLabelVisibility(TestCase):
         self.assertContains(response, '<div class="form-row hidden')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class AdminViewOnSiteTests(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-restaurants.xml']
 
     def setUp(self):
@@ -4878,9 +4876,9 @@ class AdminViewOnSiteTests(TestCase):
         self.assertIsNone(model_admin.get_view_on_site_url(Worker()))
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF="admin_views.urls")
 class InlineAdminViewOnSiteTest(TestCase):
-    urls = "admin_views.urls"
     fixtures = ['admin-views-users.xml', 'admin-views-restaurants.xml']
 
     def setUp(self):

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -181,10 +181,10 @@ class AdminFormfieldForDBFieldTests(TestCase):
         self.assertEqual(six.text_type(f.help_text), 'Hold down "Control", or "Command" on a Mac, to select more than one.')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class AdminFormfieldForDBFieldWithRequestTests(DjangoTestCase):
     fixtures = ["admin-widgets-users.xml"]
-    urls = 'admin_widgets.urls'
 
     def testFilterChoicesByRequestUser(self):
         """
@@ -196,10 +196,10 @@ class AdminFormfieldForDBFieldWithRequestTests(DjangoTestCase):
         self.assertContains(response, "Volkswagon Passat")
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class AdminForeignKeyWidgetChangeList(DjangoTestCase):
     fixtures = ["admin-widgets-users.xml"]
-    urls = 'admin_widgets.urls'
 
     def setUp(self):
         self.client.login(username="super", password="secret")
@@ -212,10 +212,10 @@ class AdminForeignKeyWidgetChangeList(DjangoTestCase):
         self.assertContains(response, '/auth/user/add/')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class AdminForeignKeyRawIdWidget(DjangoTestCase):
     fixtures = ["admin-widgets-users.xml"]
-    urls = 'admin_widgets.urls'
 
     def setUp(self):
         self.client.login(username="super", password="secret")
@@ -391,8 +391,8 @@ class AdminFileWidgetTest(DjangoTestCase):
         )
 
 
+@override_settings(ROOT_URLCONF='admin_widgets.urls')
 class ForeignKeyRawIdWidgetTest(DjangoTestCase):
-    urls = 'admin_widgets.urls'
 
     def test_render(self):
         band = models.Band.objects.create(name='Linkin Park')
@@ -465,8 +465,8 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
         )
 
 
+@override_settings(ROOT_URLCONF='admin_widgets.urls')
 class ManyToManyRawIdWidgetTest(DjangoTestCase):
-    urls = 'admin_widgets.urls'
 
     def test_render(self):
         band = models.Band.objects.create(name='Linkin Park')
@@ -518,12 +518,12 @@ class RelatedFieldWidgetWrapperTests(DjangoTestCase):
         self.assertFalse(w.can_add_related)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class DateTimePickerSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['admin_widgets'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-widgets-users.xml']
-    urls = "admin_widgets.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_show_hide_date_time_picker_widgets(self):
@@ -652,11 +652,11 @@ class DateTimePickerSeleniumIETests(DateTimePickerSeleniumFirefoxTests):
 
 @skipIf(pytz is None, "this test requires pytz")
 @override_settings(TIME_ZONE='Asia/Singapore')
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class DateTimePickerShortcutsSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
     available_apps = ['admin_widgets'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-widgets-users.xml']
-    urls = "admin_widgets.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_date_time_picker_shortcuts(self):
@@ -720,12 +720,12 @@ class DateTimePickerShortcutsSeleniumIETests(DateTimePickerShortcutsSeleniumFire
     webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class HorizontalVerticalFilterSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['admin_widgets'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-widgets-users.xml']
-    urls = "admin_widgets.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def setUp(self):
@@ -964,11 +964,11 @@ class HorizontalVerticalFilterSeleniumIETests(HorizontalVerticalFilterSeleniumFi
     webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+    ROOT_URLCONF='admin_widgets.urls')
 class AdminRawIdWidgetSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
     available_apps = ['admin_widgets'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-widgets-users.xml']
-    urls = "admin_widgets.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def setUp(self):
@@ -1055,11 +1055,11 @@ class AdminRawIdWidgetSeleniumIETests(AdminRawIdWidgetSeleniumFirefoxTests):
     webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='admin_widgets.urls')
 class RelatedFieldWidgetSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
     available_apps = ['admin_widgets'] + AdminSeleniumWebDriverTestCase.available_apps
     fixtures = ['admin-widgets-users.xml']
-    urls = "admin_widgets.urls"
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     def test_foreign_key_using_to_field(self):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2007,9 +2007,9 @@ class TestWithTemplateResponse(TestCase):
         self.assertTrue(response.has_header('ETag'))
 
 
+@override_settings(ROOT_URLCONF="admin_views.urls")
 class TestEtagWithAdmin(TestCase):
     # See https://code.djangoproject.com/ticket/16003
-    urls = "admin_views.urls"
 
     def test_admin(self):
         with self.settings(USE_ETAGS=False):

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 FULL_RESPONSE = 'Test conditional get response'
@@ -16,8 +16,8 @@ ETAG = 'b4246ffc4f62314ca13147c9d4f76974'
 EXPIRED_ETAG = '7fae4cd4b0f81e7d2914700043aa8ed6'
 
 
+@override_settings(ROOT_URLCONF='conditional_processing.urls')
 class ConditionalGet(TestCase):
-    urls = 'conditional_processing.urls'
 
     def assertFullResponse(self, response, check_last_modified=True, check_etag=True):
         self.assertEqual(response.status_code, 200)

--- a/tests/contenttypes_tests/tests.py
+++ b/tests/contenttypes_tests/tests.py
@@ -15,9 +15,9 @@ from django.utils.encoding import force_str
 from .models import Author, Article, SchemeIncludedURL
 
 
+@override_settings(ROOT_URLCONF='contenttypes_tests.urls')
 class ContentTypesViewsTests(TestCase):
     fixtures = ['testdata.json']
-    urls = 'contenttypes_tests.urls'
 
     def test_shortcut_with_absolute_url(self):
         "Can view a shortcut for an Author object that has a get_absolute_url method"

--- a/tests/context_processors/tests.py
+++ b/tests/context_processors/tests.py
@@ -1,15 +1,14 @@
 """
 Tests for Django's bundled context processors.
 """
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
+@override_settings(ROOT_URLCONF='context_processors.urls')
 class RequestContextProcessorTests(TestCase):
     """
     Tests for the ``django.core.context_processors.request`` processor.
     """
-
-    urls = 'context_processors.urls'
 
     def test_request_attributes(self):
         """

--- a/tests/deprecation/tests.py
+++ b/tests/deprecation/tests.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
 
+import os
+import unittest
 import warnings
 
 from django.test import SimpleTestCase, RequestFactory, override_settings
 from django.utils import six, translation
 from django.utils.deprecation import RenameMethodsBase
+from django.utils.encoding import force_text
 from django.utils.functional import memoize
 
 
@@ -220,3 +223,26 @@ class DeprecatingMemoizeTest(SimpleTestCase):
             self.assertEqual(msg,
                 'memoize wrapper is deprecated and will be removed in Django '
                 '1.9. Use django.utils.lru_cache instead.')
+
+
+class DeprecatingSimpleTestCaseUrls(unittest.TestCase):
+
+    def test_deprecation(self):
+        """
+        Ensure the correct warning is raised when SimpleTestCase.urls is used.
+        """
+        class TempTestCase(SimpleTestCase):
+            urls = 'tests.urls'
+
+            def test(self):
+                pass
+
+        with warnings.catch_warnings(record=True) as recorded:
+            suite = unittest.TestLoader().loadTestsFromTestCase(TempTestCase)
+            with open(os.devnull, 'w') as devnull:
+                unittest.TextTestRunner(stream=devnull, verbosity=2).run(suite)
+                msg = force_text(recorded.pop().message)
+                self.assertEqual(msg,
+                    "SimpleTestCase.urls is deprecated and will be removed in"
+                    "Django 2.0. Use @override_settings(ROOT_URLCONF=...)"
+                    "in TempTestCase instead.")

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -641,13 +641,13 @@ class ContentFileStorageTestCase(unittest.TestCase):
         self.storage.save('unicode.txt', ContentFile("español"))
 
 
+@override_settings(ROOT_URLCONF='file_storage.urls')
 class FileLikeObjectTestCase(LiveServerTestCase):
     """
     Test file-like objects (#15644).
     """
 
     available_apps = []
-    urls = 'file_storage.urls'
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -27,9 +27,8 @@ MEDIA_ROOT = sys_tempfile.mkdtemp()
 UPLOAD_TO = os.path.join(MEDIA_ROOT, 'test_upload')
 
 
-@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+@override_settings(MEDIA_ROOT=MEDIA_ROOT, ROOT_URLCONF='file_uploads.urls')
 class FileUploadTests(TestCase):
-    urls = 'file_uploads.urls'
 
     @classmethod
     def setUpClass(cls):

--- a/tests/forms_tests/tests/test_widgets.py
+++ b/tests/forms_tests/tests/test_widgets.py
@@ -1112,10 +1112,10 @@ class WidgetTests(TestCase):
             self.assertFalse(form.is_valid())
 
 
+@override_settings(ROOT_URLCONF='forms_tests.urls')
 class LiveWidgetTests(AdminSeleniumWebDriverTestCase):
 
     available_apps = ['forms_tests'] + AdminSeleniumWebDriverTestCase.available_apps
-    urls = 'forms_tests.urls'
 
     def test_textarea_trailing_newlines(self):
         """

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -18,9 +18,9 @@ from .models import (Episode, EpisodeExtra, EpisodeMaxNum, Media,
 
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
-                   TEMPLATE_DEBUG=True)
+                   TEMPLATE_DEBUG=True,
+                   ROOT_URLCONF="generic_inline_admin.urls")
 class GenericAdminViewTest(TestCase):
-    urls = "generic_inline_admin.urls"
     fixtures = ['users.xml']
 
     def setUp(self):
@@ -130,9 +130,9 @@ class GenericAdminViewTest(TestCase):
         self.assertTrue(formset.get_queryset().ordered)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="generic_inline_admin.urls")
 class GenericInlineAdminParametersTest(TestCase):
-    urls = "generic_inline_admin.urls"
     fixtures = ['users.xml']
 
     def setUp(self):
@@ -183,9 +183,9 @@ class GenericInlineAdminParametersTest(TestCase):
         self.assertEqual(formset.initial_form_count(), 1)
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF="generic_inline_admin.urls")
 class GenericInlineAdminWithUniqueTogetherTest(TestCase):
-    urls = "generic_inline_admin.urls"
     fixtures = ['users.xml']
 
     def setUp(self):
@@ -212,8 +212,8 @@ class GenericInlineAdminWithUniqueTogetherTest(TestCase):
         self.assertEqual(response.status_code, 302)  # redirect somewhere
 
 
+@override_settings(ROOT_URLCONF="generic_inline_admin.urls")
 class NoInlineDeletionTest(TestCase):
-    urls = "generic_inline_admin.urls"
 
     def test_no_deletion(self):
         fake_site = object()
@@ -235,8 +235,8 @@ request = MockRequest()
 request.user = MockSuperUser()
 
 
+@override_settings(ROOT_URLCONF="generic_inline_admin.urls")
 class GenericInlineModelAdminTest(TestCase):
-    urls = "generic_inline_admin.urls"
 
     def setUp(self):
         self.site = AdminSite()

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -5,7 +5,7 @@ import unittest
 
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 from django.views.generic import View, TemplateView, RedirectView
 
 from . import views
@@ -238,8 +238,8 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(response.status_code, 405)
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class TemplateViewTest(TestCase):
-    urls = 'generic_views.urls'
 
     rf = RequestFactory()
 
@@ -327,8 +327,8 @@ class TemplateViewTest(TestCase):
         self.assertEqual(response['Content-Type'], 'text/plain')
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class RedirectViewTest(TestCase):
-    urls = 'generic_views.urls'
 
     rf = RequestFactory()
 

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -19,9 +19,9 @@ def _make_books(n, base_date):
             pubdate=base_date - datetime.timedelta(days=i))
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class ArchiveIndexViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_archive_view(self):
         res = self.client.get('/dates/books/')
@@ -121,9 +121,9 @@ class ArchiveIndexViewTests(TestCase):
         self.assertEqual(list(res.context['date_list']), list(reversed(sorted(res.context['date_list']))))
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class YearArchiveViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_year_view(self):
         res = self.client.get('/dates/books/2008/')
@@ -206,9 +206,9 @@ class YearArchiveViewTests(TestCase):
         self.assertEqual(list(res.context['date_list']), list(sorted(res.context['date_list'])))
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class MonthArchiveViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_month_view(self):
         res = self.client.get('/dates/books/2008/oct/')
@@ -333,9 +333,9 @@ class MonthArchiveViewTests(TestCase):
         self.assertEqual(list(res.context['date_list']), list(sorted(res.context['date_list'])))
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class WeekArchiveViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_week_view(self):
         res = self.client.get('/dates/books/2008/week/39/')
@@ -430,9 +430,9 @@ class WeekArchiveViewTests(TestCase):
         self.assertEqual(res.status_code, 200)
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class DayArchiveViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_day_view(self):
         res = self.client.get('/dates/books/2008/oct/01/')
@@ -548,9 +548,9 @@ class DayArchiveViewTests(TestCase):
         self.assertEqual(res.status_code, 404)
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class DateDetailViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_date_detail_by_pk(self):
         res = self.client.get('/dates/books/2008/oct/01/1/')

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -1,15 +1,15 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.views.generic.base import View
 
 from .models import Artist, Author, Page
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class DetailViewTest(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_simple_object(self):
         res = self.client.get('/detail/obj/')

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -5,7 +5,7 @@ from unittest import expectedFailure
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.views.generic.base import View
 from django.views.generic.edit import FormMixin, ModelFormMixin, CreateView
@@ -41,8 +41,8 @@ class FormMixinTests(TestCase):
         self.assertEqual(test_string, set_kwargs.get('prefix'))
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class BasicFormTests(TestCase):
-    urls = 'generic_views.urls'
 
     def test_post_data(self):
         res = self.client.post('/contact/', {'name': "Me", 'message': "Hello"})
@@ -61,8 +61,8 @@ class ModelFormMixinTests(TestCase):
                          mixin.get_form_kwargs())
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class CreateViewTests(TestCase):
-    urls = 'generic_views.urls'
 
     def test_create(self):
         res = self.client.get('/edit/authors/create/')
@@ -168,8 +168,8 @@ class CreateViewTests(TestCase):
             MyCreateView().get_form_class()
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class UpdateViewTests(TestCase):
-    urls = 'generic_views.urls'
 
     def test_update_post(self):
         a = Author.objects.create(
@@ -305,8 +305,8 @@ class UpdateViewTests(TestCase):
         self.assertQuerysetEqual(Author.objects.all(), ['<Author: Randall Munroe (xkcd)>'])
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class DeleteViewTests(TestCase):
-    urls = 'generic_views.urls'
 
     def test_delete_by_post(self):
         a = Author.objects.create(**{'name': 'Randall Munroe', 'slug': 'randall-munroe'})

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -8,9 +8,9 @@ from django.utils.encoding import force_str
 from .models import Author, Artist
 
 
+@override_settings(ROOT_URLCONF='generic_views.urls')
 class ListViewTests(TestCase):
     fixtures = ['generic-views-test-data.json']
-    urls = 'generic_views.urls'
 
     def test_items(self):
         res = self.client.get('/list/dict/')

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -65,10 +65,10 @@ class HandlerTests(TestCase):
         self.assertEqual(request.COOKIES['want'], force_str("café"))
 
 
+@override_settings(ROOT_URLCONF='handlers.urls')
 class TransactionsPerRequestTests(TransactionTestCase):
 
     available_apps = []
-    urls = 'handlers.urls'
 
     def test_no_transaction(self):
         response = self.client.get('/in_transaction/')
@@ -93,8 +93,8 @@ class TransactionsPerRequestTests(TransactionTestCase):
         self.assertContains(response, 'False')
 
 
+@override_settings(ROOT_URLCONF='handlers.urls')
 class SignalsTests(TestCase):
-    urls = 'handlers.urls'
 
     def setUp(self):
         self.signals = []
@@ -123,8 +123,8 @@ class SignalsTests(TestCase):
         self.assertEqual(self.signals, ['started', 'finished'])
 
 
+@override_settings(ROOT_URLCONF='handlers.urls')
 class HandlerSuspiciousOpsTest(TestCase):
-    urls = 'handlers.urls'
 
     def test_suspiciousop_in_view_returns_400(self):
         response = self.client.get('/suspicious/')

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -34,12 +34,12 @@ class PermanentRedirectLocaleMiddleWare(LocaleMiddleware):
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
     ),
+    ROOT_URLCONF='i18n.patterns.urls.default',
 )
 class URLTestCaseBase(TestCase):
     """
     TestCase base-class for the URL tests.
     """
-    urls = 'i18n.patterns.urls.default'
 
     def setUp(self):
         # Make sure the cache is empty before we are doing our tests.
@@ -73,8 +73,8 @@ class URLPrefixTests(URLTestCaseBase):
         self.assertRaises(ImproperlyConfigured, lambda: reverse('account:register'))
 
 
+@override_settings(ROOT_URLCONF='i18n.patterns.urls.disabled')
 class URLDisabledTests(URLTestCaseBase):
-    urls = 'i18n.patterns.urls.disabled'
 
     @override_settings(USE_I18N=False)
     def test_prefixed_i18n_disabled(self):
@@ -84,12 +84,12 @@ class URLDisabledTests(URLTestCaseBase):
             self.assertEqual(reverse('prefixed'), '/prefixed/')
 
 
+@override_settings(ROOT_URLCONF='i18n.patterns.urls.path_unused')
 class PathUnusedTests(URLTestCaseBase):
     """
     Check that if no i18n_patterns is used in root urlconfs, then no
     language activation happens based on url prefix.
     """
-    urls = 'i18n.patterns.urls.path_unused'
 
     def test_no_lang_activate(self):
         response = self.client.get('/nl/foo/')

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1261,10 +1261,9 @@ class MultipleLocaleActivationTests(TestCase):
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
     ),
+    ROOT_URLCONF='i18n.urls',
 )
 class LocaleMiddlewareTests(TestCase):
-
-    urls = 'i18n.urls'
 
     def test_streaming_response(self):
         # Regression test for #5241
@@ -1299,10 +1298,9 @@ class LocaleMiddlewareTests(TestCase):
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
     ),
+    ROOT_URLCONF='i18n.urls'
 )
 class CountrySpecificLanguageTests(TestCase):
-
-    urls = 'i18n.urls'
 
     def setUp(self):
         super(CountrySpecificLanguageTests, self).setUp()

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -363,10 +363,8 @@ class SetupConfigureLogging(TestCase):
         self.assertTrue(dictConfig.called)
 
 
-@override_settings(DEBUG=True)
+@override_settings(DEBUG=True, ROOT_URLCONF='logging_tests.urls')
 class SecurityLoggerTest(TestCase):
-
-    urls = 'logging_tests.urls'
 
     def test_suspicious_operation_creates_log_message(self):
         with patch_logger('django.security.SuspiciousOperation', 'error') as calls:

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -20,8 +20,8 @@ from django.utils.encoding import force_str
 from django.utils.six.moves import xrange
 
 
+@override_settings(ROOT_URLCONF='middleware.urls')
 class CommonMiddlewareTest(TestCase):
-    urls = 'middleware.urls'
 
     def _get_request(self, path):
         request = HttpRequest()
@@ -303,8 +303,8 @@ class BrokenLinkEmailsMiddlewareTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
 
+@override_settings(ROOT_URLCONF='middleware.cond_get_urls')
 class ConditionalGetMiddlewareTest(TestCase):
-    urls = 'middleware.cond_get_urls'
 
     def setUp(self):
         self.req = HttpRequest()

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -101,8 +101,8 @@ class BadExceptionMiddleware(TestMiddleware):
         raise TestException('Test Exception Exception')
 
 
+@override_settings(ROOT_URLCONF='middleware_exceptions.urls')
 class BaseMiddlewareExceptionTest(TestCase):
-    urls = 'middleware_exceptions.urls'
 
     def setUp(self):
         self.exceptions = []
@@ -779,8 +779,8 @@ class BadMiddlewareTests(BaseMiddlewareExceptionTest):
 _missing = object()
 
 
+@override_settings(ROOT_URLCONF='middleware_exceptions.urls')
 class RootUrlconfTests(TestCase):
-    urls = 'middleware_exceptions.urls'
 
     @override_settings(ROOT_URLCONF=None)
     def test_missing_root_urlconf(self):

--- a/tests/model_permalink/tests.py
+++ b/tests/model_permalink/tests.py
@@ -1,10 +1,10 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from .models import Guitarist
 
 
+@override_settings(ROOT_URLCONF='model_permalink.urls')
 class PermalinkTests(TestCase):
-    urls = 'model_permalink.urls'
 
     def test_permalink(self):
         g = Guitarist(name='Adrien Moignard', slug='adrienmoignard')

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -368,10 +368,10 @@ class ProxyModelTests(TestCase):
         self.assertEqual(MyPerson(id=100), Person(id=100))
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='proxy_models.urls',)
 class ProxyModelAdminTests(TestCase):
     fixtures = ['myhorses']
-    urls = 'proxy_models.urls'
 
     def test_cascade_delete_proxy_model_admin_warning(self):
         """

--- a/tests/resolve_url/tests.py
+++ b/tests/resolve_url/tests.py
@@ -3,16 +3,16 @@ from __future__ import unicode_literals
 from django.core.urlresolvers import NoReverseMatch
 from django.contrib.auth.views import logout
 from django.shortcuts import resolve_url
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from .models import UnimportantThing
 
 
+@override_settings(ROOT_URLCONF='resolve_url.urls')
 class ResolveUrlTests(TestCase):
     """
     Tests for the ``resolve_url`` function.
     """
-    urls = 'resolve_url.urls'
 
     def test_url_path(self):
         """

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -27,6 +27,7 @@ TEST_SETTINGS = {
 }
 
 
+@override_settings(ROOT_URLCONF='servers.urls')
 class LiveServerBase(LiveServerTestCase):
 
     available_apps = [
@@ -36,7 +37,6 @@ class LiveServerBase(LiveServerTestCase):
         'django.contrib.sessions',
     ]
     fixtures = ['testdata.json']
-    urls = 'servers.urls'
 
     @classmethod
     def setUpClass(cls):

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -735,11 +735,11 @@ class TestCollectionLinks(CollectionTestCase, TestDefaults):
         self.assertTrue(os.path.islink(path))
 
 
+@override_settings(ROOT_URLCONF='staticfiles_tests.urls.default')
 class TestServeStatic(StaticFilesTestCase):
     """
     Test static asset serving view.
     """
-    urls = 'staticfiles_tests.urls.default'
 
     def _response(self, filepath):
         return self.client.get(
@@ -771,11 +771,11 @@ class TestServeStaticWithDefaultURL(TestServeStatic, TestDefaults):
     pass
 
 
+@override_settings(ROOT_URLCONF='staticfiles_tests.urls.helper')
 class TestServeStaticWithURLHelper(TestServeStatic, TestDefaults):
     """
     Test static asset serving view with staticfiles_urlpatterns helper.
     """
-    urls = 'staticfiles_tests.urls.helper'
 
 
 class TestServeAdminMedia(TestServeStatic):

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from django.contrib.syndication import views
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils.feedgenerator import rfc2822_date, rfc3339_date
 from django.utils import timezone
@@ -50,11 +50,11 @@ class FeedTestCase(TestCase):
 ######################################
 
 
+@override_settings(ROOT_URLCONF='syndication_tests.urls')
 class SyndicationFeedTest(FeedTestCase):
     """
     Tests for the high-level syndication feed framework.
     """
-    urls = 'syndication_tests.urls'
 
     def test_rss2_feed(self):
         """

--- a/tests/template_tests/test_response.py
+++ b/tests/template_tests/test_response.py
@@ -302,10 +302,10 @@ class TemplateResponseTest(TestCase):
 @override_settings(
     MIDDLEWARE_CLASSES=list(settings.MIDDLEWARE_CLASSES) + [
         'template_tests.test_response.CustomURLConfMiddleware'
-    ]
+    ],
+    ROOT_URLCONF='template_tests.urls',
 )
 class CustomURLConfTest(TestCase):
-    urls = 'template_tests.urls'
 
     def test_custom_urlconf(self):
         response = self.client.get('/template_response_view/')
@@ -318,10 +318,10 @@ class CustomURLConfTest(TestCase):
     MIDDLEWARE_CLASSES=list(settings.MIDDLEWARE_CLASSES) + [
         'django.middleware.cache.FetchFromCacheMiddleware',
         'django.middleware.cache.UpdateCacheMiddleware',
-    ]
+    ],
+    ROOT_URLCONF='template_tests.alternate_urls',
 )
 class CacheMiddlewareTest(TestCase):
-    urls = 'template_tests.alternate_urls'
 
     def test_middleware_caching(self):
         response = self.client.get('/template_response_view/')

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -529,9 +529,9 @@ class TemplateRegressionTests(TestCase):
 @override_settings(MEDIA_URL="/media/", STATIC_URL="/static/",
                    TEMPLATE_DEBUG=False, ALLOWED_INCLUDE_ROOTS=(
                        os.path.dirname(os.path.abspath(upath(__file__))),),
+                   ROOT_URLCONF='template_tests.urls',
                    )
 class TemplateTests(TestCase):
-    urls = 'template_tests.urls'
 
     def test_templates(self):
         template_tests = self.get_template_tests()

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -29,10 +29,10 @@ from django.test import override_settings
 from .views import get_view
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client.urls',)
 class ClientTest(TestCase):
     fixtures = ['testdata.json']
-    urls = 'test_client.urls'
 
     def test_get_view(self):
         "GET a view"
@@ -499,10 +499,10 @@ class ClientTest(TestCase):
 
 
 @override_settings(
-    MIDDLEWARE_CLASSES=('django.middleware.csrf.CsrfViewMiddleware',)
+    MIDDLEWARE_CLASSES=('django.middleware.csrf.CsrfViewMiddleware',),
+    ROOT_URLCONF='test_client.urls',
 )
 class CSRFEnabledClientTests(TestCase):
-    urls = 'test_client.urls'
 
     def test_csrf_enabled_client(self):
         "A client can be instantiated with CSRF checks enabled"
@@ -529,8 +529,8 @@ class CustomTestClientTest(TestCase):
         self.assertEqual(hasattr(self.client, "i_am_customized"), True)
 
 
+@override_settings(ROOT_URLCONF='test_client.urls')
 class RequestFactoryTest(TestCase):
-    urls = 'test_client.urls'
 
     def test_request_factory(self):
         factory = RequestFactory()

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -27,10 +27,10 @@ from .views import CustomTestException
 
 
 @override_settings(
-    TEMPLATE_DIRS=(os.path.join(os.path.dirname(upath(__file__)), 'templates'),)
+    TEMPLATE_DIRS=(os.path.join(os.path.dirname(upath(__file__)), 'templates'),),
+    ROOT_URLCONF='test_client_regress.urls',
 )
 class AssertContainsTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_contains(self):
         "Responses can be inspected for content, including counting repeated substrings"
@@ -191,9 +191,9 @@ class AssertContainsTests(TestCase):
         self.assertNotContains(response, 'Bye')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client_regress.urls',)
 class AssertTemplateUsedTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata.json']
 
     def test_no_context(self):
@@ -264,8 +264,8 @@ class AssertTemplateUsedTests(TestCase):
             self.assertIn("Template 'Valid POST Template' was not a template used to render the response. Actual template(s) used: form_view.html, base.html", str(e))
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class AssertRedirectsTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_redirect_page(self):
         "An assertion is raised if the original page couldn't be retrieved as expected"
@@ -459,8 +459,8 @@ class AssertRedirectsTests(TestCase):
                 self.assertRedirects(response, 'http://testserver/secure_view/', status_code=301)
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class AssertFormErrorTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_unknown_form(self):
         "An assertion is raised if the form name is unknown"
@@ -576,8 +576,8 @@ class AssertFormErrorTests(TestCase):
             self.assertIn("abc: The form 'form' in context 0 does not contain the non-field error 'Some error.' (actual errors: )", str(e))
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class AssertFormsetErrorTests(TestCase):
-    urls = 'test_client_regress.urls'
     msg_prefixes = [("", {}), ("abc: ", {"msg_prefix": "abc"})]
 
     def setUp(self):
@@ -775,9 +775,9 @@ class ProcessedMiddleware(object):
         request.has_been_processed = True
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client_regress.urls',)
 class LoginTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata']
 
     def test_login_different_client(self):
@@ -817,10 +817,10 @@ class LoginTests(TestCase):
 
 @override_settings(
     PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
-    SESSION_ENGINE='test_client_regress.session'
+    SESSION_ENGINE='test_client_regress.session',
+    ROOT_URLCONF='test_client_regress.urls',
 )
 class SessionEngineTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata']
 
     def test_login(self):
@@ -834,8 +834,8 @@ class SessionEngineTests(TestCase):
         self.assertEqual(response.context['user'].username, 'testclient')
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls',)
 class URLEscapingTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_simple_argument_get(self):
         "Get a view that has a simple string argument"
@@ -862,9 +862,9 @@ class URLEscapingTests(TestCase):
         self.assertEqual(response.content, b'Hi, Arthur')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client_regress.urls',)
 class ExceptionTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata.json']
 
     def test_exception_cleared(self):
@@ -889,8 +889,8 @@ class ExceptionTests(TestCase):
             self.fail("Staff should be able to visit this page")
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class TemplateExceptionTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def setUp(self):
         # Reset the loaders so they don't try to render cached templates.
@@ -914,8 +914,8 @@ class TemplateExceptionTests(TestCase):
 # We need two different tests to check URLconf substitution -  one to check
 # it was changed, and another one (without self.urls) to check it was reverted on
 # teardown. This pair of tests relies upon the alphabetical ordering of test execution.
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class UrlconfSubstitutionTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_urlconf_was_changed(self):
         "TestCase can enforce a custom URLconf on a per-test basis"
@@ -936,9 +936,9 @@ class zzUrlconfSubstitutionTests(TestCase):
             reverse('arg_view', args=['somename'])
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client_regress.urls',)
 class ContextTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata']
 
     def test_single_context(self):
@@ -1007,9 +1007,9 @@ class ContextTests(TestCase):
         self.assertEqual(response.context['nested'], 'yes')
 
 
-@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+@override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                   ROOT_URLCONF='test_client_regress.urls',)
 class SessionTests(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata.json']
 
     def test_session(self):
@@ -1116,8 +1116,8 @@ class SessionTests(TestCase):
         self.assertFalse(listener.executed)
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class RequestMethodTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_get(self):
         "Request a view via request method GET"
@@ -1164,8 +1164,8 @@ class RequestMethodTests(TestCase):
         self.assertEqual(response.content, b'request method: PATCH')
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class RequestMethodStringDataTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_post(self):
         "Request a view with string data via request method POST"
@@ -1192,8 +1192,8 @@ class RequestMethodStringDataTests(TestCase):
         self.assertEqual(response.content, b'request method: PATCH')
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls',)
 class QueryStringTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_get_like_requests(self):
         # See: https://code.djangoproject.com/ticket/10571.
@@ -1247,8 +1247,8 @@ class QueryStringTests(TestCase):
         self.assertEqual(response.context['request-bar'], 'bang')
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class UnicodePayloadTests(TestCase):
-    urls = 'test_client_regress.urls'
 
     def test_simple_unicode_payload(self):
         "A simple ASCII-only unicode JSON document can be POSTed"
@@ -1312,8 +1312,8 @@ class UploadedFileEncodingTest(TestCase):
                          encode_file('IGNORE', 'IGNORE', DummyFile("file.unknown"))[2])
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls',)
 class RequestHeadersTest(TestCase):
-    urls = 'test_client_regress.urls'
     fixtures = ['testdata']
 
     def test_client_headers(self):
@@ -1348,6 +1348,7 @@ class RequestHeadersTest(TestCase):
             status_code=301, target_status_code=200)
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class ReadLimitedStreamTest(TestCase):
     """
     Tests that ensure that HttpRequest.body, HttpRequest.read() and
@@ -1355,7 +1356,6 @@ class ReadLimitedStreamTest(TestCase):
 
     Refs #14753, #15785
     """
-    urls = 'test_client_regress.urls'
 
     def test_body_from_empty_request(self):
         """HttpRequest.body on a test client GET request should return
@@ -1391,6 +1391,7 @@ class ReadLimitedStreamTest(TestCase):
             content_type='text/plain').content, payload)
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class RequestFactoryStateTest(TestCase):
     """Regression tests for #15929."""
     # These tests are checking that certain middleware don't change certain
@@ -1398,7 +1399,6 @@ class RequestFactoryStateTest(TestCase):
     # ensuring test isolation behavior. So, unusually, it doesn't make sense to
     # run the tests individually, and if any are failing it is confusing to run
     # them with any other set of tests.
-    urls = 'test_client_regress.urls'
 
     def common_test_that_should_always_pass(self):
         request = RequestFactory().get('/')
@@ -1418,12 +1418,12 @@ class RequestFactoryStateTest(TestCase):
         self.common_test_that_should_always_pass()
 
 
+@override_settings(ROOT_URLCONF='test_client_regress.urls')
 class RequestFactoryEnvironmentTests(TestCase):
     """
     Regression tests for #8551 and #17067: ensure that environment variables
     are set correctly in RequestFactory.
     """
-    urls = 'test_client_regress.urls'
 
     def test_should_set_correct_env_variables(self):
         request = RequestFactory().get('/path/')

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -51,8 +51,8 @@ class SkippingClassTestCase(TestCase):
         self.assertEqual(len(result.skipped), 1)
 
 
+@override_settings(ROOT_URLCONF='test_utils.urls')
 class AssertNumQueriesTests(TestCase):
-    urls = 'test_utils.urls'
 
     def test_assert_num_queries(self):
         def test_func():
@@ -121,8 +121,8 @@ class AssertQuerysetEqualTests(TestCase):
         )
 
 
+@override_settings(ROOT_URLCONF='test_utils.urls')
 class CaptureQueriesContextManagerTests(TestCase):
-    urls = 'test_utils.urls'
 
     def setUp(self):
         self.person_pk = six.text_type(Person.objects.create(name='test').pk)
@@ -175,8 +175,8 @@ class CaptureQueriesContextManagerTests(TestCase):
         self.assertIn(self.person_pk, captured_queries[1]['sql'])
 
 
+@override_settings(ROOT_URLCONF='test_utils.urls')
 class AssertNumQueriesContextManagerTests(TestCase):
-    urls = 'test_utils.urls'
 
     def test_simple(self):
         with self.assertNumQueries(0):
@@ -214,8 +214,8 @@ class AssertNumQueriesContextManagerTests(TestCase):
             self.client.get("/test_utils/get_person/%s/" % person.pk)
 
 
+@override_settings(ROOT_URLCONF='test_utils.urls')
 class AssertTemplateUsedContextManagerTests(TestCase):
-    urls = 'test_utils.urls'
 
     def test_usage(self):
         with self.assertTemplateUsed('template_used/base.html'):

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -1070,10 +1070,10 @@ class NewFormsTests(TestCase):
 
 
 @override_settings(DATETIME_FORMAT='c', TIME_ZONE='Africa/Nairobi', USE_L10N=False, USE_TZ=True,
-                  PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',))
+                  PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
+                  ROOT_URLCONF='timezones.urls')
 class AdminTests(TestCase):
 
-    urls = 'timezones.urls'
     fixtures = ['tz_users.xml']
 
     def setUp(self):

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import unittest
 
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.core.urlresolvers import (reverse, reverse_lazy, resolve, get_callable,
     get_resolver, NoReverseMatch, Resolver404, ResolverMatch, RegexURLResolver,
@@ -152,14 +153,14 @@ test_data = (
 )
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.no_urls')
 class NoURLPatternsTests(TestCase):
-    urls = 'urlpatterns_reverse.no_urls'
 
     def test_no_urls_exception(self):
         """
         RegexURLResolver should raise an exception when no urlpatterns exist.
         """
-        resolver = RegexURLResolver(r'^$', self.urls)
+        resolver = RegexURLResolver(r'^$', settings.ROOT_URLCONF)
 
         self.assertRaisesMessage(ImproperlyConfigured,
             "The included urlconf 'urlpatterns_reverse.no_urls' does not "
@@ -168,8 +169,8 @@ class NoURLPatternsTests(TestCase):
             getattr, resolver, 'url_patterns')
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
 class URLPatternReverse(TestCase):
-    urls = 'urlpatterns_reverse.urls'
 
     def test_urlpattern_reverse(self):
         for name, expected, args, kwargs in test_data:
@@ -290,8 +291,8 @@ class ResolverTests(unittest.TestCase):
                             self.assertEqual(t.name, e['name'], 'Wrong URL name.  Expected "%s", got "%s".' % (e['name'], t.name))
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.reverse_lazy_urls')
 class ReverseLazyTest(TestCase):
-    urls = 'urlpatterns_reverse.reverse_lazy_urls'
 
     def test_redirect_with_lazy_reverse(self):
         response = self.client.get('/redirect/')
@@ -324,8 +325,8 @@ LOGIN_URL = reverse_lazy('login')""")
         self.assertNoOutput(err)
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
 class ReverseShortcutTests(TestCase):
-    urls = 'urlpatterns_reverse.urls'
 
     def test_redirect_to_object(self):
         # We don't really need a model; just something with a get_absolute_url
@@ -363,8 +364,8 @@ class ReverseShortcutTests(TestCase):
         self.assertRaises(NoReverseMatch, redirect, absolute_kwargs_view, wrong_argument=None)
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls')
 class NamespaceTests(TestCase):
-    urls = 'urlpatterns_reverse.namespace_urls'
 
     def test_ambiguous_object(self):
         "Names deployed via dynamic URL objects that require namespaces can't be resolved"
@@ -600,8 +601,8 @@ class ErrorHandlerResolutionTests(TestCase):
         self.assertEqual(self.callable_resolver.resolve500(), handler)
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls_without_full_import')
 class DefaultErrorHandlerTests(TestCase):
-    urls = 'urlpatterns_reverse.urls_without_full_import'
 
     def test_default_handler(self):
         "If the urls.py doesn't specify handlers, the defaults are used"
@@ -617,16 +618,16 @@ class DefaultErrorHandlerTests(TestCase):
             self.fail("Shouldn't get an AttributeError due to undefined 500 handler")
 
 
+@override_settings(ROOT_URLCONF=None)
 class NoRootUrlConfTests(TestCase):
     """Tests for handler404 and handler500 if urlconf is None"""
-    urls = None
 
     def test_no_handler_exception(self):
         self.assertRaises(ImproperlyConfigured, self.client.get, '/test/me/')
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls')
 class ResolverMatchTests(TestCase):
-    urls = 'urlpatterns_reverse.namespace_urls'
 
     def test_urlpattern_resolve(self):
         for path, name, app_name, namespace, func, args, kwargs in resolve_test_data:
@@ -661,8 +662,8 @@ class ResolverMatchTests(TestCase):
         self.assertIsNone(request.resolver_match)
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.erroneous_urls')
 class ErroneousViewTests(TestCase):
-    urls = 'urlpatterns_reverse.erroneous_urls'
 
     def test_erroneous_resolve(self):
         self.assertRaises(ImportError, self.client.get, '/erroneous_inner/')

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -2,8 +2,8 @@ from django.test import TestCase, override_settings, Client
 from django.utils.translation import override
 
 
+@override_settings(ROOT_URLCONF="view_tests.urls")
 class CsrfViewTests(TestCase):
-    urls = "view_tests.urls"
 
     def setUp(self):
         super(CsrfViewTests, self).setUp()

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -30,9 +30,9 @@ from ..views import (sensitive_view, non_sensitive_view, paranoid_view,
     multivalue_dict_key_error)
 
 
-@override_settings(DEBUG=True, TEMPLATE_DEBUG=True)
+@override_settings(DEBUG=True, TEMPLATE_DEBUG=True,
+                   ROOT_URLCONF="view_tests.urls")
 class DebugViewTests(TestCase):
-    urls = "view_tests.urls"
 
     def test_files(self):
         response = self.client.get('/raises/')
@@ -521,12 +521,12 @@ class ExceptionReportTestMixin(object):
                 self.assertNotIn(v, body)
 
 
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class ExceptionReporterFilterTests(TestCase, ExceptionReportTestMixin):
     """
     Ensure that sensitive information can be filtered out of error reports.
     Refs #14614.
     """
-    urls = 'view_tests.urls'
     rf = RequestFactory()
 
     def test_non_sensitive_request(self):

--- a/tests/view_tests/tests/test_defaults.py
+++ b/tests/view_tests/tests/test_defaults.py
@@ -7,9 +7,9 @@ from django.test.utils import (setup_test_template_loader,
 from ..models import UrlArticle
 
 
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class DefaultsTests(TestCase):
     """Test django views in django/views/defaults.py"""
-    urls = 'view_tests.urls'
     fixtures = ['testdata.json']
     non_existing_urls = ['/non_existing_url/',  # this is in urls.py
                          '/other_non_existing_url/']  # this NOT in urls.py

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -17,9 +17,9 @@ from django.utils.translation import override, LANGUAGE_SESSION_KEY
 from ..urls import locale_dir
 
 
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class I18NTests(TestCase):
     """ Tests django views in django/views/i18n.py """
-    urls = 'view_tests.urls'
 
     def test_setlang(self):
         """
@@ -85,12 +85,12 @@ class I18NTests(TestCase):
                     self.assertContains(response, r'"month name\u0004May": "mai"', 1)
 
 
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class JsI18NTests(TestCase):
     """
     Tests django views in django/views/i18n.py that need to change
     settings.LANGUAGE_CODE.
     """
-    urls = 'view_tests.urls'
 
     def test_jsi18n_with_missing_en_files(self):
         """
@@ -163,8 +163,8 @@ class JsI18NTests(TestCase):
             self.assertContains(response, '\\ud83d\\udca9')
 
 
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class JsI18NTestsMultiPackage(TestCase):
-    urls = 'view_tests.urls'
     """
     Tests for django views in django/views/i18n.py that need to change
     settings.LANGUAGE_CODE and merge JS translation from several packages.
@@ -207,11 +207,11 @@ skip_selenium = not os.environ.get('DJANGO_SELENIUM_TESTS', False)
 
 
 @unittest.skipIf(skip_selenium, 'Selenium tests not requested')
+@override_settings(ROOT_URLCONF='view_tests.urls')
 class JavascriptI18nTests(LiveServerTestCase):
 
     # The test cases use translations from these apps.
     available_apps = ['django.contrib.admin', 'view_tests']
-    urls = 'view_tests.urls'
     webdriver_class = 'selenium.webdriver.firefox.webdriver.WebDriver'
 
     @classmethod

--- a/tests/view_tests/tests/test_json.py
+++ b/tests/view_tests/tests/test_json.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
+@override_settings(ROOT_URLCONF='view_tests.generic_urls')
 class JsonResponseTests(TestCase):
-    urls = 'view_tests.generic_urls'
 
     def test_json_response(self):
         response = self.client.get('/json/response/')

--- a/tests/view_tests/tests/test_shortcuts.py
+++ b/tests/view_tests/tests/test_shortcuts.py
@@ -4,9 +4,9 @@ from django.test import TestCase, override_settings
 @override_settings(
     TEMPLATE_CONTEXT_PROCESSORS=('django.core.context_processors.static',),
     STATIC_URL='/path/to/static/media/',
+    ROOT_URLCONF='view_tests.generic_urls',
 )
 class ShortcutTests(TestCase):
-    urls = 'view_tests.generic_urls'
 
     def test_render_to_response(self):
         response = self.client.get('/shortcuts/render_to_response/')

--- a/tests/view_tests/tests/test_specials.py
+++ b/tests/view_tests/tests/test_specials.py
@@ -1,14 +1,14 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
+@override_settings(ROOT_URLCONF='view_tests.generic_urls')
 class URLHandling(TestCase):
     """
     Tests for URL handling in views and responses.
     """
-    urls = 'view_tests.generic_urls'
     redirect_target = "/%E4%B8%AD%E6%96%87/target/"
 
     def test_combining_redirect(self):

--- a/tests/view_tests/tests/test_static.py
+++ b/tests/view_tests/tests/test_static.py
@@ -14,11 +14,10 @@ from .. import urls
 from ..urls import media_dir
 
 
-@override_settings(DEBUG=True)
+@override_settings(DEBUG=True, ROOT_URLCONF='view_tests.urls')
 class StaticTests(SimpleTestCase):
     """Tests django views in django/views/static.py"""
 
-    urls = 'view_tests.urls'
     prefix = 'site_media'
 
     def test_serve(self):

--- a/tests/wsgi/tests.py
+++ b/tests/wsgi/tests.py
@@ -12,8 +12,8 @@ from django.test.client import RequestFactory
 from django.utils import six
 
 
+@override_settings(ROOT_URLCONF="wsgi.urls")
 class WSGITest(TestCase):
-    urls = "wsgi.urls"
 
     def setUp(self):
         request_started.disconnect(close_old_connections)


### PR DESCRIPTION
Replaced `SimpleTestCase.urls` with `@override_settings(...)`.
Added warning in the function.
Updated the docs.
