### PR TITLE
re-fix #13147 by overriding username uniqe error message

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -75,13 +75,6 @@ class UserCreationForm(forms.ModelForm):
     error_messages = {
         'password_mismatch': _("The two password fields didn't match."),
     }
-    username = forms.RegexField(label=_("Username"), max_length=30,
-        regex=r'^[\w.@+-]+$',
-        help_text=_("Required. 30 characters or fewer. Letters, digits and "
-                    "@/./+/-/_ only."),
-        error_messages={
-            'invalid': _("This value may contain only letters, numbers and "
-                         "@/./+/-/_ characters.")})
     password1 = forms.CharField(label=_("Password"),
         widget=forms.PasswordInput)
     password2 = forms.CharField(label=_("Password confirmation"),
@@ -111,13 +104,6 @@ class UserCreationForm(forms.ModelForm):
 
 
 class UserChangeForm(forms.ModelForm):
-    username = forms.RegexField(
-        label=_("Username"), max_length=30, regex=r"^[\w.@+-]+$",
-        help_text=_("Required. 30 characters or fewer. Letters, digits and "
-                    "@/./+/-/_ only."),
-        error_messages={
-            'invalid': _("This value may contain only letters, numbers and "
-                         "@/./+/-/_ characters.")})
     password = ReadOnlyPasswordHashField(label=_("Password"),
         help_text=_("Raw passwords are not stored, so there is no way to see "
                     "this user's password, but you can change the password "

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -368,7 +368,10 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         help_text=_('Required. 30 characters or fewer. Letters, digits and '
                     '@/./+/-/_ only.'),
         validators=[
-            validators.RegexValidator(r'^[\w.@+-]+$', _('Enter a valid username.'), 'invalid')
+            validators.RegexValidator(r'^[\w.@+-]+$',
+                                      _('Enter a valid username. '
+                                        'This value may contain only letters, numbers '
+                                        'and @/./+/-/_ characters.'), 'invalid'),
         ],
         error_messages={
             'unique': _("A user with that username already exists."),

--- a/django/contrib/auth/tests/test_forms.py
+++ b/django/contrib/auth/tests/test_forms.py
@@ -44,8 +44,9 @@ class UserCreationFormTest(TestCase):
         }
         form = UserCreationForm(data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form["username"].errors,
-                         [force_text(form.fields['username'].error_messages['invalid'])])
+        for validator in User._meta.get_field('username').validators:
+            if validator.code == "invalid":
+                self.assertEqual(form["username"].errors, [force_text(validator.message)])
 
     def test_password_verification(self):
         # The verification password is incorrect.
@@ -288,8 +289,9 @@ class UserChangeFormTest(TestCase):
         data = {'username': 'not valid'}
         form = UserChangeForm(data, instance=user)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form['username'].errors,
-                         [force_text(form.fields['username'].error_messages['invalid'])])
+        for validator in User._meta.get_field('username').validators:
+            if validator.code == "invalid":
+                self.assertEqual(form["username"].errors, [force_text(validator.message)])
 
     def test_bug_14242(self):
         # A regression test, introduce by adding an optimization for the


### PR DESCRIPTION
use username from field definition with custom error_messages and validators, more DRY and esay for subclass from `UserCreationForm` and `UserChangeForm`.
