### PR TITLE
Fixed #22396 admin AllValuesFieldListFilter not respecting ModelAdmin.get_queryset

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -360,7 +360,7 @@ class AllValuesFieldListFilter(FieldListFilter):
         self.lookup_val_isnull = request.GET.get(self.lookup_kwarg_isnull,
                                                  None)
         parent_model, reverse_path = reverse_field_path(model, field_path)
-        queryset = parent_model._default_manager.all()
+        queryset = model_admin.get_queryset(request)
         # optional feature: limit choices base on existing relationships
         # queryset = queryset.complex_filter(
         #    {'%s__isnull' % reverse_path: False})


### PR DESCRIPTION
Admin's AllValuesFieldListFilter object does not respect ModelAdmin.get_queryset. Instead it mysteriously calls reverse_field_path() method and uses the _default_manager to get the queryset.

It causes problems when the default database has no table for the model, and only the other databases has the table. It causes "Table not found" query error message.
