### PR TITLE
Fixed #22405 -- Fixed string error in models/queries docs.

### DIFF
--- a/docs/ref/models/queries.txt
+++ b/docs/ref/models/queries.txt
@@ -70,7 +70,7 @@ the field value on multiple objects - which could be very much faster than
 pulling them all into Python from the database, looping over them, incrementing
 the field value of each one, and saving each one back to the database::
 
-    Reporter.objects.all().update(stories_filed=F('stories_filed) + 1)
+    Reporter.objects.all().update(stories_filed=F('stories_filed') + 1)
 
 ``F()`` therefore can offer performance advantages by:
 


### PR DESCRIPTION
Ticket was opened just now by someone for this very small error regarding proper enclosing of string in `models/queries.txt`.
Refs. https://code.djangoproject.com/ticket/22405
