### PR TITLE
Fixed #18523 -- Added stream-like API to HttpResponse.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -327,7 +327,7 @@ class HttpResponseBase(six.Iterator):
         raise IOError("This %s instance cannot tell its position" % self.__class__.__name__)
 
     # These methods partially implement a stream-like object interface.
-    # See https://docs.python.org/2/library/io.html#io.IOBase
+    # See https://docs.python.org/library/io.html#io.IOBase
 
     def writable(self):
         return False
@@ -432,7 +432,7 @@ class StreamingHttpResponse(HttpResponseBase):
         return self.streaming_content
 
     def getvalue(self):
-        return self.streaming_content
+        return b''.join(self.streaming_content)
 
 
 class HttpResponseRedirectBase(HttpResponse):

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -653,9 +653,9 @@ Attributes
 
 .. attribute:: HttpResponse.closed
 
-   .. versionadded:: 1.8
+    .. versionadded:: 1.8
 
-    True if the response has been closed.
+    ``True`` if the response has been closed.
 
 Methods
 -------
@@ -777,21 +777,21 @@ Methods
 
 .. method:: HttpResponse.getvalue()
 
-   .. versionadded:: 1.8
+    .. versionadded:: 1.8
 
     Returns the value of :attr:`HttpResponse.content`. This method makes
     an :class:`HttpResponse` instance a stream-like object.
 
 .. method:: HttpResponse.writable()
 
-   .. versionadded:: 1.8
+    .. versionadded:: 1.8
 
-    Always True. This method makes an :class:`HttpResponse` instance a
+    Always ``True``. This method makes an :class:`HttpResponse` instance a
     stream-like object.
 
 .. method:: HttpResponse.writelines(lines)
 
-   .. versionadded:: 1.8
+    .. versionadded:: 1.8
 
     Writes a list of lines to the response. Line seperators are not added. This
     method makes an :class:`HttpResponse` instance a stream-like object.

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -546,6 +546,9 @@ class StreamingHttpResponseTests(TestCase):
         with self.assertRaises(Exception):
             r.tell()
 
+        r = StreamingHttpResponse(iter(['hello', 'world']))
+        self.assertEqual(r.getvalue(), 'helloworld')
+
 
 class FileCloseTests(TestCase):
 

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -23,14 +23,14 @@ class HttpResponseBaseTests(SimpleTestCase):
         r = HttpResponseBase()
         self.assertEqual(r.writable(), False)
 
-        with self.assertRaises(IOError):
+        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance is not writable'):
             r.write('asdf')
-        with self.assertRaises(IOError):
+        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance is not writable'):
             r.writelines(['asdf\n', 'qwer\n'])
 
     def test_tell(self):
         r = HttpResponseBase()
-        with self.assertRaises(IOError):
+        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance cannot tell its position'):
             r.tell()
 
 


### PR DESCRIPTION
Added getvalue() to HttpResponse to return the content of the response,
along with a few other methods to partially match io.IOBase.

I only added the methods/changes mentioned by unaizalakain in https://code.djangoproject.com/ticket/18523. If you want to add the rest of the methods from `io.IOBase`, let me know, I'm happy to make it fully compatible. :D
