### PR TITLE
Fixed #22261 - Added attempt to use reverse() to get the flatpage url.

### DIFF
--- a/django/contrib/flatpages/models.py
+++ b/django/contrib/flatpages/models.py
@@ -3,8 +3,12 @@ from __future__ import unicode_literals
 from django.db import models
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import get_script_prefix
+from django.core.urlresolvers import NoReverseMatch
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import iri_to_uri, python_2_unicode_compatible
+
+from .. import flatpages
 
 
 @python_2_unicode_compatible
@@ -31,4 +35,18 @@ class FlatPage(models.Model):
 
     def get_absolute_url(self):
         # Handle script prefix manually because we bypass reverse()
-        return iri_to_uri(get_script_prefix().rstrip('/') + self.url)
+        try:
+            # Handles a prefix on the flatpage view
+            return reverse(flatpages.views.flatpage, kwargs={'url': self.url.lstrip('/')})
+        except NoReverseMatch:
+            pass
+
+        try:
+            # For hardcoded URLs
+            return reverse(flatpages.views.flatpage, kwargs={'url': self.url})
+        except NoReverseMatch:
+            # Handles a URL via the flatpage middleware.
+            pass
+
+        return iri_to_uri(get_script_prefix().rstrip('/') + self.url) 
+

--- a/django/contrib/flatpages/tests/flatpage_test_urls_absolute.py
+++ b/django/contrib/flatpages/tests/flatpage_test_urls_absolute.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+from django.contrib.flatpages import views
+
+# special urls for flatpage test cases
+urlpatterns = [
+    url(r'^flatpage/$', views.flatpage, {'url': '/hard_coded_url/'}),
+]
+

--- a/django/contrib/flatpages/tests/flatpage_test_urls_prefix_slash.py
+++ b/django/contrib/flatpages/tests/flatpage_test_urls_prefix_slash.py
@@ -1,0 +1,7 @@
+from django.conf.urls import include, url
+
+# special urls for flatpage test cases
+urlpatterns = [
+    url(r'^flatpage/', include('django.contrib.flatpages.urls')),
+]
+

--- a/django/contrib/flatpages/tests/test_models.py
+++ b/django/contrib/flatpages/tests/test_models.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.core.urlresolvers import set_script_prefix, clear_script_prefix
 from django.contrib.flatpages.models import FlatPage
 from django.test import TestCase
-
+from django.test import override_settings
 
 class FlatpageModelTests(TestCase):
 
@@ -20,3 +20,42 @@ class FlatpageModelTests(TestCase):
             self.assertEqual(pf.get_absolute_url(), '/beverages/tea/')
         finally:
             clear_script_prefix()
+
+    @override_settings(
+        ROOT_URLCONF='django.contrib.flatpages.tests.urls',
+    )
+    def test_get_absolute_url_with_include_prefix_no_slash(self):
+        pf = FlatPage(title="TestUrlWithIncludePrefix", url=r"/test_url/")
+        # Note: We expect the url to NOT have a slash, because the URL_CONF is defined without a slash.
+        self.assertEqual(pf.get_absolute_url(), r'/flatpage_roottest_url/')
+
+    @override_settings(
+        ROOT_URLCONF='django.contrib.flatpages.tests.flatpage_test_urls_prefix_slash',
+    )
+    def test_get_absolute_url_with_include_prefix_slash(self):
+        pf = FlatPage(title="TestUrlWithIncludePrefix", url=r"/test_url/")
+        # Note: We expect the url to NOT have a slash, because the URL_CONF is defined without a slash.
+        self.assertEqual(pf.get_absolute_url(), r'/flatpage/test_url/')
+
+    @override_settings(
+        ROOT_URLCONF='django.contrib.flatpages.tests.flatpage_test_urls_absolute',
+    )
+    def test_get_absolute_url_set_with_absolute_url(self):
+        pf = FlatPage(title="TestHardCodedUrl", url=r"/hard_coded_url/")
+        self.assertEqual(pf.get_absolute_url(), r'/flatpage/')
+
+    @override_settings(
+        MIDDLEWARE_CLASSES=('django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',),
+    )
+    def test_get_absolute_url_with_middleware(self):
+        pf = FlatPage(title="TestMiddlewareWorkingUrl", url=r"/url_for_middleware/")
+        self.assertEqual(pf.get_absolute_url(), r'/url_for_middleware/')
+    
+    @override_settings(
+        MIDDLEWARE_CLASSES=('django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',),
+    )
+    def test_get_absolute_url_cant_find_random_url_with_middleware(self):
+        pf = FlatPage(title="TestMiddlewareNotWorkingUrl", url=r"/url_for_middleware/")
+        self.assertNotEqual(pf.get_absolute_url(), r'/random_url/')
+    
+


### PR DESCRIPTION
Falls back to using just the flatpage.url, in case the catchall middleware is used.
Solves 3 use cases for adding flatpages -
- Using the catchall middleware.
- Adding an include(flatware) into your urls.
- Adding flatpages hardcoded (one by one) to your urls.
