### PR TITLE
Fixed #22439 -- Improved LiveServerTestCase logging

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ answer newbie questions, and generally made Django that much better:
     Eric Boersma <eric.boersma@gmail.com>
     Joel Bohman <mail@jbohman.com>
     Matías Bordese
+    Jeremy Bowman <jmbowman@alum.mit.edu>
     Nate Bragg <jonathan.bragg@alum.rpi.edu>
     Sean Brant
     Andrew Brehaut <http://brehaut.net/blog>

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -4,7 +4,9 @@ from copy import copy
 import difflib
 import errno
 from functools import wraps
+import io
 import json
+import logging
 import os
 import posixpath
 import re
@@ -44,6 +46,8 @@ from django.views.static import serve
 
 __all__ = ('TestCase', 'TransactionTestCase',
            'SimpleTestCase', 'skipIfDBFeature', 'skipUnlessDBFeature')
+
+logger = logging.getLogger('django.request')
 
 
 def to_list(value):
@@ -953,15 +957,50 @@ def skipUnlessDBFeature(feature):
                          "Database doesn't support feature %s" % feature)
 
 
+class LoggingStream(io.TextIOBase):
+    """
+    A stream that writes to the "django.request" logger (sending a new message
+    when each newline is encountered).
+    """
+    def __init__(self, *args, **kwargs):
+        self.buffer = six.StringIO()
+        super(LoggingStream, self).__init__(*args, **kwargs)
+
+    def write(self, s):
+        parts = re.split("([^\n]+)", s)
+        for part in parts:
+            if part == "\n":
+                logger.error(self.buffer.getvalue())
+                self.buffer = six.StringIO()
+            elif part:
+                self.buffer.write(part)
+
+
 class QuietWSGIRequestHandler(WSGIRequestHandler):
     """
     Just a regular WSGIRequestHandler except it doesn't log to the standard
     output any of the requests received, so as to not clutter the output for
-    the tests' results.
+    the tests' results.  Information which is normally logged to standard
+    error or standard output is logged to the "django.request" logger instead.
     """
 
-    def log_message(*args):
-        pass
+    def get_stderr(self):
+        return LoggingStream()
+
+    def log_message(self, format, *args):
+        logger.info("[%s] %s", self.log_date_time_string(), format % args)
+
+
+class QuietWSGIServer(WSGIServer):
+    """
+    An extension of WSGIServer which doesn't output errors on stderr and stdout
+    where they would clutter the output for the tests' results.  Logs them to
+    the "django.request" logger instead.
+    """
+
+    def handle_error(self, request, client_address):
+        msg = "Exception happened during processing of request from %s"
+        logger.error(msg, client_address, exc_info=sys.exc_info())
 
 
 class FSFilesHandler(WSGIHandler):
@@ -1074,7 +1113,7 @@ class LiveServerThread(threading.Thread):
             # one that is free to use for the WSGI server.
             for index, port in enumerate(self.possible_ports):
                 try:
-                    self.httpd = WSGIServer(
+                    self.httpd = QuietWSGIServer(
                         (self.host, port), QuietWSGIRequestHandler)
                 except socket.error as e:
                     if (index + 1 < len(self.possible_ports) and

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -4,13 +4,19 @@ Tests for django.core.servers.
 """
 from __future__ import unicode_literals
 
+from contextlib import contextmanager
+import io
 import os
 import socket
+import sys
+from unittest import skipIf
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import LiveServerTestCase
 from django.test import override_settings
+from django.test.utils import patch_logger
 from django.utils.http import urlencode
+from django.utils import six
 from django.utils.six.moves.urllib.error import HTTPError
 from django.utils.six.moves.urllib.request import urlopen
 from django.utils._os import upath
@@ -185,3 +191,155 @@ class LiveServerDatabase(LiveServerBase):
             ['jane', 'robert', 'emily'],
             lambda b: b.name
         )
+
+
+@contextmanager
+def patch_sys_stream(stream_name):
+    """
+    Context manager that takes "stderr" or "stdout" as a parameter and provides
+    a BytesIO containing the output that would have been sent to that sys
+    module stream.
+    """
+    output = six.StringIO()
+
+    orig = getattr(sys, stream_name)
+    setattr(sys, stream_name, output)
+    try:
+        yield output
+    finally:
+        setattr(sys, stream_name, orig)
+
+
+class MockHTTPConnection(object):
+    """
+    Mock HTTPConnection to be used for testing the output of
+    QuietWSGIRequestHandler.
+    """
+
+    def makefile(self, mode, bufsize):
+        return io.BytesIO()
+
+
+class LiveServerLogging(LiveServerBase):
+    """
+    Test the effectiveness of QuietWSGIServer and QuietWSGIRequestHandler in
+    shifting messages that normally go to stderr and stdout to the logging
+    module instead when running a LiveServerTestCase.
+    """
+
+    logger_name = "django.request"
+
+    def create_handler_instance(self):
+        """
+        Create an instance of QuietWSGIRequestHandler to be used for message
+        output testing.
+        """
+        server = self.server_thread.httpd
+        handler_class = server.RequestHandlerClass
+        request = MockHTTPConnection()
+        return handler_class(request, ("test.wsgi.errors", 9999), server)
+
+    def test_handle_error(self):
+        """
+        Ensure that WSGI error messages are logged instead of being sent to
+        stderr and/or stdout when running a LiveServerTestCase.
+        Refs #22439.
+        """
+        server = self.server_thread.httpd
+        client_address = "test.handle.error"
+        expected = "Exception happened during processing of request from %s" % client_address
+        with patch_logger(self.logger_name, "error") as calls:
+            with patch_sys_stream("stderr") as stderr:
+                with patch_sys_stream("stdout") as stdout:
+                    server.handle_error(None, client_address)
+                    self.assertEqual(len(stderr.getvalue()), 0)
+                    self.assertEqual(len(stdout.getvalue()), 0)
+                    self.assertEqual(len(calls), 1)
+                    self.assertEqual(calls[0], expected)
+
+    def test_wsgi_errors(self):
+        """
+        Ensure that a unicode message sent to the wsgi.errors stream is logged
+        instead of being sent to stderr when running a LiveServerTestCase.
+        Refs #22439.
+        """
+        handler_instance = self.create_handler_instance()
+        message = "This should be logged - €1.00"
+        output = "%s\n" % message
+        with patch_logger(self.logger_name, "error") as calls:
+            with patch_sys_stream("stderr") as stderr:
+                handler_instance.get_stderr().write(output)
+                self.assertEqual(len(stderr.getvalue()), 0)
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0], message)
+
+    @skipIf(sys.version_info[0] > 2, "Python 3 doesn't support writing bytes to stderr")
+    def test_wsgi_errors_bytes(self):
+        """
+        Ensure that a message of bytes sent to the wsgi.errors stream in Python
+        2 is logged correctly when running a LiveServerTestCase.
+        Refs #22439.
+        """
+        handler_instance = self.create_handler_instance()
+        message = b"This should be logged"
+        output = b"%s\n" % message
+        with patch_logger(self.logger_name, "error") as calls:
+            handler_instance.get_stderr().write(output)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0], message)
+
+    def test_wsgi_errors_multiple_lines(self):
+        """
+        Ensure that a unicode message with multiple lines sent to the
+        wsgi.errors stream generates multiple log messages when running a
+        LiveServerTestCase.
+        Refs #22439.
+        """
+        handler_instance = self.create_handler_instance()
+        first_message = "This should be logged"
+        second_message = "on two lines"
+        output = "%s\n%s\n" % (first_message, second_message)
+        with patch_logger(self.logger_name, "error") as calls:
+            handler_instance.get_stderr().write(output)
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(calls[0], first_message)
+            self.assertEqual(calls[1], second_message)
+
+    def test_wsgi_errors_split(self):
+        """
+        Ensure that unicode messages sent to the wsgi.errors stream in separate
+        writes are logged in units separated by the written newlines when
+        running a LiveServerTestCase.
+        Refs #22439.
+        """
+        handler_instance = self.create_handler_instance()
+        with patch_logger(self.logger_name, "error") as calls:
+            stream = handler_instance.get_stderr()
+            stream.write("The first ")
+            self.assertEqual(len(calls), 0)
+            stream.write("line\nThe second")
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0], "The first line")
+            stream.write(" line\n")
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(calls[1], "The second line")
+
+    def test_log_message(self):
+        """
+        Ensure that HTTP status messages are logged instead of being ignored or
+        sent to stderr when running a LiveServerTestCase.
+        Refs #22439.
+        """
+        handler_instance = self.create_handler_instance()
+        format_string = '"%s" %s %s'
+        request_line = "GET /test_log_message/ HTTP/1.1"
+        status_code = "200"
+        size = "0"
+        expected = format_string % (request_line, status_code, size)
+        with patch_logger(self.logger_name, "info") as calls:
+            with patch_sys_stream("stderr") as stderr:
+                handler_instance.log_message(format_string, request_line, status_code, size)
+                self.assertEqual(len(stderr.getvalue()), 0)
+                self.assertEqual(len(calls), 1)
+                # Can't count on being able to accurately predict the exact time
+                self.assertRegexpMatches(calls[0], "\[[^\]]+\] %s" % expected)


### PR DESCRIPTION
There should no longer be any output to stderr or stdout from the
server thread.  All of the messages which had been going there, as
well as the ones which were previously being thrown away to
prevent them from interfering with the test runner output, should
now be logged to the "django.request" logger instead.