### PR TITLE
Fixed #22426 -- Django >= 1.6.0 can't handle old style messages cookie

### DIFF
--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -33,6 +33,9 @@ class MessageDecoder(json.JSONDecoder):
     def process_messages(self, obj):
         if isinstance(obj, list) and obj:
             if obj[0] == MessageEncoder.message_key:
+                if len(obj) == 3:
+                    # Compatibility with previously-encoded messages
+                    return Message(*obj[1:])
                 if obj[1]:
                     obj[3] = mark_safe(obj[3])
                 return Message(*obj[2:])


### PR DESCRIPTION
Backported the code from 1.5 that adds backwards compatibility with legacy message length. The code that's backported is from commit 9e7183073f64e541587e8dcfd8bb3ddeb47f8162.
