### PR TITLE
Fixed #22443 -- Document smtp.EmailBackend.timeout default value

### DIFF
--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -472,6 +472,9 @@ SMTP backend
         Then point the :setting:`EMAIL_BACKEND` setting at your custom backend as
         described above.
 
+        If unspecified, the default ``timeout`` will be the one provided by
+        :func:`socket.getdefaulttimeout()`, which defaults to ``None`` (no timeout).
+
 .. _topic-email-console-backend:
 
 Console backend


### PR DESCRIPTION
Django 1.7 introduces a new timeout parameter for the SMTP email backend:
http://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.backends.smtp.EmailBackend.timeout

However, there's no mention of the default value for this parameter.
