### PR TITLE
Fixed #21987 -- Add support for custom MEDIA_TYPES to Media objects.

### DIFF
--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -341,3 +341,35 @@ form::
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>
+
+Custom Media Types
+------------------
+
+By subclassing ``Media``, you can add support for media types beyond the
+default ``css`` and ``js`` types. One use case for this would be adding support
+for inline JavaScript.
+
+To add a custom media type, you need to add the type to the ``MEDIA_TYPES``
+tuple and add ``add_X`` and ``render_X`` methods for adding and rendering
+your custom type. For example::
+
+    from django.utils.html import format_html
+
+    class InlineJSMedia(Media):
+        # MEDIA_TYPES stores tuples of (media_name, constructor).
+        # __init__ will create an attribute self._media_name using the
+        # constructor.
+        MEDIA_TYPES = Media.MEDIA_TYPES + (('inline_js', list),)
+
+        # data must be the same type as the constructor in MEDIA_TYPES.
+        def add_inline_js(self, data):
+            if data:
+                for code in data:
+                    self._inline_js.append(code)
+
+        # Must return a list of strings containing the rendered media.
+        def render_inline_js(self):
+            return [
+                format_html('<script type="text/javascript">{0}</script>'.format(code))
+                for code in self._inline_js
+            ]


### PR DESCRIPTION
Moved the MEDIA_TYPES list into the Media class and updated the methods
to support subclasses that add to the list. Because some of the methods
rely on knowing that media is stored in _media_name attributes on the
Media object, MEDIA_TYPES had to be updated to store both the type's
name and the constructor for its container.

I'm not super-happy about storing the constructor in `MEDIA_TYPES`, but I couldn't think of a better way to handle things that also supported `__add__` and `__getitem__` and didn't make any major API changes.

https://code.djangoproject.com/ticket/21987