### PR TITLE
Fixed #22449 -- Colorized output of test results

### DIFF
--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -31,20 +31,26 @@ def color_style():
         DJANGO_COLORS = os.environ.get('DJANGO_COLORS', '')
         color_settings = termcolors.parse_color_setting(DJANGO_COLORS)
         if color_settings:
-            class dummy:
-                pass
-            style = dummy()
-            # The nocolor palette has all available roles.
-            # Use that palette as the basis for populating
-            # the palette as defined in the environment.
-            for role in termcolors.PALETTES[termcolors.NOCOLOR_PALETTE]:
-                format = color_settings.get(role, {})
-                setattr(style, role, termcolors.make_style(**format))
-            # For backwards compatibility,
-            # set style for ERROR_OUTPUT == ERROR
-            style.ERROR_OUTPUT = style.ERROR
+            style = make_style(color_settings)
         else:
             style = no_style()
+    return style
+
+
+def make_style(color_settings):
+    """Build a style object from a color settings dict."""
+    class dummy:
+        pass
+    style = dummy()
+    # The nocolor palette has all available roles.
+    # Use that palette as the basis for populating
+    # the palette as defined in the environment.
+    for role in termcolors.PALETTES[termcolors.NOCOLOR_PALETTE]:
+        format = color_settings.get(role, {})
+        setattr(style, role, termcolors.make_style(**format))
+    # For backwards compatibility,
+    # set style for ERROR_OUTPUT == ERROR
+    style.ERROR_OUTPUT = style.ERROR
     return style
 
 

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -5,6 +5,7 @@ from optparse import make_option, OptionParser
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.test.runner import ColorTextTestResult
 from django.test.utils import get_runner
 
 
@@ -85,6 +86,10 @@ class Command(BaseCommand):
             del options['liveserver']
 
         test_runner = TestRunner(**options)
+
+        if not options.get('no_color') and hasattr(test_runner, 'test_runner'):
+            test_runner.test_runner.resultclass = ColorTextTestResult
+
         failures = test_runner.run_tests(test_labels)
 
         if failures:

--- a/django/utils/termcolors.py
+++ b/django/utils/termcolors.py
@@ -93,6 +93,11 @@ PALETTES = {
         'MIGRATE_LABEL': {},
         'MIGRATE_SUCCESS': {},
         'MIGRATE_FAILURE': {},
+        'TEST_SUCCESS': {},
+        'TEST_FAILURE': {},
+        'TEST_SKIP': {},
+        'TEST_EXPECTED_FAILURE': {},
+        'TEST_UNEXPECTED_SUCCESS': {},
     },
     DARK_PALETTE: {
         'ERROR': {'fg': 'red', 'opts': ('bold',)},
@@ -113,6 +118,11 @@ PALETTES = {
         'MIGRATE_LABEL': {'opts': ('bold',)},
         'MIGRATE_SUCCESS': {'fg': 'green', 'opts': ('bold',)},
         'MIGRATE_FAILURE': {'fg': 'red', 'opts': ('bold',)},
+        'TEST_SUCCESS': {'fg': 'green'},
+        'TEST_FAILURE': {'fg': 'red', 'opts': ('bold',)},
+        'TEST_SKIP': {},
+        'TEST_EXPECTED_FAILURE': {},
+        'TEST_UNEXPECTED_SUCCESS': {},
     },
     LIGHT_PALETTE: {
         'ERROR': {'fg': 'red', 'opts': ('bold',)},
@@ -133,6 +143,11 @@ PALETTES = {
         'MIGRATE_LABEL': {'opts': ('bold',)},
         'MIGRATE_SUCCESS': {'fg': 'green', 'opts': ('bold',)},
         'MIGRATE_FAILURE': {'fg': 'red', 'opts': ('bold',)},
+        'TEST_SUCCESS': {'fg': 'green'},
+        'TEST_FAILURE': {'fg': 'red', 'opts': ('bold',)},
+        'TEST_SKIP': {},
+        'TEST_EXPECTED_FAILURE': {},
+        'TEST_UNEXPECTED_SUCCESS': {},
     }
 }
 DEFAULT_PALETTE = DARK_PALETTE

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1275,6 +1275,14 @@ The ``--liveserver`` option can be used to override the default address where
 the live server (used with :class:`~django.test.LiveServerTestCase`) is
 expected to run from. The default value is ``localhost:8081``.
 
+.. versionadded:: 1.8
+
+If the Pygments library is available, the tracebacks of failing tests will be
+colored. Windows users will need to have the `ANSICON library`_ installed to
+get colored output.
+
+.. _ANSICON library: https://github.com/adoxa/ansicon
+
 testserver <fixture fixture ...>
 --------------------------------
 
@@ -1628,6 +1636,14 @@ number of roles in which color is used:
 * ``http_not_found`` - A 404 HTTP Not Found server response.
 * ``http_bad_request`` - A 4XX HTTP Bad Request server response other than 404.
 * ``http_server_error`` - A 5XX HTTP Server Error response.
+
+.. versionadded:: 1.8
+
+* ``test_success`` - A passing test.
+* ``test_failure`` - A failing test.
+* ``test_skip`` - A skipped test.
+* ``test_expected_failure`` - A test that's expectedly failing.
+* ``test_unexpected_success`` - A test that's unexpectedly passing.
 
 Each of these roles can be assigned a specific foreground and
 background color, from the following list:

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -131,6 +131,12 @@ Management Commands
 * :ref:`initial-sql` now works better if the `sqlparse
   <https://pypi.python.org/pypi/sqlparse>`_ Python library is installed.
 
+* :djadmin:`test` now features colored output. If necessary, colored output
+  can be supressed using the :djadminopt:`--no-color` option. Windows users
+  will need to have the `ANSICON library`_ installed for this to work.
+
+.. _ANSICON library: https://github.com/adoxa/ansicon
+
 Models
 ^^^^^^
 


### PR DESCRIPTION
Added tests, code, and documentation for colorizing the output of the `manage.py test` commmand.
