### PR TITLE
Fixed #22457 -- Fixed contributing guide w/o github set-up

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -30,7 +30,7 @@ sample settings module that uses the SQLite database. To run the tests:
 
 .. code-block:: bash
 
-   $ git clone git@github.com:django/django.git django-repo
+   $ git clone https://github.com:django/django.git django-repo
    $ cd django-repo/tests
    $ PYTHONPATH=..:$PYTHONPATH ./runtests.py
 


### PR DESCRIPTION
The published commnand was not working when the user did not have
the git client set-up with the public-key. Changed the contributing
guide to clone it from https instead.
