### PR TITLE
Fixed #22353 -- Make sure that CachedStaticFilesMixin doesn't use ...

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -114,7 +114,7 @@ class HashedFilesMixin(object):
             unparsed_name[2] += '?'
         return urlunsplit(unparsed_name)
 
-    def url(self, name, force=False):
+    def url(self, name, force=False, avoid_cache=False):
         """
         Returns the real URL in DEBUG mode.
         """
@@ -125,7 +125,7 @@ class HashedFilesMixin(object):
             if urlsplit(clean_name).path.endswith('/'):  # don't hash paths
                 hashed_name = name
             else:
-                hashed_name = self.stored_name(clean_name)
+                hashed_name = self.stored_name(clean_name, avoid_cache=avoid_cache)
 
         final_url = super(HashedFilesMixin, self).url(hashed_name)
 
@@ -178,7 +178,7 @@ class HashedFilesMixin(object):
                 else:
                     start, end = 1, sub_level - 1
             joined_result = '/'.join(name_parts[:-start] + url_parts[end:])
-            hashed_url = self.url(unquote(joined_result), force=True)
+            hashed_url = self.url(unquote(joined_result), force=True, avoid_cache=True)
             file_name = hashed_url.split('/')[-1:]
             relative_url = '/'.join(url.split('/')[:-1] + file_name)
 
@@ -270,10 +270,10 @@ class HashedFilesMixin(object):
     def hash_key(self, name):
         return name
 
-    def stored_name(self, name):
+    def stored_name(self, name, avoid_cache=False):
         hash_key = self.hash_key(name)
         cache_name = self.hashed_files.get(hash_key)
-        if cache_name is None:
+        if cache_name is None or avoid_cache:
             cache_name = self.clean_name(self.hashed_name(name))
             # store the hashed name if there was a miss, e.g.
             # when the files are still processed

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -602,6 +602,44 @@ class TestHashedFiles(object):
         self.assertEqual("Post-processing 'faulty.css' failed!\n\n", err.getvalue())
 
 
+@override_settings(**dict(
+    TEST_SETTINGS,
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.CachedStaticFilesStorage',
+    DEBUG=False,
+))
+class TestCollectionHashedFilesCache(CollectionTestCase):
+    """
+    Test changing an image file and make sure that css files refferring to that file
+    always use the newest hash even if they get processed before the image file.
+    """
+    def setUp(self):
+        self.testimage_path = os.path.join(TEST_ROOT, 'project', 'documents', 'cached', 'css', 'img', 'window.png')
+        with open(self.testimage_path, 'r+b') as f:
+            self.orig_image_content = f.read()
+        super(TestCollectionHashedFilesCache, self).setUp()
+
+    def tearDown(self):
+        with open(self.testimage_path, 'w+b') as f:
+            f.write(self.orig_image_content)
+        super(TestCollectionHashedFilesCache, self).tearDown()
+
+    def test_stored_name_avoids_cache_on_collectstatic(self):
+        finders.get_finder.cache_clear()
+        err = six.StringIO()
+        call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
+        with open(self.testimage_path, 'w+b') as f:
+            f.write("new content of png file to change it's hash")
+
+        # and now change modification time of self.testimage_path
+        # to make shure it gets collected again
+        mtime = os.path.getmtime(self.testimage_path)
+        atime = os.path.getatime(self.testimage_path)
+        os.utime(self.testimage_path, (mtime + 1, atime + 1))
+
+        call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
+        self.assertFileContains(os.path.join(settings.STATIC_ROOT, 'cached', 'css', 'window.9db38d5169f3.css'), 'window.a836fe39729e.png')
+
+
 # we set DEBUG to False here since the template tag wouldn't work otherwise
 @override_settings(**dict(
     TEST_SETTINGS,


### PR DESCRIPTION
...invalid cache entries instead hash the actual file.
