### PR TITLE
Fixed 22336 -- Add pattern match for path to match subdirectories

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -341,7 +341,8 @@ class Command(NoArgsCommand):
             Check if the given path should be ignored or not.
             """
             filename = os.path.basename(path)
-            ignore = lambda pattern: fnmatch.fnmatchcase(filename, pattern)
+            ignore = lambda pattern: fnmatch.fnmatchcase(filename, pattern) or \
+                fnmatch.fnmatchcase(path, pattern)
             return any(ignore(pattern) for pattern in ignore_patterns)
 
         dir_suffix = '%s*' % os.sep
@@ -349,6 +350,7 @@ class Command(NoArgsCommand):
         all_files = []
         for dirpath, dirnames, filenames in os.walk(root, topdown=True, followlinks=self.symlinks):
             for dirname in dirnames[:]:
+
                 if is_ignored(os.path.normpath(os.path.join(dirpath, dirname)), norm_patterns):
                     dirnames.remove(dirname)
                     if self.verbosity > 1:

--- a/tests/i18n/commands/templates/subdir/ignored.html
+++ b/tests/i18n/commands/templates/subdir/ignored.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "This subdir should be ignored too." %}

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -342,7 +342,7 @@ class JavascriptExtractorTests(ExtractorTests):
 
 class IgnoredExtractorTests(ExtractorTests):
 
-    def test_ignore_option(self):
+    def test_ignore_directory(self):
         os.chdir(self.test_dir)
         ignore_patterns = [
             os.path.join('ignore_dir', '*'),
@@ -353,12 +353,41 @@ class IgnoredExtractorTests(ExtractorTests):
             ignore_patterns=ignore_patterns, stdout=stdout)
         data = stdout.getvalue()
         self.assertTrue("ignoring directory ignore_dir" in data)
-        self.assertTrue("ignoring file xxx_ignored.html" in data)
         self.assertTrue(os.path.exists(self.PO_FILE))
         with open(self.PO_FILE, 'r') as fp:
             po_contents = fp.read()
             self.assertMsgId('This literal should be included.', po_contents)
             self.assertNotMsgId('This should be ignored.', po_contents)
+
+    def test_ignore_subdirectory(self):
+        os.chdir(self.test_dir)
+        ignore_patterns = [
+            'templates/*/ignore.html',
+            'templates/subdir/*',
+        ]
+        stdout = StringIO()
+        management.call_command('makemessages', locale=[LOCALE], verbosity=2,
+            ignore_patterns=ignore_patterns, stdout=stdout)
+        data = stdout.getvalue()
+        self.assertTrue("ignoring directory subdir" in data)
+        self.assertTrue(os.path.exists(self.PO_FILE))
+        with open(self.PO_FILE, 'r') as fp:
+            po_contents = fp.read()
+            self.assertNotMsgId('This subdir should be ignored too.', po_contents)
+
+    def test_ignore_file_patterns(self):
+        os.chdir(self.test_dir)
+        ignore_patterns = [
+            'xxx_*',
+        ]
+        stdout = StringIO()
+        management.call_command('makemessages', locale=[LOCALE], verbosity=2,
+            ignore_patterns=ignore_patterns, stdout=stdout)
+        data = stdout.getvalue()
+        self.assertTrue("ignoring file xxx_ignored.html" in data)
+        self.assertTrue(os.path.exists(self.PO_FILE))
+        with open(self.PO_FILE, 'r') as fp:
+            po_contents = fp.read()
             self.assertNotMsgId('This should be ignored too.', po_contents)
 
 


### PR DESCRIPTION
Thanks infraredgirl for the report and Claude Paroz for the previous
fix in 20422.  I added an additional check to match the given patterns
against the full path and broke tests out to for checking filepatterns
and directory patterns.
