### PR TITLE
Fixed #22423 -- Made GIS leverage MySQL 5.6 spatial functions

### DIFF
--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.db.backends.mysql.base import DatabaseOperations
 
 from django.contrib.gis.db.backends.adapter import WKTAdapter
@@ -15,21 +16,38 @@ class MySQLOperations(DatabaseOperations, BaseSpatialOperations):
 
     Adapter = WKTAdapter
     Adaptor = Adapter  # Backwards-compatibility alias.
-
-    geometry_functions = {
-        'bbcontains': 'MBRContains',  # For consistency w/PostGIS API
-        'bboverlaps': 'MBROverlaps',  # .. ..
-        'contained': 'MBRWithin',    # .. ..
-        'contains': 'MBRContains',
-        'disjoint': 'MBRDisjoint',
-        'equals': 'MBREqual',
-        'exact': 'MBREqual',
-        'intersects': 'MBRIntersects',
-        'overlaps': 'MBROverlaps',
-        'same_as': 'MBREqual',
-        'touches': 'MBRTouches',
-        'within': 'MBRWithin',
-    }
+    if connection.mysql_version >= (5, 6, 1):
+        # mysql 5.6.1 implemented spatial queries using shape objects properly
+        # instead of bounding box checks
+        geometry_functions = {
+            'bbcontains': 'MBRContains',  # For consistency w/PostGIS API
+            'bboverlaps': 'MBROverlaps',  # .. ..
+            'contained': 'ST_Within',    # .. ..
+            'contains': 'ST_Contains',
+            'disjoint': 'ST_Disjoint',
+            'equals': 'ST_Equal',
+            'exact': 'ST_Equal',
+            'intersects': 'ST_Intersects',
+            'overlaps': 'ST_Overlaps',
+            'same_as': 'ST_Equal',
+            'touches': 'ST_Touches',
+            'within': 'ST_Within',
+        }
+    else:
+        geometry_functions = {
+            'bbcontains': 'MBRContains',  # For consistency w/PostGIS API
+            'bboverlaps': 'MBROverlaps',  # .. ..
+            'contained': 'MBRWithin',    # .. ..
+            'contains': 'MBRContains',
+            'disjoint': 'MBRDisjoint',
+            'equals': 'MBREqual',
+            'exact': 'MBREqual',
+            'intersects': 'MBRIntersects',
+            'overlaps': 'MBROverlaps',
+            'same_as': 'MBREqual',
+            'touches': 'MBRTouches',
+            'within': 'MBRWithin',
+        }
 
     gis_terms = set(geometry_functions) | set(['isnull'])
 

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -82,11 +82,16 @@ Example::
 
     Zipcode.objects.filter(poly__contained=geom)
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Within. For older version
+    it is treated as MBRContains
+
 ==========  ==========================
 Backend     SQL Equivalent
 ==========  ==========================
 PostGIS     ``poly @ geom``
-MySQL       ``MBRWithin(poly, geom)``
+MySQL       ``ST_Within(poly, geom)``
 SpatiaLite  ``MbrWithin(poly, geom)``
 ==========  ==========================
 
@@ -99,6 +104,11 @@ contains
 
 Tests if the geometry field spatially contains the lookup geometry.
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Contains. For older version
+    it is treated as MBRContains
+
 Example::
 
     Zipcode.objects.filter(poly__contains=geom)
@@ -108,7 +118,7 @@ Backend     SQL Equivalent
 ==========  ============================
 PostGIS     ``ST_Contains(poly, geom)``
 Oracle      ``SDO_CONTAINS(poly, geom)``
-MySQL       ``MBRContains(poly, geom)``
+MySQL       ``ST_Contains(poly, geom)``
 SpatiaLite  ``Contains(poly, geom)``
 ==========  ============================
 
@@ -211,12 +221,17 @@ Example::
 
     Zipcode.objects.filter(poly__disjoint=geom)
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Contains. For older version
+    it is treated as MBRContains
+
 ==========  =================================================
 Backend     SQL Equivalent
 ==========  =================================================
 PostGIS     ``ST_Disjoint(poly, geom)``
 Oracle      ``SDO_GEOM.RELATE(poly, 'DISJOINT', geom, 0.05)``
-MySQL       ``MBRDisjoint(poly, geom)``
+MySQL       ``ST_Disjoint(poly, geom)``
 SpatiaLite  ``Disjoint(poly, geom)``
 ==========  =================================================
 
@@ -246,12 +261,17 @@ Example::
 
     Zipcode.objects.filter(poly__intersects=geom)
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Contains. For older version
+    it is treated as MBRContains
+
 ==========  =================================================
 Backend     SQL Equivalent
 ==========  =================================================
 PostGIS     ``ST_Intersects(poly, geom)``
 Oracle      ``SDO_OVERLAPBDYINTERSECT(poly, geom)``
-MySQL       ``MBRIntersects(poly, geom)``
+MySQL       ``ST_Intersects(poly, geom)``
 SpatiaLite  ``Intersects(poly, geom)``
 ==========  =================================================
 
@@ -327,11 +347,16 @@ Example::
 
     Zipcode.objects.filter(poly__touches=geom)
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Contains. For older version
+    it is treated as MBRContains
+
 ==========  ==========================
 Backend     SQL Equivalent
 ==========  ==========================
 PostGIS     ``ST_Touches(poly, geom)``
-MySQL       ``MBRTouches(poly, geom)``
+MySQL       ``ST_Touches(poly, geom)``
 Oracle      ``SDO_TOUCH(poly, geom)``
 SpatiaLite  ``Touches(poly, geom)``
 ==========  ==========================
@@ -349,11 +374,16 @@ Example::
 
     Zipcode.objects.filter(poly__within=geom)
 
+.. note::
+
+    Requires MySQL 5.6.1 and above for ST_Contains. For older version
+    it is treated as MBRContains
+
 ==========  ==========================
 Backend     SQL Equivalent
 ==========  ==========================
 PostGIS     ``ST_Within(poly, geom)``
-MySQL       ``MBRWithin(poly, geom)``
+MySQL       ``ST_Within(poly, geom)``
 Oracle      ``SDO_INSIDE(poly, geom)``
 SpatiaLite  ``Within(poly, geom)``
 ==========  ==========================


### PR DESCRIPTION
MySQL 5.6.1 supports proper spatial checks for some of the functions. ( spatial object checks instead of bounding box checks).

waiting for reviewer.

Unit Test:

I have three shapes with one shape overalapping the other two. 
[City of SF shape overlapping South of Market neighborhood and Downtown neighborhood].
I selected a point in South of Market neighborhood, such that bounding box check returns all three shapes, while ST_contains returns two. (SoMA and SF).

MySQL query  (5.6.1 where st_ functions are implemented):

mysql> select count(_) from athome_shape where st_contains(geom, point(-122.4158771, 37.7792381));
+----------+
| count(_) |
+----------+
|        2 |
+----------+
1 row in set (0.00 sec)

mysql> select count(_) from athome_shape where mbrcontains(geom, point(-122.4158771, 37.7792381));
+----------+
| count(_) |
+----------+
|        3 |
+----------+
1 row in set (0.00 sec)

mysql>

Django Test:  (in older version, it would have returned 3 for both the queries).

point_wkt = 'POINT(-122.4158771 37.7792381)'
In [8]: y = Shape.objects.filter(geom__contains=point_wkt)

In [9]: y.count()
Out[9]: 2

In [10]: y = Shape.objects.filter(geom__bbcontains=point_wkt)

In [11]: y.count()
Out[11]: 3
