### PR TITLE
Fixed #22454 - Changed compatibility warning hint

### DIFF
--- a/django/core/checks/compatibility/django_1_6_0.py
+++ b/django/core/checks/compatibility/django_1_6_0.py
@@ -78,7 +78,7 @@ def _check_test_runner(app_configs=None, **kwargs):
                 hint=("Django 1.6 introduced a new default test runner. It looks like "
                       "this project was generated using Django 1.5 or earlier. You should "
                       "ensure your tests are all running & behaving as expected. See "
-                      "https://docs.djangoproject.com/en/dev/releases/1.6/#discovery-of-tests-in-any-test-module "
+                      "https://docs.djangoproject.com/en/dev/releases/1.6/#new-test-runner "
                       "for more information."),
                 obj=None,
                 id='1_6.W001',


### PR DESCRIPTION
The warning hint of `_check_test_runner` of 1.6 compatibility had a link
to a general release note. The link should be edited to refer the
relevant "Backwards incompatible changes in 1.6" section that documents
the cause and the possible solutions and workarounds of the warning.
