### PR TITLE
Fixed #22464 - included contrib/gis/static in tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ recursive-include django/contrib/formtools/templates *
 recursive-include django/contrib/formtools/tests/templates *
 recursive-include django/contrib/flatpages/fixtures *
 recursive-include django/contrib/flatpages/tests/templates *
+recursive-include django/contrib/gis/static *
 recursive-include django/contrib/gis/templates *
 recursive-include django/contrib/gis/tests/data *
 recursive-include django/contrib/gis/tests/distapp/fixtures *


### PR DESCRIPTION
After switching to setuptools in 66f546b, contrib/gis/static isn't
included in tarball anymore, this commit added that path to be
`recursive-include` in `MANIFEST.in`
