### PR TITLE
Fixed #22458 - Added a note about MySQL utf8_unicode_ci collation

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -363,6 +363,15 @@ table (usually called ``django_session``) and the
 
 .. _fixed in MySQLdb 1.2.2: http://sourceforge.net/tracker/index.php?func=detail&aid=1495765&group_id=22307&atid=374932
 
+Please note that according to `MySQL Unicode Character Sets doc`_, comparisons
+for the ``utf8_general_ci`` collation are faster, but slightly less correct, than 
+comparisons for ``utf8_unicode_ci``. If this is acceptable for your application,
+you should use ``utf8_general_ci`` because it is faster. If this is not acceptable
+(for example, if you require German dictionary order), use ``utf8_unicode_ci`` 
+because it is more accurate.
+
+.. _MySQL Unicode Character Sets doc: http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-sets.html
+
 Connecting to the database
 --------------------------
 


### PR DESCRIPTION
MySQL official documentation states cases when using utf8_unicode_ci
collation is better than utf8_general_ci collation. Added a note and a
link about both use cases to help the user decide, rather than
recommending only setting, which had been the case.
