### PR TITLE
Update the section identifier for MySQL unicode

### DIFF
--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -17,7 +17,7 @@ data. Normally, this means giving it an encoding of UTF-8 or UTF-16. If you use
 a more restrictive encoding -- for example, latin1 (iso8859-1) -- you won't be
 able to store certain characters in the database, and information will be lost.
 
-* MySQL users, refer to the `MySQL manual`_ (section 9.1.3.2 for MySQL 5.1)
+* MySQL users, refer to the `MySQL manual`_ (section 10.1.3.2 for MySQL 5.1)
   for details on how to set or alter the database character set encoding.
 
 * PostgreSQL users, refer to the `PostgreSQL manual`_ (section 22.3.2 in


### PR DESCRIPTION
The documentation has the correct link for the MySQL manual, but the section is 10.1.3.2 instead of the 9.1.3.2.  I'm updating this here, we should consider backporting it to the documentation for version currently supported.

http://dev.mysql.com/doc/refman/5.1/en/charset-database.html

![image](https://cloud.githubusercontent.com/assets/563721/2755176/267d2ba0-c964-11e3-8766-479d6823b966.png)
