### PR TITLE
Fixed #22478 -- Regression in test label discovery.

### DIFF
--- a/django/test/simple.py
+++ b/django/test/simple.py
@@ -181,7 +181,7 @@ def build_test(label):
 
     TestClass = None
     for module in test_modules:
-        TestClass = getattr(models_module, parts[1], None)
+        TestClass = getattr(module, parts[1], None)
         if TestClass is not None:
             break
 

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -12,7 +12,11 @@ from django.core.management import call_command
 from django import db
 from django.test import runner, TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.test.testcases import connections_support_transactions
-from django.test.utils import IgnoreAllDeprecationWarningsMixin, override_system_checks
+from django.test.utils import (
+    IgnoreAllDeprecationWarningsMixin,
+    override_settings,
+    override_system_checks
+)
 from django.utils import six
 
 from admin_scripts.tests import AdminScriptTestCase
@@ -240,6 +244,20 @@ class ModulesTestsPackages(IgnoreAllDeprecationWarningsMixin, unittest.TestCase)
         app_config.import_models({})
         with self.assertRaises(ImportError):
             get_tests(app_config)
+
+
+class LabelDiscoveryTest(TestCase):
+
+    @override_settings(INSTALLED_APPS=['test_runner.valid_app'])
+    def test_discover_within_package(self):
+        """
+        Verify labels like applabel.TestCase find tests defined in
+        applabel/tests/__init__.py. Fixes #22478.
+        """
+
+        from django.test.simple import build_test
+        suite = build_test('valid_app.SampleTest')
+        self.assertEqual(suite.countTestCases(), 1)
 
 
 class Sqlite3InMemoryTestDbs(TestCase):

--- a/tests/test_runner/valid_app/tests/__init__.py
+++ b/tests/test_runner/valid_app/tests/__init__.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+class SampleTest(unittest.TestCase):
+
+    def test_one(self):
+        pass


### PR DESCRIPTION
As part of the app-loading updates the old test runner was changed to not
require a models module. This introduced a regression in behavior so
applabel.TestCase failed for tests defined in a directory.

The fix is thanks to yakky and rtnpro.
