### PR TITLE
Fixed search lookup

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -358,6 +358,13 @@ default_lookups['isnull'] = IsNull
 
 class Search(BuiltinLookup):
     lookup_name = 'search'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        sql_template = connection.ops.fulltext_search_sql(field_name=lhs)
+        return sql_template, lhs_params + rhs_params
+
 default_lookups['search'] = Search
 
 


### PR DESCRIPTION
The (MySQL-only) `__search` full-text lookup wasn't properly implemented using the new ORM lookup system. It's use would result to a runtime exception:

``` python
>>> MyModel.objects.filter(field__search='hello world')
[...]
 return node.as_sql(self, self.connection)
  File "/site-packages/django/db/models/sql/where.py", line 106, in as_sql
    sql, params = qn.compile(child)
  File "/site-packages/django/db/models/sql/compiler.py", line 80, in compile
    return node.as_sql(self, self.connection)
  File "/site-packages/django/db/models/sql/where.py", line 106, in as_sql
    sql, params = qn.compile(child)
  File "/site-packages/django/db/models/sql/compiler.py", line 80, in compile
    return node.as_sql(self, self.connection)
  File "/site-packages/django/db/models/lookups.py", line 150, in as_sql
    rhs_sql = self.get_rhs_op(connection, rhs_sql)
  File "/site-packages/django/db/models/lookups.py", line 154, in get_rhs_op
    return connection.operators[self.lookup_name] % rhs
KeyError: 'search'
```

This implementation uses the existing SQL template provided by `BaseDatabaseOperations.fulltext_search_sql(field_name)`.
- Original pull request: #2597
- Trac: https://code.djangoproject.com/ticket/22489
