### PR TITLE
Fixed #3214 -- Stopped parsing SQL with regex.

### DIFF
--- a/django/core/management/sql.py
+++ b/django/core/management/sql.py
@@ -155,6 +155,7 @@ def sql_all(app_config, style, connection):
 
 
 def _split_statements(content):
+    # Private API only called from code that emits a RemovedInDjango19Warning.
     comment_re = re.compile(r"^((?:'[^']*'|[^'])*?)--.*$")
     statements = []
     statement = []
@@ -202,9 +203,7 @@ def custom_sql_for_model(model, style, connection):
     for sql_file in sql_files:
         if os.path.exists(sql_file):
             with codecs.open(sql_file, 'r' if six.PY3 else 'U', encoding=settings.FILE_CHARSET) as fp:
-                # Some backends can't execute more than one SQL statement at a time,
-                # so split into separate statements.
-                output.extend(_split_statements(fp.read()))
+                output.extend(connection.ops.prepare_sql_script(fp.read(), _allow_fallback=True))
     return output
 
 

--- a/django/db/backends/postgresql_psycopg2/base.py
+++ b/django/db/backends/postgresql_psycopg2/base.py
@@ -58,6 +58,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     nulls_order_largest = True
     closed_cursor_error_class = InterfaceError
     has_case_insensitive_like = False
+    requires_sqlparse_for_splitting = False
 
 
 class DatabaseWrapper(BaseDatabaseWrapper):

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -93,6 +93,9 @@ class DatabaseOperations(BaseDatabaseOperations):
     def no_limit_value(self):
         return None
 
+    def prepare_sql_script(self, sql, _allow_fallback=False):
+        return [sql]
+
     def quote_name(self, name):
         if name.startswith('"') and name.endswith('"'):
             return name  # Quoting once is enough.

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -166,6 +166,7 @@ dependencies:
 *  memcached_, plus a :ref:`supported Python binding <memcached>`
 *  gettext_ (:ref:`gettext_on_windows`)
 *  selenium_
+*  sqlparse_
 
 You can find these dependencies in `pip requirements files`_ inside the
 ``tests/requirements`` directory of the Django source tree and install them
@@ -197,6 +198,7 @@ associated tests will be skipped.
 .. _memcached: http://memcached.org/
 .. _gettext: http://www.gnu.org/software/gettext/manual/gettext.html
 .. _selenium: https://pypi.python.org/pypi/selenium
+.. _sqlparse: https://pypi.python.org/pypi/sqlparse
 .. _pip requirements files: http://www.pip-installer.org/en/latest/cookbook.html#requirements-files
 
 Code coverage

--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -167,25 +167,23 @@ Changes a field's name (and, unless ``db_column`` is set, its column name).
 Special Operations
 ==================
 
+.. _operation-run-sql:
+
 RunSQL
 ------
 
 ::
 
-    RunSQL(sql, reverse_sql=None, state_operations=None, multiple=False)
+    RunSQL(sql, reverse_sql=None, state_operations=None)
 
 Allows running of arbitrary SQL on the database - useful for more advanced
 features of database backends that Django doesn't support directly, like
 partial indexes.
 
-``sql``, and ``reverse_sql`` if provided, should be strings of SQL to run on the
-database. They will be passed to the database as a single SQL statement unless
-``multiple`` is set to ``True``, in which case they will be split into separate
-statements manually by the operation before being passed through.
-
-In some extreme cases, the built-in statement splitter may not be able to split
-correctly, in which case you should manually split the SQL into multiple calls
-to ``RunSQL``.
+``sql``, and ``reverse_sql`` if provided, should be strings of SQL to run on
+the database. On most database backends (all but PostgreSQL), Django will
+split the SQL into individual statements prior to executing them. This
+requires installing the sqlparse_ Python library.
 
 The ``state_operations`` argument is so you can supply operations that are
 equivalent to the SQL in terms of project state; for example, if you are
@@ -194,6 +192,7 @@ operation here so that the autodetector still has an up-to-date state of the
 model (otherwise, when you next run ``makemigrations``, it won't see any
 operation that adds that field and so will try to run it again).
 
+.. _sqlparse: https://pypi.python.org/pypi/sqlparse
 
 .. _operation-run-python:
 

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -636,6 +636,14 @@ Management Commands
 * :djadmin:`collectstatic` command with symlink option is now supported on
   Windows NT 6 (Windows Vista and newer).
 
+* :ref:`initial-sql` now works better if the sqlparse_ Python library is
+  installed.
+
+  Note that it's deprecated in favor of the :ref:`RunSQL <operation-run-sql>`
+  operation of migrations, which benefits from the improved behavior.
+
+.. _sqlparse: https://pypi.python.org/pypi/sqlparse
+
 Models
 ^^^^^^
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -128,6 +128,9 @@ Management Commands
 * :djadmin:`dumpdata` now has the option :djadminopt:`--output` which allows
   specifying the file to which the serialized data is written.
 
+* :ref:`initial-sql` now works better if the `sqlparse
+  <https://pypi.python.org/pypi/sqlparse>`_ Python library is installed.
+
 Models
 ^^^^^^
 

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -5,3 +5,4 @@ Pillow
 PyYAML
 pytz > dev
 selenium
+sqlparse


### PR DESCRIPTION
Avoided introducing a new regex-based SQL splitter in the migrations
framework, before we're bound by backwards compatibility.

Adapted this change to the legacy "initial SQL data" feature, even
though it's already deprecated, in order to facilitate the transition
to migrations.

sqlparse becomes mandatory for RunSQL on some databases (all but
PostgreSQL). There's no API to provide a single statement and tell
Django not to attempt splitting. Since we have a more robust splitting
implementation, that seems like a good tradeoff. It's easier to add a
new keyword argument later if necessary than to remove one.

Refs #22401. Many people contributed to both tickets, thank you all.
