### PR TITLE
Fixed #22533 — allowed `label_suffix` to be overriden by fields

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -61,7 +61,7 @@ class Field(object):
 
     def __init__(self, required=True, widget=None, label=None, initial=None,
                  help_text='', error_messages=None, show_hidden_initial=False,
-                 validators=[], localize=False):
+                 label_suffix=None, validators=[], localize=False):
         # required -- Boolean that specifies whether the field is required.
         #             True by default.
         # widget -- A Widget class, or instance of a Widget class, that should
@@ -79,11 +79,14 @@ class Field(object):
         #                   messages that the field will raise.
         # show_hidden_initial -- Boolean that specifies if it is needed to render a
         #                        hidden widget with initial value after widget.
+        # label_suffix -- Suffix to be added to the label. Overrides
+        #                 form's ``label_suffix``.
         # validators -- List of addtional validators to use
         # localize -- Boolean that specifies if the field should be localized.
         self.required, self.label, self.initial = required, label, initial
         self.show_hidden_initial = show_hidden_initial
         self.help_text = help_text
+        self.label_suffix = label_suffix
         widget = widget or self.widget
         if isinstance(widget, type):
             widget = widget()

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -610,8 +610,11 @@ class BoundField(object):
         label_suffix allows overriding the form's label_suffix.
         """
         contents = contents or self.label
+        if label_suffix is None:
+            label_suffix = (self.field.label_suffix if self.field.label_suffix is not None
+                            else self.form.label_suffix)
         # Only add the suffix if the label does not end in punctuation.
-        label_suffix = label_suffix if label_suffix is not None else self.form.label_suffix
+
         # Translators: If found as last label character, these punctuation
         # characters will prevent the default label_suffix to be appended to the label
         if label_suffix and contents and contents[-1] not in _(':?.!'):

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -652,8 +652,14 @@ Note that the label suffix is added only if the last character of the
 label isn't a punctuation character (in English, those are ``.``, ``!``, ``?``
 or ``:``).
 
-You can also customize the ``label_suffix`` on a per-field basis using the
-``label_suffix`` parameter to :meth:`~django.forms.BoundField.label_tag`.
+.. versionadded:: 1.8
+
+Fields can also define their own :attr:`~django.forms.Field.label_suffix` when
+being instantiated. This will take precedence over :attr:`Form.label_suffix
+<django.forms.Form.label_suffix>`. The suffix can also be overriden at run-time
+using the ``label_suffix`` parameter to
+:meth:`~django.forms.BoundField.label_tag`.
+
 
 Notes on field ordering
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -799,12 +805,12 @@ auto-generated label tag. An optional ``attrs`` dictionary may contain
 additional attributes for the ``<label>`` tag.
 
 The HTML that's generated includes the form's
-:attr:`~django.forms.Form.label_suffix` (a colon, by default). The optional
-``label_suffix`` parameter allows you to override the form's
-:attr:`~django.forms.Form.label_suffix`. For example, you can use an empty
-string to hide the label on selected fields. If you need to do this in a
-template, you could write a custom filter to allow passing parameters to
-``label_tag``.
+:attr:`~django.forms.Form.label_suffix` (a colon, by default) or, if set,
+current field's :attr:`~django.forms.Field.label_suffix`. The optional
+``label_suffix`` parameter allows you to override any previously set
+suffix. For example, you can use an empty string to hide the label on selected
+fields. If you need to do this in a template, you could write a custom
+filter to allow passing parameters to ``label_tag``.
 
 .. versionchanged:: 1.8
 

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -119,6 +119,26 @@ We've specified ``auto_id=False`` to simplify the output::
     <tr><th>Your Web site:</th><td><input type="url" name="url" /></td></tr>
     <tr><th>Comment:</th><td><input type="text" name="comment" /></td></tr>
 
+``label_suffix``
+~~~~~~~~~~~~~~~~
+
+.. attribute:: Field.label_suffix
+
+.. versionadded:: 1.8
+
+The ``label_suffix`` argument lets you override form's own
+:attr:`~django.forms.Form.label_suffix` on a per-field basis::
+
+    >>> class ContactForm(forms.Form):
+    ...     age = forms.IntegerField()
+    ...     nationality = forms.CharField()
+    ...     captcha_answer = forms.IntegerField(label='2 + 2', label_suffix=' =')
+    >>> f = ContactForm(label_suffix='?')
+    >>> print(f.as_p())
+    <p><label for="id_age">Age?</label> <input id="id_age" name="age" type="number" /></p>
+    <p><label for="id_nationality">Nationality?</label> <input id="id_nationality" name="nationality" type="text" /></p>
+    <p><label for="id_captcha_answer">2 + 2 =</label> <input id="id_captcha_answer" name="captcha_answer" type="number" /></p>
+
 ``initial``
 ~~~~~~~~~~~
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -117,6 +117,13 @@ Forms
   the ``<label>`` tags for required fields will have this class present in its
   attributes.
 
+* :class:`~django.forms.Field` now accepts being initialized with the
+  :attr:`~django.forms.Field.label_suffix` attribute, which will override
+  form's :attr:`~django.forms.Form.label_suffix`. This enables truly
+  customizing the suffix on a per-field basis — previously it wasn't possible
+  to override form's :attr:`~django.forms.Form.label_suffix` while using
+  shortcuts such as ``{{ form.as_p }}`` in templates.
+
 Internationalization
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1100,18 +1100,25 @@ class FormsTestCase(TestCase):
         class FavoriteForm(Form):
             color = CharField(label='Favorite color?')
             animal = CharField(label='Favorite animal')
+            answer = CharField(label='Secret answer', label_suffix=' =')
 
         f = FavoriteForm(auto_id=False)
         self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" /></li>
-<li>Favorite animal: <input type="text" name="animal" /></li>""")
+<li>Favorite animal: <input type="text" name="animal" /></li>
+<li>Secret answer = <input type="text" name="answer" /></li>""")
+
         f = FavoriteForm(auto_id=False, label_suffix='?')
         self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" /></li>
-<li>Favorite animal? <input type="text" name="animal" /></li>""")
+<li>Favorite animal? <input type="text" name="animal" /></li>
+<li>Secret answer = <input type="text" name="answer" /></li>""")
+
         f = FavoriteForm(auto_id=False, label_suffix='')
         self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" /></li>
-<li>Favorite animal <input type="text" name="animal" /></li>""")
+<li>Favorite animal <input type="text" name="animal" /></li>
+<li>Secret answer = <input type="text" name="answer" /></li>""")
+
         f = FavoriteForm(auto_id=False, label_suffix='\u2192')
-        self.assertHTMLEqual(f.as_ul(), '<li>Favorite color? <input type="text" name="color" /></li>\n<li>Favorite animal\u2192 <input type="text" name="animal" /></li>')
+        self.assertHTMLEqual(f.as_ul(), '<li>Favorite color? <input type="text" name="color" /></li>\n<li>Favorite animal\u2192 <input type="text" name="animal" /></li>\n<li>Secret answer = <input type="text" name="answer" /></li>')
 
     def test_initial_data(self):
         # You can specify initial data for a field by using the 'initial' argument to a


### PR DESCRIPTION
Fields can now receive the `label_suffix` attribute, which will override
form's own `label_suffix`.

This enhances the possibility to customize form's `label_suffix`, allowing
to use such customizations while using shortcuts such as
`{{ form.as_p }}`.

Note that the field's own customization can be overriden at run-time by
using the `label_prefix` parameter to `BoundField.label_tag()`.

Refs #18134.
