### PR TITLE
Fixed #21461, Add pre_update and post_update signals

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -15,7 +15,7 @@ from django.db.models.query_utils import (Q, select_related_descend,
     deferred_class_factory, InvalidQuery)
 from django.db.models.deletion import Collector
 from django.db.models.sql.constants import CURSOR
-from django.db.models import sql
+from django.db.models import signals, sql
 from django.utils.functional import partition
 from django.utils import six
 from django.utils import timezone
@@ -571,12 +571,24 @@ class QuerySet(object):
         """
         assert self.query.can_filter(), \
             "Cannot update a query once a slice has been taken."
+        meta = self.model._meta
         self._for_write = True
         query = self.query.clone(sql.UpdateQuery)
         query.add_update_values(kwargs)
+        extra_data = {}
+        if not meta.auto_created:
+            responses = signals.pre_update.send(
+                sender=self.model, update_fields=kwargs,
+                queryset=self._clone(), using=self.db)
+            for rcvr, response in responses:
+                extra_data.update(response)
         with transaction.atomic(using=self.db, savepoint=False):
             rows = query.get_compiler(self.db).execute_sql(CURSOR)
         self._result_cache = None
+        if not meta.auto_created:
+            signals.post_update.send(
+                sender=self.model, update_fields=kwargs,
+                extra_data=extra_data, using=self.db)
         return rows
     update.alters_data = True
 
@@ -585,7 +597,7 @@ class QuerySet(object):
         A version of update that accepts field objects instead of field names.
         Used primarily for model saving and not intended for use by general
         code (it requires too much poking around at model internals to be
-        useful at that level).
+        useful at that level). This does not send pre/post update signals.
         """
         assert self.query.can_filter(), \
             "Cannot update a query once a slice has been taken."

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -60,6 +60,9 @@ post_save = ModelSignal(providing_args=["instance", "raw", "created", "using", "
 pre_delete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 post_delete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 
+pre_update = ModelSignal(providing_args=["queryset", "values", "using"], use_caching=True)
+post_update = ModelSignal(providing_args=["queryset", "values", "using"], use_caching=True)
+
 m2m_changed = ModelSignal(providing_args=["action", "instance", "reverse", "model", "pk_set", "using"], use_caching=True)
 
 pre_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using"])

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -204,6 +204,74 @@ Arguments sent with this signal:
 ``using``
     The database alias being used.
 
+pre_update
+----------
+
+.. data:: django.db.models.signals.pre_update
+   :module:
+
+.. versionadded 1.8::
+
+Sent at the beginning of a queryset's
+:meth:`~django.db.models.query.QuerySet.update` method. The connected signal may
+optionlly return a dict of extra data that will later be sent to the
+:data:`post_update` signal once the update is complete. Note that other
+connected signals may also override data in this dict if they are called 
+afterwards during the same update.
+
+Arguments sent with this signal:
+
+``sender``
+    The model class.
+
+``update_fields``
+    A dict that maps the fields and values given as ``**kwargs`` to
+    the queryset's :meth:`~django.db.models.query.QuerySet.update` method.
+
+``queryset``
+    A clone of the queryset on which ``update()`` is being called.
+
+    Note that this queryset is not yet evaluated. Also there is no guarantee
+    that this queryset will fetch the same rows that will ultimately be affected,
+    as the data may change in the database before the actual update happens.
+
+``using``
+    The database alias being used.
+
+post_update
+-----------
+
+.. data:: django.db.models.signals.post_update
+   :module:
+
+.. versionadded 1.8::
+
+Like :data:`pre_update`, but sent at the end of a queryset's
+:meth:`~django.db.models.query.QuerySet.update` method. Note that
+``post_update`` receivers do not have a ``querset`` arg. This is because
+querysets are lazily evaluated, and the call to
+:meth:`~django.db.models.query.QuerySet.update` will in most cases invalidate
+the original queryset. If you want to keep track of what objects changed during
+the update, you can return arbitrary data from a :data:`pre_update` receiver,
+and it will be passed to any :data:`post_update` receivers as the ``extra_data``
+argument.
+
+Arguments sent with this signal:
+
+``sender``
+    The model class.
+
+``update_fields``
+    A dict that maps the fields and values given as ``**kwargs`` to
+    the queryset's :meth:`~django.db.models.query.QuerySet.update` method.
+
+``extra_data``
+    A dict of data returned by signals connected to :data:`pre_update`, or an
+    empty dict if no data was returned.
+
+``using``
+    The database alias being used.
+
 m2m_changed
 -----------
 


### PR DESCRIPTION
Assuming this would be targeted for 1.8, since it missed the feature freeze.
