### PR TITLE
Fixed clash caused by the newly introduced -e shorthand for makemessages...

### DIFF
--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         make_option('--locale', '-l', dest='locale', action='append', default=[],
                     help='Locale(s) to process (e.g. de_AT). Default is to process all. Can be '
                          'used multiple times.'),
-        make_option('--exclude', '-e', dest='exclude', action='append', default=[],
+        make_option('--exclude', '-x', dest='exclude', action='append', default=[],
                     help='Locales to exclude. Default is none. Can be used multiple times.'),
     )
     help = 'Compiles .po files to .mo files for use with builtin gettext support.'

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -163,7 +163,7 @@ class Command(NoArgsCommand):
         make_option('--locale', '-l', default=[], dest='locale', action='append',
             help='Creates or updates the message files for the given locale(s) (e.g. pt_BR). '
                  'Can be used multiple times.'),
-        make_option('--exclude', '-e', default=[], dest='exclude', action='append',
+        make_option('--exclude', '-x', default=[], dest='exclude', action='append',
                     help='Locales to exclude. Default is none. Can be used multiple times.'),
         make_option('--domain', '-d', default='django', dest='domain',
             help='The domain of the message files (default: "django").'),

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -176,7 +176,7 @@ output a full stack trace whenever an exception is raised.
 .I \-l, \-\-locale=LOCALE
 The locale to process when using makemessages or compilemessages.
 .TP
-.I \-e, \-\-exclude=LOCALE
+.I \-x, \-\-exclude=LOCALE
 The locale to exclude from processing when using makemessages or compilemessages.
 .TP
 .I \-d, \-\-domain=DOMAIN

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -143,7 +143,7 @@ specify the locale(s) to process. If not provided, all locales are processed.
 
 .. versionadded:: 1.8
 
-Use the :djadminopt:`--exclude` option (or its shorter version ``-e``) to
+Use the :djadminopt:`--exclude` option (or its shorter version ``-x``) to
 specify the locale(s) to exclude from processing. If not provided, no locales
 are excluded.
 
@@ -155,8 +155,8 @@ Example usage::
     django-admin.py compilemessages -l pt_BR -l fr
     django-admin.py compilemessages --exclude=pt_BR
     django-admin.py compilemessages --exclude=pt_BR --exclude=fr
-    django-admin.py compilemessages -e pt_BR
-    django-admin.py compilemessages -e pt_BR -e fr
+    django-admin.py compilemessages -x pt_BR
+    django-admin.py compilemessages -x pt_BR -x fr
 
 createcachetable
 ----------------
@@ -563,7 +563,7 @@ specify the locale(s) to process.
 
 .. versionadded:: 1.8
 
-Use the :djadminopt:`--exclude` option (or its shorter version ``-e``) to
+Use the :djadminopt:`--exclude` option (or its shorter version ``-x``) to
 specify the locale(s) to exclude from processing. If not provided, no locales
 are excluded.
 
@@ -575,8 +575,8 @@ Example usage::
     django-admin.py makemessages -l pt_BR -l fr
     django-admin.py makemessages --exclude=pt_BR
     django-admin.py makemessages --exclude=pt_BR --exclude=fr
-    django-admin.py makemessages -e pt_BR
-    django-admin.py makemessages -e pt_BR -e fr
+    django-admin.py makemessages -x pt_BR
+    django-admin.py makemessages -x pt_BR -x fr
 
 
 .. versionchanged:: 1.7

--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -1,9 +1,10 @@
 import os
 import shutil
 import stat
+import sys
 import unittest
 
-from django.core.management import call_command, CommandError
+from django.core.management import call_command, CommandError, execute_from_command_line
 from django.core.management.utils import find_command
 from django.test import SimpleTestCase
 from django.test import override_settings
@@ -137,6 +138,17 @@ class ExcludedLocaleCompilationTests(MessageCompilationTests):
 
         shutil.copytree('canned_locale', 'locale')
         self.addCleanup(self._rmrf, os.path.join(self.test_dir, 'locale'))
+
+    def test_command_help(self):
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        try:
+            # `call_command` bypasses the parser; by calling
+            # `execute_from_command_line` with the help subcommand we
+            # ensure that there are no issues with the parser itself.
+            execute_from_command_line(['django-admin', 'help', 'compilemessages'])
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
 
     def test_one_locale_excluded(self):
         call_command('compilemessages', exclude=['it'], stdout=StringIO())

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -5,12 +5,14 @@ import io
 import os
 import re
 import shutil
+import sys
 import time
 from unittest import SkipTest, skipUnless
 import warnings
 
 from django.conf import settings
 from django.core import management
+from django.core.management import execute_from_command_line
 from django.core.management.utils import find_command
 from django.test import SimpleTestCase
 from django.test import override_settings
@@ -564,6 +566,17 @@ class ExcludedLocaleExtractionTests(ExtractorTests):
         shutil.copytree('canned_locale', 'locale')
         self._set_times_for_all_po_files()
         self.addCleanup(self._rmrf, os.path.join(self.test_dir, 'locale'))
+
+    def test_command_help(self):
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = StringIO(), StringIO()
+        try:
+            # `call_command` bypasses the parser; by calling
+            # `execute_from_command_line` with the help subcommand we
+            # ensure that there are no issues with the parser itself.
+            execute_from_command_line(['django-admin', 'help', 'makemessages'])
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
 
     def test_one_locale_excluded(self):
         management.call_command('makemessages', exclude=['it'], stdout=StringIO())


### PR DESCRIPTION
... --exclude.

This fixes a regression caused by 0707b82. Refs #22328.
