### PR TITLE
Fixed #22539, duplicate exclude argument in Model.full_clean() to prevent side effects.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -988,6 +988,8 @@ class Model(six.with_metaclass(ModelBase)):
         errors = {}
         if exclude is None:
             exclude = []
+        else:
+            exclude = list(exclude)
 
         try:
             self.clean_fields(exclude=exclude)

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -59,6 +59,13 @@ class BaseModelValidationTests(ValidationTestCase):
         mtv = ModelToValidate(number=10, name='Some Name', slug='##invalid##')
         self.assertFailsValidation(mtv.full_clean, ['slug'])
 
+    def test_full_clean_does_not_mutate_exclude(self):
+        mtv = ModelToValidate(f_with_custom_validator=42)
+        exclude = ['number']
+        self.assertFailsValidation(mtv.full_clean, ['name'], exclude)
+        self.assertEqual(len(exclude), 1)
+        self.assertEqual(exclude[0], 'number')
+
 
 class ArticleForm(forms.ModelForm):
     class Meta:


### PR DESCRIPTION
Fixed side effects caused to the exclude argument sent to Model.full_clean() when a field error is raised.

Also casts the exclude argument to a list, so to prevent error if a tuple() was to be sent.
