### PR TITLE
Fixed #22540 -- Made _create_object_from_params() call create()

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -364,7 +364,8 @@ class QuerySet(object):
         """
         obj = self.model(**kwargs)
         self._for_write = True
-        obj.save(force_insert=True, using=self.db)
+        with transaction.atomic(using=self.db):
+            obj.save(force_insert=True, using=self.db)
         return obj
 
     def bulk_create(self, objs, batch_size=None):
@@ -446,10 +447,8 @@ class QuerySet(object):
         Tries to create an object using passed params.
         Used by get_or_create and update_or_create
         """
-        obj = self.model(**params)
         try:
-            with transaction.atomic(using=self.db):
-                obj.save(force_insert=True, using=self.db)
+            obj = self.create(**params)
             return obj, True
         except IntegrityError:
             exc_info = sys.exc_info()


### PR DESCRIPTION
So as the save step is centralized in create(), especially useful
when customizing behavior in subclasses.
Thanks craig.labenz@gmail.com for the report.
