### PR TITLE
Fixed #22501: Set the corrent address for LiveServerTestCase Client

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -335,9 +335,12 @@ class RequestFactory(object):
         r = {
             'PATH_INFO': self._get_path(parsed),
             'REQUEST_METHOD': str(method),
-            'SERVER_PORT': str('443') if secure else str('80'),
-            'wsgi.url_scheme': str('https') if secure else str('http'),
         }
+        if secure:
+            r.update({
+                'SERVER_PORT': str('443'),
+                'wsgi.url_scheme': str('https'),
+            })
         if data:
             r.update({
                 'CONTENT_LENGTH': len(data),

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -157,6 +157,7 @@ class SimpleTestCase(unittest.TestCase):
     # The class we'll use for the test client self.client.
     # Can be overridden in derived classes.
     client_class = Client
+    client_args = {}
     _overridden_settings = None
     _modified_settings = None
 
@@ -197,7 +198,8 @@ class SimpleTestCase(unittest.TestCase):
         if self._modified_settings:
             self._modified_context = modify_settings(self._modified_settings)
             self._modified_context.enable()
-        self.client = self.client_class()
+        # import ipdb; ipdb.set_trace()
+        self.client = self.client_class(**self.client_args)
         self._urlconf_setup()
         mail.outbox = []
 
@@ -1217,3 +1219,11 @@ class LiveServerTestCase(TransactionTestCase):
     def tearDownClass(cls):
         cls._tearDownClassInternal()
         super(LiveServerTestCase, cls).tearDownClass()
+
+    def __call__(self, result=None):
+        if hasattr(self, 'server_thread'):
+            self.client_args = {
+                  'SERVER_NAME': self.server_thread.host,
+                  'SERVER_PORT': self.server_thread.port,
+            }
+        super(LiveServerTestCase, self).__call__(result)

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -162,6 +162,10 @@ class LiveServerViews(LiveServerBase):
         f = self.urlopen('/environ_view/?%s' % urlencode({'q': 'тест'}))
         self.assertIn(b"QUERY_STRING: 'q=%D1%82%D0%B5%D1%81%D1%82'", f.read())
 
+    def test_address(self):
+        r = self.client.get('/environ_view/')
+        self.assertIn(b"SERVER_PORT: {}".format(self.server_thread.port), r.content)
+        self.assertIn(b"SERVER_NAME: u'{}'".format(self.server_thread.host), r.content)
 
 class LiveServerDatabase(LiveServerBase):
 


### PR DESCRIPTION
By default, the test client sets the server host to 'testserver' and the
port to 80.  In the case of a LiveServerTestCase, the server has a real
adress and a real port.  This fix sets the testing client adress to the
real address.

https://code.djangoproject.com/ticket/22501
