### PR TITLE
Validator comparisons

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -51,7 +51,17 @@ class RegexValidator(object):
             raise ValidationError(self.message, code=self.code)
 
     def __eq__(self, other):
-        return isinstance(other, RegexValidator) and (self.regex == other.regex) and (self.message == other.message) and (self.code == other.code)
+        return (
+            isinstance(other, RegexValidator) and
+            self.regex.pattern == other.regex.pattern and
+            self.regex.flags == other.regex.flags and
+            (self.message == other.message) and
+            (self.code == other.code) and
+            (self.inverse_match == other.inverse_match)
+        )
+
+    def __ne__(self, other):
+        return not (self == other)
 
 
 @deconstructible

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -296,6 +296,33 @@ class TestValidatorEquality(TestCase):
             RegexValidator(r'^(?:[a-z0-9\.\-]*)://'),
         )
 
+        self.assertNotEqual(
+            RegexValidator('', flags=re.IGNORECASE),
+            RegexValidator(''),
+        )
+
+        self.assertNotEqual(
+            RegexValidator(''),
+            RegexValidator('', inverse_match=True),
+        )
+
+    def test_regex_equality_nocache(self):
+        pattern = r'^(?:[a-z0-9\.\-]*)://'
+        left = RegexValidator(pattern)
+        re.purge()
+        right = RegexValidator(pattern)
+
+        self.assertEqual(
+            left,
+            right,
+        )
+
+    def test_regex_equality_blank(self):
+        self.assertEqual(
+            RegexValidator(),
+            RegexValidator(),
+        )
+
     def test_email_equality(self):
         self.assertEqual(
             EmailValidator(),


### PR DESCRIPTION
[1.7.x] Fixed #22588 -- Fix RegexValidator `__eq__`
Compare parameters instead of re.pattern instances, and add the other
parameters to the comparison. Also add a `__ne__` to make `assertNotEqual`
work properly.
