### PR TITLE
Ticket/22502

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 import copy
+import datetime
 import warnings
 
 from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
@@ -590,6 +591,12 @@ class BoundField(object):
             data = self.form.initial.get(self.name, self.field.initial)
             if callable(data):
                 data = data()
+                # If this is an auto-generated default date, nix the
+                # microseconds for standardized handling. See #22502.
+                if ((isinstance(data, datetime.datetime) or
+                        isinstance(data, datetime.time)) and
+                        not getattr(self.field.widget, 'supports_microseconds', True)):
+                    data = data.replace(microsecond=0)
         else:
             data = self.field.bound_data(
                 self.data, self.form.initial.get(self.name, self.field.initial)

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -429,6 +429,7 @@ class Textarea(Widget):
 
 class DateTimeBaseInput(TextInput):
     format_key = ''
+    supports_microseconds = False
 
     def __init__(self, attrs=None, format=None):
         super(DateTimeBaseInput, self).__init__(attrs)
@@ -863,6 +864,7 @@ class SplitDateTimeWidget(MultiWidget):
     """
     A Widget that splits datetime input into two <input type="text"> boxes.
     """
+    supports_microseconds = False
 
     def __init__(self, attrs=None, date_format=None, time_format=None):
         widgets = (DateInput(attrs=attrs, format=date_format),


### PR DESCRIPTION
Nixed microseconds on datetime BoundField values generated from a callable default. Fixed [Django ticket 22502](https://code.djangoproject.com/ticket/22502).

Explanation: If a callable default creates an initial datetime value with microseconds, those microseconds will be reflected in the hidden input used to track the initial value - but _not_ in the datetime field presented to the user. That means that the field will _always_ show up as changed when the user submits the form. This is particularly relevant for extra forms on a formset (which, due to this bug, will run validation and potentially be saved even though if the user hasn't touched them).

The only potential edge case where I could see this causing a problem would be if someone wrote a datetime field which _had_ microsecond support. I don't think that's something folks will want to do, though.
