### PR TITLE
Fix typo in multipartparser.py

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -62,7 +62,7 @@ class MultiPartParser(object):
         """
 
         #
-        # Content-Type should containt multipart and the boundary information.
+        # Content-Type should contain multipart and the boundary information.
         #
 
         content_type = META.get('HTTP_CONTENT_TYPE', META.get('CONTENT_TYPE', ''))


### PR DESCRIPTION
Change 'containt' to 'contain'
