### PR TITLE
Fixed #22490 -- removed obsolete ComplexFeed class from syndication_tests

### DIFF
--- a/tests/syndication_tests/feeds.py
+++ b/tests/syndication_tests/feeds.py
@@ -8,13 +8,6 @@ from django.utils.timezone import get_fixed_timezone
 from .models import Article, Entry
 
 
-class ComplexFeed(views.Feed):
-    def get_object(self, request, foo=None):
-        if foo is not None:
-            raise ObjectDoesNotExist
-        return None
-
-
 class TestRss2Feed(views.Feed):
     title = 'My blog'
     description = 'A more thorough description of my blog.'

--- a/tests/syndication_tests/urls.py
+++ b/tests/syndication_tests/urls.py
@@ -4,7 +4,6 @@ from . import feeds
 
 
 urlpatterns = [
-    url(r'^syndication/complex/(?P<foo>.*)/$', feeds.ComplexFeed()),
     url(r'^syndication/rss2/$', feeds.TestRss2Feed()),
     url(r'^syndication/rss2/guid_ispermalink_true/$',
         feeds.TestRss2FeedWithGuidIsPermaLinkTrue()),


### PR DESCRIPTION
It was previously used in a test that was deprecated and then removed, this cruft can be removed now.
