### PR TITLE
Fixed #22622 -- Added ugettext_lazy import in docs

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -507,6 +507,8 @@ attributes of the inner ``Meta`` class if you want to further customize a field.
 For example if you wanted to customize the wording of all user facing strings for
 the ``name`` field::
 
+    from django.utils.translation import ugettext_lazy as _
+
     class AuthorForm(ModelForm):
         class Meta:
             model = Author


### PR DESCRIPTION
This needs to be backported to 1.6 and 1.7 (doesn't look like it's needed in 1.5).

https://code.djangoproject.com/ticket/22622
