### PR TITLE
Fixed #22266 - CharField primary keys with underscores are (un)escaped differently in the admin pages

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -11,7 +11,7 @@ from django.contrib.admin import widgets, helpers
 from django.contrib.admin import validation
 from django.contrib.admin.checks import (BaseModelAdminChecks, ModelAdminChecks,
     InlineModelAdminChecks)
-from django.contrib.admin.utils import (unquote, flatten_fieldsets,
+from django.contrib.admin.utils import (quote, unquote, flatten_fieldsets,
     get_deleted_objects, model_format_dict, NestedObjects,
     lookup_needs_distinct)
 from django.contrib.admin.templatetags.admin_static import static
@@ -1099,7 +1099,7 @@ class ModelAdmin(BaseModelAdmin):
             if post_url_continue is None:
                 post_url_continue = reverse('admin:%s_%s_change' %
                                             (opts.app_label, opts.model_name),
-                                            args=(pk_value,),
+                                            args=(quote(pk_value),),
                                             current_app=self.admin_site.name)
             post_url_continue = add_preserved_filters({'preserved_filters': preserved_filters, 'opts': opts}, post_url_continue)
             return HttpResponseRedirect(post_url_continue)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1777,6 +1777,30 @@ class AdminViewStringPrimaryKeyTest(TestCase):
             args=(quote(self.pk),))
         self.assertContains(response, '<a href="%s" class="historylink"' % expected_link)
 
+    def test_redirect_on_add_view_continue_button(self):
+        """As soon as an object is added using "Save and continue editing"
+        button, the user should be redirected to the object's change_view.
+
+        In case primary key is a string containing some special characters
+        like slash or underscore, these characters must be escaped (see #22266)
+        """
+        response = self.client.post(
+            '/test_admin/admin/admin_views/modelwithstringprimarykey/add/',
+            {
+                'string_pk': '123/history',
+                "_continue": "1",  # Save and continue editing
+            }
+        )
+
+        self.assertEqual(response.status_code, 302)  # temporary redirect
+        self.assertEqual(
+            response['location'],
+            (
+                'http://testserver/test_admin/admin/admin_views/'
+                'modelwithstringprimarykey/123_2Fhistory/'  # PK is quoted
+            )
+        )
+
 
 @override_settings(PASSWORD_HASHERS=('django.contrib.auth.hashers.SHA1PasswordHasher',),
     ROOT_URLCONF="admin_views.urls")


### PR DESCRIPTION
 ModelAdmin.get_urls defines the urls like these:

```
        url(r'^$', wrap(self.changelist_view), name='%s_%s_changelist' % info),
        url(r'^add/$', wrap(self.add_view), name='%s_%s_add' % info),
        url(r'^(.+)/history/$', wrap(self.history_view), name='%s_%s_history' % info),
        url(r'^(.+)/delete/$', wrap(self.delete_view), name='%s_%s_delete' % info),
        url(r'^(.+)/$', wrap(self.change_view), name='%s_%s_change' % info),
```

As long as we do not know the exact primary key regexp, we have to use (.+)
Consider we have 2 entries with the following PKs: "test_123" and "test_123/history". There is no way to distinguish change view for "test_123/history" and history view for "test_123".
That is why PK quoting was introduced. django.contrib.admin.utils contains 2 functions: quote and unquote. So reversing admin url should usually look like:

```
reverse('admin:app_model_change', args=(quote(pk),))
```

Quoting and unquoting doesn't change numerical PKs, that is why this problem haven't been noticed before.
The first redirect doesn't work, as there is a bug with quoting not being applied in add_view.

I suppose we are really lacking the documentation (​https://docs.djangoproject.com/en/1.6/ref/contrib/admin/#overriding-vs-replacing-an-admin-template is evertyhing I could find).

There is no way to get rid of quoting if we leave (.+) url pattern for PK. So we can leave quoting/unquoting as is and fix the redirect in add_view....ntrib.admin)
