### PR TITLE
Fixed #22634 -- Changed Session and SessionStore to be easily extendable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -605,6 +605,7 @@ answer newbie questions, and generally made Django that much better:
     Sengtha Chay <sengtha@e-khmer.com>
     Senko Rašić <senko.rasic@dobarkod.hr>
     serbaut@gmail.com
+    Sergey Kolosov <m17.admin@gmail.com>
     Seth Hill <sethrh@gmail.com>
     Shai Berger <shai@platonix.com>
     Shannon -jj Behrens <http://jjinux.blogspot.com/>

--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -10,13 +10,15 @@ class SessionStore(SessionBase):
     """
     A cache-based session store.
     """
+    cache_key_prefix = KEY_PREFIX
+
     def __init__(self, session_key=None):
         self._cache = caches[settings.SESSION_CACHE_ALIAS]
         super(SessionStore, self).__init__(session_key)
 
     @property
     def cache_key(self):
-        return KEY_PREFIX + self._get_or_create_session_key()
+        return self.cache_key_prefix + self._get_or_create_session_key()
 
     def load(self):
         try:
@@ -60,14 +62,14 @@ class SessionStore(SessionBase):
             raise CreateError
 
     def exists(self, session_key):
-        return (KEY_PREFIX + session_key) in self._cache
+        return (self.cache_key_prefix + session_key) in self._cache
 
     def delete(self, session_key=None):
         if session_key is None:
             if self.session_key is None:
                 return
             session_key = self.session_key
-        self._cache.delete(KEY_PREFIX + session_key)
+        self._cache.delete(self.cache_key_prefix + session_key)
 
     @classmethod
     def clear_expired(cls):

--- a/django/contrib/sessions/tests/custom_db_backend.py
+++ b/django/contrib/sessions/tests/custom_db_backend.py
@@ -1,0 +1,43 @@
+from django.contrib.sessions.models import AbstractSession
+from django.contrib.sessions.backends.db import SessionStore as DBStore
+from django.db import models
+
+
+# This custom Session model adds an extra column to store an account ID.
+# In real-world applications it allows to provide extra security
+# by adding an option to query database for all active sessions for
+# a particular account (and to destroy "suspicious" sessions as well).
+
+class CustomSession(AbstractSession):
+    """
+    A session model with a column for an account ID.
+    """
+    account_id = models.IntegerField(null=True, db_index=True)
+
+    class Meta:
+        app_label = 'sessions'
+
+    @classmethod
+    def get_session_store_class(cls):
+        return SessionStore
+
+
+class SessionStore(DBStore):
+    """
+    A database session store, that handles updating the account ID column
+    inside the custom session model.
+    """
+    @classmethod
+    def get_session_class(cls):
+        return CustomSession
+
+    def create_session_instance(self, data):
+        obj = super(SessionStore, self).create_session_instance(data)
+
+        try:
+            account_id = int(data.get('_auth_user_id')) or None
+        except (ValueError, TypeError):
+            account_id = None
+        obj.account_id = account_id
+
+        return obj

--- a/django/contrib/sessions/tests/test_backends.py
+++ b/django/contrib/sessions/tests/test_backends.py
@@ -13,7 +13,7 @@ from django.contrib.sessions.backends.cache import SessionStore as CacheSession
 from django.contrib.sessions.backends.cached_db import SessionStore as CacheDBSession
 from django.contrib.sessions.backends.file import SessionStore as FileSession
 from django.contrib.sessions.backends.signed_cookies import SessionStore as CookieSession
-from django.contrib.sessions.models import Session
+from django.contrib.sessions.tests.custom_db_backend import SessionStore as CustomDatabaseSession
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
@@ -313,6 +313,11 @@ class SessionTestsMixin(object):
 class DatabaseSessionTests(SessionTestsMixin, TestCase):
 
     backend = DatabaseSession
+    session_engine = 'django.contrib.sessions.backends.db'
+
+    @property
+    def session_class(self):
+        return self.backend.get_session_class()
 
     def test_session_str(self):
         "Session repr should be the session key."
@@ -320,7 +325,7 @@ class DatabaseSessionTests(SessionTestsMixin, TestCase):
         self.session.save()
 
         session_key = self.session.session_key
-        s = Session.objects.get(session_key=session_key)
+        s = self.session_class.objects.get(session_key=session_key)
 
         self.assertEqual(force_text(s), session_key)
 
@@ -332,7 +337,7 @@ class DatabaseSessionTests(SessionTestsMixin, TestCase):
         self.session['x'] = 1
         self.session.save()
 
-        s = Session.objects.get(session_key=self.session.session_key)
+        s = self.session_class.objects.get(session_key=self.session.session_key)
 
         self.assertEqual(s.get_decoded(), {'x': 1})
 
@@ -344,19 +349,18 @@ class DatabaseSessionTests(SessionTestsMixin, TestCase):
         self.session['y'] = 1
         self.session.save()
 
-        s = Session.objects.get(session_key=self.session.session_key)
+        s = self.session_class.objects.get(session_key=self.session.session_key)
         # Change it
-        Session.objects.save(s.session_key, {'y': 2}, s.expire_date)
+        self.session_class.objects.save(s.session_key, {'y': 2}, s.expire_date)
         # Clear cache, so that it will be retrieved from DB
         del self.session._session_cache
         self.assertEqual(self.session['y'], 2)
 
-    @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.db")
     def test_clearsessions_command(self):
         """
         Test clearsessions command for clearing expired sessions.
         """
-        self.assertEqual(0, Session.objects.count())
+        self.assertEqual(0, self.session_class.objects.count())
 
         # One object in the future
         self.session['foo'] = 'bar'
@@ -370,15 +374,39 @@ class DatabaseSessionTests(SessionTestsMixin, TestCase):
         other_session.save()
 
         # Two sessions are in the database before clearsessions...
-        self.assertEqual(2, Session.objects.count())
-        management.call_command('clearsessions')
+        self.assertEqual(2, self.session_class.objects.count())
+        with override_settings(SESSION_ENGINE=self.session_engine):
+            management.call_command('clearsessions')
         # ... and one is deleted.
-        self.assertEqual(1, Session.objects.count())
+        self.assertEqual(1, self.session_class.objects.count())
 
 
 @override_settings(USE_TZ=True)
 class DatabaseSessionWithTimeZoneTests(DatabaseSessionTests):
     pass
+
+
+class CustomDatabaseSessionTests(DatabaseSessionTests):
+    backend = CustomDatabaseSession
+    session_engine = 'django.contrib.sessions.tests.custom_db_backend'
+
+    def test_extra_session_field(self):
+        # Set the account ID to be picked up by a custom session storage
+        # and saved to a custom session model database column.
+        self.session['_auth_user_id'] = 42
+        self.session.save()
+
+        # Make sure that the customized create_session_instance() was called
+        s = self.session_class.objects.get(session_key=self.session.session_key)
+        self.assertEqual(s.account_id, 42)
+
+        # Make the session "anonymous"
+        self.session.pop('_auth_user_id')
+        self.session.save()
+
+        # Make sure that save() on an existing session did the right job
+        s = self.session_class.objects.get(session_key=self.session.session_key)
+        self.assertEqual(s.account_id, None)
 
 
 class CacheDBSessionTests(SessionTestsMixin, TestCase):

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -177,6 +177,11 @@ Minor features
 * Session cookie is now deleted after
   :meth:`~django.contrib.sessions.backends.base.SessionBase.flush()` is called.
 
+* Session model and SessionStore classes for ``db`` and ``cached_db`` backends
+  are now reusable for a custom database session backend to be built upon those.
+  See :ref:`Extending database-backed session engines 
+  <extending-database-backed-session-engines>` for more details.
+
 :mod:`django.contrib.sitemaps`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -681,6 +681,61 @@ Technical details
 * Django only sends a cookie if it needs to. If you don't set any session
   data, it won't send a session cookie.
 
+.. _extending-database-backed-session-engines:
+
+Extending database-backed session engines
+-----------------------------------------
+
+.. versionadded:: 1.8
+
+Creating a custom database-backed session engine built upon those included 
+in Django (namely ``db`` and ``cached_db``) may be done via the inheritance
+of the abstract session model :class:`models.AbstractSession`, and an either
+one of ``SessionStore`` classes.
+
+.. class:: models.AbstractSession
+
+    The abstract base session model. Includes everything that is available
+    for the default implementation of the ``Session`` model class.
+
+The example below shows a custom database-backed session engine, that includes
+an additional database column to store an account ID (thus providing an option
+to query the database for all active sessions for an account)::
+
+    from django.contrib.sessions.models import AbstractSession
+    from django.contrib.sessions.backends.db import SessionStore as DBStore
+    from django.db import models
+
+    class CustomSession(AbstractSession):
+        account_id = models.IntegerField(null=True, db_index=True)
+
+        @classmethod
+        def get_session_store_class(cls):
+            return SessionStore
+
+    class SessionStore(DBStore):
+        @classmethod
+        def get_session_class(cls):
+            return CustomSession
+
+        def create_session_instance(self, data):
+            obj = super(SessionStore, self).create_session_instance(data)
+            try:
+                account_id = int(data.get('_auth_user_id')) or None
+            except (ValueError, TypeError):
+                account_id = None
+            obj.account_id = account_id
+            return obj
+
+In case of a migration from the Django's built-in ``cached_db`` session store,
+to a custom one based on ``cached_db``, one should override the cache key prefix
+in order to prevent namespace clash::
+
+    class SessionStore(CachedDBStore):
+        cache_key_prefix = 'mysessions.custom_cached_db_backend'
+
+        # ...
+
 Session IDs in URLs
 ===================
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -123,6 +123,7 @@ def setup(verbosity, test_labels):
         # these 'tests.migrations' modules don't actually exist, but this lets
         # us skip creating migrations for the test models.
         'auth': 'django.contrib.auth.tests.migrations',
+        'sessions': 'django.contrib.sessions.tests.migrations',
         'contenttypes': 'django.contrib.contenttypes.tests.migrations',
     }
 


### PR DESCRIPTION
Introduced abstract base model for Session, and properties enabling the developer to override session model class used by session store and the session store class used by the model.

Allowed to override KEY_PREFIX via the cache_key_prefix property.