### PR TITLE
Fix #22626: allow BinaryField defaults with SQlite

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -30,13 +30,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return '"%s"' % six.text_type(value)
         elif value is None:
             return "NULL"
-        elif isinstance(value, (bytes, memoryview, bytearray)):
-            # Bytes are only allowed for BLOB fields
-            # SQLite spec: BLOB literals are string literals containing hexadecimal data and preceded by a single "x" or "X" character.
-            # So bytes => decode as hex => output as X'deadbeef'
+        elif isinstance(value, (bytes, bytearray, six.memoryview)):
+            # Bytes are only allowed for BLOB fields, encoded as string literals containing hexadecimal data and preceded by a single "X" character.
+            # value = b'\x01\x02' => value_hex = b'0102' => return X'0102'
             value = bytes(value)
             hex_encoder = codecs.getencoder('hex_codec')
-            value_hex = hex_encoder(value)[0]
+            value_hex, _length = hex_encoder(value)
+            # Use 'ascii' encoding for b'01' => '01', no need to use force_text here.
             return "X'%s'" % value_hex.decode('ascii')
         else:
             raise ValueError("Cannot quote parameter value %r of type %s" % (value, type(value)))


### PR DESCRIPTION
Also fixes a slight issue in sqlite3.schema._remake_table where
default values where quoted with "column name" quoting rules.

Reference for quoting: http://www.sqlite.org/lang_expr.html
