### PR TITLE
Fixed #22421 -- Regression in fixtures loading.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1440,14 +1440,16 @@ class ForeignObject(RelatedField):
     @staticmethod
     def get_instance_value_for_fields(instance, fields):
         ret = []
+        opts = instance._meta
         for field in fields:
             # Gotcha: in some cases (like fixture loading) a model can have
             # different values in parent_ptr_id and parent's id. So, use
             # instance.pk (that is, parent_ptr_id) when asked for instance.id.
-            opts = instance._meta
             if field.primary_key:
                 possible_parent_link = opts.get_ancestor_link(field.model)
-                if not possible_parent_link or possible_parent_link.primary_key:
+                if (not possible_parent_link or
+                        possible_parent_link.primary_key or
+                        possible_parent_link.model._meta.abstract):
                     ret.append(instance.pk)
                     continue
             ret.append(getattr(instance, field.attname))

--- a/tests/fixtures_regress/fixtures/feature.json
+++ b/tests/fixtures_regress/fixtures/feature.json
@@ -1,0 +1,17 @@
+[
+{
+  "fields": {
+    "channels": [],
+    "title": "Title of this feature article"
+  },
+  "model": "fixtures_regress.article",
+  "pk": 1
+},
+{
+  "fields": {
+    "channels": []
+  },
+  "model": "fixtures_regress.feature",
+  "pk": 1
+}
+]

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -52,7 +52,7 @@ class Child(Parent):
     data = models.CharField(max_length=10)
 
 
-# Models to regression test #7572
+# Models to regression test #7572, #20820
 class Channel(models.Model):
     name = models.CharField(max_length=255)
 
@@ -67,6 +67,17 @@ class Article(models.Model):
 
 # Subclass of a model with a ManyToManyField for test_ticket_20820
 class SpecialArticle(Article):
+    pass
+
+
+# Models to regression test #22421
+class CommonFeature(Article):
+
+    class Meta:
+        abstract = True
+
+
+class Feature(CommonFeature):
     pass
 
 

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -486,6 +486,18 @@ class TestFixtures(TestCase):
             verbosity=0,
         )
 
+    def test_ticket_22421(self):
+        """
+        Regression for ticket #22421 -- loaddata on a model that inherits from
+        a grand-parent model with a M2M but via an abstract parent shouldn't
+        blow up.
+        """
+        management.call_command(
+            'loaddata',
+            'feature.json',
+            verbosity=0,
+        )
+
 
 class NaturalKeyFixtureTests(TestCase):
 


### PR DESCRIPTION
Loading fixtures were failing since the refactoring in 244e2b71f5 for
inheritance setups where the chain contains abstract models and the
root ancestor contains a M2M relation.

Thanks Stanislas Guerra for the report.

Refs #20946.
