### PR TITLE
Fixed #22368 -- clarified connecting to Oracle DB using service name

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -732,7 +732,8 @@ by default, but in case it is not, you'll need to grant permissions like so:
 Connecting to the database
 --------------------------
 
-Your Django settings.py file should look something like this for Oracle::
+To connect using the service name of your Oracle database, Django settings.py
+file should look something like this::
 
     DATABASES = {
         'default': {
@@ -746,8 +747,9 @@ Your Django settings.py file should look something like this for Oracle::
     }
 
 
-If you don't use a ``tnsnames.ora`` file or a similar naming method that
-recognizes the SID ("xe" in this example), then fill in both
+In this case, you should leave both :setting:`HOST` and :setting:`PORT` empty.
+However, if you don't use a ``tnsnames.ora`` file or a similar naming method
+and want to connect using the SID ("xe" in this example), then fill in both
 :setting:`HOST` and :setting:`PORT` like so::
 
     DATABASES = {
@@ -761,8 +763,9 @@ recognizes the SID ("xe" in this example), then fill in both
         }
     }
 
-You should supply both :setting:`HOST` and :setting:`PORT`, or leave both
-as empty strings.
+You should either supply both :setting:`HOST` and :setting:`PORT`, or leave
+both as empty strings. Depending on that choice, Django will use a different
+connect descriptor.
 
 Threaded option
 ----------------


### PR DESCRIPTION
Clarified "Connecting to the database" section of "Oracle notes",
explaining how to connect using service name vs using SID. Used the
official terminology listed in
http://docs.oracle.com/cd/B19306_01/network.102/b14212/glossary.htm#i997309
Thanks michael.cherkasov for the report.
