### PR TITLE
Fixed #21773 -- made daemon threads default in the development server.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -33,6 +33,8 @@ class Command(BaseCommand):
             help='Tells Django to NOT use threading.'),
         make_option('--noreload', action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
+        make_option('--nodaemon', action='store_false', dest='daemon_threads', default=True,
+            help='Tells Django to use NON-daemon threads.'),
     )
     help = "Starts a lightweight Web server for development."
     args = '[optional port number, or ipaddr:port]'
@@ -97,6 +99,7 @@ class Command(BaseCommand):
         from django.utils import translation
 
         threading = options.get('use_threading')
+        daemon_threads = options.get('daemon_threads')
         shutdown_message = options.get('shutdown_message', '')
         quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
 
@@ -130,7 +133,8 @@ class Command(BaseCommand):
         try:
             handler = self.get_handler(*args, **options)
             run(self.addr, int(self.port), handler,
-                ipv6=self.use_ipv6, threading=threading)
+                ipv6=self.use_ipv6, threading=threading,
+                daemon_threads=daemon_threads)
         except socket.error as e:
             # Use helpful error messages instead of ugly tracebacks.
             ERRORS = {

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -156,12 +156,20 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
         sys.stderr.write(msg)
 
 
-def run(addr, port, wsgi_handler, ipv6=False, threading=False):
+def run(addr, port, wsgi_handler, ipv6=False, threading=False, daemon_threads=False):
     server_address = (addr, port)
     if threading:
         httpd_cls = type(str('WSGIServer'), (socketserver.ThreadingMixIn, WSGIServer), {})
     else:
         httpd_cls = WSGIServer
     httpd = httpd_cls(server_address, WSGIRequestHandler, ipv6=ipv6)
+    if threading:
+        # ThreadingMixIn.daemon_threads indicates how threads will behave on an
+        # abrupt shutdown; like quitting the server by the user or restarting
+        # by the auto-reloader. True means the server will not wait for thread
+        # termination before it quits. This will make auto-reloader faster
+        # and will prevent the need to kill the server manually if a thread
+        # isn't terminating correctly.
+        httpd.daemon_threads = daemon_threads
     httpd.set_app(wsgi_handler)
     httpd.serve_forever()

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -69,7 +69,7 @@ Runs this project as a FastCGI application. Requires flup. Use
 .B runfcgi help
 for help on the KEY=val pairs.
 .TP
-.BI "runserver [" "\-\-noreload" "] [" "\-\-nothreading" "] [" "\-\-nostatic" "] [" "\-\-insecure" "] [" "\-\-ipv6" "] [" "port|ipaddr:port" "]"
+.BI "runserver [" "\-\-noreload" "] [" "\-\-nothreading" "] [" "\-\-nodaemon" "] [" "\-\-nostatic" "] [" "\-\-insecure" "] [" "\-\-ipv6" "] [" "port|ipaddr:port" "]"
 Starts a lightweight Web server for development.
 .TP
 .BI "shell [" "\-\-plain" "]"
@@ -155,6 +155,9 @@ Disable automatic serving of static files from STATIC_URL.
 .TP
 .I \-\-nothreading
 Disable the development server's threading.
+.TP
+.I \-\-nodaemon
+Use non-daemon threads in the development server.
 .TP
 .I \-\-insecure
 Enables serving of static files even if DEBUG is False.

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -891,6 +891,13 @@ Example usage::
 The development server is multithreaded by default. Use the ``--nothreading``
 option to disable the use of threading in the development server.
 
+.. django-admin-option:: --nodaemon
+
+The development server uses daemon threads by default. Use the ``--nodaemon``
+option to use non-daemon threads in the development server. Using non-daemon
+threads will prevent the server from properly quitting or auto-reloading if
+one of the threads isn't terminating correctly.
+
 .. django-admin-option:: --ipv6, -6
 
 Use the ``--ipv6`` (or shorter ``-6``) option to tell Django to use IPv6 for


### PR DESCRIPTION
Also added an option to use non-daemon threads in the runserver command.
The new option is documented in the docs.
Please read my comment on the code to better understand the usefulness
of changing the default.
Thanks clime for the report.
