### PR TITLE
Special-case app_label detection from the shell.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -85,7 +85,16 @@ class ModelBase(type):
 
         if getattr(meta, 'app_label', None) is None:
 
-            if app_config is None:
+            if new_class.__module__ == '__main__':
+                # Special case definitions which are almost certainly from the
+                # shell; this makes it easier for people to write simple test
+                # models which won't be saved in the database.
+                # c.f. http://stackoverflow.com/q/23757143 which shows this is
+                # a common desire and issue that people run into.
+                # This may cause issues in other places, but it's generally a
+                # good tradeoff.
+                kwargs = {'app_label': '__main__'}
+            elif app_config is None:
                 # If the model is imported before the configuration for its
                 # application is created (#21719), or isn't in an installed
                 # application (#21680), use the legacy logic to figure out the


### PR DESCRIPTION
People often seem to try to define model classes in the shell (for
better or for worse); at present this doesn't work without their also
defining app_label, leading to such comparatively popular questions as
http://stackoverflow.com/q/23757143. It is also a minor inconvenience
for experienced Django developers, because they must remember to set
app_label to a dummy value.

This takes care of that problem by assigning an app_label (a meaningless
value, of course) automatically, if the model class is in the `__main__`
module (which will close enough to always mean the shell—I don't want to
think about the alternative!).

There is no perfect solution to the problem—for this just delays the day
of judgment to another location, there being some things that you simply
can't reasonably do in the shell—but this fixes the minor papercut with
minimal side-effects.
