### PR TITLE
Make cached_property more flexible

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -45,14 +45,18 @@ class cached_property(object):
     """
     Decorator that converts a method with a single self argument into a
     property cached on the instance.
+
+    Optional ``name`` argument allows you to make cached properties of other
+    methods. (e.g.  url = cached_property(get_absolute_url, name='url') )
     """
-    def __init__(self, func):
+    def __init__(self, func, name=None):
         self.func = func
+        self.name = name or func.__name__
 
     def __get__(self, instance, type=None):
         if instance is None:
             return self
-        res = instance.__dict__[self.func.__name__] = self.func(instance)
+        res = instance.__dict__[self.name] = self.func(instance)
         return res
 
 

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -52,6 +52,11 @@ class FunctionalTestCase(unittest.TestCase):
             def value(self):
                 return 1, object()
 
+            def other_value(self):
+                return 1
+
+            other = cached_property(other_value, name='other')
+
         a = A()
 
         # check that it is cached
@@ -66,6 +71,10 @@ class FunctionalTestCase(unittest.TestCase):
 
         # check that it behaves like a property when there's no instance
         self.assertIsInstance(A.value, cached_property)
+
+        # check that overriding name works
+        self.assertEqual(a.other, 1)
+        self.assertTrue(callable(a.other_value))
 
     def test_lazy_equality(self):
         """


### PR DESCRIPTION
This allows models to have a cached property as well as a "fresh" accessor.

```
class Foo(object):

    def get_bar(self):
        .... heavy work here ....

    bar = cached_property(get_bar, name='bar')
```

We can't do this with the existing cached_property because it stuffs its cached value into the objects **dict** using the name of the function, which would mask the function itself.
