### PR TITLE
Fix reference to lookups instead of transforms.

### DIFF
--- a/docs/ref/models/custom-lookups.txt
+++ b/docs/ref/models/custom-lookups.txt
@@ -400,7 +400,7 @@ The lookup registration API is explained below.
 
 .. method:: get_transform(lookup_name)
 
-    Django uses ``get_transform(lookup_name)`` to fetch lookups. The
+    Django uses ``get_transform(lookup_name)`` to fetch transforms. The
     implementation of ``get_transform()`` looks for a subclass which is registered
     for the current class with the correct ``transform_name``.
 


### PR DESCRIPTION
I assume this was a copy-paste that wasn't edited properly. It didn't seem to make any sense to me.
