### PR TITLE
Fix #22680.

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -89,7 +89,7 @@ class FieldFile(File):
         setattr(self.instance, self.field.name, self.name)
 
         # Update the filesize cache
-        self._size = content.size
+        self._size = self.storage.size(self.name)
         self._committed = True
 
         # Save the object because it has changed, unless save is False


### PR DESCRIPTION
In FileField.save(), cache the size of the file as saved in the
underlying storage, instead of reading the size of the incoming content,
which has been closed.
