### PR TITLE
Fixed constant_time_compare on Python 2.7.7

### DIFF
--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -79,7 +79,8 @@ def get_random_string(length=12,
 
 if hasattr(hmac, "compare_digest"):
     # Prefer the stdlib implementation, when available.
-    constant_time_compare = hmac.compare_digest
+    def constant_time_compare(val1, val2):
+        return hmac.compare_digest(force_bytes(val1), force_bytes(val2))
 else:
     def constant_time_compare(val1, val2):
         """


### PR DESCRIPTION
Python 2.7.7 includes compare_digest in the hmac module, but it requires
both arguments to have the same type. This is usually not a problem on
Python 3 since everything is text, but we have mixed unicode and str on
Python 2 -- hence make sure everything is bytes before feeding it into
compare_digest.

@dstuff, @alex, @PaulMcMillan -- review please, I'd like to get this into Django 1.7
