### PR TITLE
Fixed #22675 -- makemigrations --dry-run to output migrations to stdout.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -123,8 +123,8 @@ class Command(BaseCommand):
                     self.stdout.write("  %s:\n" % (self.style.MIGRATE_LABEL(writer.filename),))
                     for operation in migration.operations:
                         self.stdout.write("    - %s\n" % operation.describe())
-                # Write it
                 if not self.dry_run:
+                    # Write the migrations file to the disk.
                     migrations_directory = os.path.dirname(writer.path)
                     if not directory_created.get(app_label, False):
                         if not os.path.isdir(migrations_directory):
@@ -137,6 +137,12 @@ class Command(BaseCommand):
                     migration_string = writer.as_string()
                     with open(writer.path, "wb") as fh:
                         fh.write(migration_string)
+                elif self.verbosity == 3:
+                    # Alternatively, makemigrations --dry-run --verbosity 3
+                    # will output the migrations to stdout rather than saving
+                    # the file to the disk.
+                    self.stdout.write(self.style.MIGRATE_HEADING("Full migrations file '%s':" % writer.filename) + "\n")
+                    self.stdout.write("%s\n" % writer.as_string())
 
     def handle_merge(self, loader, conflicts):
         """

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -663,7 +663,9 @@ your migrations.
 .. django-admin-option:: --dry-run
 
 The ``--dry-run`` option shows what migrations would be made without
-actually writing any migrations files to disk.
+actually writing any migrations files to disk. Using this option along with
+``--verbosity 3`` will also show the complete migrations files that would be
+written.
 
 .. django-admin-option:: --merge
 


### PR DESCRIPTION
`makemigrations --dry-run` will output the complete migrations file
that would be written if it's used along with `--verbosity 3`.
