### PR TITLE
#22707 Replaced misleading primary/replica terminology with widely recognized m...

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -649,11 +649,10 @@ Default: ``None``
 The alias of the database that this database should mirror during
 testing.
 
-This setting exists to allow for testing of primary/replica
-(referred to as master/slave by some databases)
+This setting exists to allow for testing of master/slave
 configurations of multiple databases. See the documentation on
-:ref:`testing primary/replica configurations
-<topics-testing-primaryreplica>` for details.
+:ref:`testing master/slave configurations
+<topics-testing-primaryslave>` for details.
 
 .. setting:: TEST_NAME
 

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -222,29 +222,29 @@ won't appear in the models cache, but the model details can be used
 for routing purposes.
 
 For example, the following router would direct all cache read
-operations to ``cache_replica``, and all write operations to
-``cache_primary``. The cache table will only be synchronized onto
-``cache_primary``::
+operations to ``cache_slave``, and all write operations to
+``cache_master``. The cache table will only be synchronized onto
+``cache_master``::
 
     class CacheRouter(object):
         """A router to control all database cache operations"""
 
         def db_for_read(self, model, **hints):
-            "All cache read operations go to the replica"
+            "All cache read operations go to the slave"
             if model._meta.app_label in ('django_cache',):
-                return 'cache_replica'
+                return 'cache_slave'
             return None
 
         def db_for_write(self, model, **hints):
-            "All cache write operations go to primary"
+            "All cache write operations go to master"
             if model._meta.app_label in ('django_cache',):
-                return 'cache_primary'
+                return 'cache_master'
             return None
 
         def allow_migrate(self, db, model):
-            "Only install the cache model on primary"
+            "Only install the cache model on master"
             if model._meta.app_label in ('django_cache',):
-                return db == 'cache_primary'
+                return db == 'cache_master'
             return None
 
 If you don't specify routing directions for the database cache model,

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -225,17 +225,16 @@ An example
     introduce referential integrity problems that Django can't
     currently handle.
 
-    The primary/replica (referred to as master/slave by some databases)
-    configuration described is also flawed -- it
+    The master/slave configuration described is also flawed -- it
     doesn't provide any solution for handling replication lag (i.e.,
     query inconsistencies introduced because of the time taken for a
-    write to propagate to the replicas). It also doesn't consider the
+    write to propagate to the slaves). It also doesn't consider the
     interaction of transactions with the database utilization strategy.
 
 So - what does this mean in practice? Let's consider another sample
 configuration. This one will have several databases: one for the
-``auth`` application, and all other apps using a primary/replica setup
-with two read replicas. Here are the settings specifying these
+``auth`` application, and all other apps using a master/slave setup
+with two read slaves. Here are the settings specifying these
 databases::
 
     DATABASES = {
@@ -245,20 +244,20 @@ databases::
             'USER': 'mysql_user',
             'PASSWORD': 'swordfish',
         },
-        'primary': {
-            'NAME': 'primary',
+        'master': {
+            'NAME': 'master',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'spam',
         },
-        'replica1': {
-            'NAME': 'replica1',
+        'slave1': {
+            'NAME': 'slave1',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'eggs',
         },
-        'replica2': {
-            'NAME': 'replica2',
+        'slave2': {
+            'NAME': 'slave2',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'bacon',
@@ -310,30 +309,30 @@ send queries for the ``auth`` app to ``auth_db``::
             return None
 
 And we also want a router that sends all other apps to the
-primary/replica configuration, and randomly chooses a replica to read
+master/slave configuration, and randomly chooses a slave to read
 from::
 
     import random
 
-    class PrimaryReplicaRouter(object):
+    class MasterSlaveRouter(object):
         def db_for_read(self, model, **hints):
             """
-            Reads go to a randomly-chosen replica.
+            Reads go to a randomly-chosen slave.
             """
-            return random.choice(['replica1', 'replica2'])
+            return random.choice(['slave1', 'slave2'])
 
         def db_for_write(self, model, **hints):
             """
-            Writes always go to primary.
+            Writes always go to master.
             """
-            return 'primary'
+            return 'master'
 
         def allow_relation(self, obj1, obj2, **hints):
             """
             Relations between objects are allowed if both objects are
-            in the primary/replica pool.
+            in the master/slave pool.
             """
-            db_list = ('primary', 'replica1', 'replica2')
+            db_list = ('master', 'slave1', 'slave2')
             if obj1._state.db in db_list and obj2._state.db in db_list:
                 return True
             return None
@@ -348,17 +347,17 @@ Finally, in the settings file, we add the following (substituting
 ``path.to.`` with the actual python path to the module(s) where the
 routers are defined)::
 
-    DATABASE_ROUTERS = ['path.to.AuthRouter', 'path.to.PrimaryReplicaRouter']
+    DATABASE_ROUTERS = ['path.to.AuthRouter', 'path.to.MasterSlaveRouter']
 
 The order in which routers are processed is significant. Routers will
 be queried in the order the are listed in the
 :setting:`DATABASE_ROUTERS` setting . In this example, the
-``AuthRouter`` is processed before the ``PrimaryReplicaRouter``, and as a
+``AuthRouter`` is processed before the ``MasterSlaveRouter``, and as a
 result, decisions concerning the models in ``auth`` are processed
 before any other decision is made. If the :setting:`DATABASE_ROUTERS`
 setting listed the two routers in the other order,
-``PrimaryReplicaRouter.allow_migrate()`` would be processed first. The
-catch-all nature of the PrimaryReplicaRouter implementation would mean
+``MasterSlaveRouter.allow_migrate()`` would be processed first. The
+catch-all nature of the MasterSlaveRouter implementation would mean
 that all models would be available on all databases.
 
 With this setup installed, lets run some Django code::
@@ -370,7 +369,7 @@ With this setup installed, lets run some Django code::
     >>> # This save will also be directed to 'auth_db'
     >>> fred.save()
 
-    >>> # These retrieval will be randomly allocated to a replica database
+    >>> # These retrieval will be randomly allocated to a slave database
     >>> dna = Person.objects.get(name='Douglas Adams')
 
     >>> # A new object has no database allocation when created
@@ -380,10 +379,10 @@ With this setup installed, lets run some Django code::
     >>> # the same database as the author object
     >>> mh.author = dna
 
-    >>> # This save will force the 'mh' instance onto the primary database...
+    >>> # This save will force the 'mh' instance onto the master database...
     >>> mh.save()
 
-    >>> # ... but if we re-retrieve the object, it will come back on a replica
+    >>> # ... but if we re-retrieve the object, it will come back on a slave
     >>> mh = Book.objects.get(title='Mostly Harmless')
 
 
@@ -443,7 +442,7 @@ Consider the following example::
 
 In statement 1, a new ``Person`` object is saved to the ``first``
 database. At this time, ``p`` doesn't have a primary key, so Django
-issues an SQL ``INSERT`` statement. This creates a primary key, and
+issues an SQL ``INSERT`` statement. This creates a master key, and
 Django assigns that primary key to ``p``.
 
 When the save occurs in statement 2, ``p`` already has a primary key
@@ -691,7 +690,7 @@ In addition, some objects are automatically created just after
   database).
 
 For common setups with multiple databases, it isn't useful to have these
-objects in more than one database. Common setups include primary/replica and
+objects in more than one database. Common setups include master/slave and
 connecting to external databases. Therefore, it's recommended:
 
 - either to run :djadmin:`migrate` only for the default database;

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -64,17 +64,16 @@ The following is a simple unit test using the request factory::
 Tests and multiple databases
 ============================
 
-.. _topics-testing-primaryreplica:
+.. _topics-testing-masterslave:
 
-Testing primary/replica configurations
+Testing master/slave configurations
 --------------------------------------
 
-If you're testing a multiple database configuration with primary/replica
-(referred to as master/slave by some databases) replication, this strategy of
-creating test databases poses a problem.
+If you're testing a multiple database configuration with master/slave
+replication, this strategy of creating test databases poses a problem.
 When the test databases are created, there won't be any replication,
-and as a result, data created on the primary won't be seen on the
-replica.
+and as a result, data created on the master won't be seen on the
+slave.
 
 To compensate for this, Django allows you to define that a database is
 a *test mirror*. Consider the following (simplified) example database
@@ -84,34 +83,34 @@ configuration::
         'default': {
             'ENGINE': 'django.db.backends.mysql',
             'NAME': 'myproject',
-            'HOST': 'dbprimary',
+            'HOST': 'dbmaster',
              # ... plus some other settings
         },
-        'replica': {
+        'slave': {
             'ENGINE': 'django.db.backends.mysql',
             'NAME': 'myproject',
-            'HOST': 'dbreplica',
+            'HOST': 'dbslave',
             'TEST_MIRROR': 'default'
             # ... plus some other settings
         }
     }
 
-In this setup, we have two database servers: ``dbprimary``, described
-by the database alias ``default``, and ``dbreplica`` described by the
-alias ``replica``. As you might expect, ``dbreplica`` has been configured
-by the database administrator as a read replica of ``dbprimary``, so in
-normal activity, any write to ``default`` will appear on ``replica``.
+In this setup, we have two database servers: ``dbmaster``, described
+by the database alias ``default``, and ``dbslave`` described by the
+alias ``slave``. As you might expect, ``dbslave`` has been configured
+by the database administrator as a read slave of ``dbmaster``, so in
+normal activity, any write to ``default`` will appear on ``slave``.
 
 If Django created two independent test databases, this would break any
-tests that expected replication to occur. However, the ``replica``
+tests that expected replication to occur. However, the ``slave``
 database has been configured as a test mirror (using the
 :setting:`TEST_MIRROR` setting), indicating that under testing,
-``replica`` should be treated as a mirror of ``default``.
+``slave`` should be treated as a mirror of ``default``.
 
-When the test environment is configured, a test version of ``replica``
-will *not* be created. Instead the connection to ``replica``
+When the test environment is configured, a test version of ``slave``
+will *not* be created. Instead the connection to ``slave``
 will be redirected to point at ``default``. As a result, writes to
-``default`` will appear on ``replica`` -- but because they are actually
+``default`` will appear on ``slave`` -- but because they are actually
 the same database, not because there is data replication between the
 two databases.
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -980,7 +980,7 @@ class MultiDBOperationTests(MigrationTestBase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a slave of the 'default'
         self.old_routers = router.routers
         router.routers = [MigrateNothingRouter()]
 

--- a/tests/multiple_database/routers.py
+++ b/tests/multiple_database/routers.py
@@ -4,7 +4,7 @@ from django.db import DEFAULT_DB_ALIAS
 
 
 class TestRouter(object):
-    # A test router. The behavior is vaguely primary/replica, but the
+    # A test router. The behavior is vaguely master/slave, but the
     # databases aren't assumed to propagate changes.
     def db_for_read(self, model, instance=None, **hints):
         if instance:

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -854,7 +854,7 @@ class QueryTestCase(TestCase):
         self.assertEqual(book.editor._state.db, 'other')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and primary/replica."""
+        """Make sure as_sql works with subqueries and master/slave."""
         sub = Person.objects.using('other').filter(name='fff')
         qs = Book.objects.filter(editor__in=sub)
 
@@ -919,7 +919,7 @@ class RouterTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a slave of the 'default'
         self.old_routers = router.routers
         router.routers = [TestRouter()]
 
@@ -1071,7 +1071,7 @@ class RouterTestCase(TestCase):
         try:
             dive.editor = marty
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1089,7 +1089,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real master/slave database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1097,7 +1097,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited = [pro, dive]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Assignment implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1111,7 +1111,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real master/slave database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1119,7 +1119,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited.add(dive)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Add implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1133,7 +1133,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real master/slave database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
 
         # If you assign a FK object when the base object hasn't
@@ -1196,7 +1196,7 @@ class RouterTestCase(TestCase):
         mark = Person.objects.using('default').create(pk=2, name="Mark Pilgrim")
 
         # Now save back onto the usual database.
-        # This simulates primary/replica - the objects exist on both database,
+        # This simulates master/slave - the objects exist on both database,
         # but the _state.db is as it is for all other tests.
         pro.save(using='default')
         marty.save(using='default')
@@ -1213,7 +1213,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set = [pro, dive]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1232,7 +1232,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set.add(dive)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1251,7 +1251,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors = [mark, marty]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1273,7 +1273,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors.add(marty)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1311,7 +1311,7 @@ class RouterTestCase(TestCase):
         try:
             bob.userprofile = alice_profile
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(alice._state.db, 'default')
@@ -1342,7 +1342,7 @@ class RouterTestCase(TestCase):
         try:
             review1.content_object = dive
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1361,7 +1361,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real master/slave database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1369,7 +1369,7 @@ class RouterTestCase(TestCase):
         try:
             dive.reviews.add(review1)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across master/slave databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1444,7 +1444,7 @@ class RouterTestCase(TestCase):
         self.assertEqual(pro.reviews.db_manager('default').all().db, 'default')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and primary/replica."""
+        """Make sure as_sql works with subqueries and master/slave."""
         # Create a book and author on the other database
 
         mark = Person.objects.using('other').create(name="Mark Pilgrim")
@@ -1482,7 +1482,7 @@ class AuthTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a slave of the 'default'
         self.old_routers = router.routers
         router.routers = [AuthRouter()]
 


### PR DESCRIPTION
...aster/slave

All occurences of "master/slave" were recently replaced with "leader/follower" (https://github.com/django/django/pull/2692), then with "primary/replica" (https://github.com/django/django/commit/beec05686ccc3bee8461f9a5a02c607a02352ae1).
This new terminology is vague, ill-advised, and '''very misleading.'''

Django is a server-side framework with the goal of making Pythonistas' life sweet. By no means this requires reforming old and widely accepted database terminology, or feeding fat internet trolls like Feminist Software Foundation.

Let's look at the famous Zen of Python:
- Special cases aren't special enough to break the rules.
- Although practicality beats purity.
- There should be one-- and preferably only one --obvious way to do it.

And, above all:
- '''Explicit is better than implicit.'''

Here are four reasons, baked in the core of the language, as well as in the core or the developers' hearts, for why changing this '''old, clear, concise and immediately recognized''' terminology is a bad idea.

This terminology has been used for a long time, and by no means those purely technical terms carry racially charged meanings to users, neither are they offending in any other way.
This patch replaces all occurrences of "primary/replica" with the good old "master/slave" together with now unnecessary comments like "referred to as master/slave by some databases".
