### PR TITLE
Fixed #22699 -- Configure default settings in some management commands.

### DIFF
--- a/tests/admin_scripts/custom_templates/project_template/additional_dir/localized.py
+++ b/tests/admin_scripts/custom_templates/project_template/additional_dir/localized.py
@@ -1,0 +1,2 @@
+# Regression for #22699.
+# Generated at {% now "DATE_FORMAT" %}


### PR DESCRIPTION
This makes it possible to run django.setup() in management commands that
don't need a settings module. In addition it simplifies error handling.
