### PR TITLE
Fixed #22711 -- Allow model's Meta.ordering attribute to have explicit ForeignKey relation fields

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1357,7 +1357,7 @@ class Model(six.with_metaclass(ModelBase)):
 
     @classmethod
     def _check_ordering(cls):
-        """ Check "ordering" option -- is it a list of lists and do all fields
+        """ Check "ordering" option -- is it a list of strings and do all fields
         exist? """
 
         from django.db.models import FieldDoesNotExist
@@ -1401,6 +1401,14 @@ class Model(six.with_metaclass(ModelBase)):
             try:
                 cls._meta.get_field(field_name, many_to_many=False)
             except FieldDoesNotExist:
+                if field_name.endswith('_id'):
+                    try:
+                        field = cls._meta.get_field(field_name[:-3], many_to_many=False)
+                    except FieldDoesNotExist:
+                        pass
+                    else:
+                        if field.attname == field_name:
+                            continue
                 errors.append(
                     checks.Error(
                         "'ordering' refers to the non-existent field '%s'." % field_name,

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -415,6 +415,40 @@ class OtherModelTests(IsolatedModelsTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_ordering_pointing_to_missing_foreignkey_field(self):
+        # Test for ticket: https://code.djangoproject.com/ticket/22711
+        
+        class Model(models.Model):
+            missing_fk_field = models.IntegerField()
+            
+            class Meta:
+                ordering = ("missing_fk_field_id",)
+    
+        errors = Model.check()
+        expected = [
+            Error(
+                "'ordering' refers to the non-existent field 'missing_fk_field_id'.",
+                hint=None,
+                obj=Model,
+                id='models.E015',
+            )
+        ]
+        self.assertEqual(errors, expected)
+    
+    def test_ordering_pointing_to_existing_foreignkey_field(self):
+        # Test for ticket: https://code.djangoproject.com/ticket/22711
+        
+        class Parent(models.Model):
+            pass
+        
+        class Child(models.Model):
+            parent = models.ForeignKey(Parent)
+            
+            class Meta:
+                ordering = ("parent_id",)
+    
+        self.assertFalse(Child.check())
+
     @override_settings(TEST_SWAPPED_MODEL_BAD_VALUE='not-a-model')
     def test_swappable_missing_app_name(self):
         class Model(models.Model):


### PR DESCRIPTION
https://github.com/django/django/commit/24ec9538b7ca400f68ba08fab380445ca95d7c02 introduced an opportunity to order by the field attr itself. But system check framework didn't reflect this change.
Also fixed a small typo in method comment.
