### PR TITLE
Fixed #20550 -- Added ability to preserve test db between runs

### DIFF
--- a/django/contrib/gis/db/backends/postgis/creation.py
+++ b/django/contrib/gis/db/backends/postgis/creation.py
@@ -82,8 +82,10 @@ class PostGISCreation(DatabaseCreation):
                 self.connection.ops.quote_name(self.template_postgis),)
         return ''
 
-    def _create_test_db(self, verbosity, autoclobber):
-        test_database_name = super(PostGISCreation, self)._create_test_db(verbosity, autoclobber)
+    def _create_test_db(self, verbosity, autoclobber, keepdb=False):
+        test_database_name = super(PostGISCreation, self)._create_test_db(verbosity, autoclobber, keepdb)
+        if keepdb:
+            return test_database_name
         if self.template_postgis is None:
             # Connect to the test database in order to create the postgis extension
             self.connection.close()

--- a/django/contrib/gis/db/backends/spatialite/creation.py
+++ b/django/contrib/gis/db/backends/spatialite/creation.py
@@ -7,7 +7,7 @@ from django.db.backends.sqlite3.creation import DatabaseCreation
 
 class SpatiaLiteCreation(DatabaseCreation):
 
-    def create_test_db(self, verbosity=1, autoclobber=False):
+    def create_test_db(self, verbosity=1, autoclobber=False, keepdb=False):
         """
         Creates a test database, prompting the user for confirmation if the
         database already exists. Returns the name of the test database created.
@@ -22,11 +22,15 @@ class SpatiaLiteCreation(DatabaseCreation):
 
         if verbosity >= 1:
             test_db_repr = ''
+            action = 'Creating'
             if verbosity >= 2:
                 test_db_repr = " ('%s')" % test_database_name
-            print("Creating test database for alias '%s'%s..." % (self.connection.alias, test_db_repr))
+            if keepdb:
+                action = 'Using existing'
+            print("%s test database for alias '%s'%s..." % (
+                action, self.connection.alias, test_db_repr))
 
-        self._create_test_db(verbosity, autoclobber)
+        self._create_test_db(verbosity, autoclobber, keepdb)
 
         self.connection.close()
         self.connection.settings_dict["NAME"] = test_database_name

--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -56,7 +56,7 @@ class DatabaseCreation(BaseDatabaseCreation):
     def __init__(self, connection):
         super(DatabaseCreation, self).__init__(connection)
 
-    def _create_test_db(self, verbosity=1, autoclobber=False):
+    def _create_test_db(self, verbosity=1, autoclobber=False, keepdb=False):
         TEST_NAME = self._test_database_name()
         TEST_USER = self._test_database_user()
         TEST_PASSWD = self._test_database_passwd()
@@ -76,6 +76,10 @@ class DatabaseCreation(BaseDatabaseCreation):
             try:
                 self._execute_test_db_creation(cursor, parameters, verbosity)
             except Exception as e:
+                # if we want to keep the db, then no need to do any of the below,
+                # just return and skip it all.
+                if keepdb:
+                    return
                 sys.stderr.write("Got an error creating the test database: %s\n" % e)
                 if not autoclobber:
                     confirm = input("It appears the test database, %s, already exists. Type 'yes' to delete it, or 'no' to cancel: " % TEST_NAME)

--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -52,8 +52,10 @@ class DatabaseCreation(BaseDatabaseCreation):
             return test_database_name
         return ':memory:'
 
-    def _create_test_db(self, verbosity, autoclobber):
+    def _create_test_db(self, verbosity, autoclobber, keepdb=False):
         test_database_name = self._get_test_db_name()
+        if keepdb:
+            return test_database_name
         if test_database_name != ':memory:':
             # Erase the old test database
             if verbosity >= 1:

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1310,6 +1310,17 @@ The ``--liveserver`` option can be used to override the default address where
 the live server (used with :class:`~django.test.LiveServerTestCase`) is
 expected to run from. The default value is ``localhost:8081``.
 
+.. django-admin-option:: --keepdb
+
+.. versionadded:: 1.8
+
+The ``--keepdb`` option can be used to preserve the test database between test
+runs. This has the advantage of skipping both the create and destroy actions
+which greatly decreases the time to run tests, especially those in a large
+test suite. If the test database does not exist, it will be created on the first
+run and then preserved for each subsequent run. Any unapplied migrations will also
+be applied to the test database before running the test suite.
+
 testserver <fixture fixture ...>
 --------------------------------
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -189,6 +189,9 @@ Tests
 * The new :meth:`~django.test.SimpleTestCase.assertJSONNotEqual` assertion
   allows you to test that two JSON fragments are not equal.
 
+* Added the ability to preserve the test database by adding the :djadminopt:`--keepdb`
+  flag.
+
 Validators
 ^^^^^^^^^^
 

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -149,6 +149,14 @@ Tests that require a database (namely, model tests) will not use your "real"
 Regardless of whether the tests pass or fail, the test databases are destroyed
 when all the tests have been executed.
 
+.. versionadded:: 1.8
+
+   You can prevent the test databases from being destroyed by adding the
+   :djadminopt:`--keepdb` flag to the test command. This will preserve the test
+   database between runs. If the database does not exist, it will first
+   be created. Any migrations will also be applied in order to keep it
+   up to date.
+
 By default the test databases get their names by prepending ``test_``
 to the value of the :setting:`NAME` settings for the databases
 defined in :setting:`DATABASES`. When using the SQLite database engine

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -310,7 +310,7 @@ class AliasedDatabaseTeardownTest(unittest.TestCase):
         try:
             destroyed_names = []
             DatabaseCreation.destroy_test_db = lambda self, old_database_name, verbosity=1: destroyed_names.append(old_database_name)
-            DatabaseCreation.create_test_db = lambda self, verbosity=1, autoclobber=False: self._get_test_db_name()
+            DatabaseCreation.create_test_db = lambda self, verbosity=1, autoclobber=False, keepdb=False: self._get_test_db_name()
 
             db.connections = db.ConnectionHandler({
                 'default': {


### PR DESCRIPTION
This adds the `--keepdb` to the test runner, which allows the database to be preserved between test runs.

Currently, I have one failing test on this, `test_runner.tests.AliasedDatabaseTeardownTest.test_setup_aliased_databases`. I'm not exactly sure why it is failing, so if anyone could give me some pointers on this, that would be great. (apologies if this is not the place to as for such feedback).

@timgraham  - git blame tells me that you were the one who wrote this test, perhaps you could shed some light here?

Thanks!
