### PR TITLE
Fixed some triggering documentation

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -181,7 +181,7 @@ Use generic views: Less code is better
 ======================================
 
 The ``detail()`` (from :doc:`Tutorial 3 </intro/tutorial03>`) and ``results()``
-views are stupidly simple -- and, as mentioned above, redundant. The ``index()``
+views are very simple -- and, as mentioned above, redundant. The ``index()``
 view (also from Tutorial 3), which displays a list of polls, is similar.
 
 These views represent a common case of basic Web development: getting data from

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -241,7 +241,7 @@ Methods
     .. note::
 
         In the usual initialization process, the ``ready`` method is only called
-        once by Django. But in some corner cases, particularly in tests which
+        once by Django. But in some special cases, particularly in tests which
         are fiddling with installed applications, ``ready`` might be called more
         than once. In that case, either write idempotents methods, or put a flag
         on your ``AppConfig`` classes to prevent re-running code which should

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -407,7 +407,7 @@ variables or to negate a given variable::
     {% if not athlete_list or coach_list %}
         There are no athletes or there are some coaches (OK, so
         writing English translations of boolean logic sounds
-        stupid; it's not our fault).
+        silly; it's not our fault).
     {% endif %}
 
     {% if athlete_list and not coach_list %}

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -512,7 +512,7 @@ Setup
    datetimes safely, their representation should include the UTC offset, or
    their values should be in UTC (or both!).
 
-   Finally, our calendar system contains interesting traps for computers::
+   Finally, our calendar system contains interesting catches for computers::
 
        >>> import datetime
        >>> def one_year_before(value):       # DON'T DO THAT!

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -204,8 +204,8 @@ Attributes
 
 The :meth:`Paginator.page` method raises an exception if the requested page is
 invalid (i.e., not an integer) or contains no objects. Generally, it's enough
-to trap the ``InvalidPage`` exception, but if you'd like more granularity, you
-can trap either of the following exceptions:
+to catch the ``InvalidPage`` exception, but if you'd like more granularity, you
+can catch either of the following exceptions:
 
 .. exception:: PageNotAnInteger
 


### PR DESCRIPTION
Because of Github's hostile environment toward feminist, trans, PoC coders such as myself, I've been forced to undergo a pseudonym for this pull request. Me and other rape victims have difficulty reading some of Django's documentation due to a few triggering words. This is only as much as I could do at one time. If there is more interest in cleaning up Django's documentation to be safer for rape victims, then I will try to do more.

Nothing in this commit directly affects Django functionality. Everything is just documentation changes.
