### PR TITLE
[1.6.X] Added missing commas to list of strings

### DIFF
--- a/django/core/checks/compatibility/django_1_6_0.py
+++ b/django/core/checks/compatibility/django_1_6_0.py
@@ -43,8 +43,8 @@ def check_boolean_field_default_value():
             "%s." % fieldnames,
             "In Django 1.6 the default value of BooleanField was changed from",
             "False to Null when Field.default isn't defined. See",
-            "https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield"
-            "for more information."
+            "https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield",
+            "for more information.",
         ]
         return ' '.join(message)
 


### PR DESCRIPTION
Currently, the strings are concatenated, breaking the url.

The checks framework has been overhauled in Django 1.7.X, so this patch is only required in 1.6.X.
