### PR TITLE
Add check for proxy models containing fields.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -45,6 +45,7 @@ Models
 * **models.E014**: ``ordering`` must be a tuple or list (even if you want to order by only one field).
 * **models.E015**: ``ordering`` refers to the non-existent field ``<field name>``.
 * **models.E016**: ``index_together/unique_together`` refers to field ``<field_name>`` which is not local to model ``<model>``.
+* **models.E017**: Proxy model ``<model>`` contains model fields.
 
 Fields
 ~~~~~~

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
+from django.core import checks
 from django.core.exceptions import FieldError
 from django.db import models, DEFAULT_DB_ALIAS
 from django.db.models import signals
@@ -143,13 +144,25 @@ class ProxyModelTests(TestCase):
         self.assertRaises(TypeError, build_no_base_classes)
 
     def test_new_fields(self):
-        def build_new_fields():
-            class NoNewFields(Person):
-                newfield = models.BooleanField()
+        class NoNewFields(Person):
+            newfield = models.BooleanField()
 
-                class Meta:
-                    proxy = True
-        self.assertRaises(FieldError, build_new_fields)
+            class Meta:
+                proxy = True
+                # don't register this model in the app_cache for the current app,
+                # otherwise the check fails when other tests are being run.
+                app_label = 'no_such_app'
+
+        errors = NoNewFields.check()
+        expected = [
+            checks.Error(
+                "Proxy model 'NoNewFields' contains model fields.",
+                hint=None,
+                obj=None,
+                id='models.E017',
+            )
+        ]
+        self.assertEqual(errors, expected)
 
     @override_settings(TEST_SWAPPABLE_MODEL='proxy_models.AlternateModel')
     def test_swappable(self):


### PR DESCRIPTION
Remove the FieldError raised by `ModelBase.__new__` in this case.

refs #22690 (https://code.djangoproject.com/ticket/22690)
