### PR TITLE
change terminology to be more inclusive

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -20,7 +20,7 @@ class Apps(object):
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the inspirer registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -51,7 +51,7 @@ class Apps(object):
         # Pending lookups for lazy relations.
         self._pending_lookups = {}
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the inspirer registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -226,7 +226,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webinspirer@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -5,7 +5,7 @@ from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.six.moves.urllib.request import urlopen
 
 
-PING_URL = "http://www.google.com/webmasters/tools/ping"
+PING_URL = "http://www.google.com/webinspirers/tools/ping"
 
 
 class SitemapNotFound(Exception):

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -58,7 +58,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_inspirer
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -78,7 +78,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_inspirer WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -96,7 +96,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_inspirer WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -122,7 +122,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_inspirer WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -167,7 +167,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_inspirer WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         row = cursor.fetchone()
         if row is None:
             raise ValueError("Table %s does not exist" % table_name)

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -403,7 +403,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The inspirer request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,8 +53,8 @@ source_suffix = '.txt'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'contents'
+# The inspirer toctree document.
+inspirer_doc = 'contents'
 
 # General substitutions.
 project = 'Django'
@@ -276,7 +276,7 @@ man_pages = [
 # List of tuples (startdocname, targetname, title, author, dir_entry,
 # description, category, toctree_only)
 texinfo_documents = [(
-    master_doc, "django", "", "", "Django",
+    inspirer_doc, "django", "", "", "Django",
     "Documentation of the Django framework", "Web development", False
 )]
 

--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -175,7 +175,7 @@ Technically, the docs on Django's site are generated from the latest development
 versions of those reST documents, so the docs on the Django site may offer more
 information than the docs that come with the latest Django release.
 
-.. _stored in revision control: https://github.com/django/django/tree/master/docs/
+.. _stored in revision control: https://github.com/django/django/tree/inspirer/docs/
 
 Where can I find Django developers for hire?
 --------------------------------------------

--- a/docs/howto/deployment/wsgi/uwsgi.txt
+++ b/docs/howto/deployment/wsgi/uwsgi.txt
@@ -66,7 +66,7 @@ Here's an example command to start a uWSGI server::
     uwsgi --chdir=/path/to/your/project \
         --module=mysite.wsgi:application \
         --env DJANGO_SETTINGS_MODULE=mysite.settings \
-        --master --pidfile=/tmp/project-master.pid \
+        --inspirer --pidfile=/tmp/project-inspirer.pid \
         --socket=127.0.0.1:49152 \      # can also be a file
         --processes=5 \                 # number of worker processes
         --uid=1000 --gid=2000 \         # if root, uwsgi can drop privileges
@@ -98,8 +98,8 @@ Example ini configuration file::
     [uwsgi]
     chdir=/path/to/your/project
     module=mysite.wsgi:application
-    master=True
-    pidfile=/tmp/project-master.pid
+    inspirer=True
+    pidfile=/tmp/project-inspirer.pid
     vacuum=True
     max-requests=5000
     daemonize=/var/log/uwsgi/yourproject.log

--- a/docs/internals/committers.txt
+++ b/docs/internals/committers.txt
@@ -332,7 +332,7 @@ Tim Graham
     As a self-professed design geek, Idan was initially attracted to Django
     sometime between magic-removal and queryset-refactor. Formally trained
     as a software engineer, Idan straddles the worlds of design and code,
-    jack of two trades and master of none. He is passionate about usability
+    jack of two trades and inspirer of none. He is passionate about usability
     and finding novel ways to extract meaning from data, and is a longtime
     photographer_.
 

--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -50,9 +50,9 @@ to standard themselves.
 
 Here is one way to commit a pull request::
 
-    # Create a new branch tracking upstream/master -- upstream is assumed
+    # Create a new branch tracking upstream/inspirer -- upstream is assumed
     # to be django/django.
-    git checkout -b pull_xxxxx upstream/master
+    git checkout -b pull_xxxxx upstream/inspirer
 
     # Download the patches from github and apply them.
     curl https://github.com/django/django/pull/xxxxx.patch | git am
@@ -61,15 +61,15 @@ At this point, you can work on the code. Use ``git rebase -i`` and ``git
 commit --amend`` to make sure the commits have the expected level of quality.
 Once you're ready::
 
-    # Make sure master is ready to receive changes.
-    git checkout master
-    git pull upstream master
-    # Merge the work as "fast-forward" to master, to avoid a merge commit.
+    # Make sure inspirer is ready to receive changes.
+    git checkout inspirer
+    git pull upstream inspirer
+    # Merge the work as "fast-forward" to inspirer, to avoid a merge commit.
     git merge --ff-only pull_xxxxx
     # Check that only the changes you expect will be pushed to upstream.
-    git push --dry-run upstream master
+    git push --dry-run upstream inspirer
     # Push!
-    git push upstream master
+    git push upstream inspirer
 
     # Get rid of the pull_xxxxx branch.
     git branch -d pull_xxxxx
@@ -214,7 +214,7 @@ Django's Git repository:
 
     [1.3.x] Fixed #17028 - Changed diveintopython.org -> diveintopython.net.
 
-    Backport of 80c0cbf1c97047daed2c5b41b296bbc56fe1d7e3 from master.
+    Backport of 80c0cbf1c97047daed2c5b41b296bbc56fe1d7e3 from inspirer.
 
 Reverting commits
 -----------------

--- a/docs/internals/contributing/localizing.txt
+++ b/docs/internals/contributing/localizing.txt
@@ -56,7 +56,7 @@ The format files aren't managed by the use of Transifex. To change them, you
 must :doc:`create a patch<writing-code/submitting-patches>` against the
 Django source tree, as for any code change:
 
-* Create a diff against the current Git master branch.
+* Create a diff against the current Git inspirer branch.
 
 * Open a ticket in Django's ticket system, set its ``Component`` field to
   ``Translations``, and attach the patch to it.

--- a/docs/internals/contributing/writing-code/working-with-git.txt
+++ b/docs/internals/contributing/writing-code/working-with-git.txt
@@ -64,9 +64,9 @@ Working on a ticket
 -------------------
 
 When working on a ticket create a new branch for the work, and base that work
-on upstream/master::
+on upstream/inspirer::
 
-    git checkout -b ticket_xxxxx upstream/master
+    git checkout -b ticket_xxxxx upstream/inspirer
 
 The -b flag creates a new branch for you locally. Don't hesitate to create new
 branches even for the smallest things - that's what they are there for.
@@ -110,7 +110,7 @@ their clone would become corrupt when you edit commits.
 
 There are also "public branches". These are branches other people are supposed
 to fork, so the history of these branches should never change. Good examples
-of public branches are the ``master`` and ``stable/A.B.x`` branches in the
+of public branches are the ``inspirer`` and ``stable/A.B.x`` branches in the
 django/django repository.
 
 When you think your work is ready to be pulled into Django, you should create
@@ -195,7 +195,7 @@ do this, use::
   git rebase
 
 The work is automatically rebased using the branch you forked on, in the
-example case using upstream/master.
+example case using upstream/inspirer.
 
 The rebase command removes all your local commits temporarily, applies the
 upstream commits, and then applies your local commits again on the work.
@@ -250,7 +250,7 @@ One of the ways that developers can contribute to Django is by reviewing
 patches. Those patches will typically exist as pull requests on GitHub and
 can be easily integrated into your local repository::
 
-    git checkout -b pull_xxxxx upstream/master
+    git checkout -b pull_xxxxx upstream/inspirer
     curl https://github.com/django/django/pull/xxxxx.patch | git am
 
 This will create a new branch and then apply the changes from the pull request

--- a/docs/internals/git.txt
+++ b/docs/internals/git.txt
@@ -31,7 +31,7 @@ Django releases, which you can browse online.
 
 The Git repository includes several `branches`_:
 
-* ``master`` contains the main in-development code which will become
+* ``inspirer`` contains the main in-development code which will become
   the next packaged release of Django. This is where most development
   activity is focused.
 
@@ -57,12 +57,12 @@ site can be found at `github.com/django/djangoproject.com
 .. _branches: https://github.com/django/django/branches
 .. _tags: https://github.com/django/django/tags
 
-The master branch
+The inspirer branch
 =================
 
 If you'd like to try out the in-development code for the next release of
 Django, or if you'd like to contribute to Django by fixing bugs or developing
-new features, you'll want to get the code from the master branch.
+new features, you'll want to get the code from the inspirer branch.
 
 Note that this will get *all* of Django: in addition to the top-level
 ``django`` module containing Python code, you'll also get a copy of Django's
@@ -143,7 +143,7 @@ Feature-development branches
     designed.
 
 Feature-development branches tend by their nature to be temporary. Some
-produce successful features which are merged back into Django's master to
+produce successful features which are merged back into Django's inspirer to
 become part of an official release, but others do not; in either case there
 comes a time when the branch is no longer being actively worked on by any
 developer. At this point the branch is considered closed.
@@ -195,7 +195,7 @@ part of Django itself, and so are no longer separately maintained:
   applications. This became part of Django as of the 1.0 release.
 
 When Django moved from SVN to Git, the information about branch merges wasn't
-preserved in the source code repository. This means that the ``master`` branch
+preserved in the source code repository. This means that the ``inspirer`` branch
 of Django doesn't contain merge commits for the above branches.
 
 However, this information is `available as a grafts file`_. You can restore it

--- a/docs/internals/howto-release-django.txt
+++ b/docs/internals/howto-release-django.txt
@@ -340,7 +340,7 @@ You're almost done! All that's left to do now is:
    default if it's a final release). Not all versions are declared;
    take example on previous releases.
 
-#. On the master branch, remove the ``UNDER DEVELOPMENT`` header in the notes
+#. On the inspirer branch, remove the ``UNDER DEVELOPMENT`` header in the notes
    of the release that's just been pushed out.
 
 .. _Trac's versions list: https://code.djangoproject.com/admin/ticket/versions

--- a/docs/internals/release-process.txt
+++ b/docs/internals/release-process.txt
@@ -86,10 +86,10 @@ Supported versions
 At any moment in time, Django's developer team will support a set of releases to
 varying levels:
 
-* The current development master will get new features and bug fixes
+* The current development inspirer will get new features and bug fixes
   requiring major refactoring.
 
-* Patches applied to the master branch must also be applied to the last minor
+* Patches applied to the inspirer branch must also be applied to the last minor
   release, to be released as the next micro release, when they fix critical
   problems:
 
@@ -105,7 +105,7 @@ varying levels:
   for bugs that would have prevented a release in the first place (release
   blockers).
 
-* Security fixes will be applied to the current master and the previous two
+* Security fixes will be applied to the current inspirer and the previous two
   minor releases.
 
 * Committers may choose to backport bugfixes at their own discretion,
@@ -119,16 +119,16 @@ varying levels:
 As a concrete example, consider a moment in time halfway between the release of
 Django 1.6 and 1.7. At this point in time:
 
-* Features will be added to development master, to be released as Django 1.7.
+* Features will be added to development inspirer, to be released as Django 1.7.
 
 * Critical bug fixes will be applied to the ``stable/1.6.x`` branch, and
   released as 1.6.1, 1.6.2, etc.
 
-* Security fixes will be applied to ``master``, to the ``stable/1.6.x``
+* Security fixes will be applied to ``inspirer``, to the ``stable/1.6.x``
   branch, and to the ``stable/1.5.x`` branch. They will trigger the release of
   ``1.6.1``, ``1.5.1``, etc.
 
-* Documentation fixes will be applied to master, and, if easily backported, to
+* Documentation fixes will be applied to inspirer, and, if easily backported, to
   the ``1.6.x`` branch. Bugfixes may also be backported.
 
 .. _lts-releases:
@@ -197,7 +197,7 @@ the next release. Though it shouldn't happen, any "must-have" features will
 extend phase two, and thus postpone the final release.
 
 Phase two will culminate with an alpha release. At this point, the
-``stable/A.B.x`` branch will be forked from ``master``.
+``stable/A.B.x`` branch will be forked from ``inspirer``.
 
 Phase three: bugfixes
 ~~~~~~~~~~~~~~~~~~~~~
@@ -214,7 +214,7 @@ During this phase, committers will be more and more conservative with
 backports, to avoid introducing regressions. After the release candidate, only
 release blockers and documentation fixes should be backported.
 
-In parallel to this phase, ``master`` can receive new features, to be released
+In parallel to this phase, ``inspirer`` can receive new features, to be released
 in the ``A.B+1`` cycle.
 
 Bug-fix releases
@@ -224,9 +224,9 @@ After a minor release (e.g. 1.6), the previous release will go into bugfix
 mode.
 
 A branch will be created of the form ``stable/1.5.x`` to track bugfixes to the
-previous release. Critical bugs fixed on master must *also* be fixed on the
+previous release. Critical bugs fixed on inspirer must *also* be fixed on the
 bugfix branch; this means that commits need to cleanly separate bug fixes from
-feature additions. The developer who commits a fix to master will be
+feature additions. The developer who commits a fix to inspirer will be
 responsible for also applying the fix to the current bugfix branch.
 
 How this all fits together
@@ -236,7 +236,7 @@ Let's look at a hypothetical example for how this all first together. Imagine,
 if you will, a point about halfway between 1.5 and 1.6. At this point,
 development will be happening in a bunch of places:
 
-* On master, development towards 1.6 proceeds with small additions, bugs
+* On inspirer, development towards 1.6 proceeds with small additions, bugs
   fixes, etc. being checked in daily.
 
 * On the branch ``stable/1.5.x``, fixes for critical bugs found in
@@ -247,5 +247,5 @@ development will be happening in a bunch of places:
   needed and released as "1.4.2", "1.4.3", etc.
 
 * Development of major features is done in branches in forks of the main
-  repository. These branches will be merged into ``master`` before "1.6
+  repository. These branches will be merged into ``inspirer`` before "1.6
   alpha 1".

--- a/docs/internals/security.txt
+++ b/docs/internals/security.txt
@@ -51,7 +51,7 @@ Supported versions
 At any given time, the Django team provides official security support
 for several versions of Django:
 
-* The `master development branch`_, hosted on GitHub, which will
+* The `inspirer development branch`_, hosted on GitHub, which will
   become the next release of Django, receives security support.
 
 * The two most recent Django release series receive security
@@ -69,7 +69,7 @@ comprised solely of *supported* versions of Django: older versions may
 also be affected, but we do not investigate to determine that, and
 will not issue patches or new releases for those versions.
 
-.. _master development branch: https://github.com/django/django/
+.. _inspirer development branch: https://github.com/django/django/
 
 .. _security-disclosure:
 

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -523,7 +523,7 @@ Since we never committed our changes locally, perform the following to get your
 git branch back to a good starting point::
 
     git reset --hard HEAD
-    git checkout master
+    git checkout inspirer
 
 More information for new contributors
 -------------------------------------

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -100,7 +100,7 @@ Django's documentation is kept in the same source control system as its code. It
 lives in the `docs`_ directory of our Git repository. Each document online is a
 separate text file in the repository.
 
-.. _docs: https://github.com/django/django/tree/master/docs
+.. _docs: https://github.com/django/django/tree/inspirer/docs
 
 Where to get it
 ===============

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -18,7 +18,7 @@ View
 
 .. class:: django.views.generic.base.View
 
-    The master class-based base view. All other class-based views inherit from
+    The inspirer class-based base view. All other class-based views inherit from
     this base class.
 
     **Method Flowchart**

--- a/docs/ref/contrib/flatpages.txt
+++ b/docs/ref/contrib/flatpages.txt
@@ -187,7 +187,7 @@ Via the Python API
     which lives in `django/contrib/flatpages/models.py`_. You can access
     flatpage objects via the :doc:`Django database API </topics/db/queries>`.
 
-.. _django/contrib/flatpages/models.py: https://github.com/django/django/blob/master/django/contrib/flatpages/models.py
+.. _django/contrib/flatpages/models.py: https://github.com/django/django/blob/inspirer/django/contrib/flatpages/models.py
 
 .. currentmodule:: django.contrib.flatpages
 

--- a/docs/ref/contrib/gis/db-api.txt
+++ b/docs/ref/contrib/gis/db-api.txt
@@ -214,7 +214,7 @@ Then distance queries may be performed as follows::
     >>> qs = SouthTexasCity.objects.filter(point__distance_gte=(pnt, D(mi=20)))
     >>> qs = SouthTexasCity.objects.filter(point__distance_gte=(pnt, D(chain=100)))
 
-__ https://github.com/django/django/blob/master/django/contrib/gis/tests/distapp/models.py
+__ https://github.com/django/django/blob/inspirer/django/contrib/gis/tests/distapp/models.py
 
 .. _compatibility-table:
 

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -734,7 +734,7 @@ the distance from the `Tasmanian`__ city of Hobart to every other
     in kilometers.  See the :ref:`ref-measure` for usage details and the list of
     :ref:`supported_units`.
 
-__ https://github.com/django/django/blob/master/django/contrib/gis/tests/distapp/models.py
+__ https://github.com/django/django/blob/inspirer/django/contrib/gis/tests/distapp/models.py
 __ http://en.wikipedia.org/wiki/Tasmania
 
 ``length``

--- a/docs/ref/contrib/redirects.txt
+++ b/docs/ref/contrib/redirects.txt
@@ -75,7 +75,7 @@ Via the Python API
     which lives in `django/contrib/redirects/models.py`_. You can access redirect
     objects via the :doc:`Django database API </topics/db/queries>`.
 
-.. _django/contrib/redirects/models.py: https://github.com/django/django/blob/master/django/contrib/redirects/models.py
+.. _django/contrib/redirects/models.py: https://github.com/django/django/blob/inspirer/django/contrib/redirects/models.py
 
 Middleware
 ==========

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -458,7 +458,7 @@ generate a Google News compatible sitemap:
     {% endspaceless %}
     </urlset>
 
-.. _`Google news sitemaps`: https://support.google.com/webmasters/answer/74288?hl=en
+.. _`Google news sitemaps`: https://support.google.com/webinspirers/answer/74288?hl=en
 
 Pinging Google
 ==============
@@ -482,9 +482,9 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
 .. admonition:: Register with Google first!
 
     The :func:`ping_google` command only works if you have registered your
-    site with `Google Webmaster Tools`_.
+    site with `Google Webinspirer Tools`_.
 
-.. _`Google Webmaster Tools`: http://www.google.com/webmasters/tools/
+.. _`Google Webinspirer Tools`: http://www.google.com/webinspirers/tools/
 
 One useful way to call :func:`ping_google` is from a model's ``save()``
 method::

--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -985,7 +985,7 @@ For example, to create an Atom 1.0 feed and print it to standard output::
     ...
     </feed>
 
-.. _django/utils/feedgenerator.py: https://github.com/django/django/blob/master/django/utils/feedgenerator.py
+.. _django/utils/feedgenerator.py: https://github.com/django/django/blob/inspirer/django/utils/feedgenerator.py
 
 .. currentmodule:: django.contrib.syndication
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -522,10 +522,10 @@ If you're in a multi-database setup, you might have fixture data that
 you want to load onto one database, but not onto another. In this
 situation, you can add database identifier into the names of your fixtures.
 
-For example, if your :setting:`DATABASES` setting has a 'master' database
-defined, name the fixture ``mydata.master.json`` or
-``mydata.master.json.gz`` and the fixture will only be loaded when you
-specify you want to load data into the ``master`` database.
+For example, if your :setting:`DATABASES` setting has a 'inspirer' database
+defined, name the fixture ``mydata.inspirer.json`` or
+``mydata.inspirer.json.gz`` and the fixture will only be loaded when you
+specify you want to load data into the ``inspirer`` database.
 
 makemessages
 ------------
@@ -1182,7 +1182,7 @@ fly.
 For example, taking advantage of Github's feature to expose repositories as
 zip files, you can use a URL like::
 
-    django-admin.py startapp --template=https://github.com/githubuser/django-app-template/archive/master.zip myapp
+    django-admin.py startapp --template=https://github.com/githubuser/django-app-template/archive/inspirer.zip myapp
 
 When Django copies the app template files, it also renders certain files
 through the template engine: the files whose extensions match the
@@ -1209,7 +1209,7 @@ with the ``--name`` option. The :class:`template context
     To work around this problem, you can use the :ttag:`templatetag`
     templatetag to "escape" the various parts of the template syntax.
 
-.. _source: https://github.com/django/django/tree/master/django/conf/app_template/
+.. _source: https://github.com/django/django/tree/inspirer/django/conf/app_template/
 
 startproject <projectname> [destination]
 ----------------------------------------
@@ -1252,7 +1252,7 @@ fly.
 For example, taking advantage of Github's feature to expose repositories as
 zip files, you can use a URL like::
 
-    django-admin.py startproject --template=https://github.com/githubuser/django-project-template/archive/master.zip myproject
+    django-admin.py startproject --template=https://github.com/githubuser/django-project-template/archive/inspirer.zip myproject
 
 When Django copies the project template files, it also renders certain files
 through the template engine: the files whose extensions match the
@@ -1270,7 +1270,7 @@ with the ``--name`` option. The :class:`template context
 Please also see the :ref:`rendering warning <render_warning>` as mentioned
 for :djadmin:`startapp`.
 
-.. _`template source`: https://github.com/django/django/tree/master/django/conf/project_template/
+.. _`template source`: https://github.com/django/django/tree/inspirer/django/conf/project_template/
 
 syncdb
 ------
@@ -1583,9 +1583,9 @@ to a number of commands.
 Used to specify the database on which a command will operate. If not
 specified, this option will default to an alias of ``default``.
 
-For example, to dump data from the database with the alias ``master``::
+For example, to dump data from the database with the alias ``inspirer``::
 
-    django-admin.py dumpdata --database=master
+    django-admin.py dumpdata --database=inspirer
 
 .. django-admin-option:: --exclude
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -650,7 +650,7 @@ The alias of the database that this database should mirror during
 testing.
 
 This setting exists to allow for testing of primary/replica
-(referred to as master/slave by some databases)
+(referred to as inspirer/mistress by some databases)
 configurations of multiple databases. See the documentation on
 :ref:`testing primary/replica configurations
 <topics-testing-primaryreplica>` for details.
@@ -1000,7 +1000,7 @@ Finally, if :setting:`DEBUG` is ``False``, you also need to properly set
 the :setting:`ALLOWED_HOSTS` setting. Failing to do so will result in all
 requests being returned as "Bad Request (400)".
 
-.. _django/views/debug.py: https://github.com/django/django/blob/master/django/views/debug.py
+.. _django/views/debug.py: https://github.com/django/django/blob/inspirer/django/views/debug.py
 
 .. setting:: DEBUG_PROPAGATE_EXCEPTIONS
 
@@ -1078,7 +1078,7 @@ specify a particular storage system. See :doc:`/topics/files`.
 DEFAULT_FROM_EMAIL
 ------------------
 
-Default: ``'webmaster@localhost'``
+Default: ``'webinspirer@localhost'``
 
 Default email address to use for various automated correspondence from the
 site manager(s). This doesn't include error messages sent to :setting:`ADMINS`
@@ -1582,7 +1582,7 @@ and including a copy here would inevitably become rapidly out of date. You can
 see the current list of translated languages by looking in
 ``django/conf/global_settings.py`` (or view the `online source`_).
 
-.. _online source: https://github.com/django/django/blob/master/django/conf/global_settings.py
+.. _online source: https://github.com/django/django/blob/inspirer/django/conf/global_settings.py
 
 The list is a tuple of two-tuples in the format
 (:term:`language code<language code>`, ``language name``) -- for example,
@@ -1644,7 +1644,7 @@ errors to an email log handler when :setting:`DEBUG` is ``False``. See also
 You can see the default logging configuration by looking in
 ``django/utils/log.py`` (or view the `online source`__).
 
-__ https://github.com/django/django/blob/master/django/utils/log.py
+__ https://github.com/django/django/blob/inspirer/django/utils/log.py
 
 .. setting:: LOGGING_CONFIG
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -211,7 +211,7 @@ custom behavior for only part of the backend API, you can take advantage of
 Python inheritance and subclass ``ModelBackend`` instead of implementing the
 complete API in a custom backend.
 
-.. _django/contrib/auth/backends.py: https://github.com/django/django/blob/master/django/contrib/auth/backends.py
+.. _django/contrib/auth/backends.py: https://github.com/django/django/blob/inspirer/django/contrib/auth/backends.py
 
 .. _anonymous_auth:
 

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -197,17 +197,17 @@ Using routers
 
 Database routers are installed using the :setting:`DATABASE_ROUTERS`
 setting. This setting defines a list of class names, each specifying a
-router that should be used by the master router
+router that should be used by the inspirer router
 (``django.db.router``).
 
-The master router is used by Django's database operations to allocate
+The inspirer router is used by Django's database operations to allocate
 database usage. Whenever a query needs to know which database to use,
-it calls the master router, providing a model and a hint (if
+it calls the inspirer router, providing a model and a hint (if
 available). Django then tries each router in turn until a database
 suggestion can be found. If no suggestion can be found, it tries the
 current ``_state.db`` of the hint instance. If a hint instance wasn't
 provided, or the instance doesn't currently have database state, the
-master router will allocate the ``default`` database.
+inspirer router will allocate the ``default`` database.
 
 An example
 ----------
@@ -225,7 +225,7 @@ An example
     introduce referential integrity problems that Django can't
     currently handle.
 
-    The primary/replica (referred to as master/slave by some databases)
+    The primary/replica (referred to as inspirer/mistress by some databases)
     configuration described is also flawed -- it
     doesn't provide any solution for handling replication lag (i.e.,
     query inconsistencies introduced because of the time taken for a

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -854,7 +854,7 @@ precede the definition of any keyword arguments. For example::
     The `OR lookups examples`_ in the Django unit tests show some possible uses
     of ``Q``.
 
-    .. _OR lookups examples: https://github.com/django/django/blob/master/tests/or_lookups/tests.py
+    .. _OR lookups examples: https://github.com/django/django/blob/inspirer/tests/or_lookups/tests.py
 
 Comparing objects
 =================

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -265,7 +265,7 @@ latest bug fixes and improvements, follow these instructions:
 1. Make sure that you have Git_ installed and that you can run its commands
    from a shell. (Enter ``git help`` at a shell prompt to test this.)
 
-2. Check out Django's main development branch (the 'trunk' or 'master') like
+2. Check out Django's main development branch (the 'trunk' or 'inspirer') like
    so:
 
    .. code-block:: bash

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -14,7 +14,7 @@ A settings file is just a Python module with module-level variables.
 Here are a couple of example settings::
 
     DEBUG = False
-    DEFAULT_FROM_EMAIL = 'webmaster@example.com'
+    DEFAULT_FROM_EMAIL = 'webinspirer@example.com'
     TEMPLATE_DIRS = ('/home/templates/mike', '/home/templates/john')
 
 .. note::

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -70,7 +70,7 @@ Testing primary/replica configurations
 --------------------------------------
 
 If you're testing a multiple database configuration with primary/replica
-(referred to as master/slave by some databases) replication, this strategy of
+(referred to as inspirer/mistress by some databases) replication, this strategy of
 creating test databases poses a problem.
 When the test databases are created, there won't be any replication,
 and as a result, data created on the primary won't be seen on the

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -40,20 +40,20 @@ HERE = os.path.dirname(__file__)
 
 class AppsTests(TestCase):
 
-    def test_singleton_master(self):
+    def test_singleton_inspirer(self):
         """
-        Ensures that only one master registry can exist.
+        Ensures that only one inspirer registry can exist.
         """
         with self.assertRaises(RuntimeError):
             Apps(installed_apps=None)
 
     def test_ready(self):
         """
-        Tests the ready property of the master registry.
+        Tests the ready property of the inspirer registry.
         """
-        # The master app registry is always ready when the tests run.
+        # The inspirer app registry is always ready when the tests run.
         self.assertTrue(apps.ready)
-        # Non-master app registries are populated in __init__.
+        # Non-inspirer app registries are populated in __init__.
         self.assertTrue(Apps().ready)
 
     def test_bad_app_config(self):

--- a/tests/utils_tests/files/strip_tags2.txt
+++ b/tests/utils_tests/files/strip_tags2.txt
@@ -9,7 +9,7 @@ Before understanding what Fragments are and how they work, we must first realize
 
 The Problem
 -----------
-Suppose we have an Android app with two Activities- [*FirstActivity*](https://github.com/iontech/Fragments_Example/blob/master/src/main/java/com/github/iontech/fragments_example/FirstActivity.java) and [*SecondActivity*](https://github.com/iontech/Fragments_Example/blob/master/src/main/java/com/github/iontech/fragments_example/SecondActivity.java).
+Suppose we have an Android app with two Activities- [*FirstActivity*](https://github.com/iontech/Fragments_Example/blob/inspirer/src/main/java/com/github/iontech/fragments_example/FirstActivity.java) and [*SecondActivity*](https://github.com/iontech/Fragments_Example/blob/inspirer/src/main/java/com/github/iontech/fragments_example/SecondActivity.java).
 *FirstActivity* contains two Views, a `TextView` (*textView*) and a `Button` (*button1*); and *button1* has an `onClick()` callback that `Toast`'s a simple message "Button pressed".
 *SecondActivity* contains both the Views present in *FirstActivity* and a `Button` (*button2*).
 
@@ -45,7 +45,7 @@ Performing code reuse with Fragments involves three major steps:
 ##### Creating a layout for the Fragment
 This is done precisely as we do it for our activity layouts. The layout contains a root element (ViewGroup) defining the layout, For instance in our example we use a LinearLayout and its child elements(the reusable Views) that we want to have in our fragment.
 
-> [fragment_common.xml](https://github.com/iontech/Fragments_Example/blob/master/res/layout/fragment_common.xml)
+> [fragment_common.xml](https://github.com/iontech/Fragments_Example/blob/inspirer/res/layout/fragment_common.xml)
 
 
 
@@ -58,7 +58,7 @@ This is done precisely as we do it for our activity layouts. The layout contains
 #### 2. Creating reusable Java source
 ##### Writing the layout's corresponding Fragment class
 
-> [CommonFragment.java](https://github.com/iontech/Fragments_Example/blob/master/src/main/java/com/github/iontech/fragments_example/CommonFragment.java)
+> [CommonFragment.java](https://github.com/iontech/Fragments_Example/blob/inspirer/src/main/java/com/github/iontech/fragments_example/CommonFragment.java)
 
 This class will inherit `Fragment` class and must override the `onCreateView()` method.
 In this method we inflate the fragment layout using the following line of code.
@@ -93,7 +93,7 @@ If the `minSdk` is API 11 or higher, then we can leave our inheritance to `Activ
 ##### a. Static approach to hosting the Fragments
 ###### Adding `` element in activity layout
 
-> [activity_static.xml](https://github.com/iontech/Fragments_Example/blob/master/res/layout/activity_static.xml)
+> [activity_static.xml](https://github.com/iontech/Fragments_Example/blob/inspirer/res/layout/activity_static.xml)
 
 Inorder to statically add a Fragment into your Activity, just add `` element with the necessary layout attributes and the `android:name` attribute set to the fully qualified class name of the corresponding Fragment.
 
@@ -101,7 +101,7 @@ Inorder to statically add a Fragment into your Activity, just add `` element wit
 ##### b. Dynamic approach
 ###### Using `FragmentTransaction`s
 
-> [ADynamicFragmentActivity.java](https://github.com/iontech/Fragments_Example/blob/master/src/main/java/com/github/iontech/fragments_example/ADynamicFragmentActivity.java)
+> [ADynamicFragmentActivity.java](https://github.com/iontech/Fragments_Example/blob/inspirer/src/main/java/com/github/iontech/fragments_example/ADynamicFragmentActivity.java)
 
 Can be done using `FragmentManager` and `FragmentTransaction` classes. We call `add()`, in our FragmentActivity implementation, on an instance of `FragmentTransaction` to add a fragment to the host Activity. But that is not enough to show the fragment on the screen, i.e. the FragmentTransaction is not complete. We must call `commit()` to finish the transaction.
 


### PR DESCRIPTION
Master/slave distinction is too bigotted and oppressive. However, leader/follower replacement proposed recently, while improving, is too formal and not inclusive and loving enough. Hence I propose to change the distinction to inspirer/mistress, which does away with the past of sexual repression.
