### PR TITLE
Fixed #18729 -- Added more precise use_distinct check for list_filter

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -103,6 +103,7 @@ class ChangeList(object):
 
         filter_specs = []
         if self.list_filter:
+            lookup_params_all = lookup_params.copy()
             for list_filter in self.list_filter:
                 if callable(list_filter):
                     # This is simply a custom list filter class.
@@ -123,8 +124,9 @@ class ChangeList(object):
                         field = get_fields_from_path(self.model, field_path)[-1]
                     spec = field_list_filter_class(field, request, lookup_params,
                         self.model, self.model_admin, field_path=field_path)
-                    # Check if we need to use distinct()
-                    use_distinct = (use_distinct or
+                    # Check if we need to use distinct() only if list_filter in params
+                    if any((field_path in k) for k in lookup_params_all):
+                        use_distinct = (use_distinct or
                                     lookup_needs_distinct(self.lookup_opts,
                                                           field_path))
                 if spec and spec.has_output():


### PR DESCRIPTION
Added check to get_filters to only flag query for distinct based on
list_filter if that list_filter is actually being used.
Queries using distinct can be _very slow_ so should be avoided if
not needed.
