### PR TITLE
Syntax error solved in ogrinspect.py script.

### DIFF
--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -113,5 +113,5 @@ class Command(LabelCommand):
             output.extend(['', '# Auto-generated `LayerMapping` dictionary for %s model' % model_name,
                            '%s_mapping = {' % model_name.lower()])
             output.extend("    '%s' : '%s'," % (rev_mapping[ogr_fld], ogr_fld) for ogr_fld in ds[options['layer_key']].fields)
-            output.extend("    '%s' : '%s'," % (options['geom_name'], mapping_dict[options['geom_name']]), '}')
+            output.extend(["    '%s' : '%s'," % (options['geom_name'], mapping_dict[options['geom_name']]), '}'])
         return '\n'.join(output) + '\n'


### PR DESCRIPTION
The last bracket was passed as second param, solved passing a list of strings.
