### PR TITLE
Document a pre-existing but little known capability of the {% comment %} tag

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -52,11 +52,13 @@ comment
 ^^^^^^^
 
 Ignores everything between ``{% comment %}`` and ``{% endcomment %}``.
+An optional meta note may be inserted (this is useful when
+commenting out code, for documenting why the code was disabled).
 
 Sample usage::
 
     <p>Rendered text with {{ pub_date|date:"c" }}</p>
-    {% comment %}
+    {% comment "Optional note" %}
         <p>Commented out text with {{ create_date|date:"c" }}</p>
     {% endcomment %}
 


### PR DESCRIPTION
This is a first time I've submitted a patch to django:

The {% comment %} tag has a nice feature, and has since the start, but it's little known.
This patch documents the ability to add a meta note to a comment:

```
{% comment 'disabled for performance reasons, see github issue #2753' %}
    code...
{% endcomment %}
```

Which is super handy, and works in all past versions of django.  There's a matching trac ticket for this at https://code.djangoproject.com/ticket/22753#ticket
