### PR TITLE
Update OLMapWidget.js

### DIFF
--- a/django/contrib/gis/static/gis/js/OLMapWidget.js
+++ b/django/contrib/gis/static/gis/js/OLMapWidget.js
@@ -202,7 +202,7 @@ function MapWidget(options) {
     var defaults_style = {
         'fillColor': '#' + this.options.color,
         'fillOpacity': this.options.opacity,
-        'strokeColor': '#' + this.options.color,
+        'strokeColor': '#' + this.options.color
     };
     if (this.options.geom_name == 'LineString') {
         defaults_style['strokeWidth'] = 3;


### PR DESCRIPTION
Deleting comma because IE8 (and below) will parse trailing commas in array and object literals incorrectly. 
