### PR TITLE
Unicode method on model should return unicode

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -444,7 +444,7 @@ For example::
         last_name = models.CharField(max_length=50)
 
         def __unicode__(self):
-            return '%s %s' % (self.first_name, self.last_name)
+            return u'%s %s' % (self.first_name, self.last_name)
 
 If you define a ``__unicode__()`` method on your model and not a
 :meth:`~Model.__str__()` method, Django will automatically provide you with a


### PR DESCRIPTION
The example of a __unicode__ model method should return a unicode value
instead of a string.

This helps us avoid errors like [these](http://twigstechtips.blogspot.com/2011/10/django-how-to-fix-annoying.html):

```
DjangoUnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 52: ordinal not in range(128)
```
