### PR TITLE
[1.6.x] Fixed #21451 -- Fixed LiveServerTestCase 404

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -144,6 +144,7 @@ answer newbie questions, and generally made Django that much better:
     Antonio Cavedoni <http://cavedoni.com/>
     cedric@terramater.net
     Chris Chamberlin <dja@cdc.msbx.net>
+    Greg Chapple <gregchapple1@gmail.com>
     Amit Chakradeo <http://amit.chakradeo.net/>
     ChaosKCW
     Kowito Charoenratchatabhan <kowito@felspar.com>

--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -60,6 +60,9 @@ class StaticFilesHandler(WSGIHandler):
                 if settings.DEBUG:
                     from django.views import debug
                     return debug.technical_404_response(request, e)
+                else:
+                    # don't swallow the 404
+                    raise
         return super(StaticFilesHandler, self).get_response(request)
 
     def __call__(self, environ, start_response):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1081,7 +1081,10 @@ class LiveServerThread(threading.Thread):
                 connections[alias] = conn
         try:
             # Create the handler for serving static and media files
-            handler = StaticFilesHandler(_MediaFilesHandler(WSGIHandler()))
+            handler = WSGIHandler()
+            if settings.MEDIA_URL:
+                handler = _MediaFilesHandler(handler)
+            handler = StaticFilesHandler(handler)
 
             # Go through the list of possible ports, hoping that we can find
             # one that is free to use for the WSGI server.

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -178,3 +178,24 @@ class LiveServerDatabase(LiveServerBase):
             ['jane', 'robert', 'emily'],
             lambda b: b.name
         )
+
+
+@override_settings(DEBUG=True)
+class LiveServerWithoutMediaUrlInDebugMode(LiveServerBase):
+
+    @classmethod
+    def setUpClass(cls):
+        # initialize without MEDIA_URL
+        MEDIA_URL = TEST_SETTINGS.pop('MEDIA_URL')
+        super(LiveServerWithoutMediaUrlInDebugMode, cls).setUpClass()
+
+        # restore original MEDIA_URL value
+        TEST_SETTINGS['MEDIA_URL'] = MEDIA_URL
+
+    def test_existing_url(self):
+        """
+        Ensure that LiveServerTestCase serves views when MEDIA_URL is unset
+        and DEBUG is True. Refs #21451.
+        """
+        f = self.urlopen('/example_view/')
+        self.assertEqual(f.read(), b'example view')


### PR DESCRIPTION
Thanks to Aymeric Augustin for the report and initial patch.

I have't really done a whole lot on this, other than test that this does indeed fix the issue described in the ticket, and add a few small comments.

The ticket also mentions not applying the StaticFilesHandler if `STATIC_URL` is not defined. I did some investigating on this by writing a test and found that if the STATIC_URL is not set, the test was throwing an exception complaining about using the staticfiles app, but not having STATIC_URL set. Some more investigating[1] found that in Django 1.6 the LiveServerTestCase used the staticfiles contrib app, which requires STATIC_URL to be set. I don't see a way around this. If anyone has any suggestions, let me know.

[1] https://docs.djangoproject.com/en/1.6/topics/testing/tools/#django.test.LiveServerTestCase 
