### PR TITLE
Fixed #22776 -- `sqlall` can now be used with a specific model.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -422,6 +422,7 @@ answer newbie questions, and generally made Django that much better:
     Javier Mansilla <javimansilla@gmail.com>
     masonsimon+django@gmail.com
     Manuzhai
+    Moayad Mardini <moayad.m@gmail.com>
     Petr Marhoun <petr.marhoun@gmail.com>
     Petar Marić <http://www.petarmaric.com/>
     Nuno Mariz <nmariz@gmail.com>

--- a/django/core/management/commands/sql.py
+++ b/django/core/management/commands/sql.py
@@ -1,26 +1,17 @@
 from __future__ import unicode_literals
 
-from optparse import make_option
-
-from django.core.management.base import AppCommand
+from django.core.management.base import SQLAppOrModelCommand
 from django.core.management.sql import sql_create
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections
 
 
-class Command(AppCommand):
+class Command(SQLAppOrModelCommand):
     help = "Prints the CREATE TABLE SQL statements for the given app name(s)."
-
-    option_list = AppCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS, help='Nominates a database to print the '
-                'SQL for.  Defaults to the "default" database.'),
-    )
-
-    output_transaction = True
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             return
         connection = connections[options.get('database')]
-        statements = sql_create(app_config, self.style, connection)
+        specific_models = options.get('specific_models')
+        statements = sql_create(app_config, self.style, connection, specific_models)
         return '\n'.join(statements)

--- a/django/core/management/commands/sqlall.py
+++ b/django/core/management/commands/sqlall.py
@@ -1,26 +1,17 @@
 from __future__ import unicode_literals
 
-from optparse import make_option
-
-from django.core.management.base import AppCommand
+from django.core.management.base import SQLAppOrModelCommand
 from django.core.management.sql import sql_all
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections
 
 
-class Command(AppCommand):
+class Command(SQLAppOrModelCommand):
     help = "Prints the CREATE TABLE, custom SQL and CREATE INDEX SQL statements for the given model module name(s)."
-
-    option_list = AppCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS, help='Nominates a database to print the '
-                'SQL for.  Defaults to the "default" database.'),
-    )
-
-    output_transaction = True
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             return
         connection = connections[options.get('database')]
-        statements = sql_all(app_config, self.style, connection)
+        specific_models = options.get('specific_models')
+        statements = sql_all(app_config, self.style, connection, specific_models)
         return '\n'.join(statements)

--- a/django/core/management/commands/sqlcustom.py
+++ b/django/core/management/commands/sqlcustom.py
@@ -1,26 +1,17 @@
 from __future__ import unicode_literals
 
-from optparse import make_option
-
-from django.core.management.base import AppCommand
+from django.core.management.base import SQLAppOrModelCommand
 from django.core.management.sql import sql_custom
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections
 
 
-class Command(AppCommand):
+class Command(SQLAppOrModelCommand):
     help = "Prints the custom table modifying SQL statements for the given app name(s)."
-
-    option_list = AppCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS, help='Nominates a database to print the '
-                'SQL for.  Defaults to the "default" database.'),
-    )
-
-    output_transaction = True
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             return
         connection = connections[options.get('database')]
-        statements = sql_custom(app_config, self.style, connection)
+        specific_models = options.get('specific_models')
+        statements = sql_custom(app_config, self.style, connection, specific_models)
         return '\n'.join(statements)

--- a/django/core/management/commands/sqlindexes.py
+++ b/django/core/management/commands/sqlindexes.py
@@ -1,27 +1,17 @@
 from __future__ import unicode_literals
 
-from optparse import make_option
-
-from django.core.management.base import AppCommand
+from django.core.management.base import SQLAppOrModelCommand
 from django.core.management.sql import sql_indexes
-from django.db import connections, DEFAULT_DB_ALIAS
+from django.db import connections
 
 
-class Command(AppCommand):
+class Command(SQLAppOrModelCommand):
     help = "Prints the CREATE INDEX SQL statements for the given model module name(s)."
-
-    option_list = AppCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_DB_ALIAS, help='Nominates a database to print the '
-                'SQL for.  Defaults to the "default" database.'),
-
-    )
-
-    output_transaction = True
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             return
         connection = connections[options.get('database')]
-        statements = sql_indexes(app_config, self.style, connection)
+        specific_models = options.get('specific_models')
+        statements = sql_indexes(app_config, self.style, connection, specific_models)
         return '\n'.join(statements)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -999,22 +999,30 @@ behavior you can use the ``--no-startup`` option. e.g.::
 
     django-admin.py shell --plain --no-startup
 
-sql <app_label app_label ...>
+sql <app_label app_label app_label.Model ...>
 -----------------------------
 
 .. django-admin:: sql
 
 Prints the CREATE TABLE SQL statements for the given app name(s).
 
+.. versionchanged:: 1.8
+
+    `sql` can also be used for a specific model `<app_label.Model>`.
+
 The :djadminopt:`--database` option can be used to specify the database for
 which to print the SQL.
 
-sqlall <app_label app_label ...>
+sqlall <app_label app_label app_label.Model ...>
 --------------------------------
 
 .. django-admin:: sqlall
 
 Prints the CREATE TABLE and initial-data SQL statements for the given app name(s).
+
+.. versionchanged:: 1.8
+
+    `sqlall` can also be used for a specific model `<app_label.Model>`.
 
 Refer to the description of :djadmin:`sqlcustom` for an explanation of how to
 specify initial data.
@@ -1032,7 +1040,7 @@ Prints the DROP TABLE SQL statements for the given app name(s).
 The :djadminopt:`--database` option can be used to specify the database for
 which to print the SQL.
 
-sqlcustom <app_label app_label ...>
+sqlcustom <app_label app_label app_label.Model ...>
 -----------------------------------
 
 .. django-admin:: sqlcustom
@@ -1052,6 +1060,10 @@ table-creation statements have been executed. Use this SQL hook to make any
 table modifications, or insert any SQL functions into the database.
 
 Note that the order in which the SQL files are processed is undefined.
+
+.. versionchanged:: 1.8
+
+    `sqlcustom` can also be used for a specific model `<app_label.Model>`.
 
 The :djadminopt:`--database` option can be used to specify the database for
 which to print the SQL.
@@ -1077,12 +1089,16 @@ command.
 The :djadminopt:`--database` option can be used to specify the database for
 which to print the SQL.
 
-sqlindexes <app_label app_label ...>
+sqlindexes <app_label app_label app_label.Model ...>
 ------------------------------------
 
 .. django-admin:: sqlindexes
 
 Prints the CREATE INDEX SQL statements for the given app name(s).
+
+.. versionchanged:: 1.8
+
+    `sqlindexes` can also be used for a specific model `<app_label.Model>`.
 
 The :djadminopt:`--database` option can be used to specify the database for
 which to print the SQL.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -167,6 +167,9 @@ Management Commands
 
 * :djadmin:`runserver` now uses daemon threads for faster reloading.
 
+* :djadmin:`sqlall`, :djadmin:`sql`, :djadmin:`sqlcustom`, and
+  :djadmin:`sqlindexes` commands can now be used for a specific model.
+
 Models
 ^^^^^^
 


### PR DESCRIPTION
Thanks smeatonj for the report.
