### PR TITLE
Fixed #18855: persist socket across runserver reloads

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -33,6 +33,8 @@ class Command(BaseCommand):
             help='Tells Django to NOT use threading.'),
         make_option('--noreload', action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
+        make_option('--nopersistsock', action='store_false', dest='use_persist_sock', default=True,
+            help='Tells Django to NOT use a persistent socket.'),
     )
     help = "Starts a lightweight Web server for development."
     args = '[optional port number, or ipaddr:port]'
@@ -86,6 +88,18 @@ class Command(BaseCommand):
         Runs the server, using the autoreloader if needed
         """
         use_reloader = options.get('use_reloader')
+
+        # test if socket.fromfd is supported on this platform as it's needed
+        # later for this code to work
+        if options.get('use_persist_sock') and getattr(socket, 'fromfd', False):
+            address_family = socket.AF_INET
+            if self.use_ipv6:
+                address_family = socket.AF_INET6
+            if not os.environ.get('DJANGO_SERVER_FD'):
+                sock = socket.socket(address_family, socket.SOCK_STREAM)
+                if getattr(sock, 'set_inheritable', None):
+                    sock.set_inheritable(sock.fileno())
+                os.environ['DJANGO_SERVER_FD'] = str(sock.fileno())
 
         if use_reloader:
             autoreload.main(self.inner_run, args, options)

--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -9,6 +9,7 @@ been reviewed for security issues. DON'T USE IT FOR PRODUCTION USE!
 
 from __future__ import unicode_literals
 
+import os
 import socket
 import sys
 from wsgiref import simple_server
@@ -66,11 +67,46 @@ class WSGIServer(simple_server.WSGIServer, object):
     def __init__(self, *args, **kwargs):
         if kwargs.pop('ipv6', False):
             self.address_family = socket.AF_INET6
-        super(WSGIServer, self).__init__(*args, **kwargs)
+
+        fd = os.environ.get('DJANGO_SERVER_FD')
+        if fd:
+            # super() will not work here because TCPServer will setup a socket
+            # when we need to setup or own socket
+            socketserver.BaseServer.__init__(self, *args, **kwargs)
+            self.socket = socket.fromfd(
+                int(fd), self.address_family, self.socket_type
+            )
+            try:
+                self.server_bind()
+            except socket.error as e:
+                if e.errno == socket.errno.EINVAL:
+                    # handle socket that is already bound
+
+                    # mimic SocketServer.TCPServer.server_bind
+                    self.server_address = self.socket.getsockname()
+                    # mimic BaseHTTPServer.HTTPServer.server_bind
+                    host, port = self.socket.getsockname()[:2]
+                    self.server_name = socket.getfqdn(host)
+                    self.server_port = port
+                    # mimic wsgiref.simple_server.WSGIServer
+                    # mimic this classes implementation of server_bind
+                    self.setup_environ()
+
+                else:
+                    raise
+            self.server_activate()
+
+        else:
+            super(WSGIServer, self).__init__(*args, **kwargs)
 
     def server_bind(self):
         """Override server_bind to store the server name."""
-        super(WSGIServer, self).server_bind()
+        try:
+            super(WSGIServer, self).server_bind()
+        except Exception as e:
+            if isinstance(e, socket.error) and e.errno == socket.errno.EINVAL:
+                raise
+            raise socket.error(e)
         self.setup_environ()
 
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -902,6 +902,16 @@ Example usage::
 The development server is multithreaded by default. Use the ``--nothreading``
 option to disable the use of threading in the development server.
 
+.. django-admin-option:: --nopersistsock
+
+.. versionadded:: 1.8
+
+The development server will persist the listening socket while reloading code
+by default.  To disable this behavior, use the ``--nopersistsock`` option.
+The caveat is that some platforms do not support the methods needed for this
+feature (``socket.fromfd``).  In particular, Python 2 on Windows will not have
+support for this, but Python 3 does.
+
 .. django-admin-option:: --ipv6, -6
 
 Use the ``--ipv6`` (or shorter ``-6``) option to tell Django to use IPv6 for

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -165,7 +165,14 @@ Management Commands
 * The :djadminopt:`--ignorenonexistent` option of the :djadmin:`loaddata`
   management command now ignores data for models that no longer exist.
 
-* :djadmin:`runserver` now uses daemon threads for faster reloading.
+* The :djadmin:`runserver` command received several improvements:
+
+  * It now uses daemon threads for faster reloading.
+
+  * It will reuse the same socket across automatic reloads which ensures that
+    requests will not fail if the browser is reloaded too quickly.
+    For Windows, this feature is only supported with Python 3.x.
+
 
 Models
 ^^^^^^


### PR DESCRIPTION
Using livereload (livereload.com) with Django becomes painful when
updating a file immediately results in reloading the webpage AND
the Django dev server.  There is a short period of time when the dev
server is not listening as it is busy reloading (frequently hit
when using livereload). This is exacerabated with larger projects as reload
time is longer.

Huge thanks to Dan LaMotte for his work and efforts.
