### PR TITLE
Fixed #22804 -- Warned on unsafe value of 'sep=' in Signer

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -38,6 +38,7 @@ from __future__ import unicode_literals
 import base64
 import json
 import time
+import warnings
 import zlib
 
 from django.conf import settings
@@ -46,6 +47,10 @@ from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.encoding import force_bytes, force_str, force_text
 from django.utils.module_loading import import_string
 
+_SEP_UNSAFE = set(
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz-_="
+)
 
 class BadSignature(Exception):
     """
@@ -150,6 +155,10 @@ class Signer(object):
     def __init__(self, key=None, sep=':', salt=None):
         # Use of native strings in all versions of Python
         self.sep = force_str(sep)
+        if self.sep in _SEP_UNSAFE:
+            warnings.warn(
+                "Unsafe Signer separator: %r (cannot be in %r)"
+                % (self.sep, "".join(_SEP_UNSAFE)))
         self.key = key or settings.SECRET_KEY
         self.salt = force_str(salt or
             '%s.%s' % (self.__class__.__module__, self.__class__.__name__))

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import time
+import warnings
 
 from django.core import signing
 from django.test import TestCase
@@ -110,6 +111,14 @@ class TestSigner(TestCase):
 
         s = signing.Signer(binary_key)
         self.assertEqual('foo:6NB0fssLW5RQvZ3Y-MTerq2rX7w', s.sign('foo'))
+
+    def test_issues_warning_on_invalid_sep(self):
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter('always')
+            signing.Signer(sep="-")
+            self.assertEqual(len(recorded), 1)
+            msg = str(recorded[0].message)
+            self.assertTrue(msg.startswith("Unsafe Signer separator"))
 
 
 class TestTimestampSigner(TestCase):


### PR DESCRIPTION
Issues a warning if the the separator passed to `django.core.signing.Signer` is an invalid value.

See also: https://code.djangoproject.com/ticket/22804
