### PR TITLE
Fixed #22798 -- `pluralize()` now adds plural_suffix for any `1 < d < 2`

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -934,7 +934,7 @@ def pluralize(value, arg='s'):
     singular_suffix, plural_suffix = bits[:2]
 
     try:
-        if int(value) != 1:
+        if float(value) != 1:
             return plural_suffix
     except ValueError:  # Invalid string that's not a number.
         pass

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -654,6 +654,11 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(pluralize(1), '')
         self.assertEqual(pluralize(0), 's')
         self.assertEqual(pluralize(2), 's')
+
+        # Ticket #22798
+        self.assertEqual(pluralize(0.5), 's')
+        self.assertEqual(pluralize(1.5), 's')
+
         self.assertEqual(pluralize(decimal.Decimal(1)), '')
         self.assertEqual(pluralize(decimal.Decimal(0)), 's')
         self.assertEqual(pluralize(decimal.Decimal(2)), 's')


### PR DESCRIPTION
Thanks Odd_Bloke for the report.
