### PR TITLE
Remove trailing slashes from test labels.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -340,6 +340,9 @@ if __name__ == "__main__":
         '--selenium', action='store_true', dest='selenium', default=False,
         help='Run the Selenium tests as well (if Selenium is installed)')
     options = parser.parse_args()
+
+    options.modules = [os.path.normpath(labels) for labels in options.modules]
+
     if options.settings:
         os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
     else:


### PR DESCRIPTION
When using tab-completion it's easy to accidentally run a test with
a trailing slash, which causes INSTALLED_APPS to be set incorrectly.
Normalize the test labels to avoid this common error.
