### PR TITLE
Update validation.txt - Fix markdown typo

### DIFF
--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -412,5 +412,5 @@ sample) looks like this::
 
 The second argument of ``add_error()`` can be a simple string, or preferably
 an instance of ``ValidationError``. See :ref:`raising-validation-error` for
-more details. Note that ``add_error()` automatically removes the field
+more details. Note that ``add_error()`` automatically removes the field
 from ``cleaned_data``.


### PR DESCRIPTION
Fix a typo which make a formatting error in the HTML output. Since it is just a character change, there is no need of a ticket according to guidelines.
