### PR TITLE
Replace primary/replica terminology with primary/secondary

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -814,7 +814,7 @@ class TransactionTestCase(SimpleTestCase):
             if self.reset_sequences:
                 self._reset_sequences(db_name)
 
-            # If we need to provide replica initial data from migrated apps,
+            # If we need to provide secondary initial data from migrated apps,
             # then do so.
             if self.serialized_rollback and hasattr(connections[db_name], "_test_serialized_contents"):
                 if self.available_apps is not None:

--- a/docs/internals/release-process.txt
+++ b/docs/internals/release-process.txt
@@ -65,7 +65,7 @@ security purposes, please see :doc:`our security policies <security>`.
       default; you can turn on display of these warnings with the ``-Wd`` option
       of Python.
 
-    * Django 1.8 will still contain the backwards-compatible replica. This
+    * Django 1.8 will still contain the backwards-compatible secondary. This
       warning becomes *loud* by default, and will likely be quite annoying.
 
     * Django 1.9 will remove the feature outright.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -651,11 +651,11 @@ Default: ``None``
 The alias of the database that this database should mirror during
 testing.
 
-This setting exists to allow for testing of primary/replica
+This setting exists to allow for testing of primary/secondary
 (referred to as master/slave by some databases)
 configurations of multiple databases. See the documentation on
-:ref:`testing primary/replica configurations
-<topics-testing-primaryreplica>` for details.
+:ref:`testing primary/secondary configurations
+<topics-testing-primarysecondary>` for details.
 
 .. setting:: TEST_NAME
 

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -222,7 +222,7 @@ won't appear in the models cache, but the model details can be used
 for routing purposes.
 
 For example, the following router would direct all cache read
-operations to ``cache_replica``, and all write operations to
+operations to ``cache_secondary``, and all write operations to
 ``cache_primary``. The cache table will only be synchronized onto
 ``cache_primary``::
 
@@ -230,9 +230,9 @@ operations to ``cache_replica``, and all write operations to
         """A router to control all database cache operations"""
 
         def db_for_read(self, model, **hints):
-            "All cache read operations go to the replica"
+            "All cache read operations go to the secondary"
             if model._meta.app_label in ('django_cache',):
-                return 'cache_replica'
+                return 'cache_secondary'
             return None
 
         def db_for_write(self, model, **hints):

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -225,17 +225,17 @@ An example
     introduce referential integrity problems that Django can't
     currently handle.
 
-    The primary/replica (referred to as master/slave by some databases)
+    The primary/secondary (referred to as master/slave by some databases)
     configuration described is also flawed -- it
     doesn't provide any solution for handling replication lag (i.e.,
     query inconsistencies introduced because of the time taken for a
-    write to propagate to the replicas). It also doesn't consider the
+    write to propagate to the secondaries). It also doesn't consider the
     interaction of transactions with the database utilization strategy.
 
 So - what does this mean in practice? Let's consider another sample
 configuration. This one will have several databases: one for the
-``auth`` application, and all other apps using a primary/replica setup
-with two read replicas. Here are the settings specifying these
+``auth`` application, and all other apps using a primary/secondary setup
+with two read secondaries. Here are the settings specifying these
 databases::
 
     DATABASES = {
@@ -251,14 +251,14 @@ databases::
             'USER': 'mysql_user',
             'PASSWORD': 'spam',
         },
-        'replica1': {
-            'NAME': 'replica1',
+        'secondary1': {
+            'NAME': 'secondary1',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'eggs',
         },
-        'replica2': {
-            'NAME': 'replica2',
+        'secondary2': {
+            'NAME': 'secondary2',
             'ENGINE': 'django.db.backends.mysql',
             'USER': 'mysql_user',
             'PASSWORD': 'bacon',
@@ -310,17 +310,17 @@ send queries for the ``auth`` app to ``auth_db``::
             return None
 
 And we also want a router that sends all other apps to the
-primary/replica configuration, and randomly chooses a replica to read
+primary/secondary configuration, and randomly chooses a secondary to read
 from::
 
     import random
 
-    class PrimaryReplicaRouter(object):
+    class PrimarySecondaryRouter(object):
         def db_for_read(self, model, **hints):
             """
-            Reads go to a randomly-chosen replica.
+            Reads go to a randomly-chosen secondary.
             """
-            return random.choice(['replica1', 'replica2'])
+            return random.choice(['secondary1', 'secondary2'])
 
         def db_for_write(self, model, **hints):
             """
@@ -331,9 +331,9 @@ from::
         def allow_relation(self, obj1, obj2, **hints):
             """
             Relations between objects are allowed if both objects are
-            in the primary/replica pool.
+            in the primary/secondary pool.
             """
-            db_list = ('primary', 'replica1', 'replica2')
+            db_list = ('primary', 'secondary1', 'secondary2')
             if obj1._state.db in db_list and obj2._state.db in db_list:
                 return True
             return None
@@ -348,17 +348,17 @@ Finally, in the settings file, we add the following (substituting
 ``path.to.`` with the actual python path to the module(s) where the
 routers are defined)::
 
-    DATABASE_ROUTERS = ['path.to.AuthRouter', 'path.to.PrimaryReplicaRouter']
+    DATABASE_ROUTERS = ['path.to.AuthRouter', 'path.to.PrimarySecondaryRouter']
 
 The order in which routers are processed is significant. Routers will
 be queried in the order the are listed in the
 :setting:`DATABASE_ROUTERS` setting . In this example, the
-``AuthRouter`` is processed before the ``PrimaryReplicaRouter``, and as a
+``AuthRouter`` is processed before the ``PrimarySecondaryRouter``, and as a
 result, decisions concerning the models in ``auth`` are processed
 before any other decision is made. If the :setting:`DATABASE_ROUTERS`
 setting listed the two routers in the other order,
-``PrimaryReplicaRouter.allow_migrate()`` would be processed first. The
-catch-all nature of the PrimaryReplicaRouter implementation would mean
+``PrimarySecondaryRouter.allow_migrate()`` would be processed first. The
+catch-all nature of the PrimarySecondaryRouter implementation would mean
 that all models would be available on all databases.
 
 With this setup installed, lets run some Django code::
@@ -370,7 +370,7 @@ With this setup installed, lets run some Django code::
     >>> # This save will also be directed to 'auth_db'
     >>> fred.save()
 
-    >>> # These retrieval will be randomly allocated to a replica database
+    >>> # These retrieval will be randomly allocated to a secondary database
     >>> dna = Person.objects.get(name='Douglas Adams')
 
     >>> # A new object has no database allocation when created
@@ -383,7 +383,7 @@ With this setup installed, lets run some Django code::
     >>> # This save will force the 'mh' instance onto the primary database...
     >>> mh.save()
 
-    >>> # ... but if we re-retrieve the object, it will come back on a replica
+    >>> # ... but if we re-retrieve the object, it will come back on a secondary
     >>> mh = Book.objects.get(title='Mostly Harmless')
 
 
@@ -691,7 +691,7 @@ In addition, some objects are automatically created just after
   database).
 
 For common setups with multiple databases, it isn't useful to have these
-objects in more than one database. Common setups include primary/replica and
+objects in more than one database. Common setups include primary/secondary and
 connecting to external databases. Therefore, it's recommended:
 
 - either to run :djadmin:`migrate` only for the default database;

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -64,17 +64,17 @@ The following is a simple unit test using the request factory::
 Tests and multiple databases
 ============================
 
-.. _topics-testing-primaryreplica:
+.. _topics-testing-primarysecondary:
 
-Testing primary/replica configurations
+Testing primary/secondary configurations
 --------------------------------------
 
-If you're testing a multiple database configuration with primary/replica
+If you're testing a multiple database configuration with primary/secondary
 (referred to as master/slave by some databases) replication, this strategy of
 creating test databases poses a problem.
 When the test databases are created, there won't be any replication,
 and as a result, data created on the primary won't be seen on the
-replica.
+secondary.
 
 To compensate for this, Django allows you to define that a database is
 a *test mirror*. Consider the following (simplified) example database
@@ -87,31 +87,31 @@ configuration::
             'HOST': 'dbprimary',
              # ... plus some other settings
         },
-        'replica': {
+        'secondary': {
             'ENGINE': 'django.db.backends.mysql',
             'NAME': 'myproject',
-            'HOST': 'dbreplica',
+            'HOST': 'dbsecondary',
             'TEST_MIRROR': 'default'
             # ... plus some other settings
         }
     }
 
 In this setup, we have two database servers: ``dbprimary``, described
-by the database alias ``default``, and ``dbreplica`` described by the
-alias ``replica``. As you might expect, ``dbreplica`` has been configured
-by the database administrator as a read replica of ``dbprimary``, so in
-normal activity, any write to ``default`` will appear on ``replica``.
+by the database alias ``default``, and ``dbsecondary`` described by the
+alias ``secondary``. As you might expect, ``dbsecondary`` has been configured
+by the database administrator as a read secondary of ``dbprimary``, so in
+normal activity, any write to ``default`` will appear on ``secondary``.
 
 If Django created two independent test databases, this would break any
-tests that expected replication to occur. However, the ``replica``
+tests that expected replication to occur. However, the ``secondary``
 database has been configured as a test mirror (using the
 :setting:`TEST_MIRROR` setting), indicating that under testing,
-``replica`` should be treated as a mirror of ``default``.
+``secondary`` should be treated as a mirror of ``default``.
 
-When the test environment is configured, a test version of ``replica``
-will *not* be created. Instead the connection to ``replica``
+When the test environment is configured, a test version of ``secondary``
+will *not* be created. Instead the connection to ``secondary``
 will be redirected to point at ``default``. As a result, writes to
-``default`` will appear on ``replica`` -- but because they are actually
+``default`` will appear on ``secondary`` -- but because they are actually
 the same database, not because there is data replication between the
 two databases.
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1103,7 +1103,7 @@ class MultiDBOperationTests(MigrationTestBase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a secondary of the 'default'
         self.old_routers = router.routers
         router.routers = [MigrateNothingRouter()]
 

--- a/tests/multiple_database/routers.py
+++ b/tests/multiple_database/routers.py
@@ -4,7 +4,7 @@ from django.db import DEFAULT_DB_ALIAS
 
 
 class TestRouter(object):
-    # A test router. The behavior is vaguely primary/replica, but the
+    # A test router. The behavior is vaguely primary/secondary, but the
     # databases aren't assumed to propagate changes.
     def db_for_read(self, model, instance=None, **hints):
         if instance:

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -804,7 +804,7 @@ class QueryTestCase(TestCase):
         self.assertEqual(book.editor._state.db, 'other')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and primary/replica."""
+        """Make sure as_sql works with subqueries and primary/secondary."""
         sub = Person.objects.using('other').filter(name='fff')
         qs = Book.objects.filter(editor__in=sub)
 
@@ -869,7 +869,7 @@ class RouterTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a secondary of the 'default'
         self.old_routers = router.routers
         router.routers = [TestRouter()]
 
@@ -1021,7 +1021,7 @@ class RouterTestCase(TestCase):
         try:
             dive.editor = marty
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1039,7 +1039,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real primary/secondary database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1047,7 +1047,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited = [pro, dive]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Assignment implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1061,7 +1061,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real primary/secondary database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1069,7 +1069,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited.add(dive)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Add implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1083,7 +1083,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real primary/secondary database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
 
         # If you assign a FK object when the base object hasn't
@@ -1147,7 +1147,7 @@ class RouterTestCase(TestCase):
         mark = Person.objects.using('default').create(pk=2, name="Mark Pilgrim")
 
         # Now save back onto the usual database.
-        # This simulates primary/replica - the objects exist on both database,
+        # This simulates primary/secondary - the objects exist on both database,
         # but the _state.db is as it is for all other tests.
         pro.save(using='default')
         marty.save(using='default')
@@ -1164,7 +1164,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set = [pro, dive]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1183,7 +1183,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set.add(dive)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1202,7 +1202,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors = [mark, marty]
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1224,7 +1224,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors.add(marty)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1262,7 +1262,7 @@ class RouterTestCase(TestCase):
         try:
             bob.userprofile = alice_profile
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(alice._state.db, 'default')
@@ -1293,7 +1293,7 @@ class RouterTestCase(TestCase):
         try:
             review1.content_object = dive
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1312,7 +1312,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real primary/replica database, so restore the original from other
+        # This isn't a real primary/secondary database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1320,7 +1320,7 @@ class RouterTestCase(TestCase):
         try:
             dive.reviews.add(review1)
         except ValueError:
-            self.fail("Assignment across primary/replica databases with a common source should be ok")
+            self.fail("Assignment across primary/secondary databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1395,7 +1395,7 @@ class RouterTestCase(TestCase):
         self.assertEqual(pro.reviews.db_manager('default').all().db, 'default')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and primary/replica."""
+        """Make sure as_sql works with subqueries and primary/secondary."""
         # Create a book and author on the other database
 
         mark = Person.objects.using('other').create(name="Mark Pilgrim")
@@ -1433,7 +1433,7 @@ class AuthTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a replica of the 'default'
+        # Make the 'other' database appear to be a secondary of the 'default'
         self.old_routers = router.routers
         router.routers = [AuthRouter()]
 


### PR DESCRIPTION
Political correctness has in recent years become a important part of the tech industry, and specially for the Django project as #2692 and #2694 have proven. Because [other](https://www.drupal.org/node/2275877) projects are now also considering to follow Django's example, I believe it is important for Django to be pro-active in this area.

Due the above stated reasons, I hereby propose changing the primary/replica terminology to primary/secondary. "replica" will most likely be a highly insulting and derogatory term used to describe human clones and human-like companion AIs in the near future.

By using primary/secondary instead of primary/replica, the Django project would be further proving that political correctness, and pro-active political correctness is an important topic that is taken seriously.
