### PR TITLE
Fixed #22879 -- Wrapped cursor iterator to intercept database errors coming from __next__ method.

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -29,7 +29,9 @@ class CursorWrapper(object):
             return cursor_attr
 
     def __iter__(self):
-        return iter(self.cursor)
+        with self.db.wrap_database_errors:
+            for item in self.cursor:
+                yield item
 
     def __enter__(self):
         return self


### PR DESCRIPTION
...ethod.

This is needed for django-sqlserver driver.

Ticket #22879
