### PR TITLE
Do not hardcode the primary key field name in admin's initial migration.

### DIFF
--- a/django/contrib/admin/migrations/0001_initial.py
+++ b/django/contrib/admin/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('action_flag', models.PositiveSmallIntegerField(verbose_name='action flag')),
                 ('change_message', models.TextField(verbose_name='change message', blank=True)),
                 ('content_type', models.ForeignKey(to_field='id', blank=True, to='contenttypes.ContentType', null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, to_field='id')),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'ordering': ('-action_time',),


### PR DESCRIPTION
This enables users of django admin to use custom user models (configured through settings.AUTH_USER_MODEL) using a primary key with a name different from 'id' (use case: 'email' or 'login' are common natural primary keys).

It's not necessary to include the field name, the default behavior of models.ForeignKey is to look up the primary key field name from the target model.
