### PR TITLE
#22907 - Test: ArrayField(CharField(...)) can't be queried

### DIFF
--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -176,6 +176,9 @@ class TestQuerying(TestCase):
             [instance]
         )
 
+    def test_char_contains(self):
+        list(CharArrayModel.objects.filter(field__contains=['text']))
+
 
 class TestChecks(TestCase):
 


### PR DESCRIPTION
When trying to make query with CharArrayModel.objects.filter(field__contains=['text']) I get:

```
ProgrammingError: operator does not exist: character varying[] @> text[]
LINE 1: ...el" WHERE "postgres_tests_chararraymodel"."field" @> ARRAY['...
                                                             ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
```
