### PR TITLE
Fixes parameter name for BaseCommand.check

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -322,7 +322,7 @@ the :meth:`~BaseCommand.handle` method must be implemented.
     potential problems. Serious problems are raised as a :class:`CommandError`;
     warnings are output to stderr; minor notifications are output to stdout.
 
-    If ``apps`` and ``tags`` are both None, all system checks are performed.
+    If ``app_configs`` and ``tags`` are both None, all system checks are performed.
     ``tags`` can be a list of check tags, like ``compatibility`` or ``models``.
 
 .. method:: BaseCommand.validate(app=None, display_num_errors=False)


### PR DESCRIPTION
This fixes a typo in the docs for [custom management commands](https://docs.djangoproject.com/en/1.7/howto/custom-management-commands/) on [`BaseCommand.check`](https://docs.djangoproject.com/en/1.7/howto/custom-management-commands/#django.core.management.BaseCommand.check)
