### PR TITLE
help: use global configuration if subcommand is help

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -170,3 +170,6 @@ class UserSettingsHolder(BaseSettings):
         return (deleted or set_locally or set_on_default)
 
 settings = LazySettings()
+if (os.environ['DJANGO_COMMAND'] is 'help'):
+    settings.configure()
+

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -306,6 +306,7 @@ class ManagementUtility(object):
         self.autocomplete()
 
         if subcommand == 'help':
+            os.environ['DJANGO_COMMAND'] = 'help'
             if '--commands' in args:
                 sys.stdout.write(self.main_help_text(commands_only=True) + '\n')
             elif len(options.args) < 1:


### PR DESCRIPTION
Hi

i'm new user of @django, and i run `django-admin.py help check`, then my shell prints:

```
django.core.exceptions.ImproperlyConfigured: Requested setting DEFAULT_INDEX_TABLESPACE, 
but settings are not configured. You must either define the environment variable 
DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```

I traced this problem is because i haven't configured my django settings file by `DJANGO_SETTINGS_MODULE`. but i don't think this should be set in help command, so i make this patch that use global configuration under `django-admin.py help [subcommand]`.
