### PR TITLE
Remove non-existent reference to args/kwargs

### DIFF
--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -297,7 +297,7 @@ returns a *subclass* of your base ``Manager`` with a copy of the custom
 
     class BaseManager(models.Manager):
         def __init__(self, *args, **kwargs):
-            ...
+            pass
 
         def manager_only_method(self):
             return
@@ -307,14 +307,14 @@ returns a *subclass* of your base ``Manager`` with a copy of the custom
             return
 
     class MyModel(models.Model):
-        objects = BaseManager.from_queryset(CustomQueryset)(*args, **kwargs)
+        objects = BaseManager.from_queryset(CustomQueryset)()
 
 You may also store the generated class into a variable::
 
     CustomManager = BaseManager.from_queryset(CustomQueryset)
 
     class MyModel(models.Model):
-        objects = CustomManager(*args, **kwargs)
+        objects = CustomManager()
 
 .. _custom-managers-and-inheritance:
 


### PR DESCRIPTION
Originally noticed by @ramiro in https://github.com/django/django/commit/31fadc120213284da76801cc7bc56e9f32d7281b#commitcomment-3725813
