### PR TITLE
Using recommended way of localising a naive datetime.

### DIFF
--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -85,7 +85,7 @@ this mode, the example above becomes::
     import datetime
     from django.utils.timezone import utc
 
-    now = datetime.datetime.utcnow().replace(tzinfo=utc)
+    now = utc.localize(datetime.datetime.utcnow())
 
 .. note::
 
@@ -554,7 +554,7 @@ Troubleshooting
        >>> import datetime
        >>> from django.utils import timezone
        >>> naive = datetime.datetime.utcnow()
-       >>> aware = naive.replace(tzinfo=timezone.utc)
+       >>> aware = timezone.utc.localize(naive)
        >>> naive == aware
        Traceback (most recent call last):
        ...


### PR DESCRIPTION
Since pytz 2014.3, doing .replace will use LMT timezones
which are not particularly useful.

The recommended way of avoiding this, is to use utc (or
whatever timezone you are using) .localize(naive).
