### PR TITLE
Updated the urlize regex to prevent it from turning some.organization, an.inter...

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -25,7 +25,7 @@ DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']
 unencoded_ampersands_re = re.compile(r'&(?!(\w+|#\d+);)')
 word_split_re = re.compile(r'(\s+)')
 simple_url_re = re.compile(r'^https?://\[?\w', re.IGNORECASE)
-simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)(.*)$', re.IGNORECASE)
+simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)($|/.*)$', re.IGNORECASE)
 simple_email_re = re.compile(r'^\S+@\S+\.\S+$')
 link_target_attribute_re = re.compile(r'(<a [^>]*?)target=[^\s>]+')
 html_gunk_re = re.compile(r'(?:<br clear="all">|<i><\/i>|<b><\/b>|<em><\/em>|<strong><\/strong>|<\/?smallcaps>|<\/?uppercase>)', re.IGNORECASE)

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -268,6 +268,8 @@ class DefaultFiltersTests(TestCase):
             '<a href="http://djangoproject.org/" rel="nofollow">djangoproject.org/</a>')
         self.assertEqual(urlize('info@djangoproject.org'),
             '<a href="mailto:info@djangoproject.org">info@djangoproject.org</a>')
+        self.assertEqual(urlize('some.organization'),
+            'some.organization'),
 
         # Check urlize with https addresses
         self.assertEqual(urlize('https://google.com'),


### PR DESCRIPTION
...n etc. into urls. Added a test to make sure this is not happening.

Changes made per this [request](https://github.com/django/django/commit/a93ee5112d42d37187e30aa4edcc1864a79d384a#commitcomment-6888030)
New changes should match foo.com foo.com/bar but not foo.commercial.
