### PR TITLE
Added a space before explanation of "Invalid HTTP_HOST header: ..."

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -89,9 +89,9 @@ class HttpRequest(object):
         else:
             msg = "Invalid HTTP_HOST header: %r." % host
             if domain:
-                msg += "You may need to add %r to ALLOWED_HOSTS." % domain
+                msg += " You may need to add %r to ALLOWED_HOSTS." % domain
             else:
-                msg += "The domain name provided is not valid according to RFC 1034/1035"
+                msg += " The domain name provided is not valid according to RFC 1034/1035."
             raise DisallowedHost(msg)
 
     def get_full_path(self):


### PR DESCRIPTION
Please let me know if you prefer to have the space at the end of `"Invalid HTTP_HOST header: %r."`, or just amend/commit it accordingly.
