### PR TITLE
Fixed #22967 -- Made Model._do_update consistent

### DIFF
--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -713,7 +713,7 @@ class SelectOnSaveTests(TestCase):
         try:
             Article._base_manager.__class__ = FakeManager
             asos = ArticleSelectOnSave.objects.create(pub_date=datetime.now())
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(3):
                 asos.save()
                 self.assertTrue(FakeQuerySet.called)
             # This is not wanted behavior, but this is how Django has always


### PR DESCRIPTION
Made _do_update behave more strictly according to its docs,
including a corner case when specific concurent updates are
executed and select_on_save is set.
