### PR TITLE
Fix #21272 - Oracle inspectdb includes Views

### DIFF
--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -49,7 +49,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_table_list(self, cursor):
         "Returns a list of table names in the current database."
-        cursor.execute("SELECT TABLE_NAME FROM USER_TABLES")
+        cursor.execute(
+            "SELECT TABLE_NAME FROM USER_TABLES UNION ALL SELECT VIEW_NAME FROM USER_VIEWS")
         return [row[0].lower() for row in cursor.fetchall()]
 
     def get_table_description(self, cursor, table_name):

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -23,6 +23,16 @@ class IntrospectionTests(TestCase):
             self.assertTrue('django_ixn_testcase_table' not in tl,
                          "django_table_names() returned a non-Django table")
 
+    def test_table_and_view_names(self):
+        with connection.cursor() as cursor:
+            cursor.execute("CREATE TABLE django_test_custom_table (id INTEGER);")
+            cursor.execute(
+                "CREATE VIEW django_test_custom_view AS "
+                "SELECT id FROM django_test_custom_table;")
+            tl = connection.introspection.table_names()
+            self.assertTrue('django_test_custom_table' in tl)
+            self.assertTrue('django_test_custom_view' in tl)
+
     def test_django_table_names_retval_type(self):
         # Ticket #15216
         with connection.cursor() as cursor:


### PR DESCRIPTION
Includes VIEWS in inspectdb output, bringing parity to Oracle. See https://code.djangoproject.com/ticket/21272
