### PR TITLE
Add a Makefile, which allows for easy `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+BUILD_DIR:=build
+VENV:=$(BUILD_DIR)/virtualenv
+
+DJANGO_SETTINGS_MODULE?=test_sqlite
+
+test: $(VENV)/bin/django-admin
+	cd tests \
+	&& PYTHONPATH=..:$$PYTHONPATH \
+		$(abspath $(VENV))/bin/python ./runtests.py \
+			--settings=$(DJANGO_SETTINGS_MODULE)
+
+$(VENV)/bin/django-admin: $(VENV)/bin/python
+	$(VENV)/bin/pip install -e .
+
+$(VENV)/bin/python: $(VENV)
+
+$(VENV):
+	virtualenv $@
+
+clean:
+	$(RM) -r $(BUILD_DIR)
+
+.PHONY: clean test


### PR DESCRIPTION
This makes a stab at providing a stub for a Makefile, currently only for providing `make test`.

It automatically sets up a virtualenv in `build/virtualenv` and honors `DJANGO_SETTINGS_MODULE` from the environment.

I think it makes a lot of sense for a project to provide an easy way to run the tests, and nothing beats `make test`.

Not having `make` available by default on some systems (e.g. on Windows) should not prevent us from providing an easy entry point.
