### PR TITLE
Fixed #22970 -- Use last migration's name in dependency to existing migrated app

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -254,13 +254,13 @@ class MigrationAutodetector(object):
                                     # If we can't find the other app, we add a first/last dependency,
                                     # but only if we've already been through once and checked everything
                                     if chop_mode:
-                                        # If the app already exists, we add __last__, as we don't know which
-                                        # migration contains the target field.
+                                        # If the app already exists, we add a dependency on the last migration,
+                                        # as we don't know which migration contains the target field.
                                         # If it's not yet migrated or has no migrations, we use __first__
-                                        if graph and not graph.root_nodes(dep[0]):
-                                            operation_dependencies.add((dep[0], "__first__"))
+                                        if graph and graph.leaf_nodes(dep[0]):
+                                            operation_dependencies.add(graph.leaf_nodes(dep[0])[0])
                                         else:
-                                            operation_dependencies.add((dep[0], "__last__"))
+                                            operation_dependencies.add((dep[0], "__first__"))
                                     else:
                                         deps_satisfied = False
                     if deps_satisfied:

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1042,7 +1042,8 @@ class AutodetectorTests(TestCase):
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
     def test_last_dependency(self):
         """
-        Tests that a dependency to an app with existing migrations uses __last__.
+        Tests that a dependency to an app with existing migrations uses the
+        last migration of that app.
         """
         # Load graph
         loader = MigrationLoader(connection)
@@ -1057,4 +1058,4 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'otherapp', 0, ["CreateModel"])
         self.assertOperationAttributes(changes, 'otherapp', 0, 0, name="Book")
         # Right dependencies?
-        self.assertEqual(changes['otherapp'][0].dependencies, [("migrations", "__last__")])
+        self.assertEqual(changes['otherapp'][0].dependencies, [("migrations", "0002_second")])


### PR DESCRIPTION
Changed the autodetector to lookup the name of the existing app's last
migration in the graph and use that as dependency.
