### PR TITLE
Fixed #22991 -- Prevented *.pyc files in autoreload monitoring

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -99,8 +99,9 @@ def gen_filenames(only_new=False):
             return _cached_filenames
 
     new_modules = module_values - _cached_modules
-    new_filenames = [filename.__file__ for filename in new_modules
-                     if hasattr(filename, '__file__')]
+    new_filenames = clean_files(
+        [filename.__file__ for filename in new_modules
+         if hasattr(filename, '__file__')])
 
     if not _cached_filenames and settings.USE_I18N:
         # Add the names of the .mo files that can be generated
@@ -119,10 +120,15 @@ def gen_filenames(only_new=False):
                     if filename.endswith('.mo'):
                         new_filenames.append(os.path.join(dirpath, filename))
 
+    _cached_modules = _cached_modules.union(new_modules)
+    _cached_filenames += new_filenames
     if only_new:
-        filelist = new_filenames
+        return new_filenames
     else:
-        filelist = _cached_filenames + new_filenames + _error_files
+        return _cached_filenames + clean_files(_error_files)
+
+
+def clean_files(filelist):
     filenames = []
     for filename in filelist:
         if not filename:
@@ -133,8 +139,6 @@ def gen_filenames(only_new=False):
             filename = filename[:-9] + ".py"
         if os.path.exists(filename):
             filenames.append(filename)
-    _cached_modules = _cached_modules.union(new_modules)
-    _cached_filenames += new_filenames
     return filenames
 
 

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -81,3 +81,4 @@ class TestFilenameGenerator(TestCase):
         filenames2 = list(gen_filenames(only_new=True))
         self.assertEqual(len(filenames2), 1)
         self.assertTrue(filenames2[0].endswith('fractions.py'))
+        self.assertFalse(any([f.endswith('.pyc') for f in gen_filenames()]))


### PR DESCRIPTION
This fixes a regression introduced in 6d302f639.
Thanks lorinkoz at gmail.com for the report and Collin Anderson
for the initial patch.
