### PR TITLE
Fixed #19508 -- Non UTF-8 now remain url encoded.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -270,10 +270,13 @@ class RequestFactory(object):
         # If there are parameters, add them
         if parsed[3]:
             path += str(";") + force_str(parsed[3])
-        path = unquote(path)
-        # WSGI requires latin-1 encoded strings. See get_path_info().
         if six.PY3:
-            path = path.encode('utf-8').decode('iso-8859-1')
+            # On Python 3 `unquote_to_bytes` is used and non-ASCII values in the
+            # WSGI environ are arbitrarily decoded with ISO-8859-1.
+            from urllib.parse import unquote_to_bytes
+            path = unquote_to_bytes(path).decode('iso-8859-1')
+        else:
+            path = unquote(path)
         return path
 
     def get(self, path, data=None, secure=False, **extra):


### PR DESCRIPTION
- When having urls like `/test/~%A9`, we get `400` when project is deployed as `WSGIHandler` has fallback for `400` in case of `UnicodeDecodeError`.
- In development we get `500` because `StaticFilesHandler` is used and it does not have that fallback.
- It cannot be reproduced in tests because the `ClientHandler` again raises `UnicodeDecodeError` in `get_path_info()`.
- The problem arises when in [get_path_info()](https://github.com/django/django/blob/master/django/core/handlers/wsgi.py#L210), we decode the url in `utf-8`.
- When we pass a url, it passes through `unquote()` in `urllib` where it converts all percent encodings, even those which should remain url-encoded.

Its not ready for merge, work still in progress.
