### PR TITLE
django.db.backends.mysql - use CHAR instead of VARCHAR when appropriate.

### DIFF
--- a/django/db/backends/creation.py
+++ b/django/db/backends/creation.py
@@ -35,6 +35,10 @@ class BaseDatabaseCreation(object):
     def __init__(self, connection):
         self.connection = connection
 
+    def db_type(self, internal_type, data):
+        """see Field.db_type()"""
+        return self.data_types[internal_type] % data
+
     @cached_property
     def _nodb_connection(self):
         """

--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -32,6 +32,14 @@ class DatabaseCreation(BaseDatabaseCreation):
         'TimeField': 'time',
     }
 
+    def db_type(self, internal_type, data):
+        """see Field.db_type()"""
+        if internal_type in ('CharField',):
+            # check for fixed-length string
+            if data['min_length'] and data['min_length'] == data['max_length']:
+                return 'char(%(max_length)s)' % data
+        return self.data_types[internal_type] % data
+
     def sql_table_creation_suffix(self):
         suffix = []
         test_settings = self.connection.settings_dict['TEST']

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -37,7 +37,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Hook for a database backend to use the cursor description to
         match a Django field type to a database column.
         """
-        if data_type == FIELD_TYPE.STRING: # != FIELD_TYPE.VAR_STRING
+        if data_type == FIELD_TYPE.STRING:  # != FIELD_TYPE.VAR_STRING
             params = {}
             params['min_length'] = params['max_length'] = int(description[3])
             return self.data_types_reverse[data_type], params

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -119,7 +119,7 @@ class Field(RegisterLookupMixin):
     description = property(_description)
 
     def __init__(self, verbose_name=None, name=None, primary_key=False,
-            max_length=None, unique=False, blank=False, null=False,
+            min_length=None, max_length=None, unique=False, blank=False, null=False,
             db_index=False, rel=None, default=NOT_PROVIDED, editable=True,
             serialize=True, unique_for_date=None, unique_for_month=None,
             unique_for_year=None, choices=None, help_text='', db_column=None,
@@ -129,7 +129,7 @@ class Field(RegisterLookupMixin):
         self.verbose_name = verbose_name  # May be set by set_attributes_from_name
         self._verbose_name = verbose_name  # Store original for deconstruction
         self.primary_key = primary_key
-        self.max_length, self._unique = max_length, unique
+        self.min_length, self.max_length, self._unique = min_length, max_length, unique
         self.blank, self.null = blank, null
         self.rel = rel
         self.default = default
@@ -532,7 +532,8 @@ class Field(RegisterLookupMixin):
         # exactly which wacky database column type you want to use.
         data = DictWrapper(self.__dict__, connection.ops.quote_name, "qn_")
         try:
-            return connection.creation.data_types[self.get_internal_type()] % data
+            internal_type = self.get_internal_type()
+            return connection.creation.db_type(internal_type, data)
         except KeyError:
             return None
 


### PR DESCRIPTION
Sometimes you know exactly how many characters go in a string and you want to avoid the extra byte for a `VARCHAR`, e.g. when storing 40-character git commit sha1. Also, when working with legacy tables (`managed = False`), you could be using `CHAR` fields that would need validation of `min_length`.
