### PR TITLE
Fixed #19508 -- Used uri_to_iri.

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -206,7 +206,6 @@ def get_path_info(environ):
     """
     path_info = get_bytes_from_wsgi(environ, 'PATH_INFO', '/')
 
-    # It'd be better to implement URI-to-IRI decoding, see #19508.
     return path_info.decode(UTF_8)
 
 
@@ -236,7 +235,6 @@ def get_script_name(environ):
     else:
         script_name = get_bytes_from_wsgi(environ, 'SCRIPT_NAME', '')
 
-    # It'd be better to implement URI-to-IRI decoding, see #19508.
     return script_name.decode(UTF_8)
 
 

--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -173,11 +173,11 @@ URL from an IRI_ -- very loosely speaking, a URI_ that can contain Unicode
 characters. Quoting and converting an IRI to URI can be a little tricky, so
 Django provides some assistance.
 
-* The function ``django.utils.encoding.iri_to_uri()`` implements the
-  conversion from IRI to URI as required by the specification (:rfc:`3987`).
+* The function :meth:`django.utils.encoding.iri_to_uri()` implements the
+  conversion from IRI to URI as required by the specification (:rfc:`3987#section-3.1`).
 
-* The functions ``django.utils.http.urlquote()`` and
-  ``django.utils.http.urlquote_plus()`` are versions of Python's standard
+* The functions :meth:`django.utils.http.urlquote()` and
+  :meth:`django.utils.http.urlquote_plus()` are versions of Python's standard
   ``urllib.quote()`` and ``urllib.quote_plus()`` that work with non-ASCII
   characters. (The data is converted to UTF-8 prior to encoding.)
 
@@ -213,12 +213,33 @@ you can construct your IRI without worrying about whether it contains
 non-ASCII characters and then, right at the end, call ``iri_to_uri()`` on the
 result.
 
-The ``iri_to_uri()`` function is also idempotent, which means the following is
-always true::
+Similarly, Django provides :meth:`django.utils.encoding.uri_to_iri()` which
+implements the conversion from URI to IRI as per :rfc:`3987#section-3.2`.
+Some percent-encodings are necessary to distinguish percent-encoded and
+unencoded uses of reserved characters. Also some percent-encodings cannot be
+interpreted as sequences of UTF-8 octets.
+
+It converts all percent encodings to corresponding ASCII octets and then
+repercents those which are not valid utf-8 sequence.
+
+An example to demonstrate::
+
+    >>> uri_to_iri('/%E2%99%A5%E2%99%A5/?utf8=%E2%9C%93').decode('utf-8')
+    '/♥♥/?utf8=✓'
+    >>> uri_to_iri('%A9helloworld').decode('utf-8')
+    '%A9helloworld'
+
+In the first example, the proper utf-8 characters and reserved characters got
+unquoted. In the second, the percent-encoding remains unchanged because it
+lies outside the valid utf-8 range.
+
+Both ``iri_to_uri()`` and ``uri_to_iri()`` functions are idempotent, which means the
+following is always true::
 
     iri_to_uri(iri_to_uri(some_string)) = iri_to_uri(some_string)
+    uri_to_iri(uri_to_iri(some_string)) = uri_to_iri(some_string)
 
-So you can safely call it multiple times on the same IRI without risking
+So you can safely call it multiple times on the same URI/IRI without risking
 double-quoting problems.
 
 .. _URI: http://www.ietf.org/rfc/rfc2396.txt

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -271,7 +271,20 @@ The functions defined in this module share the following properties:
     since we are assuming input is either UTF-8 or unicode already, we can
     simplify things a little from the full method.
 
-    Returns an ASCII string containing the encoded result.
+    Takes an IRI in UTF-8 bytes and returns ASCII bytes containing the encoded
+    result.
+
+.. function:: uri_to_iri(uri)
+
+    .. versionadded:: 1.8
+
+    Converts a Uniform Resource Identifier into an Internationalized Resource
+    Idenifier.
+
+    This is an algorithm from section 3.2 of :rfc:`3987#section-3.2`.
+
+    Takes a URI in ASCII bytes and returns UTF-8 bytes containing the encoded
+    result.
 
 .. function:: filepath_to_uri(path)
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -244,6 +244,9 @@ Requests and Responses
   This brings this class into line with the documentation and with
   ``WSGIRequest``.
 
+* ``WSGIRequestHandler`` now follows RFC in converting URI to IRI, using
+  ``uri_to_iri()``.
+
 Tests
 ^^^^^
 

--- a/tests/text/tests.py
+++ b/tests/text/tests.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from django.utils.encoding import iri_to_uri, force_text
+from django.utils.encoding import force_text
 from django.utils.functional import lazy
 from django.utils.http import (cookie_date, http_date,
     urlquote, urlquote_plus, urlunquote, urlunquote_plus)
@@ -89,17 +89,3 @@ class TextTests(TestCase):
     def test_http_date(self):
         t = 1167616461.0
         self.assertEqual(http_date(t), 'Mon, 01 Jan 2007 01:54:21 GMT')
-
-    def test_iri_to_uri(self):
-        self.assertEqual(iri_to_uri('red%09ros\xe9#red'),
-            'red%09ros%C3%A9#red')
-
-        self.assertEqual(iri_to_uri('/blog/for/J\xfcrgen M\xfcnster/'),
-            '/blog/for/J%C3%BCrgen%20M%C3%BCnster/')
-
-        self.assertEqual(iri_to_uri('locations/%s' % urlquote_plus('Paris & Orl\xe9ans')),
-            'locations/Paris+%26+Orl%C3%A9ans')
-
-    def test_iri_to_uri_idempotent(self):
-        self.assertEqual(iri_to_uri(iri_to_uri('red%09ros\xe9#red')),
-            'red%09ros%C3%A9#red')

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -6,7 +6,8 @@ import datetime
 
 from django.utils import six
 from django.utils.encoding import (force_bytes, force_text, filepath_to_uri,
-        python_2_unicode_compatible)
+        iri_to_uri, uri_to_iri, python_2_unicode_compatible)
+from django.utils.http import urlquote_plus
 
 
 class TestEncodingUtils(unittest.TestCase):
@@ -39,15 +40,77 @@ class TestEncodingUtils(unittest.TestCase):
         today = datetime.date.today()
         self.assertEqual(force_bytes(today, strings_only=True), today)
 
-    def test_filepath_to_uri(self):
-        self.assertEqual(filepath_to_uri('upload\\чубака.mp4'),
-            'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
-        self.assertEqual(filepath_to_uri('upload\\чубака.mp4'.encode('utf-8')),
-            'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
-
     @unittest.skipIf(six.PY3, "tests a class not defining __str__ under Python 2")
     def test_decorated_class_without_str(self):
         with self.assertRaises(ValueError):
             @python_2_unicode_compatible
             class NoStr(object):
                 pass
+
+
+class TestRFC3987IEncodingUtils(unittest.TestCase):
+
+    def test_filepath_to_uri(self):
+        self.assertEqual(filepath_to_uri('upload\\чубака.mp4'),
+            'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
+        self.assertEqual(filepath_to_uri('upload\\чубака.mp4'.encode('utf-8')),
+            'upload/%D1%87%D1%83%D0%B1%D0%B0%D0%BA%D0%B0.mp4')
+
+    def test_iri_to_uri(self):
+        cases = [
+            # Valid UTF-8 sequences are encoded.
+            ('red%09rosé#red', 'red%09ros%C3%A9#red'),
+            ('/blog/for/Jürgen Münster/', '/blog/for/J%C3%BCrgen%20M%C3%BCnster/'),
+            ('locations/%s' % urlquote_plus('Paris & Orléans'), 'locations/Paris+%26+Orl%C3%A9ans'),
+
+            # Reserved chars remain unescaped.
+            ('%&', '%&'),
+            ('red&♥ros%#red', 'red&%E2%99%A5ros%#red'),
+        ]
+
+        for iri, uri in cases:
+            self.assertEqual(iri_to_uri(iri), uri)
+
+            # Test idempotency.
+            self.assertEqual(iri_to_uri(iri_to_uri(iri)), uri)
+
+    def test_uri_to_iri(self):
+        cases = [
+            # Valid UTF-8 sequences are decoded.
+            ('/%E2%99%A5%E2%99%A5/', '/♥♥/'),
+            ('/%E2%99%A5%E2%99%A5/?utf8=%E2%9C%93', '/♥♥/?utf8=✓'),
+
+            # Broken UTF-8 sequences remain escaped.
+            ('/%AAd%AAj%AAa%AAn%AAg%AAo%AA/', '/%AAd%AAj%AAa%AAn%AAg%AAo%AA/'),
+            ('/%E2%99%A5%E2%E2%99%A5/', '/♥%E2♥/'),
+            ('/%E2%99%A5%E2%99%E2%99%A5/', '/♥%E2%99♥/'),
+            ('/%E2%E2%99%A5%E2%99%A5%99/', '/%E2♥♥%99/'),
+            ('/%E2%99%A5%E2%99%A5/?utf8=%9C%93%E2%9C%93%9C%93', '/♥♥/?utf8=%9C%93✓%9C%93'),
+        ]
+
+        for uri, iri in cases:
+            iri = iri.encode('utf-8')
+
+            self.assertEqual(uri_to_iri(uri), iri)
+
+            # Test idempotency.
+            self.assertEqual(uri_to_iri(uri_to_iri(uri)), iri)
+
+    def test_complementarity(self):
+        cases = [
+            ('/blog/for/J%C3%BCrgen%20M%C3%BCnster/', '/blog/for/J\xfcrgen M\xfcnster/'),
+            ('%&', '%&'),
+            ('red&%E2%99%A5ros%#red', 'red&♥ros%#red'),
+            ('/%E2%99%A5%E2%99%A5/', '/♥♥/'),
+            ('/%E2%99%A5%E2%99%A5/?utf8=%E2%9C%93', '/♥♥/?utf8=✓'),
+            ('/%AAd%AAj%AAa%AAn%AAg%AAo%AA/', '/%AAd%AAj%AAa%AAn%AAg%AAo%AA/'),
+            ('/%E2%99%A5%E2%E2%99%A5/', '/♥%E2♥/'),
+            ('/%E2%99%A5%E2%99%E2%99%A5/', '/♥%E2%99♥/'),
+            ('/%E2%E2%99%A5%E2%99%A5%99/', '/%E2♥♥%99/'),
+            ('/%E2%99%A5%E2%99%A5/?utf8=%9C%93%E2%9C%93%9C%93', '/♥♥/?utf8=%9C%93✓%9C%93'),
+        ]
+
+        for uri, iri in cases:
+            iri = iri.encode('utf-8')
+            self.assertEqual(iri_to_uri(uri_to_iri(uri)), uri)
+            self.assertEqual(uri_to_iri(iri_to_uri(iri)), iri)


### PR DESCRIPTION
This is a PR for ticket #19508 for which another PR #2919 was opened by me a few days ago.
This PR implements `uri_to_iri` as per RFC and changes the `PATH_INFO` at the very time when `environ` is being set contrary to the previous one which corrected the received url from `environ`.
