### PR TITLE
Replace instances of 'his/her' with 'their'

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -261,8 +261,8 @@ class PasswordResetForm(forms.Form):
 
 class SetPasswordForm(forms.Form):
     """
-    A form that lets a user change set his/her password without entering the
-    old password
+    A form that lets a user change set their password without entering the old
+    password
     """
     error_messages = {
         'password_mismatch': _("The two password fields didn't match."),
@@ -296,8 +296,8 @@ class SetPasswordForm(forms.Form):
 
 class PasswordChangeForm(SetPasswordForm):
     """
-    A form that lets a user change his/her password by entering
-    their old password.
+    A form that lets a user change their password by entering their old
+    password.
     """
     error_messages = dict(SetPasswordForm.error_messages, **{
         'password_incorrect': _("Your old password was entered incorrectly. "

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -308,7 +308,7 @@ class PermissionsMixin(models.Model):
     groups = models.ManyToManyField(Group, verbose_name=_('groups'),
         blank=True, help_text=_('The groups this user belongs to. A user will '
                                 'get all permissions granted to each of '
-                                'his/her group.'),
+                                'their group.'),
         related_name="user_set", related_query_name="user")
     user_permissions = models.ManyToManyField(Permission,
         verbose_name=_('user permissions'), blank=True,
@@ -320,7 +320,7 @@ class PermissionsMixin(models.Model):
 
     def get_group_permissions(self, obj=None):
         """
-        Returns a list of permission strings that this user has through his/her
+        Returns a list of permission strings that this user has through their
         groups. This method queries all available auth backends. If an object
         is passed in, only permissions matching this object are returned.
         """

--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -228,7 +228,7 @@ another committer, **before** you commit it in the first place!
 
 When a mistaken commit is discovered, please follow these guidelines:
 
-* If possible, have the original author revert his/her own commit.
+* If possible, have the original author revert their own commit.
 
 * Don't revert another author's changes without permission from the
   original author.

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -168,7 +168,7 @@ Methods
 
     .. method:: get_group_permissions(obj=None)
 
-        Returns a set of permission strings that the user has, through his/her
+        Returns a set of permission strings that the user has, through their
         groups.
 
         If ``obj`` is passed in, only returns the group permissions for

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -819,7 +819,7 @@ methods and attributes:
 
     .. method:: models.PermissionsMixin.get_group_permissions(obj=None)
 
-        Returns a set of permission strings that the user has, through his/her
+        Returns a set of permission strings that the user has, through their
         groups.
 
         If ``obj`` is passed in, only returns the group permissions for

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1225,7 +1225,7 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
 
 .. class:: SetPasswordForm
 
-    A form that lets a user change his/her password without entering the old
+    A form that lets a user change their password without entering the old
     password.
 
 .. class:: UserChangeForm
@@ -1243,7 +1243,7 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
 Authentication data in templates
 --------------------------------
 
-The currently logged-in user and his/her permissions are made available in the
+The currently logged-in user and their permissions are made available in the
 :doc:`template context </ref/templates/api>` when you use
 :class:`~django.template.RequestContext`.
 


### PR DESCRIPTION
The his/her construct is, I'm sure we can all agree, nightmarish. It's awkward to read and it's almost impossible to speak aloud. It's also exclusionary and reinforces the idea of a first and second gender.

The contribution guidelines say that if it's anything but a typo, I should file a bug. In this case, it does appear that this is on the level of typo; there are currently no instances of 'he/she' or 'his/hers' in Django, and there are already a decent number of instances of singular 'they', so I'm confident this is not a policy issue. Just in case I'm wrong about that, though, here's a conservative hunt for some examples:

```
$ ack --type-set=po:ext:po --type=nopo "user's" -C 3 | grep their
django/contrib/auth/__init__.py:107:    Removes the authenticated user's ID from the request and flushes their
docs/ref/contrib/csrf.txt-12-who visits the malicious site in their browser.  A related type of attack,
docs/ref/middleware.txt:203:Allows a user's sessions to be invalidated when their password changes. See
docs/releases/1.2-alpha-1.txt-394-malicious site in their browser. A related type of attack, 'login
docs/releases/1.2.txt-147-who visits the malicious site in their browser. A related type of attack, "login
docs/topics/auth/default.txt:114:Changing a user's password will log out all their sessions if the
docs/topics/auth/default.txt-924-    Allows a user to reset their password by generating a one-time use link
docs/topics/i18n/timezones.txt-180-they use the time zone of their primary audience or UTC. pytz_ provides
docs/topics/templates.txt-440-what would happen if the user entered their name as this::
```

Sorry about the .po files; I couldn't find anything in https://docs.djangoproject.com/en/dev/internals/contributing/ about how to run makemessages against django itself.
