### PR TITLE
When RemoteUser authentication fails, logout any user

### DIFF
--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -99,6 +99,12 @@ class RemoteUserMiddleware(object):
             # by logging the user in.
             request.user = user
             auth.login(request, user)
+        else:
+            # the attempt to login the user failed, so we logout any existing user.
+            # this can occur when the User is authenticated by the external system
+            # (e.g. AD server), but is not in the user database and the backend's
+            # create_unknown_user==False.
+            auth.logout(request)
 
     def clean_username(self, username, request):
         """


### PR DESCRIPTION
Currently, when `remoteUserBackend` fails to authenticate the
username passed in the header, and `create_unknown_user==False`,
`RemoteUserMiddleware` does nothing. Thus, if a different user
was logged in, that user will remain logged in despite the failed
attempt to log in a new user.

This is a security issue.

We fix this problem by logging out the request if the user returned
by the middleware is None (a failed login attempt).
