### PR TITLE
Warning to reader that the regex capture group name has changed

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -233,6 +233,8 @@ First, open the ``polls/urls.py`` URLconf and change it like so:
         url(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
     ]
 
+Notice that the name of the matched pattern in the regex has changed from <poll_id> to <pk>.
+
 .. _tutorial04-amend-views:
 
 Amend views


### PR DESCRIPTION
The snippet doesn't make it obvious that the capture group has changed (it was poll_id earlier in the tutorial), and it's easy to be distracted by the other changes in the line and miss this.

It's common enough that there's even a StackOverflow question about it:
http://stackoverflow.com/questions/12304050/django-tutorial-generic-views-attribute-error
