### PR TITLE
Migration operation docs fixes

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -115,7 +115,8 @@ AlterModelOptions
 
 Stores changes to miscellaneous model options (settings on a model's ``Meta``)
 like ``permissions`` and ``verbose_name``. Does not affect the database, but
-persists these changes for :class:`RunPython` instances to use.
+persists these changes for :class:`RunPython` instances to use. ``options``
+should be a dict mapping option names to values.
 
 AddField
 --------


### PR DESCRIPTION
Change a couple of the class names to match their relevant subheadings, and add a sentence to AlterModelOptions to clarify that the options argument is a dict.
