### PR TITLE
Improved docs for GEOSGeometry.simplify()

### DIFF
--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -440,17 +440,16 @@ topological relationship between this geometry and the other.
 
 .. method:: GEOSGeometry.simplify(tolerance=0.0, preserve_topology=False)
 
-Returns a new :class:`GEOSGeometry`, simplified using the Douglas-Peucker
-algorithm to the specified tolerance.  A higher tolerance value implies
-less points in the output.  If no tolerance is tolerance provided,
-it defaults to 0.
+Returns a new :class:`GEOSGeometry`, simplified to the specified tolerance,
+using the Douglas-Peucker algorithm. A higher tolerance value implies
+fewer points in the output. If no tolerance is provided, it defaults to 0.
 
-By default, this function does not preserve topology - e.g.,
-:class:`Polygon` objects can be split, collapsed into lines or disappear.
-:class:`Polygon` holes can be created or disappear, and lines can cross.
+By default, this function does not preserve topology. For example,
+:class:`Polygon` objects can be split, be collapsed into lines or disappear.
+:class:`Polygon` holes can be created or disappear, and lines may cross.
 By specifying ``preserve_topology=True``, the result will have the same
-dimension and number of components as the input, however, this is
-significantly slower.
+dimension and number of components as the input; this is significantly 
+slower, however.
 
 .. method:: GEOSGeometry.sym_difference(other)
 


### PR DESCRIPTION
Minor grammatical improvements, and one fixed typo ("tolerance is tolerance").
