### PR TITLE
Fixed #23088 -- Used `six` `range` type in `Paginator.page_range`.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -96,7 +96,7 @@ class Paginator(object):
         Returns a 1-based range of pages for iterating through within
         a template for loop.
         """
-        return range(1, self.num_pages + 1)
+        return six.moves.range(1, self.num_pages + 1)
     page_range = property(_get_page_range)
 
 

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -232,6 +232,13 @@ class PaginationTests(unittest.TestCase):
         self.assertEqual(page2.previous_page_number(), 1)
         self.assertIsNone(page2.next_page_number())
 
+    def test_page_range_type(self):
+        """
+        Ticket #23088: Paginator.page_range is of inconsistent type in Py2/Py3
+        """
+        paginator = Paginator([1, 2, 3], 2)
+        self.assertEqual(type(paginator.page_range), six.moves.range)
+
 
 class ModelPaginationTests(TestCase):
     """


### PR DESCRIPTION
Thanks Keryn Knight for the report.
