### PR TITLE
fixed #22873 -- rename use_debug_cursor to force_debug_cursor to clarify...

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -45,7 +45,7 @@ class BaseDatabaseWrapper(object):
         self.alias = alias
         # Query logging in debug mode or when explicitly enabled.
         self.queries_log = deque(maxlen=self.queries_limit)
-        self.use_debug_cursor = False
+        self.force_debug_cursor = False
 
         # Transaction related attributes.
         # Tracks if the connection is in autocommit mode. Per PEP 249, by
@@ -75,7 +75,7 @@ class BaseDatabaseWrapper(object):
 
     @property
     def queries_logged(self):
-        return self.use_debug_cursor or settings.DEBUG
+        return self.force_debug_cursor or settings.DEBUG
 
     @property
     def queries(self):

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -507,15 +507,15 @@ class CaptureQueriesContext(object):
         return self.connection.queries[self.initial_queries:self.final_queries]
 
     def __enter__(self):
-        self.use_debug_cursor = self.connection.use_debug_cursor
-        self.connection.use_debug_cursor = True
+        self.force_debug_cursor = self.connection.force_debug_cursor
+        self.connection.force_debug_cursor = True
         self.initial_queries = len(self.connection.queries_log)
         self.final_queries = None
         request_started.disconnect(reset_queries)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.connection.use_debug_cursor = self.use_debug_cursor
+        self.connection.force_debug_cursor = self.force_debug_cursor
         request_started.connect(reset_queries)
         if exc_type is not None:
             return


### PR DESCRIPTION
rename use_debug_cursor to force_debug_cursor to clarify the private API behaviour
