### PR TITLE
[1.6.x] Fixed #20292: Pass datetime objects (not formatted dates) as par...

### DIFF
--- a/docs/releases/1.6.6.txt
+++ b/docs/releases/1.6.6.txt
@@ -26,3 +26,7 @@ Bugfixes
 * Fixed transaction handling when specifying non-default database in
   ``createcachetable`` and ``flush``
   (`#23089 <https://code.djangoproject.com/ticket/23089>`_).
+
+* Fixed the "ORA-01843: not a valid month" errors when using Unicode
+  with older versions of Oracle server
+  (`#20292 <https://code.djangoproject.com/ticket/20292>`_).

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -61,6 +61,12 @@ class BooleanModel(models.Model):
     bfield = models.BooleanField(default=None)
     string = models.CharField(max_length=10, default='abc')
 
+class DateTimeModel(models.Model):
+    d = models.DateField()
+    dt = models.DateTimeField()
+    t = models.TimeField()
+
+
 class FksToBooleans(models.Model):
     """Model wih FKs to models with {Null,}BooleanField's, #15040"""
     bf = models.ForeignKey(BooleanModel)

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -20,7 +20,7 @@ from django.utils import unittest
 
 from .models import (Foo, Bar, Whiz, BigD, BigS, Image, BigInt, Post,
     NullBooleanModel, BooleanModel, DataModel, Document, RenamedField,
-    VerboseNameField, FksToBooleans)
+    DateTimeModel, VerboseNameField, FksToBooleans)
 
 
 class BasicFieldTests(test.TestCase):
@@ -153,6 +153,17 @@ class DateTimeFieldTests(unittest.TestCase):
                          datetime.time(1, 2, 3, 4))
         self.assertEqual(f.to_python('01:02:03.999999'),
                          datetime.time(1, 2, 3, 999999))
+
+    def test_datetimes_save_completely(self):
+        dat = datetime.date(2014, 3, 12)
+        datetim = datetime.datetime(2014, 3, 12, 21, 22, 23, 240000)
+        tim = datetime.time(21, 22, 23, 240000)
+        DateTimeModel.objects.create(d=dat, dt=datetim, t=tim)
+        obj = DateTimeModel.objects.first()
+        self.assertTrue(obj)
+        self.assertEqual(obj.d, dat)
+        self.assertEqual(obj.dt, datetim)
+        self.assertEqual(obj.t, tim)
 
 class BooleanFieldTests(unittest.TestCase):
     def _test_get_db_prep_lookup(self, f):


### PR DESCRIPTION
...ams to Oracle

This seems worthwhile in its own right, but also works around an Oracle
bug (in versions 10 -- 11.1) where the use of Unicode would reset the
date/time formats, causing ORA-01843 errors.

Thanks Trac users CarstenF for the report, jtiai for the initial patch,
and everyone who contributed to the discussion on the ticket.

Backport of 6983201 from master.
