### PR TITLE
Fixed #17638 -- Improve navigation between CBV pages

### DIFF
--- a/docs/ref/class-based-views/index.txt
+++ b/docs/ref/class-based-views/index.txt
@@ -2,8 +2,11 @@
 Class-based views
 =================
 
-Class-based views API reference. For introductory material, see
-:doc:`/topics/class-based-views/index`.
+Class-based views API reference.
+
+.. seealso::
+
+  For introductory material, see :doc:`/topics/class-based-views/index`.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -6,9 +6,10 @@ The Forms API
 
 .. admonition:: About this document
 
-    This document covers the gritty details of Django's forms API. You should
-    read the :doc:`introduction to working with forms </topics/forms/index>`
-    first.
+    This document covers the gritty details of Django's forms API.
+
+.. seealso::
+    For introductory material about forms, see :doc:`/topics/forms/index`.
 
 .. _ref-forms-api-bound-unbound:
 

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -2,6 +2,9 @@
 Form fields
 ===========
 
+.. seealso::
+    For introductory material about forms, see :doc:`/topics/forms/index`.
+
 .. module:: django.forms.fields
    :synopsis: Django's built-in form fields.
 

--- a/docs/ref/forms/formsets.txt
+++ b/docs/ref/forms/formsets.txt
@@ -2,6 +2,9 @@
 Formset Functions
 ====================
 
+.. seealso::
+    For introductory material about formsets, see :doc:`/topics/forms/formsets`.
+
 .. module:: django.forms.formsets
    :synopsis: Django's functions for building formsets.
 

--- a/docs/ref/forms/index.txt
+++ b/docs/ref/forms/index.txt
@@ -2,7 +2,10 @@
 Forms
 =====
 
-Detailed form API reference. For introductory material, see :doc:`/topics/forms/index`.
+Detailed form API reference.
+
+.. seealso::
+    For introductory material, see :doc:`/topics/forms/index`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -2,6 +2,9 @@
 Model Form Functions
 ====================
 
+.. seealso::
+    For introductory material about model forms, see :doc:`/topics/forms/modelforms`.
+
 .. module:: django.forms.models
    :synopsis: Django's functions for building model forms and formsets.
 

--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -5,6 +5,9 @@
 Form and field validation
 =========================
 
+.. seealso::
+    For introductory material about forms, see :doc:`/topics/forms/index`.
+
 Form validation happens when the data is cleaned. If you want to customize
 this process, there are various places you can change, each one serving a
 different purpose. Three types of cleaning methods are run during form

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -2,6 +2,9 @@
 Widgets
 =======
 
+.. seealso::
+    For introductory material about forms, see :doc:`/topics/forms/index`.
+
 .. module:: django.forms.widgets
    :synopsis: Django's built-in form widgets.
 

--- a/docs/ref/models/index.txt
+++ b/docs/ref/models/index.txt
@@ -2,7 +2,10 @@
 Models
 ======
 
-Model API reference. For introductory material, see :doc:`/topics/db/models`.
+Model API reference.
+
+.. seealso::
+    For introductory material, see :doc:`/topics/db/models`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/topics/class-based-views/index.txt
+++ b/docs/topics/class-based-views/index.txt
@@ -8,8 +8,12 @@ an example of some classes which can be used as views. These allow you
 to structure your views and reuse code by harnessing inheritance and
 mixins. There are also some generic views for simple tasks which we'll
 get to later, but you may want to design your own structure of
-reusable views which suits your use case. For full details, see the
-:doc:`class-based views reference documentation</ref/class-based-views/index>`.
+reusable views which suits your use case.
+
+.. seealso::
+
+    For more details and api documentation, see the :doc:`class-based views
+    reference documentation</ref/class-based-views/index>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -2,6 +2,9 @@
 Models
 ======
 
+.. seealso::
+    For api documentation about models, see :doc:`/ref/models/index`.
+
 .. module:: django.db.models
 
 A model is the single, definitive source of information about your data. It

--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -7,8 +7,12 @@ Working with forms
 .. admonition:: About this document
 
     This document provides an introduction to the basics of web forms and how
-    they are handled in Django. For a more detailed look at specific areas of
-    the forms API, see :doc:`/ref/forms/api`, :doc:`/ref/forms/fields`, and
+    they are handled in Django.
+
+.. seealso::
+
+    For a more detailed look at specific areas of the forms API, see
+    :doc:`/ref/forms/api`, :doc:`/ref/forms/fields`, and
     :doc:`/ref/forms/validation`.
 
 Unless you're planning to build Web sites and applications that do nothing but


### PR DESCRIPTION
Added "see also" blocks for navigation between introduction
and api reference of class based views.

Thanks to mcintyre94 who provide the initial patch.
