### PR TITLE
FIXED #12810: return validation error if a registered table name is used for m2m fields

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -148,6 +148,8 @@ Related Fields
 * **fields.E338**: The intermediary model ``<through model>`` has no field
   ``<field name>``.
 * **fields.E339**: ``<model>.<field name>`` is not a foreign key to ``<model>``.
+* **fields.E340**: Field is using a table that has already been registered
+  by ``<model>``.
 * **fields.W340**: ``null`` has no effect on ``ManyToManyField``.
 * **fields.W341**: ``ManyToManyField`` does not support ``validators``.
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/12810

Description: Throw an error with the checks framework when m2m fields are configured to use a table that is already registered.
