### PR TITLE
Fixed #23114 -- Templates variables unclear information

### DIFF
--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -95,8 +95,7 @@ Use a dot (``.``) to access attributes of a variable.
     following lookups, in this order:
 
     * Dictionary lookup
-    * Attribute lookup
-    * Method call
+    * Attribute lookup and Method call
     * List-index lookup
 
     This can cause some unexpected behavior with objects that override


### PR DESCRIPTION
  Added accurate information about the way and order of
  evaluation in variable templates of the form "X.Y".
