### PR TITLE
Adds 'true' and 'false' to `NullBooleanField`.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -753,13 +753,15 @@ class NullBooleanField(BooleanField):
     def to_python(self, value):
         """
         Explicitly checks for the string 'True' and 'False', which is what a
-        hidden field will submit for True and False, and for '1' and '0', which
-        is what a RadioField will submit. Unlike the Booleanfield we need to
-        explicitly check for True, because we are not using the bool() function
+        hidden field will submit for True and False, for 'true' and 'false',
+        which are likely to be returned by JavaScript serializations of forms,
+        and for '1' and '0', which is what a RadioField will submit. Unlike
+        the Booleanfield we need to explicitly check for True, because we are
+        not using the bool() function
         """
-        if value in (True, 'True', '1'):
+        if value in (True, 'True', 'true', '1'):
             return True
-        elif value in (False, 'False', '0'):
+        elif value in (False, 'False', 'false', '0'):
             return False
         else:
             return None

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -1000,6 +1000,8 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(None, f.clean('2'))
         self.assertEqual(None, f.clean('3'))
         self.assertEqual(None, f.clean('hello'))
+        self.assertEqual(True, f.clean('true'))
+        self.assertEqual(False, f.clean('false'))
 
     def test_nullbooleanfield_2(self):
         # Make sure that the internal value is preserved if using HiddenInput (#7753)


### PR DESCRIPTION
JavaScript serializations of forms will sometimes render the boolean values as the strings 'true' and 'false', in lower case. Rather than repeat boilerplate in the JavaScript to circumvent this, it seems reasonable to allow Django to understand the lower-case versions of the booleans.

Related to [ticket 23129](https://code.djangoproject.com/ticket/23129)
