### PR TITLE
Update base.py

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -367,7 +367,7 @@ class BaseCommand(object):
 
             # self.stderr is not guaranteed to be set here
             stderr = getattr(self, 'stderr', OutputWrapper(sys.stderr, self.style.ERROR))
-            stderr.write('%s: %s' % (e.__class__.__name__, e))
+            stderr.write(u'%s: %s' % (e.__class__.__name__, e))
             sys.exit(1)
 
     def execute(self, *args, **options):


### PR DESCRIPTION
  File "python2.7/site-packages/django/core/management/base.py", line 229, in run_from_argv
    s = '%s: %s' % (e.**class**.**name**, e)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-11: ordinal not in range(128)

Thanks @  angelo-peng
