### PR TITLE
[1.7.x] Fixed #23159 -- Skipped non-conrete fields in migrations.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -169,6 +169,8 @@ class ModelState(object):
                 continue
             if isinstance(field, OrderWrt):
                 continue
+            if field not in model._meta.concrete_fields:
+                continue
             name, path, args, kwargs = field.deconstruct()
             field_class = import_string(path)
             try:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23159

It makes sense to skip non-concrete fields in the migrations framework.
Otherwise IMHO the way django 1.7 would treat these non-concrete fields would be really inconsistent (sad). It slighlty differs already from django models than django model forms (which is daunting), and it would differ in a new way in the migration framework (not nice at all).
I hope you can consider these points in this new awsome feature that is the migration framework. I'm pretty sure one of these two solutions won't break existing tests and would ensure maximum compatibility, hence benefit future django versions lot.
