### PR TITLE
Fixed #23183 - Use timestamp when uploading duplicate filenames

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -319,6 +319,9 @@ FILE_UPLOAD_PERMISSIONS = None
 # see http://docs.python.org/lib/os-file-dir.html.
 FILE_UPLOAD_DIRECTORY_PERMISSIONS = None
 
+# Whether to append timestamp to duplicate filenames during the upload.
+FILE_UPLOAD_USETIME_DUPLICATE = True
+
 # Python module path where user will place custom format definition.
 # The directory where this setting is pointing should contain subdirectories
 # named as the locales, containing a formats.py file

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1317,6 +1317,21 @@ example, this will default to '/tmp' on \*nix-style operating systems.
 
 See :doc:`/topics/files` for details.
 
+.. setting:: FILE_UPLOAD_USETIME_DUPLICATE
+
+FILE_UPLOAD_USETIME_DUPLICATE
+-----------------------------
+
+.. versionadded:: 1.8
+
+Default: ``False``
+
+The mode to decide how to determine the new uploaded filename when a file with the same
+name already exists in the storage.
+
+If :setting:`FILE_UPLOAD_USETIME_DUPLICATE` is set to ``True``, then
+the current timestamp will be appended to the filename.
+
 .. setting:: FIRST_DAY_OF_WEEK
 
 FIRST_DAY_OF_WEEK

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -130,7 +130,10 @@ File Storage
 File Uploads
 ^^^^^^^^^^^^
 
-* ...
+* The new :setting:`FILE_UPLOAD_USETIME_DUPLICATE` setting controls if we
+  use the standard incremental method to determine the new filename or instead
+  we append a timestamp to the original filename.
+
 
 Forms
 ^^^^^


### PR DESCRIPTION
related to https://code.djangoproject.com/ticket/23183
