### PR TITLE
Fixed #21231 -- Added mechanism to limit request data upload size.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -305,6 +305,11 @@ FILE_UPLOAD_HANDLERS = (
 # file system instead of into memory.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
+# Maximum size in bytes of request data before a SuspiciousOperation will
+# be raised.  This applies to accessing request.body and also to any
+# data in form data requests, excluding file uploads.
+DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
+
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory
 # (i.e. "/tmp" on *nix systems).

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -12,7 +12,7 @@ import cgi
 import sys
 
 from django.conf import settings
-from django.core.exceptions import SuspiciousMultipartForm
+from django.core.exceptions import SuspiciousMultipartForm, SuspiciousOperation
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_text
 from django.utils import six
@@ -101,6 +101,11 @@ class MultiPartParser(object):
         self._content_length = content_length
         self._upload_handlers = upload_handlers
 
+        # Limit the maximum request data size that will be parsed and stored in
+        # memory. File upload data is not included against this limit.
+        self._max_data_size = settings.DATA_UPLOAD_MAX_MEMORY_SIZE
+        self._data_size = 0
+
     def parse(self):
         """
         Parse the POST data and break it into a FILES MultiValueDict and a POST
@@ -163,15 +168,24 @@ class MultiPartParser(object):
                 field_name = force_text(field_name, encoding, errors='replace')
 
                 if item_type == FIELD:
+                    # avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
+                    if self._max_data_size is not None:
+                        read_kwargs = {'size': self._max_data_size - self._data_size}
+                    else:
+                        read_kwargs = {}
                     # This is a post field, we can just set it in the post
                     if transfer_encoding == 'base64':
-                        raw_data = field_stream.read()
+                        raw_data = field_stream.read(**read_kwargs)
                         try:
                             data = base64.b64decode(raw_data)
                         except _BASE64_DECODE_ERROR:
                             data = raw_data
                     else:
-                        data = field_stream.read()
+                        data = field_stream.read(**read_kwargs)
+
+                    self._data_size += len(data)
+                    if self._max_data_size is not None and field_stream.read(1):
+                        raise SuspiciousOperation('Request data too large')
 
                     self._post.appendlist(field_name,
                                           force_text(data, encoding, errors='replace'))

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -854,6 +854,23 @@ TEST_TBLSPACE_TMP
     Use the :setting:`TBLSPACE_TMP <TEST_TBLSPACE_TMP>` entry in the
     :setting:`TEST <DATABASE-TEST>` dictionary.
 
+.. setting:: DATA_UPLOAD_MAX_MEMORY_SIZE
+
+DATA_UPLOAD_MAX_MEMORY_SIZE
+---------------------------
+
+.. versionadded:: 1.8
+
+Default: ``2621440`` (i.e. 2.5 MB).
+
+The maximum size (in bytes) that a request body may be before raising a
+:exc:`~django.core.exceptions.SuspiciousOperation` error. This value is applied
+when accessing ``request.body`` or ``request.POST`` and is calculated against
+the total request size excluding any file upload data. You can set it to
+``None`` to disable the check.
+
+See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
+
 .. setting:: DATABASE_ROUTERS
 
 DATABASE_ROUTERS
@@ -1254,6 +1271,8 @@ Default: ``2621440`` (i.e. 2.5 MB).
 
 The maximum size (in bytes) that an upload will be before it gets streamed to
 the file system. See :doc:`/topics/files` for details.
+
+See also :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE`.
 
 .. setting:: FILE_UPLOAD_DIRECTORY_PERMISSIONS
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -446,6 +446,14 @@ run this query::
             last_login=models.F('date_joined')
         ).update(last_login=None)
 
+Maximum size of a request body is now limited
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
+request body may be before raising a
+:exc:`~django.core.exceptions.SuspiciousOperation` error. See its documentation
+for more details.
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -710,6 +710,72 @@ class HostValidationTests(SimpleTestCase):
         )
 
 
+class DataUploadMaxMemorySizeGetTests(SimpleTestCase):
+
+    def _test_data_upload_max_memory_size_exceeded(self, content_length_header):
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'GET',
+            'wsgi.input': BytesIO(b''),
+            content_length_header: 3,
+        })
+
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=2):
+            with self.assertRaisesMessage(SuspiciousOperation, 'Request data too large'):
+                request.body
+
+        # no problem for body <= DATA_UPLOAD_MAX_MEMORY_SIZE
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=3):
+            request.body
+
+        # After a successful read, attributes on request are cached so need to
+        # create a new one.
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'GET',
+            'wsgi.input': BytesIO(b''),
+            content_length_header: 3,
+        })
+
+        # ... or DATA_UPLOAD_MAX_MEMORY_SIZE=None
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=None):
+            request.body
+
+    def test_data_upload_max_memory_size_exceeded_http_content_length(self):
+        self._test_data_upload_max_memory_size_exceeded('HTTP_CONTENT_LENGTH')
+
+    def test_data_upload_max_memory_size_exceeded_content_length(self):
+        self._test_data_upload_max_memory_size_exceeded('CONTENT_LENGTH')
+
+class DataUploadMaxMemorySizePostTests(SimpleTestCase):
+    def setUp(self):
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="name"',
+            '',
+            'value',
+            '--boundary--'
+            ''
+        ]))
+        self.request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+
+    def test_size_exceeded(self):
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=4):
+            with self.assertRaisesMessage(SuspiciousOperation, 'Request data too large'):
+                self.request._load_post_and_files()
+
+    def test_size_not_exceeded(self):
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=5):
+            self.request._load_post_and_files()
+
+    def test_no_limit(self):
+        with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=None):
+            self.request._load_post_and_files()
+
+
 class BuildAbsoluteURITestCase(SimpleTestCase):
     """
     Regression tests for ticket #18314.


### PR DESCRIPTION
Added settings.DATA_UPLOAD_MAX_MEMORY_SIZE, similar to the existing
FILE_UPLOAD_MAX_MEMORY_SIZE, and raised SuspiciousOperation on
requests that exceed it.
