### PR TITLE
Removed code that assumed BooleanField could be null.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -997,8 +997,7 @@ class BooleanField(Field):
         # Unlike most fields, BooleanField figures out include_blank from
         # self.null instead of self.blank.
         if self.choices:
-            include_blank = (self.null or
-                             not (self.has_default() or 'initial' in kwargs))
+            include_blank = not (self.has_default() or 'initial' in kwargs)
             defaults = {'choices': self.get_choices(include_blank=include_blank)}
         else:
             defaults = {'form_class': forms.BooleanField}

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -259,9 +259,6 @@ class BooleanFieldTests(unittest.TestCase):
         formfield with the blank option (#9640, #10549).
         """
         choices = [(1, 'Si'), (2, 'No')]
-        f = models.BooleanField(choices=choices, default=1, null=True)
-        self.assertEqual(f.formfield().choices, [('', '---------')] + choices)
-
         f = models.BooleanField(choices=choices, default=1, null=False)
         self.assertEqual(f.formfield().choices, choices)
 


### PR DESCRIPTION
Such a field will no longer pass model validation.
