### PR TITLE
Fixed #23130 -- BooleanField should not override 'blank' if choices are specified

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -933,7 +933,8 @@ class BooleanField(Field):
     description = _("Boolean (Either True or False)")
 
     def __init__(self, *args, **kwargs):
-        kwargs['blank'] = True
+        if 'choices' not in kwargs:
+            kwargs['blank'] = True
         super(BooleanField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -363,6 +363,19 @@ class BooleanFieldTests(unittest.TestCase):
         self.assertIsNone(nb.nbfield)
         nb.save()           # no error
 
+    def test_blank_override(self):
+        """
+        Check that a BooleanField doesn't override 'blank' when
+        choices are used. (#23130)
+        """
+        # Ensure that when choices are specified, blank is not overridden
+        choices = [(True, "Special True"), (False, "Special False")]
+        f = models.BooleanField(choices=choices)
+        self.assertEqual(f.blank, False)
+        # Ensure that when choices are not specified, blank is overridden
+        f = models.BooleanField()
+        self.assertEqual(f.blank, True)
+
 
 class ChoicesTests(test.TestCase):
     def test_choices_and_field_display(self):


### PR DESCRIPTION
- Blank override only occurs if choices are not specified.
- Wrote tests to check blank override with and without choices. 
