### PR TITLE
Fix for #22982

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -453,6 +453,9 @@ def create_generic_related_manager(superclass):
             )
         do_not_call_in_templates = True
 
+        def __str__(self):
+            return repr(self)
+
         def get_queryset(self):
             try:
                 return self.instance._prefetched_objects_cache[self.prefetch_cache_name]

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -260,3 +260,7 @@ class GenericRelationTests(TestCase):
         # where the pre_delete signal should fire and prevent deletion.
         with self.assertRaises(ProtectedError):
             related.delete()
+
+    def test_ticket_22982(self):
+        place = Place.objects.create(name='My Place')
+        str(place.links)


### PR DESCRIPTION
Here's a fix for https://code.djangoproject.com/ticket/22982

To fix I've fallen back to the `repr` method for `GenericRelatedObjectManager`s, as the `str` method results in an exception
