### PR TITLE
Fixed #23261 -- Deprecate old style list support for unordered_list

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -6,11 +6,13 @@ import random as random_module
 from decimal import Decimal, InvalidOperation, Context, ROUND_HALF_UP
 from functools import wraps
 from pprint import pformat
+import warnings
 
 from django.template.base import Variable, Library, VariableDoesNotExist
 from django.conf import settings
 from django.utils import formats
 from django.utils.dateformat import format, time_format
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.html import (conditional_escape, escapejs,
     escape, urlize as _urlize, linebreaks, strip_tags, avoid_wrapping,
@@ -705,6 +707,11 @@ def unordered_list(value, autoescape=None):
             i += 1
         return '\n'.join(output)
     value, converted = convert_old_style_list(value)
+    if converted:
+        warnings.warn(
+            "Old style lists conversion in `unordered_list` is deprecated and "
+            "will be removed in Django 2.0. Use the the new format instead.",
+            RemovedInDjango20Warning)
     return mark_safe(_helper(value))
 
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -42,6 +42,8 @@ about each item can often be found in the release notes of two versions prior.
 
 * The ``error_message`` argument of ``django.forms.RegexField`` will be removed.
 
+* The ``unordered_list`` filter will no longer convert old style lists.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2262,6 +2262,10 @@ contains ``['States', ['Kansas', ['Lawrence', 'Topeka'], 'Illinois']]``, then
 Note: An older, more restrictive and verbose input format is also supported:
 ``['States', [['Kansas', [['Lawrence', []], ['Topeka', []]]], ['Illinois', []]]]``,
 
+.. deprecated:: 2.0
+
+    Old style list conversion is deprecated and will be removed in Django 2.0
+
 .. templatefilter:: upper
 
 upper

--- a/tests/defaultfilters/tests.py
+++ b/tests/defaultfilters/tests.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import datetime
 import decimal
 import unittest
+import warnings
 
 from django.template.defaultfilters import (
     add, addslashes, capfirst, center, cut, date, default, default_if_none,
@@ -549,20 +550,23 @@ class DefaultFiltersTests(TestCase):
         self.assertEqual(unordered_list([a, b]), '\t<li>ulitem-a</li>\n\t<li>ulitem-b</li>')
 
         # Old format for unordered lists should still work
-        self.assertEqual(unordered_list(['item 1', []]), '\t<li>item 1</li>')
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
 
-        self.assertEqual(unordered_list(['item 1', [['item 1.1', []]]]),
-            '\t<li>item 1\n\t<ul>\n\t\t<li>item 1.1</li>\n\t</ul>\n\t</li>')
+            self.assertEqual(unordered_list(['item 1', []]), '\t<li>item 1</li>')
 
-        self.assertEqual(unordered_list(['item 1', [['item 1.1', []],
-            ['item 1.2', []]]]), '\t<li>item 1\n\t<ul>\n\t\t<li>item 1.1'
-            '</li>\n\t\t<li>item 1.2</li>\n\t</ul>\n\t</li>')
+            self.assertEqual(unordered_list(['item 1', [['item 1.1', []]]]),
+                '\t<li>item 1\n\t<ul>\n\t\t<li>item 1.1</li>\n\t</ul>\n\t</li>')
 
-        self.assertEqual(unordered_list(['States', [['Kansas', [['Lawrence',
-            []], ['Topeka', []]]], ['Illinois', []]]]), '\t<li>States\n\t'
-            '<ul>\n\t\t<li>Kansas\n\t\t<ul>\n\t\t\t<li>Lawrence</li>'
-            '\n\t\t\t<li>Topeka</li>\n\t\t</ul>\n\t\t</li>\n\t\t<li>'
-            'Illinois</li>\n\t</ul>\n\t</li>')
+            self.assertEqual(unordered_list(['item 1', [['item 1.1', []],
+                ['item 1.2', []]]]), '\t<li>item 1\n\t<ul>\n\t\t<li>item 1.1'
+                '</li>\n\t\t<li>item 1.2</li>\n\t</ul>\n\t</li>')
+
+            self.assertEqual(unordered_list(['States', [['Kansas', [['Lawrence',
+                []], ['Topeka', []]]], ['Illinois', []]]]), '\t<li>States\n\t'
+                '<ul>\n\t\t<li>Kansas\n\t\t<ul>\n\t\t\t<li>Lawrence</li>'
+                '\n\t\t\t<li>Topeka</li>\n\t\t</ul>\n\t\t</li>\n\t\t<li>'
+                'Illinois</li>\n\t</ul>\n\t</li>')
 
     def test_add(self):
         self.assertEqual(add('1', '2'), 3)


### PR DESCRIPTION
For some reason I cannot see the `.. deprecated:: 2.0` note in the docs. But they don't work for other deprecation notices either. Not sure what I'm doing wrong there.
