### PR TITLE
Fixed 20368 -- Make TECHNICAL_500 more resilient.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -309,7 +309,17 @@ class ExceptionReporter(object):
         frames = self.get_traceback_frames()
         for i, frame in enumerate(frames):
             if 'vars' in frame:
-                frame['vars'] = [(k, force_escape(pprint(v))) for k, v in frame['vars']]
+                vars = []
+                for k, v in frame['vars']:
+                    v = pprint(v)
+                    # The force_escape filter assume unicode, make sure that works
+                    if isinstance(v, six.binary_type):
+                        v = v.decode('utf-8', 'replace')  # don't choke on non-utf-8 input
+                    # You may be looking at large blobs of data, trim it
+                    if len(v) > 4096:
+                        v = '%s... <trimmed %d bytes string>' % (v[0:4096], len(v))
+                    vars.append((k, force_escape(v)))
+                frame['vars'] = vars
             frames[i] = frame
 
         unicode_hint = ''

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -302,6 +302,52 @@ class ExceptionReporterTests(TestCase):
         self.assertIn('<h2>Request information</h2>', html)
         self.assertIn('<p>Request data not supplied</p>', html)
 
+    def test_non_utf8_values_handling(self):
+        "Non-UTF-8 exceptions/values should not make the output generation choke."
+        try:
+            class NonUtf8Crap(Exception):
+                def __repr__(self):
+                    return b'EXC\xe9EXC'
+            somevar = b'VAL\xe9VAL'
+            raise NonUtf8Crap()
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn('VAL\\xe9VAL', html)
+        self.assertIn('EXC\\xe9EXC', html)
+
+    def test_unprintable_values_handling(self):
+        "Unprintable values should not make the output generation choke."
+        try:
+            class OomCrap(object):
+                def __repr__(self):
+                    raise MemoryError('OOM')
+            oomvalue = OomCrap()
+            raise ValueError()
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn('<td class="code"><pre>Error in formatting', html)
+
+    def test_too_large_values_handling(self):
+        "Large values should not create a large HTML."
+        large = 32 * 1024 * 1024
+        repr_of_str_adds = len(repr(''))
+        try:
+            class LargeCrap(object):
+                def __repr__(self):
+                    return repr('A' * large)
+            largevalue = LargeCrap()
+            raise ValueError()
+        except Exception:
+            exc_type, exc_value, tb = sys.exc_info()
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertEquals(len(html) // 1024 // 1024, 0)  # still fit in 1MB
+        self.assertIn('&lt;trimmed %d bytes string&gt;' % (large + repr_of_str_adds,), html)
+
     @skipIf(six.PY2, 'Bug manifests on PY3 only')
     def test_unfrozen_importlib(self):
         """


### PR DESCRIPTION
This limits large variables and non-utf-8 in the TECHNICAL_500 output.
