### PR TITLE
Fixed occasional selenium test failure on Jenkins with Chrome 36.

### DIFF
--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1079,7 +1079,7 @@ class RelatedFieldWidgetSeleniumFirefoxTests(AdminSeleniumWebDriverTestCase):
         # Click the Add User button to add new
         self.selenium.find_element_by_id('add_id_user').click()
         self.selenium.switch_to.window('id_user')
-        self.wait_page_loaded()
+        self.wait_for('#id_password')
         password_field = self.selenium.find_element_by_id('id_password')
         password_field.send_keys('password')
 


### PR DESCRIPTION
Previously find_element_by_id('id_password') on the next line failed with
NoSuchElementException and selenium.page_source was
<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body></body></html>.

Possibly related: https://code.google.com/p/selenium/issues/detail?id=1969.
