### PR TITLE
Fix #23291 -- Don't add Unicode varname/value to environment.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -380,7 +380,7 @@ class BaseCommand(object):
         if options.get('no_color'):
             self.style = no_style()
             self.stderr = OutputWrapper(options.get('stderr', sys.stderr))
-            os.environ["DJANGO_COLORS"] = "nocolor"
+            os.environ[str("DJANGO_COLORS")] = str("nocolor")
         else:
             self.stderr = OutputWrapper(options.get('stderr', sys.stderr), self.style.ERROR)
 


### PR DESCRIPTION
Windows doesn't like that and it's causes 114 failures in the
admin_scripts tests with Python 2.x.
