### PR TITLE
Fixes #23309 -- Fix call_command to parse args correctly

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -107,12 +107,9 @@ def call_command(name, *args, **options):
                            for s_opt in parser._actions if s_opt.option_strings)
         arg_options = dict((opt_mapping.get(key, key), value) for key, value in options.items())
         defaults = parser.parse_args(args=args)
-        # Move positional args out of options to mimic legacy optparse
-        if 'args' in defaults:
-            args = defaults.args
-        else:
-            args = ()
         defaults = dict(defaults._get_kwargs(), **arg_options)
+        # Move positional args out of options to mimic legacy optparse
+        args = defaults.pop('args', ())
     else:
         # Legacy optparse method
         defaults, _ = parser.parse_args(args=[])

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -350,11 +350,7 @@ class BaseCommand(object):
             options = parser.parse_args(argv[2:])
             cmd_options = vars(options)
             # Move positional args out of options to mimic legacy optparse
-            if 'args' in options:
-                args = options.args
-                del cmd_options['args']
-            else:
-                args = ()
+            args = cmd_options.pop('args', ())
         else:
             options, args = parser.parse_args(argv[2:])
             cmd_options = vars(options)

--- a/tests/user_commands/management/commands/hal.py
+++ b/tests/user_commands/management/commands/hal.py
@@ -13,13 +13,11 @@ class Command(BaseCommand):
     def handle(self, *app_labels, **options):
         app_labels = set(app_labels)
 
-        self.empty = options.get('empty', False)
-
-        if self.empty:
+        if options['empty']:
             self.stdout.write("Dave, I can't do that.")
             return
 
-        if not app_labels and not options.get('help', False):
+        if not app_labels:
             raise CommandError("I'm sorry Dave, I'm afraid I can't do that.")
 
         # raise an error if some --parameter is flowing from options to args
@@ -27,4 +25,4 @@ class Command(BaseCommand):
             if app_label.startswith('--'):
                 raise CommandError("Sorry, Dave, I can't let you do that.")
 
-        self.stdout.write("Dave, I can't do that.")
+        self.stdout.write("Dave, my mind is going. I can feel it. I can feel it.")

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -112,6 +112,7 @@ class CommandTests(SimpleTestCase):
         out = StringIO()
         with self.assertRaises(SystemExit):
             management.call_command('hal', "--help", stdout=out)
+        self.assertIn("", out.getvalue())
 
     def test_calling_a_command_with_only_empty_parameter_should_ends_gracefyully(self):
         out = StringIO()
@@ -121,12 +122,12 @@ class CommandTests(SimpleTestCase):
     def test_calling_command_with_app_labels_and_parameters_should_be_ok(self):
         out = StringIO()
         management.call_command('hal', 'myapp', "--verbosity", "3", stdout=out)
-        self.assertIn("Dave, I can't do that.\n", out.getvalue())
+        self.assertIn("Dave, my mind is going. I can feel it. I can feel it.\n", out.getvalue())
 
     def test_calling_command_with_parameters_and_app_labels_at_the_end_should_be_ok(self):
         out = StringIO()
         management.call_command('hal', "--verbosity", "3", "myapp", stdout=out)
-        self.assertIn("Dave, I can't do that.\n", out.getvalue())
+        self.assertIn("Dave, my mind is going. I can feel it. I can feel it.\n", out.getvalue())
 
     def test_calling_a_command_with_no_app_labels_and_parameters_should_raise_a_command_error(self):
         out = StringIO()


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/23309 (and https://code.djangoproject.com/ticket/23306)
