### PR TITLE
Fixed #23316 -- Supported 'datetime.time' in migrations.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ answer newbie questions, and generally made Django that much better:
     Mark Biggers <biggers@utsl.com>
     Paul Bissex <http://e-scribe.com/>
     Loïc Bistuer <loic.bistuer@sixmedia.com>
+    Lee Sanghyuck <shlee322@elab.kr>
     Simon Blanchard
     Jérémie Blaser <blaserje@gmail.com>
     Craig Blaszczyk <masterjakul@gmail.com>

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -279,6 +279,10 @@ class MigrationWriter(object):
             if isinstance(value, datetime_safe.date):
                 value_repr = "datetime.%s" % value_repr
             return value_repr, set(["import datetime"])
+        # Times
+        elif isinstance(value, datetime.time):
+            value_repr = repr(value)
+            return value_repr, set(["import datetime"])
         # Settings references
         elif isinstance(value, SettingsReference):
             return "settings.%s" % value.setting_name, set(["from django.conf import settings"])

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -240,6 +240,8 @@ Models
   Django uses whenever objects are loaded using the ORM. The method allows
   customizing model loading behavior.
 
+* Supported "datetime.time" in migrations.
+
 Signals
 ^^^^^^^
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -7,6 +7,8 @@ Migrations
 
 .. versionadded:: 1.7
 
+.. versionchanged:: 1.8
+
 Migrations are Django's way of propagating changes you make to your models
 (adding a field, deleting a model, etc.) into your database schema. They're
 designed to be mostly automatic, but you'll need to know when to make
@@ -524,7 +526,7 @@ Django can serialize the following:
 
 - ``int``, ``long``, ``float``, ``bool``, ``str``, ``unicode``, ``bytes``, ``None``
 - ``list``, ``set``, ``tuple``, ``dict``
-- ``datetime.date`` and ``datetime.datetime`` instances
+- ``datetime.date``, ``datetime.time``, ``datetime.datetime`` instances
 - ``decimal.Decimal`` instances
 - Any Django field
 - Any function or method reference (e.g. ``datetime.datetime.today``)

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -95,6 +95,7 @@ class WriterTests(TestCase):
         self.assertSerializedEqual(datetime.datetime.today)
         self.assertSerializedEqual(datetime.date.today())
         self.assertSerializedEqual(datetime.date.today)
+        self.assertSerializedEqual(datetime.datetime.now().time())
         with self.assertRaises(ValueError):
             self.assertSerializedEqual(datetime.datetime(2012, 1, 1, 1, 1, tzinfo=get_default_timezone()))
         safe_date = datetime_safe.date(2014, 3, 31)


### PR DESCRIPTION
I found migrations does supports datetime.datime and datetime.date but not datetime.time. 
example:

```
class TestModel(models.Model):
    open_time = models.TimeField(default=datetime.time(11, 0))   # Error
```

So I create datetime.time support patch and attach here. (Github Pull Request)
