### PR TITLE
RedirectResponse option to check the host of the url

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -418,6 +418,9 @@ class HttpResponseRedirectBase(HttpResponse):
         parsed = urlparse(force_text(redirect_to))
         if parsed.scheme and parsed.scheme not in self.allowed_schemes:
             raise DisallowedRedirect("Unsafe redirect to URL with protocol '%s'" % parsed.scheme)
+        if kwargs.get('strict_host', False) and not settings.DEBUG \
+           and parsed.netloc and parsed.netloc not in settings.ALLOWED_HOSTS:
+            raise SuspiciousOperation("Unsafe redirect to URL with host '%s'" % parsed.netloc)
         super(HttpResponseRedirectBase, self).__init__(*args, **kwargs)
         self['Location'] = iri_to_uri(redirect_to)
 

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -788,6 +788,10 @@ types of HTTP responses. Like ``HttpResponse``, these subclasses live in
     domain (e.g. ``'/search/'``). See :class:`HttpResponse` for other optional
     constructor arguments. Note that this returns an HTTP status code 302.
 
+    Option ``strict_host`` will check the host is one of the ``ALLOWED_HOSTS``.
+    Useful for making sure a redirect will remain only within the website.
+    Default=False
+
     .. attribute:: HttpResponseRedirect.url
 
         This read-only attribute represents the URL the response will redirect


### PR DESCRIPTION
Proposed addition.

When redirecting it's often useful to redirect to the 'next' url which is passed from the browser. This variable might be altered before it gets back to us and so we want to check that the host is a known local host and approved. Because we don't want this to be checked all the time, it's optional in the proposed code.
