### PR TITLE
Fixed #23329 -- Allowed to_field references from non-registered parent models.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -444,11 +444,13 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
             return False
 
         # Make sure at least one of the models registered for this site
-        # references this field.
+        # references this field through a FK or a M2M relationship.
         registered_models = self.admin_site._registry
-        for related_object in opts.get_all_related_objects():
-            if (related_object.model in registered_models and
-                    field in related_object.field.foreign_related_fields):
+        for related_object in (opts.get_all_related_objects() +
+                               opts.get_all_related_many_to_many_objects()):
+            related_model = related_object.model
+            if (any(issubclass(model, related_model) for model in registered_models) and
+                    related_object.field.rel.get_related_field() == field):
                 return True
 
         return False

--- a/docs/releases/1.4.15.txt
+++ b/docs/releases/1.4.15.txt
@@ -1,0 +1,13 @@
+===========================
+Django 1.4.15 release notes
+===========================
+
+*Under development*
+
+Django 1.4.15 fixes a regression in the 1.4.14 security release.
+
+Bugfixes
+========
+
+* Allowed inherited and m2m fields to be referenced in the admin
+  (`#22486 <http://code.djangoproject.com/ticket/23329>`_)

--- a/docs/releases/1.5.10.txt
+++ b/docs/releases/1.5.10.txt
@@ -1,0 +1,13 @@
+===========================
+Django 1.5.10 release notes
+===========================
+
+*Under development*
+
+Django 1.5.10 fixes a regression in the 1.5.9 security release.
+
+Bugfixes
+========
+
+* Allowed inherited and m2m fields to be referenced in the admin
+  (`#22486 <http://code.djangoproject.com/ticket/23329>`_)

--- a/docs/releases/1.6.7.txt
+++ b/docs/releases/1.6.7.txt
@@ -1,0 +1,13 @@
+==========================
+Django 1.6.7 release notes
+==========================
+
+*Under development*
+
+Django 1.6.7 fixes a regression in the 1.6.6 security release.
+
+Bugfixes
+========
+
+* Allowed inherited and m2m fields to be referenced in the admin
+  :ticket:`23329`

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -39,6 +39,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.6.7
    1.6.6
    1.6.5
    1.6.4
@@ -52,6 +53,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.5.10
    1.5.9
    1.5.8
    1.5.7
@@ -68,6 +70,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.4.15
    1.4.14
    1.4.13
    1.4.12

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -35,7 +35,8 @@ from .models import (Article, Chapter, Child, Parent, Picture, Widget,
     UnchangeableObject, UserMessenger, Simple, Choice, ShortMessage, Telegram,
     FilteredManager, EmptyModelHidden, EmptyModelVisible, EmptyModelMixin,
     State, City, Restaurant, Worker, ParentWithDependentChildren,
-    DependentChild, StumpJoke, FieldOverridePost, FunkyTag)
+    DependentChild, StumpJoke, FieldOverridePost, FunkyTag,
+    ReferencedByParent, ChildOfReferer, M2MReference)
 
 
 def callable_year(dt_value):
@@ -888,6 +889,9 @@ site.register(City, CityAdmin)
 site.register(Restaurant, RestaurantAdmin)
 site.register(Worker, WorkerAdmin)
 site.register(FunkyTag, FunkyTagAdmin)
+site.register(ReferencedByParent)
+site.register(ChildOfReferer)
+site.register(M2MReference)
 
 # We intentionally register Promo and ChapterXtra1 but not Chapter nor ChapterXtra2.
 # That way we cover all four cases:

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -822,3 +822,20 @@ class Worker(models.Model):
     work_at = models.ForeignKey(Restaurant)
     name = models.CharField(max_length=50)
     surname = models.CharField(max_length=50)
+
+
+# Models for #23329
+class ReferencedByParent(models.Model):
+    pass
+
+
+class ParentWithFK(models.Model):
+    fk = models.ForeignKey(ReferencedByParent)
+
+
+class ChildOfReferer(ParentWithFK):
+    pass
+
+
+class M2MReference(models.Model):
+    ref = models.ManyToManyField('self')

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -616,6 +616,15 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get("/test_admin/admin/admin_views/section/", {TO_FIELD_VAR: 'id'})
         self.assertEqual(response.status_code, 200)
 
+        # Specifying a field referenced by another model though a m2m should be allowed.
+        response = self.client.get("/test_admin/admin/admin_views/m2mreference/", {TO_FIELD_VAR: 'id'})
+        self.assertEqual(response.status_code, 200)
+
+        # Specifying a field that is not refered by any other model directly registered
+        # to this admin site but registered through inheritance should be allowed.
+        response = self.client.get("/test_admin/admin/admin_views/referencedbyparent/", {TO_FIELD_VAR: 'id'})
+        self.assertEqual(response.status_code, 200)
+
         # We also want to prevent the add and change view from leaking a
         # disallowed field value.
         with patch_logger('django.security.DisallowedModelAdminToField', 'error') as calls:


### PR DESCRIPTION
Thanks to Trac alias Markush2010 for the detailed report.
