### PR TITLE
Fixed #23341 -- Better stacktrace error for makemigrations

### DIFF
--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -35,11 +35,11 @@ class MigrationGraph(object):
     def add_node(self, node, implementation):
         self.nodes[node] = implementation
 
-    def add_dependency(self, child, parent):
+    def add_dependency(self, migration, child, parent):
         if child not in self.nodes:
-            raise KeyError("Dependency references nonexistent child node %r" % (child,))
+            raise KeyError("Migration %s dependencies references nonexistent child node %r" % (migration, child))
         if parent not in self.nodes:
-            raise KeyError("Dependency references nonexistent parent node %r" % (parent,))
+            raise KeyError("Migration %s dependencies references nonexistent parent node %r" % (migration, parent))
         self.dependencies.setdefault(child, set()).add(parent)
         self.dependents.setdefault(parent, set()).add(child)
 

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -230,7 +230,7 @@ class MigrationLoader(object):
                 if parent[0] != key[0] or parent[1] == '__first__':
                     # Ignore __first__ references to the same app (#22325)
                     continue
-                self.graph.add_dependency(key, parent)
+                self.graph.add_dependency(migration, key, parent)
         for key, migration in normal.items():
             for parent in migration.dependencies:
                 if parent[0] == key[0]:
@@ -238,11 +238,11 @@ class MigrationLoader(object):
                     continue
                 parent = self.check_key(parent, key[0])
                 if parent is not None:
-                    self.graph.add_dependency(key, parent)
+                    self.graph.add_dependency(migration, key, parent)
             for child in migration.run_before:
                 child = self.check_key(child, key[0])
                 if child is not None:
-                    self.graph.add_dependency(child, key)
+                    self.graph.add_dependency(migration, child, key)
 
     def detect_conflicts(self):
         """

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -156,8 +156,8 @@ class AutodetectorTests(TestCase):
         graph.add_node(("testapp", "0001_initial"), None)
         graph.add_node(("testapp", "0002_foobar"), None)
         graph.add_node(("otherapp", "0001_initial"), None)
-        graph.add_dependency(("testapp", "0002_foobar"), ("testapp", "0001_initial"))
-        graph.add_dependency(("testapp", "0002_foobar"), ("otherapp", "0001_initial"))
+        graph.add_dependency("testapp.0002_foobar", ("testapp", "0002_foobar"), ("testapp", "0001_initial"))
+        graph.add_dependency("testapp.0002_foobar", ("testapp", "0002_foobar"), ("otherapp", "0001_initial"))
         # Use project state to make a new migration change set
         before = self.make_project_state([])
         after = self.make_project_state([self.author_empty, self.other_pony, self.other_stable])

--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -23,11 +23,11 @@ class GraphTests(TestCase):
         graph.add_node(("app_a", "0004"), None)
         graph.add_node(("app_b", "0001"), None)
         graph.add_node(("app_b", "0002"), None)
-        graph.add_dependency(("app_a", "0004"), ("app_a", "0003"))
-        graph.add_dependency(("app_a", "0003"), ("app_a", "0002"))
-        graph.add_dependency(("app_a", "0002"), ("app_a", "0001"))
-        graph.add_dependency(("app_a", "0003"), ("app_b", "0002"))
-        graph.add_dependency(("app_b", "0002"), ("app_b", "0001"))
+        graph.add_dependency("app_a.0004", ("app_a", "0004"), ("app_a", "0003"))
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_a", "0002"))
+        graph.add_dependency("app_a.0002", ("app_a", "0002"), ("app_a", "0001"))
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_b", "0002"))
+        graph.add_dependency("app_b.0002", ("app_b", "0002"), ("app_b", "0001"))
         # Test root migration case
         self.assertEqual(
             graph.forwards_plan(("app_a", "0001")),
@@ -78,15 +78,15 @@ class GraphTests(TestCase):
         graph.add_node(("app_b", "0002"), None)
         graph.add_node(("app_c", "0001"), None)
         graph.add_node(("app_c", "0002"), None)
-        graph.add_dependency(("app_a", "0004"), ("app_a", "0003"))
-        graph.add_dependency(("app_a", "0003"), ("app_a", "0002"))
-        graph.add_dependency(("app_a", "0002"), ("app_a", "0001"))
-        graph.add_dependency(("app_a", "0003"), ("app_b", "0002"))
-        graph.add_dependency(("app_b", "0002"), ("app_b", "0001"))
-        graph.add_dependency(("app_a", "0004"), ("app_c", "0002"))
-        graph.add_dependency(("app_c", "0002"), ("app_c", "0001"))
-        graph.add_dependency(("app_c", "0001"), ("app_b", "0001"))
-        graph.add_dependency(("app_c", "0002"), ("app_a", "0002"))
+        graph.add_dependency("app_a.0004", ("app_a", "0004"), ("app_a", "0003"))
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_a", "0002"))
+        graph.add_dependency("app_a.0002", ("app_a", "0002"), ("app_a", "0001"))
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_b", "0002"))
+        graph.add_dependency("app_b.0002", ("app_b", "0002"), ("app_b", "0001"))
+        graph.add_dependency("app_a.0004", ("app_a", "0004"), ("app_c", "0002"))
+        graph.add_dependency("app_c.0002", ("app_c", "0002"), ("app_c", "0001"))
+        graph.add_dependency("app_c.0001", ("app_c", "0001"), ("app_b", "0001"))
+        graph.add_dependency("app_c.0002", ("app_c", "0002"), ("app_a", "0002"))
         # Test branch C only
         self.assertEqual(
             graph.forwards_plan(("app_c", "0002")),
@@ -123,11 +123,11 @@ class GraphTests(TestCase):
         graph.add_node(("app_a", "0003"), None)
         graph.add_node(("app_b", "0001"), None)
         graph.add_node(("app_b", "0002"), None)
-        graph.add_dependency(("app_a", "0003"), ("app_a", "0002"))
-        graph.add_dependency(("app_a", "0002"), ("app_a", "0001"))
-        graph.add_dependency(("app_a", "0001"), ("app_b", "0002"))
-        graph.add_dependency(("app_b", "0002"), ("app_b", "0001"))
-        graph.add_dependency(("app_b", "0001"), ("app_a", "0003"))
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_a", "0002"))
+        graph.add_dependency("app_a.0002", ("app_a", "0002"), ("app_a", "0001"))
+        graph.add_dependency("app_a.0001", ("app_a", "0001"), ("app_b", "0002"))
+        graph.add_dependency("app_b.0002", ("app_b", "0002"), ("app_b", "0001"))
+        graph.add_dependency("app_b.0001", ("app_b", "0001"), ("app_a", "0003"))
         # Test whole graph
         self.assertRaises(
             CircularDependencyError,
@@ -146,3 +146,28 @@ class GraphTests(TestCase):
 
         with self.assertRaisesMessage(ValueError, message):
             graph.backwards_plan(("app_b", "0001"))
+
+    def test_missing_parent_nodes(self):
+        """
+        Tests for missing parent nodes.
+        """
+        # Build graph
+        graph = MigrationGraph()
+        graph.add_node(("app_a", "0001"), None)
+        graph.add_node(("app_a", "0002"), None)
+        graph.add_node(("app_a", "0003"), None)
+        graph.add_node(("app_b", "0001"), None)
+        graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_a", "0002"))
+        graph.add_dependency("app_a.0002", ("app_a", "0002"), ("app_a", "0001"))
+        with self.assertRaisesMessage(KeyError, "Migration app_a.0001 dependencies references nonexistent parent node ('app_b', '0002')"):
+            graph.add_dependency("app_a.0001", ("app_a", "0001"), ("app_b", "0002"))
+
+    def test_missing_child_nodes(self):
+        """
+        Tests for missing child nodes.
+        """
+        # Build graph
+        graph = MigrationGraph()
+        graph.add_node(("app_a", "0001"), None)
+        with self.assertRaisesMessage(KeyError, "Migration app_a.0002 dependencies references nonexistent child node ('app_a', '0002')"):
+            graph.add_dependency("app_a.0002", ("app_a", "0002"), ("app_a", "0001"))


### PR DESCRIPTION
Show the migration display name when references
nonexistent migration(s)

Refs https://code.djangoproject.com/ticket/23341
