### PR TITLE
Fixed #13749 - Link from admin-site to site

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -41,6 +41,9 @@ class AdminSite(object):
     # Text to put at the top of the admin index page.
     index_title = ugettext_lazy('Site administration')
 
+    # Site URL used to display a view site link at the top of the admin page
+    site_url = '/'
+
     login_form = None
     index_template = None
     app_index_template = None
@@ -272,6 +275,7 @@ class AdminSite(object):
         return {
             'site_title': self.site_title,
             'site_header': self.site_header,
+            'site_url': self.site_url,
         }
 
     def password_change(self, request):

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -31,6 +31,9 @@
                 <strong>{% firstof user.get_short_name user.get_username %}</strong>.
             {% endblock %}
             {% block userlinks %}
+                {% if site_url %}
+                    <a href="{{ site_url }}">{% trans 'View site' %}</a> /
+                {% endif %}
                 {% url 'django-admindocs-docroot' as docsroot %}
                 {% if docsroot %}
                     <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2445,6 +2445,14 @@ Templates can override or extend base admin templates as described in
     The text to put at the end of each admin page's ``<title>`` (a string). By
     default, this is "Django site admin".
 
+.. attribute:: AdminSite.site_url
+
+    .. versionadded:: 1.8
+
+    Site link that will be displayed at the top of each admin page.
+    By default, site_url is ``/`` and will be display with the text ``View site``.
+    Set it to ``None`` to remove the link.
+
 .. attribute:: AdminSite.index_title
 
     .. versionadded:: 1.7

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -50,6 +50,10 @@ Minor features
 
 * The jQuery library embedded in the admin has been upgraded to version 1.11.1.
 
+* You can now implement :attr:`~django.contrib.admin.AdminSite.site_url` on a
+  custom :class:`~django.contrib.admin.AdminSite` in order to display a direct link
+  to the frontend site.
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -744,6 +744,16 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         color2_delete_log = LogEntry.objects.all()[0]
         self.assertEqual(color2_content_type, color2_delete_log.content_type)
 
+    def test_adminsite_display_site_url(self):
+        """
+        AdminSite should display link to frontend site 'View site'
+
+        Test for #13749
+        """
+        url = reverse('admin:index')
+        response = self.client.get(url)
+        self.assertContains(response, 'View site')
+
 
 @override_settings(TEMPLATE_DIRS=ADMIN_VIEW_TEMPLATES_DIR)
 class AdminCustomTemplateTests(AdminViewBasicTestCase):


### PR DESCRIPTION
Related to ticket https://code.djangoproject.com/ticket/13749
