### PR TITLE
[1.7.x] Fixed #23352 -- Added tests for MigrationGraph.{forwards,backwards}_plan

### DIFF
--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -133,3 +133,21 @@ class GraphTests(TestCase):
             CircularDependencyError,
             graph.forwards_plan, ("app_a", "0003"),
         )
+
+    def test_forwards_plan(self):
+        """
+        Tests for forwards_plan of nonexistent node.
+        """
+        # Build graph
+        graph = MigrationGraph()
+        with self.assertRaisesMessage(ValueError, "Node ('app_b', '0001') not a valid node") as ex:
+            graph.forwards_plan(("app_b", "0001"))
+
+    def test_backwards_plans(self):
+        """
+        Tests for backwards_plan of nonexistent node.
+        """
+        # Build graph
+        graph = MigrationGraph()
+        with self.assertRaisesMessage(ValueError, "Node ('app_b', '0001') not a valid node") as ex:
+            graph.backwards_plan(("app_b", "0001"))


### PR DESCRIPTION
Backports of eaf4ed0 from master
