### PR TITLE
makemessages -l takes a locale name, not a language code.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1257,10 +1257,9 @@ To create or update a message file, run this command::
 
     django-admin makemessages -l de
 
-...where ``de`` is the language code for the message file you want to create.
-The language code, in this case, is in :term:`locale format<locale name>`. For
-example, it's ``pt_BR`` for Brazilian Portuguese and ``de_AT`` for Austrian
-German.
+...where ``de`` is the locale name for the message file you want to create,
+in :term:`locale format<locale name>`. For example, ``pt_BR`` for Brazilian
+Portuguese, ``de_AT`` for Austrian German or ``id`` for Indonesian.
 
 The script should be run from one of two places:
 


### PR DESCRIPTION
Hi.  I'm new to translation in Django.  I read the docs for makemessage and had a lot of trouble getting translation on my web site to work properly.  It's only after a lot of messing around that I realised that makemessages should be passed a locale name not (as the docs say) a language code.

I added Indonesian as an example of where the locale code doesn't include a country code.  

I think no trac ticket needed, as there is no functionality change, and use of language code rather than locale name is a typo.
