### PR TITLE
Reverse MySQL type SHORT to a SmallIntegerField.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -178,6 +178,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_date_lookup_using_string = False
     can_introspect_binary_field = False
     can_introspect_boolean_field = False
+    can_introspect_small_integer_field = True
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
     allows_auto_pk_0 = False

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -21,7 +21,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         FIELD_TYPE.INT24: 'IntegerField',
         FIELD_TYPE.LONG: 'IntegerField',
         FIELD_TYPE.LONGLONG: 'BigIntegerField',
-        FIELD_TYPE.SHORT: 'IntegerField',
+        FIELD_TYPE.SHORT: 'SmallIntegerField',
         FIELD_TYPE.STRING: 'CharField',
         FIELD_TYPE.TIME: 'TimeField',
         FIELD_TYPE.TIMESTAMP: 'DateTimeField',

--- a/tests/introspection/models.py
+++ b/tests/introspection/models.py
@@ -11,6 +11,7 @@ class Reporter(models.Model):
     email = models.EmailField()
     facebook_user_id = models.BigIntegerField(null=True)
     raw_data = models.BinaryField(null=True)
+    small_int = models.SmallIntegerField()
 
     class Meta:
         unique_together = ('first_name', 'last_name')

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -59,7 +59,8 @@ class IntrospectionTests(TestCase):
             ['AutoField' if connection.features.can_introspect_autofield else 'IntegerField',
              'CharField', 'CharField', 'CharField',
              'BigIntegerField' if connection.features.can_introspect_big_integer_field else 'IntegerField',
-             'BinaryField' if connection.features.can_introspect_binary_field else 'TextField']
+             'BinaryField' if connection.features.can_introspect_binary_field else 'TextField',
+             'SmallIntegerField' if connection.features.can_introspect_small_integer_field else 'IntegerField']
         )
 
     # The following test fails on Oracle due to #17202 (can't correctly
@@ -80,7 +81,7 @@ class IntrospectionTests(TestCase):
         nullable_by_backend = connection.features.interprets_empty_strings_as_nulls
         self.assertEqual(
             [r[6] for r in desc],
-            [False, nullable_by_backend, nullable_by_backend, nullable_by_backend, True, True]
+            [False, nullable_by_backend, nullable_by_backend, nullable_by_backend, True, True, False]
         )
 
     # Regression test for #9991 - 'real' types in postgres


### PR DESCRIPTION
Fixes #23357
