### PR TITLE
Removed comment references to kwargs that don't exist

### DIFF
--- a/django/core/files/temp.py
+++ b/django/core/files/temp.py
@@ -28,10 +28,6 @@ if os.name == 'nt':
         """
         Temporary file object constructor that supports reopening of the
         temporary file in Windows.
-
-        Note that __init__() does not support the 'delete' keyword argument in
-        Python 2.6+, or the 'delete', 'buffering', 'encoding', or 'newline'
-        keyword arguments in Python 3.0+.
         """
         def __init__(self, mode='w+b', bufsize=-1, suffix='', prefix='',
                 dir=None):


### PR DESCRIPTION
The comment for the `__init__` function contained references to old kwargs which are no longer present, assigned, or checked for. This pull request simply updates that comment.
