### PR TITLE
Fixed #23368 -- Overhauled the Welsh formats.py file.

### DIFF
--- a/django/conf/locale/cy/formats.py
+++ b/django/conf/locale/cy/formats.py
@@ -5,20 +5,34 @@ from __future__ import unicode_literals
 
 # The *_FORMAT strings use the Django date format syntax,
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
-DATE_FORMAT = 'd F Y'
-TIME_FORMAT = 'g:i:s A'
-# DATETIME_FORMAT =
-# YEAR_MONTH_FORMAT =
-# MONTH_DAY_FORMAT =
-SHORT_DATE_FORMAT = 'j M Y'
-# SHORT_DATETIME_FORMAT =
-# FIRST_DAY_OF_WEEK =
+DATE_FORMAT = 'j F Y'                   # '25 Hydref 2006'
+TIME_FORMAT = 'P'                       # '2:30 y.b.'
+DATETIME_FORMAT = 'j F Y, P'            # '25 Hydref 2006, 2:30 y.b.'
+YEAR_MONTH_FORMAT = 'F Y'               # 'Hydref 2006'
+MONTH_DAY_FORMAT = 'j F'                # '25 Hydref'
+SHORT_DATE_FORMAT = 'd/m/Y'             # '25/10/2006'
+SHORT_DATETIME_FORMAT = 'd/m/Y P'       # '25/10/2006 2:30 y.b.'
+FIRST_DAY_OF_WEEK = 1                   # 'Dydd Llun'
 
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
 # see http://docs.python.org/library/datetime.html#strftime-strptime-behavior
-# DATE_INPUT_FORMATS =
-# TIME_INPUT_FORMATS =
-# DATETIME_INPUT_FORMATS =
-# DECIMAL_SEPARATOR =
-# THOUSAND_SEPARATOR =
-# NUMBER_GROUPING =
+DATE_INPUT_FORMATS = (
+    '%d/%m/%Y', '%d/%m/%y',             # '25/10/2006', '25/10/06'
+    )
+DATETIME_INPUT_FORMATS = (
+    '%Y-%m-%d %H:%M:%S',                # '2006-10-25 14:30:59'
+    '%Y-%m-%d %H:%M:%S.%f',             # '2006-10-25 14:30:59.000200'
+    '%Y-%m-%d %H:%M',                   # '2006-10-25 14:30'
+    '%Y-%m-%d',                         # '2006-10-25'
+    '%d/%m/%Y %H:%M:%S',                # '25/10/2006 14:30:59'
+    '%d/%m/%Y %H:%M:%S.%f',             # '25/10/2006 14:30:59.000200'
+    '%d/%m/%Y %H:%M',                   # '25/10/2006 14:30'
+    '%d/%m/%Y',                         # '25/10/2006'
+    '%d/%m/%y %H:%M:%S',                # '25/10/06 14:30:59'
+    '%d/%m/%y %H:%M:%S.%f',             # '25/10/06 14:30:59.000200'
+    '%d/%m/%y %H:%M',                   # '25/10/06 14:30'
+    '%d/%m/%y',                         # '25/10/06'
+)
+DECIMAL_SEPARATOR = '.'
+THOUSAND_SEPARATOR = ','
+NUMBER_GROUPING = 3


### PR DESCRIPTION
The only debatable thing here is setting FIRST_DAY_OF_WEEK to 1.
The only examples of calendars I can find in Welsh start on Monday,
for example, the calendar on S4C (the only all Welsh TV station).

http://www.s4c.co.uk/clic/c_clicschedule.shtml

Monday is also the first day of the week in modern en_GB usage,
though the formats.py file there doesn't yet reflect this.

For issue #23368.
