### PR TITLE
Fixed url of Django git repository.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -30,7 +30,7 @@ sample settings module that uses the SQLite database. To run the tests:
 
 .. code-block:: bash
 
-   $ git clone https://github.com:django/django.git django-repo
+   $ git clone https://github.com/django/django.git django-repo
    $ cd django-repo/tests
    $ PYTHONPATH=..:$PYTHONPATH ./runtests.py
 


### PR DESCRIPTION
The url for cloning Django in the instructions for running the unit tests
had a colon where it should have had a /.
