### PR TITLE
Fixed 23371 -- Changed en_GB first day of the week to Monday.

### DIFF
--- a/django/conf/locale/en_GB/formats.py
+++ b/django/conf/locale/en_GB/formats.py
@@ -12,7 +12,7 @@ YEAR_MONTH_FORMAT = 'F Y'               # 'October 2006'
 MONTH_DAY_FORMAT = 'j F'                # '25 October'
 SHORT_DATE_FORMAT = 'd/m/Y'             # '25/10/2006'
 SHORT_DATETIME_FORMAT = 'd/m/Y P'       # '25/10/2006 2:30 pm'
-FIRST_DAY_OF_WEEK = 0                   # Sunday
+FIRST_DAY_OF_WEEK = 1                   # Monday
 
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
 # see http://docs.python.org/library/datetime.html#strftime-strptime-behavior

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -533,6 +533,9 @@ Miscellaneous
 * When a dictionary setting is overridden in user settings, both dictionaries
   are merged by default. See :ref:`dictionary-settings`.
 
+* The ``en_GB`` locale now has Monday as the first day of the week, bringing
+  Django into line with Microsoft and Apple.
+
 .. _deprecated-features-1.8:
 
 Features deprecated in 1.8


### PR DESCRIPTION
There is occasional debate over this, but the normal week in the UK
runs Monday to Sunday.

For evidence - here's the calendar of the UK parliament:
http://services.parliament.uk/calendar/

And a couple of support threads suggesting Americans change their
locale to en_GB on Microsoft and Apple in order to get their calendars
to start the week on Monday:

http://answers.microsoft.com/en-us/winphone/forum/wp8-wpemail/how-do-i-change-the-first-day-of-the-week-in/37c27997-1a18-4e51-91b4-fe2b3cd26496
http://forums.macrumors.com/showthread.php?t=1460577
