### PR TITLE
Fixed #23349 -- Improved `RunPython` documentation.

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -241,10 +241,12 @@ ORM and/or python code for.
 
 If you're upgrading from South, this is basically the South pattern as an
 operation - one or two methods for forwards and backwards, with an ORM and
-schema operations available. You should be able to translate the ``orm.Model``
-or ``orm["appname", "Model"]`` references from South directly into
+schema operations available. Most of the time, you should be able to translate 
+the ``orm.Model`` or ``orm["appname", "Model"]`` references from South directly into
 ``apps.get_model("appname", "Model")`` references here and leave most of the
-rest of the code unchanged for data migrations.
+rest of the code unchanged for data migrations. However, ``apps`` will only have
+references to models in the current app unless migrations in other apps are
+added to the migration's dependecies.
 
 Much like :class:`RunSQL`, ensure that if you change schema inside here you're
 either doing it outside the scope of the Django model system (e.g. triggers)


### PR DESCRIPTION
Documented that the `apps` parameter is not the same as `orm` in South
Simplified language for `RunPython` as recommended in another pull request.
