### PR TITLE
Document correct kwarg for post_migrate signal

### DIFF
--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -487,7 +487,7 @@ Arguments sent with this signal:
     For example, the :mod:`django.contrib.auth` app only prompts to create a
     superuser when ``interactive`` is ``True``.
 
-``db``
+``using``
     The database alias used for synchronization. Defaults to the ``default``
     database.
 


### PR DESCRIPTION
@aaugustin changed the kwarg for the signal in https://github.com/django/django/commit/d562527a160f420c6af0d2736ad4e6c87b0d2ef1, and presumably overlooked to change the docs in this spot.
