### PR TITLE
Fixed #23370 -- defer() fails with inherited models

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ answer newbie questions, and generally made Django that much better:
     Ahmad Alhashemi <trans@ahmadh.com>
     Ahmad Al-Ibrahim
     ajs <adi@sieker.info>
+    Akis Kesoglou <akiskesoglou@gmail.com>
     alang@bright-green.com
     Alasdair Nicol <http://al.sdair.co.uk/>
     Albert Wang <aywang31@gmail.com>

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1343,12 +1343,12 @@ def get_klass_info(klass, max_depth=0, cur_depth=0, requested=None,
         init_list = []
         # Build the list of fields that *haven't* been requested
         for field, model in klass._meta.get_concrete_fields_with_model():
-            if field.name not in load_fields:
-                skip.add(field.attname)
-            elif from_parent and issubclass(from_parent, model.__class__):
+            if from_parent and model and issubclass(from_parent, model):
                 # Avoid loading fields already loaded for parent model for
                 # child models.
                 continue
+            elif field.name not in load_fields:
+                skip.add(field.attname)
             else:
                 init_list.append(field.attname)
         # Retrieve all the requested fields

--- a/docs/releases/1.6.7.txt
+++ b/docs/releases/1.6.7.txt
@@ -4,10 +4,13 @@ Django 1.6.7 release notes
 
 *Under development*
 
-Django 1.6.7 fixes a regression in the 1.6.6 security release.
+Django 1.6.7 fixes several bugs in 1.6.6, including a regression related to
+a security fix in that release.
 
 Bugfixes
 ========
 
 * Allowed inherited and m2m fields to be referenced in the admin
-  :ticket:`23329`
+  (:ticket:`23329`).
+* Fixed a crash when using `QuerySet.defer()` with `select_related()`
+  (:ticket:`23370`).

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -255,6 +255,41 @@ class ModelInheritanceTests(TestCase):
             1, lambda: ItalianRestaurant.objects.select_related("chef")[0].chef
         )
 
+    def test_select_related_defer(self):
+        # Related issue: #23370
+        
+        Restaurant.objects.create(
+            name="Demon Dogs",
+            address="944 W. Fullerton",
+            serves_hot_dogs=True,
+            serves_pizza=False,
+            rating=2
+        )
+        ItalianRestaurant.objects.create(
+            name="Ristorante Miron",
+            address="1234 W. Ash",
+            serves_hot_dogs=False,
+            serves_pizza=False,
+            serves_gnocchi=True,
+            rating=4,
+        )
+        
+        qs = (Restaurant.objects
+            .select_related("italianrestaurant")
+            .defer("italianrestaurant__serves_gnocchi")
+            .order_by("rating"))
+        
+        # Test that the field was actually defered
+        with self.assertNumQueries(2):
+            objs = list(qs.all())
+            self.assertTrue(objs[1].italianrestaurant.serves_gnocchi)
+        
+        # Test that model fields where assigned correct values
+        self.assertEqual(qs[0].name, 'Demon Dogs')
+        self.assertEqual(qs[0].rating, 2)
+        self.assertEqual(qs[1].italianrestaurant.name, 'Ristorante Miron')
+        self.assertEqual(qs[1].italianrestaurant.rating, 4)
+
     def test_mixin_init(self):
         m = MixinModel()
         self.assertEqual(m.other_attr, 1)


### PR DESCRIPTION
Related ticket: https://code.djangoproject.com/ticket/23370
