### PR TITLE
Fixed #23336 -- Added support to urlize for arbitrary link attributes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -521,6 +521,7 @@ answer newbie questions, and generally made Django that much better:
     Paul Collier <paul@paul-collier.com>
     Paul Collins <paul.collins.iii@gmail.com>
     Paul Lanier <planier@google.com>
+    Paul Logston <code@logston.me>
     Paul McLanahan <paul@mclanahan.net>
     Paul McMillan <Paul@McMillan.ws>
     Paulo Scardine <paulo@scardine.com.br>

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -232,7 +232,7 @@ def smart_urlquote(url):
     return force_text(url)
 
 
-def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
+def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False, extra_attrs=None):
     """
     Converts any URLs in text into clickable links.
 
@@ -248,11 +248,20 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
     If nofollow is True, the links will get a rel="nofollow" attribute.
 
     If autoescape is True, the link text and URLs will be autoescaped.
+
+    If given, extra_attrs should be a dictionary whose keys represent
+    link attributes and whose values represent the values of
+    the link attributes. The attribute-value pairs from the extra_attrs
+    dictionary will be applied to each link (with the exception of
+    the 'rel' attribute to email links) found in the given text.
     """
     def trim_url(x, limit=trim_url_limit):
         if limit is None or len(x) <= limit:
             return x
         return '%s...' % x[:max(0, limit - 3)]
+
+    extra_attrs = extra_attrs if extra_attrs else {}
+
     safe_input = isinstance(text, SafeData)
     words = word_split_re.split(force_text(text))
     for i, word in enumerate(words):
@@ -275,7 +284,8 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
 
             # Make URL we want to point to.
             url = None
-            nofollow_attr = ' rel="nofollow"' if nofollow else ''
+            if nofollow:
+                extra_attrs.update({'rel': 'nofollow'})
             if simple_url_re.match(middle):
                 url = smart_urlquote(middle)
             elif simple_url_2_re.match(middle):
@@ -287,15 +297,30 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
                 except UnicodeError:
                     continue
                 url = 'mailto:%s@%s' % (local, domain)
-                nofollow_attr = ''
+                if 'rel' in extra_attrs:
+                    del extra_attrs['rel']
 
             # Make link.
             if url:
+                # Build string of extra attributes.
+                extra_attrs_string = ''
+                if extra_attrs:
+                    extra_attrs_strings = []
+                    for attr_key, attr_value in extra_attrs.items():
+                        # escape attribute key and possibly attribute value
+                        # to avoid injecting malicious code.
+                        if autoescape and not isinstance(attr_value, SafeData):
+                            attr_value = escape(attr_value)
+                        extra_attrs_strings.append('%s="%s"' % (escape(attr_key), attr_value))
+                    extra_attrs_string = ' '.join(extra_attrs_strings)
+
                 trimmed = trim_url(middle)
                 if autoescape and not safe_input:
                     lead, trail = escape(lead), escape(trail)
                     url, trimmed = escape(url), escape(trimmed)
-                middle = '<a href="%s"%s>%s</a>' % (url, nofollow_attr, trimmed)
+                if extra_attrs_string:
+                    extra_attrs_string = ' ' + extra_attrs_string
+                middle = '<a href="%s"%s>%s</a>' % (url, extra_attrs_string, trimmed)
                 words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
             else:
                 if safe_input:

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -129,6 +129,14 @@ Minor features
 
 * ...
 
+:mod:`django.utils.html`
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* :func:`~django.utils.html.urlize` can now accept arbitrary attribute-value
+  pairs for inclusion in the links it creates.
+
+* ...
+
 Cache
 ^^^^^
 


### PR DESCRIPTION
Added support to urlize (django.utils.html.urlize) for arbitrary link
attributes. urlize can now accept a dictionary of attribute-value pairs
which will be converted into attribute-pairs within each link
created by urlize.
