### PR TITLE
Fixing bug in migrations.SeparateDatabaseAndState

### DIFF
--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -24,7 +24,7 @@ class SeparateDatabaseAndState(Operation):
         for database_operation in self.database_operations:
             to_state = from_state.clone()
             database_operation.state_forwards(app_label, to_state)
-            database_operation.database_forwards(self, app_label, schema_editor, from_state, to_state)
+            database_operation.database_forwards(app_label, schema_editor, from_state, to_state)
             from_state = to_state
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
@@ -36,7 +36,7 @@ class SeparateDatabaseAndState(Operation):
                 dbop.state_forwards(app_label, to_state)
             from_state = base_state.clone()
             database_operation.state_forwards(app_label, from_state)
-            database_operation.database_backwards(self, app_label, schema_editor, from_state, to_state)
+            database_operation.database_backwards(app_label, schema_editor, from_state, to_state)
 
     def describe(self):
         return "Custom state/database change combination"


### PR DESCRIPTION
The `migrations.SeparateDatabaseAndState` class currently appears to not work, which makes an ironic sort of sense, given https://code.djangoproject.com/ticket/22918

This patch fixes what seems to be an obvious error in the code, allowing the migration to actually run. Before this patch, attempting to use `migrations.SeparateDatabaseAndState` in a migration failed with the following traceback:

```
Creating test database for alias 'default'...
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/commands/test.py", line 50, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/commands/test.py", line 71, in execute
    super(Command, self).execute(*args, **options)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/commands/test.py", line 88, in handle
    failures = test_runner.run_tests(test_labels)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/test/runner.py", line 147, in run_tests
    old_config = self.setup_databases()
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/test/runner.py", line 109, in setup_databases
    return setup_databases(self.verbosity, self.interactive, **kwargs)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/test/runner.py", line 299, in setup_databases
    serialize=connection.settings_dict.get("TEST_SERIALIZE", True),
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/db/backends/creation.py", line 374, in create_test_db
    test_flush=True,
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/__init__.py", line 115, in call_command
    return klass.execute(*args, **defaults)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/core/management/commands/migrate.py", line 160, in handle
    executor.migrate(targets, plan, fake=options.get("fake", False))
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/db/migrations/executor.py", line 63, in migrate
    self.apply_migration(migration, fake=fake)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/db/migrations/executor.py", line 97, in apply_migration
    migration.apply(project_state, schema_editor)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/db/migrations/migration.py", line 107, in apply
    operation.database_forwards(self.app_label, schema_editor, project_state, new_state)
  File "/Users/dave/Workspace/crfs_products/venv/src/django/django/db/migrations/operations/special.py", line 27, in database_forwards
    database_operation.database_forwards(self, app_label, schema_editor, from_state, to_state)
TypeError: database_forwards() takes 5 positional arguments but 6 were given
```

This patch doesn't fix the related issue of no unit tests for `migrations.SeparateDatabaseAndState` (https://code.djangoproject.com/ticket/22918). I suspect that writing unit tests for DB migrations is rather specialised, so I'm assuming that the author of the new (and generally excellent) Django 1.7 migrations will handle this better than I could.
