### PR TITLE
Fixed ping_google command to use argsparse

### DIFF
--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -5,9 +5,8 @@ from django.contrib.sitemaps import ping_google
 class Command(BaseCommand):
     help = "Ping Google with an updated sitemap, pass optional url of sitemap"
 
+    def add_arguments(self, parser):
+		parser.add_argument('sitemap_url', nargs='?', default=None)
+
     def execute(self, *args, **options):
-        if len(args) == 1:
-            sitemap_url = args[0]
-        else:
-            sitemap_url = None
-        ping_google(sitemap_url=sitemap_url)
+        ping_google(sitemap_url=options['sitemap_url'])


### PR DESCRIPTION
Fixed ping_google command to use new argsparse model and be retrocompatible with old syntax
