### PR TITLE
Fixed #23397 -- Strip whitespace from base64 during chunking.

### DIFF
--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -148,7 +148,8 @@ File Storage
 File Uploads
 ^^^^^^^^^^^^
 
-* ...
+* Base64 encoded files in multipart form data can now safely include
+  whitespace.
 
 Forms
 ^^^^^

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -77,14 +77,14 @@ class FileUploadTests(TestCase):
 
             self.assertEqual(response.status_code, 200)
 
-    def _test_base64_upload(self, content):
+    def _test_base64_upload(self, content, encode=base64.b64encode):
         payload = client.FakePayload("\r\n".join([
             '--' + client.BOUNDARY,
             'Content-Disposition: form-data; name="file"; filename="test.txt"',
             'Content-Type: application/octet-stream',
             'Content-Transfer-Encoding: base64',
             '']))
-        payload.write(b"\r\n" + base64.b64encode(force_bytes(content)) + b"\r\n")
+        payload.write(b"\r\n" + encode(force_bytes(content)) + b"\r\n")
         payload.write('--' + client.BOUNDARY + '--\r\n')
         r = {
             'CONTENT_LENGTH': len(payload),
@@ -103,6 +103,10 @@ class FileUploadTests(TestCase):
 
     def test_big_base64_upload(self):
         self._test_base64_upload("Big data" * 68000)  # > 512Kb
+
+    def test_big_base64_newlines_upload(self):
+        self._test_base64_upload(
+            "Big data" * 68000, encode=base64.encodestring)
 
     def test_unicode_file_name(self):
         tdir = sys_tempfile.mkdtemp()


### PR DESCRIPTION
This insures the actual base64 content has a length a multiple of 4.
Also add a test case for the failure.
