### PR TITLE
Fixed #23396 -- Ensured ValueQuerySets are not checked by check_related_objects

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1049,6 +1049,15 @@ class QuerySet(object):
         """
         return self.query.has_filters()
 
+    def is_compatible_query_object_type(self, opts):
+        model = self.model
+        return (
+            model == opts.concrete_model or
+            opts.concrete_model in model._meta.get_parent_list() or
+            model in opts.get_parent_list()
+        )
+    is_compatible_query_object_type.queryset_only = True
+
 
 class InstanceCheckMeta(type):
     def __instancecheck__(self, instance):
@@ -1205,6 +1214,13 @@ class ValuesQuerySet(QuerySet):
             raise TypeError('Cannot use a multi-field %s as a filter value.'
                     % self.__class__.__name__)
         return self
+
+    def is_compatible_query_object_type(self, opts):
+        """
+        ValueQuerySets do not need to be checked for compatibility.
+        We trust that users of ValueQuerySets know what they are doing.
+        """
+        return True
 
 
 class ValuesListQuerySet(ValuesQuerySet):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1106,21 +1106,16 @@ class Query(object):
         Checks the type of object passed to query relations.
         """
         if field.rel:
-            # testing for iterable of models
-            if hasattr(value, '__iter__'):
-                # Check if the iterable has a model attribute, if so
-                # it is likely something like a QuerySet.
-                if hasattr(value, 'model') and hasattr(value.model, '_meta'):
-                    model = value.model
-                    if not (model == opts.concrete_model
-                            or opts.concrete_model in model._meta.get_parent_list()
-                            or model in opts.get_parent_list()):
-                        raise ValueError(
-                            'Cannot use QuerySet for "%s": Use a QuerySet for "%s".' %
-                            (model._meta.model_name, opts.object_name))
-                else:
-                    for v in value:
-                        self.check_query_object_type(v, opts)
+            # QuerySets implement `check_query_object_type` to determine
+            # compatibility with the given field.
+            if hasattr(value, 'is_compatible_query_object_type'):
+                if not value.is_compatible_query_object_type(opts):
+                    raise ValueError(
+                        'Cannot use QuerySet for "%s": Use a QuerySet for "%s".' %
+                        (value.model._meta.model_name, opts.object_name))
+            elif hasattr(value, '__iter__'):
+                for v in value:
+                    self.check_query_object_type(v, opts)
             else:
                 # expecting single model instance here
                 self.check_query_object_type(value, opts)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3465,6 +3465,14 @@ class RelatedLookupTypeTests(TestCase):
         with self.assertNumQueries(0):
             ObjectB.objects.filter(objecta__in=ObjectA.objects.all())
 
+    def test_values_queryset_lookup(self):
+        """
+        #23396 - Ensure ValueQuerySets are not checked for compatibility with the lookup field
+        """
+        self.assertQuerysetEqual(ObjectB.objects.filter(
+            objecta__in=ObjectB.objects.all().values_list('pk')
+        ).order_by('pk'), ['<ObjectB: ob>', '<ObjectB: pob>'])
+
 
 class Ticket14056Tests(TestCase):
     def test_ticket_14056(self):


### PR DESCRIPTION
Renamed method for checking compatibility

Renamed method from check_query_object_type to is_compatible_query_object_type
to avoid conflict with Query.check_query_object_type. The notation is
more appropriate given the nature of the method returning a Boolean.

Added is_compatible_query_object_type to basic.tests.ManagerTest.QUERYSET_PROXY_METHODS

Ensured QuerySet.is_compatible_query_object_type isn't copied to Manager

Removed ticket reference, refactored logic in QuerySet.is_compatible_query_object_type

Removed intermediate variable from test

Added ticket reference in test comment

Fixed Test
