### PR TITLE
Fixed #23416 -- Make sure DatabaseCreation respects checks.

### DIFF
--- a/django/db/backends/creation.py
+++ b/django/db/backends/creation.py
@@ -77,7 +77,10 @@ class BaseDatabaseCreation(object):
         pending_references = {}
         qn = self.connection.ops.quote_name
         for f in opts.local_fields:
-            col_type = f.db_type(connection=self.connection)
+            db_params = f.db_parameters(connection=self.connection)
+            col_type = db_params['type']
+            if db_params['check']:
+                col_type = '%s CHECK (%s)' % (col_type, db_params['check'])
             col_type_suffix = f.db_type_suffix(connection=self.connection)
             tablespace = f.db_tablespace or opts.db_tablespace
             if col_type is None:

--- a/tests/commands_sql/models.py
+++ b/tests/commands_sql/models.py
@@ -8,3 +8,4 @@ class Comment(models.Model):
 class Book(models.Model):
     title = models.CharField(max_length=100, db_index=True)
     comments = models.ManyToManyField(Comment)
+    counter = models.PositiveIntegerField()

--- a/tests/commands_sql/tests.py
+++ b/tests/commands_sql/tests.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import unittest
 import re
 
 from django.apps import apps
@@ -42,6 +43,18 @@ class SQLCommandsTestCase(TestCase):
         self.assertEqual(tables, {
             'commands_sql_comment', 'commands_sql_book', 'commands_sql_book_comments'
         })
+
+    @unittest.skipUnless('PositiveIntegerField' in connections[DEFAULT_DB_ALIAS].creation.data_type_check_constraints, 'Backend does not have checks.')
+    def test_sql_create_check(self):
+        """Regression test for #23416 -- Check that db_params['check'] is respected."""
+        app_config = apps.get_app_config('commands_sql')
+        output = sql_create(app_config, no_style(), connections[DEFAULT_DB_ALIAS])
+        success = False
+        for statement in output:
+            if 'CHECK' in statement:
+                success = True
+        if not success:
+            self.fail("'CHECK' not found in ouput %s" % output)
 
     def test_sql_delete(self):
         app_config = apps.get_app_config('commands_sql')


### PR DESCRIPTION
Migrations respected `Field.db_parameters()['check']`, but DatabaseCreation was still using just `Field.db_type()`.

[Ticket](https://code.djangoproject.com/ticket/23416)

@bmispelon @andrewgodwin

I believe this fixes the problem. The alternative is to attempt to rework the changes made in d22b291890c1736a40c0ad97448c7318df2eebb2 so as to maintain backwards compatibility that `db_type()` returns the check constraint, but it comes separately from `db_parameters()`. Given `db_type()` is public API I don't see a way to fix this.

This should be backported to 1.7.X and included in a 1.7.1 release, probably quite soon as it influences `CREATE TABLE` statements for any field using `CHECK` if not using migrations.
