### PR TITLE
Add note to 1.7 release docs to account for db creation prior to running runserver

### DIFF
--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1442,6 +1442,10 @@ Miscellaneous
 * Decoding the query string from URLs now falls back to the ISO-8859-1 encoding
   when the input is not valid UTF-8.
 
+* With the addition of the :class:`~django.contrib.auth.middleware.SessionAuthenticationMiddleware` to the
+  default project template, a database must be created before accessing
+  a page using :djadmin:`runserver`.
+
 .. _deprecated-features-1.7:
 
 Features deprecated in 1.7


### PR DESCRIPTION
Add note to miscellaneous section of 1.7 release docs to account for requirement for database creation prior to running runserver command.

ticket no: 23427 https://code.djangoproject.com/ticket/23427
