### PR TITLE
Fixed #23350 -- changed mod_wsgi auth example to use less memory

### DIFF
--- a/docs/howto/deployment/wsgi/apache-auth.txt
+++ b/docs/howto/deployment/wsgi/apache-auth.txt
@@ -41,7 +41,7 @@ only authenticated users to be able to view:
     WSGIPythonPath /path/to/mysite.com
 
     WSGIProcessGroup %{GLOBAL}
-    WSGIApplicationGroup django
+    WSGIApplicationGroup %{GLOBAL}
 
     <Location "/secret">
         AuthType Basic
@@ -104,7 +104,7 @@ In this case, the Apache configuration should look like this:
     WSGIScriptAlias / /path/to/mysite.com/mysite/wsgi.py
 
     WSGIProcessGroup %{GLOBAL}
-    WSGIApplicationGroup django
+    WSGIApplicationGroup %{GLOBAL}
 
     <Location "/secret">
         AuthType Basic


### PR DESCRIPTION
The docs as written use two copies of the code. This changes the docs to use
one copy of the code in the main interpreter.

See https://code.djangoproject.com/ticket/23350
