### PR TITLE
Fixed #23431 -- Allowed inline and hidden references to admin fields.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -439,6 +439,10 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         return clean_lookup in valid_lookups
 
     def to_field_allowed(self, request, to_field):
+        """
+        Returns True if the model associated with this admin should be
+        allowed to be referenced by the specified field.
+        """
         opts = self.model._meta
 
         try:
@@ -448,8 +452,13 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
 
         # Make sure at least one of the models registered for this site
         # references this field through a FK or a M2M relationship.
-        registered_models = self.admin_site._registry
-        for related_object in (opts.get_all_related_objects() +
+        registered_models = set()
+        for model, admin in self.admin_site._registry.items():
+            registered_models.add(model)
+            for inline in admin.inlines:
+                registered_models.add(inline.model)
+
+        for related_object in (opts.get_all_related_objects(include_hidden=True) +
                                opts.get_all_related_many_to_many_objects()):
             related_model = related_object.model
             if (any(issubclass(model, related_model) for model in registered_models) and

--- a/docs/releases/1.4.16.txt
+++ b/docs/releases/1.4.16.txt
@@ -1,0 +1,13 @@
+===========================
+Django 1.4.16 release notes
+===========================
+
+*Under development*
+
+Django 1.4.16 fixes a regression in the 1.4.14 security release.
+
+Bugfixes
+========
+
+* Allowed inline and hidden references to admin fields
+  (`#23431 <http://code.djangoproject.com/ticket/23431>`_).

--- a/docs/releases/1.5.11.txt
+++ b/docs/releases/1.5.11.txt
@@ -1,0 +1,13 @@
+===========================
+Django 1.5.11 release notes
+===========================
+
+*Under development*
+
+Django 1.5.11 fixes a regression in the 1.5.9 security release.
+
+Bugfixes
+========
+
+* Allowed inline and hidden references to admin fields
+  (`#23431 <http://code.djangoproject.com/ticket/23431>`_).

--- a/docs/releases/1.6.8.txt
+++ b/docs/releases/1.6.8.txt
@@ -1,0 +1,12 @@
+==========================
+Django 1.6.8 release notes
+==========================
+
+*Under development*
+
+Django 1.6.8 fixes a regression in the 1.6.6 security release.
+
+Bugfixes
+========
+
+* Allowed inline and hidden references to admin fields (:ticket:`23431`).

--- a/docs/releases/1.7.1.txt
+++ b/docs/releases/1.7.1.txt
@@ -18,3 +18,5 @@ Bugfixes
   when not using migrations (:ticket:`23416`).
 
 * Fixed serialization of ``type`` objects in migrations (:ticket:`22951`).
+
+* Allowed inline and hidden references to admin fields (:ticket:`23431`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -40,6 +40,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.6.8
    1.6.7
    1.6.6
    1.6.5
@@ -54,6 +55,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.5.11
    1.5.10
    1.5.9
    1.5.8
@@ -71,6 +73,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.4.16
    1.4.15
    1.4.14
    1.4.13

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -36,7 +36,8 @@ from .models import (Article, Chapter, Child, Parent, Picture, Widget,
     FilteredManager, EmptyModelHidden, EmptyModelVisible, EmptyModelMixin,
     State, City, Restaurant, Worker, ParentWithDependentChildren,
     DependentChild, StumpJoke, FieldOverridePost, FunkyTag,
-    ReferencedByParent, ChildOfReferer, M2MReference)
+    ReferencedByParent, ChildOfReferer, M2MReference, ReferencedByInline,
+    InlineReference, InlineReferer)
 
 
 def callable_year(dt_value):
@@ -832,6 +833,14 @@ class FunkyTagAdmin(admin.ModelAdmin):
     list_display = ('name', 'content_object')
 
 
+class InlineReferenceInline(admin.TabularInline):
+    model = InlineReference
+
+
+class InlineRefererAdmin(admin.ModelAdmin):
+    inlines = [InlineReferenceInline]
+
+
 site = admin.AdminSite(name="admin")
 site.site_url = '/my-site-url/'
 site.register(Article, ArticleAdmin)
@@ -892,6 +901,8 @@ site.register(FunkyTag, FunkyTagAdmin)
 site.register(ReferencedByParent)
 site.register(ChildOfReferer)
 site.register(M2MReference)
+site.register(ReferencedByInline)
+site.register(InlineReferer, InlineRefererAdmin)
 
 # We intentionally register Promo and ChapterXtra1 but not Chapter nor ChapterXtra2.
 # That way we cover all four cases:

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -839,3 +839,16 @@ class ChildOfReferer(ParentWithFK):
 
 class M2MReference(models.Model):
     ref = models.ManyToManyField('self')
+
+
+# Models for #23431
+class ReferencedByInline(models.Model):
+    pass
+
+
+class InlineReference(models.Model):
+    fk = models.ForeignKey(ReferencedByInline, related_name='hidden+')
+
+
+class InlineReferer(models.Model):
+    refs = models.ManyToManyField(InlineReference)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -620,9 +620,14 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         response = self.client.get("/test_admin/admin/admin_views/m2mreference/", {TO_FIELD_VAR: 'id'})
         self.assertEqual(response.status_code, 200)
 
-        # Specifying a field that is not refered by any other model directly registered
+        # #23329 - Specifying a field that is not refered by any other model directly registered
         # to this admin site but registered through inheritance should be allowed.
         response = self.client.get("/test_admin/admin/admin_views/referencedbyparent/", {TO_FIELD_VAR: 'id'})
+        self.assertEqual(response.status_code, 200)
+
+        # #23431 - Specifying a field that is only refered to by a inline of a registered
+        # model should be allowed.
+        response = self.client.get("/test_admin/admin/admin_views/referencedbyinline/", {TO_FIELD_VAR: 'id'})
         self.assertEqual(response.status_code, 200)
 
         # We also want to prevent the add and change view from leaking a


### PR DESCRIPTION
This fixes a regression introduced by the 53ff096982 security fix.

Thanks to @a1tus for the report.

refs <a target="_new" href="https://code.djangoproject.com/ticket/23329">#23329</a>.
