### PR TITLE
fix #23436 Use abspath for BASE_DIR in settings.py

### DIFF
--- a/django/conf/project_template/project_name/settings.py
+++ b/django/conf/project_template/project_name/settings.py
@@ -10,7 +10,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
cf https://code.djangoproject.com/ticket/23436, not using abspath can open you up to weirdness depending on how settings.py is imported...
