### PR TITLE
Fixed #23441: Maximum recursion depth exceeded in templates

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -1210,6 +1210,13 @@ class Library(object):
             params, varargs, varkw, defaults = getargspec(func)
 
             class InclusionNode(TagHelperNode):
+                # Prevent injecting nodes from included template into
+                # the nodes of the template in which this tag is located.
+                # This injection can lead to "maximum recursion depth exceeded"
+                # when `django.template.loaders.cached.Loader` is used and
+                # there is specific recursion logic in templates.
+                # See #23441 for details.
+                child_nodelists = ()
 
                 def render(self, context):
                     resolved_args, resolved_kwargs = self.get_resolved_arguments(context)

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -256,6 +256,14 @@ class CustomTagTests(TestCase):
         c.current_app = 'advanced'
         self.assertEqual(t.render(c).strip(), 'advanced')
 
+    def test_23441_inclusion_tag_not_inject_nodes_after_render(self):
+        t = template.Template('{% load custom %}{% inclusion_no_params %}')
+
+        self.assertEqual(0, len(t.nodelist.get_nodes_by_type(template.VariableNode)))
+
+        t.render(template.Context({}))
+        self.assertEqual(0, len(t.nodelist.get_nodes_by_type(template.VariableNode)))
+
     def test_15070_use_l10n(self):
         """
         Test that inclusion tag passes down `use_l10n` of context to the


### PR DESCRIPTION
When using custom `inclusion_tag` with recursion in templates
and `django.template.loaders.cached.Loader` for template loader.