### PR TITLE
Closed #23365 -- Makemigrations allows timezone-aware datetimes

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from django.apps import apps
-from django.utils import datetime_safe, six
+from django.utils import datetime_safe, timezone, six
 from django.utils.six.moves import input
 
 from .loader import MIGRATIONS_MODULE_NAME
@@ -108,7 +108,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
                 sys.exit(3)
             else:
                 print("Please enter the default value now, as valid Python")
-                print("The datetime module is available, so you can do e.g. datetime.date.today()")
+                print("The datetime and django.utils.timezone modules are available, so you can do e.g. timezone.now()")
                 while True:
                     if six.PY3:
                         # Six does not correctly abstract over the fact that
@@ -123,7 +123,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
                         sys.exit(1)
                     else:
                         try:
-                            return eval(code, {}, {"datetime": datetime_safe})
+                            return eval(code, {}, {"datetime": datetime_safe, "timezone": timezone})
                         except (SyntaxError, NameError) as e:
                             print("Invalid input: %s" % e)
         return None

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -16,6 +16,7 @@ from django.db.migrations.loader import MigrationLoader
 from django.utils import datetime_safe, six
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
+from django.utils.timezone import utc
 
 
 COMPILED_REGEX_TYPE = type(re.compile(''))
@@ -164,6 +165,29 @@ class MigrationWriter(object):
 
         return (MIGRATION_TEMPLATE % items).encode("utf8")
 
+    @staticmethod
+    def serialize_datetime(value):
+        """
+        Return a serialized version of a datetime object that is valid, executable python code.
+        This is an exact copy of datetime.datetime's repr implementation but enforces timezone-aware
+        values to utc with an 'executable' utc representation of tzinfo.
+        """
+        if value.tzinfo is not None and value.tzinfo != utc:
+            value = value.astimezone(utc)
+
+        L = [value.year, value.month, value.day,  # These are never zero
+             value.hour, value.minute, value.second, value.microsecond]
+        if L[-1] == 0:
+            del L[-1]
+        if L[-1] == 0:
+            del L[-1]
+        s = ", ".join(map(str, L))
+        s = "%s(%s)" % ('datetime.' + value.__class__.__name__, s)
+        if value.tzinfo is not None:
+            assert s[-1:] == ")"
+            s = s[:-1] + ", tzinfo=utc)"
+        return s
+
     @property
     def filename(self):
         return "%s.py" % self.migration.name
@@ -267,12 +291,11 @@ class MigrationWriter(object):
             return "{%s}" % (", ".join("%s: %s" % (k, v) for k, v in strings)), imports
         # Datetimes
         elif isinstance(value, datetime.datetime):
+            value_repr = cls.serialize_datetime(value)
+            imports = ["import datetime"]
             if value.tzinfo is not None:
-                raise ValueError("Cannot serialize datetime values with timezones. Either use a callable value for default or remove the timezone.")
-            value_repr = repr(value)
-            if isinstance(value, datetime_safe.datetime):
-                value_repr = "datetime.%s" % value_repr
-            return value_repr, set(["import datetime"])
+                imports.append("from django.utils.timezone import utc")
+            return value_repr, set(imports)
         # Dates
         elif isinstance(value, datetime.date):
             value_repr = repr(value)

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.utils import datetime_safe, six
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
-from django.utils.timezone import get_default_timezone
+from django.utils.timezone import get_default_timezone, utc, FixedOffset
 
 import custom_migration_operations.operations
 import custom_migration_operations.more_operations
@@ -96,8 +96,8 @@ class WriterTests(TestCase):
         self.assertSerializedEqual(datetime.date.today())
         self.assertSerializedEqual(datetime.date.today)
         self.assertSerializedEqual(datetime.datetime.now().time())
-        with self.assertRaises(ValueError):
-            self.assertSerializedEqual(datetime.datetime(2012, 1, 1, 1, 1, tzinfo=get_default_timezone()))
+        self.assertSerializedEqual(datetime.datetime(2014, 1, 1, 1, 1, tzinfo=get_default_timezone()))
+        self.assertSerializedEqual(datetime.datetime(2014, 1, 1, 1, 1, tzinfo=FixedOffset(180)))
         safe_date = datetime_safe.date(2014, 3, 31)
         string, imports = MigrationWriter.serialize(safe_date)
         self.assertEqual(string, repr(datetime.date(2014, 3, 31)))
@@ -106,6 +106,10 @@ class WriterTests(TestCase):
         string, imports = MigrationWriter.serialize(safe_datetime)
         self.assertEqual(string, repr(datetime.datetime(2014, 3, 31, 16, 4, 31)))
         self.assertEqual(imports, {'import datetime'})
+        timezone_aware_datetime = datetime.datetime(2012, 1, 1, 1, 1, tzinfo=utc)
+        string, imports = MigrationWriter.serialize(timezone_aware_datetime)
+        self.assertEqual(string, "datetime.datetime(2012, 1, 1, 1, 1, tzinfo=utc)")
+        self.assertEqual(imports, {'import datetime', 'from django.utils.timezone import utc'})
         # Django fields
         self.assertSerializedFieldEqual(models.CharField(max_length=255))
         self.assertSerializedFieldEqual(models.TextField(null=True, blank=True))
@@ -299,3 +303,22 @@ class WriterTests(TestCase):
             result['custom_migration_operations'].operations.TestOperation,
             result['custom_migration_operations'].more_operations.TestOperation
         )
+
+    def test_serialize_datetime(self):
+        """
+        Ticket #23365 allow timezone-aware datetimes in migrations.
+        """
+        # Test naive datetime
+        naive_datetime = datetime.datetime(2014, 1, 1, 1, 1)
+        self.assertEqual(MigrationWriter.serialize_datetime(naive_datetime),
+                         "datetime.datetime(2014, 1, 1, 1, 1)")
+
+        # Test datetime with utc timezone
+        utc_datetime = datetime.datetime(2014, 1, 1, 1, 1, tzinfo=utc)
+        self.assertEqual(MigrationWriter.serialize_datetime(utc_datetime),
+                         "datetime.datetime(2014, 1, 1, 1, 1, tzinfo=utc)")
+
+        # Test datetime with FixedOffset tzinfo
+        fixed_offset_datetime = datetime.datetime(2014, 1, 1, 1, 1, tzinfo=FixedOffset(180))
+        self.assertEqual(MigrationWriter.serialize_datetime(fixed_offset_datetime),
+                         "datetime.datetime(2013, 12, 31, 22, 1, tzinfo=utc)")


### PR DESCRIPTION
When a user is adding a new, non-nullable datetime field to their model, 
they're now able to use django util's timezone module to supply a 
timezone-aware value. The prompt also shows an example using the 
preferred timezone.now() instead of datetime's naive now().
