### PR TITLE
Fixed #23305 -- Added documentation item

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -238,6 +238,11 @@ Methods
         separate from the production settings, ``manage.py test`` would still
         execute some queries against your **production** database!
 
+    .. warning::
+
+        Additionally, avoid importing models in __init__.py; doing so leads to
+        inconsistent behavior.
+
     .. note::
 
         In the usual initialization process, the ``ready`` method is only called


### PR DESCRIPTION
Warned against importing models in **init**.py

This PR addresses this Trac ticket: https://code.djangoproject.com/ticket/23305

Although this doc modification might not be a perfect fit in applications.txt, it seemed better than other alternatives.

I tested this locally, which generated this html when doing a `make html`:

```
<div class="admonition warning">
<p class="first admonition-title">Warning</p>
<p class="last">Additionally, avoid importing models in __init__.py; doing so leads to
inconsistent behavior.</p>
</div>
```
