### PR TITLE
Fixed #23434 -- Coerce Oracle bool params to int

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -772,9 +772,9 @@ class OracleParam(object):
         # Oracle doesn't recognize True and False correctly in Python 3.
         # The conversion done below works both in 2 and 3.
         if param is True:
-            param = "1"
+            param = 1
         elif param is False:
-            param = "0"
+            param = 0
         if hasattr(param, 'bind_parameter'):
             self.force_bytes = param.bind_parameter(cursor)
         elif isinstance(param, Database.Binary):


### PR DESCRIPTION
Oracle boolean query parameters are coerced to the strings "1" and "0" rather than the ints 1 and 0. This causes issues when trying to write a query like:

```
cursor.execute("SELECT %s as bool_value ...", True)
```

These kinds of queries can be generated with #2496 , and prevent result converters from operating on the correct type. By changing the parameters to integers, we get the appropriate type back from the database (a number), and the converters correctly change that value to the appropriate bool.
