### PR TITLE
Fixed #23196 -- Don't translate empty string as gettext metadata

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -292,15 +292,22 @@ def do_translate(message, translation_function):
 
     # str() is allowing a bytestring message to remain bytestring on Python 2
     eol_message = message.replace(str('\r\n'), str('\n')).replace(str('\r'), str('\n'))
-    t = getattr(_active, "value", None)
-    if t is not None:
-        result = getattr(t, translation_function)(eol_message)
+
+    if len(eol_message) == 0:
+        # Returns empty value of corresponding type if empty message given
+        # Instead of metadata what is default GNU gettext behavior
+        result = type(message)("")
+
     else:
-        if _default is None:
-            _default = translation(settings.LANGUAGE_CODE)
-        result = getattr(_default, translation_function)(eol_message)
+
+        _default = _default or translation(settings.LANGUAGE_CODE)
+        translation_object = getattr(_active, "value", _default)
+
+        result = getattr(translation_object, translation_function)(eol_message)
+
     if isinstance(message, SafeData):
         return mark_safe(result)
+
     return result
 
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -345,6 +345,18 @@ class TranslationTests(TestCase):
         """
         self.assertEqual('django', six.text_type(string_concat("dja", "ngo")))
 
+    def test_empty_value(self):
+        """
+        Empty value must stays empty value after translation
+        """
+        with translation.override('de'):
+            s = ""
+            self.assertEqual(s, ugettext(s))
+            s = u""
+            self.assertEqual(s, ugettext(s))
+            s = mark_safe("")
+            self.assertEqual(s, ugettext(s))
+
     def test_safe_status(self):
         """
         Translating a string requiring no auto-escaping shouldn't change the "safe" status.


### PR DESCRIPTION
Returns empty value of corresponding type in case of empty string.
