### PR TITLE
Adding the ISO8601 format to the utils.format class.

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -26,7 +26,10 @@ ISO_INPUT_FORMATS = {
         '%Y-%m-%d %H:%M:%S',
         '%Y-%m-%d %H:%M:%S.%f',
         '%Y-%m-%d %H:%M',
-        '%Y-%m-%d'
+        '%Y-%m-%d',
+        '%Y-%m-%dT%H:%M:%S.%f',
+        '%Y-%m-%dT%H:%M:%S',
+        '%Y-%m-%dT%H:%M'
     ),
 }
 

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -8,6 +8,15 @@ from django.utils.dateformat import format
 from django.utils import dateformat
 from django.utils.timezone import utc, get_fixed_timezone, get_default_timezone, make_aware
 from django.utils import translation
+from django.utils.formats import ISO_INPUT_FORMATS
+
+
+class DateTimeISO8601Format(TestCase):
+    def test_format_from_string(self):
+        expected_date = datetime.now()
+        test_date_8601 = expected_date.isoformat()
+        result_date = datetime.strptime(test_date_8601, ISO_INPUT_FORMATS['DATETIME_INPUT_FORMATS'][4])
+        self.assertEqual(expected_date, result_date)
 
 
 @override_settings(TIME_ZONE='Europe/Copenhagen')


### PR DESCRIPTION
This will allow django_filters and django_rest_framework to properly filter by iso 8601 formatted date time strings. Currently those two projects pull in the ISO_INPUT_FORMATS dictionary from django.utils.format to determine if a string passed in is formatted as a date time. Currently all ISO8601 dates passed into the rest framework are not correctly filtered. This change addresses that by allowing them to be parsed and filtered correctly.
