### PR TITLE
Fixed #23338 -- Added warning when unique=True on ForeigKey

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1642,6 +1642,7 @@ class ForeignKey(ForeignObject):
     def check(self, **kwargs):
         errors = super(ForeignKey, self).check(**kwargs)
         errors.extend(self._check_on_delete())
+        errors.extend(self._check_unique())
         return errors
 
     def _check_on_delete(self):
@@ -1666,6 +1667,21 @@ class ForeignKey(ForeignObject):
             ]
         else:
             return []
+
+    def _check_unique(self, **kwargs):
+        warnings = []
+
+        if self.unique:
+            warnings.append(
+                checks.Warning(
+                    'Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.',
+                    hint='Change the field type from ForeignKey to OneToOneField, and remove unique=True.',
+                    obj=self,
+                    id='fields.W342',
+                )
+            )
+
+        return warnings
 
     def deconstruct(self):
         name, path, args, kwargs = super(ForeignKey, self).deconstruct()


### PR DESCRIPTION
Added a warning when unique is set to True on a ForeignKey, telling
the user to replace it with a OneToOneField and remove unique=True.
