### PR TITLE
Fixed #23451 -- Fixed typo in _get_foreign_key

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -949,7 +949,7 @@ def _get_foreign_key(parent_model, model, fk_name=None, can_fail=False):
                     (fk.rel.to != parent_model and
                      fk.rel.to not in parent_model._meta.get_parent_list()):
                 raise ValueError(
-                    "fk_name '%s' is not a ForeignKey to '%s.%'."
+                    "fk_name '%s' is not a ForeignKey to '%s.%s'."
                     % (fk_name, parent_model._meta.app_label, parent_model._meta.object_name))
         elif len(fks_to_parent) == 0:
             raise ValueError(

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -815,6 +815,12 @@ class ModelFormsetTest(TestCase):
         formset = AuthorBooksFormSet(data, instance=author, queryset=custom_qs)
         self.assertTrue(formset.is_valid())
 
+    def test_inline_formsets_with_wrong_fk_name(self):
+        """ Regression for #23451 """
+        message = "fk_name 'title' is not a ForeignKey to 'model_formsets.Author'."
+        with self.assertRaisesMessage(ValueError, message):
+            inlineformset_factory(Author, Book, fields="__all__", fk_name='title')
+
     def test_custom_pk(self):
         # We need to ensure that it is displayed
 


### PR DESCRIPTION
Fixed problem in `django.forms.models._get_foreign_key`. Who tries to throw ValueError, but passes badly string with not enough specifiers. So, instead it threw ValueError with cryptic message.

https://code.djangoproject.com/ticket/23451
