### PR TITLE
Update 1.7 release notes re: User.get_absolute_url

### DIFF
--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1354,8 +1354,8 @@ Miscellaneous
   :meth:`~django.db.models.Model.get_absolute_url()` method. The old definition
   returned  ``"/users/%s/" % urlquote(self.username)`` which was arbitrary
   since applications may or may not define such a url in ``urlpatterns``.
-  Define a ``get_absolute_url()`` method on your own custom user object or use
-  :setting:`ABSOLUTE_URL_OVERRIDES` if you want a URL for your user.
+  Define a ``get_absolute_url()`` method on your own custom user object if you
+  want a URL for your user.
 
 * The static asset-serving functionality of the
   :class:`django.test.LiveServerTestCase` class has been simplified: Now it's


### PR DESCRIPTION
`ABSOLUTE_URL_OVERRIDES` no longer works for the default auth.User model, as [explained here](http://stackoverflow.com/questions/25734384/accessing-user-get-absolute-url-in-django-1-7), and this should be reflected in the 1.7 release notes.

As a side note, a solution is proposed here: https://code.djangoproject.com/ticket/11775

I would think that this warrants a newly documented backwards incompatible change in 1.7, but figured would hold off on that to see what people have to say about this first.
