### PR TITLE
Fixed #23452 -- Do not create migration on empty foo_together model option

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -871,23 +871,28 @@ class MigrationAutodetector(object):
             old_model_name = self.renamed_models.get((app_label, model_name), model_name)
             old_model_state = self.from_state.models[app_label, old_model_name]
             new_model_state = self.to_state.models[app_label, model_name]
+
             # We run the old version through the field renames to account for those
-            if old_model_state.options.get(option_name) is None:
-                old_value = None
-            else:
+            old_value = old_model_state.options.get(option_name) or set()
+            if old_value:
                 old_value = set([
                     tuple(
                         self.renamed_fields.get((app_label, model_name, n), n)
                         for n in unique
                     )
-                    for unique in old_model_state.options[option_name]
+                    for unique in old_value
                 ])
-            if old_value != new_model_state.options.get(option_name):
+
+            new_value = new_model_state.options.get(option_name) or set()
+            if new_value:
+                new_value = set(new_value)
+
+            if old_value != new_value:
                 self.add_operation(
                     app_label,
                     operation(
                         name=model_name,
-                        **{option_name: new_model_state.options.get(option_name)}
+                        **{option_name: new_value}
                     )
                 )
 

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -233,9 +233,7 @@ class AlterUniqueTogether(Operation):
     def __init__(self, name, unique_together):
         self.name = name
         unique_together = normalize_together(unique_together)
-        # need None rather than an empty set to prevent infinite migrations
-        # after removing unique_together from a model
-        self.unique_together = set(tuple(cons) for cons in unique_together) or None
+        self.unique_together = set(tuple(cons) for cons in unique_together)
 
     def state_forwards(self, app_label, state):
         model_state = state.models[app_label, self.name.lower()]
@@ -273,9 +271,7 @@ class AlterIndexTogether(Operation):
     def __init__(self, name, index_together):
         self.name = name
         index_together = normalize_together(index_together)
-        # need None rather than an empty set to prevent infinite migrations
-        # after removing unique_together from a model
-        self.index_together = set(tuple(cons) for cons in index_together) or None
+        self.index_together = set(tuple(cons) for cons in index_together)
 
     def state_forwards(self, app_label, state):
         model_state = state.models[app_label, self.name.lower()]

--- a/docs/releases/1.7.1.txt
+++ b/docs/releases/1.7.1.txt
@@ -31,3 +31,6 @@ Bugfixes
   ``'auth.User'`` model (:ticket:`11775`). As a side effect, the setting now
   adds a ``get_absolute_url()`` method to any model that appears in
   ``ABSOLUTE_URL_OVERRIDES`` but doesn't define ``get_absolute_url()``.
+
+* Empty ``index_together`` or ``unique_together`` model options no longer
+  results in infinite migrations (:ticket:`23452`).


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/23452
