### PR TITLE
Fixed #23483 -- Prevented ImproperlyConfigured with dotted app names

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -124,6 +124,7 @@ class AppConfigStub(AppConfig):
     path = ''
 
     def __init__(self, label):
+        self.label = label
         super(AppConfigStub, self).__init__(label, None)
 
     def import_models(self, all_models):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -254,6 +254,27 @@ class StateTests(TestCase):
         with self.assertRaises(InvalidBasesError):
             project_state.render()
 
+    def test_render_unique_app_labels(self):
+        """
+        Tests that the ProjectState render method doesn't raise an
+        ImproperlyConfigured exception about unique labels if two dotted app
+        names have the same last part.
+        """
+        class A(models.Model):
+            class Meta:
+                app_label = "django.contrib.auth"
+
+        class B(models.Model):
+            class Meta:
+                app_label = "vendor.auth"
+
+        # Make a ProjectState and render it
+        project_state = ProjectState()
+        project_state.add_model_state(ModelState.from_model(A))
+        project_state.add_model_state(ModelState.from_model(B))
+        final_apps = project_state.render()
+        self.assertEqual(len(final_apps.get_models()), 2)
+
     def test_equality(self):
         """
         Tests that == and != are implemented correctly.


### PR DESCRIPTION
Made sure the app labels stay unique for the AppConfigStubs, so migrations wouldn't fail if two dotted app names has the same last part (e.g. django.contrib.auth and vendor.auth)
