### PR TITLE
Fixed #23461 -- Added EMAIL_TIMEOUT setting

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -196,6 +196,7 @@ EMAIL_USE_TLS = False
 EMAIL_USE_SSL = False
 EMAIL_SSL_CERTFILE = None
 EMAIL_SSL_KEYFILE = None
+EMAIL_TIMEOUT = None
 
 # List of strings representing installed apps.
 INSTALLED_APPS = ()

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -24,7 +24,7 @@ class EmailBackend(BaseEmailBackend):
         self.password = settings.EMAIL_HOST_PASSWORD if password is None else password
         self.use_tls = settings.EMAIL_USE_TLS if use_tls is None else use_tls
         self.use_ssl = settings.EMAIL_USE_SSL if use_ssl is None else use_ssl
-        self.timeout = timeout
+        self.timeout = settings.EMAIL_TIMEOUT if timeout is None else timeout
         self.ssl_keyfile = settings.EMAIL_SSL_KEYFILE if ssl_keyfile is None else ssl_keyfile
         self.ssl_certfile = settings.EMAIL_SSL_CERTFILE if ssl_certfile is None else ssl_certfile
         if self.use_ssl and self.use_tls:

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1266,6 +1266,16 @@ connection. Please refer to the documentation of Python's
 :func:`python:ssl.wrap_socket` function for details on how the certificate chain
 file and private key file are handled.
 
+EMAIL_TIMEOUT
+-------------
+
+.. versionadded:: 1.8
+
+Default: ``None``
+
+Specifies a timeout in seconds for blocking operations like the connection
+attempt.
+
 .. setting:: FILE_CHARSET
 
 FILE_CHARSET
@@ -3090,6 +3100,7 @@ Email
 * :setting:`EMAIL_SSL_KEYFILE`
 * :setting:`EMAIL_SUBJECT_PREFIX`
 * :setting:`EMAIL_USE_TLS`
+* :setting*`EMAIL_TIMEOUT`
 * :setting:`MANAGERS`
 * :setting:`SERVER_EMAIL`
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -154,6 +154,9 @@ Email
   authentication with the :setting:`EMAIL_SSL_CERTFILE` and
   :setting:`EMAIL_SSL_KEYFILE` settings.
 
+* The SMTP :class:`~django.core.mail.backends.smtp.EmailBackend` now supports
+  setting the ``timeout`` parameter with the :setting:`EMAIL_TIMEOUT` setting.
+
 File Storage
 ^^^^^^^^^^^^
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -451,8 +451,9 @@ SMTP backend
     The server address and authentication credentials are set in the
     :setting:`EMAIL_HOST`, :setting:`EMAIL_PORT`, :setting:`EMAIL_HOST_USER`,
     :setting:`EMAIL_HOST_PASSWORD`, :setting:`EMAIL_USE_TLS`,
-    :setting:`EMAIL_USE_SSL`, :setting:`EMAIL_SSL_CERTFILE` and
-    :setting:`EMAIL_SSL_KEYFILE` settings in your settings file.
+    :setting:`EMAIL_USE_SSL`, :setting:`EMAIL_TIMEOUT`,
+    :setting:`EMAIL_SSL_CERTFILE` and :setting:`EMAIL_SSL_KEYFILE` settings
+    in your settings file.
 
     The SMTP backend is the default configuration inherited by Django. If you
     want to specify it explicitly, put the following in your settings::
@@ -484,8 +485,8 @@ SMTP backend
 
     .. versionchanged:: 1.8
 
-        The ``ssl_keyfile`` and ``ssl_certfile`` parameters and
-        corresponding settings were added.
+        The ``timeout``, ``ssl_keyfile``, and ``ssl_certfile`` parameters
+        and corresponding settings were added.
 
 .. _topic-email-console-backend:
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1033,3 +1033,8 @@ class SMTPBackendTests(BaseEmailBackendTests, SimpleTestCase):
         self.assertEqual(myemailbackend.timeout, 42)
         self.assertEqual(myemailbackend.connection.timeout, 42)
         myemailbackend.close()
+
+    @override_settings(EMAIL_TIMEOUT=10)
+    def test_email_timeout_override_settings(self):
+        backend = smtp.EmailBackend()
+        self.assertEqual(backend.timeout, 10)


### PR DESCRIPTION
The `timeout` parameter was added to the SMTP backend in [#21271](https://code.djangoproject.com/ticket/21271), but done awkwardly to avoid using a setting. Now that we are fine adding the [setting](https://groups.google.com/d/msg/django-developers/ZWpRbTwTxmo/VJ93xb5V5qoJ), I'm adding it.

Based on [00535e8e6b402cab29ea3dbb7b4cc470f9839678](https://code.djangoproject.com/changeset/00535e8e6b402cab29ea3dbb7b4cc470f9839678/).
