### PR TITLE
Fixed #23497 -- Made admin system checks run for custom AdminSites

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -11,12 +11,9 @@ from django.forms.models import BaseModelForm, _get_foreign_key, BaseModelFormSe
 
 
 def check_admin_app(**kwargs):
-    from django.contrib.admin.sites import site
+    from django.contrib.admin.sites import system_check_errors
 
-    return list(chain.from_iterable(
-        model_admin.check(model, **kwargs)
-        for model, model_admin in site._registry.items()
-    ))
+    return system_check_errors
 
 
 class BaseModelAdminChecks(object):

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -14,6 +14,8 @@ from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.decorators.cache import never_cache
 from django.conf import settings
 
+system_check_errors = []
+
 
 class AlreadyRegistered(Exception):
     pass
@@ -72,6 +74,8 @@ class AdminSite(object):
 
         If a model is abstract, this will raise ImproperlyConfigured.
         """
+        global system_check_errors
+
         if not admin_class:
             admin_class = ModelAdmin
 
@@ -98,7 +102,7 @@ class AdminSite(object):
                     admin_class = type("%sAdmin" % model.__name__, (admin_class,), options)
 
                 if admin_class is not ModelAdmin and settings.DEBUG:
-                    admin_class.check(model)
+                    system_check_errors.extend(admin_class.check(model))
 
                 # Instantiate the admin class to save in the registry
                 self._registry[model] = admin_class(model, self)


### PR DESCRIPTION
- Create system_check_errors in django.contrib.admin.sites
- Modifies register() to store results of admin_check in
  system_check_errors
- Modifies checks to read from system_check_errors instead of re-running
  all of the checks
