### PR TITLE
Fixes #23499 - Error in built-in template tag "now" documentation

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -776,11 +776,11 @@ Example::
     It is {% now "jS F Y H:i" %}
 
 Note that you can backslash-escape a format string if you want to use the
-"raw" value. In this example, "f" is backslash-escaped, because otherwise
-"f" is a format string that displays the time. The "o" doesn't need to be
-escaped, because it's not a format character::
+"raw" value. In this example, both "o" and "f" are backslash-escaped, because 
+otherwise each is a format string that displays the year and the time, 
+respectively::
 
-    It is the {% now "jS o\f F" %}
+    It is the {% now "jS \o\f F" %}
 
 This would display as "It is the 4th of September".
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23499

Small documentation change. I built the documentation (`make html`) and there were no errors. 
