### PR TITLE
Fixed Oracle GIS gml() test failure introduced by e910340; refs #18757.

### DIFF
--- a/django/contrib/gis/db/models/sql/compiler.py
+++ b/django/contrib/gis/db/models/sql/compiler.py
@@ -151,6 +151,8 @@ class GeoSQLCompiler(compiler.SQLCompiler):
         converters = super(GeoSQLCompiler, self).get_converters(fields)
         for i, alias in enumerate(self.query.extra_select):
             field = self.query.extra_select_fields.get(alias)
+            if alias == 'gml':
+                converters[i] = (self.connection.ops.get_db_converters('GeometryField'), [], None)
             if field:
                 backend_converters = self.connection.ops.get_db_converters(field.get_internal_type())
                 converters[i] = (backend_converters, [field.from_db_value], field)


### PR DESCRIPTION
@mjtamlyn, one more test failure related to the converters change. The results of [GeoQuerySet.gml()](https://github.com/django/django/blob/9d30412a5ad1c72b3d319b4c2bceacb53a0ff1da/django/contrib/gis/db/models/query.py#L168-L179v) aren't coerced to a string. `extra_select_fields.get('gml')` here doesn't return a field so the converters aren't run. I hope you can suggest a more elegant solution.
