### PR TITLE
Don't recommend using sudo when installing uwsgi

### DIFF
--- a/docs/howto/deployment/wsgi/uwsgi.txt
+++ b/docs/howto/deployment/wsgi/uwsgi.txt
@@ -27,10 +27,10 @@ command. For example:
 .. code-block:: bash
 
     # Install current stable version.
-    $ sudo pip install uwsgi
+    $ pip install uwsgi
 
     # Or install LTS (long term support).
-    $ sudo pip install http://projects.unbit.it/downloads/uwsgi-lts.tar.gz
+    $ pip install http://projects.unbit.it/downloads/uwsgi-lts.tar.gz
 
 .. _installation procedures: http://uwsgi-docs.readthedocs.org/en/latest/Install.html
 


### PR DESCRIPTION
This was added with https://github.com/django/django/commit/c0e73a4909832e0db7cac5345128979a21529786 but I feel that this is something we shouldn't be recommending users to do.

cc-ing @aaugustin just in case there was a valid reason for this.
