### PR TITLE
Fixed #23529 -- Replaced comments tag library with humanize in docs

### DIFF
--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -664,18 +664,18 @@ Custom tag and filter libraries
 Certain applications provide custom tag and filter libraries. To access them in
 a template, use the :ttag:`load` tag::
 
-    {% load comments %}
+    {% load humanize %}
 
-    {% comment_form for blogs.entries entry.id with is_public yes %}
+    {{ 45000|intcomma }}
 
-In the above, the :ttag:`load` tag loads the ``comments`` tag library, which then
-makes the ``comment_form`` tag available for use. Consult the documentation
+In the above, the :ttag:`load` tag loads the ``humanize`` tag library, which then
+makes the ``intcomma`` filter available for use. Consult the documentation
 area in your admin to find the list of custom libraries in your installation.
 
 The :ttag:`load` tag can take multiple library names, separated by spaces.
 Example::
 
-    {% load comments i18n %}
+    {% load humanize i18n %}
 
 See :doc:`/howto/custom-template-tags` for information on writing your own custom
 template libraries.
@@ -687,9 +687,9 @@ When you load a custom tag or filter library, the tags/filters are only made
 available to the current template -- not any parent or child templates along
 the template-inheritance path.
 
-For example, if a template ``foo.html`` has ``{% load comments %}``, a child
+For example, if a template ``foo.html`` has ``{% load humanize %}``, a child
 template (e.g., one that has ``{% extends "foo.html" %}``) will *not* have
-access to the comments template tags and filters. The child template is
-responsible for its own ``{% load comments %}``.
+access to the humanize template tags and filters. The child template is
+responsible for its own ``{% load humanize %}``.
 
 This is a feature for the sake of maintainability and sanity.


### PR DESCRIPTION
I replaced removed comments tag library example in docs with humanize tag library. 

Ticket: https://code.djangoproject.com/ticket/23529
