### PR TITLE
Changed Oracle test-user creation to grant privileges instead of roles

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -672,14 +672,38 @@ database user must have privileges to run the following commands:
 * CREATE PROCEDURE
 * CREATE TRIGGER
 
-To run Django's test suite, the user needs these *additional* privileges:
+To run a project's test suite, the user usually needs these *additional*
+privileges:
 
 * CREATE USER
 * DROP USER
 * CREATE TABLESPACE
 * DROP TABLESPACE
-* CONNECT WITH ADMIN OPTION
-* RESOURCE WITH ADMIN OPTION
+* CREATE SESSION WITH ADMIN OPTION
+* CREATE TABLE WITH ADMIN OPTION
+* CREATE SEQUENCE WITH ADMIN OPTION
+* CREATE PROCEDURE WITH ADMIN OPTION
+* CREATE TRIGGER WITH ADMIN OPTION
+
+Note that, while the RESOURCE role has the required CREATE TABLE, CREATE
+SEQUENCE, CREATE PROCEDURE and CREATE TRIGGER privileges, and a user
+granted RESOURCE WITH ADMIN OPTION can grant RESOURCE, such a user cannot
+grant the individual privileges (e.g. CREATE TABLE), and thus RESOURCE
+WITH ADMIN OPTION is not usually sufficient for running tests.
+
+Some test suites also create views; to run these, the user also needs
+the CREATE VIEW WITH ADMIN OPTION privilege. 
+
+.. comment: In particular, this is needed for Django's own test suite.
+
+.. versionchanged:: 1.8
+
+    Prior to Django 1.8, the test user was granted the CONNECT and RESOURCE
+    roles, so the extra privileges required for running the test suite were
+    different.
+
+All of these privileges are included in the DBA role, which is appropriate
+for use on a private developer's database.
 
 The Oracle database backend uses the ``SYS.DBMS_LOB`` package, so your user
 will require execute permissions on it. It's normally accessible to all users

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -499,6 +499,16 @@ The end of upstream support periods was reached in July 2010 for Oracle 9.2,
 January 2012 for Oracle 10.1, and July 2013 for Oracle 10.2. As a consequence,
 Django 1.8 sets 11.1 as the minimum Oracle version it officially supports.
 
+Specific privileges used instead of roles for tests on Oracle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Earlier versions of Django granted the CONNECT and RESOURCE roles to the test
+user on Oracle. These roles have been deprecated, so Django 1.8 uses the
+specific underlying priveleges instead. This changes the priveleges required
+of the main user for running tests (unless the project is configured to avoid
+creating a test user). The exact privileges required now are detailed in
+:ref:`Oracle notes <oracle-notes>`.
+
 ``AbstractUser.last_login`` allows null values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
because the roles (specifically RESOURCE) are deprecated.
Also added optional support for creating views in tests.
