### PR TITLE
Fixed #23532 -- Fixed Macedonian locale date formats

### DIFF
--- a/django/conf/locale/mk/formats.py
+++ b/django/conf/locale/mk/formats.py
@@ -7,37 +7,37 @@ from __future__ import unicode_literals
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
 DATE_FORMAT = 'd F Y'
 TIME_FORMAT = 'H:i'
-DATETIME_FORMAT = 'j. F Y. H:i'
-YEAR_MONTH_FORMAT = 'F Y.'
+DATETIME_FORMAT = 'j. F Y H:i'
+YEAR_MONTH_FORMAT = 'F Y'
 MONTH_DAY_FORMAT = 'j. F'
-SHORT_DATE_FORMAT = 'j.m.Y.'
-SHORT_DATETIME_FORMAT = 'j.m.Y. H:i'
+SHORT_DATE_FORMAT = 'j.m.Y'
+SHORT_DATETIME_FORMAT = 'j.m.Y H:i'
 FIRST_DAY_OF_WEEK = 1
 
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
 # see http://docs.python.org/library/datetime.html#strftime-strptime-behavior
 DATE_INPUT_FORMATS = (
-    '%d.%m.%Y.', '%d.%m.%y.',       # '25.10.2006.', '25.10.06.'
-    '%d. %m. %Y.', '%d. %m. %y.',   # '25. 10. 2006.', '25. 10. 06.'
+    '%d.%m.%Y', '%d.%m.%y',       # '25.10.2006', '25.10.06'
+    '%d. %m. %Y', '%d. %m. %y',   # '25. 10. 2006', '25. 10. 06'
 )
 
 DATETIME_INPUT_FORMATS = (
-    '%d.%m.%Y. %H:%M:%S',       # '25.10.2006. 14:30:59'
-    '%d.%m.%Y. %H:%M:%S.%f',    # '25.10.2006. 14:30:59.000200'
-    '%d.%m.%Y. %H:%M',          # '25.10.2006. 14:30'
-    '%d.%m.%Y.',                # '25.10.2006.'
-    '%d.%m.%y. %H:%M:%S',       # '25.10.06. 14:30:59'
-    '%d.%m.%y. %H:%M:%S.%f',    # '25.10.06. 14:30:59.000200'
-    '%d.%m.%y. %H:%M',          # '25.10.06. 14:30'
-    '%d.%m.%y.',                # '25.10.06.'
-    '%d. %m. %Y. %H:%M:%S',     # '25. 10. 2006. 14:30:59'
-    '%d. %m. %Y. %H:%M:%S.%f',  # '25. 10. 2006. 14:30:59.000200'
-    '%d. %m. %Y. %H:%M',        # '25. 10. 2006. 14:30'
-    '%d. %m. %Y.',              # '25. 10. 2006.'
-    '%d. %m. %y. %H:%M:%S',     # '25. 10. 06. 14:30:59'
-    '%d. %m. %y. %H:%M:%S.%f',  # '25. 10. 06. 14:30:59.000200'
-    '%d. %m. %y. %H:%M',        # '25. 10. 06. 14:30'
-    '%d. %m. %y.',              # '25. 10. 06.'
+    '%d.%m.%Y %H:%M:%S',       # '25.10.2006 14:30:59'
+    '%d.%m.%Y %H:%M:%S.%f',    # '25.10.2006 14:30:59.000200'
+    '%d.%m.%Y %H:%M',          # '25.10.2006 14:30'
+    '%d.%m.%Y',                # '25.10.2006'
+    '%d.%m.%y %H:%M:%S',       # '25.10.06 14:30:59'
+    '%d.%m.%y %H:%M:%S.%f',    # '25.10.06 14:30:59.000200'
+    '%d.%m.%y %H:%M',          # '25.10.06 14:30'
+    '%d.%m.%y',                # '25.10.06'
+    '%d. %m. %Y %H:%M:%S',     # '25. 10. 2006 14:30:59'
+    '%d. %m. %Y %H:%M:%S.%f',  # '25. 10. 2006 14:30:59.000200'
+    '%d. %m. %Y %H:%M',        # '25. 10. 2006 14:30'
+    '%d. %m. %Y',              # '25. 10. 2006'
+    '%d. %m. %y %H:%M:%S',     # '25. 10. 06 14:30:59'
+    '%d. %m. %y %H:%M:%S.%f',  # '25. 10. 06 14:30:59.000200'
+    '%d. %m. %y %H:%M',        # '25. 10. 06 14:30'
+    '%d. %m. %y',              # '25. 10. 06'
 )
 
 DECIMAL_SEPARATOR = ','


### PR DESCRIPTION
The Macedonian locale (mk_MK) date format currently has an extra dot after the year. The date shouldn't end with a dot.

Current format: '%d.%m.%Y. %H:%M:%S' 25.10.2006. 14:30:59
Correct format: '%d.%m.%Y %H:%M:%S' 25.10.2006 14:30:59
