### PR TITLE
Fixed #8408 -- Added ModelAdmin option to avoid expensive COUNT()

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -110,6 +110,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
     readonly_fields = ()
     ordering = None
     view_on_site = True
+    show_full_result_count = True
 
     # Validation of ModelAdmin definitions
     # Old, deprecated style:

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -87,9 +87,9 @@
       {% endif %}
 
       {% block result_list %}
-          {% if action_form and actions_on_top and cl.full_result_count %}{% admin_actions %}{% endif %}
+          {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
           {% result_list cl %}
-          {% if action_form and actions_on_bottom and cl.full_result_count %}{% admin_actions %}{% endif %}
+          {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
       {% endblock %}
       {% block pagination %}{% pagination cl %}{% endblock %}
       </form>

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -6,7 +6,7 @@
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" />
 <input type="submit" value="{% trans 'Search' %}" />
 {% if show_result_count %}
-    <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>)</span>
+    <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
 {% endif %}
 {% for pair in cl.params.items %}
     {% ifnotequal pair.0 search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endifnotequal %}

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -177,10 +177,13 @@ class ChangeList(object):
         # Perform a slight optimization:
         # full_result_count is equal to paginator.count if no filters
         # were applied
-        if self.get_filters_params() or self.params.get(SEARCH_VAR):
-            full_result_count = self.root_queryset.count()
+        if self.model_admin.show_full_result_count:
+            if self.get_filters_params() or self.params.get(SEARCH_VAR):
+                full_result_count = self.root_queryset.count()
+            else:
+                full_result_count = result_count
         else:
-            full_result_count = result_count
+            full_result_count = None
         can_show_all = result_count <= self.list_max_show_all
         multi_page = result_count > self.list_per_page
 
@@ -194,6 +197,10 @@ class ChangeList(object):
                 raise IncorrectLookupParameters
 
         self.result_count = result_count
+        self.show_full_result_count = self.model_admin.show_full_result_count
+        # Admin actions are shown if there is at least one entry
+        # or if entries are not counted because show_full_result_count is disabled
+        self.show_admin_actions = self.show_full_result_count or bool(full_result_count)
         self.full_result_count = full_result_count
         self.result_list = result_list
         self.can_show_all = can_show_all

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1160,6 +1160,19 @@ subclass::
     :meth:`ModelAdmin.get_search_results` to provide additional or alternate
     search behavior.
 
+.. attribute:: ModelAdmin.show_full_result_count
+
+    .. versionadded:: 1.8
+
+    Set ``show_full_result_count`` to control whether the full count of objects
+    should be displayed on a filtered admin page (e.g. ``99 results (103 total)``).
+    If this option is set to ``False``, a text like ``99 results (See all)``
+    is displayed instead.
+
+    Setting ``show_full_result_count`` to ``True`` (the default) generates an
+    extra query performing a full count on the table which can be expensive if
+    the table contains a large number of rows.
+
 .. attribute:: ModelAdmin.view_on_site
 
     .. versionadded:: 1.7

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -72,6 +72,10 @@ Minor features
   <django.contrib.admin.AdminSite.site_url>` in order to display a link to the
   front-end site.
 
+* You can now specify :attr:`ModelAdmin.show_full_result_count
+  <django.contrib.admin.ModelAdmin.show_full_result_count>` to control whether
+  or not the full count of objects should be displayed on a filtered admin page.
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -327,6 +327,7 @@ class LanguageAdmin(admin.ModelAdmin):
 
 
 class RecommendationAdmin(admin.ModelAdmin):
+    show_full_result_count = False
     search_fields = ('=titletranslation__text', '=recommender__titletranslation__text',)
 
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -2474,9 +2474,26 @@ class AdminSearchTest(TestCase):
         """
         Test presence of reset link in search bar ("1 result (_x total_)").
         """
-        response = self.client.get('/test_admin/admin/admin_views/person/?q=Gui')
+        #   1 query for session + 1 for fetching user
+        # + 1 for filtered result + 1 for filtered count
+        # + 1 for total count
+        with self.assertNumQueries(5):
+            response = self.client.get('/test_admin/admin/admin_views/person/?q=Gui')
         self.assertContains(response,
             """<span class="small quiet">1 result (<a href="?">3 total</a>)</span>""",
+            html=True)
+
+    def test_no_total_count(self):
+        """
+        Test absence of total count for ModelAdmin with show_full_result_count = False.
+        Refs #8408
+        """
+        #   1 query for session + 1 for fetching user
+        # + 1 for filtered result + 1 for filtered count
+        with self.assertNumQueries(4):
+            response = self.client.get('/test_admin/admin/admin_views/recommendation/?q=bar')
+        self.assertContains(response,
+            """<span class="small quiet">1 result (<a href="?">Show all</a>)</span>""",
             html=True)
 
 


### PR DESCRIPTION
A full `SELECT COUNT(*) FROM "foo"` is performed on admin pages even when the current list being displayed is restricted to a small subset of entries.

This extra query result — which can be very expensive on large tables as explained in https://code.djangoproject.com/ticket/8408 — is used for two purposes:
1. Displaying a "99 results (103 total)" link next to the search field
2. Determining whether the table contains at least one entry so that the actions form is shown.

With this PR, if `ModelAdmin.show_full_result_count` is set to `False`, the link in 1 is replaced by "99 results (See all)" and the actions form is always shown — which shouldn't be a problem.

Also, I think https://code.djangoproject.com/ticket/8851 could be a next step after that, as it would allow the default admin page for models with many instances to be filtered by default, so that it doesn't take too long to load.
