### PR TITLE
Bail early on formsets.all_valid check

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -433,8 +433,7 @@ def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
 
 def all_valid(formsets):
     """Returns true if every formset in formsets is valid."""
-    valid = True
     for formset in formsets:
         if not formset.is_valid():
-            valid = False
-    return valid
+            return False
+    return True


### PR DESCRIPTION
There's no reason to iterate over all formsets after the first one is invalid

This can also be done as:

``` python
def all_valid(formsets):
    return not any(not formset.is_valid() for formset in formsets)
```

But I find that harder to parse personally.
