### PR TITLE
Cleanup some django.contrib.gis tests and fix random failure.

### DIFF
--- a/django/contrib/gis/tests/geoapp/tests.py
+++ b/django/contrib/gis/tests/geoapp/tests.py
@@ -607,7 +607,9 @@ class GeoQuerySetTest(TestCase):
             '-95.23506 38.971823,-87.650175 41.850385,-123.305196 48.462611)',
             srid=4326
         )
-        self.assertEqual(ref_line, City.objects.make_line())
+        # We check for equality with a tolerance of 10e-5 which is a lower bound
+        # of the precisions of ref_line coordinates
+        self.assertTrue(ref_line.equals_exact(City.objects.make_line(), tolerance=10e-5))
 
     @skipUnlessDBFeature("has_num_geom_method")
     def test_num_geom(self):


### PR DESCRIPTION
I wanted to fix the random `django.contrib.gis.tests.geoapp.tests.GeoQuerySetTest.test_make_line` failure happening on some builds and I realized that the assertion functions used needed some cleanup too. I put it all in this PR.

The `tolerance=10e-5` parameter might look arbitrary, but since it's the minimum precision of the ref_line coordinates I think there is no need to check with a better precision.
