### PR TITLE
Fixed potential problem with IndexError in QuerySet.first()

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -516,21 +516,19 @@ class QuerySet(object):
         """
         Returns the first object of a query, returns None if no match is found.
         """
-        qs = self if self.ordered else self.order_by('pk')
-        try:
-            return qs[0]
-        except IndexError:
-            return None
+        objects = list((self if self.ordered else self.order_by('pk'))[:1])
+        if objects:
+            return objects[0]
+        return None
 
     def last(self):
         """
         Returns the last object of a query, returns None if no match is found.
         """
-        qs = self.reverse() if self.ordered else self.order_by('-pk')
-        try:
-            return qs[0]
-        except IndexError:
-            return None
+        objects = list((self.reverse() if self.ordered else self.order_by('-pk'))[:1])
+        if objects:
+            return objects[0]
+        return None
 
     def in_bulk(self, id_list):
         """

--- a/tests/get_earliest_or_latest/models.py
+++ b/tests/get_earliest_or_latest/models.py
@@ -14,3 +14,20 @@ class Person(models.Model):
     name = models.CharField(max_length=30)
     birthday = models.DateField()
     # Note that this model doesn't have "get_latest_by" set.
+
+
+# Ticket #23555
+
+class IndexErrorQuerySet(models.QuerySet):
+    """
+    Raises IndexError on __iter__() call.
+
+    This emulates the case when some internal code raises unexpected IndexError
+    that should not be considered as a signal of the element absense.
+    """
+    def __iter__(self):
+        raise IndexError
+
+
+class IndexErrorArticle(Article):
+    objects = IndexErrorQuerySet.as_manager()


### PR DESCRIPTION
The current implementation may suppress internal IndexError exceptions.

Please see ticket 23555 for more details. https://code.djangoproject.com/ticket/23555#ticket
