### PR TITLE
Fixed #23455 -- Force related_name to be a string during deconstruction

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -14,7 +14,7 @@ from django.db.models.lookups import IsNull
 from django.db.models.related import RelatedObject, PathInfo
 from django.db.models.query import QuerySet
 from django.db.models.sql.datastructures import Col
-from django.utils.encoding import smart_text
+from django.utils.encoding import force_text, smart_text
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.utils.functional import curry, cached_property
@@ -1400,7 +1400,7 @@ class ForeignObject(RelatedField):
         kwargs['from_fields'] = self.from_fields
         kwargs['to_fields'] = self.to_fields
         if self.rel.related_name is not None:
-            kwargs['related_name'] = self.rel.related_name
+            kwargs['related_name'] = force_text(self.rel.related_name)
         if self.rel.related_query_name is not None:
             kwargs['related_query_name'] = self.rel.related_query_name
         if self.rel.on_delete != CASCADE:
@@ -2190,7 +2190,7 @@ class ManyToManyField(RelatedField):
         if self.rel.db_constraint is not True:
             kwargs['db_constraint'] = self.rel.db_constraint
         if self.rel.related_name is not None:
-            kwargs['related_name'] = self.rel.related_name
+            kwargs['related_name'] = force_text(self.rel.related_name)
         if self.rel.related_query_name is not None:
             kwargs['related_query_name'] = self.rel.related_query_name
         # Rel needs more work.

--- a/docs/releases/1.7.1.txt
+++ b/docs/releases/1.7.1.txt
@@ -76,3 +76,7 @@ Bugfixes
 
 * Added ``SchemaEditor`` for MySQL GIS backend so that spatial indexes will be
   created for apps with migrations (:ticket:`23538`).
+
+* Coerced the ``related_name`` model field option to unicode during migration
+  generation to generate migrations that work with both Python 2 and 3
+  (:ticket:`23455`).

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import warnings
 
 from django.db import models
@@ -209,6 +211,12 @@ class FieldDeconstructionTests(TestCase):
         self.assertEqual(path, "django.db.models.ForeignKey")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "foobar"})
+        # Test related_name unicode conversion
+        field = models.ForeignKey("auth.Permission", related_name=b"foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ForeignKey")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "foobar"})
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_foreign_key_swapped(self):
@@ -285,6 +293,12 @@ class FieldDeconstructionTests(TestCase):
         self.assertEqual(kwargs, {"to": "auth.Permission", "db_table": "custom_table"})
         # Test related_name
         field = models.ManyToManyField("auth.Permission", related_name="custom_table")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ManyToManyField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "custom_table"})
+        # Test related_name unicode conversion
+        field = models.ManyToManyField("auth.Permission", related_name=b"custom_table")
         name, path, args, kwargs = field.deconstruct()
         self.assertEqual(path, "django.db.models.ManyToManyField")
         self.assertEqual(args, [])


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/23455
