### PR TITLE
Replaced set([foo, ...]) by {foo, ...} literals.

### DIFF
--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -275,7 +275,7 @@ class ChangeList(object):
         # ordering fields so we can guarantee a deterministic order across all
         # database backends.
         pk_name = self.lookup_opts.pk.name
-        if not (set(ordering) & set(['pk', '-pk', pk_name, '-' + pk_name])):
+        if not (set(ordering) & {'pk', '-pk', pk_name, '-' + pk_name}):
             # The two sets do not intersect, meaning the pk isn't present. So
             # we add it.
             ordering.append('-pk')

--- a/django/contrib/auth/tests/test_auth_backends.py
+++ b/django/contrib/auth/tests/test_auth_backends.py
@@ -71,7 +71,7 @@ class BaseModelBackendTest(object):
 
         # reloading user to purge the _perm_cache
         user = self.UserModel._default_manager.get(pk=self.user.pk)
-        self.assertEqual(user.get_all_permissions() == set(['auth.test']), True)
+        self.assertEqual(user.get_all_permissions() == {'auth.test'}, True)
         self.assertEqual(user.get_group_permissions(), set([]))
         self.assertEqual(user.has_module_perms('Group'), False)
         self.assertEqual(user.has_module_perms('auth'), True)
@@ -81,7 +81,7 @@ class BaseModelBackendTest(object):
         perm = Permission.objects.create(name='test3', content_type=content_type, codename='test3')
         user.user_permissions.add(perm)
         user = self.UserModel._default_manager.get(pk=self.user.pk)
-        self.assertEqual(user.get_all_permissions(), set(['auth.test2', 'auth.test', 'auth.test3']))
+        self.assertEqual(user.get_all_permissions(), {'auth.test2', 'auth.test', 'auth.test3'})
         self.assertEqual(user.has_perm('test'), False)
         self.assertEqual(user.has_perm('auth.test'), True)
         self.assertEqual(user.has_perms(['auth.test2', 'auth.test3']), True)
@@ -91,9 +91,9 @@ class BaseModelBackendTest(object):
         group.permissions.add(perm)
         user.groups.add(group)
         user = self.UserModel._default_manager.get(pk=self.user.pk)
-        exp = set(['auth.test2', 'auth.test', 'auth.test3', 'auth.test_group'])
+        exp = {'auth.test2', 'auth.test', 'auth.test3', 'auth.test_group'}
         self.assertEqual(user.get_all_permissions(), exp)
-        self.assertEqual(user.get_group_permissions(), set(['auth.test_group']))
+        self.assertEqual(user.get_group_permissions(), {'auth.test_group'})
         self.assertEqual(user.has_perms(['auth.test3', 'auth.test_group']), True)
 
         user = AnonymousUser()
@@ -110,7 +110,7 @@ class BaseModelBackendTest(object):
         self.assertEqual(user.has_perm('auth.test', 'object'), False)
         self.assertEqual(user.get_all_permissions('object'), set([]))
         self.assertEqual(user.has_perm('auth.test'), True)
-        self.assertEqual(user.get_all_permissions(), set(['auth.test']))
+        self.assertEqual(user.get_all_permissions(), {'auth.test'})
 
     def test_anonymous_has_no_permissions(self):
         """
@@ -129,9 +129,9 @@ class BaseModelBackendTest(object):
         user.groups.add(group)
         group.permissions.add(group_perm)
 
-        self.assertEqual(backend.get_all_permissions(user), set(['auth.test_user', 'auth.test_group']))
-        self.assertEqual(backend.get_user_permissions(user), set(['auth.test_user', 'auth.test_group']))
-        self.assertEqual(backend.get_group_permissions(user), set(['auth.test_group']))
+        self.assertEqual(backend.get_all_permissions(user), {'auth.test_user', 'auth.test_group'})
+        self.assertEqual(backend.get_user_permissions(user), {'auth.test_user', 'auth.test_group'})
+        self.assertEqual(backend.get_group_permissions(user), {'auth.test_group'})
 
         user.is_anonymous = lambda: True
 
@@ -156,9 +156,9 @@ class BaseModelBackendTest(object):
         user.groups.add(group)
         group.permissions.add(group_perm)
 
-        self.assertEqual(backend.get_all_permissions(user), set(['auth.test_user', 'auth.test_group']))
-        self.assertEqual(backend.get_user_permissions(user), set(['auth.test_user', 'auth.test_group']))
-        self.assertEqual(backend.get_group_permissions(user), set(['auth.test_group']))
+        self.assertEqual(backend.get_all_permissions(user), {'auth.test_user', 'auth.test_group'})
+        self.assertEqual(backend.get_user_permissions(user), {'auth.test_user', 'auth.test_group'})
+        self.assertEqual(backend.get_group_permissions(user), {'auth.test_group'})
 
         user.is_active = False
         user.save()
@@ -367,14 +367,14 @@ class RowlevelBackendTest(TestCase):
         self.assertEqual(self.user3.has_perms(['simple', 'advanced'], TestObj()), False)
 
     def test_get_all_permissions(self):
-        self.assertEqual(self.user1.get_all_permissions(TestObj()), set(['simple']))
-        self.assertEqual(self.user2.get_all_permissions(TestObj()), set(['simple', 'advanced']))
+        self.assertEqual(self.user1.get_all_permissions(TestObj()), {'simple'})
+        self.assertEqual(self.user2.get_all_permissions(TestObj()), {'simple', 'advanced'})
         self.assertEqual(self.user2.get_all_permissions(), set([]))
 
     def test_get_group_permissions(self):
         group = Group.objects.create(name='test_group')
         self.user3.groups.add(group)
-        self.assertEqual(self.user3.get_group_permissions(TestObj()), set(['group_perm']))
+        self.assertEqual(self.user3.get_group_permissions(TestObj()), {'group_perm'})
 
 
 class AnonymousUserBackendTest(TestCase):
@@ -405,7 +405,7 @@ class AnonymousUserBackendTest(TestCase):
         self.assertEqual(self.user1.has_module_perms("app2"), False)
 
     def test_get_all_permissions(self):
-        self.assertEqual(self.user1.get_all_permissions(TestObj()), set(['anon']))
+        self.assertEqual(self.user1.get_all_permissions(TestObj()), {'anon'})
 
 
 @skipIfCustomUser

--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -31,7 +31,7 @@ class MySQLOperations(DatabaseOperations, BaseSpatialOperations):
         'within': 'MBRWithin',
     }
 
-    gis_terms = set(geometry_functions) | set(['isnull'])
+    gis_terms = set(geometry_functions) | {'isnull'}
 
     def geo_db_type(self, f):
         return f.geom_type

--- a/django/contrib/gis/db/backends/oracle/operations.py
+++ b/django/contrib/gis/db/backends/oracle/operations.py
@@ -137,7 +137,7 @@ class OracleOperations(DatabaseOperations, BaseSpatialOperations):
     }
     geometry_functions.update(distance_functions)
 
-    gis_terms = set(['isnull'])
+    gis_terms = {'isnull'}
     gis_terms.update(geometry_functions)
 
     truncate_params = {'relate': None}

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -177,7 +177,7 @@ class PostGISOperations(DatabaseOperations, BaseSpatialOperations):
         }
 
         # Creating a dictionary lookup of all GIS terms for PostGIS.
-        self.gis_terms = set(['isnull'])
+        self.gis_terms = {'isnull'}
         self.gis_terms.update(self.geometry_operators)
         self.gis_terms.update(self.geometry_functions)
 

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -134,7 +134,7 @@ class SpatiaLiteOperations(DatabaseOperations, BaseSpatialOperations):
         super(DatabaseOperations, self).__init__(connection)
 
         # Creating the GIS terms dictionary.
-        self.gis_terms = set(['isnull'])
+        self.gis_terms = {'isnull'}
         self.gis_terms.update(self.geometry_functions)
 
     @cached_property

--- a/django/contrib/gis/tests/geo3d/tests.py
+++ b/django/contrib/gis/tests/geo3d/tests.py
@@ -204,7 +204,7 @@ class Geo3DTest(TestCase):
         union = City3D.objects.aggregate(Union('point'))['point__union']
         self.assertTrue(union.hasz)
         # Ordering of points in the resulting geometry may vary between implementations
-        self.assertSetEqual(set([p.ewkt for p in ref_union]), set([p.ewkt for p in union]))
+        self.assertSetEqual({p.ewkt for p in ref_union}, {p.ewkt for p in union})
 
     def test_extent(self):
         """

--- a/django/contrib/gis/tests/relatedapp/tests.py
+++ b/django/contrib/gis/tests/relatedapp/tests.py
@@ -113,9 +113,9 @@ class RelatedGeoModelTest(TestCase):
 
         # Ordering of points in the result of the union is not defined and
         # implementation-dependent (DB backend, GEOS version)
-        self.assertSetEqual(set([p.ewkt for p in ref_u1]), set([p.ewkt for p in u1]))
-        self.assertSetEqual(set([p.ewkt for p in ref_u2]), set([p.ewkt for p in u2]))
-        self.assertSetEqual(set([p.ewkt for p in ref_u1]), set([p.ewkt for p in u3]))
+        self.assertSetEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u1})
+        self.assertSetEqual({p.ewkt for p in ref_u2}, {p.ewkt for p in u2})
+        self.assertSetEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u3})
 
     def test05_select_related_fk_to_subclass(self):
         "Testing that calling select_related on a query over a model with an FK to a model subclass works"

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -64,7 +64,7 @@ def make_msgid(idstring=None):
 
 
 # Header names that contain structured address data (RFC #5322)
-ADDRESS_HEADERS = set([
+ADDRESS_HEADERS = {
     'from',
     'sender',
     'reply-to',
@@ -76,7 +76,7 @@ ADDRESS_HEADERS = set([
     'resent-to',
     'resent-cc',
     'resent-bcc',
-])
+}
 
 
 def forbid_multi_line_headers(name, val, encoding):

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -44,9 +44,9 @@ def handle_extensions(extensions=('html',), ignored=('py',)):
     would result in an extension list: ['.js', '.txt', '.xhtml']
 
     >>> handle_extensions(['.html', 'html,js,py,py,py,.py', 'py,.py'])
-    set(['.html', '.js'])
+    {'.html', '.js'}
     >>> handle_extensions(['.html, txt,.tpl'])
-    set(['.html', '.tpl', '.txt'])
+    {'.html', '.tpl', '.txt'}
     """
     ext_list = []
     for ext in extensions:

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -1337,10 +1337,10 @@ class BaseDatabaseIntrospection(object):
         for app_config in apps.get_app_configs():
             all_models.extend(router.get_migratable_models(app_config, self.connection.alias))
         tables = list(map(self.table_name_converter, tables))
-        return set([
+        return {
             m for m in all_models
             if self.table_name_converter(m._meta.db_table) in tables
-        ])
+        }
 
     def sequence_list(self):
         "Returns a list of information about all DB sequences for all models in all apps."

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -873,13 +873,13 @@ class MigrationAutodetector(object):
             # We run the old version through the field renames to account for those
             old_value = old_model_state.options.get(option_name) or set()
             if old_value:
-                old_value = set([
+                old_value = {
                     tuple(
                         self.renamed_fields.get((app_label, model_name, n), n)
                         for n in unique
                     )
                     for unique in old_value
-                ])
+                }
 
             new_value = new_model_state.options.get(option_name) or set()
             if new_value:

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -54,9 +54,9 @@ def DO_NOTHING(collector, field, sub_objs, using):
 class Collector(object):
     def __init__(self, using):
         self.using = using
-        # Initially, {model: set([instances])}, later values become lists.
+        # Initially, {model: {instances}}, later values become lists.
         self.data = {}
-        self.field_updates = {}  # {model: {(field, value): set([instances])}}
+        self.field_updates = {}  # {model: {(field, value): {instances}}}
         # fast_deletes is a list of queryset-likes that can be deleted without
         # fetching the objects into memory.
         self.fast_deletes = []
@@ -66,7 +66,7 @@ class Collector(object):
         # should be included, as the dependencies exist only between actual
         # database tables; proxy models are represented here by their concrete
         # parent.
-        self.dependencies = {}  # {model: set([models])}
+        self.dependencies = {}  # {model: {models}}
 
     def add(self, objs, source=None, nullable=False, reverse_dependency=False):
         """

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -349,7 +349,7 @@ class Field(RegisterLookupMixin):
             "validators": "_validators",
             "verbose_name": "_verbose_name",
         }
-        equals_comparison = set(["choices", "validators", "db_tablespace"])
+        equals_comparison = {"choices", "validators", "db_tablespace"}
         for name, default in possibles.items():
             value = getattr(self, attr_overrides.get(name, name))
             # Unroll anything iterable for choices into a concrete list

--- a/django/db/models/sql/constants.py
+++ b/django/db/models/sql/constants.py
@@ -8,12 +8,12 @@ import re
 # Valid query types (a set is used for speedy lookups). These are (currently)
 # considered SQL-specific; other storage systems may choose to use different
 # lookup types.
-QUERY_TERMS = set([
+QUERY_TERMS = {
     'exact', 'iexact', 'contains', 'icontains', 'gt', 'gte', 'lt', 'lte', 'in',
     'startswith', 'istartswith', 'endswith', 'iendswith', 'range', 'year',
     'month', 'day', 'week_day', 'hour', 'minute', 'second', 'isnull', 'search',
     'regex', 'iregex',
-])
+}
 
 # Size of each "chunk" for get_iterator calls.
 # Larger values are slightly faster at the expense of more storage space.

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -574,7 +574,7 @@ class Query(object):
             return
         orig_opts = self.get_meta()
         seen = {}
-        must_include = {orig_opts.concrete_model: set([orig_opts.pk])}
+        must_include = {orig_opts.concrete_model: {orig_opts.pk}}
         for field_name in field_names:
             parts = field_name.split(LOOKUP_SEP)
             cur_model = self.model._meta.concrete_model
@@ -2024,7 +2024,7 @@ def add_to_dict(data, key, value):
     if key in data:
         data[key].add(value)
     else:
-        data[key] = set([value])
+        data[key] = {value}
 
 
 def is_reverse_o2o(field):

--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -298,7 +298,7 @@ def _non_atomic_requests(view, using):
     try:
         view._non_atomic_requests.add(using)
     except AttributeError:
-        view._non_atomic_requests = set([using])
+        view._non_atomic_requests = {using}
     return view
 
 

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -17,7 +17,7 @@ setting_changed = Signal(providing_args=["setting", "value", "enter"])
 # except for cases where the receiver is related to a contrib app.
 
 # Settings that may not work well when using 'override_settings' (#19031)
-COMPLEX_OVERRIDE_SETTINGS = set(['DATABASES'])
+COMPLEX_OVERRIDE_SETTINGS = {'DATABASES'}
 
 
 @receiver(setting_changed)

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -225,8 +225,8 @@ def sanitize_separators(value):
                 # Special case where we suspect a dot meant decimal separator (see #22171)
                 pass
             else:
-                for replacement in set([
-                        thousand_sep, unicodedata.normalize('NFKD', thousand_sep)]):
+                for replacement in {
+                        thousand_sep, unicodedata.normalize('NFKD', thousand_sep)}:
                     value = value.replace(replacement, '')
         parts.append(value)
         value = '.'.join(reversed(parts))

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -310,7 +310,7 @@ Argument        Value
 ``model``       ``Topping`` (the class of the objects added to the
                 ``Pizza``)
 
-``pk_set``      ``set([t.id])`` (since only ``Topping t`` was added to the relation)
+``pk_set``      ``{t.id}`` (since only ``Topping t`` was added to the relation)
 
 ``using``       ``"default"`` (since the default router sends writes here)
 ==============  ============================================================
@@ -337,7 +337,7 @@ Argument        Value
 ``model``       ``Pizza`` (the class of the objects removed from the
                 ``Topping``)
 
-``pk_set``      ``set([p.id])`` (since only ``Pizza p`` was removed from the
+``pk_set``      ``{p.id}`` (since only ``Pizza p`` was removed from the
                 relation)
 
 ``using``       ``"default"`` (since the default router sends writes here)

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -91,11 +91,11 @@ class DepartmentListFilterLookupWithNonStringValue(SimpleListFilter):
     parameter_name = 'department'
 
     def lookups(self, request, model_admin):
-        return sorted(set([
+        return sorted({
             (employee.department.id,  # Intentionally not a string (Refs #19318)
              employee.department.code)
             for employee in model_admin.get_queryset(request).all()
-        ]))
+        })
 
     def queryset(self, request, queryset):
         if self.value():

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -429,7 +429,7 @@ class ModelTest(TestCase):
             pub_date=datetime(2008, 12, 31, 23, 59, 59, 999999),
         )
 
-        s = set([a10, a11, a12])
+        s = {a10, a11, a12}
         self.assertTrue(Article.objects.get(headline='Article 11') in s)
 
     def test_field_ordering(self):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1422,16 +1422,16 @@ class CacheUtils(TestCase):
     def test_patch_cache_control(self):
         tests = (
             # Initial Cache-Control, kwargs to patch_cache_control, expected Cache-Control parts
-            (None, {'private': True}, set(['private'])),
+            (None, {'private': True}, {'private'}),
 
             # Test whether private/public attributes are mutually exclusive
-            ('private', {'private': True}, set(['private'])),
-            ('private', {'public': True}, set(['public'])),
-            ('public', {'public': True}, set(['public'])),
-            ('public', {'private': True}, set(['private'])),
-            ('must-revalidate,max-age=60,private', {'public': True}, set(['must-revalidate', 'max-age=60', 'public'])),
-            ('must-revalidate,max-age=60,public', {'private': True}, set(['must-revalidate', 'max-age=60', 'private'])),
-            ('must-revalidate,max-age=60', {'public': True}, set(['must-revalidate', 'max-age=60', 'public'])),
+            ('private', {'private': True}, {'private'}),
+            ('private', {'public': True}, {'public'}),
+            ('public', {'public': True}, {'public'}),
+            ('public', {'private': True}, {'private'}),
+            ('must-revalidate,max-age=60,private', {'public': True}, {'must-revalidate', 'max-age=60', 'public'}),
+            ('must-revalidate,max-age=60,public', {'private': True}, {'must-revalidate', 'max-age=60', 'private'}),
+            ('must-revalidate,max-age=60', {'public': True}, {'must-revalidate', 'max-age=60', 'public'}),
         )
 
         cc_delim_re = re.compile(r'\s*,\s*')

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -281,9 +281,9 @@ class FileStorageTests(unittest.TestCase):
         os.mkdir(os.path.join(self.temp_dir, 'storage_dir_1'))
 
         dirs, files = self.storage.listdir('')
-        self.assertEqual(set(dirs), set(['storage_dir_1']))
+        self.assertEqual(set(dirs), {'storage_dir_1'})
         self.assertEqual(set(files),
-                         set(['storage_test_1', 'storage_test_2']))
+                         {'storage_test_1', 'storage_test_2'})
 
         self.storage.delete('storage_test_1')
         self.storage.delete('storage_test_2')

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -55,7 +55,7 @@ class IntrospectionTests(TestCase):
     def test_installed_models(self):
         tables = [Article._meta.db_table, Reporter._meta.db_table]
         models = connection.introspection.installed_models(tables)
-        self.assertEqual(models, set([Article, Reporter]))
+        self.assertEqual(models, {Article, Reporter})
 
     def test_sequence_list(self):
         sequences = connection.introspection.sequence_list()
@@ -129,8 +129,8 @@ class IntrospectionTests(TestCase):
             key_columns = connection.introspection.get_key_columns(cursor, Article._meta.db_table)
         self.assertEqual(
             set(key_columns),
-            set([('reporter_id', Reporter._meta.db_table, 'id'),
-                 ('response_to_id', Article._meta.db_table, 'id')]))
+            {('reporter_id', Reporter._meta.db_table, 'id'),
+                 ('response_to_id', Article._meta.db_table, 'id')})
 
     def test_get_primary_key_column(self):
         with connection.cursor() as cursor:

--- a/tests/known_related_objects/tests.py
+++ b/tests/known_related_objects/tests.py
@@ -34,7 +34,7 @@ class ExistingRelatedInstancesTests(TestCase):
         with self.assertNumQueries(1):
             pools = tournament_1.pool_set.all() | tournament_2.pool_set.all()
             related_objects = set(pool.tournament for pool in pools)
-            self.assertEqual(related_objects, set((tournament_1, tournament_2)))
+            self.assertEqual(related_objects, {tournament_1, tournament_2})
 
     def test_queryset_or_different_cached_items(self):
         tournament = Tournament.objects.get(pk=1)
@@ -52,12 +52,12 @@ class ExistingRelatedInstancesTests(TestCase):
         with self.assertNumQueries(2):
             pools = tournament_1.pool_set.all() | Pool.objects.filter(pk=3)
             related_objects = set(pool.tournament for pool in pools)
-            self.assertEqual(related_objects, set((tournament_1, tournament_2)))
+            self.assertEqual(related_objects, {tournament_1, tournament_2})
         # and the other direction
         with self.assertNumQueries(2):
             pools = Pool.objects.filter(pk=3) | tournament_1.pool_set.all()
             related_objects = set(pool.tournament for pool in pools)
-            self.assertEqual(related_objects, set((tournament_1, tournament_2)))
+            self.assertEqual(related_objects, {tournament_1, tournament_2})
 
     def test_queryset_and(self):
         tournament = Tournament.objects.get(pk=1)

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -114,7 +114,7 @@ class LookupTests(TestCase):
         self.assertEqual(arts[self.a1.id], self.a1)
         self.assertEqual(arts[self.a2.id], self.a2)
         self.assertEqual(Article.objects.in_bulk([self.a3.id]), {self.a3.id: self.a3})
-        self.assertEqual(Article.objects.in_bulk(set([self.a3.id])), {self.a3.id: self.a3})
+        self.assertEqual(Article.objects.in_bulk({self.a3.id}), {self.a3.id: self.a3})
         self.assertEqual(Article.objects.in_bulk(frozenset([self.a3.id])), {self.a3.id: self.a3})
         self.assertEqual(Article.objects.in_bulk((self.a3.id,)), {self.a3.id: self.a3})
         self.assertEqual(Article.objects.in_bulk([1000]), {})

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -25,7 +25,7 @@ class RecorderTests(TestCase):
         recorder.record_applied("myapp", "0432_ponies")
         self.assertEqual(
             set((x, y) for (x, y) in recorder.applied_migrations() if x == "myapp"),
-            set([("myapp", "0432_ponies")]),
+            {("myapp", "0432_ponies")},
         )
         # That should not affect records of another database
         recorder_other = MigrationRecorder(connections['other'])

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -66,7 +66,7 @@ class StateTests(TestCase):
         self.assertEqual(author_state.fields[1][1].max_length, 255)
         self.assertEqual(author_state.fields[2][1].null, False)
         self.assertEqual(author_state.fields[3][1].null, True)
-        self.assertEqual(author_state.options, {"unique_together": set([("name", "bio")]), "index_together": set([("bio", "age")])})
+        self.assertEqual(author_state.options, {"unique_together": {("name", "bio")}, "index_together": {("bio", "age")}})
         self.assertEqual(author_state.bases, (models.Model, ))
 
         self.assertEqual(book_state.app_label, "migrations")

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -78,7 +78,7 @@ class WriterTests(TestCase):
         self.assertEqual(string, "'foobar'")
         self.assertSerializedEqual({1: 2})
         self.assertSerializedEqual(["a", 2, True, None])
-        self.assertSerializedEqual(set([2, 3, "eighty"]))
+        self.assertSerializedEqual({2, 3, "eighty"})
         self.assertSerializedEqual({"lalalala": ["yeah", "no", "maybe"]})
         self.assertSerializedEqual(_('Hello'))
         # Builtins
@@ -120,7 +120,7 @@ class WriterTests(TestCase):
             SettingsReference("someapp.model", "AUTH_USER_MODEL"),
             (
                 "settings.AUTH_USER_MODEL",
-                set(["from django.conf import settings"]),
+                {"from django.conf import settings"},
             )
         )
         self.assertSerializedResultEqual(

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -719,9 +719,9 @@ class GenericRelationTests(TestCase):
             # If we limit to books, we know that they will have 'read_by'
             # attributes, so the following makes sense:
             qs = TaggedItem.objects.filter(content_type=ct, tag='awesome').prefetch_related('content_object__read_by')
-            readers_of_awesome_books = set([r.name for tag in qs
-                                            for r in tag.content_object.read_by.all()])
-            self.assertEqual(readers_of_awesome_books, set(["me", "you", "someone"]))
+            readers_of_awesome_books = {r.name for tag in qs
+                                            for r in tag.content_object.read_by.all()}
+            self.assertEqual(readers_of_awesome_books, {"me", "you", "someone"})
 
     def test_nullable_GFK(self):
         TaggedItem.objects.create(tag="awesome", content_object=self.book1,

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -91,10 +91,10 @@ class Queries1Tests(BaseQuerysetTest):
         qs1 = Tag.objects.filter(pk__lte=0)
         qs2 = Tag.objects.filter(parent__in=qs1)
         qs3 = Tag.objects.filter(parent__in=qs2)
-        self.assertEqual(qs3.query.subq_aliases, set(['T', 'U', 'V']))
+        self.assertEqual(qs3.query.subq_aliases, {'T', 'U', 'V'})
         self.assertIn('v0', str(qs3.query).lower())
         qs4 = qs3.filter(parent__in=qs1)
-        self.assertEqual(qs4.query.subq_aliases, set(['T', 'U', 'V']))
+        self.assertEqual(qs4.query.subq_aliases, {'T', 'U', 'V'})
         # It is possible to reuse U for the second subquery, no need to use W.
         self.assertNotIn('w0', str(qs4.query).lower())
         # So, 'U0."id"' is referenced twice.
@@ -1972,29 +1972,29 @@ class SubqueryTests(TestCase):
     def test_ordered_subselect(self):
         "Subselects honor any manual ordering"
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[0:2])
-        self.assertEqual(set(query.values_list('id', flat=True)), set([3, 4]))
+        self.assertEqual(set(query.values_list('id', flat=True)), {3, 4})
 
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[:2])
-        self.assertEqual(set(query.values_list('id', flat=True)), set([3, 4]))
+        self.assertEqual(set(query.values_list('id', flat=True)), {3, 4})
 
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[1:2])
-        self.assertEqual(set(query.values_list('id', flat=True)), set([3]))
+        self.assertEqual(set(query.values_list('id', flat=True)), {3})
 
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[2:])
-        self.assertEqual(set(query.values_list('id', flat=True)), set([1, 2]))
+        self.assertEqual(set(query.values_list('id', flat=True)), {1, 2})
 
     def test_slice_subquery_and_query(self):
         """
         Slice a query that has a sliced subquery
         """
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[0:2])[0:2]
-        self.assertEqual(set([x.id for x in query]), set([3, 4]))
+        self.assertEqual({x.id for x in query}, {3, 4})
 
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[1:3])[1:3]
-        self.assertEqual(set([x.id for x in query]), set([3]))
+        self.assertEqual({x.id for x in query}, {3})
 
         query = DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[2:])[1:]
-        self.assertEqual(set([x.id for x in query]), set([2]))
+        self.assertEqual({x.id for x in query}, {2})
 
     def test_related_sliced_subquery(self):
         """
@@ -2010,18 +2010,18 @@ class SubqueryTests(TestCase):
         query = ManagedModel.normal_manager.filter(
             tag__in=Tag.objects.order_by('-id')[:1]
         )
-        self.assertEqual(set([x.id for x in query]), set([mm2.id]))
+        self.assertEqual({x.id for x in query}, {mm2.id})
 
     def test_sliced_delete(self):
         "Delete queries can safely contain sliced subqueries"
         DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[0:1]).delete()
-        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), set([1, 2, 3]))
+        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), {1, 2, 3})
 
         DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[1:2]).delete()
-        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), set([1, 3]))
+        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), {1, 3})
 
         DumbCategory.objects.filter(id__in=DumbCategory.objects.order_by('-id')[1:]).delete()
-        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), set([3]))
+        self.assertEqual(set(DumbCategory.objects.values_list('id', flat=True)), {3})
 
 
 class CloneTests(TestCase):
@@ -2360,7 +2360,7 @@ class ToFieldTests(TestCase):
 
         self.assertEqual(
             set(Eaten.objects.filter(food__in=[apple, pear])),
-            set([lunch, dinner]),
+            {lunch, dinner},
         )
 
     def test_reverse_in(self):
@@ -2371,7 +2371,7 @@ class ToFieldTests(TestCase):
 
         self.assertEqual(
             set(Food.objects.filter(eaten__in=[lunch_apple, lunch_pear])),
-            set([apple, pear])
+            {apple, pear}
         )
 
     def test_single_object(self):
@@ -2381,7 +2381,7 @@ class ToFieldTests(TestCase):
 
         self.assertEqual(
             set(Eaten.objects.filter(food=apple)),
-            set([lunch, dinner])
+            {lunch, dinner}
         )
 
     def test_single_object_reverse(self):
@@ -2390,7 +2390,7 @@ class ToFieldTests(TestCase):
 
         self.assertEqual(
             set(Food.objects.filter(eaten=lunch)),
-            set([apple])
+            {apple}
         )
 
     def test_recursive_fk(self):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -68,7 +68,7 @@ class RequestsTests(SimpleTestCase):
         self.assertEqual(list(request.GET.keys()), [])
         self.assertEqual(list(request.POST.keys()), [])
         self.assertEqual(list(request.COOKIES.keys()), [])
-        self.assertEqual(set(request.META.keys()), set(['PATH_INFO', 'REQUEST_METHOD', 'SCRIPT_NAME', 'wsgi.input']))
+        self.assertEqual(set(request.META.keys()), {'PATH_INFO', 'REQUEST_METHOD', 'SCRIPT_NAME', 'wsgi.input'})
         self.assertEqual(request.META['PATH_INFO'], 'bogus')
         self.assertEqual(request.META['REQUEST_METHOD'], 'bogus')
         self.assertEqual(request.META['SCRIPT_NAME'], '')

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -993,8 +993,8 @@ class ContextTests(TestCase):
         l = ContextList([c1, c2])
         # None, True and False are builtins of BaseContext, and present
         # in every Context without needing to be added.
-        self.assertEqual(set(['None', 'True', 'False', 'hello', 'goodbye',
-                              'python', 'dolly']),
+        self.assertEqual({'None', 'True', 'False', 'hello', 'goodbye',
+                              'python', 'dolly'},
                          l.keys())
 
     def test_15368(self):

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -266,7 +266,7 @@ class SimpleLazyObjectTestCase(LazyObjectTestCase):
 
     def test_list_set(self):
         lazy_list = SimpleLazyObject(lambda: [1, 2, 3, 4, 5])
-        lazy_set = SimpleLazyObject(lambda: set([1, 2, 3, 4]))
+        lazy_set = SimpleLazyObject(lambda: {1, 2, 3, 4})
         self.assertTrue(1 in lazy_list)
         self.assertTrue(1 in lazy_set)
         self.assertFalse(6 in lazy_list)


### PR DESCRIPTION
Using literals is optimal as it avoids a list creation and a function call — this won't make any big performance difference but since it also is the nominal way to create a set in Python2.7+ and does not affect readability there is no reason not to use it.

For reference:

``` bash
$ python2.7 -m timeit -n 1000000 -r 5 -v 'set(["foo", "bar", "baz", "qux"])'
raw times: 0.784 0.678 0.686 0.753 0.777
1000000 loops, best of 5: 0.678 usec per loop

$ python2.7 -m timeit -n 1000000 -r 5 -v '{"foo", "bar", "baz", "qux"}'
raw times: 0.198 0.207 0.19 0.237 0.274
1000000 loops, best of 5: 0.19 usec per loop
```

See also http://doughellmann.com/2012/11/12/the-performance-impact-of-using-dict-instead-of-in-cpython-2-7-2.html
