### PR TITLE
Added cross-referencing links to templates, migrations, models, settings

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -28,6 +28,8 @@ output incorrect code.
 All of the core Django operations are available from the
 ``django.db.migrations.operations`` module.
 
+For introductory material, see :doc:`/topics/migrations`.
+
 Schema Operations
 =================
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -18,7 +18,7 @@ Core settings
 
 Here's a list of settings available in Django core and their default values.
 Settings provided by contrib apps are listed below, followed by a topical index
-of the core settings.
+of the core settings. For introductory material, see :doc:`/topics/settings`.
 
 .. setting:: ABSOLUTE_URL_OVERRIDES
 

--- a/docs/ref/templates/index.txt
+++ b/docs/ref/templates/index.txt
@@ -5,7 +5,8 @@ Templates
 Django's template engine provides a powerful mini-language for defining the
 user-facing layer of your application, encouraging a clean separation of
 application and presentation logic. Templates can be maintained by anyone with
-an understanding of HTML; no knowledge of Python is required.
+an understanding of HTML; no knowledge of Python is required. For introductory
+material, see :doc:`/topics/templates`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1374,3 +1374,9 @@ different database tables).
 
 Django will raise a :exc:`~django.core.exceptions.FieldError` if you override
 any model field in any ancestor model.
+
+.. seealso::
+
+    :doc:`The Models Reference </ref/models/index>`
+        Covers the full API reference, including model fields, related
+        objects, and QuerySet API.

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -657,3 +657,9 @@ your Django migrations in the ``migrations`` directory.
 
 More information is available in the
 `South 1.0 release notes <http://south.readthedocs.org/en/latest/releasenotes/1.0.html#library-migration-path>`_.
+
+.. seealso::
+
+    :doc:`The Migrations Reference </ref/migration-operations>`
+        Covers the full schema operations, special operations, and writing your
+        own operations.

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -267,3 +267,9 @@ It boils down to this: Use exactly one of either ``configure()`` or
 ``DJANGO_SETTINGS_MODULE``. Not both, and not neither.
 
 .. _@login_required: ../authentication/#the-login-required-decorator
+
+.. seealso::
+
+    :doc:`The Settings Reference </ref/settings>`
+        Covers the full API reference, including core settings, auth, comments,
+        messages, sessions, sites, and static files.

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -693,3 +693,9 @@ access to the humanize template tags and filters. The child template is
 responsible for its own ``{% load humanize %}``.
 
 This is a feature for the sake of maintainability and sanity.
+
+.. seealso::
+
+    :doc:`The Templates Reference </ref/templates/index>`
+        Covers built-in tags, built-in filters, render_to_string shortcut, and
+        using an alternative template language.


### PR DESCRIPTION
Following comments and what has already been done, I added links to the bottom of the topics pages for templates, settings, models, and migrations that go to the corresponding reference pages. I also added links to the top of ref/settings, ref/migration-operations, and ref/templates/index that go to the corresponding topics pages.
