### PR TITLE
Fixed #23569 -- Allow use fileConfig() in logging

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -596,6 +596,7 @@ answer newbie questions, and generally made Django that much better:
     Sengtha Chay <sengtha@e-khmer.com>
     Senko Rašić <senko.rasic@dobarkod.hr>
     serbaut@gmail.com
+    Seth Hill <sethrh@gmail.com>
     Shai Berger <shai@platonix.com>
     Shannon -jj Behrens <http://jjinux.blogspot.com/>
     Shawn Milochik <shawn@milochik.com>

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -77,7 +77,7 @@ def configure_logging(logging_config, logging_settings):
         # First find the logging configuration function ...
         logging_config_func = import_string(logging_config)
 
-        logging_config_func(DEFAULT_LOGGING)
+        dictConfig(DEFAULT_LOGGING)
 
         # ... then invoke it with the logging settings
         if logging_settings:

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+import tempfile
 import warnings
 
 from django.core import mail
@@ -356,7 +357,8 @@ class SetupConfigureLogging(TestCase):
     """
     Test that calling django.setup() initializes the logging configuration.
     """
-    @override_settings(LOGGING_CONFIG='logging_tests.tests.dictConfig')
+    @override_settings(LOGGING_CONFIG='logging_tests.tests.dictConfig',
+                       LOGGING=OLD_LOGGING)
     def test_configure_initializes_logging(self):
         from django import setup
         setup()
@@ -386,3 +388,40 @@ class SecurityLoggerTest(TestCase):
         self.client.get('/suspicious/')
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn('path:/suspicious/,', mail.outbox[0].body)
+
+
+class SettingsCustomLoggingTest(AdminScriptTestCase):
+    """
+    Test that using a logging defaults are still applied when using a custom
+    callable in LOGGING_CONFIG (i.e., logging.config.fileConfig).
+    """
+    def setUp(self):
+        logging_conf = """[loggers]
+keys=root
+[handlers]
+keys=stream
+[formatters]
+keys=simple
+[logger_root]
+handlers=stream
+[handler_stream]
+class=StreamHandler
+formatter=simple
+args=(sys.stdout,)
+[formatter_simple]
+format=%(message)s
+"""
+        self.temp_file = tempfile.NamedTemporaryFile()
+        self.temp_file.write(logging_conf.encode('utf-8'))
+        self.temp_file.flush()
+        sdict = {'LOGGING_CONFIG': '"logging.config.fileConfig"',
+                 'LOGGING': '"%s"' % self.temp_file.name}
+        self.write_settings('settings.py', sdict=sdict)
+
+    def tearDown(self):
+        self.temp_file.close()
+
+    def test_custom_logging(self):
+        out, err = self.run_manage(['validate'])
+        self.assertNoOutput(err)
+        self.assertOutput(out, "System check identified no issues (0 silenced).")


### PR DESCRIPTION
settings.LOGGING_CONFIG assumes dictConfig(). If you're using a different logging config function, django sends it a dictionary of options as the first argument. It looks like the intention was to initialize a default set of options with a dictionary, and then allow the user settings to override. 

This little change should fix that. 

https://code.djangoproject.com/ticket/23569
