### PR TITLE
Fixed #8149 -- Fixed File.__iter__() to handle other newline types.

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -102,16 +102,22 @@ class File(FileProxyMixin):
         # Iterate over this file-like object by newlines
         buffer_ = None
         for chunk in self.chunks():
-            chunk_buffer = BytesIO(chunk)
-
-            for line in chunk_buffer:
+            for line in chunk.splitlines(True):
                 if buffer_:
-                    line = buffer_ + line
+                    if endswith_cr(buffer_) and not equals_lf(line):
+                        # Line split after a \r newline; yield buffer_.
+                        yield buffer_
+                        # Continue with line.
+                    else:
+                        # Line either split without a newline (line
+                        # continues after buffer_) or with \r\n
+                        # newline (line == b'\n').
+                        line = buffer_ + line
+                    # buffer_ handled, clear it.
                     buffer_ = None
 
-                # If this is the end of a line, yield
-                # otherwise, wait for the next round
-                if line[-1:] in (b'\n', b'\r'):
+                # If this is the end of a \n or \r\n line, yield.
+                if endswith_lf(line):
                     yield line
                 else:
                     buffer_ = line
@@ -165,3 +171,24 @@ class ContentFile(File):
 
     def close(self):
         pass
+
+
+def endswith_cr(line):
+    """
+    Return True if line, a text or byte string, ends with '\r'.
+    """
+    return line.endswith('\r' if isinstance(line, six.text_type) else b'\r')
+
+
+def endswith_lf(line):
+    """
+    Return True if line, a text or byte string, ends with '\n'.
+    """
+    return line.endswith('\n' if isinstance(line, six.text_type) else b'\n')
+
+
+def equals_lf(line):
+    """
+    Return True if line, a text or byte string, equals '\n'.
+    """
+    return line == ('\n' if isinstance(line, six.text_type) else b'\n')

--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -53,6 +53,15 @@ The ``File`` Class
 
         Iterate over the file yielding one line at a time.
 
+        .. versionchanged:: 1.8
+
+            ``File`` now uses `universal newlines`_. The following are
+            recognized as ending a line: the Unix end-of-line convention
+            ``'\n'``, the Windows convention ``'\r\n'``, and the old Macintosh
+            convention ``'\r'``.
+
+            .. _universal newlines: http://www.python.org/dev/peps/pep-0278
+
     .. method:: chunks([chunk_size=None])
 
         Iterate over the file yielding "chunks" of a given size. ``chunk_size``

--- a/docs/ref/files/uploads.txt
+++ b/docs/ref/files/uploads.txt
@@ -82,10 +82,16 @@ Here are some useful attributes of ``UploadedFile``:
         for line in uploadedfile:
             do_something_with(line)
 
-    However, *unlike* standard Python files, :class:`UploadedFile` only
-    understands ``\n`` (also known as "Unix-style") line endings. If you know
-    that you need to handle uploaded files with different line endings, you'll
-    need to do so in your view.
+    Lines are split using `universal newlines`_. The following are recognized
+    as ending a line: the Unix end-of-line convention ``'\n'``, the Windows
+    convention ``'\r\n'``, and the old Macintosh convention ``'\r'``.
+
+    .. _universal newlines: http://www.python.org/dev/peps/pep-0278
+
+    .. versionchanged:: 1.8
+
+        Previously lines were only split on ``'\n'`` or the Unix end-of-line
+        convention.
 
 Subclasses of ``UploadedFile`` include:
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -367,6 +367,13 @@ Backwards incompatible changes in 1.8
     deprecation timeline for a given feature, its removal may appear as a
     backwards incompatible change.
 
+* When iterating over lines, :class:`~django.core.files.File` now uses
+  `universal newlines`_. The following are recognized as ending a line: the
+  Unix end-of-line convention ``'\n'``, the Windows convention ``'\r\n'``, and
+  the old Macintosh convention ``'\r'``.
+
+  .. _universal newlines: http://www.python.org/dev/peps/pep-0278
+
 Related object operations are run in a transaction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixed File to use universal newlines. The following are recognized as
ending a line: the Unix end-of-line convention '\n', the Windows
convention '\r\n', and the old Macintosh convention '\r'.
