### PR TITLE
Fixed #23580 -- Changed NullBooleanField to handle required arguemnt.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -770,6 +770,13 @@ class NullBooleanField(BooleanField):
     """
     widget = NullBooleanSelect
 
+    def __init__(self, *args, **kwargs):
+        # To keep existing behavior with Django < 1.8, set required to
+        # False by default unless explicitly set.
+        if not args and 'required' not in kwargs:
+            kwargs['required'] = False
+        super(NullBooleanField, self).__init__(*args, **kwargs)
+
     def to_python(self, value):
         """
         Explicitly checks for the string 'True' and 'False', which is what a
@@ -787,7 +794,8 @@ class NullBooleanField(BooleanField):
             return None
 
     def validate(self, value):
-        pass
+        if value is None and self.required:
+            raise ValidationError(self.error_messages['required'], code='required')
 
     def has_changed(self, initial, data):
         # None (unknown) and False (No) are not the same

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -799,7 +799,18 @@ For each field, we describe the default widget used if you don't specify
     * Default widget: :class:`NullBooleanSelect`
     * Empty value: ``None``
     * Normalizes to: A Python ``True``, ``False`` or ``None`` value.
-    * Validates nothing (i.e., it never raises a ``ValidationError``).
+    * Validates that the value is ``True`` or ``False`` if the field has
+      ``required=True``.
+
+    .. note::
+
+        Unlike other fields, ``NullBooleanField`` has ``required=False`` by
+        default to keep existing behavior with older versions of Django.
+
+    .. versionchanged:: 1.8
+
+        Validates that the value is ``True`` or ``False`` if the field has
+        ``required=True``.
 
 ``RegexField``
 ~~~~~~~~~~~~~~

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -216,6 +216,11 @@ Forms
   will also update ``UploadedFile.content_type`` with the image's content type
   as determined by Pillow.
 
+* :class:`~django.forms.NullBooleanField` now handles the ``required``
+  argument. When ``required`` is ``True``, values ``True`` and ``False``
+  validate while ``None`` is invalid. To keep existing behavior with older
+  version of Django, ``NullBooleanField`` has ``required=False`` by default.
+
 Generic Views
 ^^^^^^^^^^^^^
 

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -1078,6 +1078,20 @@ class FieldsTests(SimpleTestCase):
         self.assertTrue(f.has_changed(True, None))
         self.assertTrue(f.has_changed(True, False))
 
+    def test_nullbooleanfield_required_false_default(self):
+        f = NullBooleanField()
+        self.assertFalse(f.required)
+        f = NullBooleanField(True)
+        self.assertTrue(f.required)
+        f = NullBooleanField(required=True)
+        self.assertTrue(f.required)
+
+    def test_nullbooleanfield_required(self):
+        f = NullBooleanField(required=True)
+        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        self.assertEqual(False, f.clean(False))
+        self.assertEqual(True, f.clean(True))
+
     # MultipleChoiceField #########################################################
 
     def test_multiplechoicefield_1(self):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1909,7 +1909,7 @@ class FormsTestCase(TestCase):
         p.required_css_class = 'required'
 
         self.assertHTMLEqual(p.as_ul(), """<li class="required error"><ul class="errorlist"><li>This field is required.</li></ul><label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" /></li>
-<li class="required"><label class="required" for="id_is_cool">Is cool:</label> <select name="is_cool" id="id_is_cool">
+<li><label for="id_is_cool">Is cool:</label> <select name="is_cool" id="id_is_cool">
 <option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
@@ -1919,7 +1919,7 @@ class FormsTestCase(TestCase):
 
         self.assertHTMLEqual(p.as_p(), """<ul class="errorlist"><li>This field is required.</li></ul>
 <p class="required error"><label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" /></p>
-<p class="required"><label class="required" for="id_is_cool">Is cool:</label> <select name="is_cool" id="id_is_cool">
+<p><label for="id_is_cool">Is cool:</label> <select name="is_cool" id="id_is_cool">
 <option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
@@ -1929,7 +1929,7 @@ class FormsTestCase(TestCase):
 <p class="required error"><label class="required" for="id_age">Age:</label> <input type="number" name="age" id="id_age" /></p>""")
 
         self.assertHTMLEqual(p.as_table(), """<tr class="required error"><th><label class="required" for="id_name">Name:</label></th><td><ul class="errorlist"><li>This field is required.</li></ul><input type="text" name="name" id="id_name" /></td></tr>
-<tr class="required"><th><label class="required" for="id_is_cool">Is cool:</label></th><td><select name="is_cool" id="id_is_cool">
+<tr><th><label for="id_is_cool">Is cool:</label></th><td><select name="is_cool" id="id_is_cool">
 <option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>


### PR DESCRIPTION
Changed NullBooleanField to handle the required argument. When
required is True, values True and False validate while None is
invalid. To keep existing behavior with older version of Django,
NullBooleanField has required=False by default.
