### PR TITLE
Fixed #23583 - Makemessages for javascript

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -217,9 +217,10 @@ class Command(NoArgsCommand):
         if options.get('use_default_ignore_patterns'):
             ignore_patterns += ['CVS', '.*', '*~', '*.pyc']
         base_path = os.path.abspath('.')
-        for path in (settings.MEDIA_ROOT, settings.STATIC_ROOT):
-            if path and path.startswith(base_path):
-                ignore_patterns.append('%s*' % path[len(base_path) + 1:])
+        if self.domain != 'djangojs':
+            for path in (settings.MEDIA_ROOT, settings.STATIC_ROOT):
+                if path and path.startswith(base_path):
+                    ignore_patterns.append('%s*' % path[len(base_path) + 1:])
         self.ignore_patterns = list(set(ignore_patterns))
 
         # Avoid messing with mutable class variables


### PR DESCRIPTION
Makemessages looks in STATIC and MEDIA dirs for javascript files.

See https://code.djangoproject.com/ticket/23583
