### PR TITLE
Better error message: Models aren't loaded yet. Ensure django.setup() has been called.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -128,7 +128,7 @@ class Apps(object):
         Raises an exception if all models haven't been imported yet.
         """
         if not self.models_ready:
-            raise AppRegistryNotReady("Models aren't loaded yet.")
+            raise AppRegistryNotReady("Models aren't loaded yet. Ensure django.setup() has been called.")
 
     def get_app_configs(self):
         """


### PR DESCRIPTION
I'm hoping a better error message here could help some people out. I can open a ticket if needed.

I realize there's other error messages too, but I think this is the most important one.
