### PR TITLE
Allow reloading the same app, #23621

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -207,7 +207,7 @@ class Apps(object):
         # call get_app_config().
         model_name = model._meta.model_name
         app_models = self.all_models[app_label]
-        if model_name in app_models:
+        if model_name in app_models and str(app_models[model_name]) != str(model):
             raise RuntimeError(
                 "Conflicting '%s' models in application '%s': %s and %s." %
                 (model_name, app_label, app_models[model_name], model))


### PR DESCRIPTION
The exception made it impossible to use IPython autoreloading.
This error is to prevent loading of different modules (with same base name) but it also blocks autoreloading of absolutely the same app.

original reopened ticket:
https://code.djangoproject.com/ticket/22280
new ticket:
https://code.djangoproject.com/ticket/23621
