### PR TITLE
Fix references in docs/ref/contrib/admin/index.txt

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -413,7 +413,7 @@ subclass::
     form rather than specifying an entirely new one by using the
     :meth:`ModelAdmin.get_form` method.
 
-    For an example see the section `Adding custom validation to the admin`_.
+    For an example see the section :ref:`admin-custom-validation`.
 
     .. admonition:: Note
 
@@ -1207,7 +1207,7 @@ subclass::
 Custom template options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The `Overriding Admin Templates`_ section describes how to override or extend
+The :ref:`admin-overriding-templates` section describes how to override or extend
 the default admin templates.  Use the following options to override the default
 templates used by the :class:`ModelAdmin` views:
 
@@ -1861,6 +1861,8 @@ return the uncompressed versions of the various JavaScript files, including
 
 .. _jQuery: http://jquery.com
 
+.. _admin-custom-validation:
+
 Adding custom validation to the admin
 -------------------------------------
 
@@ -2306,6 +2308,8 @@ other inline. In your ``admin.py`` for this example app::
 See the :doc:`contenttypes documentation </ref/contrib/contenttypes>` for more
 specific information.
 
+.. _admin-overriding-templates:
+
 Overriding admin templates
 ==========================
 
@@ -2442,7 +2446,7 @@ creating your own ``AdminSite`` instance (see below), and changing the
 ------------------------
 
 Templates can override or extend base admin templates as described in
-`Overriding Admin Templates`_.
+:ref:`admin-overriding-templates`.
 
 .. attribute:: AdminSite.site_header
 


### PR DESCRIPTION
According to the recommendation in [Sphinx doc](http://sphinx-doc.org/markup/inline.html#cross-referencing-arbitrary-locations).

This allows to translate references names in documentation translations.
