### PR TITLE
movable django migrations

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -110,10 +110,12 @@ class MigrationLoader(object):
                 if not hasattr(migration_module, "Migration"):
                     raise BadMigrationError("Migration %s in app %s has no Migration class" % (migration_name, app_config.label))
                 # Ignore South-style migrations
-                if hasattr(migration_module.Migration, "forwards"):
+                migration = migration_module.Migration
+                if hasattr(migration, "forwards"):
                     south_style_migrations = True
                     break
-                self.disk_migrations[app_config.label, migration_name] = migration_module.Migration(migration_name, app_config.label)
+                app_label = getattr(migration, 'app_label', app_config.label)
+                self.disk_migrations[app_label, migration_name] = migration(migration_name, app_label)
             if south_style_migrations:
                 self.unmigrated_apps.add(app_config.label)
 

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -120,6 +120,7 @@ class MigrationWriter(object):
         """
         items = {
             "replaces_str": "",
+            "app_label": self.migration.app_label,
         }
 
         imports = set()
@@ -408,6 +409,8 @@ from django.db import models, migrations
 
 class Migration(migrations.Migration):
 %(replaces_str)s
+    app_label = "%(app_label)s"
+
     dependencies = [
 %(dependencies)s\
     ]


### PR DESCRIPTION
Hello, it would be nice, if we be able to move the migration from one application to another.

For example, we have local app with FooModel:

```
class FooModel(models.Model):
    first_field = models.CharField(max_length=255)
    second_field = models.CharField(max_length=255)
```

and some third-party app with BazModel.
If we want add new field to BazModel in the our project, we use method contribute_to_class in foo.models:

```
models.ManyToManyField(FooModel, blank=True, null=True).contribute_to_class(BazModel, 'foo_field')
```

New migration added to /path_to_third_party_app/migrations/, and we move it to /path_to_proj/foo/migrations/. It need to store changes in models of third-party applications in project.
