### PR TITLE
Fixed #23611 -- update_or_create failing from a related manager

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -537,6 +537,20 @@ def create_generic_related_manager(superclass):
             return super(GenericRelatedObjectManager, self).using(db).create(**kwargs)
         create.alters_data = True
 
+        def get_or_create(self, **kwargs):
+            kwargs[self.content_type_field_name] = self.content_type
+            kwargs[self.object_id_field_name] = self.pk_val
+            db = router.db_for_write(self.model, instance=self.instance)
+            return super(GenericRelatedObjectManager, self).using(db).get_or_create(**kwargs)
+        get_or_create.alters_data = True
+
+        def update_or_create(self, **kwargs):
+            kwargs[self.content_type_field_name] = self.content_type
+            kwargs[self.object_id_field_name] = self.pk_val
+            db = router.db_for_write(self.model, instance=self.instance)
+            return super(GenericRelatedObjectManager, self).using(db).update_or_create(**kwargs)
+        update_or_create.alters_data = True
+
     return GenericRelatedObjectManager
 
 

--- a/docs/releases/1.7.1.txt
+++ b/docs/releases/1.7.1.txt
@@ -9,6 +9,9 @@ Django 1.7.1 fixes several bugs in 1.7.
 Bugfixes
 ========
 
+* Missing ``get_or_create`` and ``update_or_create`` causing ``IntegrityError``
+  (:ticket:`23611`).
+
 * Allowed related many-to-many fields to be referenced in the admin
   (:ticket:`23604`).
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -35,6 +35,54 @@ class GenericRelationsTests(TestCase):
             obj.tag, obj.content_type.model_class(), obj.object_id
         )
 
+    def test_generic_update_or_create_when_created(self):
+        """
+        Should be able to use update_or_create from the generic related to
+        create a tag. Refs #23611.
+        """
+        count = self.bacon.tags.count()
+        tag, created = self.bacon.tags.update_or_create(tag='stinky')
+        self.assertTrue(created)
+        self.assertEqual(count + 1, self.bacon.tags.count())
+
+    def test_generic_update_or_create_when_updated(self):
+        """
+        Should be able to use update_or_create from the generic related to
+        update a tag. Refs #23611.
+        """
+        count = self.bacon.tags.count()
+        tag = self.bacon.tags.create(tag='stinky')
+        self.assertEqual(count + 1, self.bacon.tags.count())
+        tag, created = self.bacon.tags.update_or_create(defaults={'tag': 'juicy'}, id=tag.id)
+        self.assertFalse(created)
+        self.assertEqual(count + 1, self.bacon.tags.count())
+        self.assertEqual(tag.tag, 'juicy')
+
+    def test_generic_get_or_create_when_created(self):
+        """
+        Should be able to use get_or_create from the generic related to create
+        a tag. Refs #23611.
+        """
+        count = self.bacon.tags.count()
+        tag, created = self.bacon.tags.get_or_create(tag='stinky')
+        self.assertTrue(created)
+        self.assertEqual(count + 1, self.bacon.tags.count())
+
+    def test_generic_get_or_create_when_exists(self):
+        """
+        Should be able to use get_or_create from the generic related to get a
+        tag. Refs #23611.
+        """
+        count = self.bacon.tags.count()
+        tag = self.bacon.tags.create(tag="stinky")
+        self.assertEqual(count + 1, self.bacon.tags.count())
+        tag, created = self.bacon.tags.get_or_create(id=tag.id, defaults={'tag': 'juicy'})
+        self.assertFalse(created)
+        self.assertEqual(count + 1, self.bacon.tags.count())
+        # shouldn't had changed the tag
+        self.assertEqual(tag.tag, 'stinky')
+
+
     def test_generic_relations_m2m_mimic(self):
         """
         Objects with declared GenericRelations can be tagged directly -- the

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -9,7 +9,7 @@ from django.utils.encoding import DjangoUnicodeDecodeError
 from django.test import TestCase, TransactionTestCase
 
 from .models import (DefaultPerson, Person, ManualPrimaryKeyTest, Profile,
-    Tag, Thing, Publisher, Author)
+    Tag, Thing, Publisher, Author, Book)
 
 
 class GetOrCreateTests(TestCase):
@@ -238,6 +238,45 @@ class UpdateOrCreateTests(TestCase):
         except IntegrityError:
             formatted_traceback = traceback.format_exc()
             self.assertIn('obj.save', formatted_traceback)
+
+    def test_create_with_related_manager(self):
+        """
+        Should be able to use update_or_create from the related_manager to
+        create a book. Refs #23611.
+        """
+        p = Publisher.objects.create(name="Acme Publishing")
+        book, created = p.books.update_or_create(name="The Book of Ed & Fred")
+        self.assertTrue(created)
+        self.assertEqual(p.books.count(), 1)
+
+    def test_update_with_related_manager(self):
+        p = Publisher.objects.create(name="Acme Publishing")
+        book = Book.objects.create(name="The Book of Ed & Fred", publisher=p)
+        self.assertEqual(p.books.count(), 1)
+        name = "The Book of Django"
+        book, created = p.books.update_or_create(defaults={'name': name}, id=book.id)
+        self.assertFalse(created)
+        self.assertEqual(book.name, name)
+        self.assertEqual(p.books.count(), 1)
+
+    def test_create_with_many(self):
+        p = Publisher.objects.create(name="Acme Publishing")
+        author = Author.objects.create(name="Ted")
+        book, created = author.books.update_or_create(name="The Book of Ed & Fred", publisher=p)
+        self.assertTrue(created)
+        self.assertEqual(author.books.count(), 1)
+
+    def test_update_with_many(self):
+        p = Publisher.objects.create(name="Acme Publishing")
+        author = Author.objects.create(name="Ted")
+        book = Book.objects.create(name="The Book of Ed & Fred", publisher=p)
+        book.authors.add(author)
+        self.assertEqual(author.books.count(), 1)
+        name = "The Book of Django"
+        book, created = author.books.update_or_create(defaults={'name': name}, id=book.id)
+        self.assertFalse(created)
+        self.assertEqual(book.name, name)
+        self.assertEqual(author.books.count(), 1)
 
     def test_related(self):
         p = Publisher.objects.create(name="Acme Publishing")


### PR DESCRIPTION
update_or_create from the RelatedManager would cause an IntegrityError
since the instance was missing in the kwargs.
