### PR TITLE
Fixed #23420 - broken warning for unbound naive datetime objects

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1402,9 +1402,13 @@ class DateTimeField(DateField):
             # For backwards compatibility, interpret naive datetimes in local
             # time. This won't work during DST change, but we can't do much
             # about it, so we let the exceptions percolate up the call stack.
-            warnings.warn("DateTimeField %s.%s received a naive datetime (%s)"
+            try:
+                name = '%s.%s' % (self.model.__name__, self.name)
+            except AttributeError:
+                name = '(unbound)'
+            warnings.warn("DateTimeField %s received a naive datetime (%s)"
                           " while time zone support is active." %
-                          (self.model.__name__, self.name, value),
+                          (name, value),
                           RuntimeWarning)
             default_timezone = timezone.get_default_timezone()
             value = timezone.make_aware(value, default_timezone)

--- a/docs/howto/custom-lookups.txt
+++ b/docs/howto/custom-lookups.txt
@@ -142,8 +142,24 @@ applied, Django uses the ``output_field`` attribute. We didn't need to specify
 this here as it didn't change, but supposing we were applying ``AbsoluteValue``
 to some field which represents a more complex type (for example a point
 relative to an origin, or a complex number) then we may have wanted to specify
-``output_field = FloatField``, which will ensure that further lookups like
-``abs__lte`` behave as they would for a ``FloatField``.
+that the transform return a ``FloatField`` type for further lookups. This can
+be done by adding an ``output_field`` attribute to the transform::
+
+  from django.db.models import FloatField, Transform
+
+  class AbsoluteValue(Transform):
+      lookup_name = 'abs'
+
+      def as_sql(self, qn, connection):
+          lhs, params = qn.compile(self.lhs)
+          return "ABS(%s)" % lhs, params
+
+      @property
+      def output_field(self):
+          return FloatField()
+
+This ensures that further lookups like ``abs__lte`` behave as they would for
+a ``FloatField``.
 
 Writing an efficient abs__lt lookup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/custom_lookups/models.py
+++ b/tests/custom_lookups/models.py
@@ -1,3 +1,4 @@
+import calendar, time
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -8,6 +9,13 @@ class Author(models.Model):
     age = models.IntegerField(null=True)
     birthdate = models.DateField(null=True)
     average_rating = models.FloatField(null=True)
+
+    def __str__(self):
+        return self.name
+
+@python_2_unicode_compatible
+class MySQLUnixTimestamp(models.Model):
+    ts = models.PositiveIntegerField()
 
     def __str__(self):
         return self.name

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -1,13 +1,14 @@
 from __future__ import unicode_literals
 
-from datetime import date
+from datetime import date, datetime
+import time
 import unittest
 
 from django.core.exceptions import FieldError
 from django.db import models
 from django.db import connection
-from django.test import TestCase
-from .models import Author
+from django.test import TestCase, override_settings
+from .models import Author, MySQLUnixTimestamp
 
 
 class Div3Lookup(models.Lookup):
@@ -150,6 +151,18 @@ class InMonth(models.lookups.Lookup):
                 (lhs, rhs, lhs, rhs), params)
 
 
+class DateTimeTransform(models.Transform): 
+    lookup_name = 'as_datetime'
+        
+    @property 
+    def output_field(self): 
+        return models.DateTimeField()
+
+    def as_sql(self, qn, connection): 
+        lhs, params = qn.compile(self.lhs) 
+        return 'from_unixtime({})'.format(lhs), params
+
+
 class LookupTests(TestCase):
     def test_basic_lookup(self):
         a1 = Author.objects.create(name='a1', age=1)
@@ -227,6 +240,21 @@ class LookupTests(TestCase):
                 [a2, a3], lambda x: x)
         finally:
             models.IntegerField._unregister_lookup(Div3Transform)
+
+
+@override_settings(USE_TZ=True)
+class DateTimeLookupTests(TestCase):
+    @unittest.skipUnless(connection.vendor == 'mysql', "MySQL specific SQL used")
+    def test_datetime_output_field(self):
+        models.PositiveIntegerField.register_lookup(DateTimeTransform)
+        try:
+            ut = MySQLUnixTimestamp.objects.create(ts=time.time())
+            y2k = datetime(2000, 1, 1)
+            self.assertQuerysetEqual(
+                MySQLUnixTimestamp.objects.filter(ts__as_datetime__gt=y2k),
+                [ut], lambda x: x)
+        finally:
+            models.PositiveIntegerField._unregister_lookup(DateTimeTransform)
 
 
 class YearLteTests(TestCase):


### PR DESCRIPTION
Fixes issue with warning message displayed for unbound naive datetime objects when `USE_TZ` is True. Adds unit test that demonstrates the issue (discoverable when using a custom lookup in MySQL) and clarifies docs.

Ticket [#23420](https://code.djangoproject.com/ticket/23420)
