### PR TITLE
Fixed #20349 -- Don't load django.test when not testing.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -8,7 +8,7 @@ import importlib
 
 from django.dispatch import receiver
 from django.conf import settings
-from django.test.signals import setting_changed
+from django.core.signals import setting_changed
 from django.utils.encoding import force_bytes, force_str, force_text
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.crypto import (

--- a/django/core/signals.py
+++ b/django/core/signals.py
@@ -3,3 +3,4 @@ from django.dispatch import Signal
 request_started = Signal(providing_args=["environ"])
 request_finished = Signal()
 got_request_exception = Signal(providing_args=["request"])
+setting_changed = Signal(providing_args=["setting", "value", "enter"])

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -4,6 +4,7 @@ import threading
 import warnings
 
 from django.conf import settings
+from django.core.signals import setting_changed
 from django.db import connections, router
 from django.db.utils import ConnectionRouter
 from django.dispatch import receiver, Signal
@@ -11,8 +12,6 @@ from django.utils import timezone
 from django.utils.functional import empty
 
 template_rendered = Signal(providing_args=["template", "context"])
-
-setting_changed = Signal(providing_args=["setting", "value", "enter"])
 
 # Most setting_changed receivers are supposed to be added below,
 # except for cases where the receiver is related to a contrib app.

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -13,8 +13,8 @@ from django.apps import apps
 from django.conf import settings
 from django.conf.locale import LANG_INFO
 from django.core.exceptions import AppRegistryNotReady
+from django.core.signals import setting_changed
 from django.dispatch import receiver
-from django.test.signals import setting_changed
 from django.utils.deprecation import RemovedInDjango19Warning
 from django.utils.encoding import force_text
 from django.utils._os import upath

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -666,6 +666,9 @@ It's actually sent twice: when the new value is applied ("setup") and when the
 original value is restored ("teardown"). Use the ``enter`` argument to
 distinguish between the two.
 
+You can also import this signal from django.core.signals to avoid importing
+from django.test in non-test situations.
+
 Arguments sent with this signal:
 
 ``sender``

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -775,7 +775,7 @@ class SecondUrls:
 
 class OverrideSettingsTests(TestCase):
 
-    # #21518 -- If neither override_settings nor a settings_changed receiver
+    # #21518 -- If neither override_settings nor a setting_changed receiver
     # clears the URL cache between tests, then one of test_first or
     # test_second will fail.
 


### PR DESCRIPTION
Could be a controversial change, but it lowers the memory footprint by almost a megabyte.
https://code.djangoproject.com/ticket/20349
