### PR TITLE
Fixed #23613 -- Deprecated django.utils.checksums

### DIFF
--- a/django/utils/checksums.py
+++ b/django/utils/checksums.py
@@ -4,7 +4,16 @@ Common checksum routines.
 
 __all__ = ['luhn']
 
+import warnings
+
 from django.utils import six
+from django.utils.deprecation import RemovedInDjango20Warning
+
+warnings.warn(
+    "django.utils.checksums will be removed in Django 2.0. The "
+    "``luhn`` validator is now included in django-localflavor.",
+    RemovedInDjango20Warning
+)
 
 LUHN_ODD_LOOKUP = (0, 2, 4, 6, 8, 1, 3, 5, 7, 9)  # sum_of_digits(index * 2)
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -59,6 +59,9 @@ about each item can often be found in the release notes of two versions prior.
 
 * ``django.db.models.field.subclassing.SubfieldBase`` will be removed.
 
+* ``django.utils.checksums`` will be removed; its functionality is included
+  in django-localflavor.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -823,3 +823,11 @@ in ``.values()`` calls or in aggregates. It has been replaced with
 :meth:`~django.db.models.Field.from_db_value`. Note that the new approach does
 not call the :meth:`~django.db.models.Field.to_python` method on assignment
 as was the case with ``SubfieldBase``.
+
+``django.utils.checksums``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The module ``django.utils.checksums`` has been deprecated and will be removed
+in Django 2.0. The functionality it provided (validating checksum using the
+Luhn algorithm) was undocumented and not used in Django. The module has been
+moved to the django-localflavor package.

--- a/tests/utils_tests/test_checksums.py
+++ b/tests/utils_tests/test_checksums.py
@@ -1,6 +1,12 @@
 import unittest
+import warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 
-from django.utils import checksums
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        'ignore', 'django.utils.checksums will be removed in Django 2.0.',
+        RemovedInDjango20Warning)
+    from django.utils import checksums
 
 
 class TestUtilsChecksums(unittest.TestCase):


### PR DESCRIPTION
All of this is under the assumption that https://github.com/django/django-localflavor/pull/122 will get merged
