### PR TITLE
Fixed #23546 -- Added kwargs support for callproc for oracle

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -560,6 +560,7 @@ answer newbie questions, and generally made Django that much better:
     Raúl Cumplido <raulcumplido@gmail.com>
     Remco Wendt <remco.wendt@gmail.com>
     Renaud Parent <renaud.parent@gmail.com>
+    Renbi Yu <averybigant@gmail.com>
     Reza Mohammadi <reza@zeerak.ir>
     rhettg@gmail.com
     Ricardo Javier Cárdenes Medina <ricardo.cardenes@gmail.com>

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -683,6 +683,10 @@ class BaseDatabaseFeatures(object):
     # Does the backend support "select for update" queries with limit (and offset)?
     supports_select_for_update_with_limit = True
 
+    # Does the backend support keyword parameters for cursor.callproc()?
+    # See ticket #23546
+    callproc_supports_kwargs = False
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -688,9 +688,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if not self.get_autocommit():
             self.commit()
 
-    def make_cursor(self, cursor):
-        return CursorWrapper(cursor, self)
-
     def create_cursor(self):
         return FormatStylePlaceholderCursor(self.connection)
 
@@ -752,22 +749,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return int(self.oracle_full_version.split('.')[0])
         except ValueError:
             return None
-
-
-# Ticket #23546: though keyword parameters for callproc are not supported in
-# PEP 249, since we are just forwarding arguments to cx_Oracle which supports
-# keyword parameters, such deviation seems acceptable. This subclass is meant
-# to implement this.
-class CursorWrapper(backend_utils.CursorWrapper):
-    def callproc(self, procname, params=None, kparams=None):
-        self.db.validate_no_broken_transaction()
-        with self.db.wrap_database_errors:
-            if params is None and kparams is None:
-                return self.cursor.callproc(procname)
-            elif kparams is None:
-                return self.cursor.callproc(procname, params)
-            else:
-                return self.cursor.callproc(procname, params, kparams)
 
 
 class OracleParam(object):

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -124,6 +124,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     uppercases_column_names = True
     # select for update with limit can be achieved on Oracle, but not with the current backend.
     supports_select_for_update_with_limit = False
+    callproc_supports_kwargs = True
 
     def introspected_boolean_field_type(self, field=None, created_separately=False):
         """

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -45,14 +45,21 @@ class CursorWrapper(object):
 
     # The following methods cannot be implemented in __getattr__, because the
     # code must run when the method is invoked, not just when it is accessed.
-
-    def callproc(self, procname, params=None):
+    # Ticket #23546: though keyword parameters for callproc are not supported
+    # in PEP 249, since we are just forwarding arguments to underlying backends
+    # which may supports keyword parameters(e.g cx_Oracle), such deviation
+    # seems acceptable.
+    def callproc(self, procname, params=None, kparams=None):
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:
-            if params is None:
+            if params is None and kparams is None:
                 return self.cursor.callproc(procname)
-            else:
+            elif kparams is None:
                 return self.cursor.callproc(procname, params)
+            elif params is None:
+                return self.cursor.callproc(procname, [], kparams)
+            else:
+                return self.cursor.callproc(procname, params, kparams)
 
     def execute(self, sql, params=None):
         self.db.validate_no_broken_transaction()

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -9,6 +9,7 @@ from time import time
 from django.conf import settings
 from django.utils.encoding import force_bytes
 from django.utils.timezone import utc
+from django.db.utils import NotSupportedError
 
 
 logger = logging.getLogger('django.db.backends')
@@ -50,6 +51,9 @@ class CursorWrapper(object):
     # which may supports keyword parameters(e.g cx_Oracle), such deviation
     # seems acceptable.
     def callproc(self, procname, params=None, kparams=None):
+        if kparams is not None and not self.db.features.callproc_supports_kwargs:
+            raise NotSupportedError("The {} backend does not support keyword parameters for callproc"
+                    .format(self.db.vendor))
         self.db.validate_no_broken_transaction()
         with self.db.wrap_database_errors:
             if params is None and kparams is None:

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -302,6 +302,10 @@ Models
 * :doc:`Custom Lookups</howto/custom-lookups>` can now be registered using
   a decorator pattern.
 
+* :meth:`cursor.callproc() <django.db.models.Cursor.callproc>` now
+  supports keyword parameters, however, only when the underlying backend
+  supports keyword parameters (e.g cx_Oracle) can it work properly.
+
 Signals
 ^^^^^^^
 

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -336,3 +336,18 @@ is equivalent to::
         c.execute(...)
     finally:
         c.close()
+
+.. versionchanged:: 1.8
+
+Though :pep:`249` does not support keyword parameters for
+``cursor.callproc()``, some database backends do (e.g cx_Oracle), so you can
+pass keyword parameters to ``cursor.callproc()`` if the backend you are using
+supports it.
+
+.. method:: Cursor.callproc(procname, params=None, kparams=None)
+
+.. warning::
+
+    Most database backends do not support keyword parameters, and the support
+    of it is nonstandard, never pass keyword parameters to
+    ``cursor.callproc()`` when in doubt.

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -348,6 +348,6 @@ supports it.
 
 .. warning::
 
-    Most database backends do not support keyword parameters, and the support
-    of it is nonstandard, never pass keyword parameters to
-    ``cursor.callproc()`` when in doubt.
+    Most database backends do not support keyword parameters for
+    ``cursor.callproc()``, and the support of it is nonstandard, never pass
+    keyword parameters to ``cursor.callproc()`` when in doubt.

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -65,6 +65,8 @@ class OracleTests(unittest.TestCase):
             # cx_Oracle.Cursor.callproc. See ticket #23546.
             cursor.callproc(convert_unicode('DBMS_SESSION.SET_IDENTIFIER'), [],
                     {convert_unicode('client_id'): convert_unicode('_django_testing!')})
+            cursor.callproc(convert_unicode('DBMS_SESSION.SET_IDENTIFIER'),
+                    kparams={convert_unicode('client_id'): convert_unicode('_django_testing!')})
 
     def test_cursor_var(self):
         # If the backend is Oracle, test that we can pass cursor variables

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -61,6 +61,11 @@ class OracleTests(unittest.TestCase):
             cursor.callproc(convert_unicode('DBMS_SESSION.SET_IDENTIFIER'),
                             [convert_unicode('_django_testing!')])
 
+            # Make sure cursor.callproc accepts keyword parameters as
+            # cx_Oracle.Cursor.callproc. See ticket #23546.
+            cursor.callproc(convert_unicode('DBMS_SESSION.SET_IDENTIFIER'), [],
+                    {convert_unicode('client_id'): convert_unicode('_django_testing!')})
+
     def test_cursor_var(self):
         # If the backend is Oracle, test that we can pass cursor variables
         # as query parameters.


### PR DESCRIPTION
add kwargs or args parameters to callproc method for those backends that support more parameters for callproc method (e.g cx_oracle) 
https://code.djangoproject.com/ticket/23546
already tested on ubuntu 12.04 server(amd64) with oracle XE 11g