### PR TITLE
Fixed #23642 -- Made LocMemCache.incr() thread-safe as documented

### DIFF
--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -157,7 +157,7 @@ Minor features
 Cache
 ^^^^^
 
-* ...
+* :meth:`LocMemCache.incr` is now thread-safe.
 
 Email
 ^^^^^


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/23642, the following script generated random results before the patch:

``` Python
import threading

from django.core.cache.backends.locmem import LocMemCache

cache = LocMemCache('test', {})

cache.set('foo', 0)

def increment(key):
    cache.incr(key)

threads = []
for i in range(20):
    t = threading.Thread(target=increment, args=('foo',))
    t.start()
    threads.append(t)

for t in threads:
    t.join()

print cache.get('foo')   # Random results — 20 is expected
```
