### PR TITLE
Fixed #23638 -- Prevented crash while parsing invalid cookie content

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -263,4 +263,4 @@ def get_str_from_wsgi(environ, key, default):
     """
     value = environ.get(str(key), str(default))
     # Same comment as above
-    return value if six.PY2 else value.encode(ISO_8859_1).decode(UTF_8)
+    return value if six.PY2 else value.encode(ISO_8859_1).decode(UTF_8, errors='replace')

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -80,6 +80,16 @@ class HandlerTests(TestCase):
         # much more work than fixing #20557. Feel free to remove force_str()!
         self.assertEqual(request.COOKIES['want'], force_str("café"))
 
+    def test_invalid_unicode_cookie(self):
+        """
+        Invalid cookie content should result in absent cookie, but not in a
+        crash while trying to decode it (#23638).
+        """
+        environ = RequestFactory().get('/').environ
+        environ['HTTP_COOKIE'] = 'x=W\x03c(h]\x8e'
+        request = WSGIRequest(environ)
+        self.assertEqual(request.COOKIES, {})
+
 
 @override_settings(ROOT_URLCONF='handlers.urls')
 class TransactionsPerRequestTests(TransactionTestCase):


### PR DESCRIPTION
Thanks Philip Gatt for the report.
