### PR TITLE
Added documentation on blocktrans tags (issue #23534)

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -628,6 +628,9 @@ You can use multiple expressions inside a single ``blocktrans`` tag::
 .. note:: The previous more verbose format is still supported:
    ``{% blocktrans with book|title as book_t and author|title as author_t %}``
 
+Other block tags like ``{% for %}`` and ``{% if %}`` are not allowed
+inside a ``blocktrans`` tag.
+
 If resolving one of the block arguments fails, blocktrans will fall back to
 the default language by deactivating the currently active language
 temporarily with the :func:`~django.utils.translation.deactivate_all`


### PR DESCRIPTION
Mentioned that other block tags are not allowed inside
a blocktrans template tag. 
