### PR TITLE
Clarify usage of serialized_rollback for certain test classes

### DIFF
--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -242,7 +242,9 @@ Rollback emulation
 Any initial data loaded in migrations will only be available in ``TestCase``
 tests and not in ``TransactionTestCase`` tests, and additionally only on
 backends where transactions are supported (the most important exception being
-MyISAM).
+MyISAM). This is also true for tests which rely on ``TransactionTestCase``
+such as :class:`LiveServerTestCase` and 
+:class:`~django.contrib.staticfiles.testing.StaticLiveServerTestCase`
 
 Django can reload that data for you on a per-testcase basis by
 setting the ``serialized_rollback`` option to ``True`` in the body of the


### PR DESCRIPTION
[This ticket](https://code.djangoproject.com/ticket/23640) highlighted that it is not overly clear that the serialized_rollback attribute should be used for tests inheriting from StaticLiveServerTestCase and LiveServerTestCase. The documentation only referenced TransactionTestCase, from which the others inherit. It may not be obvious to users that these classes inherit from TransactionTestCase, so I just added a mention of this here.
