### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -114,7 +114,7 @@ def create_permissions(app_config, verbosity=2, interactive=True, using=DEFAULT_
     Permission.objects.using(using).bulk_create(perms)
     if verbosity >= 2:
         for perm in perms:
-            print("Adding permission '%s'" % perm)
+            print(u"Adding permission '%s'" % perm)
 
 
 def get_system_username():


### PR DESCRIPTION
If permission details contains non-ASCII symbols this line produces UnicodeDecodeError, eg:
`task_cloner | Задание на клонирование | Может набирать задания` 
-> 
`UnicodeEncodeError: 'ascii' codec can't encode characters in position 33-39: ordinal not in range(128)`.
