### PR TITLE
Fixed #9893 -- Filename could exceed max_length on a collision

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -1,8 +1,12 @@
 import os
 import errno
+import warnings
+
 from datetime import datetime
+from inspect import getargspec
 
 from django.conf import settings
+from django.core.exceptions import SuspiciousFileOperation
 from django.core.files import locks, File
 from django.core.files.move import file_move_safe
 from django.utils.crypto import get_random_string
@@ -13,6 +17,7 @@ from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.text import get_valid_filename
 from django.utils._os import safe_join, abspathu
 from django.utils.deconstruct import deconstructible
+from django.utils.deprecation import RemovedInDjango20Warning
 
 
 __all__ = ('Storage', 'FileSystemStorage', 'DefaultStorage', 'default_storage')
@@ -33,7 +38,7 @@ class Storage(object):
         """
         return self._open(name, mode)
 
-    def save(self, name, content):
+    def save(self, name, content, max_length=None):
         """
         Saves new content to the file specified by name. The content should be
         a proper File object or any python file-like object, ready to be read
@@ -46,7 +51,17 @@ class Storage(object):
         if not hasattr(content, 'chunks'):
             content = File(content)
 
-        name = self.get_available_name(name)
+        args, varargs, varkw, defaults = getargspec(self.get_available_name)
+        if 'max_length' in args:
+            name = self.get_available_name(name, max_length=max_length)
+        else:
+            warnings.warn(
+                'Backwards compatibility for storage backends without '
+                'support for `max_length` will be removed in Django 2.0.',
+                RemovedInDjango20Warning, stacklevel=2
+            )
+            name = self.get_available_name(name)
+
         name = self._save(name, content)
 
         # Store filenames with forward slashes, even on Windows
@@ -61,7 +76,7 @@ class Storage(object):
         """
         return get_valid_filename(name)
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         Returns a filename that's free on the target storage system, and
         available for new content to be written to.
@@ -71,10 +86,24 @@ class Storage(object):
         # If the filename already exists, add an underscore and a random 7
         # character alphanumeric string (before the file extension, if one
         # exists) to the filename until the generated filename doesn't exist.
-        while self.exists(name):
+        # Truncate original name if required, so the new filename does not
+        # exceed the max_length.
+        while self.exists(name) or (max_length and len(name) > max_length):
             # file_ext includes the dot.
             name = os.path.join(dir_name, "%s_%s%s" % (file_root, get_random_string(7), file_ext))
-
+            if max_length is None:
+                continue
+            # Truncate file_root if max_length exceeded.
+            truncation = len(name) - max_length
+            if truncation > 0:
+                file_root = file_root[:-truncation]
+                # Entire file_root was truncated in attempt to find an available filename.
+                if not file_root:
+                    raise SuspiciousFileOperation(
+                        'Storage can not find an available filename for "%s". Please make sure '
+                        'that the corresponding file field allows sufficient "max_length".' % name
+                    )
+                name = os.path.join(dir_name, "%s_%s%s" % (file_root, get_random_string(7), file_ext))
         return name
 
     def path(self, name):

--- a/docs/howto/custom-file-storage.txt
+++ b/docs/howto/custom-file-storage.txt
@@ -96,12 +96,27 @@ how non-standard characters are converted to safe filenames.
 The code provided on ``Storage`` retains only alpha-numeric characters, periods
 and underscores from the original filename, removing everything else.
 
-.. method:: get_available_name(name)
+.. method:: get_available_name(name, max_length=None)
 
 Returns a filename that is available in the storage mechanism, possibly taking
 the provided filename into account. The ``name`` argument passed to this method
 will have already cleaned to a filename valid for the storage system, according
-to the ``get_valid_name()`` method described above.
+to the ``get_valid_name()`` method described above. The new filename length
+will not exceed ``max_length``, that is 100 by default, which matches similar
+argument of :class:`~django.db.models.FileField`.
+
+.. versionchanged:: 1.8
+
+    Added ``max_length`` argument to implement maximum filename length
+    constraint. Filenames exceeding this argument will get truncated.
+
+    Previously, when a file was uploaded to a field, if its length was close to
+    the field's ``max_length``, and such filename already presented on the
+    storage, appending an underscore and a char-sequence to the filename could
+    cause a database-level error.
+
+    If no free unique filename is available, :exc:`SuspiciousFileOperation
+    <SuspiciousOperation>` exception will be raised.
 
 .. versionchanged:: 1.7
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -140,6 +140,9 @@ details on these changes.
 
 * The ``ssi`` template tag will be removed.
 
+* The backwards compatibility shim to allow ``Storage.get_available_name()`` to be
+  defined with no default value for its ``max_length`` argument will be removed.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -114,15 +114,30 @@ The Storage Class
         in the storage system, or ``False`` if the name is available for a new
         file.
 
-    .. method:: get_available_name(name)
+    .. method:: get_available_name(name, max_length=100)
 
         Returns a filename based on the ``name`` parameter that's free and
         available for new content to be written to on the target storage
-        system.
+        system. The new filename length will not exceed ``max_length``, that is
+        100 by default, which matches similar argument of
+        :class:`~django.db.models.FileField`.
 
         If a file with ``name`` already exists, an underscore plus a random
         7 character alphanumeric string is appended to the filename before
         the extension.
+
+        .. versionchanged:: 1.8
+
+            Added ``max_length`` argument to implement maximum filename length
+            constraint. Filenames exceeding this argument will get truncated.
+
+            Previously, when a file was uploaded to a field, if its length was
+            close to the field's ``max_length``, and such filename already
+            presented on the storage, appending an underscore and a char-sequence
+            to the filename could cause a database-level error.
+
+            If no free unique filename is available, :exc:`SuspiciousFileOperation
+            <SuspiciousOperation>` exception will be raised.
 
         .. versionchanged:: 1.7
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -728,7 +728,7 @@ associated with this instance in the mode specified by ``mode``.
 Behaves like the standard Python ``file.close()`` method and closes the file
 associated with this instance.
 
-.. method:: FieldFile.save(name, content, save=True)
+.. method:: FieldFile.save(name, content, save=True, **kwargs)
 
 This method takes a filename and file contents and passes them to the storage
 class for the field, then associates the stored file with the model field.
@@ -737,10 +737,9 @@ If you want to manually associate file data with
 method is used to persist that file data.
 
 Takes two required arguments: ``name`` which is the name of the file, and
-``content`` which is an object containing the file's contents.  The
-optional ``save`` argument controls whether or not the model instance is
-saved after the file associated with this field has been altered. Defaults to
-``True``.
+``content`` which is an object containing the file's contents.  The optional
+``save`` argument controls whether or not the model instance is saved after
+the file associated with this field has been altered. Defaults to ``True``.
 
 Note that the ``content`` argument should be an instance of
 :class:`django.core.files.File`, not Python's built-in file object.
@@ -758,6 +757,11 @@ Or you can construct one from a Python string like this::
     myfile = ContentFile("hello world")
 
 For more information, see :doc:`/topics/files`.
+
+.. versionchanged:: 1.8
+
+    Added ``**kwargs`` to pass extra arguments to the storage. This allows
+    to implement maximum filename length constraint on the storage.
 
 .. method:: FieldFile.delete(save=True)
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -308,7 +308,12 @@ File Storage
 File Uploads
 ^^^^^^^^^^^^
 
-* ...
+* :meth:`Storage.get_available_name()
+  <django.core.files.storage.Storage.get_available_name>` now takes
+  ``max_length`` argument to implement storage-level maximum filename length
+  constraint. Filenames exceeding this argument will get truncated. This
+  prevents a database error, when appending a unique suffix to a long filename,
+  that already exists on the storage.
 
 Forms
 ^^^^^
@@ -511,6 +516,10 @@ Models
 
 * You can now get the set of deferred fields for a model using
   :meth:`Model.get_deferred_fields() <django.db.models.Model.get_deferred_fields>`.
+
+* :meth:`FieldFile.save()
+  <django.db.models.fields.FieldFile.save>` now takes ``**kwargs``. This allows
+  to pass ``max_length`` argument onto the storage.
 
 Signals
 ^^^^^^^
@@ -1404,6 +1413,14 @@ loader that inherits ``BaseLoader``, you must inherit ``Loader`` instead.
 
 Private API ``django.test.utils.TestTemplateLoader`` is deprecated in favor of
 ``django.template.loaders.locmem.Loader``.
+
+``django.core.files.storage.Storage.get_available_name()``’s ``max_length`` argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Storage`` subclasses that override the ``get_available_name()`` method should
+make sure to provide a default value for the ``max_length`` argument. Support
+for storages that do not accept this argument in ``get_available_name()`` will
+be removed in Django 2.0.
 
 ``qn`` replaced by ``compiler``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/file_storage/models.py
+++ b/tests/file_storage/models.py
@@ -11,10 +11,26 @@ import tempfile
 
 from django.db import models
 from django.core.files.storage import FileSystemStorage
+from django.utils.crypto import get_random_string
+
+
+class OldStyleFSStorage(FileSystemStorage):
+    """
+    Storage backend without support for ``max_length`` argument in
+    ``get_available_name()``.
+    Used for backward-compatibility and deprecation testing.
+    """
+    def get_available_name(self, name):
+        dir_name, file_name = os.path.split(name)
+        file_root, file_ext = os.path.splitext(file_name)
+        while self.exists(name):
+            name = os.path.join(dir_name, "%s_%s%s" % (file_root, get_random_string(7), file_ext))
+        return name
 
 
 temp_storage_location = tempfile.mkdtemp(dir=os.environ['DJANGO_TEST_TEMP_DIR'])
 temp_storage = FileSystemStorage(location=temp_storage_location)
+temp_old_style_storage = OldStyleFSStorage(location=temp_storage_location)
 
 
 class Storage(models.Model):
@@ -31,3 +47,6 @@ class Storage(models.Model):
     random = models.FileField(storage=temp_storage, upload_to=random_upload_to)
     default = models.FileField(storage=temp_storage, upload_to='tests', default='tests/default.txt')
     empty = models.FileField(storage=temp_storage)
+    limited_length = models.FileField(storage=temp_storage, upload_to='tests', max_length=20)
+    extended_length = models.FileField(storage=temp_storage, upload_to='tests', max_length=300)
+    old_style = models.FileField(storage=temp_old_style_storage, upload_to='tests')


### PR DESCRIPTION
Passing max_length argument into the Storage's save() and get_available_name() methods.
Rewriting get_available_name() so filenames do not exceed max_length when there is a collision.
Adding test for the case.