### PR TITLE
Fixed #23637 -- Removed TUX, lighttpd, and Cherokee as common.

### DIFF
--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -118,11 +118,8 @@ server you choose.
 We recommend using a separate Web server -- i.e., one that's not also running
 Django -- for serving media. Here are some good choices:
 
-* lighttpd_
 * Nginx_
-* TUX_
 * A stripped-down version of Apache_
-* Cherokee_
 
 If, however, you have no option but to serve media files on the same Apache
 ``VirtualHost`` as Django, you can set up Apache to serve some URLs as
@@ -161,11 +158,8 @@ If you are using a version of Apache older than 2.4, replace
 ``Require all granted`` with ``Allow from all`` and also add the line
 ``Order deny,allow`` above it.
 
-.. _lighttpd: http://www.lighttpd.net/
 .. _Nginx: http://wiki.nginx.org/Main
-.. _TUX: http://en.wikipedia.org/wiki/TUX_web_server
 .. _Apache: http://httpd.apache.org/
-.. _Cherokee: http://www.cherokee-project.com/
 
 .. More details on configuring a mod_wsgi site to serve static files can be found
 .. in the mod_wsgi documentation on `hosting static files`_.

--- a/docs/howto/static-files/deployment.txt
+++ b/docs/howto/static-files/deployment.txt
@@ -70,17 +70,11 @@ Most larger Django sites use a separate Web server -- i.e., one that's not also
 running Django -- for serving static files. This server often runs a different
 type of web server -- faster but less full-featured. Some common choices are:
 
-* lighttpd_
 * Nginx_
-* TUX_
-* Cherokee_
 * A stripped-down version of Apache_
 
-.. _lighttpd: http://www.lighttpd.net/
 .. _Nginx: http://wiki.nginx.org/Main
-.. _TUX: http://en.wikipedia.org/wiki/TUX_web_server
 .. _Apache: http://httpd.apache.org/
-.. _Cherokee: http://www.cherokee-project.com/
 
 Configuring these servers is out of scope of this document; check each
 server's respective documentation for instructions.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23637
