### PR TITLE
 Fixed #23668 -- Changed make_aware() and make_naive() to use the current timezone by default

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -350,10 +350,12 @@ def is_naive(value):
     return value.tzinfo is None or value.tzinfo.utcoffset(value) is None
 
 
-def make_aware(value, timezone):
+def make_aware(value, timezone=None):
     """
     Makes a naive datetime.datetime in a given time zone aware.
     """
+    if timezone is None:
+        timezone = get_current_timezone()
     if hasattr(timezone, 'localize'):
         # This method is available for pytz time zones.
         return timezone.localize(value, is_dst=None)
@@ -366,10 +368,12 @@ def make_aware(value, timezone):
         return value.replace(tzinfo=timezone)
 
 
-def make_naive(value, timezone):
+def make_naive(value, timezone=None):
     """
     Makes an aware datetime.datetime naive in a given time zone.
     """
+    if timezone is None:
+        timezone = get_current_timezone()
     # If `value` is naive, astimezone() will raise a ValueError,
     # so we don't need to perform a redundant check.
     value = value.astimezone(timezone)

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -954,20 +954,30 @@ appropriate entities.
     Returns ``True`` if ``value`` is naive, ``False`` if it is aware. This
     function assumes that ``value`` is a :class:`~datetime.datetime`.
 
-.. function:: make_aware(value, timezone)
+.. function:: make_aware(value, timezone=None)
 
     Returns an aware :class:`~datetime.datetime` that represents the same
     point in time as ``value`` in ``timezone``, ``value`` being a naive
-    :class:`~datetime.datetime`.
+    :class:`~datetime.datetime`. If ``timezone`` is set to ``None``,
+    defaults to the :ref:`current time zone <default-current-time-zone>`.
 
     This function can raise an exception if ``value`` doesn't exist or is
     ambiguous because of DST transitions.
 
-.. function:: make_naive(value, timezone)
+    .. versionchanged:: 1.8
+
+        In older versions of Django, ``timezone`` was a required argument.
+
+.. function:: make_naive(value, timezone=None)
 
     Returns an naive :class:`~datetime.datetime` that represents in
     ``timezone``  the same point in time as ``value``, ``value`` being an
-    aware :class:`~datetime.datetime`
+    aware :class:`~datetime.datetime`. If ``timezone`` is set to ``None``,
+    defaults to the :ref:`current time zone <default-current-time-zone>`.
+
+    .. versionchanged:: 1.8
+
+        In older versions of Django, ``timezone`` was a required argument.
 
 .. _pytz: http://pytz.sourceforge.net/
 


### PR DESCRIPTION
When calling `make_aware()`, either `get_current_timezone()` or `get_default_timezone()` seem to be a logical default. In my opinion, `get_current_timezone()` is seems more correct most of the time. That is, when handling a naive datetimes, converting it to the current time zone is the most typical operation. This change makes using `make_aware()` easier to use as it will now generally do the right thing by default. If the user wants to use a different timezone, the option is still available.
