### PR TITLE
Fix #23662 - Make __nonzero__(), __len__() lazy

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -140,8 +140,7 @@ class QuerySet(object):
         return repr(data)
 
     def __len__(self):
-        self._fetch_all()
-        return len(self._result_cache)
+        return self.count()
 
     def __iter__(self):
         """
@@ -163,8 +162,7 @@ class QuerySet(object):
         return iter(self._result_cache)
 
     def __nonzero__(self):
-        self._fetch_all()
-        return bool(self._result_cache)
+        return self.exists()
 
     def __getitem__(self, k):
         """


### PR DESCRIPTION
QuerySet.**nonzero**(), QuerySet.**len**() caused unexpected behaviour by unnecessary queryset evaluation.
Methods rewritten using proper lazy methods of QuerySet.
