### PR TITLE
Fixed #23664 -- Provided a consistent definition for OrderedSet.__bool__

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -162,9 +162,12 @@ class QuerySet(object):
         self._fetch_all()
         return iter(self._result_cache)
 
-    def __nonzero__(self):
+    def __bool__(self):
         self._fetch_all()
         return bool(self._result_cache)
+
+    def __nonzero__(self):      # Python 2 compatibility
+        return type(self).__bool__(self)
 
     def __getitem__(self, k):
         """

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -271,8 +271,11 @@ class OrderedSet(object):
     def __contains__(self, item):
         return item in self.dict
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.dict)
+
+    def __nonzero__(self):      # Python 2 compatibility
+        return type(self).__bool__(self)
 
 
 class MultiValueDictKeyError(KeyError):

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -8,7 +8,7 @@ import pickle
 from django.test import SimpleTestCase
 from django.test.utils import IgnoreDeprecationWarningsMixin
 from django.utils.datastructures import (DictWrapper, ImmutableList,
-    MultiValueDict, MultiValueDictKeyError, MergeDict, SortedDict)
+    MultiValueDict, MultiValueDictKeyError, MergeDict, OrderedSet, SortedDict)
 from django.utils import six
 
 
@@ -204,6 +204,16 @@ class MergeDictTests(IgnoreDeprecationWarningsMixin, SimpleTestCase):
         d1 = MergeDict({'key1': 42})
         with six.assertRaisesRegex(self, KeyError, 'key2'):
             d1['key2']
+
+
+class OrderedSetTests(SimpleTestCase):
+
+    def test_bool(self):
+        # Refs #23664
+        s = OrderedSet()
+        self.assertFalse(s)
+        s.add(1)
+        self.assertTrue(s)
 
 
 class MultiValueDictTests(SimpleTestCase):


### PR DESCRIPTION
This also defines `QuerySet.__bool__` for consistency though this should not have any consequence as `bool(qs)` used to fallback on `QuerySet.__len__` in Py3.
