### PR TITLE
Fixed IRC channel name in submitting-patches.txt.

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -324,7 +324,7 @@ All code changes
   guidelines? Are there any ``flake8`` errors?
 * If the change is backwards incompatible in any way, is there a note
   in the release notes (``docs/releases/A.B.txt``)?
-* Is Django's test suite passing? Ask in ``#django-developers`` for a core dev
+* Is Django's test suite passing? Ask in ``#django-dev`` for a core dev
   to build the pull request against our continuous integration server.
 
 All tickets


### PR DESCRIPTION
The development channel is #django-dev.
