### PR TITLE
add file name

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -46,7 +46,7 @@ class Storage(object):
             name = content.name
 
         if not hasattr(content, 'chunks'):
-            content = File(content)
+            content = File(content, name)
 
         name = self.get_available_name(name)
         name = self._save(name, content)


### PR DESCRIPTION
In openstack swiftclient and other clients, typically used to determine whether a file exists:

if xxx_file:

So if not name, returns false, this will cause a lot of errors.

see django.core.files.base.File
