### PR TITLE
Fixes #23684 -- Use correct pip package name for ImageField Pillow HINT

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -391,7 +391,7 @@ class ImageField(FileField):
                 checks.Error(
                     'Cannot use ImageField because Pillow is not installed.',
                     hint=('Get Pillow at https://pypi.python.org/pypi/Pillow '
-                          'or run command "pip install pillow".'),
+                          'or run command "pip install Pillow".'),
                     obj=self,
                     id='fields.E210',
                 )

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -505,7 +505,7 @@ class ImageFieldTests(IsolatedModelsTestCase):
             Error(
                 'Cannot use ImageField because Pillow is not installed.',
                 hint=('Get Pillow at https://pypi.python.org/pypi/Pillow '
-                      'or run command "pip install pillow".'),
+                      'or run command "pip install Pillow".'),
                 obj=field,
                 id='fields.E210',
             ),


### PR DESCRIPTION
If you use an ImageField without installing the Pillow package, a field hint mentions that you should "pip install pillow". The correct package name is "Pillow" with an uppercase P. 

See: https://code.djangoproject.com/ticket/23684
