### PR TITLE
Fixed a typo in urlencode documentation.

### DIFF
--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -698,7 +698,7 @@ escaping HTML.
 .. function:: urlencode(query, doseq=0)
 
     A version of Python's urllib.urlencode() function that can operate on
-    unicode strings. The parameters are first case to UTF-8 encoded strings
+    unicode strings. The parameters are first cast to UTF-8 encoded strings
     and then encoded as per normal.
 
 .. function:: cookie_date(epoch_seconds=None)


### PR DESCRIPTION
In the [reference docs](https://docs.djangoproject.com/en/dev/ref/utils/#module-django.utils.http), a similar docstring in sources is fine.
