### PR TITLE
Fixed #23444 -- Prevented unnecessary ContentType object creation when using inlines

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from django import forms
 from django.contrib.admin.utils import (flatten_fieldsets, lookup_field,
     display_for_field, label_for_field, help_text_for_field)
@@ -8,7 +10,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.fields.related import ManyToManyRel
 from django.forms.utils import flatatt
 from django.template.defaultfilters import capfirst, linebreaksbr
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text, smart_text
+from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils import six
@@ -270,15 +274,25 @@ class InlineAdminForm(AdminForm):
         self.formset = formset
         self.model_admin = model_admin
         self.original = original
-        if original is not None:
-            # Since this module gets imported in the application's root package,
-            # it cannot import models from other applications at the module level.
-            from django.contrib.contenttypes.models import ContentType
-            self.original_content_type_id = ContentType.objects.get_for_model(original).pk
         self.show_url = original and view_on_site_url is not None
         self.absolute_url = view_on_site_url
         super(InlineAdminForm, self).__init__(form, fieldsets, prepopulated_fields,
             readonly_fields, model_admin)
+
+    @cached_property
+    def original_content_type_id(self):
+        warnings.warn(
+            'InlineAdminForm.original_content_type_id is deprecated and will be '
+            'removed in Django 2.0. If you were using this attribute to construct '
+            'the "view on site" URL, use the `absolute_url` attribute instead.',
+            RemovedInDjango20Warning, stacklevel=2
+        )
+        if self.original is not None:
+            # Since this module gets imported in the application's root package,
+            # it cannot import models from other applications at the module level.
+            from django.contrib.contenttypes.models import ContentType
+            return ContentType.objects.get_for_model(self.original).pk
+        raise AttributeError
 
     def __iter__(self):
         for name, options in self.fieldsets:

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -62,6 +62,9 @@ about each item can often be found in the release notes of two versions prior.
 * ``django.utils.checksums`` will be removed; its functionality is included
   in django-localflavor 1.1+.
 
+* The ``original_content_type_id`` attribute on
+  ``django.contrib.admin.helpers.InlineAdminForm`` will be removed.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -855,3 +855,11 @@ Luhn algorithm) was undocumented and not used in Django. The module has been
 moved to the `django-localflavor`_ package (version 1.1+).
 
 .. _django-localflavor: https://pypi.python.org/pypi/django-localflavor
+
+``django.contrib.admin.helpers.InlineAdminForm.original_content_type_id``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``original_content_type_id`` attribute on ``InlineAdminForm`` has been
+deprecated and will be removed in Django 2.0. Historically, it was used
+to show ``view_on_site`` link. It has been replaced with the ``absolute_url``
+attribute of the form object.


### PR DESCRIPTION
Migrated from this PR:
https://github.com/django/django/pull/3201
