### PR TITLE
#17906 -- Fix docs error introduced in commit 1ea44a3

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -263,11 +263,11 @@ Sample usage::
 This is equivalent to::
 
     {% if var1 %}
-        {{ var1|safe }}
+        {{ var1 }}
     {% elif var2 %}
-        {{ var2|safe }}
+        {{ var2 }}
     {% elif var3 %}
-        {{ var3|safe }}
+        {{ var3 }}
     {% endif %}
 
 You can also use a literal string as a fallback value in case all


### PR DESCRIPTION
Issue #17906 was relatively recently, but the equivalent code sample for `firstof` in the documentation still incorrectly showed the `|safe` filter.
