### PR TITLE
Removed unused import from the JSON serialization example.

### DIFF
--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -247,7 +247,6 @@ Be aware that not all Django output can be passed unmodified to :mod:`json`.
 In particular, :ref:`lazy translation objects <lazy-translations>` need a
 `special encoder`_ written for them. Something like this will work::
 
-    import json
     from django.utils.functional import Promise
     from django.utils.encoding import force_text
     from django.core.serializers.json import DjangoJSONEncoder


### PR DESCRIPTION
This is a leftover from 5612f54bd56086e2a375e86474ec734c172e7d1f.
