### PR TITLE
Fixed documentation of make_password arg name

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -211,7 +211,7 @@ from the ``User`` model.
     database to check against, and returns ``True`` if they match, ``False``
     otherwise.
 
-.. function:: make_password(password[, salt, hashers])
+.. function:: make_password(password[, salt, hasher])
 
     Creates a hashed password in the format used by this application. It takes
     one mandatory argument: the password in plain-text. Optionally, you can


### PR DESCRIPTION
Optional argument name is `hasher`, not `hashers`
