### PR TITLE
Fixed typo in squashing migrations documentation

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -459,7 +459,7 @@ Once the operation sequence has been reduced as much as possible - the amount
 possible depends on how closely intertwined your models are and if you have
 any :class:`~django.db.migrations.operations.RunSQL`
 or :class:`~django.db.migrations.operations.RunPython` operations (which can't
-be optimized through) - Django will them write it back out into a new set of
+be optimized through) - Django will then write it back out into a new set of
 initial migration files.
 
 These files are marked to say they replace the previously-squashed migrations,


### PR DESCRIPTION
The [squashing migrations documentation](https://docs.djangoproject.com/en/1.7/topics/migrations/#squashing-migrations) should read "Django will then write it back out" instead of "them"
