### PR TITLE
Fixed #23614 -- Changed the way the migration autodetector orders unique/index_together

### DIFF
--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -27,3 +27,6 @@ Bugfixes
 
 * Fixed MySQL 5.6+ crash with ``GeometryField``\s in migrations
   (:ticket:`23719`).
+
+* Fixed a migration crash when removing a field that is referenced in
+  ``AlterIndexTogether`` or ``AlterUniqueTogether`` (:ticket:`23614`).


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/23614

This patch only solves the problem for one situation: removing a field. Renaming a field and keeping it in the `index/unique_together` option shouldn't be a problem, since `_generate_altered_foo_together` works on the renamed fields.
