### PR TITLE
Fixed #23721 -- check_related_objects without calling __iter__

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1102,12 +1102,11 @@ class Query(object):
                         'Cannot use QuerySet for "%s": Use a QuerySet for "%s".' %
                         (value.model._meta.model_name, opts.object_name)
                     )
+            elif hasattr(value, '_meta'):
+                self.check_query_object_type(value, opts)
             elif hasattr(value, '__iter__'):
                 for v in value:
                     self.check_query_object_type(v, opts)
-            else:
-                # expecting single model instance here
-                self.check_query_object_type(value, opts)
 
     def build_lookup(self, lookups, lhs, rhs):
         lookups = lookups[:]

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -408,6 +408,10 @@ class ObjectA(models.Model):
     def __str__(self):
         return self.name
 
+    def __iter__(self):
+        # Ticket #23721
+        assert False, 'type checking should happen without calling model __iter__'
+
 
 class ProxyObjectA(ObjectA):
     class Meta:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23721
