### PR TITLE
Fixed #23728 -- Added --exit flag to makemigrations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -646,6 +646,7 @@ answer newbie questions, and generally made Django that much better:
     Thomas Stromberg <tstromberg@google.com>
     tibimicu@gmx.net
     Tim Graham <timograham@gmail.com>
+    Tim Heap <tim@timheap.me>
     Tim Saylor <tim.saylor@gmail.com>
     Tobias McNulty <http://www.caktusgroup.com/blog>
     tobias@neuyork.de

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -714,6 +714,14 @@ a merge.
 The ``--name`` option allows you to give the migration(s) a custom name instead
 of a generated one.
 
+.. django-admin-option:: --exit, -e
+
+.. versionadded:: 1.8
+
+The ``--exit`` option will cause ``makemigrations`` to exit with error code 1
+when no migration are created (or would have been created, if combined with
+``--dry-run``)
+
 migrate [<app_label> [<migrationname>]]
 ---------------------------------------
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -543,3 +543,20 @@ class MakeMigrationsTests(MigrationTestBase):
         content = cmd("0002", migration_name_0002, "--empty")
         self.assertIn("dependencies=[\n('migrations','0001_%s'),\n]" % migration_name_0001, content)
         self.assertIn("operations=[\n]", content)
+
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_no_changes"})
+    def test_makemigrations_exit_no_changes(self):
+        """
+        Ticket #23728 -- Makes sure that makemigrations --exit exits with
+        sys.exit(1) when there are no changes to an app.
+        """
+        with self.assertRaises(SystemExit):
+            call_command("makemigrations", "--exit", "migrations", verbosity=0)
+
+    def test_makemigrations_exit_with_changes(self):
+        """
+        Ticket #23728 -- Makes sure that makemigrations --exit does not exit
+        when there are changes to an app.
+        """
+        with override_settings(MIGRATION_MODULES={"migrations": self.migration_pkg}):
+            call_command("makemigrations", "--exit", "migrations", verbosity=0)


### PR DESCRIPTION
If no changes are found, makemigrations calls sys.exit(1). Users can use this to check for changes that need a migration as part of an automated test suite, continuous deployment, or other system.

See [ticket 23728](https://code.djangoproject.com/ticket/23728) and the [django-developers mailing list](https://groups.google.com/forum/#!topic/django-developers/I3M6B-wYYd8) for discussions.
