### PR TITLE
Adjust documentation about django admin documentation generator

### DIFF
--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -12,9 +12,18 @@ docstrings of models, views, template tags, and template filters for any app in
 :setting:`INSTALLED_APPS` and makes that documentation available from the
 :mod:`Django admin <django.contrib.admin>`.
 
-In addition to providing offline documentation for all template tags and
-template filters that ship with Django, you may utilize admindocs to quickly
-document your own code.
+This way, Django admin documentation generator provides offline documentation
+for all custom and built-in template tags and template filters.
+
+.. admonition:: Note
+
+    You may, to some extent, utilize :mod:`~django.contrib.admindocs` app to
+    quickly document your own code. Although this has limited usage, as
+    admindocs app is primarily intended for documenting templates, template
+    tags and filters, it can still be useful since it doesn't require you to
+    write any extra documentation (besides docstrings) and is conveniently
+    available from the :mod:`Django admin <django.contrib.admin>`.
+
 
 Overview
 ========


### PR DESCRIPTION
Django admindocs is used for documenting templates, template tags and filters, which is why it skips
model methods that take arguments - that makes it not a perfect match for project documentation
purposes, which is what the documentation was proposing. I changed this part of documentation
in order to remove the misleading part.
