### PR TITLE
Fixed #23731 -- Fixed migrations crash when adding blank GeometryFields on PostGIS.

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -277,7 +277,7 @@ class GeometryField(Field):
 
     def get_db_prep_save(self, value, connection):
         "Prepares the value for saving in the database."
-        if value is None:
+        if not value:
             return None
         else:
             return connection.ops.Adapter(self.get_prep_value(value))

--- a/django/contrib/gis/tests/gis_migrations/test_operations.py
+++ b/django/contrib/gis/tests/gis_migrations/test_operations.py
@@ -67,10 +67,38 @@ class OperationTests(TransactionTestCase):
         Tests the AddField operation with a GIS-enabled column.
         """
         project_state = self.set_up_test_model()
+        self.current_state = project_state
         operation = migrations.AddField(
             "Neighborhood",
             "path",
             fields.LineStringField(srid=4326),
+        )
+        new_state = project_state.clone()
+        operation.state_forwards("gis", new_state)
+        with connection.schema_editor() as editor:
+            operation.database_forwards("gis", editor, project_state, new_state)
+        self.current_state = new_state
+        self.assertColumnExists("gis_neighborhood", "path")
+
+        # Test GeometryColumns when available
+        if HAS_GEOMETRY_COLUMNS:
+            self.assertGeometryColumnsCount(2)
+
+        if self.has_spatial_indexes:
+            with connection.cursor() as cursor:
+                indexes = connection.introspection.get_indexes(cursor, "gis_neighborhood")
+            self.assertIn('path', indexes)
+
+    def test_add_blank_gis_field(self):
+        """
+        Should be able to add a GeometryField with blank=True.
+        """
+        project_state = self.set_up_test_model()
+        self.current_state = project_state
+        operation = migrations.AddField(
+            "Neighborhood",
+            "path",
+            fields.LineStringField(blank=True, srid=4326),
         )
         new_state = project_state.clone()
         operation.state_forwards("gis", new_state)
@@ -93,6 +121,7 @@ class OperationTests(TransactionTestCase):
         Tests the RemoveField operation with a GIS-enabled column.
         """
         project_state = self.set_up_test_model()
+        self.current_state = project_state
         operation = migrations.RemoveField("Neighborhood", "geom")
         new_state = project_state.clone()
         operation.state_forwards("gis", new_state)

--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -40,3 +40,6 @@ Bugfixes
 
 * Fixed a migration crash that prevented changing a nullable field with a
   default to non-nullable with the same default (:ticket:`23738`).
+
+* Fixed a migrations crash when adding ``GeometryField``\s with ``blank=True``
+  on PostGIS (:ticket:`23731`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23731
