### PR TITLE
Mysql db check should handle None db_type returns. 

### DIFF
--- a/django/db/backends/mysql/validation.py
+++ b/django/db/backends/mysql/validation.py
@@ -17,6 +17,10 @@ class DatabaseValidation(BaseDatabaseValidation):
         if getattr(field, 'rel', None) is None:
             field_type = field.db_type(connection)
 
+            # Ignore any non-concrete fields
+            if field_type is None:
+                return errors
+
             if (field_type.startswith('varchar')  # Look for CharFields...
                     and field.unique  # ... that are unique
                     and (field.max_length is None or int(field.max_length) > 255)):


### PR DESCRIPTION
When implementing a custom field type with a db_type() method that returns None, on Django 1.6 and below we would signify not to create a column at all.
With Django 1.7, this causes a crash with the mysql backend.
The issue is already fixed in master and this simply backports the safety check.

Backport from https://github.com/django/django/commit/e9103402c0fa873aea58a6a11dba510cd308cb84#diff-14.

https://code.djangoproject.com/ticket/23761
