### PR TITLE
Fixed #24011-- Added Range fields for contrib.postgres

### DIFF
--- a/django/contrib/postgres/fields/__init__.py
+++ b/django/contrib/postgres/fields/__init__.py
@@ -1,2 +1,3 @@
 from .array import *  # NOQA
 from .hstore import *  # NOQA
+from .ranges import *  # NOQA

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -75,12 +75,6 @@ class ArrayField(Field):
             return [self.base_field.get_prep_value(i) for i in value]
         return value
 
-    def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
-        if lookup_type == 'contains':
-            return [self.get_prep_value(value)]
-        return super(ArrayField, self).get_db_prep_lookup(lookup_type, value,
-                connection, prepared=False)
-
     def deconstruct(self):
         name, path, args, kwargs = super(ArrayField, self).deconstruct()
         if path == 'django.contrib.postgres.fields.array.ArrayField':

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -1,9 +1,10 @@
 import json
 
+from django.contrib.postgres import lookups
 from django.contrib.postgres.forms import SimpleArrayField
 from django.contrib.postgres.validators import ArrayMaxLengthValidator
 from django.core import checks, exceptions
-from django.db.models import Field, Lookup, Transform, IntegerField
+from django.db.models import Field, Transform, IntegerField
 from django.utils import six
 from django.utils.translation import string_concat, ugettext_lazy as _
 
@@ -156,46 +157,21 @@ class ArrayField(Field):
 
 
 @ArrayField.register_lookup
-class ArrayContainsLookup(Lookup):
-    lookup_name = 'contains'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        type_cast = self.lhs.output_field.db_type(connection)
-        return '%s @> %s::%s' % (lhs, rhs, type_cast), params
+class ArrayContains(lookups.DataContains):
+    def as_sql(self, qn, connection):
+        sql, params = super(ArrayContains, self).as_sql(qn, connection)
+        sql += '::%s' % self.lhs.output_field.db_type(connection)
+        return sql, params
 
 
-@ArrayField.register_lookup
-class ArrayContainedByLookup(Lookup):
-    lookup_name = 'contained_by'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s <@ %s' % (lhs, rhs), params
-
-
-@ArrayField.register_lookup
-class ArrayOverlapLookup(Lookup):
-    lookup_name = 'overlap'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s && %s' % (lhs, rhs), params
+ArrayField.register_lookup(lookups.ContainedBy)
+ArrayField.register_lookup(lookups.Overlap)
 
 
 @ArrayField.register_lookup
 class ArrayLenTransform(Transform):
     lookup_name = 'len'
-
-    @property
-    def output_field(self):
-        return IntegerField()
+    output_field = IntegerField()
 
     def as_sql(self, compiler, connection):
         lhs, params = compiler.compile(self.lhs)

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -1,9 +1,9 @@
 import json
 
-from django.contrib.postgres import forms
+from django.contrib.postgres import forms, lookups
 from django.contrib.postgres.fields.array import ArrayField
 from django.core import exceptions
-from django.db.models import Field, Lookup, Transform, TextField
+from django.db.models import Field, Transform, TextField
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
@@ -60,48 +60,20 @@ class HStoreField(Field):
         return super(HStoreField, self).formfield(**defaults)
 
 
-@HStoreField.register_lookup
-class HStoreContainsLookup(Lookup):
-    lookup_name = 'contains'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s @> %s' % (lhs, rhs), params
+HStoreField.register_lookup(lookups.DataContains)
+HStoreField.register_lookup(lookups.ContainedBy)
 
 
 @HStoreField.register_lookup
-class HStoreContainedByLookup(Lookup):
-    lookup_name = 'contained_by'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s <@ %s' % (lhs, rhs), params
-
-
-@HStoreField.register_lookup
-class HasKeyLookup(Lookup):
+class HasKeyLookup(lookups.PostgresSimpleLookup):
     lookup_name = 'has_key'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s ? %s' % (lhs, rhs), params
+    operator = '?'
 
 
 @HStoreField.register_lookup
-class HasKeysLookup(Lookup):
+class HasKeysLookup(lookups.PostgresSimpleLookup):
     lookup_name = 'has_keys'
-
-    def as_sql(self, compiler, connection):
-        lhs, lhs_params = self.process_lhs(compiler, connection)
-        rhs, rhs_params = self.process_rhs(compiler, connection)
-        params = lhs_params + rhs_params
-        return '%s ?& %s' % (lhs, rhs), params
+    operator = '?&'
 
 
 class KeyTransform(Transform):
@@ -126,20 +98,14 @@ class KeyTransformFactory(object):
 
 
 @HStoreField.register_lookup
-class KeysTransform(Transform):
+class KeysTransform(lookups.FunctionTransform):
     lookup_name = 'keys'
+    function = 'akeys'
     output_field = ArrayField(TextField())
-
-    def as_sql(self, compiler, connection):
-        lhs, params = compiler.compile(self.lhs)
-        return 'akeys(%s)' % lhs, params
 
 
 @HStoreField.register_lookup
-class ValuesTransform(Transform):
+class ValuesTransform(lookups.FunctionTransform):
     lookup_name = 'values'
+    function = 'avals'
     output_field = ArrayField(TextField())
-
-    def as_sql(self, compiler, connection):
-        lhs, params = compiler.compile(self.lhs)
-        return 'avals(%s)' % lhs, params

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -21,12 +21,6 @@ class HStoreField(Field):
     def db_type(self, connection):
         return 'hstore'
 
-    def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
-        if lookup_type == 'contains':
-            return [self.get_prep_value(value)]
-        return super(HStoreField, self).get_db_prep_lookup(lookup_type, value,
-                connection, prepared=False)
-
     def get_transform(self, name):
         transform = super(HStoreField, self).get_transform(name)
         if transform:

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -15,13 +15,20 @@ __all__ = [
 class RangeField(models.Field):
     empty_strings_allowed = False
 
+    def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
+        if lookup_type == 'contains':
+            return [self.get_prep_value(value)]
+        return super(RangeField, self).get_db_prep_lookup(lookup_type, value,
+                connection, prepared=False)
+
     def get_prep_value(self, value):
         if value is None:
             return None
         elif isinstance(value, Range):
             return value
-        else:
+        elif isinstance(value, (list, tuple)):
             return self.range_type(value[0], value[1])
+        return value
 
     def to_python(self, value):
         if isinstance(value, six.string_types):
@@ -79,3 +86,119 @@ class DateRangeField(RangeField):
 
     def db_type(self, connection):
         return 'daterange'
+
+
+@RangeField.register_lookup
+class RangeContainsLookup(models.Lookup):
+    lookup_name = 'contains'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s @> %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class RangeContainedByLookup(models.Lookup):
+    lookup_name = 'contained_by'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s <@ %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class RangeOverlapLookup(models.Lookup):
+    lookup_name = 'overlap'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s && %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class FullyLessThanLookup(models.Lookup):
+    lookup_name = 'fully_lt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s << %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class FullGreaterThanLookup(models.Lookup):
+    lookup_name = 'fully_gt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s >> %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class NotLessThanLookup(models.Lookup):
+    lookup_name = 'not_lt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s &> %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class NotGreaterThanLookup(models.Lookup):
+    lookup_name = 'not_gt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s &< %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class AdjacentToLookup(models.Lookup):
+    lookup_name = 'adjacent_to'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s -|- %s' % (lhs, rhs), params
+
+
+@RangeField.register_lookup
+class RangeStartsWithTransform(models.Transform):
+    lookup_name = 'startswith'
+
+    def as_sql(self, qn, connection):
+        lhs, params = qn.compile(self.lhs)
+        return "lower(%s)" % lhs, params
+
+
+@RangeField.register_lookup
+class RangeEndsWithTransform(models.Transform):
+    lookup_name = 'endswith'
+
+    def as_sql(self, qn, connection):
+        lhs, params = qn.compile(self.lhs)
+        return "upper(%s)" % lhs, params
+
+
+@RangeField.register_lookup
+class RangeIsEmptyTransform(models.Transform):
+    lookup_name = 'isempty'
+    output_type = models.BooleanField()
+
+    def as_sql(self, qn, connection):
+        lhs, params = qn.compile(self.lhs)
+        return "isempty(%s)" % lhs, params

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -1,0 +1,81 @@
+import json
+
+from django.db import models
+from django.utils import six
+
+from psycopg2.extras import Range, NumericRange, DateRange, DateTimeTZRange
+
+
+__all__ = [
+    'RangeField', 'IntegerRangeField', 'BigIntegerRangeField',
+    'FloatRangeField', 'DateTimeRangeField', 'DateRangeField',
+]
+
+
+class RangeField(models.Field):
+    empty_strings_allowed = False
+
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+        elif isinstance(value, Range):
+            return value
+        else:
+            return self.range_type(value[0], value[1])
+
+    def to_python(self, value):
+        if isinstance(value, six.string_types):
+            value = self.range_type(**json.loads(value))
+        return value
+
+    def value_to_string(self, obj):
+        value = self._get_val_from_obj(obj)
+        if value is None:
+            return None
+        if value.isempty:
+            return json.dumps({"empty": True})
+        return json.dumps({
+            "lower": value.lower,
+            "upper": value.upper,
+            "bounds": value._bounds,
+        })
+
+
+class IntegerRangeField(RangeField):
+    base_field = models.IntegerField()
+    range_type = NumericRange
+
+    def db_type(self, connection):
+        return 'int4range'
+
+
+class BigIntegerRangeField(RangeField):
+    base_field = models.BigIntegerField()
+    range_type = NumericRange
+
+    def db_type(self, connection):
+        return 'int8range'
+
+
+class FloatRangeField(RangeField):
+    base_field = models.FloatField()
+    range_type = NumericRange
+
+    def db_type(self, connection):
+        return 'numrange'
+
+
+class DateTimeRangeField(RangeField):
+    base_field = models.FloatField()
+    range_type = DateTimeTZRange
+
+    def db_type(self, connection):
+        return 'tstzrange'
+
+
+class DateRangeField(RangeField):
+    base_field = models.FloatField()
+    range_type = DateRange
+
+    def db_type(self, connection):
+        return 'daterange'

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -16,12 +16,6 @@ __all__ = [
 class RangeField(models.Field):
     empty_strings_allowed = False
 
-    def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
-        if lookup_type == 'contains':
-            return [self.get_prep_value(value)]
-        return super(RangeField, self).get_db_prep_lookup(lookup_type, value,
-                connection, prepared=False)
-
     def get_prep_value(self, value):
         if value is None:
             return None

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -1,6 +1,6 @@
 import json
 
-from django.contrib.postgres import lookups
+from django.contrib.postgres import lookups, forms
 from django.db import models
 from django.utils import six
 
@@ -44,10 +44,15 @@ class RangeField(models.Field):
             "bounds": value._bounds,
         })
 
+    def formfield(self, **kwargs):
+        kwargs.setdefault('form_class', self.form_field)
+        return super(RangeField, self).formfield(**kwargs)
+
 
 class IntegerRangeField(RangeField):
     base_field = models.IntegerField()
     range_type = NumericRange
+    form_field = forms.IntegerRangeField
 
     def db_type(self, connection):
         return 'int4range'
@@ -56,6 +61,7 @@ class IntegerRangeField(RangeField):
 class BigIntegerRangeField(RangeField):
     base_field = models.BigIntegerField()
     range_type = NumericRange
+    form_field = forms.IntegerRangeField
 
     def db_type(self, connection):
         return 'int8range'
@@ -64,6 +70,7 @@ class BigIntegerRangeField(RangeField):
 class FloatRangeField(RangeField):
     base_field = models.FloatField()
     range_type = NumericRange
+    form_field = forms.FloatRangeField
 
     def db_type(self, connection):
         return 'numrange'
@@ -72,6 +79,7 @@ class FloatRangeField(RangeField):
 class DateTimeRangeField(RangeField):
     base_field = models.DateTimeField()
     range_type = DateTimeTZRange
+    form_field = forms.DateTimeRangeField
 
     def db_type(self, connection):
         return 'tstzrange'
@@ -80,6 +88,7 @@ class DateTimeRangeField(RangeField):
 class DateRangeField(RangeField):
     base_field = models.DateField()
     range_type = DateRange
+    form_field = forms.DateRangeField
 
     def db_type(self, connection):
         return 'daterange'

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -28,6 +28,8 @@ class RangeField(models.Field):
     def to_python(self, value):
         if isinstance(value, six.string_types):
             value = self.range_type(**json.loads(value))
+        elif isinstance(value, (list, tuple)):
+            value = self.range_type(value[0], value[1])
         return value
 
     def value_to_string(self, obj):

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -70,7 +70,7 @@ class FloatRangeField(RangeField):
 
 
 class DateTimeRangeField(RangeField):
-    base_field = models.FloatField()
+    base_field = models.DateTimeField()
     range_type = DateTimeTZRange
 
     def db_type(self, connection):
@@ -78,7 +78,7 @@ class DateTimeRangeField(RangeField):
 
 
 class DateRangeField(RangeField):
-    base_field = models.FloatField()
+    base_field = models.DateField()
     range_type = DateRange
 
     def db_type(self, connection):

--- a/django/contrib/postgres/forms/__init__.py
+++ b/django/contrib/postgres/forms/__init__.py
@@ -1,2 +1,3 @@
 from .array import *  # NOQA
 from .hstore import *  # NOQA
+from .ranges import *  # NOQA

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -1,0 +1,79 @@
+from django.core import exceptions
+from django import forms
+from django.utils.translation import ugettext_lazy as _, string_concat
+
+from psycopg2.extras import NumericRange, DateRange, DateTimeTZRange
+
+
+__all__ = ['IntegerRangeField', 'FloatRangeField', 'DateTimeRangeField', 'DateRangeField']
+
+
+class BaseRangeField(forms.Field):
+    default_error_messages = {
+        'invalid': _('Enter two valid values.'),
+        'lower_invalid': _('Enter a valid start value: '),
+        'upper_invalid': _('Enter a valid end value: '),
+        'bound_order': _('The start of the range must not exceed the end of the range.'),
+    }
+
+    def __init__(self, **kwargs):
+        widget = forms.MultiWidget([self.base_field.widget, self.base_field.widget])
+        kwargs.setdefault('widget', widget)
+        super(BaseRangeField, self).__init__(**kwargs)
+
+    def prepare_value(self, value):
+        if isinstance(value, self.range_type):
+            return [value.lower, value.upper]
+        if value is None:
+            return [None, None]
+        return value
+
+    def to_python(self, value):
+        base_field = self.base_field()
+        try:
+            lower, upper = value
+        except ValueError:
+            raise exceptions.ValidationError(self.error_messages['invalid'],
+                    code='invalid')
+        try:
+            lower = base_field.to_python(lower)
+        except exceptions.ValidationError as e:
+            message = string_concat(self.error_messages['lower_invalid'], e.message)
+            raise exceptions.ValidationError(message, code='lower_invalid')
+        try:
+            upper = base_field.to_python(upper)
+        except exceptions.ValidationError as e:
+            message = string_concat(self.error_messages['upper_invalid'], e.message)
+            raise exceptions.ValidationError(message, code='upper_invalid')
+        if lower is None and upper is None:
+            return None
+        if lower > upper:
+            raise exceptions.ValidationError(self.error_messages['bound_order'],
+                    code='bound_order')
+        try:
+            range_value = self.range_type(lower, upper)
+        except TypeError:
+            raise exceptions.ValidationError(self.error_messages['invalid'],
+                    code='invalid')
+        else:
+            return range_value
+
+
+class IntegerRangeField(BaseRangeField):
+    base_field = forms.IntegerField
+    range_type = NumericRange
+
+
+class FloatRangeField(BaseRangeField):
+    base_field = forms.FloatField
+    range_type = NumericRange
+
+
+class DateTimeRangeField(BaseRangeField):
+    base_field = forms.DateTimeField
+    range_type = DateTimeTZRange
+
+
+class DateRangeField(BaseRangeField):
+    base_field = forms.DateField
+    range_type = DateRange

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -1,6 +1,6 @@
 from django.core import exceptions
 from django import forms
-from django.utils.translation import ugettext_lazy as _, string_concat
+from django.utils.translation import ugettext_lazy as _
 
 from psycopg2.extras import NumericRange, DateRange, DateTimeTZRange
 
@@ -8,17 +8,18 @@ from psycopg2.extras import NumericRange, DateRange, DateTimeTZRange
 __all__ = ['IntegerRangeField', 'FloatRangeField', 'DateTimeRangeField', 'DateRangeField']
 
 
-class BaseRangeField(forms.Field):
+class BaseRangeField(forms.MultiValueField):
     default_error_messages = {
         'invalid': _('Enter two valid values.'),
-        'lower_invalid': _('Enter a valid start value: '),
-        'upper_invalid': _('Enter a valid end value: '),
         'bound_order': _('The start of the range must not exceed the end of the range.'),
     }
 
     def __init__(self, **kwargs):
         widget = forms.MultiWidget([self.base_field.widget, self.base_field.widget])
         kwargs.setdefault('widget', widget)
+        kwargs.setdefault('fields', [self.base_field(required=False), self.base_field(required=False)])
+        kwargs.setdefault('required', False)
+        kwargs.setdefault('require_all_fields', False)
         super(BaseRangeField, self).__init__(**kwargs)
 
     def prepare_value(self, value):
@@ -28,25 +29,10 @@ class BaseRangeField(forms.Field):
             return [None, None]
         return value
 
-    def to_python(self, value):
-        base_field = self.base_field()
-        try:
-            lower, upper = value
-        except ValueError:
-            raise exceptions.ValidationError(self.error_messages['invalid'],
-                    code='invalid')
-        try:
-            lower = base_field.to_python(lower)
-        except exceptions.ValidationError as e:
-            message = string_concat(self.error_messages['lower_invalid'], e.message)
-            raise exceptions.ValidationError(message, code='lower_invalid')
-        try:
-            upper = base_field.to_python(upper)
-        except exceptions.ValidationError as e:
-            message = string_concat(self.error_messages['upper_invalid'], e.message)
-            raise exceptions.ValidationError(message, code='upper_invalid')
-        if lower is None and upper is None:
+    def compress(self, values):
+        if not values:
             return None
+        lower, upper = values
         if lower is not None and upper is not None and lower > upper:
             raise exceptions.ValidationError(self.error_messages['bound_order'],
                     code='bound_order')

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -47,7 +47,7 @@ class BaseRangeField(forms.Field):
             raise exceptions.ValidationError(message, code='upper_invalid')
         if lower is None and upper is None:
             return None
-        if lower > upper:
+        if lower is not None and upper is not None and lower > upper:
             raise exceptions.ValidationError(self.error_messages['bound_order'],
                     code='bound_order')
         try:

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -11,7 +11,7 @@ __all__ = ['IntegerRangeField', 'FloatRangeField', 'DateTimeRangeField', 'DateRa
 class BaseRangeField(forms.MultiValueField):
     default_error_messages = {
         'invalid': _('Enter two valid values.'),
-        'bound_order': _('The start of the range must not exceed the end of the range.'),
+        'bound_ordering': _('The start of the range must not exceed the end of the range.'),
     }
 
     def __init__(self, **kwargs):
@@ -34,13 +34,17 @@ class BaseRangeField(forms.MultiValueField):
             return None
         lower, upper = values
         if lower is not None and upper is not None and lower > upper:
-            raise exceptions.ValidationError(self.error_messages['bound_order'],
-                    code='bound_order')
+            raise exceptions.ValidationError(
+                self.error_messages['bound_ordering'],
+                code='bound_ordering',
+            )
         try:
             range_value = self.range_type(lower, upper)
         except TypeError:
-            raise exceptions.ValidationError(self.error_messages['invalid'],
-                    code='invalid')
+            raise exceptions.ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+            )
         else:
             return range_value
 

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,10 +1,36 @@
-from django.db.models import Transform
+from django.db.models import Lookup, Transform
 
 
-class Unaccent(Transform):
+class PostgresSimpleLookup(Lookup):
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return '%s %s %s' % (lhs, self.operator, rhs), params
+
+
+class FunctionTransform(Transform):
+    def as_sql(self, qn, connection):
+        lhs, params = qn.compile(self.lhs)
+        return "%s(%s)" % (self.function, lhs), params
+
+
+class DataContains(PostgresSimpleLookup):
+    lookup_name = 'contains'
+    operator = '@>'
+
+
+class ContainedBy(PostgresSimpleLookup):
+    lookup_name = 'contained_by'
+    operator = '<@'
+
+
+class Overlap(PostgresSimpleLookup):
+    lookup_name = 'overlap'
+    operator = '&&'
+
+
+class Unaccent(FunctionTransform):
     bilateral = True
     lookup_name = 'unaccent'
-
-    def as_postgresql(self, compiler, connection):
-        lhs, params = compiler.compile(self.lhs)
-        return "UNACCENT(%s)" % lhs, params
+    function = 'UNACCENT'

--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -1,7 +1,10 @@
 import copy
 
 from django.core.exceptions import ValidationError
-from django.core.validators import MaxLengthValidator, MinLengthValidator
+from django.core.validators import (
+    MaxLengthValidator, MinLengthValidator, MaxValueValidator,
+    MinValueValidator,
+)
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import ungettext_lazy, ugettext_lazy as _
 
@@ -63,3 +66,13 @@ class KeysValidator(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+
+class RangeMaxValueValidator(MaxValueValidator):
+    compare = lambda self, a, b: a.upper > b
+    message = _('Ensure that this range is completely less than or equal to %(limit_value)s.')
+
+
+class RangeMinValueValidator(MinValueValidator):
+    compare = lambda self, a, b: a.lower < b
+    message = _('Ensure that this range is completely greater than or equal to %(limit_value)s.')

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -711,7 +711,9 @@ class Field(RegisterLookupMixin):
             return QueryWrapper(('(%s)' % sql), params)
 
         if lookup_type in ('month', 'day', 'week_day', 'hour', 'minute',
-                           'second', 'search', 'regex', 'iregex'):
+                           'second', 'search', 'regex', 'iregex', 'contains',
+                           'icontains', 'iexact', 'startswith', 'endswith',
+                           'istartswith', 'iendswith'):
             return [value]
         elif lookup_type in ('exact', 'gt', 'gte', 'lt', 'lte'):
             return [self.get_db_prep_value(value, connection=connection,
@@ -719,14 +721,6 @@ class Field(RegisterLookupMixin):
         elif lookup_type in ('range', 'in'):
             return [self.get_db_prep_value(v, connection=connection,
                                            prepared=prepared) for v in value]
-        elif lookup_type in ('contains', 'icontains'):
-            return ["%%%s%%" % connection.ops.prep_for_like_query(value)]
-        elif lookup_type == 'iexact':
-            return [connection.ops.prep_for_iexact_query(value)]
-        elif lookup_type in ('startswith', 'istartswith'):
-            return ["%s%%" % connection.ops.prep_for_like_query(value)]
-        elif lookup_type in ('endswith', 'iendswith'):
-            return ["%%%s" % connection.ops.prep_for_like_query(value)]
         elif lookup_type == 'isnull':
             return []
         elif lookup_type == 'year':

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -327,8 +327,8 @@ class Contains(PatternLookup):
     lookup_name = 'contains'
 
     def process_rhs(self, qn, connection):
-        rhs, params = super(IContains, self).process_rhs(qn, connection)
-        if params:
+        rhs, params = super(Contains, self).process_rhs(qn, connection)
+        if params and not self.bilateral_transforms:
             params[0] = "%%%s%%" % connection.ops.prep_for_like_query(params[0])
         return rhs, params
 
@@ -348,7 +348,7 @@ class StartsWith(PatternLookup):
 
     def process_rhs(self, qn, connection):
         rhs, params = super(StartsWith, self).process_rhs(qn, connection)
-        if params:
+        if params and not self.bilateral_transforms:
             params[0] = "%s%%" % connection.ops.prep_for_like_query(params[0])
         return rhs, params
 
@@ -361,7 +361,7 @@ class IStartsWith(PatternLookup):
 
     def process_rhs(self, qn, connection):
         rhs, params = super(IStartsWith, self).process_rhs(qn, connection)
-        if params:
+        if params and not self.bilateral_transforms:
             params[0] = "%s%%" % connection.ops.prep_for_like_query(params[0])
         return rhs, params
 
@@ -374,7 +374,7 @@ class EndsWith(PatternLookup):
 
     def process_rhs(self, qn, connection):
         rhs, params = super(EndsWith, self).process_rhs(qn, connection)
-        if params:
+        if params and not self.bilateral_transforms:
             params[0] = "%%%s" % connection.ops.prep_for_like_query(params[0])
         return rhs, params
 
@@ -387,7 +387,7 @@ class IEndsWith(PatternLookup):
 
     def process_rhs(self, qn, connection):
         rhs, params = super(IEndsWith, self).process_rhs(qn, connection)
-        if params:
+        if params and not self.bilateral_transforms:
             params[0] = "%%%s" % connection.ops.prep_for_like_query(params[0])
         return rhs, params
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -222,6 +222,14 @@ default_lookups['exact'] = Exact
 
 class IExact(BuiltinLookup):
     lookup_name = 'iexact'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(IExact, self).process_rhs(qn, connection)
+        if params:
+            params[0] = connection.ops.prep_for_iexact_query(params[0])
+        return rhs, params
+
+
 default_lookups['iexact'] = IExact
 
 
@@ -317,31 +325,73 @@ class PatternLookup(BuiltinLookup):
 
 class Contains(PatternLookup):
     lookup_name = 'contains'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(IContains, self).process_rhs(qn, connection)
+        if params:
+            params[0] = "%%%s%%" % connection.ops.prep_for_like_query(params[0])
+        return rhs, params
+
+
 default_lookups['contains'] = Contains
 
 
-class IContains(PatternLookup):
+class IContains(Contains):
     lookup_name = 'icontains'
+
+
 default_lookups['icontains'] = IContains
 
 
 class StartsWith(PatternLookup):
     lookup_name = 'startswith'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(StartsWith, self).process_rhs(qn, connection)
+        if params:
+            params[0] = "%s%%" % connection.ops.prep_for_like_query(params[0])
+        return rhs, params
+
+
 default_lookups['startswith'] = StartsWith
 
 
 class IStartsWith(PatternLookup):
     lookup_name = 'istartswith'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(IStartsWith, self).process_rhs(qn, connection)
+        if params:
+            params[0] = "%s%%" % connection.ops.prep_for_like_query(params[0])
+        return rhs, params
+
+
 default_lookups['istartswith'] = IStartsWith
 
 
 class EndsWith(PatternLookup):
     lookup_name = 'endswith'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(EndsWith, self).process_rhs(qn, connection)
+        if params:
+            params[0] = "%%%s" % connection.ops.prep_for_like_query(params[0])
+        return rhs, params
+
+
 default_lookups['endswith'] = EndsWith
 
 
 class IEndsWith(PatternLookup):
     lookup_name = 'iendswith'
+
+    def process_rhs(self, qn, connection):
+        rhs, params = super(IEndsWith, self).process_rhs(qn, connection)
+        if params:
+            params[0] = "%%%s" % connection.ops.prep_for_like_query(params[0])
+        return rhs, params
+
+
 default_lookups['iendswith'] = IEndsWith
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,7 @@ intersphinx_mapping = {
     'sphinx': ('http://sphinx-doc.org/', None),
     'six': ('http://pythonhosted.org/six/', None),
     'formtools': ('http://django-formtools.readthedocs.org/en/latest/', None),
+    'psycopg2': ('http://initd.org/psycopg/docs/', None),
 }
 
 # Python's docs don't change every week.

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -403,6 +403,7 @@ using in conjunction with lookups on
     >>> Dog.objects.filter(data__values__contains=['collie'])
     [<Dog: Meg>]
 
+.. _range-fields:
 
 Range Fields
 ------------

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -402,3 +402,253 @@ using in conjunction with lookups on
 
     >>> Dog.objects.filter(data__values__contains=['collie'])
     [<Dog: Meg>]
+
+
+Range Fields
+------------
+
+There are five range field types, corresponding to the built-in range types in
+PostgreSQL. These fields are used to store a range of values, for example the
+start and end timestamps of an event, or the range of ages an activity is
+suitable for.
+
+All of the range fields translate to :ref:`psycopg2 Range objects
+<psycopg2:adapt-range>` in python, but also accept tuples as input if no bound
+information is necessary. The default is lower bound included, upper bound
+excluded.
+
+IntegerRangeField
+^^^^^^^^^^^^^^^^^
+
+.. class:: IntegerRangeField(**options)
+
+    Stores a range of integers. Based on a
+    :class:`~django.db.models.IntegerField`. Represented by a ``int4range`` in
+    the database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
+    Python.
+
+BigIntegerRangeField
+^^^^^^^^^^^^^^^^^^^^
+
+.. class:: BigIntegerRangeField(**options)
+
+    Stores a range of large integers. Based on a
+    :class:`~django.db.models.BigIntegerField`. Represented by a ``int8range``
+    in the database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
+    Python.
+
+FloatRangeField
+^^^^^^^^^^^^^^^
+
+.. class:: FloatRangeField(**options)
+
+    Stores a range of floating point values. Based on a
+    :class:`~django.db.models.FloatField`. Represented by a ``numrange`` in the
+    database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in Python.
+
+DateTimeRangeField
+^^^^^^^^^^^^^^^^^^
+
+.. class:: DateTimeRangeField(**options)
+
+    Stores a range of timestamps. Based on a
+    :class:`~django.db.models.DateTimeField`. Represented by a ``tztsrange`` in
+    the database, and a :class:`~psycopg2:psycopg2.extras.DateTimeTZRange` in
+    Python.
+
+DateRangeField
+^^^^^^^^^^^^^^
+
+.. class:: DateRangeField(**options)
+
+    Stores a range of dates. Based on a
+    :class:`~django.db.models.DateField`. Represented by a ``daterange`` in the
+    database, and a :class:`~psycopg2:psycopg2.extras.DateRange` in Python.
+
+Querying Range Fields
+^^^^^^^^^^^^^^^^^^^^^
+
+There are a number of custom lookups and transforms for range fields. They are
+available on all the above fields, but we will use the following example
+model::
+
+    from django.db import models
+    from django.contrib.postgres.fields import DateTimeRangeField
+
+    class Event(models.Model):
+        name = models.CharField(max_length=200)
+        ages = models.IntegerRangeField()
+
+        def __str__(self):  # __unicode__ on Python 2
+            return self.name
+
+We will also use the following example objects::
+
+    >>> Event.objects.create(name='Soft play', ages=(0, 10))
+    >>> Event.objects.create(name='Pub trip', ages=(21, None))
+
+Containment functions
+~~~~~~~~~~~~~~~~~~~~~
+
+As with other PostgreSQL fields, there are three standard containment
+operators: ``contains``, ``contained_by`` and ``overlap``, using the SQL
+operators ``@>``, ``<@`` and ``&&`` respectively.
+
+.. fieldlookup:: rangefield.contains
+
+contains
+''''''''
+
+    >>> Event.objects.filter(ages__contains=NumericRange(4, 5))
+    [<Event: Soft play>]
+
+.. fieldlookup:: rangefield.contained_by
+
+contained_by
+''''''''''''
+
+    >>> Event.objects.filter(ages__contains=NumericRange(0, 15))
+    [<Event: Soft play>]
+
+.. fieldlookup:: rangefield.overlap
+
+overlap
+'''''''
+
+    >>> Event.objects.filter(ages__overlap=NumericRange(8, 12))
+    [<Event: Soft play>]
+
+Comparison functions
+~~~~~~~~~~~~~~~~~~~~
+
+Range fields support the standard lookups: :lookup:`lt`, :lookup:`gt`,
+:lookup:`lte` and :lookup:`gte`. These are not particularly helpful - they
+compare the lower bounds first and then the upper bounds only if necessary.
+This is also the strategy used to order by a range field. It is better to use
+the specific range comparison operators.
+
+.. fieldlookup:: rangefield.fully_lt
+
+fully_lt
+''''''''
+
+The returned ranges are strictly less than than passed range, that is the upper
+bound of the retured range is less than the lower bound of the passed range.
+
+    >>> Event.objects.filter(ages__fully_lt=NumericRange(11, 15))
+    [<Event: Soft play>]
+
+.. fieldlookup:: rangefield.fully_gt
+
+fully_gt
+''''''''
+
+The returned ranges are strictly greater than than passed range, that is the
+lower bound of the returned range is greater than the upper bound of the passed
+range.
+
+    >>> Event.objects.filter(ages__fully_gt=NumericRange(11, 15))
+    [<Event: Pub trip>]
+
+.. fieldlookup:: rangefield.not_lt
+
+not_lt
+''''''
+
+The returned ranges do not contain any points less than the passed range, that
+is the lower bound of the returned range is at least the lower bound of the
+passed range.
+
+    >>> Event.objects.filter(ages__not_lt=NumericRange(0, 15))
+    [<Event: Soft play>]
+
+.. fieldlookup:: rangefield.not_gt
+
+not_gt
+''''''
+
+The returned ranges do not contain any points greater than the passed range, that
+is the upper bound of the returned range is at most than the upper bound of
+the passed range.
+
+    >>> Event.objects.filter(ages__not_gt=NumericRange(3, 10))
+    [<Event: Soft play>]
+
+.. fieldlookup:: rangefield.adjacent_to
+
+adjacent_to
+'''''''''''
+
+The returned ranges share a bound with the passed range.
+
+    >>> Event.objects.filter(ages__adjacent_to=NumericRange(10, 21))
+    [<Event: Soft play>, <Event: Pub trip>]
+
+Querying using the bounds
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are three transforms available for use in queries. You can extract the
+lower or upper bound, or query based on emptiness.
+
+.. fieldlookup:: rangefield.startswith
+
+startswith
+''''''''''
+
+Returned objects have the given lower bound. Can be chained to valid lookups
+for the base field.
+
+    >>> Event.objects.filter(ages__startswith=21)
+    [<Event: Pub trip>]
+
+.. fieldlookup:: rangefield.endswith
+
+endswith
+''''''''
+
+Returned objects have the given upper bound. Can be chained to valid lookups
+for the base field.
+
+    >>> Event.objects.filter(ages__endswith=10)
+    [<Event: Soft play>]
+
+isempty
+'''''''
+
+Returned objects are empty ranges. Can be chained to valid lookups for a
+:class:`~django.db.models.BooleanField`.
+
+    >>> Event.objects.filter(ages__isempty=True)
+    []
+
+Defining your own range types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PostgreSQL allows the definition of custom range types. Django's model and form
+field implementations use base classes mentioned below, and psycopg2 provides
+a :func:`~psycopg2:psycopg2.extras.register_range` to allow use of custom range
+types.
+
+.. class:: RangeField(**options)
+
+    Base class for other range fields.
+
+    .. attribute:: base_field
+
+        The model field used.
+
+    .. attribute:: range_type
+
+        The psycopg2 range type used.
+
+.. class:: django.contrib.postgres.forms.BaseRangeField
+
+    Base class for form range fields.
+
+    .. attribute:: base_field
+
+        The form field used.
+
+    .. attribute:: range_type
+
+        The psycopg2 range type used.

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -409,12 +409,12 @@ Range Fields
 ------------
 
 There are five range field types, corresponding to the built-in range types in
-PostgreSQL. These fields are used to store a range of values, for example the
+PostgreSQL. These fields are used to store a range of values; for example the
 start and end timestamps of an event, or the range of ages an activity is
 suitable for.
 
 All of the range fields translate to :ref:`psycopg2 Range objects
-<psycopg2:adapt-range>` in python, but also accept tuples as input if no bound
+<psycopg2:adapt-range>` in python, but also accept tuples as input if no bounds
 information is necessary. The default is lower bound included, upper bound
 excluded.
 
@@ -423,9 +423,9 @@ IntegerRangeField
 
 .. class:: IntegerRangeField(**options)
 
-    Stores a range of integers. Based on a
-    :class:`~django.db.models.IntegerField`. Represented by a ``int4range`` in
-    the database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
+    Stores a range of integers. Based on an
+    :class:`~django.db.models.IntegerField`. Represented by an ``int4range`` in
+    the database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
     Python.
 
 BigIntegerRangeField
@@ -434,8 +434,8 @@ BigIntegerRangeField
 .. class:: BigIntegerRangeField(**options)
 
     Stores a range of large integers. Based on a
-    :class:`~django.db.models.BigIntegerField`. Represented by a ``int8range``
-    in the database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
+    :class:`~django.db.models.BigIntegerField`. Represented by an ``int8range``
+    in the database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
     Python.
 
 FloatRangeField
@@ -445,7 +445,7 @@ FloatRangeField
 
     Stores a range of floating point values. Based on a
     :class:`~django.db.models.FloatField`. Represented by a ``numrange`` in the
-    database, and a :class:`~psycopg2:psycopg2.extras.NumericRange` in Python.
+    database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in Python.
 
 DateTimeRangeField
 ^^^^^^^^^^^^^^^^^^
@@ -454,7 +454,7 @@ DateTimeRangeField
 
     Stores a range of timestamps. Based on a
     :class:`~django.db.models.DateTimeField`. Represented by a ``tztsrange`` in
-    the database, and a :class:`~psycopg2:psycopg2.extras.DateTimeTZRange` in
+    the database and a :class:`~psycopg2:psycopg2.extras.DateTimeTZRange` in
     Python.
 
 DateRangeField
@@ -464,7 +464,7 @@ DateRangeField
 
     Stores a range of dates. Based on a
     :class:`~django.db.models.DateField`. Represented by a ``daterange`` in the
-    database, and a :class:`~psycopg2:psycopg2.extras.DateRange` in Python.
+    database and a :class:`~psycopg2:psycopg2.extras.DateRange` in Python.
 
 Querying Range Fields
 ^^^^^^^^^^^^^^^^^^^^^
@@ -473,12 +473,12 @@ There are a number of custom lookups and transforms for range fields. They are
 available on all the above fields, but we will use the following example
 model::
 
+    from django.contrib.postgres.fields import IntegerRangeField
     from django.db import models
-    from django.contrib.postgres.fields import DateTimeRangeField
 
     class Event(models.Model):
         name = models.CharField(max_length=200)
-        ages = models.IntegerRangeField()
+        ages = IntegerRangeField()
 
         def __str__(self):  # __unicode__ on Python 2
             return self.name
@@ -488,12 +488,16 @@ We will also use the following example objects::
     >>> Event.objects.create(name='Soft play', ages=(0, 10))
     >>> Event.objects.create(name='Pub trip', ages=(21, None))
 
+and ``NumericRange``:
+
+    >>> from psycopg2.extras import NumericRange
+
 Containment functions
 ~~~~~~~~~~~~~~~~~~~~~
 
 As with other PostgreSQL fields, there are three standard containment
 operators: ``contains``, ``contained_by`` and ``overlap``, using the SQL
-operators ``@>``, ``<@`` and ``&&`` respectively.
+operators ``@>``, ``<@``, and ``&&`` respectively.
 
 .. fieldlookup:: rangefield.contains
 
@@ -508,7 +512,7 @@ contains
 contained_by
 ''''''''''''
 
-    >>> Event.objects.filter(ages__contains=NumericRange(0, 15))
+    >>> Event.objects.filter(ages__contained_by=NumericRange(0, 15))
     [<Event: Soft play>]
 
 .. fieldlookup:: rangefield.overlap
@@ -533,8 +537,9 @@ the specific range comparison operators.
 fully_lt
 ''''''''
 
-The returned ranges are strictly less than than passed range, that is the upper
-bound of the retured range is less than the lower bound of the passed range.
+The returned ranges are strictly less than the passed range. In other words,
+all the points in the returned range are less than all those in the passed
+range.
 
     >>> Event.objects.filter(ages__fully_lt=NumericRange(11, 15))
     [<Event: Soft play>]
@@ -544,9 +549,9 @@ bound of the retured range is less than the lower bound of the passed range.
 fully_gt
 ''''''''
 
-The returned ranges are strictly greater than than passed range, that is the
-lower bound of the returned range is greater than the upper bound of the passed
-range.
+The returned ranges are strictly greater than the passed range. In other words,
+the all the points in the returned range are greater than all those in the
+passed range.
 
     >>> Event.objects.filter(ages__fully_gt=NumericRange(11, 15))
     [<Event: Pub trip>]
@@ -561,7 +566,7 @@ is the lower bound of the returned range is at least the lower bound of the
 passed range.
 
     >>> Event.objects.filter(ages__not_lt=NumericRange(0, 15))
-    [<Event: Soft play>]
+    [<Event: Soft play>, <Event: Pub trip>]
 
 .. fieldlookup:: rangefield.not_gt
 
@@ -569,8 +574,8 @@ not_gt
 ''''''
 
 The returned ranges do not contain any points greater than the passed range, that
-is the upper bound of the returned range is at most than the upper bound of
-the passed range.
+is the upper bound of the returned range is at most the upper bound of the
+passed range.
 
     >>> Event.objects.filter(ages__not_gt=NumericRange(3, 10))
     [<Event: Soft play>]
@@ -613,6 +618,8 @@ for the base field.
     >>> Event.objects.filter(ages__endswith=10)
     [<Event: Soft play>]
 
+.. fieldlookup:: rangefield.isempty
+
 isempty
 '''''''
 
@@ -626,21 +633,26 @@ Defining your own range types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PostgreSQL allows the definition of custom range types. Django's model and form
-field implementations use base classes mentioned below, and psycopg2 provides
-a :func:`~psycopg2:psycopg2.extras.register_range` to allow use of custom range
+field implementations use base classes below, and psycopg2 provides a
+:func:`~psycopg2:psycopg2.extras.register_range` to allow use of custom range
 types.
 
 .. class:: RangeField(**options)
 
-    Base class for other range fields.
+    Base class for model range fields.
 
     .. attribute:: base_field
 
-        The model field used.
+        The model field to use.
 
     .. attribute:: range_type
 
-        The psycopg2 range type used.
+        The psycopg2 range type to use.
+
+    .. attribute:: form_field
+
+        The form field class to use. Should be a sublcass of
+        :class:`django.contrib.postgres.forms.BaseRangeField`.
 
 .. class:: django.contrib.postgres.forms.BaseRangeField
 
@@ -648,8 +660,8 @@ types.
 
     .. attribute:: base_field
 
-        The form field used.
+        The form field to use.
 
     .. attribute:: range_type
 
-        The psycopg2 range type used.
+        The psycopg2 range type to use.

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -154,3 +154,49 @@ HStoreField
         On occasions it may be useful to require or restrict the keys which are
         valid for a given field. This can be done using the
         :class:`~django.contrib.postgres.validators.KeysValidator`.
+
+
+Range Fields
+------------
+
+This group of fields all share similar functionality for accepting range data.
+They are based on :class:`~django.forms.fields.MultiValueField`. They treat one
+omitted value as an unbounded range. They also validate that the lower bound is
+not greater than the upper bound.
+
+IntegerRangeField
+~~~~~~~~~~~~~~~~~
+
+.. class:: IntegerRangeField
+
+    Based on :class:`~django.forms.fields.IntegerField` and translates its
+    input into :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    :class:`~django.contrib.postgres.fields.IntegerRangeField` and
+    :class:`~django.contrib.postgres.fields.BigIntegerRangeField`.
+
+FloatRangeField
+~~~~~~~~~~~~~~~
+
+.. class:: FloatRangeField
+
+    Based on :class:`~django.forms.fields.FloatField` and translates its input
+    into :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    :class:`~django.contrib.postgres.fields.FloatRangeField`.
+
+DateTimeRangeField
+~~~~~~~~~~~~~~~
+
+.. class:: DateTimeRangeField
+
+    Based on :class:`~django.forms.fields.DateTimeField` and translates its
+    input into :class:`~psycopg2:psycopg2.extras.DateTimeTZRange`. Default for
+    :class:`~django.contrib.postgres.fields.DateTimeRangeField`.
+
+DateRangeField
+~~~~~~~~~~~~~~~
+
+.. class:: DateRangeField
+
+    Based on :class:`~django.forms.fields.DateField` and translates its input
+    into :class:`~psycopg2:psycopg2.extras.DateRange`. Default for
+    :class:`~django.contrib.postgres.fields.DateRangeField`.

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -160,7 +160,7 @@ Range Fields
 ------------
 
 This group of fields all share similar functionality for accepting range data.
-They are based on :class:`~django.forms.fields.MultiValueField`. They treat one
+They are based on :class:`~django.forms.MultiValueField`. They treat one
 omitted value as an unbounded range. They also validate that the lower bound is
 not greater than the upper bound.
 
@@ -169,8 +169,8 @@ IntegerRangeField
 
 .. class:: IntegerRangeField
 
-    Based on :class:`~django.forms.fields.IntegerField` and translates its
-    input into :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    Based on :class:`~django.forms.IntegerField` and translates its input into
+    :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
     :class:`~django.contrib.postgres.fields.IntegerRangeField` and
     :class:`~django.contrib.postgres.fields.BigIntegerRangeField`.
 
@@ -179,24 +179,24 @@ FloatRangeField
 
 .. class:: FloatRangeField
 
-    Based on :class:`~django.forms.fields.FloatField` and translates its input
-    into :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    Based on :class:`~django.forms.FloatField` and translates its input into
+    :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
     :class:`~django.contrib.postgres.fields.FloatRangeField`.
 
 DateTimeRangeField
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. class:: DateTimeRangeField
 
-    Based on :class:`~django.forms.fields.DateTimeField` and translates its
-    input into :class:`~psycopg2:psycopg2.extras.DateTimeTZRange`. Default for
+    Based on :class:`~django.forms.DateTimeField` and translates its input into
+    :class:`~psycopg2:psycopg2.extras.DateTimeTZRange`. Default for
     :class:`~django.contrib.postgres.fields.DateTimeRangeField`.
 
 DateRangeField
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. class:: DateRangeField
 
-    Based on :class:`~django.forms.fields.DateField` and translates its input
-    into :class:`~psycopg2:psycopg2.extras.DateRange`. Default for
+    Based on :class:`~django.forms.DateField` and translates its input into
+    :class:`~psycopg2:psycopg2.extras.DateRange`. Default for
     :class:`~django.contrib.postgres.fields.DateRangeField`.

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -155,7 +155,6 @@ HStoreField
         valid for a given field. This can be done using the
         :class:`~django.contrib.postgres.validators.KeysValidator`.
 
-
 Range Fields
 ------------
 

--- a/docs/ref/contrib/postgres/validators.txt
+++ b/docs/ref/contrib/postgres/validators.txt
@@ -18,3 +18,16 @@ Validators
     .. note::
         Note that this checks only for the existence of a given key, not that
         the value of a key is non-empty.
+
+Range validators
+----------------
+
+.. class:: RangeMaxValueValidator(limit_value, message=None)
+
+    Validates that the upper bound of the range is not greater than
+    ``limit_value``.
+
+.. class:: RangeMinValueValidator(limit_value, message=None)
+
+    Validates that the lower bound of the range is not less than the
+    ``limit_value``.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -46,7 +46,7 @@ New PostgreSQL specific functionality
 
 Django now has a module with extensions for PostgreSQL specific features, such
 as :class:`~django.contrib.postgres.fields.ArrayField`,
-:class:`~django.contrib.postgres.fields.HStoreField`, :ref:`range-fields` and
+:class:`~django.contrib.postgres.fields.HStoreField`, :ref:`range-fields`, and
 :lookup:`unaccent` lookup. A full breakdown of the features is available
 :doc:`in the documentation </ref/contrib/postgres/index>`.
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -46,9 +46,9 @@ New PostgreSQL specific functionality
 
 Django now has a module with extensions for PostgreSQL specific features, such
 as :class:`~django.contrib.postgres.fields.ArrayField`,
-:class:`~django.contrib.postgres.fields.HStoreField`, and :lookup:`unaccent`
-lookup. A full breakdown of the features is available :doc:`in the
-documentation </ref/contrib/postgres/index>`.
+:class:`~django.contrib.postgres.fields.HStoreField`, :ref:`range-fields` and
+:lookup:`unaccent` lookup. A full breakdown of the features is available
+:doc:`in the documentation </ref/contrib/postgres/index>`.
 
 New data types
 ~~~~~~~~~~~~~~

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -309,6 +309,7 @@ irc
 iregex
 iriencode
 ise
+isempty
 isnull
 iso
 istartswith

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -91,4 +91,18 @@ class Migration(migrations.Migration):
             options=None,
             bases=None,
         ),
+        migrations.CreateModel(
+            name='RangesModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('ints', django.contrib.postgres.fields.IntegerRangeField(null=True, blank=True)),
+                ('bigints', django.contrib.postgres.fields.BigIntegerRangeField(null=True, blank=True)),
+                ('floats', django.contrib.postgres.fields.FloatRangeField(null=True, blank=True)),
+                ('timestamps', django.contrib.postgres.fields.DateTimeRangeField(null=True, blank=True)),
+                ('dates', django.contrib.postgres.fields.DateRangeField(null=True, blank=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
     ]

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -91,6 +91,9 @@ class Migration(migrations.Migration):
             options=None,
             bases=None,
         ),
+    ]
+
+    pg_92_operations = [
         migrations.CreateModel(
             name='RangesModel',
             fields=[
@@ -106,3 +109,9 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
     ]
+
+    def apply(self, project_state, schema_editor, collect_sql=False):
+        PG_VERSION = schema_editor.connection.pg_version
+        if PG_VERSION >= 90200:
+            self.operations = self.operations + self.pg_92_operations
+        return super(Migration, self).apply(project_state, schema_editor, collect_sql)

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -1,4 +1,7 @@
-from django.contrib.postgres.fields import ArrayField, HStoreField
+from django.contrib.postgres.fields import (
+    ArrayField, HStoreField, IntegerRangeField, BigIntegerRangeField,
+    FloatRangeField, DateTimeRangeField, DateRangeField,
+)
 from django.db import models
 
 
@@ -32,6 +35,14 @@ class CharFieldModel(models.Model):
 
 class TextFieldModel(models.Model):
     field = models.TextField()
+
+
+class RangesModel(models.Model):
+    ints = IntegerRangeField(blank=True, null=True)
+    bigints = BigIntegerRangeField(blank=True, null=True)
+    floats = FloatRangeField(blank=True, null=True)
+    timestamps = DateTimeRangeField(blank=True, null=True)
+    dates = DateRangeField(blank=True, null=True)
 
 
 class ArrayFieldSubclass(ArrayField):

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -2,7 +2,7 @@ from django.contrib.postgres.fields import (
     ArrayField, HStoreField, IntegerRangeField, BigIntegerRangeField,
     FloatRangeField, DateTimeRangeField, DateRangeField,
 )
-from django.db import models
+from django.db import connection, models
 
 
 class IntegerArrayModel(models.Model):
@@ -37,12 +37,18 @@ class TextFieldModel(models.Model):
     field = models.TextField()
 
 
-class RangesModel(models.Model):
-    ints = IntegerRangeField(blank=True, null=True)
-    bigints = BigIntegerRangeField(blank=True, null=True)
-    floats = FloatRangeField(blank=True, null=True)
-    timestamps = DateTimeRangeField(blank=True, null=True)
-    dates = DateRangeField(blank=True, null=True)
+# Only create this model for databases which support it
+if connection.vendor == 'postgresql' and connection.pg_version >= 90200:
+    class RangesModel(models.Model):
+        ints = IntegerRangeField(blank=True, null=True)
+        bigints = BigIntegerRangeField(blank=True, null=True)
+        floats = FloatRangeField(blank=True, null=True)
+        timestamps = DateTimeRangeField(blank=True, null=True)
+        dates = DateRangeField(blank=True, null=True)
+else:
+    # create an object with this name so we don't have failing imports
+    class RangesModel(object):
+        pass
 
 
 class ArrayFieldSubclass(ArrayField):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -237,6 +237,7 @@ class TestMigrations(TestCase):
         name, path, args, kwargs = field.deconstruct()
         self.assertEqual(path, 'postgres_tests.models.ArrayFieldSubclass')
 
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
     @override_settings(MIGRATION_MODULES={
         "postgres_tests": "postgres_tests.array_default_migrations",
     })

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -331,3 +331,11 @@ class TestFormField(TestCase):
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean(['1', 'b'])
         self.assertEqual(cm.exception.messages[0], 'Enter a whole number.')
+
+    def test_required(self):
+        field = pg_forms.IntegerRangeField(required=True)
+        with self.assertRaises(exceptions.ValidationError) as cm:
+            field.clean(['', ''])
+        self.assertEqual(cm.exception.messages[0], 'This field is required.')
+        value = field.clean([1, ''])
+        self.assertEqual(value, NumericRange(1, None))

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -196,7 +196,11 @@ class TestSerialization(TestCase):
     def test_dumping(self):
         instance = RangesModel(ints=NumericRange(0, 10), floats=NumericRange(empty=True))
         data = serializers.serialize('json', [instance])
-        self.assertEqual(json.loads(data), json.loads(self.test_data))
+        dumped = json.loads(data)
+        dumped[0]['fields']['ints'] = json.loads(dumped[0]['fields']['ints'])
+        check = json.loads(self.test_data)
+        check[0]['fields']['ints'] = json.loads(check[0]['fields']['ints'])
+        self.assertEqual(dumped, check)
 
     def test_loading(self):
         instance = list(serializers.deserialize('json', self.test_data))[0].object

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -179,6 +179,12 @@ class TestQuerying(TestCase):
             [self.objs[2]],
         )
 
+    def test_startswith_chaining(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__startswith__gte=0),
+            [self.objs[0], self.objs[1]],
+        )
+
 
 @skipUnlessPG92
 class TestSerialization(TestCase):

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -1,0 +1,95 @@
+import datetime
+import json
+import unittest
+
+from django.core import serializers
+from django.db import connection
+from django.test import TestCase
+from django.utils import timezone
+
+from psycopg2.extras import NumericRange, DateTimeTZRange, DateRange
+
+from .models import RangesModel
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+class TestSaveLoad(TestCase):
+
+    def test_all_fields(self):
+        now = timezone.now()
+        instance = RangesModel(
+            ints=NumericRange(0, 10),
+            bigints=NumericRange(10, 20),
+            floats=NumericRange(20, 30),
+            timestamps=DateTimeTZRange(now - datetime.timedelta(hours=1), now),
+            dates=DateRange(now.date() - datetime.timedelta(days=1), now.date()),
+        )
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(instance.ints, loaded.ints)
+        self.assertEqual(instance.bigints, loaded.bigints)
+        self.assertEqual(instance.floats, loaded.floats)
+        self.assertEqual(instance.timestamps, loaded.timestamps)
+        self.assertEqual(instance.dates, loaded.dates)
+
+    def test_range_object(self):
+        r = NumericRange(0, 10)
+        instance = RangesModel(ints=r)
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(r, loaded.ints)
+
+    def test_tuple(self):
+        instance = RangesModel(ints=(0, 10))
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(NumericRange(0, 10), loaded.ints)
+
+    def test_range_object_boundaries(self):
+        r = NumericRange(0, 10, '[]')
+        instance = RangesModel(floats=r)
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(r, loaded.floats)
+        self.assertTrue(10 in loaded.floats)
+
+    def test_unbounded(self):
+        r = NumericRange(None, None, '()')
+        instance = RangesModel(floats=r)
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(r, loaded.floats)
+
+    def test_empty(self):
+        r = NumericRange(empty=True)
+        instance = RangesModel(ints=r)
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(r, loaded.ints)
+
+    def test_null(self):
+        instance = RangesModel(ints=None)
+        instance.save()
+        loaded = RangesModel.objects.get()
+        self.assertEqual(None, loaded.ints)
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+class TestQuerying(TestCase):
+    pass
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+class TestSerialization(TestCase):
+    test_data = '[{"fields": {"ints": "{\\"upper\\": 10, \\"lower\\": 0, \\"bounds\\": \\"[)\\"}", "floats": "{\\"empty\\": true}", "bigints": null, "timestamps": null, "dates": null}, "model": "postgres_tests.rangesmodel", "pk": null}]'
+
+    def test_dumping(self):
+        instance = RangesModel(ints=NumericRange(0, 10), floats=NumericRange(empty=True))
+        data = serializers.serialize('json', [instance])
+        self.assertEqual(json.loads(data), json.loads(self.test_data))
+
+    def test_loading(self):
+        instance = list(serializers.deserialize('json', self.test_data))[0].object
+        self.assertEqual(instance.ints, NumericRange(0, 10))
+        self.assertEqual(instance.floats, NumericRange(empty=True))
+        self.assertEqual(instance.dates, None)

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import unittest
 
-from django.contrib.postgres import forms as pg_forms
+from django.contrib.postgres import forms as pg_forms, fields as pg_fields
 from django.contrib.postgres.validators import RangeMaxValueValidator, RangeMinValueValidator
 from django.core import exceptions, serializers
 from django.db import connection
@@ -343,3 +343,28 @@ class TestFormField(TestCase):
         self.assertEqual(cm.exception.messages[0], 'This field is required.')
         value = field.clean([1, ''])
         self.assertEqual(value, NumericRange(1, None))
+
+    def test_model_field_formfield_integer(self):
+        model_field = pg_fields.IntegerRangeField()
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, pg_forms.IntegerRangeField)
+
+    def test_model_field_formfield_biginteger(self):
+        model_field = pg_fields.BigIntegerRangeField()
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, pg_forms.IntegerRangeField)
+
+    def test_model_field_formfield_float(self):
+        model_field = pg_fields.FloatRangeField()
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, pg_forms.FloatRangeField)
+
+    def test_model_field_formfield_date(self):
+        model_field = pg_fields.DateRangeField()
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, pg_forms.DateRangeField)
+
+    def test_model_field_formfield_datetime(self):
+        model_field = pg_fields.DateTimeRangeField()
+        form_field = model_field.formfield()
+        self.assertIsInstance(form_field, pg_forms.DateTimeRangeField)

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -85,7 +85,99 @@ class TestSaveLoad(TestCase):
 
 @skipUnlessPG92
 class TestQuerying(TestCase):
-    pass
+
+    def setUp(self):
+        self.objs = [
+            RangesModel.objects.create(ints=NumericRange(0, 10)),
+            RangesModel.objects.create(ints=NumericRange(5, 15)),
+            RangesModel.objects.create(ints=NumericRange(None, 0)),
+            RangesModel.objects.create(ints=NumericRange(empty=True)),
+            RangesModel.objects.create(ints=None),
+        ]
+
+    def test_exact(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__exact=NumericRange(0, 10)),
+            [self.objs[0]],
+        )
+
+    def test_isnull(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__isnull=True),
+            [self.objs[4]],
+        )
+
+    def test_isempty(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__isempty=True),
+            [self.objs[3]],
+        )
+
+    def test_contains(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__contains=8),
+            [self.objs[0], self.objs[1]],
+        )
+
+    def test_contains_range(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__contains=NumericRange(3, 8)),
+            [self.objs[0]],
+        )
+
+    def test_contained_by(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__contained_by=NumericRange(0, 20)),
+            [self.objs[0], self.objs[1], self.objs[3]],
+        )
+
+    def test_overlap(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__overlap=NumericRange(3, 8)),
+            [self.objs[0], self.objs[1]],
+        )
+
+    def test_fully_lt(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__fully_lt=NumericRange(5, 10)),
+            [self.objs[2]],
+        )
+
+    def test_fully_gt(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__fully_gt=NumericRange(5, 10)),
+            [],
+        )
+
+    def test_not_lt(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__not_lt=NumericRange(5, 10)),
+            [self.objs[1]],
+        )
+
+    def test_not_gt(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__not_gt=NumericRange(5, 10)),
+            [self.objs[0], self.objs[2]],
+        )
+
+    def test_adjacent_to(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__adjacent_to=NumericRange(0, 5)),
+            [self.objs[1], self.objs[2]],
+        )
+
+    def test_startswith(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__startswith=0),
+            [self.objs[0]],
+        )
+
+    def test_endswith(self):
+        self.assertSequenceEqual(
+            RangesModel.objects.filter(ints__endswith=0),
+            [self.objs[2]],
+        )
 
 
 @skipUnlessPG92

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -251,8 +251,11 @@ class TestFormField(TestCase):
         self.assertEqual(value, DateRange(lower, upper))
 
     def test_using_split_datetime_widget(self):
+        class SplitDateTimeRangeField(pg_forms.DateTimeRangeField):
+            base_field = forms.SplitDateTimeField
+
         class SplitForm(forms.Form):
-            field = pg_forms.DateTimeRangeField(widget=forms.MultiWidget([forms.SplitDateTimeWidget, forms.SplitDateTimeWidget]))
+            field = SplitDateTimeRangeField()
 
         form = SplitForm()
         self.assertHTMLEqual(str(form), '''
@@ -310,20 +313,6 @@ class TestFormField(TestCase):
         value = field.clean(['', '0'])
         self.assertEqual(value, NumericRange(None, 0))
 
-    def test_too_many_args(self):
-        field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
-            field.clean(['1', '2', '3'])
-        self.assertEqual(cm.exception.messages[0], 'Enter two valid values.')
-        self.assertEqual(cm.exception.code, 'invalid')
-
-    def test_not_enough_args(self):
-        field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
-            field.clean(['1'])
-        self.assertEqual(cm.exception.messages[0], 'Enter two valid values.')
-        self.assertEqual(cm.exception.code, 'invalid')
-
     def test_incorrect_data_type(self):
         field = pg_forms.IntegerRangeField()
         with self.assertRaises(exceptions.ValidationError) as cm:
@@ -335,12 +324,10 @@ class TestFormField(TestCase):
         field = pg_forms.IntegerRangeField()
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean(['a', '2'])
-        self.assertEqual(cm.exception.messages[0], 'Enter a valid start value: Enter a whole number.')
-        self.assertEqual(cm.exception.code, 'lower_invalid')
+        self.assertEqual(cm.exception.messages[0], 'Enter a whole number.')
 
     def test_invalid_upper(self):
         field = pg_forms.IntegerRangeField()
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean(['1', 'b'])
-        self.assertEqual(cm.exception.messages[0], 'Enter a valid end value: Enter a whole number.')
-        self.assertEqual(cm.exception.code, 'upper_invalid')
+        self.assertEqual(cm.exception.messages[0], 'Enter a whole number.')

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -12,7 +12,16 @@ from psycopg2.extras import NumericRange, DateTimeTZRange, DateRange
 from .models import RangesModel
 
 
-@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+def skipUnlessPG92(test):
+    if not connection.vendor == 'postgresql':
+        return unittest.skip('PostgreSQL required')(test)
+    PG_VERSION = connection.pg_version
+    if PG_VERSION < 90200:
+        return unittest.skip('PostgreSQL >= 9.2 required')(test)
+    return test
+
+
+@skipUnlessPG92
 class TestSaveLoad(TestCase):
 
     def test_all_fields(self):
@@ -74,12 +83,12 @@ class TestSaveLoad(TestCase):
         self.assertEqual(None, loaded.ints)
 
 
-@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+@skipUnlessPG92
 class TestQuerying(TestCase):
     pass
 
 
-@unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
+@skipUnlessPG92
 class TestSerialization(TestCase):
     test_data = '[{"fields": {"ints": "{\\"upper\\": 10, \\"lower\\": 0, \\"bounds\\": \\"[)\\"}", "floats": "{\\"empty\\": true}", "bigints": null, "timestamps": null, "dates": null}, "model": "postgres_tests.rangesmodel", "pk": null}]'
 


### PR DESCRIPTION
TODO:
- [x] Custom lookups
- [x] Validators
- [x] Form fields
- [x] Documentation

Provisional lookup/transform list:
- contains
- contained_by
- overlap
- fully_lt
- fully_gt
- not_lt
- not_gt
- adjacent_to
- startswith (lowerbound)
- endswith (upperbound)
- isempty

Proposed validators:
- Non-empty
- MinValue (applies to lower bound)
- MaxValue (applies to upper bound)

Two basic variants of form fields, one assumes all ranges are `[)` and has just two copies of the base field's inputs. The other also includes two checkboxes labelled "include lower bound" and "include upper bound". To get an empty range, you would enter the same value twice (e.g. (0, 0)).