### PR TITLE
Fixed #16358 - Failure to set a memcache key deletes the key

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -86,7 +86,9 @@ class BaseMemcachedCache(six.with_metaclass(BaseMemcachedCacheMethods, BaseCache
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)
-        self._cache.set(key, value, self.get_backend_timeout(timeout))
+        if not self._cache.set(key, value, self.get_backend_timeout(timeout)):
+            # make sure the key doesn't keep its old value in case of failure to set (memcached's 1MB limit)
+            self._cache.delete(key)
 
     def delete(self, key, version=None):
         key = self.make_key(key, version=version)

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -729,6 +729,10 @@ Miscellaneous
 
   .. _universal newlines: http://www.python.org/dev/peps/pep-0278
 
+* The Memcached cache backends ``MemcachedCache`` and ``PyLibMCCache`` will
+  delete a key if ``set()`` fails. This is necessary to ensure the ``cache_db``
+  session store always fetches the most current session data.
+
 .. _deprecated-features-1.8:
 
 Features deprecated in 1.8


### PR DESCRIPTION
Default Memcached configuration allows for a maximum object of 1MB and
will fail to set the key if it is too large. The key will be deleted from
memcached if it fails to be set. This is needed to avoid an issue with
cache_db session backend using the old value stored in memcached, instead
of the newer value stored in the database.
