### PR TITLE
Fix FormFields w/ queryset but no limit_choices_to

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -329,7 +329,7 @@ class BaseModelForm(BaseForm):
         for field_name in self.fields:
             formfield = self.fields[field_name]
             if hasattr(formfield, 'queryset'):
-                limit_choices_to = formfield.limit_choices_to
+                limit_choices_to = getattr(formfield, 'limit_choices_to', None)
                 if limit_choices_to is not None:
                     if callable(limit_choices_to):
                         limit_choices_to = limit_choices_to()


### PR DESCRIPTION
Django assumes a form field with a `queryset` attribute always has a `limit_choices_to` attribute.
For example, a field programmatically altered to have a `queryset` attribute (which works fine), may not be altered to also have a `limit_choices_to` attribute. So the assumption and code are wrong.
Fix proposed for master, affects 1.7 and above.
