### PR TITLE
Fixed #23799 -- squashmigrations --no-optimize still optimizes

### DIFF
--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -59,3 +59,6 @@ Bugfixes
 
 * Fixed a custom field type validation error with MySQL backend when
   ``db_type`` returned ``None`` (:ticket:`23761`).
+
+* Fixed skipping optimization in :djadmin:`squashmigrations` using the
+  ``--no-optimize`` parameter (:ticket:`23799`).


### PR DESCRIPTION
I opted to not remove it because it might become useful when the migration optimizer breaks for some reason.
