### PR TITLE
Fixed #23665 -- Added a note about precedence of the USE_L10N setting in

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1933,6 +1933,9 @@ drilldown, the header for a given day displays the day and month. Different
 locales have different formats. For example, U.S. English would say
 "January 1," whereas Spanish might say "1 Enero."
 
+Note that if :setting:`USE_L10N` is set to ``True``, then the corresponding
+locale-dictated format has higher precedence and will be applied.
+
 See :tfilter:`allowed date format strings <date>`. See also
 :setting:`DATE_FORMAT`, :setting:`DATETIME_FORMAT`,
 :setting:`TIME_FORMAT` and :setting:`YEAR_MONTH_FORMAT`.
@@ -2616,6 +2619,9 @@ For example, when a Django admin change-list page is being filtered by a date
 drilldown, the header for a given month displays the month and the year.
 Different locales have different formats. For example, U.S. English would say
 "January 2006," whereas another locale might say "2006/January."
+
+Note that if :setting:`USE_L10N` is set to ``True``, then the corresponding
+locale-dictated format has higher precedence and will be applied.
 
 See :tfilter:`allowed date format strings <date>`. See also
 :setting:`DATE_FORMAT`, :setting:`DATETIME_FORMAT`, :setting:`TIME_FORMAT`


### PR DESCRIPTION
the MONTH_DAY_FORMAT and YEAR_MONTH_FORMAT documentations.

https://code.djangoproject.com/ticket/23665
