### PR TITLE
Added tests/README.rst

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,6 @@
+To run the test suite::
+
+    $ PYTHONPATH=..:$PYTHONPATH ./runtests.py
+
+For more information about the test suite, see
+https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/.


### PR DESCRIPTION
Every time I want to run the test suite, I have to google until I find
the docs about how to do it. This commit adds a QUICKSTART.rst file
with the necessary commands in it. For all other documentation, it
simply points to the upstream docs.
