### PR TITLE
Moved bilateral transform fetching to models.lookups

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -78,14 +78,25 @@ class Transform(RegisterLookupMixin):
     def get_group_by_cols(self):
         return self.lhs.get_group_by_cols()
 
+    def get_bilateral_transforms(self):
+        if hasattr(self.lhs, 'get_bilateral_transforms'):
+            bilateral_transforms = self.lhs.get_bilateral_transforms()
+        else:
+            bilateral_transforms = []
+        if self.bilateral:
+            bilateral_transforms.append((self.__class__, self.init_lookups))
+        return bilateral_transforms
+
 
 class Lookup(RegisterLookupMixin):
     lookup_name = None
 
-    def __init__(self, lhs, rhs, bilateral_transforms=None):
+    def __init__(self, lhs, rhs):
         self.lhs, self.rhs = lhs, rhs
         self.rhs = self.get_prep_lookup()
-        if bilateral_transforms is None:
+        if hasattr(self.lhs, 'get_bilateral_transforms'):
+            bilateral_transforms = self.lhs.get_bilateral_transforms()
+        else:
             bilateral_transforms = []
         if bilateral_transforms:
             # We should warn the user as soon as possible if he is trying to apply

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1077,7 +1077,6 @@ class Query(object):
         and get_transform().
         """
         lookups = lookups[:]
-        bilaterals = []
         while lookups:
             name = lookups[0]
             # If there is just one part left, try first get_lookup() so
@@ -1089,21 +1088,19 @@ class Query(object):
                     # We didn't find a lookup. We are going to interpret
                     # the name as transform, and do an Exact lookup against
                     # it.
-                    lhs = self.try_transform(lhs, name, lookups, bilaterals)
+                    lhs = self.try_transform(lhs, name, lookups)
                     final_lookup = lhs.get_lookup('exact')
-                return final_lookup(lhs, rhs, bilaterals)
-            lhs = self.try_transform(lhs, name, lookups, bilaterals)
+                return final_lookup(lhs, rhs)
+            lhs = self.try_transform(lhs, name, lookups)
             lookups = lookups[1:]
 
-    def try_transform(self, lhs, name, rest_of_lookups, bilaterals):
+    def try_transform(self, lhs, name, rest_of_lookups):
         """
         Helper method for build_lookup. Tries to fetch and initialize
         a transform for name parameter from lhs.
         """
         next = lhs.get_transform(name)
         if next:
-            if getattr(next, 'bilateral', False):
-                bilaterals.append((next, rest_of_lookups))
             return next(lhs, rest_of_lookups)
         else:
             raise FieldError(


### PR DESCRIPTION
Move the implementation of bilaterals from sql.Query to models.lookups. Reasons:
1. sql.Query doesn't need to know anything about bilaterals
2. If transforms are used in other context than Lookup's lhs value (in Expressions for example), then we can still apply the transforms.

I can create a ticket for this if needed, but I think this is rather minor change which can go in without a ticket. @timgraham if you are happy with this change then please commit. 
