### PR TITLE
Fixed #23690 - fixed examples of manual rendering of form fields

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -527,24 +527,36 @@ in a Django template, will be rendered appropriately. For example:
     {{ form.non_field_errors }}
     <div class="fieldWrapper">
         {{ form.subject.errors }}
-        <label for="id_subject">Email subject:</label>
+        <label for="{{ form.subject.id_for_label }}">Email subject:</label>
         {{ form.subject }}
     </div>
     <div class="fieldWrapper">
         {{ form.message.errors }}
-        <label for="id_message">Your message:</label>
+        <label for="{{ form.message.id_for_label }}">Your message:</label>
         {{ form.message }}
     </div>
     <div class="fieldWrapper">
         {{ form.sender.errors }}
-        <label for="id_sender">Your email address:</label>
+        <label for="{{ form.sender.id_for_label }}">Your email address:</label>
         {{ form.sender }}
     </div>
     <div class="fieldWrapper">
         {{ form.cc_myself.errors }}
-        <label for="id_cc_myself">CC yourself?</label>
+        <label for="{{ form.cc_myself.id_for_label }}">CC yourself?</label>
         {{ form.cc_myself }}
     </div>
+
+Complete ``<label>`` element can also be generated using the
+:meth:`~django.forms.BoundField.label_tag`. For example:
+
+.. code-block:: html+django
+
+    <div class="fieldWrapper">
+        {{ form.subject.errors }}
+        {{ form.subject.label_tag }}
+        {{ form.subject }}
+    </div>
+
 
 Rendering form error messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Documentation for rendering form fields manually is now updated to use fields id_for_label instead of hardcoded values with additional mention of label_tag for alternative generation of complete label tag.
