### PR TITLE
Fixed #23829 -- Allowed customizing the ping_google sitemap URL

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -14,13 +14,7 @@ class SitemapNotFound(Exception):
     pass
 
 
-def ping_google(sitemap_url=None, site_domain=None, is_secure=False, ping_url=PING_URL):
-    """
-    Alerts Google that the sitemap for the current site has been updated.
-    If sitemap_url is provided, it should be an absolute path to the sitemap
-    for this site -- e.g., '/sitemap.xml'. If sitemap_url is not provided, this
-    function will attempt to deduce it by using urlresolvers.reverse().
-    """
+def _get_sitemap_url(sitemap_url=None, site_domain=None, is_secure=False):
     if sitemap_url is None:
         try:
             # First, try to get the "index" sitemap URL.
@@ -43,9 +37,19 @@ def ping_google(sitemap_url=None, site_domain=None, is_secure=False, ping_url=PI
         domain = current_site.domain
     else:
         domain = site_domain
-    url = "%s://%s%s" % ('https' if is_secure else 'http', domain, sitemap_url)
-    params = urlencode({'sitemap': url})
-    urlopen("%s?%s" % (ping_url, params))
+    return "%s://%s%s" % ('https' if is_secure else 'http', domain, sitemap_url)
+
+
+def ping_google(sitemap_url=None, ping_url=PING_URL, site_domain=None,
+        is_secure=False):
+    """
+    Alerts Google that the sitemap for the current site has been updated.
+    If sitemap_url is provided, it should be an absolute path to the sitemap
+    for this site -- e.g., '/sitemap.xml'. If sitemap_url is not provided, this
+    function will attempt to deduce it by using urlresolvers.reverse().
+    """
+    sitemap_url = _get_sitemap_url(sitemap_url, site_domain, is_secure)
+    urlopen("%s?%s" % (ping_url, urlencode({'sitemap': sitemap_url})))
 
 
 class Sitemap(object):

--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -14,7 +14,7 @@ class SitemapNotFound(Exception):
     pass
 
 
-def ping_google(sitemap_url=None, ping_url=PING_URL):
+def ping_google(sitemap_url=None, site_domain=None, url_scheme='http', ping_url=PING_URL):
     """
     Alerts Google that the sitemap for the current site has been updated.
     If sitemap_url is provided, it should be an absolute path to the sitemap
@@ -35,11 +35,15 @@ def ping_google(sitemap_url=None, ping_url=PING_URL):
     if sitemap_url is None:
         raise SitemapNotFound("You didn't provide a sitemap_url, and the sitemap URL couldn't be auto-detected.")
 
-    if not django_apps.is_installed('django.contrib.sites'):
-        raise ImproperlyConfigured("ping_google requires django.contrib.sites, which isn't installed.")
-    Site = django_apps.get_model('sites.Site')
-    current_site = Site.objects.get_current()
-    url = "http://%s%s" % (current_site.domain, sitemap_url)
+    if not site_domain:
+        if not django_apps.is_installed('django.contrib.sites'):
+            raise ImproperlyConfigured("ping_google requires django.contrib.sites, which isn't installed.")
+        Site = django_apps.get_model('sites.Site')
+        current_site = Site.objects.get_current()
+        domain = current_site.domain
+    else:
+        domain = site_domain
+    url = "%s://%s%s" % (url_scheme, domain, sitemap_url)
     params = urlencode({'sitemap': url})
     urlopen("%s?%s" % (ping_url, params))
 

--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -14,7 +14,7 @@ class SitemapNotFound(Exception):
     pass
 
 
-def ping_google(sitemap_url=None, site_domain=None, url_scheme='http', ping_url=PING_URL):
+def ping_google(sitemap_url=None, site_domain=None, is_secure=False, ping_url=PING_URL):
     """
     Alerts Google that the sitemap for the current site has been updated.
     If sitemap_url is provided, it should be an absolute path to the sitemap
@@ -43,7 +43,7 @@ def ping_google(sitemap_url=None, site_domain=None, url_scheme='http', ping_url=
         domain = current_site.domain
     else:
         domain = site_domain
-    url = "%s://%s%s" % (url_scheme, domain, sitemap_url)
+    url = "%s://%s%s" % ('https' if is_secure else 'http', domain, sitemap_url)
     params = urlencode({'sitemap': url})
     urlopen("%s?%s" % (ping_url, params))
 

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -7,6 +7,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('sitemap_url', nargs='?', default=None)
+        parser.add_argument('site_domain', nargs='?', default=None)
+        parser.add_argument('url_scheme', narg='?', default='http')
 
     def handle(self, *args, **options):
-        ping_google(sitemap_url=options['sitemap_url'])
+        ping_google(sitemap_url=options['sitemap_url'], site_domain=options['site_domain'], scheme=options['url_scheme'])

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -11,5 +11,5 @@ class Command(BaseCommand):
         parser.add_argument('-s', '--is_secure', default=False, action='store_true')
 
     def handle(self, *args, **options):
-        ping_google(sitemap_url=options['sitemap_url'], site_domain=options['site_domain'],
-                    is_secure=options['is_secure'])
+        ping_google(sitemap_url=options['sitemap_url'],
+            site_domain=options['site_domain'], is_secure=options['is_secure'])

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -7,8 +7,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('sitemap_url', nargs='?', default=None)
-        parser.add_argument('site_domain', nargs='?', default=None)
-        parser.add_argument('is_secure', narg='?', default=False)
+        parser.add_argument('-d', '--site_domain', default=None)
+        parser.add_argument('-s', '--is_secure', default=False, action='store_true')
 
     def handle(self, *args, **options):
         ping_google(sitemap_url=options['sitemap_url'], site_domain=options['site_domain'],

--- a/django/contrib/sitemaps/management/commands/ping_google.py
+++ b/django/contrib/sitemaps/management/commands/ping_google.py
@@ -8,7 +8,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('sitemap_url', nargs='?', default=None)
         parser.add_argument('site_domain', nargs='?', default=None)
-        parser.add_argument('url_scheme', narg='?', default='http')
+        parser.add_argument('is_secure', narg='?', default=False)
 
     def handle(self, *args, **options):
-        ping_google(sitemap_url=options['sitemap_url'], site_domain=options['site_domain'], scheme=options['url_scheme'])
+        ping_google(sitemap_url=options['sitemap_url'], site_domain=options['site_domain'],
+                    is_secure=options['is_secure'])

--- a/django/contrib/sitemaps/tests/test_command.py
+++ b/django/contrib/sitemaps/tests/test_command.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+
+from django.contrib.sitemaps import _get_sitemap_url
+
+from .base import SitemapTestsBase
+
+
+class PingGoogleTests(SitemapTestsBase):
+    """
+    Test the function used to generate the URL sent to Google as site map.
+    """
+    def test_https(self):
+        kwargs = {}
+        url = _get_sitemap_url(**kwargs)
+        self.assertEqual(url, 'http://example.com/simple/custom-index.xml')
+
+        kwargs = {
+            'sitemap_url': None,
+            'site_domain': None,
+            'is_secure': True,
+        }
+        url = _get_sitemap_url(**kwargs)
+        self.assertEqual(url, 'https://example.com/simple/custom-index.xml')
+
+    def test_domain_override(self):
+        kwargs = {
+            'sitemap_url': None,
+            'site_domain': 'djangosite.com',
+            'is_secure': False,
+        }
+        url = _get_sitemap_url(**kwargs)
+        self.assertEqual(url, 'http://djangosite.com/simple/custom-index.xml')
+
+    def test_path_override(self):
+        kwargs = {
+            'sitemap_url': '/sitemap.xml',
+            'site_domain': None,
+            'is_secure': False,
+        }
+        url = _get_sitemap_url(**kwargs)
+        self.assertEqual(url, 'http://example.com/sitemap.xml')

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -487,11 +487,17 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
 
 .. function:: ping_google
 
-    :func:`ping_google` takes an optional argument, ``sitemap_url``,
-    which should be the absolute path to your site's sitemap (e.g.,
-    :file:`'/sitemap.xml'`). If this argument isn't provided,
-    :func:`ping_google` will attempt to figure out your
-    sitemap by performing a reverse looking in your URLconf.
+    :func:`ping_google` takes the following optional arguments:
+         * ``sitemap_url``, which should be the absolute path to your site's sitemap (e.g.,
+                            :file:`'/sitemap.xml'`). If this argument isn't provided,
+                            :func:`ping_google` will attempt to figure out your
+                            sitemap by performing a reverse looking in your URLconf.
+
+         * ``site_domain``, If you are not using ``django.contrib.sites``, use this
+                            to pass your site's domain (e.g., ``example.com``)
+
+         * ``is_secure``, A boolean. Use this if your site is running on ``https://``, defaults
+                          to ``False``.
 
     :func:`ping_google` raises the exception
     ``django.contrib.sitemaps.SitemapNotFound`` if it cannot determine your

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -493,10 +493,10 @@ that: :func:`django.contrib.sitemaps.ping_google()`.
                             :func:`ping_google` will attempt to figure out your
                             sitemap by performing a reverse looking in your URLconf.
 
-         * ``site_domain``, If you are not using ``django.contrib.sites``, use this
-                            to pass your site's domain (e.g., ``example.com``)
+         * ``-d --site_domain``, If you are not using ``django.contrib.sites``, use this
+                                 to pass your site's domain (e.g., ``example.com``)
 
-         * ``is_secure``, A boolean. Use this if your site is running on ``https://``, defaults
+         * ``-s --is_secure``, A boolean. Use this if your site is running on ``https://``, defaults
                           to ``False``.
 
     :func:`ping_google` raises the exception


### PR DESCRIPTION
This pull requests fixes the actual problem with #23829 and also makes the command work if django.contrib.sites is not installed.

`django.contrib.sites` will default to the current requests to get the domain, but this is not applicable when running as a management command.

I could not find any existing tests for this, so I did not know which tests to enhance. However, I will work on writing some mocks to ensure that the request is being passed correctly.