### PR TITLE
Fixed #23712 -- field_name no longer raises KeyError

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -253,7 +253,8 @@ class BaseForm(object):
                     # so insert a new, empty row.
                     last_row = (normal_row % {'errors': '', 'label': '',
                                               'field': '', 'help_text': '',
-                                              'html_class_attr': html_class_attr})
+                                              'html_class_attr': html_class_attr,
+                                              'field_name': ''})
                     output.append(last_row)
                 output[-1] = last_row[:-len(row_ender)] + str_hidden + row_ender
             else:

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2176,6 +2176,42 @@ class FormsTestCase(TestCase):
         form = SomeForm()
         self.assertHTMLEqual(form.as_p(), '<p id="p_some_field"></p>')
 
+    def test_field_name_with_hidden_input(self):
+        """#23712 BaseForm._html_output() uses inconsistent formatting for normal row"""
+        class SomeForm(Form):
+            some_field = CharField()
+            hidden_field = CharField(widget=HiddenInput)
+
+            def as_p(self):
+                return self._html_output(
+                    normal_row='<p%(html_class_attr)s>%(field)s %(field_name)s</p>',
+                    error_row='%s',
+                    row_ender='</p>',
+                    help_text_html='<span>%(help_text)s</span>',
+                    errors_on_separate_row=True)
+
+        form = SomeForm()
+        self.assertEqual(form.as_p(), '<p><input id="id_some_field" name="some_field" type="text" /> some_field'
+                                      '<input id="id_hidden_field" name="hidden_field" type="hidden" /></p>')
+
+    def test_field_name_with_hidden_input_and_non_matching_row_ender(self):
+        """#23712 BaseForm._html_output() uses inconsistent formatting for normal row"""
+        class SomeForm(Form):
+            some_field = CharField()
+            hidden_field = CharField(widget=HiddenInput)
+
+            def as_p(self):
+                return self._html_output(
+                    normal_row='<p%(html_class_attr)s>%(field)s %(field_name)s</p>',
+                    error_row='%s',
+                    row_ender='</a>',
+                    help_text_html='<span>%(help_text)s</span>',
+                    errors_on_separate_row=True)
+
+        form = SomeForm()
+        self.assertEqual(form.as_p(), '<p><input id="id_some_field" name="some_field" type="text" /> some_field</p>\n'
+                                      '<p> <input id="id_hidden_field" name="hidden_field" type="hidden" /></a>')
+
     def test_error_dict(self):
         class MyForm(Form):
             foo = CharField()


### PR DESCRIPTION
`field_name` was added in 053de6131af83c (#5749) to the part that
builds the output list but not to the part that inserts hidden fields
to the last row when the last row doesn't end with `row_ender`.

Added the `field_name` to the dict in said location.