### PR TITLE
Fixed #23832 -- timezone aware Storage API.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -82,6 +82,11 @@ details on these changes.
 * The backwards compatibility shim to allow ``FormMixin.get_form()`` to be
   defined with no default value for its ``form_class`` argument will be removed.
 
+* The ``accessed_time``, ``created_time`` and ``modified_time``
+  methods of the :class:`~django.core.files.storage.Storage` API, as
+  called without the ``aware`` parameter, will no longer return naive
+  ``datetime`` objects.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -82,25 +82,36 @@ The Storage Class
     behaviors that all other storage systems can inherit or override
     as necessary.
 
-    .. note::
-        For methods returning naive ``datetime`` objects, the
-        effective timezone used will be the current value of
-        ``os.environ['TZ']``; note that this is usually set from
-        Django's :setting:`TIME_ZONE`.
+    .. versionchanged:: 1.8
 
-    .. method:: accessed_time(name)
+        The ``aware`` attribute was added to methods returning
+        ``datetime`` objects. Naive objects will use the current
+        value of ``os.environ['TZ']`` as their effective timezone.
+        Note that ``os.environ['TZ']`` is usually set from Django's
+        :setting:`TIME_ZONE`.
 
-        Returns a naive ``datetime`` object containing the last
-        accessed time of the file. For storage systems that aren't
-        able to return the last accessed time this will raise
+    .. method:: accessed_time(name, aware=None)
+
+        Returns a ``datetime`` object containing the last accessed
+        time of the file. For storage systems that aren't able to
+        return the last accessed time this will raise
         ``NotImplementedError`` instead.
 
-    .. method:: created_time(name)
+        .. deprecated:: 1.8
 
-        Returns a naive ``datetime`` object containing the creation
-        time of the file.  For storage systems that aren't able to
-        return the creation time this will raise
-        ``NotImplementedError`` instead.
+            You should explicitly pass ``aware=False`` to receive
+            naive ``datetime`` objects.
+
+    .. method:: created_time(name, aware=None)
+
+        Returns a ``datetime`` object containing the creation time of
+        the file.  For storage systems that aren't able to return the
+        creation time this will raise ``NotImplementedError`` instead.
+
+        .. deprecated:: 1.8
+
+            You should explicitly pass ``aware=False`` to receive
+            naive ``datetime`` objects.
 
     .. method:: delete(name)
 
@@ -145,12 +156,17 @@ The Storage Class
         storage systems that aren't able to provide such a listing, this will
         raise a ``NotImplementedError`` instead.
 
-    .. method:: modified_time(name)
+    .. method:: modified_time(name, aware=None)
 
-        Returns a naive ``datetime`` object containing the last
-        modified time. For storage systems that aren't able to return
-        the last modified time, this will raise
-        ``NotImplementedError`` instead.
+        Returns a ``datetime`` object containing the last modified
+        time. For storage systems that aren't able to return the last
+        modified time, this will raise ``NotImplementedError``
+        instead.
+
+        .. deprecated:: 1.8
+
+            You should explicitly pass ``aware=False`` to receive
+            naive ``datetime`` objects.
 
     .. method:: open(name, mode='rb')
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -224,7 +224,15 @@ Email
 File Storage
 ^^^^^^^^^^^^
 
-* ...
+* The :class:`~django.core.files.storage.Storage` API now supports an
+  ``aware`` parameter to the ``accessed_time``, ``created_time`` and
+  ``modified_time`` methods, to return a timezone-aware ``datetime``
+  object.
+
+  People implementing third-party storage systems should add the same
+  parameter with the same semantics: ``True`` means return aware
+  objects, ``False`` means return naive objects, and ``None`` (the
+  default) is deprecated and means return naive objects.
 
 File Uploads
 ^^^^^^^^^^^^
@@ -1028,6 +1036,17 @@ The decorators :func:`~django.test.override_settings` and
 :func:`~django.test.modify_settings` now act at the class level when used as
 class decorators. As a consequence, when overriding ``setUpClass()`` or
 ``tearDownClass()``, the ``super`` implementation should always be called.
+
+``Storage`` API datetime calls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With the introduction of the ``aware`` parameter to the
+``accessed_time``, ``created_time`` and ``modified_time`` methods of
+the :class:`~django.core.files.storage.Storage` API, the behavior of
+getting naive objects when not specifying ``aware`` is
+deprecated. Users should start passing the ``aware`` parameter
+explicitly to get their desired behavior.
+
 
 .. removed-features-1.8:
 


### PR DESCRIPTION
Added an `aware` parameter to the relevant Storage methods, with
False/None returning naive objects, True returning aware objects,
and None (the default) deprecated for 2.0, allowing a transition
to a future where we only return aware objects (or at least we
return aware objects by default).