### PR TITLE
Demonstrate ticket 15101 is indeed fixed.

### DIFF
--- a/django/contrib/gis/tests/geoapp/tests.py
+++ b/django/contrib/gis/tests/geoapp/tests.py
@@ -484,6 +484,13 @@ class GeoQuerySetTest(TestCase):
         for val, exp in zip(extent, expected):
             self.assertAlmostEqual(exp, val, 4)
 
+    @skipUnlessDBFeature("supports_extent_aggr")
+    def test_extent_with_limit(self):
+        "Testing if extent supports limit."
+        extent1 = City.objects.all().extent()
+        extent2 = City.objects.all()[:3].extent()
+        self.assertNotEquals(extent1, extent2)
+
     @skipUnlessDBFeature("has_force_rhr_method")
     def test_force_rhr(self):
         "Testing GeoQuerySet.force_rhr()."


### PR DESCRIPTION
Before Django 1.7 calling extent on a GeoQueryset together with a limit did not work. This test shows that it has been fixed with the aggregrates-with-limit fix from ticket 12886 (see https://code.djangoproject.com/ticket/12886#comment:15).

Reference: https://code.djangoproject.com/ticket/15101
