### PR TITLE
Fixed #23794 - FieldDoesNotExist error in migration with deleted fields and unique_together constraint

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -374,17 +374,11 @@ class MigrationAutodetector(object):
             )
         # Field is removed and part of an index/unique_together
         elif dependency[2] is not None and dependency[3] == "foo_together_change":
-            if operation.name.lower() == dependency[1].lower():
-                return (
-                    (
-                        isinstance(operation, operations.AlterUniqueTogether) and
-                        any(dependency[2] not in t for t in operation.unique_together)
-                    ) or
-                    (
-                        isinstance(operation, operations.AlterIndexTogether) and
-                        any(dependency[2] not in t for t in operation.index_together)
-                    )
-                )
+            return (
+                isinstance(operation, (operations.AlterUniqueTogether,
+                                       operations.AlterIndexTogether)) and
+                operation.name.lower() == dependency[1].lower()
+            )
         # Unknown dependency. Raise an error.
         else:
             raise ValueError("Can't handle dependency %r" % (dependency, ))

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -908,6 +908,27 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together=set())
         self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together=set())
 
+    def test_foo_together_remove_fk(self):
+        "Tests unique_together and field removal detection & ordering"
+        # Make state
+        before = self.make_project_state([self.author_empty,
+                                          self.book_foo_together])
+        after = self.make_project_state([self.author_empty,
+                                         self.book_with_no_author])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(changes, "otherapp", 0, [
+            "AlterUniqueTogether", "AlterIndexTogether", "RemoveField"
+        ])
+        self.assertOperationAttributes(changes, "otherapp", 0, 0,
+                                       name="book", unique_together=set())
+        self.assertOperationAttributes(changes, "otherapp", 0, 1,
+                                       name="book", index_together=set())
+        self.assertOperationAttributes(changes, "otherapp", 0, 2,
+                                       model_name="book", name="author")
+
     def test_foo_together_no_changes(self):
         """
         Tests that index/unique_together doesn't generate a migration if no


### PR DESCRIPTION
The code in `check_dependency` is too specific. For instance the `any` function for `operation.unique_together=set([])` always returned `False` which caused the bug to happen. This PR contains following changes:
- added test case for this bug
- added simplified condition

https://code.djangoproject.com/ticket/23794
