### PR TITLE
Minor caption change at the password_reset_done view & template.

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_done.html
+++ b/django/contrib/admin/templates/registration/password_reset_done.html
@@ -12,7 +12,7 @@
 {% block content_title %}<h1>{{ title }}</h1>{% endblock %}
 {% block content %}
 
-<p>{% trans "We've emailed you instructions for setting your password. You should be receiving them shortly." %}</p>
+<p>{% trans "We've emailed you instructions for setting your password, if an account exists with the email you entered. You should receive them shortly." %}</p>
 
 <p>{% trans "If you don't receive an email, please make sure you've entered the address you registered with, and check your spam folder." %}</p>
 

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -187,7 +187,7 @@ def password_reset_done(request,
                         template_name='registration/password_reset_done.html',
                         current_app=None, extra_context=None):
     context = {
-        'title': _('Password reset successful'),
+        'title': _('Password reset sent'),
     }
     if extra_context is not None:
         context.update(extra_context)


### PR DESCRIPTION
The old captions were creating confusion for the developers and users.
It was displaying a success message even if it didn't send an email at all.

Submitted for the ticket 23793.
