### PR TITLE
Fixed #23838: LazyObject is missing __iter__

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -327,11 +327,11 @@ class LazyObject(object):
     __ne__ = new_method_proxy(operator.ne)
     __hash__ = new_method_proxy(hash)
 
-    # Dictionary methods support
+    # List/Tuple/Dictionary methods support
     __getitem__ = new_method_proxy(operator.getitem)
     __setitem__ = new_method_proxy(operator.setitem)
     __delitem__ = new_method_proxy(operator.delitem)
-
+    __iter__ = new_method_proxy(iter)
     __len__ = new_method_proxy(len)
     __contains__ = new_method_proxy(operator.contains)
 

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -57,6 +57,40 @@ class LazyObjectTestCase(TestCase):
         with self.assertRaises(AttributeError):
             obj.bar
 
+    def test_iter_list(self):
+
+        lazy_list = self.lazy_wrap(['one', 'two', 'three'])
+        new_list = []
+
+        for item in lazy_list:
+            new_list.append(item)
+
+        self.assertEqual(new_list[0], 'one')
+        self.assertEqual(new_list[1], 'two')
+        self.assertEqual(new_list[2], 'three')
+
+    def test_iter_dict(self):
+
+        original_dict = {
+            'one': 'ONE',
+            'two': 'TWO',
+            'three': 'THREE'
+        }
+        lazy_dict = self.lazy_wrap(original_dict)
+
+        new_dict = {}
+
+        for key, value in lazy_dict.items():
+            new_dict[key] = value
+
+        self.assertEqual(len(new_dict), 3)
+        self.assertIn('one', new_dict)
+        self.assertIn('two', new_dict)
+        self.assertIn('three', new_dict)
+        self.assertEqual(new_dict['one'], 'ONE')
+        self.assertEqual(new_dict['two'], 'TWO')
+        self.assertEqual(new_dict['three'], 'THREE')
+
     def test_cmp(self):
         obj1 = self.lazy_wrap('foo')
         obj2 = self.lazy_wrap('bar')


### PR DESCRIPTION
Adds the `__iter__` method in `LazyObject`. Unit tests for this are included.
