### PR TITLE
Designated Django 1.8 as the next LTS.

### DIFF
--- a/docs/internals/release-process.txt
+++ b/docs/internals/release-process.txt
@@ -134,7 +134,11 @@ regardless of the pace of releases afterwards.
 
 The follow releases have been designated for long-term support:
 
-* Django 1.4, supported until at least March 2015.
+* Django 1.8, supported for at least 3 years after its release (scheduled for
+  April 2015).
+* Django 1.4, supported for 6 months after the release of Django 1.8. As
+  Django 1.8 is scheduled to be released around April 2015, support for 1.4
+  will end around October 2015.
 
 .. _release-process:
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -10,6 +10,11 @@ incompatible changes`_ you'll want to be aware of when upgrading from Django
 features`_, and some features have reached the end of their deprecation process
 and `have been removed`_.
 
+Django 1.8 has been designated as Django's second :ref:`"Long-Term Support"
+(LTS) <lts-releases>` release. It will receive security updates for at least
+three years after its release. Support for the previous LTS, Django 1.4, will
+end 6 months from the release date of Django 1.8.
+
 .. _`new features`: `What's new in Django 1.8`_
 .. _`backwards incompatible changes`: `Backwards incompatible changes in 1.8`_
 .. _`begun the deprecation process for some features`: `Features deprecated in 1.8`_


### PR DESCRIPTION
As discussed among the core team at Django Under the Hood.
