### PR TITLE
Removed support for function-based template loaders.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -85,8 +85,6 @@ details on these changes.
 * The backwards compatibility alias ``django.template.loader.BaseLoader`` will
   be removed.
 
-* Support for function-based template loaders will be removed.
-
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1040,13 +1040,6 @@ class decorators. As a consequence, when overriding ``setUpClass()`` or
 ``django.template.loaders.base.Loader``. If you've written a custom template
 loader that inherits ``BaseLoader``, you must inherit ``Loader`` instead.
 
-Function-based template loaders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to the documented class-based API for custom template loaders,
-Django still supported to some extent an earlier function-based API. This
-private API wasn't maintained or tested. Now it's formally deprecated.
-
 ``django.test.utils.TestTemplateLoader``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
They were deprecated in Django 1.2 but not all the supporting code was
removed in Django 1.4. Since the remaining code was unlikely to be
functional (pun intended) e.g. it would crash unless the loader
function had an is_usable attribute, this commit completes the removal
immediately instead of starting another deprecation path.
