### PR TITLE
Fix link target markup

### DIFF
--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -12,7 +12,7 @@ collection of objects. This topic guide describes the ways that aggregate values
 can be generated and returned using Django queries.
 
 Throughout this guide, we'll refer to the following models. These models are
-used to track the inventory for a series of online bookstores::
+used to track the inventory for a series of online bookstores:
 
 .. _queryset-model-example:
 


### PR DESCRIPTION
This markup for a code block is redundant with the code-block directive below,
and blocks the following line from working as link target.
