### PR TITLE
Remove text-mangling of default values.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -94,14 +94,6 @@ class ArrayField(Field):
             value = [self.base_field.to_python(val) for val in vals]
         return value
 
-    def get_default(self):
-        """Overridden from the default to prevent string-mangling."""
-        if self.has_default():
-            if callable(self.default):
-                return self.default()
-            return self.default
-        return None
-
     def value_to_string(self, obj):
         values = []
         vals = self._get_val_from_obj(obj)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -722,7 +722,7 @@ class Field(RegisterLookupMixin):
         if self.has_default():
             if callable(self.default):
                 return self.default()
-            return force_text(self.default, strings_only=True)
+            return self.default
         if (not self.empty_strings_allowed or (self.null and
                    not connection.features.interprets_empty_strings_as_nulls)):
             return None


### PR DESCRIPTION
I don't seem to get any failures with this locally. Would need a ticket and docs for merge, making this a PR for the CI.

The behaviour is weird at present - if you pass a fixed value then we force to text, but we don't for callable defaults, implying tht we support non-text values elsewhere. I've had some issues to fix or work around in contrib.postgres as a result of this code.
