### PR TITLE
Fixes #23714 -- `date` filter during DST change

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import datetime
 import os
 import re
 import sys
@@ -18,6 +17,7 @@ from django.utils.html import escape
 from django.utils.encoding import force_bytes, smart_text
 from django.utils.module_loading import import_string
 from django.utils import six
+from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
 HIDDEN_SETTINGS = re.compile('API|TOKEN|KEY|SECRET|PASS|SIGNATURE')
@@ -344,7 +344,7 @@ class ExceptionReporter(object):
             'settings': get_safe_settings(),
             'sys_executable': sys.executable,
             'sys_version_info': '%d.%d.%d' % sys.version_info[0:3],
-            'server_time': datetime.datetime.now(),
+            'server_time': now(),
             'django_version_info': get_version(),
             'sys_path': sys.path,
             'template_info': self.template_info,

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1397,6 +1397,13 @@ representation of a ``datetime`` value. E.g.::
 
     {{ value|date:"D d M Y" }} {{ value|time:"H:i" }}
 
+.. warning::
+
+    When the datetime being formatted is naive, it contains ambiguous time
+    during DST change. Within this one hour a year, the filter tag returns
+    empty string. Use timezone aware datetimes and set :setting:`USE_TZ` to
+    ``True`` to avoid this.
+
 .. templatefilter:: default
 
 default


### PR DESCRIPTION
The except block catching all exceptions is ugly, but I can't rely on `pytz` library, which is optional, and therefore I can't catch `pytz.exceptions.AmbiguousTimeError` exception.