### PR TITLE
Fixed #23883 -- Stop flatatt modifying its argument

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -29,16 +29,17 @@ def flatatt(attrs):
 
     The result is passed through 'mark_safe'.
     """
+    key_value_attrs = []
     boolean_attrs = []
-    for attr, value in list(attrs.items()):
-        if value is True:
-            boolean_attrs.append((attr,))
-            del attrs[attr]
-        elif value is False:
-            del attrs[attr]
+    for attr, value in attrs.items():
+        if isinstance(value, bool):
+            if value:
+                boolean_attrs.append((attr,))
+        else:
+            key_value_attrs.append((attr, value))
 
     return (
-        format_html_join('', ' {0}="{1}"', sorted(attrs.items())) +
+        format_html_join('', ' {0}="{1}"', sorted(key_value_attrs)) +
         format_html_join('', ' {0}', sorted(boolean_attrs))
     )
 

--- a/tests/forms_tests/tests/test_util.py
+++ b/tests/forms_tests/tests/test_util.py
@@ -27,6 +27,23 @@ class FormsUtilTestCase(TestCase):
         self.assertEqual(flatatt({'class': "news", 'title': "Read this", 'required': False}), ' class="news" title="Read this"')
         self.assertEqual(flatatt({}), '')
 
+    def test_flatatt_no_side_effects(self):
+        """
+        Fixes #23883 -- Check that flatatt does not modify the dict passed in
+        """
+        attrs = {'foo': 'bar', 'true': True, 'false': False}
+        attrs_copy = copy.copy(attrs)
+        self.assertEqual(attrs, attrs_copy)
+
+        first_run = flatatt(attrs)
+        self.assertEqual(attrs, attrs_copy)
+        self.assertEqual(first_run, ' foo="bar" true')
+
+        second_run = flatatt(attrs)
+        self.assertEqual(attrs, attrs_copy)
+
+        self.assertEqual(first_run, second_run)
+
     def test_validation_error(self):
         ###################
         # ValidationError #


### PR DESCRIPTION
The `django.forms.utils.flatatt` function modifies the dict passed in, deleting any boolean attributes it encounters. Calling the function twice using the same dict that contains boolean attributes will thus result in different output, as the boolean attributes have been deleted:

``` python
>>> attrs = {'hello': 'world', 'data-true': True, 'data-false': False}
>>> flatatt(attrs)
' hello="world" data-true'
>>> flatatt(attrs)
' hello="world"'
```

The function should not modify the dict passed in like it does, leaving it unchanged. Fixing this will make the function behave as expected when called with the same dict twice.

https://code.djangoproject.com/ticket/23883#ticket
