### PR TITLE
Updated testing documentation following 498ae3a36069e2d

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -633,10 +633,12 @@ TransactionTestCase
 
 Django's ``TestCase`` class (described below) makes use of database transaction
 facilities to speed up the process of resetting the database to a known state
-at the beginning of each test. A consequence of this, however, is that the
-effects of transaction commit and rollback cannot be tested by a Django
-``TestCase`` class. If your test requires testing of such transactional
-behavior, you should use a Django ``TransactionTestCase``.
+at the beginning of each test. A consequence of this, however, is that some
+database behaviors cannot be tested within a Django ``TestCase`` class. For
+instance, you cannot test that a block of code is executing within a transaction,
+as it is required when using
+:meth:`~django.db.models.query.QuerySet.select_for_update()`. In those cases,
+you should use ``TransactionTestCase``.
 
 ``TransactionTestCase`` and ``TestCase`` are identical except for the manner
 in which the database is reset to a known state and the ability for test code
@@ -648,9 +650,7 @@ to test the effects of commit and rollback:
 
 * A ``TestCase``, on the other hand, does not truncate tables after a test.
   Instead, it encloses the test code in a database transaction that is rolled
-  back at the end of the test. Both explicit commits like
-  ``transaction.commit()`` and implicit ones that may be caused by
-  ``transaction.atomic()`` are replaced with a ``nop`` operation. This
+  back at the end of the test. This
   guarantees that the rollback at the end of the test restores the database to
   its initial state.
 
@@ -665,16 +665,6 @@ to test the effects of commit and rollback:
   if you need this functionality (for example, third-party apps should enable
   this) you can set ``serialized_rollback = True`` inside the
   ``TestCase`` body.
-
-.. warning::
-
-    While ``commit`` and ``rollback`` operations still *appear* to work when
-    used in ``TestCase``, no actual commit or rollback will be performed by the
-    database. This can cause your tests to pass or fail unexpectedly. Always
-    use ``TransactionTestCase`` when testing transactional behavior or any code
-    that can't normally be executed in autocommit mode
-    (:meth:`~django.db.models.query.QuerySet.select_for_update()` is an
-    example).
 
 ``TransactionTestCase`` inherits from :class:`~django.test.SimpleTestCase`.
 
@@ -700,6 +690,12 @@ additions, including:
 
 * Django-specific assertions for testing for things like redirection and form
   errors.
+
+.. warning::
+
+    If you want to test some specific database behavior regarding transaction,
+    you should use ``TransactionTestCase``, as ``TestCase`` will wrap test
+    execution within an ``atomic`` block.
 
 ``TestCase`` inherits from :class:`~django.test.TransactionTestCase`.
 


### PR DESCRIPTION
- commit/rollback are no longer replaced by nop
- the warning about not using TestCase when testing transactional behavior belongs to TestCase section, not TransactionTestCase
