### PR TITLE
Allow users to specify an authentication backend when manually authentic...

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -20,10 +20,13 @@ def load_backend(path):
     return import_string(path)()
 
 
-def get_backends():
+def get_backends(authentication_backend=None):
     backends = []
-    for backend_path in settings.AUTHENTICATION_BACKENDS:
-        backends.append(load_backend(backend_path))
+    if not authentication_backend:
+        for backend_path in settings.AUTHENTICATION_BACKENDS:
+            backends.append(load_backend(backend_path))
+    else:
+        backends.append(load_backend(authentication_backend))
     if not backends:
         raise ImproperlyConfigured(
             'No authentication backends have been defined. Does '
@@ -47,11 +50,11 @@ def _clean_credentials(credentials):
     return credentials
 
 
-def authenticate(**credentials):
+def authenticate(authentication_backend=None, **credentials):
     """
     If the given credentials are valid, return a User object.
     """
-    for backend in get_backends():
+    for backend in get_backends(authentication_backend):
         try:
             inspect.getcallargs(backend.authenticate, **credentials)
         except TypeError:

--- a/django/contrib/auth/tests/test_auth_backends.py
+++ b/django/contrib/auth/tests/test_auth_backends.py
@@ -286,6 +286,33 @@ class CustomUserModelBackendAuthenticateTest(TestCase):
         self.assertEqual(test_user, authenticated_user)
 
 
+class SpecificAuthenticationBackendTest(TestCase):
+    """
+    Tests that the authentication function can accept an authentication_backend
+    argument
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user('test', 'test@example.com', 'test')
+
+    def test_authentication(self):
+        authenticated_user = authenticate(authentication_backend='django.contrib.auth.backends.ModelBackend', username='test', password='test')
+        self.assertEqual(self.user, authenticated_user)
+
+
+class InvalidSpecificAuthenticationBackendTest(TestCase):
+    """
+    Tests that a valid exception is raised when an invalid authentication
+    backend is provided to the authenticate() function
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user('test', 'test@example.com', 'test')
+
+    def test_raises_exception(self):
+        self.assertRaises(ImportError, authenticate, authentication_backend='django.contrib.auth.backends.NoSuchBackend', username='test', password='test')
+
+
 class TestObj(object):
     pass
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -117,7 +117,7 @@ enabled. See :ref:`session-invalidation-on-password-change` for details.
 Authenticating Users
 --------------------
 
-.. function:: authenticate(\**credentials)
+.. function:: authenticate(authentication_backend=None, \**credentials)
 
     To authenticate a given username and password, use
     :func:`~django.contrib.auth.authenticate()`. It takes credentials in the


### PR DESCRIPTION
...ating

I've recently come across an interesting use case in which I needed to target a specific AUTHENTICATION_BACKEND when authenticating specific users.  I couldn't find a clean way to do this so I thought it might be best to submit a request and see how others felt about it.
