### PR TITLE
Silenced a flake8 warning.

### DIFF
--- a/tests/shortcuts/views.py
+++ b/tests/shortcuts/views.py
@@ -42,6 +42,7 @@ def render_to_response_with_context_instance_misuse(request):
     # Incorrect -- context_instance should be passed as a keyword argument.
     return render_to_response('shortcuts/render_test.html', context_instance)
 
+
 def render_view(request):
     return render(request, 'shortcuts/render_test.html', {
         'foo': 'FOO',


### PR DESCRIPTION
../tests/shortcuts/views.py:45:1: E302 expected 2 blank lines, found 1

Just saw this at http://djangoci.com/job/django-pull-requests/1725/database=sqlite3,python=python2.7/console
