### PR TITLE
fixed #23898 delete_selected's context, missing admin_site.each_context()

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -74,6 +74,9 @@ def delete_selected(modeladmin, request, queryset):
         "opts": opts,
         'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
     }
+    
+    #populate the context with admin_site's each_context values
+    context.update(modeladmin.admin_site.each_context())
 
     # Display the confirmation page
     return TemplateResponse(request, modeladmin.delete_selected_confirmation_template or [


### PR DESCRIPTION
fixes delete_selected's context passed to template, as it misses admin_site.each_context(), and thus always renders default values for site_header, site_title and site_url.
