### PR TITLE
Minor correction of inconsistency in manage.py docs

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -12,7 +12,7 @@ This document outlines all it can do.
 
 In addition, ``manage.py`` is automatically created in each Django project.
 ``manage.py`` is a thin wrapper around ``django-admin`` that takes care of
-two things for you before delegating to ``django-admin``:
+three things for you before delegating to ``django-admin``:
 
 * It puts your project's package on ``sys.path``.
 


### PR DESCRIPTION
Nowadays (since 1.7) manage.py actually does three things (debatable, depending on definition of "thing") before delegating. In the current paragraph text it states that it does two things, but then goes on to list three things. This tiny pull request (my first for Django) fixes this minor documentation inconsistency.
