### PR TITLE
Fix object references in OneToOneTests.test_foreign_key

### DIFF
--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -97,9 +97,12 @@ class OneToOneTests(TestCase):
         assert_filter_waiters(restaurant__place__exact=self.p1)
         assert_filter_waiters(restaurant__place__pk=self.p1.pk)
         assert_filter_waiters(restaurant__exact=self.r1.pk)
+        assert_filter_waiters(restaurant__exact=self.r1)
         assert_filter_waiters(restaurant__pk=self.r1.pk)
         assert_filter_waiters(restaurant=self.r1.pk)
         assert_filter_waiters(restaurant=self.r1)
+        assert_filter_waiters(id__exact=w.pk)
+        assert_filter_waiters(pk=w.pk)
         # Delete the restaurant; the waiter should also be removed
         r = Restaurant.objects.get(pk=self.r1.pk)
         r.delete()


### PR DESCRIPTION
It seems that as the result of a copy-paste-o, there were several incorrect references being made in the assertions in this test.  The test just passed by fluke because the IDs happened to be the same.

Some of the assertions which used to exist had also been been removed, seemingly because they failed when Django's query behaviour changed to introduce checking of object types as well as PK values, but no one realised that the assertions were referencing the wrong objects!  So now that the references have been fixed, I've restored those assertions as well.

All tests pass.
