### PR TITLE
Update db.py

### DIFF
--- a/django/contrib/sessions/backends/db.py
+++ b/django/contrib/sessions/backends/db.py
@@ -26,7 +26,6 @@ class SessionStore(SessionBase):
                 logger = logging.getLogger('django.security.%s' %
                         e.__class__.__name__)
                 logger.warning(force_text(e))
-            self.create()
             return {}
 
     def exists(self, session_key):


### PR DESCRIPTION
It seems inappropriate to create a new session record just because one does not exist yet.

This means that is a developer calls request.session (just to read what is there, or if it is empty) that a new record will be written to the db.  It seems more appropriate to write to the db when something is actually modified.
