### PR TITLE
Fixed #23924 -- Made EmailMessage raise TypeError for type checks

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -224,17 +224,20 @@ class EmailMessage(object):
         necessary encoding conversions.
         """
         if to:
-            assert not isinstance(to, six.string_types), '"to" argument must be a list or tuple'
+            if isinstance(to, six.string_types):
+                raise TypeError('"to" argument must be a list or tuple')
             self.to = list(to)
         else:
             self.to = []
         if cc:
-            assert not isinstance(cc, six.string_types), '"cc" argument must be a list or tuple'
+            if isinstance(cc, six.string_types):
+                raise TypeError('"cc" argument must be a list or tuple')
             self.cc = list(cc)
         else:
             self.cc = []
         if bcc:
-            assert not isinstance(bcc, six.string_types), '"bcc" argument must be a list or tuple'
+            if isinstance(bcc, six.string_types):
+                raise TypeError('"bcc" argument must be a list or tuple')
             self.bcc = list(bcc)
         else:
             self.bcc = []

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -95,6 +95,14 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         self.assertEqual(message['Cc'], 'cc@example.com, cc.other@example.com')
         self.assertEqual(email.recipients(), ['to@example.com', 'other@example.com', 'cc@example.com', 'cc.other@example.com', 'bcc@example.com'])
 
+    def test_recipients_as_string(self):
+        with self.assertRaisesMessage(TypeError, '"to" argument must be a list or tuple'):
+            EmailMessage(to='foo@example.com')
+        with self.assertRaisesMessage(TypeError, '"cc" argument must be a list or tuple'):
+            EmailMessage(cc='foo@example.com')
+        with self.assertRaisesMessage(TypeError, '"bcc" argument must be a list or tuple'):
+            EmailMessage(bcc='foo@example.com')
+
     def test_header_injection(self):
         email = EmailMessage('Subject\nInjection Test', 'Content', 'from@example.com', ['to@example.com'])
         self.assertRaises(BadHeaderError, email.message)


### PR DESCRIPTION
This change avoids silently producing broken `To`, `Cc` and `Bcc` headers when passed a string instead of a list of strings.
