### PR TITLE
Fixed #23925 -- Allowed settings.AUTHENTICATION_BACKENDS to reference import aliases

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -20,20 +20,20 @@ def load_backend(path):
     return import_string(path)()
 
 
-def _get_backend_tuples():
-    backend_tuples = []
+def get_backends(return_tuples=False):
+    backends = []
     for backend_path in settings.AUTHENTICATION_BACKENDS:
-        backend_tuples.append((load_backend(backend_path), backend_path))
-    if not backend_tuples:
+        backend = load_backend(backend_path)
+        if return_tuples:
+            backends.append((backend, backend_path))
+        else:
+            backends.append(backend)
+    if not backends:
         raise ImproperlyConfigured(
             'No authentication backends have been defined. Does '
             'AUTHENTICATION_BACKENDS contain anything?'
         )
-    return backend_tuples
-
-
-def get_backends():
-    return [backend_tuple[0] for backend_tuple in _get_backend_tuples()]
+    return backends
 
 
 def _clean_credentials(credentials):
@@ -55,7 +55,7 @@ def authenticate(**credentials):
     """
     If the given credentials are valid, return a User object.
     """
-    for backend, backend_path in _get_backend_tuples():
+    for backend, backend_path in get_backends(return_tuples=True):
         try:
             inspect.getcallargs(backend.authenticate, **credentials)
         except TypeError:

--- a/django/contrib/auth/tests/__init__.py
+++ b/django/contrib/auth/tests/__init__.py
@@ -1,3 +1,4 @@
 # The password for the fixture data users is 'password'
 
+# For testing auth backends can be referenced using a convenience import
 from django.contrib.auth.tests.test_auth_backends import ImportedModelBackend

--- a/django/contrib/auth/tests/test_auth_backends.py
+++ b/django/contrib/auth/tests/test_auth_backends.py
@@ -614,32 +614,21 @@ class ImportedModelBackend(ModelBackend):
     pass
 
 
-class RighBackendPathInSessionTest(TestCase):
+class ImportedBackendTests(TestCase):
     """
-    Tests that the backend path added to the session is the same
+    #23925 - The backend path added to the session should be the same
     as the one defined in AUTHENTICATION_BACKENDS setting.
-
-    Regression test for ticket #23925
     """
 
     backend = 'django.contrib.auth.tests.ImportedModelBackend'
-    TEST_USERNAME = 'test_user'
-    TEST_PASSWORD = 'test_password'
-    TEST_EMAIL = 'test@example.com'
-
-    def setUp(self):
-        User.objects.create_user(self.TEST_USERNAME,
-                                 self.TEST_EMAIL,
-                                 self.TEST_PASSWORD)
 
     @override_settings(AUTHENTICATION_BACKENDS=(backend, ))
-    def test_right_backend_path(self):
-        # Get a session for the test user
-        self.assertTrue(self.client.login(
-            username=self.TEST_USERNAME,
-            password=self.TEST_PASSWORD)
-        )
-
+    def test_backend_path(self):
+        username = 'username'
+        password = 'password'
+        user = User.objects.create_user(username, 'email', password)
+        self.assertTrue(self.client.login(username=username, password=password))
         request = HttpRequest()
         request.session = self.client.session
         self.assertEqual(request.session[BACKEND_SESSION_KEY], self.backend)
+        user.delete()


### PR DESCRIPTION
Added the right auth backend path in session, based on the
path defined in settings.AUTHENTICATION_BACKENDS and not on
the actual path of the backend object.
