### PR TITLE
Add default charset to render_javascript_catalog

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -186,7 +186,8 @@ def render_javascript_catalog(catalog=None, plural=None):
         'plural': plural,
     })
 
-    return http.HttpResponse(template.render(context), 'text/javascript')
+    content_type = 'text/javascript; charset=%s' % (settings.DEFAULT_CHARSET)
+    return http.HttpResponse(template.render(context), content_type)
 
 
 def get_javascript_catalog(locale, domain, packages):


### PR DESCRIPTION
While doing a site scan with skipfish I found that responses from javascript_catalog were missing the charset. Clearly this has been harmless so far but let's try fixing it up anyway.

Please note this patch has (sadly) not been tested - it might not even compile... Hopefully I've followed your style guidelines but apologies if not.
