### PR TITLE
Fixed a double article in model forms docs.

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -485,10 +485,9 @@ To specify a custom widget for a field, use the ``widgets`` attribute of the
 inner ``Meta`` class. This should be a dictionary mapping field names to widget
 classes or instances.
 
-For example, if you want the a ``CharField`` for the ``name``
-attribute of ``Author`` to be represented by a ``<textarea>`` instead
-of its default ``<input type="text">``, you can override the field's
-widget::
+For example, if you want the ``CharField`` for the ``name`` attribute of
+``Author`` to be represented by a ``<textarea>`` instead of its default
+``<input type="text">``, you can override the field's widget::
 
     from django.forms import ModelForm, Textarea
     from myapp.models import Author


### PR DESCRIPTION
A stray "a" above the first example in the section on [overriding default form fields](https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#overriding-the-default-fields).
