### PR TITLE
Fixed #23922 -- Corrected parsing of URLs containing a # char in RequestFactory.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -348,7 +348,7 @@ class RequestFactory(object):
                 content_type='application/octet-stream', secure=False,
                 **extra):
         """Constructs an arbitrary HTTP request."""
-        parsed = urlparse(path)
+        parsed = urlparse(path, allow_fragments=False)
         data = force_bytes(data, settings.DEFAULT_CHARSET)
         r = {
             'PATH_INFO': self._get_path(parsed),

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -611,3 +611,11 @@ class RequestFactoryTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, echoed_request_line)
+
+    def test_quoting_path(self):
+        request = self.request_factory.get('/needsquoting#')
+        response = get_view(request)
+
+        self.assertEqual(request.path_info, '/needsquoting#')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'This is a test')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23922
