### PR TITLE
Fixed #5986 -- Added ability to customize order of Form fields

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from collections import OrderedDict
-
 from django import forms
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.hashers import (
@@ -303,6 +301,8 @@ class PasswordChangeForm(SetPasswordForm):
     old_password = forms.CharField(label=_("Old password"),
                                    widget=forms.PasswordInput)
 
+    field_order = ['old_password', 'new_password1', 'new_password2']
+
     def clean_old_password(self):
         """
         Validates that the old_password field is correct.
@@ -314,11 +314,6 @@ class PasswordChangeForm(SetPasswordForm):
                 code='password_incorrect',
             )
         return old_password
-
-PasswordChangeForm.base_fields = OrderedDict(
-    (k, PasswordChangeForm.base_fields[k])
-    for k in ['old_password', 'new_password1', 'new_password2']
-)
 
 
 class AdminPasswordChangeForm(forms.Form):

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -700,6 +700,31 @@ example, in the ``ContactForm`` example, the fields are defined in the order
 ``subject``, ``message``, ``sender``, ``cc_myself``. To reorder the HTML
 output, just change the order in which those fields are listed in the class.
 
+There are three options to specify the order:
+
+.. attribute:: Form.field_order
+
+.. versionadded:: 1.9
+
+By default, ``field_order`` is not defined, which retains the order in which
+you define them in your class (default order). If ``field_order`` is a list of
+field names, the fields are ordered as specified by the list, and remaining fields are
+appended according to the default order for backward compatibility.
+Unknown field names in the list are ignored. This makes it possible to disable a field
+in a subclass by overriding it with None.
+
+You can also use the :attr:`~Form.field_order` argument to a :class:`Form` to override
+the field order. Note that if a :class:`~django.forms.Form` defines
+:attr:`~Form.field_order` *and* you include ``field_order`` when instantiating the
+``Form``, then the latter ``field_order`` will have precedence.
+
+.. method:: Form.order_fields(field_order = None)
+
+.. versionadded:: 1.9
+
+You may rearrange the fields any time using ``order_fields()`` with a list of field names
+as in :attr:`~django.forms.Form.field_order`.
+
 How errors are displayed
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -118,6 +118,10 @@ Forms
   ``field_classes`` to customize the type of the fields. See
   :ref:`modelforms-overriding-default-fields` for details.
 
+* You can now specify the order in which fields are rendered with the
+  class attribute :attr:`~django.forms.Form.field_order`, the constructor
+  argument `field_order`, or the :meth:`~django.forms.Form.order_fields`.
+
 Generic Views
 ^^^^^^^^^^^^^
 

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -1046,6 +1046,49 @@ class FormsTestCase(TestCase):
 <tr><th>Field13:</th><td><input type="text" name="field13" /></td></tr>
 <tr><th>Field14:</th><td><input type="text" name="field14" /></td></tr>""")
 
+    def test_explicit_field_order(self):
+        class TestFormParent(Form):
+            field1 = CharField()
+            field2 = CharField()
+            field4 = CharField()
+            field5 = CharField()
+            field6 = CharField()
+            field_order = ['field6', 'field5', 'field4', 'field2', 'field1']
+
+        class TestForm(TestFormParent):
+            field3 = CharField()
+            field_order = ['field2', 'field4', 'field3', 'field5', 'field6']
+
+        class TestFormRemove(TestForm):
+            field1 = None
+
+        class TestFormMissing(TestForm):
+            field_order = ['field2', 'field4', 'field3', 'field5', 'field6', 'field1']
+            field1 = None
+
+        class TestFormInit(TestFormParent):
+            field3 = CharField()
+            field_order = None
+
+            def __init__(self, **kwargs):
+                super(TestFormInit, self).__init__(**kwargs)
+                self.order_fields(field_order=TestForm.field_order)
+
+        p = TestFormParent(auto_id=False)
+        self.assertEqual(p.fields.keys(), TestFormParent.field_order)
+        p = TestFormRemove(auto_id=False)
+        self.assertEqual(p.fields.keys(), TestForm.field_order)
+        p = TestFormMissing(auto_id=False)
+        self.assertEqual(p.fields.keys(), TestForm.field_order)
+        p = TestForm(auto_id=False)
+        self.assertEqual(p.fields.keys(), TestFormMissing.field_order)
+        p = TestFormInit(auto_id=False)
+        order = list(TestForm.field_order) + ['field1']
+        self.assertEqual(p.fields.keys(), order)
+        TestForm.field_order = ['unknown']
+        p = TestForm(auto_id=False)
+        self.assertEqual(p.fields.keys(), ['field1', 'field2', 'field4', 'field5', 'field6', 'field3'])
+
     def test_form_html_attributes(self):
         # Some Field classes have an effect on the HTML attributes of their associated
         # Widget. If you set max_length in a CharField and its associated widget is


### PR DESCRIPTION
It is sometimes necessary to alter the order in which fields are rendered, or remove individual fields, especially when subclassing forms.
With this patch one can easily override the default order with a list of field names.

Ticket https://code.djangoproject.com/ticket/23936