### PR TITLE
Fixed #23941 -- Aggregating over decimal field regression

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -1188,8 +1188,6 @@ class BaseDatabaseOperations(object):
         Transform a decimal.Decimal value to an object compatible with what is
         expected by the backend driver for decimal (numeric) columns.
         """
-        if value is None:
-            return None
         return utils.format_number(value, max_digits, decimal_places)
 
     def year_lookup_bounds_for_date_field(self, value):

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -312,9 +312,7 @@ WHEN (new.%(col_name)s IS NULL)
         return value
 
     def convert_decimalfield_value(self, value, field):
-        if value is not None:
-            value = backend_utils.typecast_decimal(field.format_number(value))
-        return value
+        return backend_utils.typecast_decimal(field.format_number(value))
 
     # cx_Oracle always returns datetime.datetime objects for
     # DATE and TIMESTAMP columns, but Django wants to see a

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -277,9 +277,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return converters
 
     def convert_decimalfield_value(self, value, field):
-        if value is not None:
-            value = backend_utils.typecast_decimal(field.format_number(value))
-        return value
+        return backend_utils.typecast_decimal(field.format_number(value))
 
     def convert_datefield_value(self, value, field):
         if value is not None and not isinstance(value, datetime.date):

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -191,9 +191,18 @@ def format_number(value, max_digits, decimal_places):
     Formats a number into a string with the requisite number of digits and
     decimal places.
     """
+    if value is None:
+        return None
     if isinstance(value, decimal.Decimal):
         context = decimal.getcontext().copy()
-        context.prec = max_digits
-        return "{0:f}".format(value.quantize(decimal.Decimal(".1") ** decimal_places, context=context))
-    else:
+        if max_digits is not None:
+            context.prec = max_digits
+        if decimal_places is not None:
+            value = value.quantize(decimal.Decimal(".1") ** decimal_places, context=context)
+        else:
+            context.traps[decimal.Rounded] = 1
+            value = context.create_decimal(value)
+        return "{0:f}".format(value)
+    if decimal_places is not None:
         return "%.*f" % (decimal_places, value)
+    return "{0:f}".format(value)

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -255,7 +255,7 @@ class ExpressionNode(CombinableMixin):
         elif internal_type.endswith('IntegerField'):
             return int(value)
         elif internal_type == 'DecimalField':
-            return backend_utils.typecast_decimal(field.format_number(value))
+            return backend_utils.typecast_decimal(value)
         return value
 
     def get_lookup(self, lookup):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1536,7 +1536,7 @@ class DecimalField(Field):
             )
 
     def _format(self, value):
-        if isinstance(value, six.string_types) or value is None:
+        if isinstance(value, six.string_types):
             return value
         else:
             return self.format_number(value)

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -259,6 +259,13 @@ The ``output_field`` argument requires a model field instance, like
 ``IntegerField()`` or ``BooleanField()``, into which Django will load the value
 after it's retrieved from the database.
 
+.. note::
+
+    When instantiating a model field for use as the output_field parameter,
+    usually no arguments are needed. Any arguments relating to data validation
+    (max_length, max_digits, etc.) will not be enforced on the expression's output
+    value.
+
 Note that ``output_field`` is only required when Django is unable to determine
 what field type the result should be. Complex expressions that mix field types
 should define the desired ``output_field``. For example, adding an
@@ -319,6 +326,13 @@ values into their corresponding database type.
 The ``output_field`` argument should be a model field instance, like
 ``IntegerField()`` or ``BooleanField()``, into which Django will load the value
 after it's retrieved from the database.
+
+.. note::
+
+    When instantiating a model field for use as the output_field parameter,
+    usually no arguments are needed. Any arguments relating to data validation
+    (max_length, max_digits, etc.) will not be enforced on the expression's output
+    value.
 
 
 Technical Information

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import copy
 import datetime
-from decimal import Decimal
+from decimal import Decimal, Rounded
 import re
 import threading
 import unittest
@@ -1047,6 +1047,22 @@ class BackendUtilTests(TestCase):
               '0.1')
         equal('0.1234567890', 12, 0,
               '0')
+        equal('0.1234567890', None, 0,
+              '0')
+        equal('1234567890.1234567890', None, 0,
+              '1234567890')
+        equal('1234567890.1234567890', None, 2,
+              '1234567890.12')
+        equal('0.1234', 5, None,
+              '0.1234')
+        equal('123.12', 5, None,
+              '123.12')
+        with self.assertRaises(Rounded):
+            equal('0.1234567890', 5, None,
+                  '0.12346')
+        with self.assertRaises(Rounded):
+            equal('1234567890.1234', 5, None,
+                  '1234600000')
 
 
 class DBTestSettingsRenamedTests(IgnoreAllDeprecationWarningsMixin, TestCase):


### PR DESCRIPTION
This patch fixes the regression but probably isn't ready for commit just yet. 

What this patch does is ignores the "max_digits" and "decimal_places" arguments of a DecimalField for all annotations. Setting your own arbitrary digits/decimals makes no sense with regards to aggregation, but it may make sense for other annotations.
