### PR TITLE
Fixed #23913 -- Deprecation of `=` comparison in `if` template tag

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -992,7 +992,9 @@ def do_if(parser, token):
     ``{% if 1>2 %}`` is not a valid if tag.
 
     All supported operators are: ``or``, ``and``, ``in``, ``not in``
-    ``==`` (or ``=``), ``!=``, ``>``, ``>=``, ``<`` and ``<=``.
+    ``==``, ``!=``, ``>``, ``>=``, ``<`` and ``<=``.
+
+    Operator ``=`` is deprecated and will be removed in Django 2.0
 
     Operator precedence follows Python.
     """

--- a/django/template/smartif.py
+++ b/django/template/smartif.py
@@ -1,9 +1,8 @@
-import warnings
-from django.utils.deprecation import RemovedInDjango20Warning
-
 """
 Parser and utilities for the smart 'if' tag
 """
+import warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 
 
 # Using a simple top down parser, as described here:
@@ -180,7 +179,7 @@ class IfParser(object):
         else:
             if token == '=':
                 warnings.warn(
-                    "Operator ``=`` is deprecated and will be removed in Django 2.0. Use ``==`` instead.",
+                    "Operator '=' is deprecated and will be removed in Django 2.0. Use '==' instead.",
                     RemovedInDjango20Warning, stacklevel=2
                 )
             return op()

--- a/django/template/smartif.py
+++ b/django/template/smartif.py
@@ -1,3 +1,6 @@
+import warnings
+from django.utils.deprecation import RemovedInDjango20Warning
+
 """
 Parser and utilities for the smart 'if' tag
 """
@@ -99,6 +102,7 @@ OPERATORS = {
     'not': prefix(8, lambda context, x: not x.eval(context)),
     'in': infix(9, lambda context, x, y: x.eval(context) in y.eval(context)),
     'not in': infix(9, lambda context, x, y: x.eval(context) not in y.eval(context)),
+    # This should be removed with Django 2.0:
     '=': infix(10, lambda context, x, y: x.eval(context) == y.eval(context)),
     '==': infix(10, lambda context, x, y: x.eval(context) == y.eval(context)),
     '!=': infix(10, lambda context, x, y: x.eval(context) != y.eval(context)),
@@ -174,6 +178,11 @@ class IfParser(object):
         except (KeyError, TypeError):
             return self.create_var(token)
         else:
+            if token == '=':
+                warnings.warn(
+                    "Operator ``=`` is deprecated and will be removed in Django 2.0. Use ``==`` instead.",
+                    RemovedInDjango20Warning, stacklevel=2
+                )
             return op()
 
     def next_token(self):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -95,6 +95,8 @@ details on these changes.
   * ``django.shortcuts.render()``
   * ``django.shortcuts.render_to_response()``
 
+* The ``=`` comparison operator in ``if`` template tag will be removed.
+
 .. _deprecation-removed-in-1.9:
 
 1.9

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1144,6 +1144,13 @@ The default value of the
 :attr:`RedirectView.permanent <django.views.generic.base.RedirectView.permanent>`
 attribute will change from ``True`` to ``False`` in Django 1.9.
 
+``=`` as comparison operator in ``if`` template tag
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There was an undocumented and untested feature introduced in Django 1.2 that allowed
+ you to use both ``==`` and ``=`` to check if objects are equal in ``if`` template tag.
+It's now deprecated in favor of ``==``.
+
 .. removed-features-1.8:
 
 Features removed in 1.8

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -1,6 +1,7 @@
 from django.template.base import TemplateSyntaxError
 from django.template.loader import get_template
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango20Warning
 
 from .utils import render, setup, TestObj
 
@@ -108,6 +109,62 @@ class IfTagTests(TestCase):
     def test_if_tag_eq05(self):
         output = render('if-tag-eq05')
         self.assertEqual(output, 'no')
+
+    # This five following tests should be changed to template.TemplateSyntaxError when deprication path ends in Django 2.0
+    @setup({'if-tag-eq06': '{% if foo = bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq06(self):
+        with self.assertRaises(RemovedInDjango20Warning):
+            output = render('if-tag-eq06', {'foo': 1})
+            self.assertEqual(output, 'yes')
+
+    @setup({'if-tag-eq07': '{% if foo = bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq07(self):
+        with self.assertRaises(RemovedInDjango20Warning):
+            output = render('if-tag-eq07', {'foo': 1})
+            self.assertEqual(output, 'no')
+
+    @setup({'if-tag-eq08': '{% if foo = bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq08(self):
+        with self.assertRaises(RemovedInDjango20Warning):
+            output = render('if-tag-eq08', {'foo': 1, 'bar': 1})
+            self.assertEqual(output, 'yes')
+
+    @setup({'if-tag-eq09': '{% if foo = bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq09(self):
+        with self.assertRaises(RemovedInDjango20Warning):
+            output = render('if-tag-eq09', {'foo': 1, 'bar': 2})
+            self.assertEqual(output, 'no')
+
+    @setup({'if-tag-eq10': '{% if foo = '' %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq10(self):
+        with self.assertRaises(RemovedInDjango20Warning):
+            output = render('if-tag-eq10')
+            self.assertEqual(output, 'no')
+
+    @setup({'if-tag-eq11': '{% if foo=bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq11(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render('if-tag-eq11', {'foo': 1})
+
+    @setup({'if-tag-eq12': '{% if foo=bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq12(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render('if-tag-eq12', {'foo': 1})
+
+    @setup({'if-tag-eq13': '{% if foo=bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq13(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render('if-tag-eq13', {'foo': 1, 'bar': 1})
+
+    @setup({'if-tag-eq14': '{% if foo=bar %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq14(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render('if-tag-eq14', {'foo': 1, 'bar': 2})
+
+    @setup({'if-tag-eq15': '{% if foo='' %}yes{% else %}no{% endif %}'})
+    def test_if_tag_eq15(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render('if-tag-eq15')
 
     # Comparison
     @setup({'if-tag-gt-01': '{% if 2 > 1 %}yes{% else %}no{% endif %}'})


### PR DESCRIPTION
This is a pull request for ticket [#23913](https://code.djangoproject.com/ticket/23913) that deprecates the "feature" that allows for comparison in `if` template tag using `=` operator (instead of `==`). There was some dicussion in the tickets if this change should be made, but I believe that we shouldn't let people create wrong coding patterns, even if it means that one day they will have to fix mistakes of using this undocumented feature in their old code.

I am not entirely sure that this is how you do deprecation path and I also couldn't find docs for that in contribution guidelines, so I'd be happy to fix whatever I did wrong :)