### PR TITLE
Fixed incorrect use of rst section heirarchy in form fields docs.

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -895,7 +895,7 @@ For each field, we describe the default widget used if you don't specify
     These are the same as ``CharField.max_length`` and ``CharField.min_length``.
 
 ``UUIDField``
--------------
+~~~~~~~~~~~~~
 
 .. versionadded:: 1.8
 


### PR DESCRIPTION
Correct that `UUIDField` is not on list with other fields.

HTML currently looks as follows:

```
<li><a class="reference internal" href="#slugfield"><tt class="docutils literal"><span class="pre">SlugField</span></tt></a></li>
<li><a class="reference internal" href="#timefield"><tt class="docutils literal"><span class="pre">TimeField</span></tt></a></li>
<li><a class="reference internal" href="#urlfield"><tt class="docutils literal"><span class="pre">URLField</span></tt></a></li>
</ul>
</li>
<li><a class="reference internal" href="#uuidfield"><tt class="docutils literal"><span class="pre">UUIDField</span></tt></a></li>
<li><a class="reference internal" href="#slightly-complex-built-in-field-classes">Slightly complex built-in <tt class="docutils literal"><span class="pre">Field</span></tt> classes</a><ul>
<li>
```

After this change: 

```
<li><a class="reference internal" href="#slugfield"><tt class="docutils literal"><span class="pre">SlugField</span></tt></a></li>
<li><a class="reference internal" href="#timefield"><tt class="docutils literal"><span class="pre">TimeField</span></tt></a></li>
<li><a class="reference internal" href="#urlfield"><tt class="docutils literal"><span class="pre">URLField</span></tt></a></li>
<li><a class="reference internal" href="#uuidfield"><tt class="docutils literal"><span class="pre">UUIDField</span></tt></a></li>
</ul>
</li>
<li><a class="reference internal" href="#slightly-complex-built-in-field-classes">Slightly complex built-in <tt class="docutils literal"><span class="pre">Field</span></tt> classes</a><ul>
```
