### PR TITLE
Fixed "no such test method" error in template_tests.

### DIFF
--- a/tests/template_tests/syntax_tests/utils.py
+++ b/tests/template_tests/syntax_tests/utils.py
@@ -52,6 +52,7 @@ def setup(templates, *args):
                 ('django.template.loaders.locmem.Loader', templates),
             ]),
         ])
+        @functools.wraps(func)
         def inner(self):
             loader = Engine.get_default().template_loaders[0]
 


### PR DESCRIPTION
Without this patch, you couldn't run an individual test
case in template_tests.

Refs #23768
