### PR TITLE
Fixed #12118 - Added ability to share sqlite in-memory database in threads.

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.creation import BaseDatabaseCreation
 from django.utils.six.moves import input
 
@@ -51,14 +52,21 @@ class DatabaseCreation(BaseDatabaseCreation):
     def _get_test_db_name(self):
         test_database_name = self.connection.settings_dict['TEST']['NAME']
         if test_database_name and test_database_name != ':memory:':
+            if 'mode=memory' in test_database_name:
+                raise ImproperlyConfigured(
+                    "Using `mode=memory` parameter in the database name is not allowed, "
+                    "use `:memory:` instead.")
             return test_database_name
+        if self.connection.features.can_share_in_memory_db:
+            return 'file:memorydb_%s?mode=memory&cache=shared' % self.connection.alias
         return ':memory:'
 
     def _create_test_db(self, verbosity, autoclobber, keepdb=False):
         test_database_name = self._get_test_db_name()
+
         if keepdb:
             return test_database_name
-        if test_database_name != ':memory:':
+        if not self.connection.is_in_memory_db(test_database_name):
             # Erase the old test database
             if verbosity >= 1:
                 print("Destroying old test database '%s'..." % self.connection.alias)
@@ -80,7 +88,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         return test_database_name
 
     def _destroy_test_db(self, test_database_name, verbosity):
-        if test_database_name and test_database_name != ":memory:":
+        if test_database_name and not self.connection.is_in_memory_db(test_database_name):
             # Remove the SQLite database file
             os.remove(test_database_name)
 
@@ -92,8 +100,8 @@ class DatabaseCreation(BaseDatabaseCreation):
         SQLite since the databases will be distinct despite having the same
         TEST NAME. See http://www.sqlite.org/inmemorydb.html
         """
-        test_dbname = self._get_test_db_name()
+        test_database_name = self._get_test_db_name()
         sig = [self.connection.settings_dict['NAME']]
-        if test_dbname == ':memory:':
+        if self.connection.is_in_memory_db(test_database_name):
             sig.append(self.connection.alias)
         return tuple(sig)

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1212,8 +1212,7 @@ class LiveServerTestCase(TransactionTestCase):
         for conn in connections.all():
             # If using in-memory sqlite databases, pass the connections to
             # the server thread.
-            if (conn.vendor == 'sqlite'
-                    and conn.settings_dict['NAME'] == ':memory:'):
+            if conn.vendor == 'sqlite' and conn.is_in_memory_db(conn.settings_dict['NAME']):
                 # Explicitly enable thread-shareability for this connection
                 conn.allow_thread_sharing = True
                 connections_override[conn.alias] = conn
@@ -1267,10 +1266,9 @@ class LiveServerTestCase(TransactionTestCase):
             cls.server_thread.terminate()
             cls.server_thread.join()
 
-        # Restore sqlite connections' non-shareability
+        # Restore sqlite in-memory database connections' non-shareability
         for conn in connections.all():
-            if (conn.vendor == 'sqlite'
-                    and conn.settings_dict['NAME'] == ':memory:'):
+            if conn.vendor == 'sqlite' and conn.is_in_memory_db(conn.settings_dict['NAME']):
                 conn.allow_thread_sharing = False
 
     @classmethod

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -561,6 +561,9 @@ Tests
 
 * Added test client support for file uploads with file-like objects.
 
+* Added ability to share SQLite3 in-memory database between threads, when
+  using Python 3.4+ and SQLite3 3.7.13+
+
 Validators
 ^^^^^^^^^^
 

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -191,6 +191,12 @@ and other advanced settings.
    setting used to be separate options in the database settings dictionary,
    prefixed with ``TEST_``.
 
+.. versionadded:: 1.8
+
+   If using SQLite in-memory database with Python 3.4+ and SQLite 3.7.13+,
+   shared cache will be enabled, so you can write tests with ability to
+   share database between threads.
+
 .. admonition:: Finding data from your production database when running tests?
 
     If your code attempts to access the database when its modules are compiled,


### PR DESCRIPTION
Sqlite3 with version >=3.7.13 can share in-memory database between threads.
Built-in sqlite module of python2 comes without ability to specify in-memory database name as URI, but since python3.4 can do this,
So, need to use database name as URI to prevent fails in tests.
I'm returning URI manually, if database name is specified as `:memory:` in settings to give ability to use shared cache without specifying it manually (people will have this after update).
