### PR TITLE
SimpleTestCase should not be used when data is created

### DIFF
--- a/tests/admin_util/tests.py
+++ b/tests/admin_util/tests.py
@@ -11,7 +11,7 @@ from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
 from django.contrib.sites.models import Site
 from django.db import models, DEFAULT_DB_ALIAS
 from django import forms
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 from django.utils.formats import localize
 from django.utils.safestring import mark_safe
 from django.utils import six
@@ -91,7 +91,7 @@ class NestedObjectsTests(TestCase):
         n.collect([Vehicle.objects.first()])
 
 
-class UtilTests(SimpleTestCase):
+class UtilTests(TestCase):
     def test_values_from_lookup_field(self):
         """
         Regression test for #12654: lookup_field


### PR DESCRIPTION
That might cause the error I observed here http://djangoci.com/job/django-pull-requests/1921/database=sqlite3,python=python3.2/testReport/junit/syndication_tests.tests/SyndicationFeedTest/test_atom_feed/, though I'm not sure since I cannot reproduce it...
