### PR TITLE
Cleaned up a note in docs/topics/db/sql.txt.

### DIFF
--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -203,7 +203,7 @@ dictionary key, of course), regardless of your database engine.  Such
 placeholders will be replaced with parameters from the ``params``
 argument.
 
-.. note:: Dictionary params not supported with SQLite
+.. note::
 
    Dictionary params are not supported with the SQLite backend; with
    this backend, you must pass parameters as a list.


### PR DESCRIPTION
The note under [Passing parameters into raw()](https://docs.djangoproject.com/en/dev/topics/db/sql/#passing-parameters-into-raw) would look better without the title.
