### PR TITLE
Fixed #23405 - Fixed asking for default value for `CharField` and `TextField` in migrations

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -794,8 +794,11 @@ class MigrationAutodetector(object):
                         None,
                         True
                     ))
-            # You can't just add NOT NULL fields with no default
-            if not field.null and not field.has_default() and not isinstance(field, models.ManyToManyField):
+            # You can't just add NOT NULL fields with no default or fields,
+            # which are not allowing empty strings as default.
+            if (not field.null and not field.has_default()
+                    and not isinstance(field, models.ManyToManyField)
+                    and not (field.blank and field.empty_strings_allowed)):
                 field = field.clone()
                 field.default = self.questioner.ask_not_null_addition(field_name, model_name)
                 self.add_operation(

--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -128,3 +128,6 @@ Bugfixes
 * Always converted ``related_name`` to text (unicode), since that is required
   on Python 3 for interpolation. Removed conversion of ``related_name`` to text
   in migration deconstruction (:ticket:`23455` and :ticket:`23982`).
+
+* ``makemigrations`` no longer prompts for a default value when adding
+  ``TextField()`` or ``CharField()`` without a default (:ticket:`23405`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import TestCase, mock, override_settings
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.state import ProjectState, ModelState
@@ -62,6 +62,16 @@ class AutodetectorTests(TestCase):
         ("name", models.CharField(max_length=200, default=models.IntegerField())),
     ])
     author_custom_pk = ModelState("testapp", "Author", [("pk_field", models.IntegerField(primary_key=True))])
+    author_with_biography_non_blank = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200)),
+        ("biography", models.TextField()),
+    ])
+    author_with_biography_blank = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200, blank=True)),
+        ("biography", models.TextField(blank=True)),
+    ])
     author_with_book = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
@@ -1682,3 +1692,37 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'a', 1)
         self.assertOperationTypes(changes, 'a', 0, ["CreateModel"])
         self.assertMigrationDependencies(changes, 'a', 0, [])
+
+    def test_add_blank_textfield_and_charfield(self):
+        """
+        #23405 - Adding a NOT NULL and blank `CharField` or `TextField`
+        without default should not prompt for a default.
+        """
+        class CustomQuestioner(MigrationQuestioner):
+            def ask_not_null_addition(self, field_name, model_name):
+                raise Exception("Should not have prompted for not null addition")
+
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_with_biography_blank])
+        autodetector = MigrationAutodetector(before, after, CustomQuestioner())
+        changes = autodetector._detect_changes()
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField"])
+        self.assertOperationAttributes(changes, 'testapp', 0, 0)
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition')
+    def test_add_non_blank_textfield_and_charfield(self, mocked_ask_method):
+        """
+        #23405 - Adding a NOT NULL and non-blank `CharField` or `TextField`
+        without default should prompt for a default.
+        """
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_with_biography_non_blank])
+        autodetector = MigrationAutodetector(before, after, MigrationQuestioner())
+        changes = autodetector._detect_changes()
+        # need to check for questioner call
+        self.assertTrue(mocked_ask_method.called)
+        self.assertEqual(mocked_ask_method.call_count, 2)
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField"])
+        self.assertOperationAttributes(changes, 'testapp', 0, 0)


### PR DESCRIPTION
I think modifying autodetector will be enough.
When migration will be applying, `django.db.backends.schema.BaseDatabaseSchemaEditor#effective_default` set correct value (empty string) for `TextField` and `CharField`, if they are blank, but NOT NULL.
