### PR TITLE
fixed #23674 fixed way of populing initial data

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -582,7 +582,7 @@ class BoundField(object):
             name = self.html_name
         else:
             name = self.html_initial_name
-        return force_text(widget.render(name, self.value(), attrs=attrs))
+        return force_text(widget.render(name, self.value(only_initial), attrs=attrs))
 
     def as_text(self, attrs=None, **kwargs):
         """
@@ -607,12 +607,13 @@ class BoundField(object):
         """
         return self.field.widget.value_from_datadict(self.form.data, self.form.files, self.html_name)
 
-    def value(self):
+    def value(self, only_initial=False):
         """
         Returns the value for this BoundField, using the initial value if
-        the form is not bound or the data otherwise.
+        the form is not bound or if we want value for initial field
+        then we check does form is bound and passed validation otherwise we return the data.
         """
-        if not self.form.is_bound:
+        if not self.form.is_bound or (only_initial and self.form.is_bound and not self.form.is_valid()):
             data = self.form.initial.get(self.name, self.field.initial)
             if callable(data):
                 data = data()

--- a/tests/generic_inline_admin/admin.py
+++ b/tests/generic_inline_admin/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 
 from .models import (Media, PhoneNumber, Episode, Contact,
-    Category, EpisodePermanent)
+    Category, EpisodePermanent, Event)
 
 
 site = admin.AdminSite(name="admin")
@@ -30,4 +30,5 @@ class MediaPermanentInline(GenericTabularInline):
 site.register(Episode, EpisodeAdmin)
 site.register(Contact, inlines=[PhoneNumberInline])
 site.register(Category)
+site.register(Event)
 site.register(EpisodePermanent, inlines=[MediaPermanentInline])

--- a/tests/generic_inline_admin/models.py
+++ b/tests/generic_inline_admin/models.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.fields import (
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils import timezone
 
 
 class Episode(models.Model):
@@ -56,3 +57,8 @@ class Contact(models.Model):
 #
 class EpisodePermanent(Episode):
     pass
+
+
+#model wit default column
+class Event(models.Model):
+    creation_date = models.DateTimeField(default=timezone.now)


### PR DESCRIPTION
if form didn't pass validation we don't use that
data for popolating initial instead of we use original
initial data.
