### PR TITLE
Clean up d.c.sites cache after each test

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -186,6 +186,11 @@ class SimpleTestCase(unittest.TestCase):
                 result.addError(self, sys.exc_info())
                 return
 
+    def _clear_caches(self):
+        """Clear various caches after each test"""
+        from django.contrib.sites.models import Site
+        Site.objects.clear_cache()
+
     def _pre_setup(self):
         """Performs any pre-test setup. This includes:
 
@@ -214,6 +219,7 @@ class SimpleTestCase(unittest.TestCase):
 
         * Putting back the original ROOT_URLCONF if it was changed.
         """
+        self._clear_caches()
         self._urlconf_teardown()
 
     def _urlconf_teardown(self):


### PR DESCRIPTION
`django.contrib.sites.models.Site` instances are cached in a global variable `SITE_CACHE`, which can make tests interfere with each other.
For instance, before this commit, tests are failing when run in the following order:
`python tests/runtests.py contenttypes_tests.tests.ContentTypesViewsTests.test_shortcut_with_absolute_url syndication_tests`
