### PR TITLE
Fixed #23977 -- Added setdefault method to HttpResponse

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -261,6 +261,11 @@ class HttpResponseBase(six.Iterator):
         if httponly:
             self.cookies[key]['httponly'] = True
 
+    def setdefault(self, key, value):
+        """Sets a header unless it has already been set."""
+        if key not in self:
+            self[key] = value
+
     def set_signed_cookie(self, key, value, salt='', **kwargs):
         value = signing.get_cookie_signer(salt=key + salt).sign(value)
         return self.set_cookie(key, value, **kwargs)

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -708,6 +708,12 @@ Methods
     Returns ``True`` or ``False`` based on a case-insensitive check for a
     header with the given name.
 
+.. method:: HttpResponse.setdefault(header, value)
+
+    .. versionadded:: 1.8
+
+    Sets a header unless it has already been set.
+
 .. method:: HttpResponse.set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=False)
 
     Sets a cookie. The parameters are the same as in the

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -483,6 +483,10 @@ Requests and Responses
   like :meth:`~django.http.HttpResponse.getvalue` so that instances can be used
   as stream objects.
 
+* :class:`~django.http.HttpResponse` now implements an additional method
+  :meth:`~django.http.HttpResponse.setdefault` 
+  to set a header unless it has been explicticly set by the view.
+
 Tests
 ^^^^^
 

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -33,6 +33,20 @@ class HttpResponseBaseTests(SimpleTestCase):
         with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance cannot tell its position'):
             r.tell()
 
+    def test_setdefault(self):
+        """
+        HttpResponseBase should not change an existing header
+        and should be case insensitive.
+        """
+        r = HttpResponseBase()
+
+        r['Header'] = 'Value'
+        r.setdefault('header', 'changed')
+        self.assertEqual(r['header'], 'Value')
+
+        r.setdefault('x-header', 'DefaultValue')
+        self.assertEqual(r['X-Header'], 'DefaultValue')
+
 
 class HttpResponseTests(SimpleTestCase):
     def test_status_code(self):


### PR DESCRIPTION
Ticket #23977. Created set_default method for more convenient default headers setting in HttpResponse.
