### PR TITLE
[1.7.x] Fixed #23986 -- clear_dir no longer fails if dir doesn't exist

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -199,6 +199,8 @@ class Command(NoArgsCommand):
         """
         Deletes the given relative path using the destination storage backend.
         """
+        if not os.path.isdir(self.storage.location):
+            return
         dirs, files = self.storage.listdir(path)
         for f in files:
             fpath = os.path.join(path, f)


### PR DESCRIPTION
If the target directory didn't exist when running `collectstatic
--clear` then an OSError exeception would be raised. After this
fix, if the directory doesn't exist then the clear_dir function
will return early. If by chance the user has a file matching the
name of the target directory a NotADirectoryError will now be raised.
