### PR TITLE
Fixed #23983 - Fixed a crash in migration when adding `order_with_respect_to` to table with data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ answer newbie questions, and generally made Django that much better:
     Andrew Godwin <andrew@aeracode.org>
     Andrew Pinkham <http://AndrewsForge.com>
     Andrews Medina <andrewsmedina@gmail.com>
+    Andriy Sokolovskiy <sokandpal@yandex.ru>
     Andy Dustman <farcepest@gmail.com>
     Andy Gayton <andy-django@thecablelounge.com>
     andy@jadedplanet.net

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -404,6 +404,8 @@ class AlterOrderWithRespectTo(Operation):
             # it's likely a rename)
             elif to_model._meta.order_with_respect_to and not from_model._meta.order_with_respect_to:
                 field = to_model._meta.get_field_by_name("_order")[0]
+                if not field.has_default():
+                    field.default = 0
                 schema_editor.add_field(
                     from_model,
                     field,

--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -143,3 +143,6 @@ Bugfixes
 
 * ``makemigrations`` no longer prompts for a default value when adding
   ``TextField()`` or ``CharField()`` without a ``default`` (:ticket:`23405`).
+
+* Fixed migration crash when adding ``order_with_respect_to`` to table
+  with existing rows (:ticket:`23983`).

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1237,10 +1237,19 @@ class OperationTests(OperationTestBase):
         self.assertEqual(new_state.models["test_alorwrtto", "rider"].options.get("order_with_respect_to", None), "pony")
         # Make sure there's no matching index
         self.assertColumnNotExists("test_alorwrtto_rider", "_order")
+        # Create some rows before alteration
+        rendered_state = project_state.render()
+        pony = rendered_state.get_model("test_alorwrtto", "Pony").objects.create(weight=50)
+        rendered_state.get_model("test_alorwrtto", "Rider").objects.create(pony=pony, friend_id=1)
+        rendered_state.get_model("test_alorwrtto", "Rider").objects.create(pony=pony, friend_id=2)
         # Test the database alteration
         with connection.schema_editor() as editor:
             operation.database_forwards("test_alorwrtto", editor, project_state, new_state)
         self.assertColumnExists("test_alorwrtto_rider", "_order")
+        # Check for correct value in row
+        updated_riders = new_state.render().get_model("test_alorwrtto", "Rider").objects.filter()
+        self.assertEqual(updated_riders[0]._order, 0)
+        self.assertEqual(updated_riders[1]._order, 0)
         # And test reversal
         with connection.schema_editor() as editor:
             operation.database_backwards("test_alorwrtto", editor, new_state, project_state)


### PR DESCRIPTION
Need to check `if not field.has_default()` to give users ability to set default in migration if they need it
