### PR TITLE
Fixed #23893: Added tzinfo to constant datetime in unit test

### DIFF
--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -4,6 +4,8 @@ from datetime import date, datetime
 import time
 import unittest
 
+from django.utils.timezone import get_default_timezone
+
 from django.core.exceptions import FieldError
 from django.db import models
 from django.db import connection
@@ -376,7 +378,7 @@ class DateTimeLookupTests(TestCase):
         models.PositiveIntegerField.register_lookup(DateTimeTransform)
         try:
             ut = MySQLUnixTimestamp.objects.create(timestamp=time.time())
-            y2k = datetime(2000, 1, 1)
+            y2k = datetime(2000, 1, 1, tzinfo=get_default_timezone())
             self.assertQuerysetEqual(
                 MySQLUnixTimestamp.objects.filter(timestamp__as_datetime__gt=y2k),
                 [ut], lambda x: x)


### PR DESCRIPTION
Added tzinfo to y2k constant (01/01/2000) in custom_lookups.tests.DateTimeLookupTests.test_datetime_output_field to fix warning message regarding naive datetimes. Using default timezone from config (since pytz may not be available).
