### PR TITLE
Fixed #23893: Added tzinfo to constant datetime in unit test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -465,6 +465,7 @@ answer newbie questions, and generally made Django that much better:
     Maximillian Dornseif <md@hudora.de>
     mccutchen@gmail.com
     Meir Kriheli <http://mksoft.co.il/>
+    Michael Hall <mhall1@ualberta.ca>
     Michael Josephson <http://www.sdjournal.com/>
     Michael Manfre <mmanfre@gmail.com>
     michael.mcewan@gmail.com

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -8,6 +8,7 @@ from django.core.exceptions import FieldError
 from django.db import models
 from django.db import connection
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from .models import Author, MySQLUnixTimestamp
 
 
@@ -376,7 +377,7 @@ class DateTimeLookupTests(TestCase):
         models.PositiveIntegerField.register_lookup(DateTimeTransform)
         try:
             ut = MySQLUnixTimestamp.objects.create(timestamp=time.time())
-            y2k = datetime(2000, 1, 1)
+            y2k = timezone.make_aware(datetime(2000, 1, 1))
             self.assertQuerysetEqual(
                 MySQLUnixTimestamp.objects.filter(timestamp__as_datetime__gt=y2k),
                 [ut], lambda x: x)


### PR DESCRIPTION
Added tzinfo to y2k constant (01/01/2000) in
custom_lookups.tests.DateTimeLookupTests.test_datetime_output_field
to fix warning message regarding naive datetimes.

Using default timezone from config (since pytz may not be available).
