### PR TITLE
Fix python3 / python2 issue in tests

### DIFF
--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -1,6 +1,7 @@
 import datetime
 import pickle
 import subprocess
+import sys
 import tempfile
 import warnings
 
@@ -82,7 +83,7 @@ print(article.headline)"""
             script.write(script_template % pickle.dumps(a))
             script.flush()
             try:
-                result = subprocess.check_output(['python', script.name])
+                result = subprocess.check_output([sys.executable, script.name])
             except subprocess.CalledProcessError:
                 self.fail("Unable to reload model pickled data")
         self.assertEqual(result.strip().decode(), "Some object")


### PR DESCRIPTION
If I run tests using `python3 runtests.py`, I get a failure because my
python binary is python2.

Refs #24007

```
collin@anakin:~/django1.8/tests$ PYTHONPATH=.. python3 runtests.py model_regress.test_pickle
Testing against Django installed in '/home/collin/django1.8/django'
Creating test database for alias 'default'...
Creating test database for alias 'other'...
.Traceback (most recent call last):
  File "/home/collin/django1.8/tests/tmpeqwmbhyl.py", line 9, in <module>
    article = pickle.loads(data)
  File "/usr/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/usr/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/usr/lib/python2.7/pickle.py", line 886, in load_proto
    raise ValueError, "unsupported pickle protocol: %d" % proto
ValueError: unsupported pickle protocol: 3
F.
======================================================================
FAIL: test_unpickling_when_appregistrynotready (model_regress.test_pickle.ModelPickleTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/collin/django1.8/tests/model_regress/test_pickle.py", line 85, in test_unpickling_when_appregistrynotready
    result = subprocess.check_output(['python', script.name])
subprocess.CalledProcessError: Command '['python', '/home/collin/django1.8/tests/tmpeqwmbhyl.py']' returned non-zero exit status 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/collin/django1.8/tests/model_regress/test_pickle.py", line 87, in test_unpickling_when_appregistrynotready
    self.fail("Unable to reload model pickled data")
AssertionError: Unable to reload model pickled data

----------------------------------------------------------------------
Ran 3 tests in 0.062s

FAILED (failures=1)
Destroying test database for alias 'default'...
Destroying test database for alias 'other'...
```
