### PR TITLE
Redirect to translated url after setting language

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -3,12 +3,13 @@ import json
 import os
 import gettext as gettext_module
 
+from urlparse import urlsplit, urlunsplit
 from django import http
 from django.apps import apps
 from django.conf import settings
 from django.core.urlresolvers import resolve, reverse, NoReverseMatch, Resolver404
 from django.template import Context, Template
-from django.utils.translation import check_for_language, to_locale, get_language, LANGUAGE_SESSION_KEY
+from django.utils.translation import activate, check_for_language, to_locale, get_language, LANGUAGE_SESSION_KEY
 from django.utils.encoding import smart_text
 from django.utils.formats import get_format_modules, get_format
 from django.utils._os import upath


### PR DESCRIPTION
Implemented redirection to proper, translated URL after language was changed. This fixes not changing language preference at all when using i18n_patterns and redirecting to 404 page when translated urls are used (and no i18n_patterns used, because if used, language won't change at all).
