### PR TITLE
Fixed #24034 -- Don't always overwrite deconstruct path.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -82,7 +82,8 @@ class ArrayField(Field):
 
     def deconstruct(self):
         name, path, args, kwargs = super(ArrayField, self).deconstruct()
-        path = 'django.contrib.postgres.fields.ArrayField'
+        if path == 'django.contrib.postgres.fields.array.ArrayField':
+            path = 'django.contrib.postgres.fields.ArrayField'
         kwargs.update({
             'base_field': self.base_field,
             'size': self.size,

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -32,3 +32,8 @@ class CharFieldModel(models.Model):
 
 class TextFieldModel(models.Model):
     field = models.TextField()
+
+
+class ArrayFieldSubclass(ArrayField):
+    def __init__(self, *args, **kwargs):
+        super(ArrayFieldSubclass, self).__init__(models.IntegerField())

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -10,7 +10,7 @@ from django import forms
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from .models import IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel, DateTimeArrayModel, NestedIntegerArrayModel
+from .models import IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel, DateTimeArrayModel, NestedIntegerArrayModel, ArrayFieldSubclass
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
@@ -227,6 +227,15 @@ class TestMigrations(TestCase):
         name, path, args, kwargs = field.deconstruct()
         new = ArrayField(*args, **kwargs)
         self.assertEqual(new.base_field.max_length, field.base_field.max_length)
+
+    def test_subclass_deconstruct(self):
+        field = ArrayField(models.IntegerField())
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, 'django.contrib.postgres.fields.ArrayField')
+
+        field = ArrayFieldSubclass()
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, 'postgres_tests.models.ArrayFieldSubclass')
 
     @override_settings(MIGRATION_MODULES={
         "postgres_tests": "postgres_tests.array_default_migrations",


### PR DESCRIPTION
Made deconstruct path overwriting for ArrayField conditional, so it only occurs when the deconstructed field is an instance of ArrayField itself and not a subclass.

See ticket https://code.djangoproject.com/ticket/24034.
