### PR TITLE
[1.7.x] Fixed #24008 -- ValidationError crashes with list of dicts

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -118,7 +118,10 @@ class ValidationError(Exception):
                 # Normalize plain strings to instances of ValidationError.
                 if not isinstance(message, ValidationError):
                     message = ValidationError(message)
-                self.error_list.extend(message.error_list)
+                if hasattr(message, 'error_dict'):
+                    self.error_list.extend(reduce(operator.add, message.error_dict.values()))
+                else:
+                    self.error_list.extend(message.error_list)
 
         else:
             self.message = message

--- a/tests/forms_tests/tests/test_util.py
+++ b/tests/forms_tests/tests/test_util.py
@@ -45,9 +45,13 @@ class FormsUtilTestCase(TestCase):
         self.assertHTMLEqual(str(ErrorList(ValidationError(["Error one.", "Error two."]).messages)),
                          '<ul class="errorlist"><li>Error one.</li><li>Error two.</li></ul>')
 
+        # Can take a dict.
+        self.assertHTMLEqual(str(ErrorList(ValidationError({'error_1': "Error one.", 'error_2': "Error two."}).messages)),
+                         '<ul class="errorlist"><li>Error one.</li><li>Error two.</li></ul>')
+
         # Can take a mixture in a list.
-        self.assertHTMLEqual(str(ErrorList(ValidationError(["First error.", "Not \u03C0.", ugettext_lazy("Error.")]).messages)),
-                         '<ul class="errorlist"><li>First error.</li><li>Not π.</li><li>Error.</li></ul>')
+        self.assertHTMLEqual(str(ErrorList(ValidationError(["First error.", "Not \u03C0.", ugettext_lazy("Error."), {'error_1': 'First dict error.', 'error_2': 'Second dict error.'}]).messages)),
+                         '<ul class="errorlist"><li>First error.</li><li>Not π.</li><li>Error.</li><li>First dict error.</li><li>Second dict error.</li></ul>')
 
         @python_2_unicode_compatible
         class VeryBadError:


### PR DESCRIPTION
ValidationError crashes if initialised with list which contains dicts.
Example:

```
>>> ValidationError([{'1': 'one', '2': 'two'}])
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/am/.virtualenvs/test/local/lib/python2.7/site-packages/django/core/exceptions.py", line 121, in __init__
    self.error_list.extend(message.error_list)
AttributeError: 'ValidationError' object has no attribute 'error_list'
```
