### PR TITLE
M2M __in filtering after a Count annotation

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -126,6 +126,36 @@ class NonAggregateAnnotationTestCase(TestCase):
             lambda b: b.store_name
         )
 
+    def test_annotation_with_m2m_then_filter(self):
+        author1 = Author.objects.get(pk=5)
+        author2 = Author.objects.get(pk=6)
+        author3 = Author.objects.get(pk=7)
+
+        books = (
+          Book.objects.annotate(num_authors=Count('authors'))
+          .filter(num_authors=3)
+          .filter(authors=author1)
+          .filter(authors=author2)
+          .filter(authors=author3)
+        )
+
+        self.assertQuerysetEqual(
+          books, ['<Book: Python Web Development with Django>'])
+
+    def test_annotation_with_m2m_then_filter_using_in(self):
+        author1 = Author.objects.get(pk=5)
+        author2 = Author.objects.get(pk=6)
+        author3 = Author.objects.get(pk=7)
+
+        books = (
+          Book.objects.annotate(num_authors=Count('authors'))
+          .filter(num_authors=3)
+          .filter(authors__in=[author1, author2, author3])
+        )
+
+        self.assertQuerysetEqual(
+          books, ['<Book: Python Web Development with Django>'])
+
     def test_values_annotation(self):
         """
         Annotations can reference fields in a values clause,


### PR DESCRIPTION
See [ticket#24039](https://code.djangoproject.com/ticket/24039)

After annotating and filtering a queryset for the number of m2m related objects, subsequent filters using `__in` falsely return an empty result.

In this PR, the first test passes to demonstrate the expected behavior.  The following test—which is really the same logic as the first test, only written differently—fails.

Also see some pdb output from my personal project to show this in action: http://dpaste.com/3JQYWTZ#line-31

Specifically, **it is the annotated _filter_ that triggers the bug**.

Consider this output:

``` python
>>> annotated_query = Book.objects.annotate(c=Count('authors'))
>>> annotated_query.filter(authors=author1).filter(authors=author2).filter(authors=author3)
[<Book: Python Web Development with Django>]
>>> annotated_query.filter(authors__in=[author1, author2, author3])
[<Book: Python Web Development with Django>]
```

versus this output with the annotated filter:

``` python
>>> annotated_query = Book.objects.annotate(c=Count('authors')).filter(c=3)
>>> annotated_query.filter(authors=author1).filter(authors=author2).filter(authors=author3)
[<Book: Python Web Development with Django>]
>>> annotated_query.filter(authors__in=[author1, author2, author3])
[]
```
