### PR TITLE
Ensure TypedChoiceField validates any non-empty value

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -861,7 +861,11 @@ class ChoiceField(Field):
         Validates that the input is in self.choices.
         """
         super(ChoiceField, self).validate(value)
-        if value and not self.valid_value(value):
+        if value is None:
+            return
+        if value in self.empty_values:
+            return
+        if not self.valid_value(value):
             raise ValidationError(
                 self.error_messages['invalid_choice'],
                 code='invalid_choice',

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -1069,6 +1069,12 @@ class FieldsTests(SimpleTestCase):
             "'Select a valid choice. 3 is not one of the available choices.'",
             f.clean, '3')
 
+    def test_typedchoicefield_using_zero(self):
+        f = TypedChoiceField(choices=[], coerce=int, required=True, empty_value=None)
+        self.assertRaisesMessage(ValidationError,
+            "'Select a valid choice. 0 is not one of the available choices.'",
+            f.clean, '0')
+
     # NullBooleanField ############################################################
 
     def test_nullbooleanfield_1(self):


### PR DESCRIPTION
This ensures that a '0' value in an integer-based TypedChoiceField gets validated correctly.

Previously this would not ever get validated, as passing a '0' value would skip any kind of field validation:

```
class MyForm(forms.Form):
    choice = forms.TypedChoiceField(choices=[], coerce=int)
```
