### PR TITLE
Fixed #24268 -- removed Query.having

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1767,6 +1767,7 @@ class ForeignObject(RelatedField):
             root_constraint.add(lookup_class(targets[0].get_col(alias, sources[0]), value), AND)
         elif lookup_type == 'in':
             values = [get_normalized_value(value) for value in raw_value]
+            root_constraint.connector = OR
             for value in values:
                 value_constraint = constraint_class()
                 for source, target, val in zip(sources, targets, value):

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -87,6 +87,10 @@ class Transform(RegisterLookupMixin):
             bilateral_transforms.append((self.__class__, self.init_lookups))
         return bilateral_transforms
 
+    @cached_property
+    def contains_aggregate(self):
+        return self.lhs.contains_aggregate
+
 
 class Lookup(RegisterLookupMixin):
     lookup_name = None
@@ -188,6 +192,10 @@ class Lookup(RegisterLookupMixin):
 
     def as_sql(self, compiler, connection):
         raise NotImplementedError
+
+    @cached_property
+    def contains_aggregate(self):
+        return self.lhs.contains_aggregate or getattr(self.rhs, 'contains_aggregate', False)
 
 
 class BuiltinLookup(Lookup):

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -35,6 +35,8 @@ class QueryWrapper(object):
     A type that indicates the contents are an SQL fragment and the associate
     parameters. Can be used to pass opaque data to a where-clause, for example.
     """
+    contains_aggregate = False
+
     def __init__(self, sql, params):
         self.data = sql, list(params)
 

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -54,10 +54,8 @@ class DeleteQuery(Query):
         self.get_initial_alias()
         innerq_used_tables = [t for t in innerq.tables
                               if innerq.alias_refcount[t]]
-        if ((not innerq_used_tables or innerq_used_tables == self.tables)
-                and not len(innerq.having)):
-            # There is only the base table in use in the query, and there is
-            # no aggregate filtering going on.
+        if not innerq_used_tables or innerq_used_tables == self.tables:
+            # There is only the base table in use in the query.
             self.where = innerq.where
         else:
             pk = query.model._meta.pk

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -12,14 +12,6 @@ AND = 'AND'
 OR = 'OR'
 
 
-class EmptyShortCircuit(Exception):
-    """
-    Internal exception used to indicate that a "matches nothing" node should be
-    added to the where-clause.
-    """
-    pass
-
-
 class WhereNode(tree.Node):
     """
     Used to represent the SQL where-clause.

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -1,9 +1,10 @@
 """
 Code to manage the creation and SQL rendering of 'where' constraints.
 """
+
 from django.db.models.sql.datastructures import EmptyResultSet
-from django.utils.functional import cached_property
 from django.utils import tree
+from django.utils.functional import cached_property
 
 
 # Connection types
@@ -36,6 +37,37 @@ class WhereNode(tree.Node):
     variable.
     """
     default = AND
+
+    def split_having(self, negated=False):
+        """
+        Returns two possibly None nodes, one for those parts of self that
+        should be pushed to having, and one for those parts of self
+        that should be in where.
+        """
+        in_negated = negated ^ self.negated
+        # If the effective connector is OR, and this node contains an aggregate,
+        # then we need to push the whole branch to HAVING clause.
+        may_need_split = (
+            (in_negated and self.connector == AND) or
+            (not in_negated and self.connector == OR))
+        if may_need_split and self.contains_aggregate:
+            return None, self
+        where_parts = []
+        having_parts = []
+        for c in self.children:
+            if hasattr(c, 'split_having'):
+                where_part, having_part = c.split_having(in_negated)
+                if where_part:
+                    where_parts.append(where_part)
+                if having_part:
+                    having_parts.append(having_part)
+            elif c.contains_aggregate:
+                having_parts.append(c)
+            else:
+                where_parts.append(c)
+        having_node = self.__class__(having_parts, self.connector, self.negated) if having_parts else None
+        where_node = self.__class__(where_parts, self.connector, self.negated) if where_parts else None
+        return where_node, having_node
 
     def as_sql(self, compiler, connection):
         """
@@ -145,27 +177,20 @@ class WhereNode(tree.Node):
 
     @classmethod
     def _contains_aggregate(cls, obj):
-        if not isinstance(obj, tree.Node):
-            return getattr(obj.lhs, 'contains_aggregate', False) or getattr(obj.rhs, 'contains_aggregate', False)
-        return any(cls._contains_aggregate(c) for c in obj.children)
+        if isinstance(obj, tree.Node):
+            return any(cls._contains_aggregate(c) for c in obj.children)
+        return obj.contains_aggregate
 
     @cached_property
     def contains_aggregate(self):
         return self._contains_aggregate(self)
 
 
-class EmptyWhere(WhereNode):
-    def add(self, data, connector):
-        return
-
-    def as_sql(self, compiler=None, connection=None):
-        raise EmptyResultSet
-
-
 class EverythingNode(object):
     """
     A node that matches everything.
     """
+    contains_aggregate = False
 
     def as_sql(self, compiler=None, connection=None):
         return '', []
@@ -175,11 +200,16 @@ class NothingNode(object):
     """
     A node that matches nothing.
     """
+    contains_aggregate = False
+
     def as_sql(self, compiler=None, connection=None):
         raise EmptyResultSet
 
 
 class ExtraWhere(object):
+    # The contents are a black box - assume no aggregates are used.
+    contains_aggregate = False
+
     def __init__(self, sqls, params):
         self.sqls = sqls
         self.params = params
@@ -190,6 +220,10 @@ class ExtraWhere(object):
 
 
 class SubqueryConstraint(object):
+    # Even if aggregates would be used in a subquery, the outer query isn't
+    # interested about those.
+    contains_aggregate = False
+
     def __init__(self, alias, columns, targets, query_object):
         self.alias = alias
         self.columns = columns

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -28,22 +28,22 @@ class WhereNode(tree.Node):
     the correct SQL).
 
     A child is usually an expression producing boolean values. Most likely the
-    expression is a Lookup instance, but other types of objects fulfilling the
-    required API could be used too (for example, sql.where.EverythingNode).
+    expression is a Lookup instance.
 
     However, a child could also be any class with as_sql() and either
-    relabeled_clone() method or relabel_aliases() and clone() methods. The
-    second alternative should be used if the alias is not the only mutable
-    variable.
+    relabeled_clone() method or relabel_aliases() and clone() methods and
+    contains_aggregate attribute.
     """
     default = AND
 
     def split_having(self, negated=False):
         """
         Returns two possibly None nodes, one for those parts of self that
-        should be pushed to having, and one for those parts of self
-        that should be in where.
+        should be included in the WHERE clause, and one for those parts of
+        self that must be included in the HAVING clause.
         """
+        if not self.contains_aggregate:
+            return self, None
         in_negated = negated ^ self.negated
         # If the effective connector is OR, and this node contains an aggregate,
         # then we need to push the whole branch to HAVING clause.
@@ -57,9 +57,9 @@ class WhereNode(tree.Node):
         for c in self.children:
             if hasattr(c, 'split_having'):
                 where_part, having_part = c.split_having(in_negated)
-                if where_part:
+                if where_part is not None:
                     where_parts.append(where_part)
-                if having_part:
+                if having_part is not None:
                     having_parts.append(having_part)
             elif c.contains_aggregate:
                 having_parts.append(c)
@@ -76,55 +76,39 @@ class WhereNode(tree.Node):
         None, [] if this node is empty, and raises EmptyResultSet if this
         node can't match anything.
         """
-        # Note that the logic here is made slightly more complex than
-        # necessary because there are two kind of empty nodes: Nodes
-        # containing 0 children, and nodes that are known to match everything.
-        # A match-everything node is different than empty node (which also
-        # technically matches everything) for backwards compatibility reasons.
-        # Refs #5261.
         result = []
         result_params = []
-        everything_childs, nothing_childs = 0, 0
-        non_empty_childs = len(self.children)
+        if self.connector == AND:
+            full_needed, empty_needed = len(self.children), 1
+        else:
+            full_needed, empty_needed = 1, len(self.children)
 
         for child in self.children:
             try:
                 sql, params = compiler.compile(child)
             except EmptyResultSet:
-                nothing_childs += 1
+                empty_needed -= 1
             else:
                 if sql:
                     result.append(sql)
                     result_params.extend(params)
                 else:
-                    if sql is None:
-                        # Skip empty childs totally.
-                        non_empty_childs -= 1
-                        continue
-                    everything_childs += 1
+                    full_needed -= 1
             # Check if this node matches nothing or everything.
             # First check the amount of full nodes and empty nodes
             # to make this node empty/full.
-            if self.connector == AND:
-                full_needed, empty_needed = non_empty_childs, 1
-            else:
-                full_needed, empty_needed = 1, non_empty_childs
             # Now, check if this node is full/empty using the
             # counts.
-            if empty_needed - nothing_childs <= 0:
+            if empty_needed == 0:
                 if self.negated:
                     return '', []
                 else:
                     raise EmptyResultSet
-            if full_needed - everything_childs <= 0:
+            if full_needed == 0:
                 if self.negated:
                     raise EmptyResultSet
                 else:
                     return '', []
-
-        if non_empty_childs == 0:
-            # All the child nodes were empty, so this one is empty, too.
-            return None, []
         conn = ' %s ' % self.connector
         sql_string = conn.join(result)
         if sql_string:
@@ -184,16 +168,6 @@ class WhereNode(tree.Node):
     @cached_property
     def contains_aggregate(self):
         return self._contains_aggregate(self)
-
-
-class EverythingNode(object):
-    """
-    A node that matches everything.
-    """
-    contains_aggregate = False
-
-    def as_sql(self, compiler=None, connection=None):
-        return '', []
 
 
 class NothingNode(object):


### PR DESCRIPTION
The idea is to split the where and having parts in compiler stage. This should be faster on those queries that do not use aggregates, and the logic is easier to implement in compiler.