### PR TITLE
Fixed #24037 -- Prevented data loss possibility when changing Meta.managed.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -431,6 +431,7 @@ class AlterModelOptions(Operation):
     # Model options we want to compare and preserve in an AlterModelOptions op
     ALTER_OPTION_KEYS = [
         "get_latest_by",
+        "managed",
         "ordering",
         "permissions",
         "default_permissions",

--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -162,3 +162,8 @@ Bugfixes
 * Added ``datetime.time`` support to migrations questioner (:ticket:`23998`).
 
 * Fixed admindocs crash on apps installed as eggs (:ticket:`23525`).
+
+* Changed migrations autodetector to generate an ``AlterModelOptions`` operation
+  instead of ``DeleteModel`` and ``CreateModel`` operations when changing
+  ``Meta.managed``. This prevents data loss when changing ``managed`` from
+  ``False`` to ``True`` and vice versa (:ticket:`24037`).


### PR DESCRIPTION
The migrations autodetector now issues AlterModelOptions operations for
Meta.managed changes instead of DeleteModel + CreateModel.

https://code.djangoproject.com/ticket/24037
