### PR TITLE
typo: change "data" to "truth"

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -327,7 +327,7 @@ The first step in writing a database Web app in Django is to define your models
 
 .. admonition:: Philosophy
 
-   A model is the single, definitive source of data about your data. It contains
+   A model is the single, definitive source of truth about your data. It contains
    the essential fields and behaviors of the data you're storing. Django follows
    the :ref:`DRY Principle <dry>`. The goal is to define your data model in one
    place and automatically derive things from it.


### PR DESCRIPTION
This doc currently says "the single, definitive source of data about your data."  I'm pretty confident the first 'data' is supposed to be 'truth', as the DRY principle is usually stated in terms of a 'single source of truth.'
