### PR TITLE
Fixed #22728 - Prohibited lookups usage for get_or_create

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -435,7 +435,7 @@ class QuerySet(object):
         Returns a tuple of (object, created), where created is a boolean
         specifying whether an object was created.
         """
-        lookup, params = self._extract_model_params(defaults, **kwargs)
+        lookup, params = self._extract_model_params(defaults, lookup_parameters_allowed=False, **kwargs)
         self._for_write = True
         try:
             return self.get(**lookup), False
@@ -482,7 +482,7 @@ class QuerySet(object):
                 pass
             six.reraise(*exc_info)
 
-    def _extract_model_params(self, defaults, **kwargs):
+    def _extract_model_params(self, defaults, lookup_parameters_allowed=True, **kwargs):
         """
         Prepares `lookup` (kwargs that are valid model attributes), `params`
         (for creating a model instance) based on given kwargs; for use by
@@ -494,6 +494,10 @@ class QuerySet(object):
             if f.attname in lookup:
                 lookup[f.name] = lookup.pop(f.attname)
         params = {k: v for k, v in kwargs.items() if LOOKUP_SEP not in k}
+        lookup_parameters = set(kwargs.keys()) - set(params.keys())
+        if not lookup_parameters_allowed and lookup_parameters:
+            raise TypeError("Lookups are not allowed for get_or_create. "
+                            "Wrong parameters: %s" % list(lookup_parameters))
         params.update(defaults)
         return lookup, params
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1680,6 +1680,14 @@ whenever a request to a page has a side effect on your data. For more, see
   chapter because it isn't related to that book, but it can't create it either
   because ``title`` field should be unique.
 
+.. warning::
+
+  Lookups usage is not allowed for ``get_or_create()``.
+  If you will try to use it, ``TypeError`` will be raised::
+
+      >>> Person.objects.get_or_create(name='Bob', birthday__gte=date(1800, 12, 12))
+      *** TypeError: Lookups are not allowed for get_or_create. Wrong parameters: ['birthday__gte']
+
 update_or_create
 ~~~~~~~~~~~~~~~~
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -924,6 +924,8 @@ Miscellaneous
   different in some cases. There is no change to default values which are the
   result of a callable.
 
+* Lookups usage in ``get_or_create()`` was prohibited.
+
 .. _deprecated-features-1.8:
 
 Features deprecated in 1.8

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -125,6 +125,14 @@ class GetOrCreateTests(TestCase):
         # The publisher should have three books.
         self.assertEqual(p.books.count(), 3)
 
+    def test_get_or_create_with_lookups_raises_exception(self):
+        Person.objects.create(first_name="Morihei", last_name="Ueshiba", birthday=date(1883, 12, 14))
+        self.assertRaises(
+            TypeError,
+            Person.objects.get_or_create,
+            name__iexact='morihei', last_name="Ueshiba", birthday__gte=date(1800, 12, 12)
+        )
+
 
 class GetOrCreateTestsWithManualPKs(TestCase):
 


### PR DESCRIPTION
Patch proposes how this problem can be solved.
I decided to make this backwards incompatible, because the way django does it now should not be encouraged.

One more thing - ticket is about `get_or_create`, but I think `update_or_create` should have the same behavior.