### PR TITLE
[1.7.2] Fixed #24051 -- Backported code from master to 1.7.2.

### DIFF
--- a/django/db/backends/schema.py
+++ b/django/db/backends/schema.py
@@ -254,6 +254,13 @@ class BaseDatabaseSchemaEditor(object):
             "table": self.quote_name(model._meta.db_table),
             "definition": ", ".join(column_sqls)
         }
+
+        # Add tablespace statement to ddl if needed
+        if model._meta.db_tablespace:
+            tablespace_sql = self.connection.ops.tablespace_sql(model._meta.db_tablespace)
+            if tablespace_sql:
+                sql += ' ' + tablespace_sql
+
         self.execute(sql, params)
 
         # Add any field index and index_together's (deferred as SQLite3 _remake_table needs it)

--- a/docs/releases/1.7.2.txt
+++ b/docs/releases/1.7.2.txt
@@ -170,3 +170,7 @@ Bugfixes
 
 * Enabled the ``sqlsequencereset`` command on apps with migrations
   (:ticket:`24054`).
+
+* Fixed issue where new models were not being created in correct tablespace
+  if the tablespace was defined in the model or settings. (:ticket:`24051`).
+

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -175,3 +175,9 @@ class Thing(models.Model):
 
 class Note(models.Model):
     info = models.TextField()
+
+class Tablespace(models.Model):
+    name = models.TextField()
+
+    class Meta:
+        db_tablespace = 'django_test_d_01'


### PR DESCRIPTION
Prevent table from being created in default schema when the
schema is specified in the model or in the settings.

For ticket #24051
