### PR TITLE
Fixed #20488 -- Added copy and move methods to the storage API

### DIFF
--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -1,0 +1,41 @@
+"""
+Copy a file in the safest way possible::
+
+    >>> from django.core.files.copy import file_copy_safe
+    >>> file_copy_safe("/tmp/old_file", "/tmp/new_file")
+"""
+
+import os
+from shutil import copystat
+
+from django.core.files import locks
+
+
+__all__ = ['file_copy_safe']
+
+
+def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overwrite=False):
+    """
+    Copy a file from one location to another in the safest way possible.
+
+    If the destination file exists and ``allow_overwrite`` is ``False``, this
+    function will throw an ``IOError``.
+    """
+    # first open the old file, so that it won't go away
+    with open(old_file_name, 'rb') as old_file:
+        # now open the new file, not forgetting allow_overwrite
+        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT | getattr(os, 'O_BINARY', 0) |
+                                    (not allow_overwrite and os.O_EXCL or 0))
+        try:
+            locks.lock(fd, locks.LOCK_EX)
+            current_chunk = None
+            while current_chunk != b'':
+                current_chunk = old_file.read(chunk_size)
+                os.write(fd, current_chunk)
+        except OSError:
+            os.remove(new_file_name)
+            raise
+        finally:
+            locks.unlock(fd)
+            os.close(fd)
+    copystat(old_file_name, new_file_name)

--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -14,7 +14,8 @@ from django.core.files import locks
 __all__ = ['file_copy_safe']
 
 
-def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overwrite=False):
+def file_copy_safe(old_file_name, new_file_name, chunk_size=1024 * 64,
+                   allow_overwrite=False):
     """
     Copy a file from one location to another in the safest way possible.
 
@@ -24,8 +25,9 @@ def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overw
     # first open the old file, so that it won't go away
     with open(old_file_name, 'rb') as old_file:
         # now open the new file, not forgetting allow_overwrite
-        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT | getattr(os, 'O_BINARY', 0) |
-                                    (not allow_overwrite and os.O_EXCL or 0))
+        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT |
+                     getattr(os, 'O_BINARY', 0) |
+                     (not allow_overwrite and os.O_EXCL or 0))
         try:
             locks.lock(fd, locks.LOCK_EX)
             current_chunk = None

--- a/django/core/files/move.py
+++ b/django/core/files/move.py
@@ -26,7 +26,6 @@ def _samefile(src, dst):
             os.path.normcase(os.path.abspath(dst)))
 
 
-
 def file_move_safe(old_file_name, new_file_name, chunk_size=1024 * 64, allow_overwrite=False):
     """
     Moves a file from one location to another in the safest way possible.

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -314,7 +314,7 @@ class FileSystemStorage(Storage):
         try:
             operation(src_path, dst_path)
         except OSError as e:
-            if e .errno == errno.EEXIST:
+            if e.errno == errno.EEXIST:
                 raise ValueError('Destination already exists')
             else:
                 raise

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -95,6 +95,15 @@ The Storage Class
         able to return the last accessed time this will raise
         ``NotImplementedError`` instead.
 
+    .. method:: copy(src_name, dst_name)
+
+        Copy the file specified by ``src_name`` to ``dst_name``. If
+	``dst_name`` already exists ``ValueError`` will be raised. For
+	storage systems that don't support copy this will raise
+	``NotImplementedError`` instead.
+
+        .. versionadded:: 1.8
+
     .. method:: created_time(name)
 
         Returns a naive ``datetime`` object containing the creation
@@ -151,6 +160,15 @@ The Storage Class
         modified time. For storage systems that aren't able to return
         the last modified time, this will raise
         ``NotImplementedError`` instead.
+
+    .. method:: move(src_name, dst_name)
+
+        Move the file specified by ``src_name`` to ``dst_name``. If
+	``dst_name`` already exists ``ValueError`` will be raised. For storage
+	systems that don't support move this will raise ``NotImplementedError``
+	instead.
+
+        .. versionadded:: 1.8
 
     .. method:: open(name, mode='rb')
 

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -98,9 +98,9 @@ The Storage Class
     .. method:: copy(src_name, dst_name)
 
         Copy the file specified by ``src_name`` to ``dst_name``. If
-	``dst_name`` already exists ``ValueError`` will be raised. For
-	storage systems that don't support copy this will raise
-	``NotImplementedError`` instead.
+        ``dst_name`` already exists ``ValueError`` will be raised. For
+        storage systems that don't support copy this will raise
+        ``NotImplementedError`` instead.
 
         .. versionadded:: 1.8
 
@@ -164,9 +164,9 @@ The Storage Class
     .. method:: move(src_name, dst_name)
 
         Move the file specified by ``src_name`` to ``dst_name``. If
-	``dst_name`` already exists ``ValueError`` will be raised. For storage
-	systems that don't support move this will raise ``NotImplementedError``
-	instead.
+        ``dst_name`` already exists ``ValueError`` will be raised. For storage
+        systems that don't support move this will raise ``NotImplementedError``
+        instead.
 
         .. versionadded:: 1.8
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -271,7 +271,9 @@ Email
 File Storage
 ^^^^^^^^^^^^
 
-* ...
+* :class:`~django.core.files.storage.Storage` and
+  :class:`~django.core.files.storage.FileSystemStorage` now have ``move``
+  and ``copy`` methods
 
 File Uploads
 ^^^^^^^^^^^^

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -272,8 +272,9 @@ File Storage
 ^^^^^^^^^^^^
 
 * :class:`~django.core.files.storage.Storage` and
-  :class:`~django.core.files.storage.FileSystemStorage` now have ``move``
-  and ``copy`` methods
+  :class:`~django.core.files.storage.FileSystemStorage` now have
+  :meth:`~django.core.files.storage.Storage.move()` and
+  :meth:`~django.core.files.storage.Storage.copy()` methods
 
 File Uploads
 ^^^^^^^^^^^^

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -450,7 +450,6 @@ class FileStorageTests(FileStorageTestsBase):
             self.storage.move(src_name, '../../../../../../../../tmp/passwd')
 
 
-
 class CustomStorage(FileSystemStorage):
     def get_available_name(self, name):
         """


### PR DESCRIPTION
* implemented these methods in the default FileSystemStorage
* fix issue with storage tests: each test from FileStorageTests
   was run twice (when inheriting from a TestCase class all test_
   methods are ran in the subclass as well)

Previous incarnations of the same PR:

https://github.com/django/django/pull/1206
https://github.com/django/django/pull/2664
