### PR TITLE
Fixed #23753 -- Oracle failure with Coalesce

### DIFF
--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -56,6 +56,18 @@ class FunctionTests(TestCase):
             lambda a: a.headline
         )
 
+        # mixed Text and Char wrapped
+        article = Article.objects.annotate(
+            headline=Coalesce(Lower('summary'), Lower('text'), output_field=TextField()),
+        )
+
+        self.assertQuerysetEqual(
+            article.order_by('title'), [
+                lorem_ipsum.lower(),
+            ],
+            lambda a: a.headline
+        )
+
     def test_concat(self):
         Author.objects.create(name='Jayden')
         Author.objects.create(name='John Smith', alias='smithj', goes_by='John')


### PR DESCRIPTION
This fixes the Oracle errors on CI when mixing CharFields and TextFields. We cast each input to Coalesce to NCLOB when the output of the expression is expected to be TextField (database NCLOB). We can't do this with a converter because the inputs need to be cast, not just the output.
