### PR TITLE
[1.7.x] Fixed #24063 -- Locale code validation too strict

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -45,7 +45,10 @@ accept_language_re = re.compile(r'''
         (?:\s*,\s*|$)                                 # Multiple accepts per header.
         ''', re.VERBOSE)
 
-language_code_re = re.compile(r'^[a-z]{1,8}(?:-[a-z0-9]{1,8})*$', re.IGNORECASE)
+language_code_re = re.compile(
+    r'^[a-z]{1,8}(?:-[a-z0-9]{1,8})*(?:@[a-z0-9]{1,20})?$',
+    re.IGNORECASE
+)
 
 language_code_prefix_re = re.compile(r'^/([\w-]+)(/|$)')
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1335,8 +1335,11 @@ class CountrySpecificLanguageTests(TestCase):
         self.assertTrue(check_for_language('en'))
         self.assertTrue(check_for_language('en-us'))
         self.assertTrue(check_for_language('en-US'))
+        self.assertTrue(check_for_language('be'))
+        self.assertTrue(check_for_language('be@latin'))
         self.assertFalse(check_for_language('en-ü'))
         self.assertFalse(check_for_language('en\x00'))
+        self.assertFalse(check_for_language('be@ '))
 
     def test_get_language_from_request(self):
         # issue 19919


### PR DESCRIPTION
The locale code can contain variant after @, so let's allow the
validation of it to pass.

Backport of 7c4393689f2e54993d57958d02a4757d84133d50 from master.
