### PR TITLE
Fixed #23749 -- Added an example of using database routers in migrations

### DIFF
--- a/docs/ref/schema-editor.txt
+++ b/docs/ref/schema-editor.txt
@@ -149,3 +149,18 @@ If the database has the ``supports_combined_alters``, Django will try and
 do as many of these in a single database call as possible; otherwise, it will
 issue a separate ALTER statement for each change, but will not issue ALTERs
 where no change is required (as South often did).
+
+Attributes
+==========
+
+All attributes should be considered read-only, unless stated otherwise
+below.
+
+.. attribute:: SchemaEditor.connection
+
+A connection object to the database. A useful attribute of the connection is
+``alias`` which can be used to determine the name of the database being
+accessed.
+
+This in turn is useful when doing data migrations for :ref:`migrations with
+multiple database backends <data-migrations-and-multiple-databases>`.

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -467,6 +467,75 @@ You can pass a second callable to
 want executed when migrating backwards. If this callable is omitted, migrating
 backwards will raise an exception.
 
+.. _data-migrations-and-multiple-databases:
+
+Data migrations and multiple databases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One of the challenges that can be encountered is figuring out whether or not to
+run a migration when using multiple databases.
+
+For example, you may want to **only** run a migration against a particular
+database.
+
+In order to do that you can check the connection alias inside a ``RunPython``
+forwards and backwards operation by looking at the
+``schema_editor.connection.alias`` attribute::
+
+    from django.db import migrations
+
+    def forwards(apps, schema_editor):
+        if not schema_editor.connection.alias == 'master-db':
+            return
+        # Your migration code goes here
+
+    class Migration(migrations.Migration):
+
+        dependencies = [
+            # Dependencies to other migrations
+        ]
+
+        operations = [
+            migrations.RunPython(forwards),
+        ]
+
+You can also use your database router's ``allow_migrate`` method, but keep in
+mind that the imported router needs to stay around as long as it is referenced
+inside a migration:
+
+.. snippet::
+    :filename: myapp/dbrouters.py
+
+    class MyRouter(object):
+
+        def allow_migrate(self, db, model):
+            return db == 'default':
+
+Then, to leverage this in your migrations, do the following::
+
+    from django.db import models, migrations
+
+    from myappname.dbrouters import MyRouter
+
+    def forwards(apps, schema_editor):
+        MyModel = apps.get_model("myappname", "MyModel")
+        if not MyRouter().allow_migrate(schema_editor.connection.alias, MyModel):
+            return
+        # Your migration code goes here
+
+    class Migration(migrations.Migration):
+
+        dependencies = [
+            # Dependencies to other migrations
+        ]
+
+        operations = [
+            migrations.RunPython(forwards),
+        ]
+
+More advanced migrations
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 If you're interested in the more advanced migration operations, or want
 to be able to write your own, see the :doc:`migration operations reference
 </ref/migration-operations>`.


### PR DESCRIPTION
The ticket https://code.djangoproject.com/ticket/23749 explains the issue where the ```schema_editor.connection.alias``` should be documented.  It is now documented with some examples included.