### PR TITLE
Fixed: #23940 -- Added checks for 'exact' fieldnames

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -224,6 +224,15 @@ class Field(RegisterLookupMixin):
                     id='fields.E003',
                 )
             ]
+        elif self.name == 'exact':
+            return [
+                checks.Error(
+                    "'exact' is a reserved word that cannot be used as a field name.",
+                    hint=None,
+                    obj=self,
+                    id='fields.E008',
+                )
+            ]
         else:
             return []
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -78,6 +78,7 @@ Fields
   human readable name)`` tuples.
 * **fields.E006**: ``db_index`` must be ``None``, ``True`` or ``False``.
 * **fields.E007**: Primary keys must not have ``null=True``.
+* **fields.E008**: ``exact`` is a reserved word that cannot be used as a field.
 * **fields.E100**: ``AutoField``\s must set primary_key=True.
 * **fields.E110**: ``BooleanField``\s do not accept null values.
 * **fields.E120**: ``CharField``\s must define a ``max_length`` attribute.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -473,6 +473,9 @@ Models
 * You can now get the set of deferred fields for a model using
   :meth:`Model.get_deferred_fields() <django.db.models.Model.get_deferred_fields>`.
 
+* Added a system check on the base field to ensure no fields are given the name 
+  ``exact`` as this is conflicting with the SQL keyword.
+
 Signals
 ^^^^^^^
 

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -423,6 +423,21 @@ class FieldNamesTests(IsolatedModelsTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_exact(self):
+        class Model(models.Model):
+            exact = models.BooleanField()
+
+        errors = Model.check()
+        expected = [
+            Error(
+                "'exact' is a reserved word that cannot be used as a field name.",
+                hint=None,
+                obj=Model._meta.get_field('exact'),
+                id='fields.E008',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
 
 class ShadowingFieldsTests(IsolatedModelsTestCase):
 


### PR DESCRIPTION
Adds a system check on base field to ensure that no feilds are given the
name 'exact' as this is conflicting with the SQL keyword.