### PR TITLE
Removed formtools entries from MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,9 +21,6 @@ recursive-include django/contrib/admindocs/templates *
 recursive-include django/contrib/auth/fixtures *
 recursive-include django/contrib/auth/templates *
 recursive-include django/contrib/auth/tests/templates *
-recursive-include django/contrib/formtools/templates *
-recursive-include django/contrib/formtools/tests/templates *
-recursive-include django/contrib/formtools/tests/wizard/wizardtests/templates *
 recursive-include django/contrib/flatpages/fixtures *
 recursive-include django/contrib/flatpages/tests/templates *
 recursive-include django/contrib/gis/gdal/tests/data *


### PR DESCRIPTION
```
warning: no files found matching '*' under directory 'django/contrib/formtools/templates'
    warning: no files found matching '*' under directory 'django/contrib/formtools/tests/templates'
    warning: no files found matching '*' under directory 'django/contrib/formtools/tests/wizard/wizardtests/templates'
```