### PR TITLE
Renamed internally used flag for detecting managers built from QuerySets with as_manager()

### DIFF
--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -92,7 +92,7 @@ class BaseManager(object):
         Raises a ValueError if the manager is dynamically generated.
         """
         qs_class = self._queryset_class
-        if getattr(self, '_built_as_manager', False):
+        if getattr(self, '_built_with_as_manager', False):
             # using MyQuerySet.as_manager()
             return (
                 True,  # as_manager

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -68,7 +68,7 @@ class QuerySet(object):
         # Address the circular dependency between `Queryset` and `Manager`.
         from django.db.models.manager import Manager
         manager = Manager.from_queryset(cls)()
-        manager._built_as_manager = True
+        manager._built_with_as_manager = True
         return manager
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)


### PR DESCRIPTION
This rename is intended to prevent confusion with the variable naming which @loic pointed out to me.