### PR TITLE
Fixed #21231 -- Enforced a max size for POST values read into memory

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -290,6 +290,10 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 # data in form data requests, excluding file uploads.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
+# Maxinum number of fields in a form post that will be allowed before raising
+# a SuspiciousOperation.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 100
+
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory
 # (i.e. "/tmp" on *nix systems).

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -285,6 +285,11 @@ FILE_UPLOAD_HANDLERS = [
 # file system instead of into memory.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
+# Maximum size in bytes of request data before a SuspiciousOperation will
+# be raised.  This applies to accessing request.body and also to any
+# data in form data requests, excluding file uploads.
+DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
+
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory
 # (i.e. "/tmp" on *nix systems).

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -285,8 +285,8 @@ FILE_UPLOAD_HANDLERS = [
 # file system instead of into memory.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
-# Maximum size in bytes of request data before a SuspiciousOperation will
-# be raised.  This applies to accessing request.body and also to any
+# Maximum size in bytes of request data that will be read before raising a
+# SuspiciousOperation. This applies to accessing request.body and also to any
 # data in form data requests, excluding file uploads.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -292,7 +292,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Maximum number of keys in a POST request that will be allowed before raising
 # a SuspiciousOperation.
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 100
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
 
 # Directory in which upload streamed files will be temporarily saved. A value of
 # `None` will make Django use the operating system's default temporary directory

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -286,12 +286,25 @@ FILE_UPLOAD_HANDLERS = [
 FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Maximum size in bytes of request data that will be read before raising a
-# SuspiciousOperation. This applies to accessing request.body and also to any
-# data in form data requests, excluding file uploads.
+# SuspiciousOperation. This applies to any data in form data requests,
+# excluding file uploads. Since web servers typically do not do deep
+# request inspection it's not possible to limit there the amount of data Django
+# would have to process excluding file uploads. This amount of data is directly
+# correlated to the amount of memory needed to process the request and populate
+# the GET and POST dictionaries. As such, it could be used as an attack vector
+# if left unchecked. Installations that are supposed to receive form posts with
+# large values (> 2.5MB in total) should review the default value of this setting.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Maximum number of keys in a POST request that will be allowed before raising
-# a SuspiciousOperation.
+# a SuspiciousOperation. Since web servers typically do not do deep request
+# inspection it's not possible to limit there the amount of parameters Django
+# would have to process. This number of parameters is directly correlated to
+# the amount of time needed to process the request and populate the GET and
+# POST dictionaries. As such, it could be used as an attack vector if left
+# unchecked. Installations that are supposed to receive form posts with a
+# large number (> 1000) of parameters should review the default value of this
+# setting.
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
 
 # Directory in which upload streamed files will be temporarily saved. A value of

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -287,24 +287,11 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Maximum size in bytes of request data that will be read before raising a
 # SuspiciousOperation. This applies to any data in form data requests,
-# excluding file uploads. Since web servers typically do not do deep
-# request inspection it's not possible to limit there the amount of data Django
-# would have to process excluding file uploads. This amount of data is directly
-# correlated to the amount of memory needed to process the request and populate
-# the GET and POST dictionaries. As such, it could be used as an attack vector
-# if left unchecked. Installations that are supposed to receive form posts with
-# large values (> 2.5MB in total) should review the default value of this setting.
+# excluding file uploads.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
 # Maximum number of keys in a POST request that will be allowed before raising
-# a SuspiciousOperation. Since web servers typically do not do deep request
-# inspection it's not possible to limit there the amount of parameters Django
-# would have to process. This number of parameters is directly correlated to
-# the amount of time needed to process the request and populate the GET and
-# POST dictionaries. As such, it could be used as an attack vector if left
-# unchecked. Installations that are supposed to receive form posts with a
-# large number (> 1000) of parameters should review the default value of this
-# setting.
+# a SuspiciousOperation.
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
 
 # Directory in which upload streamed files will be temporarily saved. A value of

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -290,7 +290,7 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 # data in form data requests, excluding file uploads.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440  # i.e. 2.5 MB
 
-# Maxinum number of fields in a form post that will be allowed before raising
+# Maximum number of keys in a POST request that will be allowed before raising
 # a SuspiciousOperation.
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 100
 

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -61,9 +61,9 @@ class TooManyFieldsSent(SuspiciousOperation):
     pass
 
 
-class RequestBodyTooBig(SuspiciousOperation):
+class RequestDataTooBig(SuspiciousOperation):
     """
-    The size of the request body (excluding any file uploads)
+    The size of the request (excluding any file uploads)
     exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
     """
     pass

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -53,6 +53,16 @@ class DisallowedRedirect(SuspiciousOperation):
     pass
 
 
+class TooManyFieldsSent(SuspiciousOperation):
+    """Request has too many fields to parse"""
+    pass
+
+
+class RequestBodyTooBig(SuspiciousOperation):
+    """Request is too big to parse"""
+    pass
+
+
 class PermissionDenied(Exception):
     """The user did not have permission to do that"""
     pass

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -54,12 +54,18 @@ class DisallowedRedirect(SuspiciousOperation):
 
 
 class TooManyFieldsSent(SuspiciousOperation):
-    """Request has too many fields to parse"""
+    """
+    The number of fields in a POST request exceeded
+    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.
+    """
     pass
 
 
 class RequestBodyTooBig(SuspiciousOperation):
-    """Request is too big to parse"""
+    """
+    The size of the request body (excluding any file uploads)
+    exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.
+    """
     pass
 
 

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -13,7 +13,7 @@ import sys
 
 from django.conf import settings
 from django.core.exceptions import (
-    RequestBodyTooBig, SuspiciousMultipartForm, TooManyFieldsSent,
+    RequestDataTooBig, SuspiciousMultipartForm, TooManyFieldsSent,
 )
 from django.core.files.uploadhandler import (
     SkipFile, StopFutureHandlers, StopUpload,
@@ -202,8 +202,8 @@ class MultiPartParser(object):
                     self._data_size += len(field_name) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
                             (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
-                        raise RequestBodyTooBig(
-                            'The size of the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
+                        raise RequestDataTooBig(
+                            'The amount of data in the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
                         )
 
                     self._post.appendlist(field_name,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -173,7 +173,8 @@ class MultiPartParser(object):
                 if item_type == FIELD:
                     # avoid storing more than DATA_UPLOAD_MAX_NUMBER_FIELDS
                     num_inserted_fields += 1
-                    if settings.DATA_UPLOAD_MAX_NUMBER_FIELDS is not None and settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < num_inserted_fields:
+                    if (settings.DATA_UPLOAD_MAX_NUMBER_FIELDS is not None and
+                    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < num_inserted_fields):
                         raise SuspiciousOperation('Too many fields')
 
                     # avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
@@ -192,7 +193,8 @@ class MultiPartParser(object):
                         data = field_stream.read(**read_kwargs)
 
                     self._data_size += len(field_name) + len(data) + 2
-                    if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and field_stream.read(1):
+                    if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
+                    (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
                         raise SuspiciousOperation('Request data too large')
 
                     self._post.appendlist(field_name,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -199,7 +199,7 @@ class MultiPartParser(object):
                     # check that also includes '&='
                     self._data_size += len(field_name) + len(data) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
-                    (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
+                            (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
                         raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
                     self._post.appendlist(field_name,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -103,7 +103,7 @@ class MultiPartParser(object):
         self._encoding = encoding or settings.DEFAULT_CHARSET
         self._content_length = content_length
         self._upload_handlers = upload_handlers
-
+        # Number of bytes that have been read.
         self._data_size = 0
 
     def parse(self):
@@ -147,9 +147,9 @@ class MultiPartParser(object):
         old_field_name = None
         counters = [0] * len(handlers)
 
-        # To count the number of fields
-        num_inserted_fields = 0
-
+        # To count the number of keys in the request.
+        num_post_keys = 0
+        # To limit the amount of data read from the request.
         read_kwargs = {}
 
         try:
@@ -173,13 +173,13 @@ class MultiPartParser(object):
                 field_name = force_text(field_name, encoding, errors='replace')
 
                 if item_type == FIELD:
-                    # avoid storing more than DATA_UPLOAD_MAX_NUMBER_FIELDS
-                    num_inserted_fields += 1
+                    # Avoid storing more than DATA_UPLOAD_MAX_NUMBER_FIELDS
+                    num_post_keys += 1
                     if (settings.DATA_UPLOAD_MAX_NUMBER_FIELDS is not None and
-                    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < num_inserted_fields):
+                            settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < num_post_keys):
                         raise SuspiciousOperation('Too many fields')
 
-                    # avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
+                    # Avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
                     if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None:
                         read_kwargs = {'size': settings.DATA_UPLOAD_MAX_MEMORY_SIZE - self._data_size}
 

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -150,7 +150,7 @@ class MultiPartParser(object):
         # To count the number of keys in the request.
         num_post_keys = 0
         # To limit the amount of data read from the request.
-        read_kwargs = {}
+        read_size = None
 
         try:
             for item_type, meta_data, field_stream in Parser(stream, self._boundary):
@@ -181,17 +181,17 @@ class MultiPartParser(object):
 
                     # Avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
                     if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None:
-                        read_kwargs = {'size': settings.DATA_UPLOAD_MAX_MEMORY_SIZE - self._data_size}
+                        read_size = settings.DATA_UPLOAD_MAX_MEMORY_SIZE - self._data_size
 
                     # This is a post field, we can just set it in the post
                     if transfer_encoding == 'base64':
-                        raw_data = field_stream.read(**read_kwargs)
+                        raw_data = field_stream.read(size=read_size)
                         try:
                             data = base64.b64decode(raw_data)
                         except _BASE64_DECODE_ERROR:
                             data = raw_data
                     else:
-                        data = field_stream.read(**read_kwargs)
+                        data = field_stream.read(size=read_size)
 
                     self._data_size += len(field_name) + len(data) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -197,7 +197,7 @@ class MultiPartParser(object):
                         data = field_stream.read(size=read_size)
                         self._data_size += len(data)
 
-                    # We add 2 here to make the check consistent with the GET
+                    # We add 2 here to make the check consistent with the x-www-form-urlencoded
                     # check that also includes '&='
                     self._data_size += len(field_name) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -13,7 +13,7 @@ import sys
 
 from django.conf import settings
 from django.core.exceptions import (
-    RequestBodyTooBig, SuspiciousMultipartForm, TooManyFieldsSent
+    RequestBodyTooBig, SuspiciousMultipartForm, TooManyFieldsSent,
 )
 from django.core.files.uploadhandler import (
     SkipFile, StopFutureHandlers, StopUpload,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -202,7 +202,9 @@ class MultiPartParser(object):
                     self._data_size += len(field_name) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
                             (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
-                        raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
+                        raise RequestBodyTooBig(
+                            'The size of the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
+                        )
 
                     self._post.appendlist(field_name,
                                           force_text(data, encoding, errors='replace'))

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -193,6 +193,8 @@ class MultiPartParser(object):
                     else:
                         data = field_stream.read(size=read_size)
 
+                    # We add 2 here to make the check consistent with the GET
+                    # check that also includes '&='
                     self._data_size += len(field_name) + len(data) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
                     (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -104,9 +104,6 @@ class MultiPartParser(object):
         self._content_length = content_length
         self._upload_handlers = upload_handlers
 
-        # Limit the maximum request data size that will be parsed and stored in
-        # memory. File upload data is not included against this limit.
-        self._max_data_size = settings.DATA_UPLOAD_MAX_MEMORY_SIZE
         self._data_size = 0
 
     def parse(self):
@@ -172,8 +169,8 @@ class MultiPartParser(object):
 
                 if item_type == FIELD:
                     # avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
-                    if self._max_data_size is not None:
-                        read_kwargs = {'size': self._max_data_size - self._data_size}
+                    if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None:
+                        read_kwargs = {'size': settings.DATA_UPLOAD_MAX_MEMORY_SIZE - self._data_size}
                     else:
                         read_kwargs = {}
                     # This is a post field, we can just set it in the post
@@ -186,8 +183,8 @@ class MultiPartParser(object):
                     else:
                         data = field_stream.read(**read_kwargs)
 
-                    self._data_size += len(field_name) + len(data)
-                    if self._max_data_size is not None and field_stream.read(1):
+                    self._data_size += len(field_name) + len(data) + 2
+                    if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and field_stream.read(1):
                         raise SuspiciousOperation('Request data too large')
 
                     self._post.appendlist(field_name,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -12,7 +12,9 @@ import cgi
 import sys
 
 from django.conf import settings
-from django.core.exceptions import SuspiciousMultipartForm, SuspiciousOperation
+from django.core.exceptions import (
+    RequestBodyTooBig, SuspiciousMultipartForm, TooManyFieldsSent
+)
 from django.core.files.uploadhandler import (
     SkipFile, StopFutureHandlers, StopUpload,
 )
@@ -177,7 +179,7 @@ class MultiPartParser(object):
                     num_post_keys += 1
                     if (settings.DATA_UPLOAD_MAX_NUMBER_FIELDS is not None and
                             settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < num_post_keys):
-                        raise SuspiciousOperation('Too many fields')
+                        raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
 
                     # Avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
                     if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None:
@@ -198,7 +200,7 @@ class MultiPartParser(object):
                     self._data_size += len(field_name) + len(data) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
                     (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
-                        raise SuspiciousOperation('Request data too large')
+                        raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
                     self._post.appendlist(field_name,
                                           force_text(data, encoding, errors='replace'))

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -188,16 +188,18 @@ class MultiPartParser(object):
                     # This is a post field, we can just set it in the post
                     if transfer_encoding == 'base64':
                         raw_data = field_stream.read(size=read_size)
+                        self._data_size += len(raw_data)
                         try:
                             data = base64.b64decode(raw_data)
                         except _BASE64_DECODE_ERROR:
                             data = raw_data
                     else:
                         data = field_stream.read(size=read_size)
+                        self._data_size += len(data)
 
                     # We add 2 here to make the check consistent with the GET
                     # check that also includes '&='
-                    self._data_size += len(field_name) + len(data) + 2
+                    self._data_size += len(field_name) + 2
                     if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
                             (self._data_size > settings.DATA_UPLOAD_MAX_MEMORY_SIZE or field_stream.read(1))):
                         raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -150,6 +150,8 @@ class MultiPartParser(object):
         # To count the number of fields
         num_inserted_fields = 0
 
+        read_kwargs = {}
+
         try:
             for item_type, meta_data, field_stream in Parser(stream, self._boundary):
                 if old_field_name:
@@ -180,8 +182,7 @@ class MultiPartParser(object):
                     # avoid reading more than DATA_UPLOAD_MAX_MEMORY_SIZE
                     if settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None:
                         read_kwargs = {'size': settings.DATA_UPLOAD_MAX_MEMORY_SIZE - self._data_size}
-                    else:
-                        read_kwargs = {}
+
                     # This is a post field, we can just set it in the post
                     if transfer_encoding == 'base64':
                         raw_data = field_stream.read(**read_kwargs)

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -19,9 +19,7 @@ from django.utils.datastructures import ImmutableList, MultiValueDict
 from django.utils.encoding import (
     escape_uri_path, force_bytes, force_str, force_text, iri_to_uri,
 )
-from django.utils.http import (
-    is_same_domain, limited_parse_qsl_py2, limited_parse_qsl_py3,
-)
+from django.utils.http import is_same_domain, limited_parse_qsl
 from django.utils.six.moves.urllib.parse import (
     quote, urlencode, urljoin, urlsplit,
 )
@@ -397,10 +395,10 @@ class QueryDict(MultiValueDict):
                 except UnicodeDecodeError:
                     # ... but some user agents are misbehaving :-(
                     query_string = query_string.decode('iso-8859-1')
-            for key, value in limited_parse_qsl_py3(query_string, **parse_qsl_kwargs):
+            for key, value in limited_parse_qsl(query_string, **parse_qsl_kwargs):
                 self.appendlist(key, value)
         else:
-            for key, value in limited_parse_qsl_py2(query_string, **parse_qsl_kwargs):
+            for key, value in limited_parse_qsl(query_string, **parse_qsl_kwargs):
                 try:
                     value = value.decode(encoding)
                 except UnicodeDecodeError:

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -9,7 +9,7 @@ from itertools import chain
 from django.conf import settings
 from django.core import signing
 from django.core.exceptions import (
-    DisallowedHost, ImproperlyConfigured, SuspiciousOperation,
+    DisallowedHost, ImproperlyConfigured, RequestBodyTooBig, SuspiciousOperation
 )
 from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser, MultiPartParserError
@@ -301,7 +301,7 @@ class HttpRequest(object):
 
                 if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
                         and content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
-                    raise SuspiciousOperation('Request data too large')
+                    raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
                 self._post, self._files = QueryDict(self.body, encoding=self._encoding), MultiValueDict()
             else:

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -18,7 +18,9 @@ from django.utils.datastructures import ImmutableList, MultiValueDict
 from django.utils.encoding import (
     escape_uri_path, force_bytes, force_str, force_text, iri_to_uri,
 )
-from django.utils.http import is_same_domain, limited_parse_qsl_py2, limited_parse_qsl_py3
+from django.utils.http import (
+    is_same_domain, limited_parse_qsl_py2, limited_parse_qsl_py3,
+)
 from django.utils.six.moves.urllib.parse import (
     quote, urlencode, urljoin, urlsplit,
 )

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -9,7 +9,8 @@ from itertools import chain
 from django.conf import settings
 from django.core import signing
 from django.core.exceptions import (
-    DisallowedHost, ImproperlyConfigured, RequestBodyTooBig, SuspiciousOperation
+    DisallowedHost, ImproperlyConfigured, RequestBodyTooBig,
+    SuspiciousOperation,
 )
 from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser, MultiPartParserError

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -8,7 +8,9 @@ from itertools import chain
 
 from django.conf import settings
 from django.core import signing
-from django.core.exceptions import DisallowedHost, ImproperlyConfigured, SuspiciousOperation
+from django.core.exceptions import (
+    DisallowedHost, ImproperlyConfigured, SuspiciousOperation,
+)
 from django.core.files import uploadhandler
 from django.http.multipartparser import MultiPartParser, MultiPartParserError
 from django.utils import six

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -387,6 +387,7 @@ class QueryDict(MultiValueDict):
         parse_qsl_kwargs = {
             'keep_blank_values': True,
             'fields_limit': settings.DATA_UPLOAD_MAX_NUMBER_FIELDS,
+            'encoding': encoding,
         }
         if six.PY3:
             parse_qsl_kwargs['encoding'] = encoding

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -381,6 +381,7 @@ class QueryDict(MultiValueDict):
         if not encoding:
             encoding = settings.DEFAULT_CHARSET
         self.encoding = encoding
+        self.num_inserted_items = 0
         if six.PY3:
             if isinstance(query_string, bytes):
                 # query_string normally contains URL-encoded data, a subset of ASCII.
@@ -456,6 +457,9 @@ class QueryDict(MultiValueDict):
         key = bytes_to_text(key, self.encoding)
         value = bytes_to_text(value, self.encoding)
         super(QueryDict, self).appendlist(key, value)
+        self.num_inserted_items += 1
+        if settings.DATA_UPLOAD_MAX_NUMBER_FIELDS is not None and settings.DATA_UPLOAD_MAX_NUMBER_FIELDS < self.num_inserted_items:
+            raise SuspiciousOperation('Too many fields')
 
     def pop(self, key, *args):
         self._assert_mutable()

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -390,7 +390,6 @@ class QueryDict(MultiValueDict):
             'encoding': encoding,
         }
         if six.PY3:
-            parse_qsl_kwargs['encoding'] = encoding
             if isinstance(query_string, bytes):
                 # query_string normally contains URL-encoded data, a subset of ASCII.
                 try:

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -9,7 +9,7 @@ from itertools import chain
 from django.conf import settings
 from django.core import signing
 from django.core.exceptions import (
-    DisallowedHost, ImproperlyConfigured, RequestBodyTooBig,
+    DisallowedHost, ImproperlyConfigured, RequestDataTooBig,
     SuspiciousOperation,
 )
 from django.core.files import uploadhandler
@@ -300,7 +300,7 @@ class HttpRequest(object):
 
                 if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None
                         and content_length > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
-                    raise RequestBodyTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
+                    raise RequestDataTooBig('Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
                 self._post, self._files = QueryDict(self.body, encoding=self._encoding), MultiValueDict()
             else:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -314,7 +314,11 @@ def is_safe_url(url, host=None):
 
 
 # Functions lifted from their respective modules in order to implement
-# several checks which were not possible with the stdlib
+# several checks which were not possible with the stdlib, namely limiting
+# the number of fields that will be parsed.
+#
+# Copyright (C) 2013 Python Software Foundation, see license.python.txt for
+# details.
 def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limit=None):
     """
     Parse a query given as a string argument and return a list.

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -320,7 +320,7 @@ def is_safe_url(url, host=None):
 #
 # Copyright (C) 2013 Python Software Foundation, see license.python.txt for
 # details.
-def limited_parse_qsl_py2(qs, encoding, keep_blank_values=0, strict_parsing=0, fields_limit=None):
+def limited_parse_qsl_py2(qs, encoding, keep_blank_values=0, fields_limit=None):
     """
     Parse a query given as a string argument and return a list.
 
@@ -338,10 +338,6 @@ def limited_parse_qsl_py2(qs, encoding, keep_blank_values=0, strict_parsing=0, f
         strings.  The default false value indicates that blank values
         are to be ignored and treated as if they were  not included.
 
-    strict_parsing: flag indicating what to do with parsing errors. If
-        false (the default), errors are silently ignored. If true,
-        errors raise a ValueError exception.
-
     fields_limit: maximum number of fields parsed, or an exception
         is raised. None means no limit and is the default.
     """
@@ -354,12 +350,10 @@ def limited_parse_qsl_py2(qs, encoding, keep_blank_values=0, strict_parsing=0, f
         pairs = FIELDS_MATCH.split(qs)
     r = []
     for name_value in pairs:
-        if not name_value and not strict_parsing:
+        if not name_value:
             continue
         nv = name_value.split(b'=', 1)
         if len(nv) != 2:
-            if strict_parsing:
-                raise ValueError("bad query field: %r" % (name_value,))
             # Handle case of a control-name with no equal sign
             if keep_blank_values:
                 nv.append(b'')

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -40,6 +40,7 @@ PROTOCOL_TO_PORT = {
     'https': 443,
 }
 
+FIELDS_MATCH = re.compile('[&;]')
 
 @keep_lazy_text
 def urlquote(url, safe='/'):
@@ -342,10 +343,13 @@ def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limi
     fields_limit: maximum number of fields parsed, or an exception
         is raised. None means no limit and is the default.
     """
-    fields_limit = fields_limit or 0
-    pairs = re.split('[&;]', qs, fields_limit)
-    if fields_limit > 0 and len(pairs) > fields_limit:
-        raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+
+    if fields_limit:
+        pairs = FIELDS_MATCH.split(qs, fields_limit)
+        if len(pairs) > fields_limit:
+             raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+    else:
+        pairs = FIELDS_MATCH.split(qs)
     r = []
     for name_value in pairs:
         if not name_value and not strict_parsing:
@@ -427,11 +431,13 @@ def limited_parse_qsl_py3(qs, keep_blank_values=False, strict_parsing=False,
     fields_limit: maximum number of fields parsed or an exception
         is raised. None means no limit and is the default.
     """
-    fields_limit = fields_limit or 0
     qs, _coerce_result = _coerce_args(qs)
-    pairs = re.split('[&;]', qs, fields_limit)
-    if fields_limit > 0 and len(pairs) > fields_limit:
-        raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+    if fields_limit:
+        pairs = FIELDS_MATCH.split(qs, fields_limit)
+        if len(pairs) > fields_limit:
+             raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+    else:
+        pairs = FIELDS_MATCH.split(qs)
     r = []
     for name_value in pairs:
         if not name_value and not strict_parsing:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -320,7 +320,7 @@ def is_safe_url(url, host=None):
 #
 # Copyright (C) 2013 Python Software Foundation, see license.python.txt for
 # details.
-def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limit=None):
+def limited_parse_qsl_py2(qs, encoding, keep_blank_values=0, strict_parsing=0, fields_limit=None):
     """
     Parse a query given as a string argument and return a list.
 
@@ -329,6 +329,8 @@ def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limi
     Arguments:
 
     qs: percent-encoded query string to be parsed
+
+    encoding: ignored value
 
     keep_blank_values: flag indicating whether blank values in
         percent-encoded queries should be treated as blank strings.  A

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -9,7 +9,7 @@ import unicodedata
 from binascii import Error as BinasciiError
 from email.utils import formatdate
 
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import TooManyFieldsSent
 from django.utils import six
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_bytes, force_str, force_text
@@ -345,7 +345,7 @@ def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limi
     fields_limit = fields_limit or 0
     pairs = re.split('[&;]', qs, fields_limit)
     if fields_limit > 0 and len(pairs) > fields_limit:
-        raise SuspiciousOperation('Too many fields')
+        raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
     r = []
     for name_value in pairs:
         if not name_value and not strict_parsing:
@@ -431,7 +431,7 @@ def limited_parse_qsl_py3(qs, keep_blank_values=False, strict_parsing=False,
     qs, _coerce_result = _coerce_args(qs)
     pairs = re.split('[&;]', qs, fields_limit)
     if fields_limit > 0 and len(pairs) > fields_limit:
-        raise SuspiciousOperation('Too many fields')
+        raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
     r = []
     for name_value in pairs:
         if not name_value and not strict_parsing:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -312,13 +312,14 @@ def is_safe_url(url, host=None):
     return ((not url_info.netloc or url_info.netloc == host) and
             (not url_info.scheme or url_info.scheme in ['http', 'https']))
 
+
 # Functions lifted from their respective modules in order to implement
 # several checks which were not possible with the stdlib
+def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limit=None):
+    """
+    Parse a query given as a string argument and return a list.
 
-
-def parse_qsl2(qs, keep_blank_values=0, strict_parsing=0, fields_limit=0):
-    """Parse a query given as a string argument. Lifted from
-    urlparse.
+    Lifted from urlparse with an additional "fields_limit" argument.
 
     Arguments:
 
@@ -335,10 +336,9 @@ def parse_qsl2(qs, keep_blank_values=0, strict_parsing=0, fields_limit=0):
         errors raise a ValueError exception.
 
     fields_limit: maximum number of fields parsed, or an exception
-        is raised. 0 means no limit and is the default.
-
-    Returns a list, as G-d intended.
+        is raised. None means no limit and is the default.
     """
+    fields_limit = fields_limit or 0
     pairs = re.split('[&;]', qs, fields_limit)
     if fields_limit > 0 and len(pairs) > fields_limit:
         raise SuspiciousOperation('Too many fields')
@@ -396,9 +396,12 @@ def _coerce_args(*args):
     return _decode_args(args) + (_encode_result,)
 
 
-def parse_qsl3(qs, keep_blank_values=False, strict_parsing=False,
-               encoding='utf-8', errors='replace', fields_limit=0):
-    """Parse a query given as a string argument. Lifted from urllib.
+def limited_parse_qsl_py3(qs, keep_blank_values=False, strict_parsing=False,
+               encoding='utf-8', errors='replace', fields_limit=None):
+    """
+    Parse a query given as a string argument and return a list.
+
+    Lifted from urlparse with an additional "fields_limit" argument.
 
     Arguments:
 
@@ -417,11 +420,10 @@ def parse_qsl3(qs, keep_blank_values=False, strict_parsing=False,
     encoding and errors: specify how to decode percent-encoded sequences
         into Unicode characters, as accepted by the bytes.decode() method.
 
-    fields_limit: maximum number of fields parsed, or an exception
-        is raised. 0 means no limit and is the default.
-
-    Returns a list, as G-d intended.
+    fields_limit: maximum number of fields parsed or an exception
+        is raised. None means no limit and is the default.
     """
+    fields_limit = fields_limit or 0
     qs, _coerce_result = _coerce_args(qs)
     pairs = re.split('[&;]', qs, fields_limit)
     if fields_limit > 0 and len(pairs) > fields_limit:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -353,7 +353,7 @@ def limited_parse_qsl(qs, keep_blank_values=False,
     for name_value in pairs:
         if not name_value:
             continue
-        nv = name_value.split('=' if six.PY3 else b'=', 1)
+        nv = name_value.split(str('='), 1)
         if len(nv) != 2:
             # Handle case of a control-name with no equal sign
             if keep_blank_values:

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -347,7 +347,7 @@ def limited_parse_qsl_py2(qs, keep_blank_values=0, strict_parsing=0, fields_limi
     if fields_limit:
         pairs = FIELDS_MATCH.split(qs, fields_limit)
         if len(pairs) > fields_limit:
-             raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+            raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
     else:
         pairs = FIELDS_MATCH.split(qs)
     r = []
@@ -435,7 +435,7 @@ def limited_parse_qsl_py3(qs, keep_blank_values=False, strict_parsing=False,
     if fields_limit:
         pairs = FIELDS_MATCH.split(qs, fields_limit)
         if len(pairs) > fields_limit:
-             raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+            raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
     else:
         pairs = FIELDS_MATCH.split(qs)
     r = []

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -42,6 +42,7 @@ PROTOCOL_TO_PORT = {
 
 FIELDS_MATCH = re.compile('[&;]')
 
+
 @keep_lazy_text
 def urlquote(url, safe='/'):
     """

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -346,7 +346,9 @@ def limited_parse_qsl(qs, keep_blank_values=False,
     if fields_limit:
         pairs = FIELDS_MATCH.split(qs, fields_limit)
         if len(pairs) > fields_limit:
-            raise TooManyFieldsSent('Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.')
+            raise TooManyFieldsSent(
+                'The number of fields in a POST request exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.'
+            )
     else:
         pairs = FIELDS_MATCH.split(qs)
     r = []

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -888,6 +888,20 @@ or with a large number of fields, this limit may need to be increased.
 
 See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 
+.. setting:: DATA_UPLOAD_MAX_NUMBER_FIELDS
+
+DATA_UPLOAD_MAX_NUMBER_FIELDS
+-----------------------------
+
+.. versionadded:: 1.9
+
+Default: ``100``
+
+The maximum number of parameters received either via GET, or FORM POST before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. You can set it to
+``None`` to disable the check. When processing forms with a very large number
+of fields, this limit may need to be increased.
+
 .. setting:: DATABASE_ROUTERS
 
 ``DATABASE_ROUTERS``
@@ -3256,6 +3270,7 @@ Globalization (``i18n``/``l10n``)
 HTTP
 ----
 * :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE`
+* :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS`
 * :setting:`DEFAULT_CHARSET`
 * :setting:`DEFAULT_CONTENT_TYPE`
 * :setting:`DISALLOWED_USER_AGENTS`

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -870,6 +870,23 @@ This is an Oracle-specific setting.
 
 The maximum size that the DATAFILE_TMP is allowed to grow to.
 
+.. setting:: DATA_UPLOAD_MAX_MEMORY_SIZE
+
+DATA_UPLOAD_MAX_MEMORY_SIZE
+---------------------------
+
+.. versionadded:: 1.9
+
+Default: ``2621440`` (i.e. 2.5 MB).
+
+The maximum size (in bytes) that a request body may be before raising a
+:exc:`~django.core.exceptions.SuspiciousOperation` error. This value is applied
+when accessing ``request.body`` or ``request.POST`` and is calculated against
+the total request size excluding any file upload data. You can set it to
+``None`` to disable the check.
+
+See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
+
 .. setting:: DATABASE_ROUTERS
 
 ``DATABASE_ROUTERS``
@@ -1316,6 +1333,8 @@ Default: ``2621440`` (i.e. 2.5 MB).
 
 The maximum size (in bytes) that an upload will be before it gets streamed to
 the file system. See :doc:`/topics/files` for details.
+
+See also :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE`.
 
 .. setting:: FILE_UPLOAD_DIRECTORY_PERMISSIONS
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -884,7 +884,14 @@ The maximum size (in bytes) that a request body may be before a
 when accessing ``request.body`` or ``request.POST`` and is calculated against
 the total request size excluding any file upload data. You can set it to
 ``None`` to disable the check. When processing forms with very large field values,
-or with a large number of fields, this limit may need to be increased.
+or with a large number of fields, this limit may need to be increased. Since web
+servers typically do not do deep request inspection it's not possible to limit
+there the amount of data Django would have to process excluding file uploads.
+This amount of data is directly correlated to the amount of memory needed to
+process the request and populate the GET and POST dictionaries. As such, it could
+be used as an attack vector if left unchecked. Installations that are supposed to
+receive form posts with large values (> 2.5MB in total) should review the default
+value of this setting.
 
 See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 
@@ -900,7 +907,14 @@ Default: ``1000``
 The maximum number of parameters received either via GET, or FORM POST before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised. You can set it to
 ``None`` to disable the check. When processing forms with a very large number
-of fields, this limit may need to be increased.
+of fields, this limit may need to be increased. Since web servers typically do
+not do deep request inspection it's not possible to limit there the amount of
+parameters Django would have to process. This number of parameters is directly
+correlated to the amount of time needed to process the request and populate the
+GET and POST dictionaries. As such, it could be used as an attack vector if
+left unchecked. Installations that are supposed to receive form posts with a
+large number (> 1000) of parameters should review the default value of this
+setting.
 
 .. setting:: DATABASE_ROUTERS
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -875,7 +875,7 @@ The maximum size that the DATAFILE_TMP is allowed to grow to.
 DATA_UPLOAD_MAX_MEMORY_SIZE
 ---------------------------
 
-.. versionadded:: 1.9
+.. versionadded:: 1.10
 
 Default: ``2621440`` (i.e. 2.5 MB).
 
@@ -893,7 +893,7 @@ See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 DATA_UPLOAD_MAX_NUMBER_FIELDS
 -----------------------------
 
-.. versionadded:: 1.9
+.. versionadded:: 1.10
 
 Default: ``1000``
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -895,7 +895,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS
 
 .. versionadded:: 1.9
 
-Default: ``100``
+Default: ``1000``
 
 The maximum number of parameters received either via GET, or FORM POST before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised. You can set it to

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -879,11 +879,12 @@ DATA_UPLOAD_MAX_MEMORY_SIZE
 
 Default: ``2621440`` (i.e. 2.5 MB).
 
-The maximum size (in bytes) that a request body may be before raising a
-:exc:`~django.core.exceptions.SuspiciousOperation` error. This value is applied
+The maximum size (in bytes) that a request body may be before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. This value is applied
 when accessing ``request.body`` or ``request.POST`` and is calculated against
 the total request size excluding any file upload data. You can set it to
-``None`` to disable the check.
+``None`` to disable the check. When processing forms with very large field values,
+or with a large number of fields, this limit may need to be increased.
 
 See also :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE`.
 
@@ -3254,6 +3255,7 @@ Globalization (``i18n``/``l10n``)
 
 HTTP
 ----
+* :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE`
 * :setting:`DEFAULT_CHARSET`
 * :setting:`DEFAULT_CONTENT_TYPE`
 * :setting:`DISALLOWED_USER_AGENTS`

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -25,7 +25,7 @@ What's new in Django 1.10
 =========================
 
 Maximum size of a request body is now limited
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------------
 
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
@@ -33,7 +33,7 @@ request body may be before a
 not count towards this limit.
 
 Maximum number of form parameters is now limited
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------
 
 The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
 form fields parsed before a

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -24,6 +24,21 @@ recommend** and only officially support the latest release of each series.
 What's new in Django 1.10
 =========================
 
+Maximum size of a request body is now limited
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
+request body may be before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
+not count towards this limit.
+
+Maximum number of form parameters is now limited
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
+form fields parsed before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
+
 ...
 
 Minor features

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -822,7 +822,7 @@ Maximum number of form parameters is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
-form parameters parsed before a
+form fields parsed before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised.
 
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -815,9 +815,8 @@ Maximum size of a request body is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
-request body may be before raising a
-:exc:`~django.core.exceptions.SuspiciousOperation` error. See its documentation
-for more details.
+request body may be before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
 
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -816,7 +816,8 @@ Maximum size of a request body is now limited
 
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
+not count towards this limit.
 
 Maximum number of form parameters is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -811,6 +811,13 @@ by ``ForeignKey`` and ``GenericForeignKey`` changed from a series of
 ``Model.save()`` calls to a single ``QuerySet.update()`` call. The change means
 that ``pre_save`` and ``post_save`` signals aren't sent anymore. You can use
 the ``bulk=False`` keyword argument to revert to the previous behavior.
+Maximum size of a request body is now limited
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
+request body may be before raising a
+:exc:`~django.core.exceptions.SuspiciousOperation` error. See its documentation
+for more details.
 
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -811,6 +811,7 @@ by ``ForeignKey`` and ``GenericForeignKey`` changed from a series of
 ``Model.save()`` calls to a single ``QuerySet.update()`` call. The change means
 that ``pre_save`` and ``post_save`` signals aren't sent anymore. You can use
 the ``bulk=False`` keyword argument to revert to the previous behavior.
+
 Maximum size of a request body is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -818,6 +818,13 @@ The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised.
 
+Maximum number of form parameters is now limited
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
+form parameters parsed before a
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
+
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -818,12 +818,12 @@ Maximum size of a request body is now limited
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
-not count towards this limit. Since frontend servers typically do not do deep
+not count towards this limit. Since web servers typically do not do deep
 request inspection it's not possible to limit there the amount of data Django
 would have to process excluding file uploads. This amount of data is directly
 correlated to the amount of memory needed to process the request and populate
 the GET and POST dictionaries. As such, it could be used as an attack vector
-if left unchecked. Instalations that are supposed to receive form posts with
+if left unchecked. Installations that are supposed to receive form posts with
 large values should review the default value of this setting.
 
 Maximum number of form parameters is now limited
@@ -831,7 +831,7 @@ Maximum number of form parameters is now limited
 
 The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
 form fields parsed before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised. Since frontend
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. Since web
 servers typically do not do deep request inspection it's not possible to limit
 there the amount of parameters Django would have to process. This number of
 parameters is directly correlated to the amount of time needed to process the

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -818,27 +818,14 @@ Maximum size of a request body is now limited
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
-not count towards this limit. Since web servers typically do not do deep
-request inspection it's not possible to limit there the amount of data Django
-would have to process excluding file uploads. This amount of data is directly
-correlated to the amount of memory needed to process the request and populate
-the GET and POST dictionaries. As such, it could be used as an attack vector
-if left unchecked. Installations that are supposed to receive form posts with
-large values should review the default value of this setting.
+not count towards this limit.
 
 Maximum number of form parameters is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
 form fields parsed before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised. Since web
-servers typically do not do deep request inspection it's not possible to limit
-there the amount of parameters Django would have to process. This number of
-parameters is directly correlated to the amount of time needed to process the
-request and populate the GET and POST dictionaries. As such, it could be used
-as an attack vector if left unchecked. Installations that are supposed to
-receive form posts with a large number of parameters should review the default
-value of this setting.
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
 
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -812,21 +812,6 @@ by ``ForeignKey`` and ``GenericForeignKey`` changed from a series of
 that ``pre_save`` and ``post_save`` signals aren't sent anymore. You can use
 the ``bulk=False`` keyword argument to revert to the previous behavior.
 
-Maximum size of a request body is now limited
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
-request body may be before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
-not count towards this limit.
-
-Maximum number of form parameters is now limited
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
-form fields parsed before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
-
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -818,14 +818,27 @@ Maximum size of a request body is now limited
 The new :setting:`DATA_UPLOAD_MAX_MEMORY_SIZE` setting limits the size that a
 request body may be before a
 :exc:`~django.core.exceptions.SuspiciousOperation` is raised. File uploads do
-not count towards this limit.
+not count towards this limit. Since frontend servers typically do not do deep
+request inspection it's not possible to limit there the amount of data Django
+would have to process excluding file uploads. This amount of data is directly
+correlated to the amount of memory needed to process the request and populate
+the GET and POST dictionaries. As such, it could be used as an attack vector
+if left unchecked. Instalations that are supposed to receive form posts with
+large values should review the default value of this setting.
 
 Maximum number of form parameters is now limited
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The new :setting:`DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limits the number of
 form fields parsed before a
-:exc:`~django.core.exceptions.SuspiciousOperation` is raised.
+:exc:`~django.core.exceptions.SuspiciousOperation` is raised. Since frontend
+servers typically do not do deep request inspection it's not possible to limit
+there the amount of parameters Django would have to process. This number of
+parameters is directly correlated to the amount of time needed to process the
+request and populate the GET and POST dictionaries. As such, it could be used
+as an attack vector if left unchecked. Installations that are supposed to
+receive form posts with a large number of parameters should review the default
+value of this setting.
 
 Template ``LoaderOrigin`` and ``StringOrigin`` are removed
 ----------------------------------------------------------

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -859,7 +859,7 @@ class DataUploadMaxMemorySizeMPostTests(SimpleTestCase):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
             with self.assertRaisesMessage(
                     RequestDataTooBig,
-                    'The size of the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
+                    'The amount of data in the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
             ):
                 self.request._load_post_and_files()
 

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from itertools import chain
 
 from django.core.exceptions import (
-    RequestBodyTooBig, SuspiciousOperation, TooManyFieldsSent
+    RequestBodyTooBig, SuspiciousOperation, TooManyFieldsSent,
 )
 from django.core.handlers.wsgi import LimitedStream, WSGIRequest
 from django.http import (

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from itertools import chain
 
 from django.core.exceptions import (
-    RequestBodyTooBig, SuspiciousOperation, TooManyFieldsSent,
+    RequestDataTooBig, SuspiciousOperation, TooManyFieldsSent,
 )
 from django.core.handlers.wsgi import LimitedStream, WSGIRequest
 from django.http import (
@@ -825,7 +825,7 @@ class DataUploadMaxMemorySizeFPostTests(SimpleTestCase):
 
     def test_size_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=12):
-            with self.assertRaisesMessage(RequestBodyTooBig,
+            with self.assertRaisesMessage(RequestDataTooBig,
                                           'Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.'):
                 self.request._load_post_and_files()
 
@@ -858,7 +858,7 @@ class DataUploadMaxMemorySizeMPostTests(SimpleTestCase):
     def test_size_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
             with self.assertRaisesMessage(
-                    RequestBodyTooBig,
+                    RequestDataTooBig,
                     'The size of the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
             ):
                 self.request._load_post_and_files()

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -836,7 +836,7 @@ class DataUploadMaxMemorySizeGetTests(SimpleTestCase):
             content_length_header: 3,
         })
 
-        # ... or DATA_UPLOAD_MAX_MEMORY_SIZE=None
+        # no problem for DATA_UPLOAD_MAX_MEMORY_SIZE=None
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=None):
             request.body
 
@@ -900,12 +900,12 @@ class DataUploadMaxNumberOfFieldsMPost(SimpleTestCase):
         })
 
     def test_number_exceeded(self):
-        with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=1):
+        with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=2):
             with self.assertRaisesMessage(SuspiciousOperation, 'Too many fields'):
                 self.request._load_post_and_files()
 
     def test_number_not_exceeded(self):
-        with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=2):
+        with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=3):
             self.request._load_post_and_files()
 
     def test_no_limit(self):
@@ -916,7 +916,7 @@ class DataUploadMaxNumberOfFieldsMPost(SimpleTestCase):
 class DataUploadMaxNumberOfFieldsFPost(SimpleTestCase):
     def setUp(self):
         payload = FakePayload("\r\n".join([
-            'a=1&a=2',
+            'a=1&a=2;a=3',
             ''
         ]))
         self.request = WSGIRequest({

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -857,8 +857,10 @@ class DataUploadMaxMemorySizeMPostTests(SimpleTestCase):
 
     def test_size_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
-            with self.assertRaisesMessage(RequestBodyTooBig,
-                                          'Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.'):
+            with self.assertRaisesMessage(
+                    RequestBodyTooBig,
+                    'The size of the request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.'
+            ):
                 self.request._load_post_and_files()
 
     def test_size_not_exceeded(self):
@@ -893,8 +895,10 @@ class DataUploadMaxNumberOfFieldsGet(SimpleTestCase):
 
     def test_get_max_fields_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=1):
-            with self.assertRaisesMessage(TooManyFieldsSent,
-                                          'Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.'):
+            with self.assertRaisesMessage(
+                    TooManyFieldsSent,
+                    'The number of fields in a POST request exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.'
+            ):
                 request = WSGIRequest({
                     'REQUEST_METHOD': 'GET',
                     'wsgi.input': BytesIO(b''),
@@ -963,8 +967,10 @@ class DataUploadMaxNumberOfFieldsFPost(SimpleTestCase):
 
     def test_number_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=2):
-            with self.assertRaisesMessage(TooManyFieldsSent,
-                                          'Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.'):
+            with self.assertRaisesMessage(
+                    TooManyFieldsSent,
+                    'The number of fields in a POST request exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.'
+            ):
                 self.request._load_post_and_files()
 
     def test_number_not_exceeded(self):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -6,7 +6,9 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from itertools import chain
 
-from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import (
+    RequestBodyTooBig, SuspiciousOperation, TooManyFieldsSent
+)
 from django.core.handlers.wsgi import LimitedStream, WSGIRequest
 from django.http import (
     HttpRequest, HttpResponse, RawPostDataException, UnreadablePostError,
@@ -830,7 +832,8 @@ class DataUploadMaxMemorySizePostTests(SimpleTestCase):
 
     def test_size_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=10):
-            with self.assertRaisesMessage(SuspiciousOperation, 'Request data too large'):
+            with self.assertRaisesMessage(RequestBodyTooBig,
+                                          'Request body too big. Check DATA_UPLOAD_MAX_MEMORY_SIZE.'):
                 self.request._load_post_and_files()
 
     def test_size_not_exceeded(self):
@@ -865,7 +868,8 @@ class DataUploadMaxNumberOfFieldsGet(SimpleTestCase):
 
     def test_get_max_fields_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=1):
-            with self.assertRaisesMessage(SuspiciousOperation, 'Too many fields'):
+            with self.assertRaisesMessage(TooManyFieldsSent,
+                                          'Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.'):
                 request = WSGIRequest({
                     'REQUEST_METHOD': 'GET',
                     'wsgi.input': BytesIO(b''),
@@ -906,7 +910,8 @@ class DataUploadMaxNumberOfFieldsMPost(SimpleTestCase):
 
     def test_number_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=1):
-            with self.assertRaisesMessage(SuspiciousOperation, 'Too many fields'):
+            with self.assertRaisesMessage(TooManyFieldsSent,
+                                          'Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.'):
                 self.request._load_post_and_files()
 
     def test_number_not_exceeded(self):
@@ -933,7 +938,8 @@ class DataUploadMaxNumberOfFieldsFPost(SimpleTestCase):
 
     def test_number_exceeded(self):
         with self.settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=2):
-            with self.assertRaisesMessage(SuspiciousOperation, 'Too many fields'):
+            with self.assertRaisesMessage(TooManyFieldsSent,
+                                          'Too many fields sent. Check DATA_UPLOAD_MAX_NUMBER_FIELDS.'):
                 self.request._load_post_and_files()
 
     def test_number_not_exceeded(self):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -815,10 +815,7 @@ class HostValidationTests(SimpleTestCase):
 
 class DataUploadMaxMemorySizeFPostTests(SimpleTestCase):
     def setUp(self):
-        payload = FakePayload("\r\n".join([
-            'a=1&a=2;a=3',
-            ''
-        ]))
+        payload = FakePayload('a=1&a=2;a=3\r\n')
         self.request = WSGIRequest({
             'REQUEST_METHOD': 'POST',
             'CONTENT_TYPE': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Enforce a maximum size for form field values read into memory.
Based on https://github.com/django/django/pull/3020 and https://github.com/django/django/pull/2403.