### PR TITLE
Fixed #23953 -- Changed makemigrations numeration

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1014,7 +1014,7 @@ class MigrationAutodetector(object):
         and fixes the names and dependencies of the changes so they
         extend the graph from the leaf nodes for each app.
         """
-        leaves = graph.leaf_nodes()
+        leaves = graph.extended_leaf_nodes()
         name_map = {}
         for app_label, migrations in list(changes.items()):
             if not migrations:
@@ -1022,7 +1022,9 @@ class MigrationAutodetector(object):
             # Find the app label's current leaf node
             app_leaf = None
             for leaf in leaves:
-                if leaf[0] == app_label:
+                # Checks if it is a leaf of current application and it is
+                # not squashed
+                if leaf[0] == app_label and not leaf[2]:
                     app_leaf = leaf
                     break
             # Do they want an initial migration for this app?
@@ -1040,7 +1042,7 @@ class MigrationAutodetector(object):
             # Name each migration
             for i, migration in enumerate(migrations):
                 if i == 0 and app_leaf:
-                    migration.dependencies.append(app_leaf)
+                    migration.dependencies.append((app_leaf[0], app_leaf[1]))
                 if i == 0 and not app_leaf:
                     new_name = "0001_initial"
                 else:

--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -97,6 +97,21 @@ class MigrationGraph(object):
                 leaves.add(node)
         return sorted(leaves)
 
+    def extended_leaf_nodes(self, app=None):
+        """
+        Does the same as the method above but with flag as
+        the third element of each returning tuple
+        to determine if it is a squashed migration or not.
+        """
+        leaves = set()
+        for node in self.nodes:
+            if (not any(key[0] == node[0] for key in self.dependents.get(node, set()))
+                    and (not app or app == node[0])):
+                replaces = self.nodes[node].replaces if self.nodes[node] else None
+                replaces = replaces is not None and len(replaces)
+                leaves.add((node[0], node[1], replaces))
+        return sorted(leaves)
+
     def ensure_not_cyclic(self, start, get_children):
         # Algo from GvR:
         # http://neopythonic.blogspot.co.uk/2009/01/detecting-cycles-in-directed-graph.html

--- a/docs/releases/1.7.3.txt
+++ b/docs/releases/1.7.3.txt
@@ -4,7 +4,7 @@ Django 1.7.3 release notes
 
 *Under development*
 
-Django 1.7.3 fixes several bugs in 1.7.2.
+Django 1.7.3 fixes several bugs in 1.7.2 and adds minor updates.
 
 
 
@@ -20,3 +20,13 @@ Bugfixes
 
 * Fixed a crash in the CSRF middleware when handling non-ASCII referer header
   (:ticket:`23815`).
+
+
+
+Minor updates
+=============
+
+* Changed numeration behaviour in makemigrations after squashing
+  (:ticket:`23953`).
+  Now migrations numeration goes after the latest existing migration
+  instead of the squashed one.


### PR DESCRIPTION
Changed numeration behaviour in makemigrations after squashing.
Now migrations numeration goes after the latest existing migration
instead of the squashed one.

---

All useful comments and improvements are strongly welcome :)