### PR TITLE
Create __main__.py

### DIFF
--- a/django/__main__.py
+++ b/django/__main__.py
@@ -1,0 +1,13 @@
+"""
+Django main module. When the package is run with `python -m django` this module
+is run, so there is no need to test the __name__ variable. It *will* be "__main__".
+"""
+
+import os.path
+import sys
+
+from django.utils.version import get_version
+    
+sys.exit("""Django version {}
+Loaded from {}
+Python {}""".format(get_version(), os.path.dirname( __file__) , sys.version))


### PR DESCRIPTION
It's always irked me that I had to start an interactive interpreter to discover which version of django I was running. This module takes advantage of Python's recently-added ability to run a package.

After the addition of this module, the command `python -m django` reports various useful version data. Here's a sample output from a current virtual environment:

    (training-site)airhead:training-site sholden$ python -m django
    Django version 1.7.2
    Loaded from /Users/sholden/.virtualenvs/training-site/lib/python2.7/site-packages/django
    Python 2.7.2 (default, Oct 11 2012, 20:14:37)
    [GCC 4.2.1 Compatible Apple Clang 4.0 (tags/Apple/clang-418.0.60)]

I'm not sure how to integrate a test for this feature, and will happily take advice from more experienced devs. This just scratches an itch for me. I hope this file will always stay small!