### PR TITLE
Fixed #24060 -- Added OrderBy Expressions

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -300,7 +300,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         columns. If no ordering would otherwise be applied, we don't want any
         implicit sorting going on.
         """
-        return [(None, ("NULL", [], 'asc', False))]
+        return [(None, ("NULL", [], False))]
 
     def fulltext_search_sql(self, field_name):
         return 'MATCH (%s) AGAINST (%%s IN BOOLEAN MODE)' % field_name

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1691,14 +1691,14 @@ class Query(object):
         """
         Adds items from the 'ordering' sequence to the query's "order by"
         clause. These items are either field names (not column names) --
-        possibly with a direction prefix ('-' or '?') -- or ordinals,
-        corresponding to column positions in the 'select' list.
+        possibly with a direction prefix ('-' or '?') -- or OrderBy
+        expressions.
 
         If 'ordering' is empty, all ordering is cleared from the query.
         """
         errors = []
         for item in ordering:
-            if not ORDER_PATTERN.match(item):
+            if not hasattr(item, 'resolve_expression') and not ORDER_PATTERN.match(item):
                 errors.append(item)
         if errors:
             raise FieldError('Invalid order_by arguments: %s' % errors)

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -5,7 +5,7 @@ Query Expressions
 .. currentmodule:: django.db.models
 
 Query expressions describe a value or a computation that can be used as part of
-a filter, an annotation, or an aggregation. There are a number of built-in
+a filter, order by, annotation, or aggregate. There are a number of built-in
 expressions (documented below) that can be used to help you write queries.
 Expressions can be combined, or in some cases nested, to form more complex
 computations.
@@ -57,6 +57,10 @@ Some examples
 
     # Aggregates can contain complex computations also
     Company.objects.annotate(num_offerings=Count(F('products') + F('services')))
+
+    # Expressions can also be used in order_by()
+    Company.objects.order_by(Length('name').asc())
+    Company.objects.order_by(Length('name').desc())
 
 
 Built-in Expressions
@@ -427,6 +431,24 @@ calling the appropriate methods on the wrapped expression.
         this expression. ``get_group_by_cols()`` should be called on any
         nested expressions. ``F()`` objects, in particular, hold a reference
         to a column.
+
+    .. method:: asc()
+
+        Returns the expression ready to be sorted in ascending order.
+
+    .. method:: desc()
+
+        Returns the expression ready to be sorted in descending order.
+
+    .. method:: reverse_ordering()
+
+        Returns ``self`` with any modifications required to reverse the sort
+        order within an ``order_by`` call. As an example, an expression
+        implementing ``NULLS LAST`` would change its value to be
+        ``NULLS FIRST``. Modifications are only required for expressions that
+        implement sort order like ``OrderBy``. This method is called when
+        :meth:`~django.db.models.query.QuerySet.reverse()` is called on a
+        queryset.
 
 Writing your own Query Expressions
 ----------------------------------

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -322,17 +322,28 @@ identical to::
 
     Entry.objects.order_by('blog__name')
 
+It is also possible to order a queryset by a related field, without incurring
+the cost of a JOIN, by referring to the ``_id`` of the related field::
+
+    # No Join
+    Entry.objects.order_by('blog_id')
+
+    # Join
+    Entry.objects.order_by('blog__id')
+
 .. versionadded:: 1.7
 
-    Note that it is also possible to order a queryset by a related field,
-    without incurring the cost of a JOIN, by referring to the ``_id`` of the
-    related field::
+    The ability to order a queryset by a related field, without incurring
+    the cost of a JOIN was added.
 
-        # No Join
-        Entry.objects.order_by('blog_id')
+You can also order by :doc:`query expressions </ref/models/expressions>` by
+calling ``asc()`` or ``desc()`` on the expression::
 
-        # Join
-        Entry.objects.order_by('blog__id')
+    Entry.objects.order_by(Coalesce('summary', 'headline').desc())
+
+.. versionadded:: 1.8
+
+    Ordering by query expressions was added.
 
 Be cautious when ordering by fields in related models if you are also using
 :meth:`distinct()`. See the note in :meth:`distinct` for an explanation of how
@@ -366,6 +377,16 @@ related model ordering can change the expected results.
 There's no way to specify whether ordering should be case sensitive. With
 respect to case-sensitivity, Django will order results however your database
 backend normally orders them.
+
+You can order by a field converted to lowercase with
+:class:`~django.db.models.functions.Lower` which will achieve case-consistent
+ordering::
+
+    Entry.objects.order_by(Lower('headline').desc())
+
+.. versionadded:: 1.8
+
+    The ability to order by expressions like ``Lower`` was added.
 
 If you don't want any ordering to be applied to a query, not even the default
 ordering, call :meth:`order_by()` with no parameters.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -100,7 +100,8 @@ Query Expressions and Database Functions
 customize, and compose complex SQL expressions. This has enabled annotate
 to accept expressions other than aggregates. Aggregates are now able to
 reference multiple fields, as well as perform arithmetic, similar to ``F()``
-objects.
+objects. :meth:`~django.db.models.query.QuerySet.order_by` has also gained the
+ability to accept expressions.
 
 A collection of :doc:`database functions </ref/models/database-functions>` is
 also included with functionality such as

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -68,6 +68,37 @@ class FunctionTests(TestCase):
             lambda a: a.headline
         )
 
+    def test_coalesce_ordering(self):
+        Author.objects.create(name='John Smith', alias='smithj')
+        Author.objects.create(name='Rhonda')
+
+        authors = Author.objects.order_by(Coalesce('alias', 'name'))
+        self.assertQuerysetEqual(
+            authors, [
+                'Rhonda',
+                'John Smith',
+            ],
+            lambda a: a.name
+        )
+
+        authors = Author.objects.order_by(Coalesce('alias', 'name').asc())
+        self.assertQuerysetEqual(
+            authors, [
+                'Rhonda',
+                'John Smith',
+            ],
+            lambda a: a.name
+        )
+
+        authors = Author.objects.order_by(Coalesce('alias', 'name').desc())
+        self.assertQuerysetEqual(
+            authors, [
+                'John Smith',
+                'Rhonda',
+            ],
+            lambda a: a.name
+        )
+
     def test_concat(self):
         Author.objects.create(name='Jayden')
         Author.objects.create(name='John Smith', alias='smithj', goes_by='John')
@@ -184,6 +215,22 @@ class FunctionTests(TestCase):
 
         self.assertEqual(authors.filter(alias_length__lte=Length('name')).count(), 1)
 
+    def test_length_ordering(self):
+        Author.objects.create(name='John Smith', alias='smithj')
+        Author.objects.create(name='John Smith', alias='smithj1')
+        Author.objects.create(name='Rhonda', alias='ronny')
+
+        authors = Author.objects.order_by(Length('name'), Length('alias'))
+
+        self.assertQuerysetEqual(
+            authors, [
+                ('Rhonda', 'ronny'),
+                ('John Smith', 'smithj'),
+                ('John Smith', 'smithj1'),
+            ],
+            lambda a: (a.name, a.alias)
+        )
+
     def test_substr(self):
         Author.objects.create(name='John Smith', alias='smithj')
         Author.objects.create(name='Rhonda')
@@ -230,3 +277,25 @@ class FunctionTests(TestCase):
 
         with six.assertRaisesRegex(self, ValueError, "'pos' must be greater than 0"):
             Author.objects.annotate(raises=Substr('name', 0))
+
+    def test_nested_function_ordering(self):
+        Author.objects.create(name='John Smith')
+        Author.objects.create(name='Rhonda Simpson', alias='ronny')
+
+        authors = Author.objects.order_by(Length(Coalesce('alias', 'name')))
+        self.assertQuerysetEqual(
+            authors, [
+                'Rhonda Simpson',
+                'John Smith',
+            ],
+            lambda a: a.name
+        )
+
+        authors = Author.objects.order_by(Length(Coalesce('alias', 'name')).desc())
+        self.assertQuerysetEqual(
+            authors, [
+                'John Smith',
+                'Rhonda Simpson',
+            ],
+            lambda a: a.name
+        )


### PR DESCRIPTION
This is the initial implementation of being able to use expressions in the order_by clause. It's still a bit rough around the edges. Still need:

- [x] Lots more tests
- [x] Documentation
- [x] ~~Implement NULLS LAST/FIRST~~ Cutting due to time

I think I'm on the right track though. Eventually I'd like to move a lot of the order processing from the compiler and into the expression itself, but that's polish that can wait until another version.