### PR TITLE
Fixed #24089 -- Added check for when ModelAdmin.fieldsets[1]['fields'] isn't a tuple.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -130,7 +130,9 @@ class BaseModelAdminChecks(object):
                     id='admin.E011',
                 )
             ]
-
+        elif not isinstance(fieldset[1]['fields'], (list, tuple)):
+            # user missed the ',' following field name tuple probably
+            return must_be('a list or tuple', option="fieldsets[1]['fields']", obj=cls, id='admin.E008')
         fields = flatten(fieldset[1]['fields'])
         if len(fields) != len(set(fields)):
             return [

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -124,6 +124,53 @@ class SystemChecksTestCase(TestCase):
         errors = ValidFormFieldsets.check(model=Song)
         self.assertEqual(errors, [])
 
+    def test_fieldsets_tuple(self):
+        """
+        Tests for basic tuple/lists within field sets (#24089)
+        """
+        class NotATupleAdmin(admin.ModelAdmin):
+            list_display = ["pk", "title"]
+            list_editable = ["title"]
+            fieldsets = [
+                (None, {
+                    "fields": ("title")  # expect a comma
+                }),
+            ]
+        errors = NotATupleAdmin.check(model=Song)
+        expected = [
+            checks.Error(
+                "The value of 'fieldsets[1]['fields']' must be a list or tuple.",
+                hint=None,
+                obj=NotATupleAdmin,
+                id='admin.E008',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
+    def test_nonfirst_fieldset(self):
+        """
+        Tests for tuple/lists within the second fieldset
+        """
+        class NotATupleAdmin(admin.ModelAdmin):
+            fieldsets = [
+                (None, {
+                    "fields": ("title",)
+                }),
+                ('foo', {
+                    "fields": "author"  # not a tuple
+                }),
+            ]
+        errors = NotATupleAdmin.check(model=Song)
+        expected = [
+            checks.Error(
+                "The value of 'fieldsets[1]['fields']' must be a list or tuple.",
+                hint=None,
+                obj=NotATupleAdmin,
+                id='admin.E008',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
     def test_exclude_values(self):
         """
         Tests for basic system checks of 'exclude' option values (#12689)


### PR DESCRIPTION
Change to check for tuple/list on the label 'fields' of fieldsets field of ModelAdmin.
Ticket 24089