### PR TITLE
Fixed #24092 -- Widened base field support for ArrayField.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -4,11 +4,9 @@ from django.contrib.postgres import lookups
 from django.contrib.postgres.forms import SimpleArrayField
 from django.contrib.postgres.validators import ArrayMaxLengthValidator
 from django.core import checks, exceptions
-from django.db.models import Field, Transform, IntegerField, GenericIPAddressField
+from django.db.models import Field, Transform, IntegerField
 from django.utils import six
 from django.utils.translation import string_concat, ugettext_lazy as _
-
-from psycopg2.extras import Inet
 
 
 __all__ = ['ArrayField']
@@ -73,8 +71,6 @@ class ArrayField(Field):
         return '%s[%s]' % (self.base_field.db_type(connection), size)
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(self.base_field, GenericIPAddressField):
-            return [Inet(i) for i in value]
         if isinstance(value, list) or isinstance(value, tuple):
             return [self.base_field.get_db_prep_value(i, connection, prepared) for i in value]
         return value

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -977,7 +977,7 @@ class BaseDatabaseOperations(object):
         """
         return cursor.lastrowid
 
-    def lookup_cast(self, lookup_type):
+    def lookup_cast(self, lookup_type, internal_type=None):
         """
         Returns the string to use in a query when performing lookups
         ("contains", "like", etc). The resulting string should contain a '%s'

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -581,6 +581,9 @@ class BaseDatabaseFeatures(object):
     supports_subqueries_in_group_by = True
     supports_bitwise_or = True
 
+    # Is there a true datatype for uuid?
+    has_native_uuid_field = False
+
     # Is there a true datatype for timedeltas?
     has_native_duration_field = False
 
@@ -1231,6 +1234,12 @@ class BaseDatabaseOperations(object):
         expected by the backend driver for decimal (numeric) columns.
         """
         return utils.format_number(value, max_digits, decimal_places)
+
+    def value_to_db_ipaddress(self, value):
+        """Transform a string representation of an ip address into the expected
+        type for the backend driver.
+        """
+        return value
 
     def year_lookup_bounds_for_date_field(self, value):
         """

--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -1201,7 +1201,7 @@ class BaseDatabaseOperations(object):
 
     def value_to_db_date(self, value):
         """
-        Transform a date value to an object compatible with what is expected
+        Transforms a date value to an object compatible with what is expected
         by the backend driver for date columns.
         """
         if value is None:
@@ -1210,7 +1210,7 @@ class BaseDatabaseOperations(object):
 
     def value_to_db_datetime(self, value):
         """
-        Transform a datetime value to an object compatible with what is expected
+        Transforms a datetime value to an object compatible with what is expected
         by the backend driver for datetime columns.
         """
         if value is None:
@@ -1219,7 +1219,7 @@ class BaseDatabaseOperations(object):
 
     def value_to_db_time(self, value):
         """
-        Transform a time value to an object compatible with what is expected
+        Transforms a time value to an object compatible with what is expected
         by the backend driver for time columns.
         """
         if value is None:
@@ -1230,13 +1230,14 @@ class BaseDatabaseOperations(object):
 
     def value_to_db_decimal(self, value, max_digits, decimal_places):
         """
-        Transform a decimal.Decimal value to an object compatible with what is
+        Transforms a decimal.Decimal value to an object compatible with what is
         expected by the backend driver for decimal (numeric) columns.
         """
         return utils.format_number(value, max_digits, decimal_places)
 
     def value_to_db_ipaddress(self, value):
-        """Transform a string representation of an ip address into the expected
+        """
+        Transforms a string representation of an ip address into the expected
         type for the backend driver.
         """
         return value

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -360,7 +360,7 @@ WHEN (new.%(col_name)s IS NULL)
         cursor.execute('SELECT "%s".currval FROM dual' % sq_name)
         return cursor.fetchone()[0]
 
-    def lookup_cast(self, lookup_type):
+    def lookup_cast(self, lookup_type, internal_type=None):
         if lookup_type in ('iexact', 'icontains', 'istartswith', 'iendswith'):
             return "UPPER(%s)"
         return "%s"

--- a/django/db/backends/postgresql_psycopg2/base.py
+++ b/django/db/backends/postgresql_psycopg2/base.py
@@ -37,7 +37,7 @@ psycopg2.extensions.register_adapter(SafeText, psycopg2.extensions.QuotedString)
 psycopg2.extras.register_uuid()
 
 # Register support for inet[] manually so we don't have to handle the Inet()
-# object on load all the time
+# object on load all the time.
 INETARRAY_OID = 1041
 INETARRAY = psycopg2.extensions.new_array_type(
     (INETARRAY_OID,),

--- a/django/db/backends/postgresql_psycopg2/base.py
+++ b/django/db/backends/postgresql_psycopg2/base.py
@@ -36,6 +36,16 @@ psycopg2.extensions.register_adapter(SafeBytes, psycopg2.extensions.QuotedString
 psycopg2.extensions.register_adapter(SafeText, psycopg2.extensions.QuotedString)
 psycopg2.extras.register_uuid()
 
+# Register support for inet[] manually so we don't have to handle the Inet()
+# object on load all the time
+INETARRAY_OID = 1041
+INETARRAY = psycopg2.extensions.new_array_type(
+    (INETARRAY_OID,),
+    'INETARRAY',
+    psycopg2.extensions.UNICODE,
+)
+psycopg2.extensions.register_type(INETARRAY)
+
 
 def utc_tzinfo_factory(offset):
     if offset != 0:
@@ -47,6 +57,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     needs_datetime_string_cast = False
     can_return_id_from_insert = True
     has_real_datatype = True
+    has_native_uuid_field = True
     has_native_duration_field = True
     driver_supports_timedelta_args = True
     can_defer_constraint_checks = True

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db.backends import BaseDatabaseOperations
 
+from psycopg2.extras import Inet
+
 
 class DatabaseOperations(BaseDatabaseOperations):
 
@@ -212,3 +214,15 @@ class DatabaseOperations(BaseDatabaseOperations):
     def bulk_insert_sql(self, fields, num_values):
         items_sql = "(%s)" % ", ".join(["%s"] * len(fields))
         return "VALUES " + ", ".join([items_sql] * num_values)
+
+    def value_to_db_date(self, value):
+        return value
+
+    def value_to_db_datetime(self, value):
+        return value
+
+    def value_to_db_time(self, value):
+        return value
+
+    def value_to_db_ipaddress(self, value):
+        return Inet(value)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1983,7 +1983,7 @@ class GenericIPAddressField(Field):
     def get_db_prep_value(self, value, connection, prepared=False):
         if not prepared:
             value = self.get_prep_value(value)
-        return value or None
+        return connection.ops.value_to_db_ipaddress(value)
 
     def get_prep_value(self, value):
         value = super(GenericIPAddressField, self).get_prep_value(value)
@@ -2366,8 +2366,10 @@ class UUIDField(Field):
     def get_internal_type(self):
         return "UUIDField"
 
-    def get_prep_value(self, value):
+    def get_db_prep_value(self, value, connection, prepared=False):
         if isinstance(value, uuid.UUID):
+            if connection.features.has_native_uuid_field:
+                return value
             return value.hex
         if isinstance(value, six.string_types):
             return value.replace('-', '')

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -198,7 +198,7 @@ class BuiltinLookup(Lookup):
         db_type = self.lhs.output_field.db_type(connection=connection)
         lhs_sql = connection.ops.field_cast_sql(
             db_type, field_internal_type) % lhs_sql
-        lhs_sql = connection.ops.lookup_cast(self.lookup_name) % lhs_sql
+        lhs_sql = connection.ops.lookup_cast(self.lookup_name, field_internal_type) % lhs_sql
         return lhs_sql, params
 
     def as_sql(self, compiler, connection):

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -695,6 +695,11 @@ class GenericIPAddressFieldTests(test.TestCase):
         o = GenericIPAddress.objects.get()
         self.assertIsNone(o.ip)
 
+    def test_save_load(self):
+        instance = GenericIPAddress.objects.create(ip='::1')
+        loaded = GenericIPAddress.objects.get()
+        self.assertEqual(loaded.ip, instance.ip)
+
 
 class PromiseTest(test.TestCase):
     def test_AutoField(self):

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -27,7 +27,9 @@ class Migration(migrations.Migration):
             name='DateTimeArrayModel',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('field', django.contrib.postgres.fields.ArrayField(models.DateTimeField(), size=None)),
+                ('datetimes', django.contrib.postgres.fields.ArrayField(models.DateTimeField(), size=None)),
+                ('dates', django.contrib.postgres.fields.ArrayField(models.DateField(), size=None)),
+                ('times', django.contrib.postgres.fields.ArrayField(models.TimeField(), size=None)),
             ],
             options={
             },
@@ -38,6 +40,18 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', django.contrib.postgres.fields.hstore.HStoreField(blank=True, null=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='OtherTypesArrayModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('ips', django.contrib.postgres.fields.ArrayField(models.GenericIPAddressField(), size=None)),
+                ('uuids', django.contrib.postgres.fields.ArrayField(models.UUIDField(), size=None)),
+                ('decimals', django.contrib.postgres.fields.ArrayField(models.DecimalField(max_digits=5, decimal_places=2), size=None)),
             ],
             options={
             },

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -18,11 +18,19 @@ class CharArrayModel(models.Model):
 
 
 class DateTimeArrayModel(models.Model):
-    field = ArrayField(models.DateTimeField())
+    datetimes = ArrayField(models.DateTimeField())
+    dates = ArrayField(models.DateField())
+    times = ArrayField(models.TimeField())
 
 
 class NestedIntegerArrayModel(models.Model):
     field = ArrayField(ArrayField(models.IntegerField()))
+
+
+class OtherTypesArrayModel(models.Model):
+    ips = ArrayField(models.GenericIPAddressField())
+    uuids = ArrayField(models.UUIDField())
+    decimals = ArrayField(models.DecimalField(max_digits=5, decimal_places=2))
 
 
 class HStoreModel(models.Model):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1,5 +1,7 @@
+import decimal
 import json
 import unittest
+import uuid
 
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.forms import SimpleArrayField, SplitArrayField
@@ -10,7 +12,7 @@ from django import forms
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from .models import IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel, DateTimeArrayModel, NestedIntegerArrayModel, ArrayFieldSubclass
+from .models import IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel, DateTimeArrayModel, NestedIntegerArrayModel, OtherTypesArrayModel, ArrayFieldSubclass
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')
@@ -29,10 +31,16 @@ class TestSaveLoad(TestCase):
         self.assertEqual(instance.field, loaded.field)
 
     def test_dates(self):
-        instance = DateTimeArrayModel(field=[timezone.now()])
+        instance = DateTimeArrayModel(
+            datetimes=[timezone.now()],
+            dates=[timezone.now().date()],
+            times=[timezone.now().time()],
+        )
         instance.save()
         loaded = DateTimeArrayModel.objects.get()
-        self.assertEqual(instance.field, loaded.field)
+        self.assertEqual(instance.datetimes, loaded.datetimes)
+        self.assertEqual(instance.dates, loaded.dates)
+        self.assertEqual(instance.times, loaded.times)
 
     def test_tuples(self):
         instance = IntegerArrayModel(field=(1,))
@@ -69,6 +77,18 @@ class TestSaveLoad(TestCase):
         instance.save()
         loaded = NestedIntegerArrayModel.objects.get()
         self.assertEqual(instance.field, loaded.field)
+
+    def test_other_array_types(self):
+        instance = OtherTypesArrayModel(
+            ips=['192.168.0.1', '::1'],
+            uuids=[uuid.uuid4()],
+            decimals=[decimal.Decimal(1.25), 1.75],
+        )
+        instance.save()
+        loaded = OtherTypesArrayModel.objects.get()
+        self.assertEqual(instance.ips, loaded.ips)
+        self.assertEqual(instance.uuids, loaded.uuids)
+        self.assertEqual(instance.decimals, loaded.decimals)
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -12,7 +12,11 @@ from django import forms
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from .models import IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel, DateTimeArrayModel, NestedIntegerArrayModel, OtherTypesArrayModel, ArrayFieldSubclass
+from .models import (
+    IntegerArrayModel, NullableIntegerArrayModel, CharArrayModel,
+    DateTimeArrayModel, NestedIntegerArrayModel, OtherTypesArrayModel,
+    ArrayFieldSubclass,
+)
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL required')


### PR DESCRIPTION
Several issues resolved here, following from a report that a `base_field` of `GenericIpAddressField` was failing.

We were using `get_prep_value` instead of `get_db_prep_value` in `ArrayField` which was bypassing any extra modifications to the value being made in the base field's `get_db_prep_value`. Changing this broke datetime support, so the postgres backend has gained the relevant operation methods to send dates/times/datetimes directly to the db backend instead of casting them to strings. Similarly, a new database feature has been added allowing the uuid to be passed directly to the backend, as we do with timedeltas.

On the other side, psycopg2 expects an `Inet()` instance for ip address fields, so we add a `value_to_db_ipaddress` method to wrap the strings on postgres. We also have to manually add a database adapter to psycopg2, as we do not wish to use the built in adapter which would turn everything into `Inet()` instances.

Main question: Do I need to ensure that we properly support `ArrayField(IPAddressField())` given that `IPAddressField()` is deprecated, or can the answer to the inevitable bug report be "don't use `IPAddressField()`?