### PR TITLE
Fixed #24118 -- Added --debug-sql option for tests.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -286,7 +286,7 @@ For example, suppose that the failing test that works on its own is
 
 .. code-block:: bash
 
-   $ ./runtests.py --bisect basic.tests.ModelTest.test_eq
+    $ ./runtests.py --bisect basic.tests.ModelTest.test_eq
 
 will try to determine a test that interferes with the given one. First, the
 test is run with the first half of the test suite. If a failure occurs, the
@@ -302,7 +302,7 @@ failure. So:
 
 .. code-block:: bash
 
-   $ ./runtests.py --pair basic.tests.ModelTest.test_eq
+    $ ./runtests.py --pair basic.tests.ModelTest.test_eq
 
 will pair ``test_eq`` with every test label.
 
@@ -313,7 +313,7 @@ the first one:
 
 .. code-block:: bash
 
-   $ ./runtests.py --pair basic.tests.ModelTest.test_eq queries transactions
+    $ ./runtests.py --pair basic.tests.ModelTest.test_eq queries transactions
 
 You can also try running any set of tests in reverse using the ``--reverse``
 option in order to verify that executing tests in a different order does not
@@ -321,8 +321,16 @@ cause any trouble:
 
 .. code-block:: bash
 
-   $ ./runtests.py basic --reverse
+    $ ./runtests.py basic --reverse
+
+If you wish to examine the SQL being run in failing tests, you can turn on
+:ref:`SQL logging <django-db-logger>` using the ``--debug-sql`` option. If you
+combine this with ``--verbosity=2``, all SQL queries will be output.
+
+.. code-block:: bash
+
+    $ ./runtests.py basic --debug-sql
 
 .. versionadded:: 1.8
 
-    The ``--reverse`` option was added.
+    The ``--reverse`` and ``--debug-sql`` options were added.

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1449,6 +1449,14 @@ This may help in debugging tests that aren't properly isolated and have side
 effects. :ref:`Grouping by test class <order-of-tests>` is preserved when using
 this option.
 
+.. django-admin-option:: --debug-sql
+
+.. versionadded:: 1.8
+
+The ``--debug-sql`` option can be used to enable :ref:`SQL logging
+<django-db-logger>` for failing tests. If :djadminopt:`--verbosity` is ``2``,
+then queries in passing tests are also output.
+
 testserver <fixture fixture ...>
 --------------------------------
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -625,8 +625,9 @@ Tests
   allows you to test that two JSON fragments are not equal.
 
 * Added options to the :djadmin:`test` command to preserve the test database
-  (:djadminopt:`--keepdb`) and to run the test cases in reverse order
-  (:djadminopt:`--reverse`).
+  (:djadminopt:`--keepdb`), to run the test cases in reverse order
+  (:djadminopt:`--reverse`), and to enable SQL logging for failing tests
+  (:djadminopt:`--debug-sql`).
 
 * Added the :attr:`~django.test.Response.resolver_match` attribute to test
   client responses.

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -439,6 +439,8 @@ Messages to this logger have the following extra context:
 * ``request``: The request object that generated the logging
   message.
 
+.. _django-db-logger:
+
 ``django.db.backends``
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -355,7 +355,7 @@ behavior. This class defines the ``run_tests()`` entry point, plus a
 selection of other methods that are used to by ``run_tests()`` to set up,
 execute and tear down the test suite.
 
-.. class:: DiscoverRunner(pattern='test*.py', top_level=None, verbosity=1, interactive=True, failfast=True, keepdb=False, reverse=False, **kwargs)
+.. class:: DiscoverRunner(pattern='test*.py', top_level=None, verbosity=1, interactive=True, failfast=True, keepdb=False, reverse=False, debug_sql=False, **kwargs)
 
     ``DiscoverRunner`` will search for tests in any file matching ``pattern``.
 
@@ -386,6 +386,11 @@ execute and tear down the test suite.
     and have side effects. :ref:`Grouping by test class <order-of-tests>` is
     preserved when using this option.
 
+    If ``debug_sql`` is ``True``, failing test cases will output SQL queries
+    logged to the :ref:`django.db.backends logger <django-db-logger>` as well
+    as the traceback. If ``verbosity`` is ``2``, then queries in all tests are
+    output.
+
     Django may, from time to time, extend the capabilities of the test runner
     by adding new arguments. The ``**kwargs`` declaration allows for this
     expansion. If you subclass ``DiscoverRunner`` or write your own test
@@ -402,7 +407,7 @@ execute and tear down the test suite.
         subclassed test runner to add options to the list of command-line
         options that the :djadmin:`test` command could use.
 
-        The ``keepdb`` and the ``reverse`` arguments were added.
+        The ``keepdb``, ``reverse``, and ``debug_sql`` arguments were added.
 
 Attributes
 ~~~~~~~~~~

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -217,7 +217,7 @@ def teardown(state):
         setattr(settings, key, value)
 
 
-def django_tests(verbosity, interactive, failfast, keepdb, reverse, test_labels):
+def django_tests(verbosity, interactive, failfast, keepdb, reverse, test_labels, debug_sql):
     state = setup(verbosity, test_labels)
     extra_tests = []
 
@@ -232,6 +232,7 @@ def django_tests(verbosity, interactive, failfast, keepdb, reverse, test_labels)
         failfast=failfast,
         keepdb=keepdb,
         reverse=reverse,
+        debug_sql=debug_sql,
     )
     # Catch warnings thrown in test DB setup -- remove in Django 1.9
     with warnings.catch_warnings():
@@ -386,6 +387,9 @@ if __name__ == "__main__":
     parser.add_argument(
         '--selenium', action='store_true', dest='selenium', default=False,
         help='Run the Selenium tests as well (if Selenium is installed)')
+    parser.add_argument(
+        '--debug-sql', action='store_true', dest='debug_sql', default=False,
+        help='Turn on the SQL query logger within tests')
     options = parser.parse_args()
 
     # mock is a required dependency
@@ -421,6 +425,7 @@ if __name__ == "__main__":
     else:
         failures = django_tests(options.verbosity, options.interactive,
                                 options.failfast, options.keepdb,
-                                options.reverse, options.modules)
+                                options.reverse, options.modules,
+                                options.debug_sql)
         if failures:
             sys.exit(bool(failures))

--- a/tests/test_runner/test_debug_sql.py
+++ b/tests/test_runner/test_debug_sql.py
@@ -1,0 +1,102 @@
+import unittest
+
+from django.db import connection
+from django.test import TestCase
+from django.test.runner import DiscoverRunner
+from django.utils import six
+
+from .models import Person
+
+
+@unittest.skipUnless(connection.vendor == 'sqlite', 'Only run on sqlite so we can check output SQL.')
+class TestDebugSQL(unittest.TestCase):
+
+    class PassingTest(TestCase):
+        def runTest(self):
+            Person.objects.filter(first_name='pass').count()
+
+    class FailingTest(TestCase):
+        def runTest(self):
+            Person.objects.filter(first_name='fail').count()
+            self.fail()
+
+    class ErrorTest(TestCase):
+        def runTest(self):
+            Person.objects.filter(first_name='error').count()
+            raise Exception
+
+    def _test_output(self, verbosity):
+        runner = DiscoverRunner(debug_sql=True, verbosity=0)
+        suite = runner.test_suite()
+        suite.addTest(self.FailingTest())
+        suite.addTest(self.ErrorTest())
+        suite.addTest(self.PassingTest())
+        old_config = runner.setup_databases()
+        stream = six.StringIO()
+        resultclass = runner.get_resultclass()
+        runner.test_runner(
+            verbosity=verbosity,
+            stream=stream,
+            resultclass=resultclass,
+        ).run(suite)
+        runner.teardown_databases(old_config)
+
+        stream.seek(0)
+        return stream.read()
+
+    def test_output_normal(self):
+        full_output = self._test_output(1)
+        for output in self.expected_outputs:
+            self.assertIn(output, full_output)
+        for output in self.verbose_expected_outputs:
+            self.assertNotIn(output, full_output)
+
+    def test_output_verbose(self):
+        full_output = self._test_output(2)
+        for output in self.expected_outputs:
+            self.assertIn(output, full_output)
+        for output in self.verbose_expected_outputs:
+            self.assertIn(output, full_output)
+
+    if six.PY3:
+        expected_outputs = [
+            ('''QUERY = 'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = ('*', 'error');'''),
+            ('''QUERY = 'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = ('*', 'fail');'''),
+        ]
+    else:
+        expected_outputs = [
+            ('''QUERY = u'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = (u'*', u'error');'''),
+            ('''QUERY = u'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = (u'*', u'fail');'''),
+        ]
+
+    verbose_expected_outputs = [
+        'runTest (test_runner.test_debug_sql.FailingTest) ... FAIL',
+        'runTest (test_runner.test_debug_sql.ErrorTest) ... ERROR',
+        'runTest (test_runner.test_debug_sql.PassingTest) ... ok',
+    ]
+    if six.PY3:
+        verbose_expected_outputs += [
+            ('''QUERY = 'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = ('*', 'pass');'''),
+        ]
+    else:
+        verbose_expected_outputs += [
+            ('''QUERY = u'SELECT COUNT(%s) AS "__count" '''
+                '''FROM "test_runner_person" WHERE '''
+                '''"test_runner_person"."first_name" = %s' '''
+                '''- PARAMS = (u'*', u'pass');'''),
+        ]


### PR DESCRIPTION
This will need documentation and preferably some tests if we decide it's a feature we like.

From the ticket:

> It's a common problem (*especially* when working on ORM code) to want to print the complete sql queries run during a failing test, especially when parts of the run sql are in the traceback...

Example output:

```
> ./runtests.py expressions --debug-sql
Testing against Django installed in '/Users/marc/code/django/django'
Creating test database for alias 'default'...
Creating test database for alias 'other'...
.........s...............................s...F.Es...
======================================================================
ERROR: test_invalid_operator (expressions.tests.FTimeDeltaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marc/code/django/tests/expressions/tests.py", line 779, in test_invalid_operator
    1/0
ZeroDivisionError: integer division or modulo by zero

----------------------------------------------------------------------
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e0', u'2010-06-25', u'2010-06-25', 0.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:15:30.747000'); args=[u'e0', u'2010-06-25', u'2010-06-25', 0.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:15:30.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e1', u'2010-06-25', u'2010-06-26', 253000.0, u'2010-06-26 12:15:30.747000', u'2010-06-26 12:15:31'); args=[u'e1', u'2010-06-25', u'2010-06-26', 253000.0, u'2010-06-26 12:15:30.747000', u'2010-06-26 12:15:31']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e2', u'2010-06-22', u'2010-06-25', 3600000000.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:16:14.747000'); args=[u'e2', u'2010-06-22', u'2010-06-25', 3600000000.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:16:14.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e3', u'2010-06-25', u'2010-06-30', 76080000000.0, u'2010-06-29 12:15:30.747000', u'2010-06-30 09:23:30.747000'); args=[u'e3', u'2010-06-25', u'2010-06-30', 76080000000.0, u'2010-06-29 12:15:30.747000', u'2010-06-30 09:23:30.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e4', u'2010-06-15', u'2010-07-05', 777600000000.0, u'2010-06-25 12:15:30.747000', u'2010-07-05 12:15:30.747000'); args=[u'e4', u'2010-06-15', u'2010-07-05', 777600000000.0, u'2010-06-25 12:15:30.747000', u'2010-07-05 12:15:30.747000']
(0.000) QUERY = u'SELECT "expressions_experiment"."id", "expressions_experiment"."name", "expressions_experiment"."assigned", "expressions_experiment"."completed", "expressions_experiment"."estimated_time", "expressions_experiment"."start", "expressions_experiment"."end" FROM "expressions_experiment" ORDER BY "expressions_experiment"."name" ASC' - PARAMS = (); args=()

======================================================================
FAIL: test_durationfield_add (expressions.tests.FTimeDeltaTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marc/code/django/tests/expressions/tests.py", line 793, in test_durationfield_add
    self.fail()
AssertionError: None

----------------------------------------------------------------------
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e0', u'2010-06-25', u'2010-06-25', 0.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:15:30.747000'); args=[u'e0', u'2010-06-25', u'2010-06-25', 0.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:15:30.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e1', u'2010-06-25', u'2010-06-26', 253000.0, u'2010-06-26 12:15:30.747000', u'2010-06-26 12:15:31'); args=[u'e1', u'2010-06-25', u'2010-06-26', 253000.0, u'2010-06-26 12:15:30.747000', u'2010-06-26 12:15:31']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e2', u'2010-06-22', u'2010-06-25', 3600000000.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:16:14.747000'); args=[u'e2', u'2010-06-22', u'2010-06-25', 3600000000.0, u'2010-06-25 12:15:30.747000', u'2010-06-25 12:16:14.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e3', u'2010-06-25', u'2010-06-30', 76080000000.0, u'2010-06-29 12:15:30.747000', u'2010-06-30 09:23:30.747000'); args=[u'e3', u'2010-06-25', u'2010-06-30', 76080000000.0, u'2010-06-29 12:15:30.747000', u'2010-06-30 09:23:30.747000']
(0.000) QUERY = u'INSERT INTO "expressions_experiment" ("name", "assigned", "completed", "estimated_time", "start", "end") VALUES (%s, %s, %s, %s, %s, %s)' - PARAMS = (u'e4', u'2010-06-15', u'2010-07-05', 777600000000.0, u'2010-06-25 12:15:30.747000', u'2010-07-05 12:15:30.747000'); args=[u'e4', u'2010-06-15', u'2010-07-05', 777600000000.0, u'2010-06-25 12:15:30.747000', u'2010-07-05 12:15:30.747000']
(0.000) QUERY = u'SELECT "expressions_experiment"."id", "expressions_experiment"."name", "expressions_experiment"."assigned", "expressions_experiment"."completed", "expressions_experiment"."estimated_time", "expressions_experiment"."start", "expressions_experiment"."end" FROM "expressions_experiment" ORDER BY "expressions_experiment"."name" ASC' - PARAMS = (); args=()
(0.001) QUERY = u'SELECT "expressions_experiment"."id", "expressions_experiment"."name", "expressions_experiment"."assigned", "expressions_experiment"."completed", "expressions_experiment"."estimated_time", "expressions_experiment"."start", "expressions_experiment"."end" FROM "expressions_experiment" WHERE "expressions_experiment"."start" = ((django_format_dtdelta(\'+\', "expressions_experiment"."start", "expressions_experiment"."estimated_time"))) ORDER BY "expressions_experiment"."name" ASC' - PARAMS = (); args=()
(0.001) QUERY = u'SELECT "expressions_experiment"."id", "expressions_experiment"."name", "expressions_experiment"."assigned", "expressions_experiment"."completed", "expressions_experiment"."estimated_time", "expressions_experiment"."start", "expressions_experiment"."end" FROM "expressions_experiment" WHERE "expressions_experiment"."end" < ((django_format_dtdelta(\'+\', "expressions_experiment"."start", "expressions_experiment"."estimated_time"))) ORDER BY "expressions_experiment"."name" ASC' - PARAMS = (); args=()
(0.001) QUERY = u'SELECT "expressions_experiment"."id", "expressions_experiment"."name", "expressions_experiment"."assigned", "expressions_experiment"."completed", "expressions_experiment"."estimated_time", "expressions_experiment"."start", "expressions_experiment"."end" FROM "expressions_experiment" WHERE "expressions_experiment"."end" >= ((django_format_dtdelta(\'+\', (django_format_dtdelta(\'+\', "expressions_experiment"."start", "expressions_experiment"."estimated_time")), \'01:00:00\'))) ORDER BY "expressions_experiment"."name" ASC' - PARAMS = (); args=()

----------------------------------------------------------------------
Ran 52 tests in 0.315s

FAILED (failures=1, errors=1, skipped=3)
Destroying test database for alias 'default'...
Destroying test database for alias 'other'...
```