### PR TITLE
Docs - Auth example - Password not hashed

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -993,9 +993,9 @@ authentication app::
             birth and password.
             """
             user = self.create_user(email,
-                password=password,
                 date_of_birth=date_of_birth
             )
+            user.set_password(password)
             user.is_admin = True
             user.save(using=self._db)
             return user


### PR DESCRIPTION
I have followed the "Full Example of Custom User Authentication" in docs and, when I tested all worked fine except for the password field that was saved on clear form on database when I was syncing the database.

This is happened because doc states that the password field should be directly saved into the model, avoiding the password hashing.
Calling method *set_password* solved the problem for me, so I updated the example in this commit.