### PR TITLE
Updated supports_binary_field flag for MySQL-Python3

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -169,8 +169,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_select_for_update = True
     has_select_for_update_nowait = False
     supports_forward_references = False
-    # XXX MySQL DB-API drivers currently fail on binary data on Python 3.
-    supports_binary_field = six.PY2
     supports_regex_backreferencing = False
     supports_date_lookup_using_string = False
     can_introspect_autofield = True


### PR DESCRIPTION
The current recommended MySQL driver for Python 3 (mysqlclient)
does support binary fields. Refs #20377.