### PR TITLE
Fixed #24124 -- Used default context_processors in tests.

### DIFF
--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -800,10 +800,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
     'OPTIONS': {
         'context_processors': [
             'django.template.context_processors.debug',
-            'django.template.context_processors.i18n',
-            'django.template.context_processors.tz',
-            'django.template.context_processors.media',
-            'django.template.context_processors.static',
+            'django.template.context_processors.request',
             'django.contrib.auth.context_processors.auth',
             'django.contrib.messages.context_processors.messages',
         ],
@@ -4499,9 +4496,7 @@ class AdminDocsTest(TestCase):
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.debug',
-                'django.template.context_processors.tz',
-                'django.template.context_processors.media',
-                'django.template.context_processors.static',
+                'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -123,12 +123,9 @@ def setup(verbosity, test_labels):
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
         },

--- a/tests/shortcuts/templates/shortcuts/render_test.html
+++ b/tests/shortcuts/templates/shortcuts/render_test.html
@@ -1,1 +1,1 @@
-{{ foo }}.{{ bar }}.{{ baz }}.{{ STATIC_URL }}
+{{ foo }}.{{ bar }}.{{ baz }}.{{ request.path }}

--- a/tests/shortcuts/tests.py
+++ b/tests/shortcuts/tests.py
@@ -3,7 +3,6 @@ from django.test import TestCase, ignore_warnings, override_settings
 
 
 @override_settings(
-    STATIC_URL='/path/to/static/media/',
     ROOT_URLCONF='shortcuts.urls',
 )
 class ShortcutTests(TestCase):
@@ -23,7 +22,7 @@ class ShortcutTests(TestCase):
     def test_render_to_response_with_request_context(self):
         response = self.client.get('/render_to_response/request_context/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'FOO.BAR../path/to/static/media/\n')
+        self.assertEqual(response.content, b'FOO.BAR../render_to_response/request_context/\n')
         self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')
 
     def test_render_to_response_with_content_type(self):
@@ -52,14 +51,14 @@ class ShortcutTests(TestCase):
     def test_render(self):
         response = self.client.get('/render/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'FOO.BAR../path/to/static/media/\n')
+        self.assertEqual(response.content, b'FOO.BAR../render/\n')
         self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')
         self.assertFalse(hasattr(response.context.request, 'current_app'))
 
     def test_render_with_multiple_templates(self):
         response = self.client.get('/render/multiple_templates/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'FOO.BAR../path/to/static/media/\n')
+        self.assertEqual(response.content, b'FOO.BAR../render/multiple_templates/\n')
 
     @ignore_warnings(category=RemovedInDjango20Warning)
     def test_render_with_base_context(self):
@@ -71,13 +70,13 @@ class ShortcutTests(TestCase):
     def test_render_with_content_type(self):
         response = self.client.get('/render/content_type/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'FOO.BAR../path/to/static/media/\n')
+        self.assertEqual(response.content, b'FOO.BAR../render/content_type/\n')
         self.assertEqual(response['Content-Type'], 'application/x-rendertest')
 
     def test_render_with_status(self):
         response = self.client.get('/render/status/')
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.content, b'FOO.BAR../path/to/static/media/\n')
+        self.assertEqual(response.content, b'FOO.BAR../render/status/\n')
 
     @ignore_warnings(category=RemovedInDjango20Warning)
     def test_render_with_current_app(self):

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -16,8 +16,10 @@ from django.core import serializers
 from django.core.urlresolvers import reverse
 from django.db.models import Min, Max
 from django.http import HttpRequest
-from django.template import Context, RequestContext, Template, TemplateSyntaxError
-from django.test import TestCase, override_settings, skipIfDBFeature, skipUnlessDBFeature
+from django.template import (
+    context_processors, Context, RequestContext, Template, TemplateSyntaxError)
+from django.test import (
+    TestCase, override_settings, skipIfDBFeature, skipUnlessDBFeature)
 from django.test.utils import requires_tz_support
 from django.utils import six
 from django.utils import timezone
@@ -935,8 +937,10 @@ class TemplateTests(TestCase):
         Test the django.template.context_processors.tz template context processor.
         """
         tpl = Template("{{ TIME_ZONE }}")
-        self.assertEqual(tpl.render(Context()), "")
-        self.assertEqual(tpl.render(RequestContext(HttpRequest())), "Africa/Nairobi" if pytz else "EAT")
+        context = Context()
+        self.assertEqual(tpl.render(context), "")
+        request_context = RequestContext(HttpRequest(), processors=[context_processors.tz])
+        self.assertEqual(tpl.render(request_context), "Africa/Nairobi" if pytz else "EAT")
 
     @requires_tz_support
     def test_date_and_time_template_filters(self):


### PR DESCRIPTION
Patch from Aymeric

https://code.djangoproject.com/ticket/24124