### PR TITLE
Fixed #24143 - Changed Http404 usages in docs to use instantiated versions

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -442,7 +442,7 @@ for a given poll. Here's the view:
         try:
             question = Question.objects.get(pk=question_id)
         except Question.DoesNotExist:
-            raise Http404
+            raise Http404("Question does not exist")
         return render(request, 'polls/detail.html', {'question': question})
 
 The new concept here: The view raises the :exc:`~django.http.Http404` exception

--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -88,7 +88,7 @@ This accomplishes several things quite nicely:
           try:
               a = Article.objects.get(id=article_id, sites__id=get_current_site(request).id)
           except Article.DoesNotExist:
-              raise Http404
+              raise Http404("Article does not exist on this site")
           # ...
 
 .. _ljworld.com: http://www.ljworld.com/

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -313,7 +313,7 @@ This example is equivalent to::
         try:
             my_object = MyModel.objects.get(pk=1)
         except MyModel.DoesNotExist:
-            raise Http404
+            raise Http404("No MyModel matches the given query.")
 
 The most common use case is to pass a :class:`~django.db.models.Model`, as
 shown above. However, you can also pass a
@@ -383,4 +383,4 @@ This example is equivalent to::
     def my_view(request):
         my_objects = list(MyModel.objects.filter(published=True))
         if not my_objects:
-            raise Http404
+            raise Http404("No MyModel matches the given query.")

--- a/docs/topics/http/views.txt
+++ b/docs/topics/http/views.txt
@@ -119,12 +119,17 @@ Example usage::
         try:
             p = Poll.objects.get(pk=poll_id)
         except Poll.DoesNotExist:
-            raise Http404
+            raise Http404("Poll does not exist")
         return render_to_response('polls/detail.html', {'poll': p})
 
 In order to use the ``Http404`` exception to its fullest, you should create a
 template that is displayed when a 404 error is raised. This template should be
 called ``404.html`` and located in the top level of your template tree.
+
+Any message given when raising the ``Http404`` exception will appear in the
+standard error template displayed when :setting:`DEBUG` is ``True`` for 
+debugging purposes. These messages are generally not suitable for use in a
+production 404 template.
 
 .. _customizing-error-views:
 


### PR DESCRIPTION
Preferring `raise Http404("message")` over `raise Http404`