### PR TITLE
Fixed #24136 -- Prevented crash when convert_extent input is None

### DIFF
--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -193,6 +193,8 @@ class PostGISOperations(DatabaseOperations, BaseSpatialOperations):
         the bounding box text returned by PostGIS (`box` argument), for
         example: "BOX(-90.0 30.0, -85.0 40.0)".
         """
+        if box is None:
+            return None
         ll, ur = box[4:-1].split(',')
         xmin, ymin = map(float, ll.split())
         xmax, ymax = map(float, ur.split())
@@ -204,6 +206,8 @@ class PostGISOperations(DatabaseOperations, BaseSpatialOperations):
         the 3d bounding-box text returned by PostGIS (`box3d` argument), for
         example: "BOX3D(-90.0 30.0 1, -85.0 40.0 2)".
         """
+        if box3d is None:
+            return None
         ll, ur = box3d[6:-1].split(',')
         xmin, ymin, zmin = map(float, ll.split())
         xmax, ymax, zmax = map(float, ur.split())

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -134,6 +134,8 @@ class SpatiaLiteOperations(DatabaseOperations, BaseSpatialOperations):
         """
         Convert the polygon data received from Spatialite to min/max values.
         """
+        if box is None:
+            return None
         shell = Geometry(box, srid).shell
         xmin, ymin = shell[0][:2]
         xmax, ymax = shell[2][:2]

--- a/django/contrib/gis/tests/geo3d/tests.py
+++ b/django/contrib/gis/tests/geo3d/tests.py
@@ -222,6 +222,7 @@ class Geo3DTest(TestCase):
 
         for e3d in [extent1, extent2]:
             check_extent3d(e3d)
+        self.assertIsNone(City3D.objects.none().extent3d())
 
     def test_perimeter(self):
         """

--- a/django/contrib/gis/tests/geoapp/tests.py
+++ b/django/contrib/gis/tests/geoapp/tests.py
@@ -482,6 +482,7 @@ class GeoQuerySetTest(TestCase):
 
         for val, exp in zip(extent, expected):
             self.assertAlmostEqual(exp, val, 4)
+        self.assertIsNone(City.objects.filter(name=('Smalltown')).extent())
 
     @skipUnlessDBFeature("has_force_rhr_method")
     def test_force_rhr(self):


### PR DESCRIPTION
Thanks Max Demars for the report.