### PR TITLE
Refs #24148 -- Documented the bug with case expressions in SQLite < 3.7....

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -603,6 +603,23 @@ substring filtering.
 
 .. _documented at sqlite.org: http://www.sqlite.org/faq.html#q18
 
+SQLite 3.7.0 or newer strongly recommended
+------------------------------------------
+
+Versions of SQLite 3.6.23.1 and older contain a bug when `handling query
+parameters`_ in a ``CASE`` expression that contains an ``ELSE`` and arithmetic.
+
+SQLite 3.6.23.1 was released in March 2010, and most current binary
+distributions for different platforms include a newer version of SQLite, with
+the notable exception of the Python 2.7 installers for Windows.
+
+As of this writing, the latest release for Windows - Python 2.7.9 - includes
+SQLite 3.6.21. It is recommended that you install ``pysqlite2`` or replace
+``sqlite3.dll`` (by default installed in ``C:\Python27\DLLs``) with a newer
+version from http://www.sqlite.org/
+
+.. _handling query parameters: https://code.djangoproject.com/ticket/24148
+
 .. _using-newer-versions-of-pysqlite:
 
 Using newer versions of the SQLite DB-API 2.0 driver

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -7,7 +7,7 @@ import unittest
 from uuid import UUID
 
 from django.core.exceptions import FieldError
-from django.db import models
+from django.db import connection, models
 from django.db.models import F, Q, Value, Min, Max
 from django.db.models.expressions import Case, When
 from django.test import TestCase
@@ -253,6 +253,13 @@ class CaseExpressionTests(TestCase):
             [(1, 3), (2, 2), (3, 4), (2, 2), (3, 4), (3, 4), (4, 4)],
             transform=attrgetter('integer', 'test')
         )
+
+    if connection.vendor == 'sqlite' and connection.Database.sqlite_version_info < (3, 7, 0):
+        # There is a bug in sqlite versions before 3.7.0, where placeholder
+        # order is lost, and the above query returns for each matching case
+        # <condition_value> + <result_value> instead of <result_value> + 1.
+        # For details see #24148.
+        test_combined_expression = unittest.expectedFailure(test_combined_expression)
 
     def test_in_subquery(self):
         self.assertQuerysetEqual(


### PR DESCRIPTION
...0

I've done some testing, and SQLite 3.7.0 is the first version where the failing test case passes.