### PR TITLE
Fix typo in template caching doc

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -688,7 +688,7 @@ a cached item, for example:
     >>> from django.core.cache import cache
     >>> from django.core.cache.utils import make_template_fragment_key
     # cache key for {% cache 500 sidebar username %}
-    >>> key = make_template_fragment_key('sidebar', [username])
+    >>> key = make_template_fragment_key('sidebar', ['username'])
     >>> cache.delete(key) # invalidates cached template fragment
 
 


### PR DESCRIPTION
Noticed this while reading the docs for django.core.cache.utils.make_template_fragment_key.  I did not check the code, but it makes sense for the objects in the *vary_on* arguments to be strings.