### PR TITLE
Fixed #22232 -- Raised custom exception for recursive template extends

### DIFF
--- a/django/template/__init__.py
+++ b/django/template/__init__.py
@@ -54,8 +54,10 @@ __all__ = ('Engine', 'engines')
 ### Django Template Language
 
 # Public exceptions
-from .base import (TemplateDoesNotExist, TemplateSyntaxError,           # NOQA
-                   VariableDoesNotExist)
+from .base import (                                                     # NOQA
+    TemplateCyclicDependencyError, TemplateDoesNotExist, TemplateSyntaxError,
+    VariableDoesNotExist,
+)
 from .context import ContextPopException                                # NOQA
 
 # Template parts

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -134,6 +134,10 @@ class TemplateEncodingError(Exception):
     pass
 
 
+class TemplateCyclicDependencyError(Exception):
+    pass
+
+
 @python_2_unicode_compatible
 class VariableDoesNotExist(Exception):
 

--- a/tests/template_tests/templates/cyclic_extends_child.html
+++ b/tests/template_tests/templates/cyclic_extends_child.html
@@ -1,0 +1,1 @@
+{% extends "cyclic_extends_parent.html" %}

--- a/tests/template_tests/templates/cyclic_extends_parent.html
+++ b/tests/template_tests/templates/cyclic_extends_parent.html
@@ -1,0 +1,1 @@
+{% extends "cyclic_extends_child.html" %}

--- a/tests/template_tests/templates/cyclic_extends_self.html
+++ b/tests/template_tests/templates/cyclic_extends_self.html
@@ -1,0 +1,1 @@
+{% extends "cyclic_extends_self.html" %}

--- a/tests/template_tests/templates/cyclic_extends_variable.html
+++ b/tests/template_tests/templates/cyclic_extends_variable.html
@@ -1,0 +1,1 @@
+{% extends var %}


### PR DESCRIPTION
Fixed the RuntimeError Recursion Depth Exceeded caused in the case of templates being loaded cyclicly.
Added tests for template extension using variable names as well as constant file names.