### PR TITLE
Fixed #24154 -- Backends can now check support for expressions

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -98,12 +98,12 @@ class BaseSpatialOperations(object):
         """
         raise NotImplementedError('subclasses of BaseSpatialOperations must provide a geo_db_placeholder() method')
 
-    def check_aggregate_support(self, aggregate):
-        if isinstance(aggregate, self.disallowed_aggregates):
+    def check_expression_support(self, expression):
+        if isinstance(expression, self.disallowed_aggregates):
             raise NotImplementedError(
-                "%s spatial aggregation is not supported by this database backend." % aggregate.name
+                "%s spatial aggregation is not supported by this database backend." % expression.name
             )
-        super(BaseSpatialOperations, self).check_aggregate_support(aggregate)
+        super(BaseSpatialOperations, self).check_expression_support(expression)
 
     def spatial_aggregate_name(self, agg_name):
         raise NotImplementedError('Aggregate support not implemented for this spatial backend.')

--- a/django/contrib/gis/db/models/aggregates.py
+++ b/django/contrib/gis/db/models/aggregates.py
@@ -9,6 +9,9 @@ class GeoAggregate(Aggregate):
     is_extent = False
 
     def as_sql(self, compiler, connection):
+        # this will be called again in parent, but it's needed now - before
+        # we get the spatial_aggregate_name
+        connection.ops.check_expression_support(self)
         self.function = connection.ops.spatial_aggregate_name(self.name)
         return super(GeoAggregate, self).as_sql(compiler, connection)
 

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -1,3 +1,5 @@
+from django.db.models.aggregates import StdDev
+from django.db.models.expressions import Value
 from django.db.utils import ProgrammingError
 from django.utils.functional import cached_property
 
@@ -226,12 +228,8 @@ class BaseDatabaseFeatures(object):
     @cached_property
     def supports_stddev(self):
         """Confirm support for STDDEV and related stats functions."""
-        class StdDevPop(object):
-            contains_aggregate = True
-            sql_function = 'STDDEV_POP'
-
         try:
-            self.connection.ops.check_aggregate_support(StdDevPop())
+            self.connection.ops.check_expression_support(StdDev(Value(1)))
             return True
         except NotImplementedError:
             return False

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -1,12 +1,14 @@
 import datetime
 import decimal
 from importlib import import_module
+import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.backends import utils
 from django.utils import six, timezone
 from django.utils.dateparse import parse_duration
+from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.encoding import force_text
 
 
@@ -517,12 +519,20 @@ class BaseDatabaseOperations(object):
         return value
 
     def check_aggregate_support(self, aggregate_func):
-        """Check that the backend supports the provided aggregate
+        warnings.warn(
+            "check_aggregate_support has been deprecated. Use "
+            "check_expression_support instead.",
+            RemovedInDjango21Warning, stacklevel=2)
+        return self.check_expression_support(aggregate_func)
 
-        This is used on specific backends to rule out known aggregates
-        that are known to have faulty implementations. If the named
-        aggregate function has a known problem, the backend should
-        raise NotImplementedError.
+    def check_expression_support(self, expression):
+        """
+        Check that the backend supports the provided expression.
+
+        This is used on specific backends to rule out known expressions
+        that have problematic or nonexistent implementations. If the
+        expression has a known problem, the backend should raise
+        NotImplementedError.
         """
         pass
 

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -60,7 +60,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         """Confirm support for STDDEV and related stats functions
 
         SQLite supports STDDEV as an extension package; so
-        connection.ops.check_aggregate_support() can't unilaterally
+        connection.ops.check_expression_support() can't unilaterally
         rule out support for STDDEV. We need to manually check
         whether the call works.
         """

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -25,17 +25,6 @@ class Aggregate(Func):
         c._patch_aggregate(query)  # backward-compatibility support
         return c
 
-    def refs_field(self, aggregate_types, field_types):
-        try:
-            return (isinstance(self, aggregate_types) and
-                    isinstance(self.input_field._output_field_or_none, field_types))
-        except FieldError:
-            # Sometimes we don't know the input_field's output type (for example,
-            # doing Sum(F('datetimefield') + F('datefield'), output_type=DateTimeField())
-            # is OK, but the Expression(F('datetimefield') + F('datefield')) doesn't
-            # have any output field.
-            return False
-
     @property
     def input_field(self):
         return self.source_expressions[0]

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -230,11 +230,6 @@ class Query(object):
             raise ValueError("Need either using or connection")
         if using:
             connection = connections[using]
-
-        # Check that the compiler will be able to execute the query
-        for alias, annotation in self.annotation_select.items():
-            connection.ops.check_aggregate_support(annotation)
-
         return connection.ops.compiler(self.compiler)(self, connection, using)
 
     def get_meta(self):

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -153,17 +153,6 @@ class WhereNode(tree.Node):
     def contains_aggregate(self):
         return self._contains_aggregate(self)
 
-    @classmethod
-    def _refs_field(cls, obj, aggregate_types, field_types):
-        if not isinstance(obj, tree.Node):
-            if hasattr(obj.rhs, 'refs_field'):
-                return obj.rhs.refs_field(aggregate_types, field_types)
-            return False
-        return any(cls._refs_field(c, aggregate_types, field_types) for c in obj.children)
-
-    def refs_field(self, aggregate_types, field_types):
-        return self._refs_field(self, aggregate_types, field_types)
-
 
 class EmptyWhere(WhereNode):
     def add(self, data, connector):

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -127,12 +127,19 @@ class SQLiteTests(TestCase):
         #19360: Raise NotImplementedError when aggregating on date/time fields.
         """
         for aggregate in (Sum, Avg, Variance, StdDev):
-            self.assertRaises(NotImplementedError,
+            self.assertRaises(
+                NotImplementedError,
                 models.Item.objects.all().aggregate, aggregate('time'))
-            self.assertRaises(NotImplementedError,
+            self.assertRaises(
+                NotImplementedError,
                 models.Item.objects.all().aggregate, aggregate('date'))
-            self.assertRaises(NotImplementedError,
+            self.assertRaises(
+                NotImplementedError,
                 models.Item.objects.all().aggregate, aggregate('last_modified'))
+            self.assertRaises(
+                NotImplementedError,
+                models.Item.objects.all().aggregate,
+                **{'complex': aggregate('last_modified') + aggregate('last_modified')})
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', "Test only for PostgreSQL")


### PR DESCRIPTION
This fixes a bug where complex aggregates may not have been checked by the backend. It also extends the utility to all expression types that may need to be checked.

Obviously correct expressions like `Col` do not opt in to checking - since they will work across all backends.

There are no docs because this is not a public API. 3rd party expressions should not opt into checking, because backends can not know if they are supported or not.

The backend method `check_aggregate_support` has been renamed to `check_expression_support` and a warning inserted. Unsure whether or not this should be documented in release notes separately, or just as part of #24106.