### PR TITLE
Fixed #24174 -- Fixed extra order by descending

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -261,8 +261,10 @@ class SQLCompiler(object):
                 # on verbatim.
                 table, col = col.split('.', 1)
                 order_by.append((
-                    OrderBy(RawSQL('%s.%s' % (self.quote_name_unless_alias(table), col), [])),
-                    False))
+                    OrderBy(
+                        RawSQL('%s.%s' % (self.quote_name_unless_alias(table), col), []),
+                        descending=descending
+                    ), False))
                 continue
 
             if not self.query._extra or col not in self.query._extra:

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -166,6 +166,26 @@ class OrderingTests(TestCase):
             attrgetter("headline")
         )
 
+    def test_extra_ordering_with_table_name(self):
+        self.assertQuerysetEqual(
+            Article.objects.extra(order_by=['ordering_article.headline']), [
+                "Article 1",
+                "Article 2",
+                "Article 3",
+                "Article 4",
+            ],
+            attrgetter("headline")
+        )
+        self.assertQuerysetEqual(
+            Article.objects.extra(order_by=['-ordering_article.headline']), [
+                "Article 4",
+                "Article 3",
+                "Article 2",
+                "Article 1",
+            ],
+            attrgetter("headline")
+        )
+
     def test_order_by_pk(self):
         """
         Ensure that 'pk' works as an ordering option in Meta.


### PR DESCRIPTION
Fixed a regression where the ordering direction was ignored for extra(order_by=..) where the table name was also referenced:

```
.extra(order_by=['-table.col'])
```