### PR TITLE
Fixed incorrect method used: validate instead of check

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
         quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
 
         self.stdout.write("Performing system checks...\n\n")
-        self.validate(display_num_errors=True)
+        self.check(display_num_errors=True)
         try:
             self.check_migrations()
         except ImproperlyConfigured:


### PR DESCRIPTION
In previous commits changed the call of check to validate. That generates errors because of no method called validate is present in current class or parent.