### PR TITLE
Cleaned up expressions

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -94,6 +94,13 @@ class Count(Aggregate):
         super(Count, self).__init__(
             expression, distinct='DISTINCT ' if distinct else '', output_field=IntegerField(), **extra)
 
+    def __repr__(self):
+        return "{}({}, distinct={})".format(
+            self.__class__.__name__,
+            self.arg_joiner.join(str(arg) for arg in self.source_expressions),
+            'False' if self.extra['distinct'] == '' else 'True',
+        )
+
     def convert_value(self, value, connection, context):
         if value is None:
             return 0
@@ -117,6 +124,13 @@ class StdDev(Aggregate):
         self.function = 'STDDEV_SAMP' if sample else 'STDDEV_POP'
         super(StdDev, self).__init__(expression, output_field=FloatField(), **extra)
 
+    def __repr__(self):
+        return "{}({}, sample={})".format(
+            self.__class__.__name__,
+            self.arg_joiner.join(str(arg) for arg in self.source_expressions),
+            'False' if self.function == 'STDDEV_POP' else 'True',
+        )
+
     def convert_value(self, value, connection, context):
         if value is None:
             return value
@@ -134,6 +148,13 @@ class Variance(Aggregate):
     def __init__(self, expression, sample=False, **extra):
         self.function = 'VAR_SAMP' if sample else 'VAR_POP'
         super(Variance, self).__init__(expression, output_field=FloatField(), **extra)
+
+    def __repr__(self):
+        return "{}({}, sample={})".format(
+            self.__class__.__name__,
+            self.arg_joiner.join(str(arg) for arg in self.source_expressions),
+            'False' if self.function == 'VAR_POP' else 'True',
+        )
 
     def convert_value(self, value, connection, context):
         if value is None:

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 
-class CombinableMixin(object):
+class Combinable(object):
     """
     Provides the ability to combine one or two objects with
     some connector. For example F('foo') + F('bar').
@@ -184,6 +184,7 @@ class BaseExpression(object):
            in this query
          * reuse: a set of reusable joins for multijoins
          * summarize: a terminal aggregate clause
+         * for_save: whether this expression about to be used in a save or update
 
         Returns: an ExpressionNode to be added to the query.
         """
@@ -297,9 +298,6 @@ class BaseExpression(object):
                 return agg, lookup
         return False, ()
 
-    def prepare_database_save(self, field):
-        return self
-
     def get_group_by_cols(self):
         if not self.contains_aggregate:
             return [self]
@@ -325,7 +323,7 @@ class BaseExpression(object):
         return self
 
 
-class ExpressionNode(BaseExpression, CombinableMixin):
+class ExpressionNode(BaseExpression, Combinable):
     """
     An expression that can be combined with other expressions.
     """

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -137,6 +137,28 @@ class OrderingTests(TestCase):
             attrgetter("headline")
         )
 
+    def test_reverse_ordering_pure(self):
+        qs1 = Article.objects.order_by(F('headline').asc())
+        qs2 = qs1.reverse()
+        self.assertQuerysetEqual(
+            qs1, [
+                "Article 1",
+                "Article 2",
+                "Article 3",
+                "Article 4",
+            ],
+            attrgetter("headline")
+        )
+        self.assertQuerysetEqual(
+            qs2, [
+                "Article 4",
+                "Article 3",
+                "Article 2",
+                "Article 1",
+            ],
+            attrgetter("headline")
+        )
+
     def test_extra_ordering(self):
         """
         Ordering can be based on fields included from an 'extra' clause


### PR DESCRIPTION
Fixes some cruft that was accidentally left in. Adds repr methods to the majority of expressions. Renames CombinableMixin to Combinable.

I was also going to add a commit to introduce the concept of Resolvable, but it was unclear which methods should be moved to that type, and it unnecessarily complicated the implementation so I ditched the idea.

I can split the changes here into multiple commits if need be, and add tickets for each one also.