### PR TITLE
Fixed a query failure on Python 3.5; refs #23763.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -402,7 +402,7 @@ class Query(object):
             # Remove any aggregates marked for reduction from the subquery
             # and move them to the outer AggregateQuery.
             col_cnt = 0
-            for alias, expression in inner_query.annotation_select.items():
+            for alias, expression in list(inner_query.annotation_select.items()):
                 if expression.is_summary:
                     expression, col_cnt = inner_query.rewrite_cols(expression, col_cnt)
                     outer_query.annotations[alias] = expression.relabeled_clone(relabels)


### PR DESCRIPTION
The failure was introduced in Django by
c7fd9b242d2d63406f1de6cc3204e35aaa025233 and the change in
Python 3.5 is https://hg.python.org/cpython/rev/a3c345ba3563.

Sample test failure:
```
======================================================================
ERROR: test_tickets_1878_2939 (queries.tests.Queries1Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tim/code/django/tests/queries/tests.py", line 217, in test_tickets_1878_2939
    self.assertEqual(Item.objects.values('creator').distinct().count(), 3)
  File "/home/tim/code/django/django/db/models/query.py", line 313, in count
    return self.query.get_count(using=self.db)
  File "/home/tim/code/django/django/db/models/sql/query.py", line 447, in get_count
    number = obj.get_aggregation(using, ['__count'])['__count']
  File "/home/tim/code/django/django/db/models/sql/query.py", line 405, in get_aggregation
    for alias, expression in inner_query.annotation_select.items():
  File "/home/tim/code/cpython/Lib/_collections_abc.py", line 509, in __iter__
    for key in self._mapping:
  File "/home/tim/code/cpython/Lib/collections/__init__.py", line 112, in __iter__
    yield curr.key
AttributeError: 'NoneType' object has no attribute 'key'
```