### PR TITLE
Fixed #23617 -- Documented caveats with pk=UUIDField.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1061,7 +1061,9 @@ it is recommended to use :attr:`~Field.default`::
         # other fields
 
 Note that a callable (with the parentheses omitted) is passed to ``default``,
-not an instance of ``UUID``.
+not an instance of ``UUID``. Note also that :ref:`copying a model instance
+<_topics-db-queries-copy>` will not work simply by setting `instance.pk = None`
+in this case, you must manually set the new value.
 
 Relationship fields
 ===================

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -970,6 +970,14 @@ field to ``Author``::
     entry.save()
     entry.authors = old_authors # saves new many2many relations
 
+.. note::
+
+    Note that this behaviour expects the primary key to be an
+    :class:`~django.db.models.AutoField`. If you have chosen another primary
+    key type, such as :class:`~django.db.models.UUIDField` you will need to
+    explicitly set a new primary key as the database will not generate a new
+    one.
+
 .. _topics-db-queries-update:
 
 Updating multiple objects at once


### PR DESCRIPTION
Setting another field type than AutoField as the primary key does not necessarily guarantee AutoField like behaviour.