### PR TITLE
Fixes #24169 -- More arrayfield specific lookups.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -158,8 +158,20 @@ class ArrayContains(lookups.DataContains):
         return sql, params
 
 
-ArrayField.register_lookup(lookups.ContainedBy)
-ArrayField.register_lookup(lookups.Overlap)
+@ArrayField.register_lookup
+class ArrayContainedBy(lookups.ContainedBy):
+    def as_sql(self, qn, connection):
+        sql, params = super(ArrayContainedBy, self).as_sql(qn, connection)
+        sql += '::%s' % self.lhs.output_field.db_type(connection)
+        return sql, params
+
+
+@ArrayField.register_lookup
+class ArrayOverlap(lookups.Overlap):
+    def as_sql(self, qn, connection):
+        sql, params = super(ArrayOverlap, self).as_sql(qn, connection)
+        sql += '::%s' % self.lhs.output_field.db_type(connection)
+        return sql, params
 
 
 @ArrayField.register_lookup

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -156,6 +156,18 @@ class TestQuerying(TestCase):
             []
         )
 
+    def test_contained_by_charfield(self):
+        self.assertSequenceEqual(
+            CharArrayModel.objects.filter(field__contained_by=['text']),
+            []
+        )
+
+    def test_overlap_charfield(self):
+        self.assertSequenceEqual(
+            CharArrayModel.objects.filter(field__overlap=['text']),
+            []
+        )
+
     def test_index(self):
         self.assertSequenceEqual(
             NullableIntegerArrayModel.objects.filter(field__0=2),


### PR DESCRIPTION
varchar()[] cannot compare itself to text[]

Thanks to joelburton for the patch.