### PR TITLE
Fix #24204 - Add character remaining count to fields with maxlengths

### DIFF
--- a/django/contrib/admin/static/admin/css/chars-remaining.css
+++ b/django/contrib/admin/static/admin/css/chars-remaining.css
@@ -1,0 +1,7 @@
+input[maxlength] + span {
+    margin-left: 1em;
+}
+
+input[maxlength] + span .count {
+    margin-right: .5em;
+}

--- a/django/contrib/admin/static/admin/css/chars-remaining.css
+++ b/django/contrib/admin/static/admin/css/chars-remaining.css
@@ -1,5 +1,6 @@
 input[maxlength] + span {
     margin-left: 1em;
+    display: none;
 }
 
 input[maxlength] + span .count {

--- a/django/contrib/admin/static/admin/js/chars-remaining.js
+++ b/django/contrib/admin/static/admin/js/chars-remaining.js
@@ -1,0 +1,12 @@
+(function($) {
+    function updateCount() {
+        var $this = $(this);
+        var remaining = parseInt($this.attr('maxlength'), 10) - $this.val().length;
+        $this.next().find('.count').html(remaining);
+    }
+
+    var container = $(document);
+    container.on('change', 'input[maxlength]', updateCount);
+    container.on('keyup', 'input[maxlength]', updateCount);
+
+})(django.jQuery);

--- a/django/contrib/admin/static/admin/js/chars-remaining.js
+++ b/django/contrib/admin/static/admin/js/chars-remaining.js
@@ -1,4 +1,8 @@
 (function($) {
+    function toggleVisibility() {
+        $(this).next().toggle();
+    }
+
     function updateCount() {
         var $this = $(this);
         var remaining = parseInt($this.attr('maxlength'), 10) - $this.val().length;
@@ -6,6 +10,8 @@
     }
 
     var container = $(document);
+    container.on('focusin', 'input[maxlength]', toggleVisibility);
+    container.on('focusout', 'input[maxlength]', toggleVisibility);
     container.on('change', 'input[maxlength]', updateCount);
     container.on('keyup', 'input[maxlength]', updateCount);
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -339,6 +339,26 @@ class AdminTextInputWidget(forms.TextInput):
             final_attrs.update(attrs)
         super(AdminTextInputWidget, self).__init__(attrs=final_attrs)
 
+    @property
+    def media(self):
+        return forms.Media(css={'all': [static('admin/css/chars-remaining.css')]},
+                           js=[static('admin/js/chars-remaining.js')])
+
+    def render(self, name, value, attrs=None):
+        if value is None:
+            value = ''
+        final_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
+        if value != '':
+            final_attrs['value'] = force_text(self._format_value(value))
+        maxlength = final_attrs.get('maxlength')
+        if maxlength is None:
+            return format_html('<input{} />', flatatt(final_attrs))
+
+        current = int(maxlength) - len(value)
+        html = format_html('<input{} /><span><span class="count">{}</span>{}</span>',
+                           flatatt(final_attrs), current, _('character(s) remaining'))
+        return html
+
 
 class AdminEmailInputWidget(forms.EmailInput):
     def __init__(self, attrs=None):


### PR DESCRIPTION

I have a bunch of questions/would like review.

* Proper placement of the chars remaining and if it needs to be that much text (maybe just a character count instead of the phrase "character(s) remaining") since it looks a bit cluttered.

![chars_remaining](https://cloud.githubusercontent.com/assets/2245080/5866311/097afe50-a25e-11e4-87b1-5a4dd872f9bf.png)

* Should this also be used for email fields. The email widget is the same as the TextInput widget currently in admin.contrib.widgets.

* Should styling be separated out like that, it doesn't look as through there is any separate css styling in the admin.contrib.widgets file.

* General implementation, I had to duplicate the code from forms.widgets.

Also a shout out to https://github.com/timmyomahony/django-charsleft-widget from which I got the original idea.