### PR TITLE
[1.6.x] Fixed #4444 - Made runserver suppress 'broken pipe' errors

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -98,6 +98,11 @@ class ServerHandler(simple_server.ServerHandler, object):
             self.close()
 
 
+def is_broken_pipe_error():
+    exc_type, exc_value = sys.exc_info()[:2]
+    return issubclass(exc_type, socket.error) and exc_value.args[0] == 32
+
+
 class WSGIServer(simple_server.WSGIServer, object):
     """BaseHTTPServer that implements the Python WSGI protocol"""
 
@@ -112,6 +117,19 @@ class WSGIServer(simple_server.WSGIServer, object):
         """Override server_bind to store the server name."""
         super(WSGIServer, self).server_bind()
         self.setup_environ()
+
+    def handle_error(self, request, client_address):
+        if is_broken_pipe_error():
+            sys.stderr.write("- Broken pipe from %s\n" % (client_address,))
+        else:
+            super(WSGIServer, self).handle_error(request, client_address)
+
+
+class ServerHandler(simple_server.ServerHandler):
+    def handle_error(self):
+        # Ignore broken pipe errors, otherwise pass on
+        if not is_broken_pipe_error():
+            super(ServerHandler, self).handle_error()
 
 
 class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
@@ -167,6 +185,26 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
                 del self.headers[k]
 
         return super(WSGIRequestHandler, self).get_environ()
+
+    def handle(self):
+        """Copy of WSGIRequestHandler, but with different ServerHandler"""
+
+        self.raw_requestline = self.rfile.readline(65537)
+        if len(self.raw_requestline) > 65536:
+            self.requestline = ''
+            self.request_version = ''
+            self.command = ''
+            self.send_error(414)
+            return
+
+        if not self.parse_request():  # An error code has been sent, just exit
+            return
+
+        handler = ServerHandler(
+            self.rfile, self.wfile, self.get_stderr(), self.get_environ()
+        )
+        handler.request_handler = self      # backpointer for logging
+        handler.run(self.server.get_app())
 
 
 def run(addr, port, wsgi_handler, ipv6=False, threading=False):


### PR DESCRIPTION
One handler in WSGIServer, to catch the error when raised from
SocketServer.BaseServer's finish_request, and one in WSGIRequestHandler
(by creating a subclass of ServerHandler), to catch the error when
raised in wsgiref.handlers.BaseHandler's finish_response.

(cherry picked from commit 9253042d53d61b23b3f727a00c41e8089be73836)

-----

Backporter note: is this the correct way to get patches backported to still supported versions? Shall I do the same for 1.7?