### PR TITLE
[1.8.alpha1] Fixed #24209 -- Wrong configured encoded headers RFC 2231

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -643,7 +643,8 @@ def parse_header(line):
                 # Lang/encoding embedded in the value (like "filename*=UTF-8''file.ext")
                 # http://tools.ietf.org/html/rfc2231#section-4
                 name = name[:-1]
-                has_encoding = True
+                if p.count(b"'") == 2:
+                    has_encoding = True
             value = p[i + 1:].strip()
             if has_encoding:
                 encoding, lang, value = value.split(b"'")

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -584,3 +584,16 @@ class MultiParserTests(unittest.TestCase):
         for raw_line, expected_title in test_data:
             parsed = parse_header(raw_line)
             self.assertEqual(parsed[1]['title'], expected_title)
+
+    def test_rfc2231_wrong_title(self):
+        test_data = (
+            (b"Content-Type: application/x-stuff; title*='This%20is%20%2A%2A%2Afun%2A%2A%2A",
+             b"'This%20is%20%2A%2A%2Afun%2A%2A%2A"),
+            (b"Content-Type: application/x-stuff; title*='foo.html",
+             b"'foo.html"),
+            (b"Content-Type: application/x-stuff; title*=bar.html",
+             b"bar.html"),
+        )
+        for raw_line, expected_title in test_data:
+            parsed = parse_header(raw_line)
+            self.assertEqual(parsed[1]['title'], expected_title)


### PR DESCRIPTION
This fixes wrongly configured Content-type headers as per RFC 2231.

Not sure what we want to do when the header is of the type:
```
title*='This%20is%20%2A%2A%2Afun%2A%2A%2A
```
As per RFC I think we should raise a Wrong Header Exception as RFC says that the two delimiters ```'```` MUST be present. (The current behaviour is continue silently as you can see at the unit tests):
```
   Note also that the single quote
   delimiters MUST be present even when one of the field values is
   omitted.  This is done when either character set, language, or both
   are not relevant to the parameter value at hand.  This MUST NOT be
   done in order to indicate a default character set or language --
   parameter field definitions MUST NOT assign a default character set
   or language.
```
We also do not implement the section 4.1 of the RFC. I can raise a PR with section 4.1:
http://tools.ietf.org/html/rfc2231#section-4.1 