### PR TITLE
Changed Azerbaijani language name in Django locales

### DIFF
--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -33,7 +33,7 @@ LANG_INFO = {
         'bidi': True,
         'code': 'az',
         'name': 'Azerbaijani',
-        'name_local': 'Azərbaycan dili',
+        'name_local': 'Azərbaycanca',
     },
     'be': {
         'bidi': False,

--- a/django/conf/locale/__init__.py
+++ b/django/conf/locale/__init__.py
@@ -33,7 +33,7 @@ LANG_INFO = {
         'bidi': True,
         'code': 'az',
         'name': 'Azerbaijani',
-        'name_local': 'azərbaycan dili',
+        'name_local': 'Azərbaycan dili',
     },
     'be': {
         'bidi': False,


### PR DESCRIPTION
Changed Azerbaijani language name for Django locales

Azerbaijani language name is not correct, so it displays wrong in language switcher. First letter should be upper case and all open source communities in Azerbaijan are using 'Azərbaycanca' as language name (Mozilla, RoR, Ubuntu and etc.).