### PR TITLE
[1.7.x] Fixed #24236 -- Treated inherited m2m fields as such if they don't define get_internal_type()

### DIFF
--- a/django/db/backends/schema.py
+++ b/django/db/backends/schema.py
@@ -3,6 +3,7 @@ import operator
 
 from django.db.backends.creation import BaseDatabaseCreation
 from django.db.backends.utils import truncate_name
+from django.db.models.fields.related import ManyToManyField
 from django.db.transaction import atomic
 from django.utils.encoding import force_bytes
 from django.utils.log import getLogger
@@ -358,7 +359,8 @@ class BaseDatabaseSchemaEditor(object):
         table instead (for M2M fields)
         """
         # Special-case implicit M2M tables
-        if field.get_internal_type() == 'ManyToManyField' and field.rel.through._meta.auto_created:
+        if ((isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField') and
+                field.rel.through._meta.auto_created):
             return self.create_model(field.rel.through)
         # Get the column's definition
         definition, params = self.column_sql(model, field, include_default=True)
@@ -402,7 +404,8 @@ class BaseDatabaseSchemaEditor(object):
         but for M2Ms may involve deleting a table.
         """
         # Special-case implicit M2M tables
-        if field.get_internal_type() == 'ManyToManyField' and field.rel.through._meta.auto_created:
+        if ((isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField') and
+                field.rel.through._meta.auto_created):
             return self.delete_model(field.rel.through)
         # It might not actually have a column behind it
         if field.db_parameters(connection=self.connection)['type'] is None:

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from django.utils import six
 from django.apps.registry import Apps
 from django.db.backends.schema import BaseDatabaseSchemaEditor
+from django.db.models.fields.related import ManyToManyField
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
@@ -69,7 +70,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         for field in create_fields:
             body[field.name] = field
             # Choose a default and insert it into the copy map
-            if not field.get_internal_type() == 'ManyToManyField':
+            if not (isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField'):
                 mapping[field.column] = self.quote_value(
                     self.effective_default(field)
                 )
@@ -92,7 +93,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             del body[field.name]
             del mapping[field.column]
             # Remove any implicit M2M tables
-            if field.get_internal_type() == 'ManyToManyField' and field.rel.through._meta.auto_created:
+            if ((isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField') and
+                    field.rel.through._meta.auto_created):
                 return self.delete_model(field.rel.through)
         # Work inside a new app registry
         apps = Apps()
@@ -171,7 +173,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         table instead (for M2M fields)
         """
         # Special-case implicit M2M tables
-        if field.get_internal_type() == 'ManyToManyField' and field.rel.through._meta.auto_created:
+        if ((isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField') and
+                field.rel.through._meta.auto_created):
             return self.create_model(field.rel.through)
         self._remake_table(model, create_fields=[field])
 
@@ -181,7 +184,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         but for M2Ms may involve deleting a table.
         """
         # M2M fields are a special case
-        if field.get_internal_type() == 'ManyToManyField':
+        if isinstance(field, ManyToManyField) or field.get_internal_type() == 'ManyToManyField':
             # For implicit M2M tables, delete the auto-created table
             if field.rel.through._meta.auto_created:
                 self.delete_model(field.rel.through)

--- a/docs/releases/1.7.5.txt
+++ b/docs/releases/1.7.5.txt
@@ -13,3 +13,6 @@ Bugfixes
   ``contrib.contenttypes``’s or ``contrib.auth``’s first migration
   (:ticket:`24075`) due to severe impact on the test performance
   (:ticket:`24251`) and problems in multi-database setups (:ticket:`24298`).
+
+* Fixed a regression that prevented custom fields inheriting from
+  ``ManyToManyField`` from being recognized in migrations (:ticket:`24236`).

--- a/tests/schema/fields.py
+++ b/tests/schema/fields.py
@@ -52,3 +52,7 @@ class CustomManyToManyField(RelatedField):
     _get_m2m_attr = ManyToManyField.__dict__['_get_m2m_attr']
     _get_m2m_reverse_attr = ManyToManyField.__dict__['_get_m2m_reverse_attr']
     _get_m2m_db_table = ManyToManyField.__dict__['_get_m2m_db_table']
+
+
+class InheritedManyToManyField(ManyToManyField):
+    pass

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -7,7 +7,7 @@ from django.db.models.fields import (BinaryField, BooleanField, CharField, Integ
     PositiveIntegerField, SlugField, TextField)
 from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField
 from django.db.transaction import atomic
-from .fields import CustomManyToManyField
+from .fields import CustomManyToManyField, InheritedManyToManyField
 from .models import (Author, AuthorWithDefaultHeight, AuthorWithM2M, Book, BookWithLongName,
     BookWithSlug, BookWithM2M, Tag, TagIndexed, TagM2MTest, TagUniqueRename,
     UniqueTest, Thing, TagThrough, BookWithM2MThrough, AuthorTag, AuthorWithM2MThrough,
@@ -1322,6 +1322,50 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(TagM2MTest)
         # Create an M2M field
         new_field = CustomManyToManyField("schema.TagM2MTest", related_name="authors")
+        new_field.contribute_to_class(AuthorWithM2M, "tags")
+        # Ensure there's no m2m table there
+        self.assertRaises(DatabaseError, self.column_classes, new_field.rel.through)
+        try:
+            # Add the field
+            with connection.schema_editor() as editor:
+                editor.add_field(
+                    AuthorWithM2M,
+                    new_field,
+                )
+            # Ensure there is now an m2m table there
+            columns = self.column_classes(new_field.rel.through)
+            self.assertEqual(columns['tagm2mtest_id'][0], "IntegerField")
+
+            # "Alter" the field. This should not rename the DB table to itself.
+            with connection.schema_editor() as editor:
+                editor.alter_field(
+                    AuthorWithM2M,
+                    new_field,
+                    new_field,
+                )
+
+            # Remove the M2M table again
+            with connection.schema_editor() as editor:
+                editor.remove_field(
+                    AuthorWithM2M,
+                    new_field,
+                )
+            # Ensure there's no m2m table there
+            self.assertRaises(DatabaseError, self.column_classes, new_field.rel.through)
+        finally:
+            # Cleanup model states
+            AuthorWithM2M._meta.local_many_to_many.remove(new_field)
+
+    def test_inherited_manytomanyfield(self):
+        """
+        #24104 - Schema editors should look for internal type of field
+        """
+        # Create the tables
+        with connection.schema_editor() as editor:
+            editor.create_model(AuthorWithM2M)
+            editor.create_model(TagM2MTest)
+        # Create an M2M field
+        new_field = InheritedManyToManyField("schema.TagM2MTest", related_name="authors")
         new_field.contribute_to_class(AuthorWithM2M, "tags")
         # Ensure there's no m2m table there
         self.assertRaises(DatabaseError, self.column_classes, new_field.rel.through)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24236