### PR TITLE
Fixed #23617 -- Added get_pk_value_on_save()

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -771,6 +771,9 @@ class Model(six.with_metaclass(ModelBase)):
                        if f.name in update_fields or f.attname in update_fields]
 
         pk_val = self._get_pk_val(meta)
+        if pk_val is None:
+            pk_val = meta.pk.get_pk_value_on_save(self)
+            setattr(self, meta.pk.attname, pk_val)
         pk_set = pk_val is not None
         if not pk_set and (force_update or update_fields):
             raise ValueError("Cannot force an update in save() with no primary key.")

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -503,6 +503,17 @@ class Field(RegisterLookupMixin):
         return _load_field, (self.model._meta.app_label, self.model._meta.object_name,
                              self.name)
 
+    def get_pk_value_on_save(self, instance):
+        """
+        Hook to generate new PK values on save. This method is called when
+        saving instances with no primary key value set. If this method returns
+        something else than None, then the returned value is used when saving
+        the new instance.
+        """
+        if self.default:
+            return self.get_default()
+        return None
+
     def to_python(self, value):
         """
         Converts the input value into the expected Python data type, raising

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -217,6 +217,14 @@ Note that ``lambda``\s cannot be used for field options like ``default``
 because they cannot be :ref:`serialized by migrations <migration-serializing>`.
 See that documentation for other caveats.
 
+The default value is used when new model instances are created, and no value is
+provided for the field. When the field is a primary key, the default is used
+also when the field is set to ``None``.
+
+.. versionchanged:: 1.8
+
+    The default wasn't used for ``None`` primary key values in previous versions.
+
 ``editable``
 ------------
 

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -87,3 +87,20 @@ class TestAsPrimaryKey(TestCase):
         PrimaryKeyUUIDModel.objects.create()
         loaded = PrimaryKeyUUIDModel.objects.get()
         self.assertIsInstance(loaded.pk, uuid.UUID)
+
+    def test_uuid_pk_on_save(self):
+        saved = PrimaryKeyUUIDModel.objects.create(id=None)
+        loaded = PrimaryKeyUUIDModel.objects.get()
+        self.assertIsNotNone(loaded.id, None)
+        self.assertEqual(loaded.id, saved.id)
+
+    def test_uuid_pk_on_bulk_create(self):
+        u1 = PrimaryKeyUUIDModel()
+        u2 = PrimaryKeyUUIDModel(id=None)
+        PrimaryKeyUUIDModel.objects.bulk_create([u1, u2])
+        # Check that the two objects were correctly created.
+        u1_found = PrimaryKeyUUIDModel.objects.filter(id=u1.id).exists()
+        u2_found = PrimaryKeyUUIDModel.objects.exclude(id=u1.id).exists()
+        self.assertTrue(u1_found)
+        self.assertTrue(u2_found)
+        self.assertEqual(PrimaryKeyUUIDModel.objects.count(), 2)


### PR DESCRIPTION
The method is mainly intended for use with UUIDField. For UUIDField we
want to call the field's default even when primary key value is
explicitly set to None to match the behaviour of AutoField.