### PR TITLE
Fixed #24223 - SessionMiddlewareTests now use django.test.TestCase

### DIFF
--- a/django/contrib/sessions/tests.py
+++ b/django/contrib/sessions/tests.py
@@ -513,7 +513,8 @@ class CacheSessionTests(SessionTestsMixin, unittest.TestCase):
         self.assertNotEqual(caches['sessions'].get(self.session.cache_key), None)
 
 
-class SessionMiddlewareTests(unittest.TestCase):
+# DB flushing required since Session objects created, so use TestCase
+class SessionMiddlewareTests(TestCase):
 
     @override_settings(SESSION_COOKIE_SECURE=True)
     def test_secure_session_cookie(self):

--- a/django/contrib/sessions/tests.py
+++ b/django/contrib/sessions/tests.py
@@ -606,7 +606,7 @@ class SessionMiddlewareTests(TestCase):
         )
 
 
-class CookieSessionTests(SessionTestsMixin, TestCase):
+class CookieSessionTests(SessionTestsMixin, unittest.TestCase):
 
     backend = CookieSession
 


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/24223 for more info