### PR TITLE
Removed threading fallback imports.

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -10,10 +10,7 @@ from django.db.backends import utils
 from django.db.transaction import TransactionManagementError
 from django.db.utils import DatabaseError, DatabaseErrorWrapper
 from django.utils.functional import cached_property
-try:
-    from django.utils.six.moves import _thread as thread
-except ImportError:
-    from django.utils.six.moves import _dummy_thread as thread
+from django.utils.six.moves import _thread as thread
 
 
 NO_DB_ALIAS = '__no_db__'

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -39,10 +39,7 @@ import traceback
 from django.apps import apps
 from django.conf import settings
 from django.core.signals import request_finished
-try:
-    from django.utils.six.moves import _thread as thread
-except ImportError:
-    from django.utils.six.moves import _dummy_thread as thread
+from django.utils.six.moves import _thread as thread
 
 # This import does nothing, but it's necessary to avoid some race conditions
 # in the threading module. See http://code.djangoproject.com/ticket/2330 .

--- a/django/utils/synch.py
+++ b/django/utils/synch.py
@@ -7,10 +7,7 @@ Synchronization primitives:
 """
 
 import contextlib
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
 
 
 class RWLock(object):

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -6,15 +6,11 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
 import time
 import unittest
 import warnings
 from datetime import datetime, timedelta
-
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
 
 from django.core.cache import cache
 from django.core.exceptions import SuspiciousOperation, SuspiciousFileOperation

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
+import threading
 import time
-import unittest
 
 from django.conf import settings
 from django.db import transaction, connection, router
@@ -14,14 +14,6 @@ from django.test import (
 from multiple_database.routers import TestRouter
 
 from .models import Person
-
-# Some tests require threading, which might not be available. So create a
-# skip-test decorator for those test functions.
-try:
-    import threading
-except ImportError:
-    threading = None
-requires_threading = unittest.skipUnless(threading, 'requires threading')
 
 
 # We need to set settings.DEBUG to True so we can capture the output SQL
@@ -92,7 +84,6 @@ class SelectForUpdateTests(TransactionTestCase):
             list(Person.objects.all().select_for_update(nowait=True))
         self.assertTrue(self.has_for_update_sql(connection, nowait=True))
 
-    @requires_threading
     @skipUnlessDBFeature('has_select_for_update_nowait')
     def test_nowait_raises_error_on_block(self):
         """
@@ -173,7 +164,6 @@ class SelectForUpdateTests(TransactionTestCase):
             # database connection. Close it without waiting for the GC.
             connection.close()
 
-    @requires_threading
     @skipUnlessDBFeature('has_select_for_update')
     @skipUnlessDBFeature('supports_transactions')
     def test_block(self):
@@ -223,7 +213,6 @@ class SelectForUpdateTests(TransactionTestCase):
         p = Person.objects.get(pk=self.person.pk)
         self.assertEqual('Fred', p.name)
 
-    @requires_threading
     @skipUnlessDBFeature('has_select_for_update')
     def test_raw_lock_not_available(self):
         """

--- a/tests/transactions/tests.py
+++ b/tests/transactions/tests.py
@@ -1,10 +1,7 @@
 from __future__ import unicode_literals
 
 import sys
-try:
-    import threading
-except ImportError:
-    threading = None
+import threading
 import time
 from unittest import skipIf, skipUnless
 


### PR DESCRIPTION
Django imports threading in many other places without fallback.