### PR TITLE
Use `.format` for Python 3 compatibility

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -420,7 +420,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         """
         Returns the first_name plus the last_name, with a space in between.
         """
-        full_name = '%s %s' % (self.first_name, self.last_name)
+        full_name = '{} {}'.format(self.first_name, self.last_name)
         return full_name.strip()
 
     def get_short_name(self):


### PR DESCRIPTION
This is recommended for Python 3. It would also be worth considering just doing something like `' '.join(self.first_name, self.last_name)` but I was trying to maintain the same semantics as the original code here.