### PR TITLE
Fixed #24249 -- Improved field shadowing validation in model multi-inheritance

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1314,7 +1314,7 @@ class Model(six.with_metaclass(ModelBase)):
         used_fields = {}  # name or attname -> field
 
         # Check that multi-inheritance doesn't cause field name shadowing.
-        for parent in cls._meta.parents:
+        for parent in cls._meta.get_parent_list():
             for f in parent._meta.local_fields:
                 clash = used_fields.get(f.name) or used_fields.get(f.attname) or None
                 if clash:

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -483,6 +483,31 @@ class ShadowingFieldsTests(IsolatedModelsTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_multigeneration_inheritance(self):
+        class GrandParent(models.Model):
+            clash = models.IntegerField()
+
+        class Parent(GrandParent):
+            pass
+
+        class Child(Parent):
+            pass
+
+        class GrandChild(Child):
+            clash = models.IntegerField()
+
+        errors = GrandChild.check()
+        expected = [
+            Error(
+                ("The field 'clash' clashes with the field 'clash' "
+                 "from model 'invalid_models_tests.grandparent'."),
+                hint=None,
+                obj=GrandChild._meta.get_field('clash'),
+                id='models.E006',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
     def test_id_clash(self):
         class Target(models.Model):
             pass


### PR DESCRIPTION
Improve forbidding field shadowing in model
multi-inheritance more than one generation.