### PR TITLE
Skip empty strings and Nones in MIDDLEWARE_CLASSES

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -46,6 +46,9 @@ class BaseHandler(object):
 
         request_middleware = []
         for middleware_path in settings.MIDDLEWARE_CLASSES:
+            if middleware_path in (None, ''):
+                continue
+
             mw_class = import_string(middleware_path)
             try:
                 mw_instance = mw_class()


### PR DESCRIPTION
If we skip empty strings and Nones while loading middleware the code to
skip middleware in settings.py when DEBUG is set is trivial:

    MIDDLEWARE_CLASSES = (
        ...
        '' if DEBUG else 'middlewareNotRequiredWhileDebugging',
    )