### PR TITLE
Fixed #24112 -- Fixed counting of html elements if needle has no root element

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -95,6 +95,9 @@ class Element(object):
         if not isinstance(element, six.string_types):
             if self == element:
                 return 1
+        if isinstance(element, RootElement):
+            raise ValueError('Needle HTML does not have a root element')
+
         i = 0
         for child in self.children:
             # child is text content and element is also text content, then

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -573,6 +573,11 @@ class HTMLEqualTests(TestCase):
         dom1 = parse_html('<p>bar</p>')
         self.assertIn(dom1, dom2)
 
+        # when a root element is used for the needle but not the haystack
+        dom1 = parse_html('<p>foo</p><p>bar</p>')
+        dom2 = parse_html('<div><p>foo</p><p>bar</p></div>')
+        self.assertIn(dom1, dom2)
+
     def test_count(self):
         # equal html contains each other one time
         dom1 = parse_html('<p>foo')

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -576,7 +576,8 @@ class HTMLEqualTests(TestCase):
         # when a root element is used for the needle but not the haystack
         dom1 = parse_html('<p>foo</p><p>bar</p>')
         dom2 = parse_html('<div><p>foo</p><p>bar</p></div>')
-        self.assertIn(dom1, dom2)
+        with self.assertRaises(ValueError):
+            self.assertIn(dom1, dom2)
 
     def test_count(self):
         # equal html contains each other one time


### PR DESCRIPTION
The `parse_html` method (at the bottom of test/html.py) creates a instance of Parser and feeds in the html. The parser starts with a RootElement and adds to it as it parses, meaning that what parse_html gets back always has an additional RootElement above the rest of the HTML. It then removes this if it can, ie, if the RootElement only has one child (ie, the given HTML had a root element of its own).

This means that if the html passed to `parse_html` has no root node, it will retain its RootElement from the parser.

We can then check this when counting to see if the needle HTML has multiple top level elements. If it does, then counting becomes much more fiddly, so my current patch just raises a ValueError.

There aren't any tests as I couldn't find any existing ones for this module. Should things within the `test` module get tests?
