### PR TITLE
Refactored tests that rely on an ImportError for Python 3.5 compatibility

### DIFF
--- a/tests/apps/failing_app/__init__.py
+++ b/tests/apps/failing_app/__init__.py
@@ -1,1 +1,0 @@
-raise ImportError("Oops")

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -172,7 +172,7 @@ class AppsTests(TestCase):
         App discovery should preserve stack traces. Regression test for #22920.
         """
         with six.assertRaisesRegex(self, ImportError, "Oops"):
-            with self.settings(INSTALLED_APPS=['apps.failing_app']):
+            with self.settings(INSTALLED_APPS=['import_error_package']):
                 pass
 
     def test_models_py(self):

--- a/tests/import_error_package/__init__.py
+++ b/tests/import_error_package/__init__.py
@@ -1,0 +1,3 @@
+# A package that raises an ImportError that can be shared among test apps and
+# excluded from test discovery.
+raise ImportError("Oops")

--- a/tests/migrations/faulty_migrations/import_error/__init__.py
+++ b/tests/migrations/faulty_migrations/import_error/__init__.py
@@ -1,1 +1,0 @@
-import fake_python_module  # NOQA

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -159,7 +159,7 @@ class LoaderTests(TestCase):
             migration_loader.get_migration_by_prefix("migrations", "blarg")
 
     def test_load_import_error(self):
-        with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.import_error"}):
+        with override_settings(MIGRATION_MODULES={"migrations": "import_error_package"}):
             with self.assertRaises(ImportError):
                 MigrationLoader(connection)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -35,6 +35,7 @@ os.environ['DJANGO_TEST_TEMP_DIR'] = TEMP_DIR
 
 SUBDIRS_TO_SKIP = [
     'data',
+    'import_error_package',
     'test_discovery_sample',
     'test_discovery_sample2',
     'test_runner_deprecation_app',


### PR DESCRIPTION
A change in Python test discovery [1] causes the old packages that raised
an error to be discovered; now we use a common directory that's
ignored during discovery. Refs #23763.

[1] http://bugs.python.org/issue7559