### PR TITLE
Fixed #24241 - Fixed copying models in StateApps

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -189,8 +189,10 @@ class StateApps(Apps):
         Return a clone of this registry, mainly used by the migration framework.
         """
         clone = StateApps([], {})
-        clone.all_models = copy.deepcopy(self.all_models)
         clone.app_configs = copy.deepcopy(self.app_configs)
+        for app in self.all_models.values():
+            for model in app.values():
+                ModelState.from_model(model).render(clone)
         return clone
 
     def register_model(self, app_label, model):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -403,6 +403,36 @@ class StateTests(TestCase):
         self.assertNotEqual(project_state, other_state)
         self.assertEqual(project_state == other_state, False)
 
+    def test_clone(self):
+        """
+        Tests that ProjectState clone method returns a deep copy
+        """
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState(
+            "migrations",
+            "Tag",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=100)),
+                ("hidden", models.BooleanField()),
+            ],
+            {},
+            None,
+        ))
+        project_state.apps
+        other_state = project_state.clone()
+        self.assertIsNot(project_state, other_state)
+        self.assertIsNot(project_state.apps, other_state.apps)
+        self.assertIsNot(
+            project_state.apps.get_app_config("migrations"),
+            other_state.apps.get_app_config("migrations")
+        )
+        self.assertIsNot(
+            project_state.apps.get_model("migrations", "tag"),
+            other_state.apps.get_model("migrations", "tag")
+        )
+
     def test_dangling_references_throw_error(self):
         new_apps = Apps()
 


### PR DESCRIPTION
Fixed the issue that StateApps.clone did not create a copy of the
models in self.all_models. Changed copy method of all_models to use
a ModelState rather than deepcopy to create a new model class.

Ticket: https://code.djangoproject.com/ticket/24241