### PR TITLE
docs: cross reference patches and new contributors pages

### DIFF
--- a/docs/internals/contributing/new-contributors.txt
+++ b/docs/internals/contributing/new-contributors.txt
@@ -5,6 +5,12 @@ Advice for new contributors
 New contributor and not sure what to do? Want to help but just don't know how
 to get started? This is the section for you.
 
+.. admonition:: Basic tools and workflow
+
+    If you are new to, or unfamiliar with, contributing to Django the
+    :doc:`/intro/contributing` tutorial will give you an introduction to the
+    tools and the workflow.
+
 First steps
 -----------
 

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -16,6 +16,12 @@ We'll walk you through the entire process, so you can learn by example.
 Who's this tutorial for?
 ------------------------
 
+.. note::
+
+    If you are looking for a reference on how to submit patches see the
+    :doc:`/internals/contributing/writing-code/submitting-patches`
+    documentation.
+
 For this tutorial, we expect that you have at least a basic understanding of
 how Django works. This means you should be comfortable going through the
 existing tutorials on :doc:`writing your first Django app</intro/tutorial01>`.


### PR DESCRIPTION
Add a reference to submitting patches in the "Write your first patch"
tutorial. This is useful because the page is the first result when searching
"django patches" so that people looking for a reference of submitting patches
can find the relevant documentation.

For a similar reason reference in the "Advice for new
contributors" page the "First django patch" tutorial since it covers
the basics tools and workflow.