### PR TITLE
Don't use nullable char fields in example.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -40,7 +40,7 @@ ArrayField
             class ChessBoard(models.Model):
                 board = ArrayField(
                     ArrayField(
-                        CharField(max_length=10, blank=True, null=True),
+                        CharField(max_length=10, blank=True),
                         size=8),
                     size=8)
 

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -40,9 +40,11 @@ ArrayField
             class ChessBoard(models.Model):
                 board = ArrayField(
                     ArrayField(
-                        CharField(max_length=10, blank=True),
-                        size=8),
-                    size=8)
+                        models.CharField(max_length=10, blank=True),
+                        size=8
+                    ),
+                    size=8
+                )
 
         Transformation of values between the database and the model, validation
         of data and configuration, and serialization are all delegated to the


### PR DESCRIPTION
It's a bad idea to use nullable char fields, so let's have this just be `blank=True` in the example.