### PR TITLE
Fixed test broken by 71ada3a8e689a883b5ffdeb1744ea16f176ab730.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -554,15 +554,15 @@ def create_generic_related_manager(superclass):
         _clear.alters_data = True
 
         def set(self, objs, **kwargs):
+            # Force evaluation of `objs` in case it's a queryset whose value
+            # could be affected by `manager.clear()`. Refs #19816.
+            objs = tuple(objs)
+
             clear = kwargs.pop('clear', False)
 
             db = router.db_for_write(self.model, instance=self.instance)
             with transaction.atomic(using=db, savepoint=False):
                 if clear:
-                    # Force evaluation of `objs` in case it's a queryset whose value
-                    # could be affected by `manager.clear()`. Refs #19816.
-                    objs = tuple(objs)
-
                     self.clear()
                     self.add(*objs)
                 else:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -797,16 +797,16 @@ def create_foreign_related_manager(superclass, rel_field, rel_model):
             _clear.alters_data = True
 
         def set(self, objs, **kwargs):
+            # Force evaluation of `objs` in case it's a queryset whose value
+            # could be affected by `manager.clear()`. Refs #19816.
+            objs = tuple(objs)
+
             clear = kwargs.pop('clear', False)
 
             if rel_field.null:
                 db = router.db_for_write(self.model, instance=self.instance)
                 with transaction.atomic(using=db, savepoint=False):
                     if clear:
-                        # Force evaluation of `objs` in case it's a queryset whose value
-                        # could be affected by `manager.clear()`. Refs #19816.
-                        objs = tuple(objs)
-
                         self.clear()
                         self.add(*objs)
                     else:
@@ -1029,15 +1029,15 @@ def create_many_related_manager(superclass, rel):
                     (opts.app_label, opts.object_name)
                 )
 
+            # Force evaluation of `objs` in case it's a queryset whose value
+            # could be affected by `manager.clear()`. Refs #19816.
+            objs = tuple(objs)
+
             clear = kwargs.pop('clear', False)
 
             db = router.db_for_write(self.through, instance=self.instance)
             with transaction.atomic(using=db, savepoint=False):
                 if clear:
-                    # Force evaluation of `objs` in case it's a queryset whose value
-                    # could be affected by `manager.clear()`. Refs #19816.
-                    objs = tuple(objs)
-
                     self.clear()
                     self.add(*objs)
                 else:


### PR DESCRIPTION
During direct assignment, evaluating the iterable before the transaction
is started avoids leaving the transaction dirty if an exception is raised.
This is slightly more wasteful but probably not enough to warrant a change
of behavior.