### PR TITLE
Fixed #24285 -- Made for_user argument optional for {% get_admin_log %} tag 

### DIFF
--- a/django/contrib/admin/templatetags/log.py
+++ b/django/contrib/admin/templatetags/log.py
@@ -13,14 +13,13 @@ class AdminLogNode(template.Node):
 
     def render(self, context):
         if self.user is None:
-            context[self.varname] = LogEntry.objects.all().select_related('content_type', 'user')[:self.limit]
+            entries = LogEntry.objects.all()
         else:
             user_id = self.user
             if not user_id.isdigit():
                 user_id = context[self.user].pk
-            context[self.varname] = LogEntry.objects.filter(
-                user__pk=user_id,
-            ).select_related('content_type', 'user')[:int(self.limit)]
+            entries = LogEntry.objects.filter(user__pk=user_id)
+        context[self.varname] = entries.select_related('content_type', 'user')[:int(self.limit)]
         return ''
 
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -3,11 +3,13 @@ from __future__ import unicode_literals
 import datetime
 
 from django.contrib import admin
+from django.contrib.admin.models import LogEntry
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.templatetags.admin_list import pagination
 from django.contrib.admin.tests import AdminSeleniumWebDriverTestCase
 from django.contrib.admin.views.main import ALL_VAR, SEARCH_VAR, ChangeList
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.template import Context, Template
 from django.test import TestCase, override_settings
@@ -684,6 +686,25 @@ class AdminLogNodeTestCase(TestCase):
         # Rendering should be u'' since this templatetag just logs,
         # it doesn't render any string.
         self.assertEqual(template.render(context), '')
+
+    def test_get_admin_log_templatetag_no_user(self):
+        """
+        The {% get_admin_log %} tag should work without specifying a user.
+        """
+        # Create a user and log it.
+        user = User(username='jondoe', password='secret', email='super@example.com')
+        user.save()
+        ct = ContentType.objects.get_for_model(User)
+        LogEntry.objects.log_action(user.pk, ct.pk, user.pk, repr(user), 1)
+
+        t = Template(
+            '{% load log %}'
+            '{% get_admin_log 100 as admin_log %}'
+            '{% for entry in admin_log %}'
+            '{{entry|safe}}'
+            '{% endfor %}'
+        )
+        self.assertEqual(t.render(Context({})), 'Added "<User: jondoe>".')
 
 
 @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'],


### PR DESCRIPTION
Using `{% get_admin_log 10 as admin_log %}` (without the `for_user` option) raises a `TypeError`: `
unorderable types: str() >= int()` (testing with Python 3.4.2 and Django 1.7.1).

The code had repeated the `.select_related('content_type', 'user')[:self.limit]` logic in two code branches (`if` and `else`) and in commit c2d59e55 (2002.10.14) one branch had a fix changing `self.limit` to `int(self.limit)`, but only in the `else` branch.
The problem was probably never discovered because the admin site only uses this template with the `for_user` option specified.