### PR TITLE
Fixed #24275 - Migration files now comply with PEP8 line wrapping word limit by default [WIP]

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -30,6 +30,8 @@ class Command(BaseCommand):
             help='Tells Django to NOT prompt the user for input of any kind.')
         parser.add_argument('-n', '--name', action='store', dest='name', default=None,
             help="Use this name for migration file(s).")
+        parser.add_argument('--chars-per-line', type=int, dest='chars_per_line', default=79,
+            help="Specifies the maximum number of chars in a line before attempting to wrap the line")
         parser.add_argument('-e', '--exit', action='store_true', dest='exit_code', default=False,
             help='Exit with error code 1 if no changes needing migrations are found.')
 
@@ -41,6 +43,7 @@ class Command(BaseCommand):
         self.merge = options.get('merge', False)
         self.empty = options.get('empty', False)
         self.migration_name = options.get('name', None)
+        self.chars_per_line = options.get('chars_per_line', 79)
         self.exit_code = options.get('exit_code', False)
 
         # Make sure the app they asked for exists
@@ -150,7 +153,7 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.MIGRATE_HEADING("Migrations for '%s':" % app_label) + "\n")
             for migration in app_migrations:
                 # Describe the migration
-                writer = MigrationWriter(migration)
+                writer = MigrationWriter(migration, self.chars_per_line)
                 if self.verbosity >= 1:
                     self.stdout.write("  %s:\n" % (self.style.MIGRATE_LABEL(writer.filename),))
                     for operation in migration.operations:
@@ -231,7 +234,7 @@ class Command(BaseCommand):
                     "dependencies": [(app_label, migration.name) for migration in merge_migrations],
                 })
                 new_migration = subclass("%04i_merge" % (biggest_number + 1), app_label)
-                writer = MigrationWriter(new_migration)
+                writer = MigrationWriter(new_migration, self.chars_per_line)
                 with open(writer.path, "wb") as fh:
                     fh.write(writer.as_string())
                 if self.verbosity > 0:

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -41,7 +41,7 @@ class SettingsReference(str):
 class CleanWriter(object):
 
     def __init__(self, chars_per_line=79):
-        self.chars_per_line = chars_per_line - 2 # because the last char is one of the unaccounted-for  '(' or ',' token used when the line is shifted.
+        self.chars_per_line = chars_per_line - 2  # because the last char is one of the unaccounted-for  '(' or ',' token used when the line is shifted.
         self._breakable_chunks = {'commas': None, 'parens': None}
         self._joining_mapping = {'commas': ', ', 'parens': '( '}
 
@@ -58,7 +58,7 @@ class CleanWriter(object):
         possible_by_managing_parens = self._finder(chunks_paren, 'parens')
         if possible_by_managing_parens[0]:
             _ = possible_by_managing_parens
-            return "(\n ".join([ _[1], _[2]])
+            return "(\n ".join([_[1], _[2]])
 
         bp_comma = self._breakable_chunks['commas']
         if bp_comma is not None:
@@ -110,7 +110,7 @@ class CleanWriter(object):
     def _is_line_dirty(self, blob):
         return len(blob) > self.chars_per_line
 
-    def _fast_reconstruct(self, chunks, joiner = ", "):
+    def _fast_reconstruct(self, chunks, joiner=", "):
         return ''.join([self.indent_spaces, joiner.join(chunks)])
 
     def clean(self, line):

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -119,9 +119,6 @@ class CleanWriter(object):
             line = self._clean_line(line)
         return line.rstrip()
 
-# a = CleanWriter()
-# line =  "                ('id', models.AutoField(verbose_name='ID', serialize=False112512512512512523123123, auto_created=True, primary_key=True, serialize=False, auto_created=True, primary_key=True, seweghwoieughwoiueghwoieughwoeiugrializasdughoisudahgiaosudghisaue=False, auto_created=True, primary_key=True, serialize=False, auto_created=True, pasdhashshasdhjsfjdsfjdsfjsefjrimary_key=True)),"
-
 
 class OperationWriter(object):
     indentation = 2

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -40,12 +40,12 @@ class SettingsReference(str):
 
 class CleanWriter(object):
 #
-    def __init__(self, words_per_line=79):
-        self.words_per_line = words_per_line - 4
-        self._breakable = {'commas': None, 'parens': None}
-        self._mapping = {'commas': ', ', 'parens': '( '}
+    def __init__(self, chars_per_line=79):
+        self.chars_per_line = chars_per_line - 2 # because the last char is one of the unaccounted-for  '(' or ',' token used when the line is shifted.
+        self._breakable_chunks = {'commas': None, 'parens': None}
+        self._joining_mapping = {'commas': ', ', 'parens': '( '}
 #
-    def _clean_line(self, line, space):
+    def _clean_line(self, line):
         # break into chunks wherever it's possible to start a new line
         chunks_commas = map(lambda x: x.strip(), line.strip().split(','))
         chunks_paren  = map(lambda x: x.strip(), line.strip().split('('))
@@ -53,54 +53,54 @@ class CleanWriter(object):
         possible_by_managing_commas = self._finder(chunks_commas, 'commas')
         if possible_by_managing_commas[0]:
             _ = possible_by_managing_commas
-            return ",\n    ".join([_[1], _[2]])
+            return ",\n ".join([_[1], _[2]])
 #
         possible_by_managing_parens = self._finder(chunks_paren, 'parens')
         if possible_by_managing_parens[0]:
             _ = possible_by_managing_parens
-            return "(\n    ".join([ _[1], _[2]])
+            return "(\n ".join([ _[1], _[2]])
 #
-        bp_comma = self._breakable['commas']
+        bp_comma = self._breakable_chunks['commas']
         if bp_comma is not None:
             dirty_line = self._fast_reconstruct(chunks_commas[bp_comma:])
-            trial = CleanWriter(self.words_per_line).clean(dirty_line, space)
+            trial = CleanWriter(self.chars_per_line).clean(dirty_line)
             if trial is not None:
                 old_clean_line = self._fast_reconstruct(chunks_commas[:bp_comma])
-                return (",\n    " + " " * space).join([old_clean_line, trial])
+                return ",\n ".join([old_clean_line, trial])
 #
-        bp_paren = self._breakable['parens']
+        bp_paren = self._breakable_chunks['parens']
         if bp_paren is not None:
             dirty_line = self._fast_reconstruct(chunks_paren[bp_paren:], '( ')
-            trial = CleanWriter(self.words_per_line).clean(dirty_line, space)
+            trial = CleanWriter(self.chars_per_line).clean(dirty_line)
             if trial is not None:
-               old_clean_line = self._fast_reconstruct(chunks_paren[:bp_paren])
-               return ("(\n    " + " " * space).join([old_clean_line, trial])
+                old_clean_line = self._fast_reconstruct(chunks_paren[:bp_paren])
+                return "(\n ".join([old_clean_line, trial])
 #
         if len(chunks_commas[0]) <= len(chunks_paren[0]):
-            return self.indent_spaces + chunks_commas[0] + ",  # NOQA\n    " + CleanWriter(self.words_per_line).clean(
-                self._fast_reconstruct(chunks_commas[1:]), space=space)
+            return self.indent_spaces + chunks_commas[0] + ",  # NOQA\n " + CleanWriter(self.chars_per_line).clean(
+                self._fast_reconstruct(chunks_commas[1:]))
 #
-        return self.indent_spaces + chunks_paren[0] + "(  # NOQA\n    " + CleanWriter(self.words_per_line).clean(
-            self._fast_reconstruct(chunks_paren[1:], '( '), space=space)
+        return self.indent_spaces + chunks_paren[0] + "(  # NOQA\n " + CleanWriter(self.chars_per_line).clean(
+            self._fast_reconstruct(chunks_paren[1:], '( '))
 #
-    def _finder(self, chunks, chunk_name):
-        for i, blob in enumerate(reversed(chunks)):
+    def _finder(self, chunks, delimiter_name):
+        delimeter =  self._joining_mapping[delimiter_name]
+        for i, _ in enumerate(reversed(chunks)):
             break_point = len(chunks) - i
             first_part  = chunks[:break_point]
             last_part   = chunks[break_point:]
             if len(last_part) == 0 or len(first_part) == 0: continue
 #
-            try_first   = self._fast_reconstruct(first_part, self._mapping[chunk_name])
-            try_last    = self._fast_reconstruct(last_part, self._mapping[chunk_name])
+            try_first   = self._fast_reconstruct(first_part, delimeter)
+            try_last    = self._fast_reconstruct(last_part, delimeter)
 #
             if self._is_line_dirty(try_first): continue
             elif self._is_line_dirty(try_last):
-                _ = self._breakable[chunk_name]
-                self._breakable[chunk_name] = break_point if _ is None else _
+                _ = self._breakable_chunks[delimiter_name]
+                self._breakable_chunks[delimiter_name] = break_point if _ is None else _
                 break
             else:
-                delimeter = "(" if chunk_name == "parens" else ","
-                return (True, try_first, try_last, delimeter)
+                return (True, try_first, try_last)
 #
         return (False, )
 #
@@ -108,16 +108,16 @@ class CleanWriter(object):
         return len(blob) - len(blob.lstrip())
 #
     def _is_line_dirty(self, blob):
-        return len(blob) > self.words_per_line
+        return len(blob) > self.chars_per_line
 #
     def _fast_reconstruct(self, chunks, joiner = ", "):
         return ''.join([self.indent_spaces, joiner.join(chunks)])
 #
-    def clean(self, line, space=0):
+    def clean(self, line):
         self.indent_spaces = self._get_indent_spaces(line) * " "
         if self._is_line_dirty(line):
-            line = self._clean_line(line, space)
-        return line
+            line = self._clean_line(line)
+        return line.rstrip()
 
 a = CleanWriter()
 line =  "                ('id', models.AutoField(verbose_name='ID', serialize=False112512512512512523123123, auto_created=True, primary_key=True, serialize=False, auto_created=True, primary_key=True, seweghwoieughwoiueghwoieughwoeiugrializasdughoisudahgiaosudghisaue=False, auto_created=True, primary_key=True, serialize=False, auto_created=True, pasdhashshasdhjsfjdsfjdsfjsefjrimary_key=True)),"

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -48,7 +48,7 @@ class CleanWriter(object):
     def _clean_line(self, line):
         # break into chunks wherever it's possible to start a new line
         chunks_commas = map(lambda x: x.strip(), line.strip().split(','))
-        chunks_paren  = map(lambda x: x.strip(), line.strip().split('('))
+        chunks_paren = map(lambda x: x.strip(), line.strip().split('('))
 
         possible_by_managing_commas = self._finder(chunks_commas, 'commas')
         if possible_by_managing_commas[0]:
@@ -84,17 +84,19 @@ class CleanWriter(object):
             self._fast_reconstruct(chunks_paren[1:], '( '))
 
     def _finder(self, chunks, delimiter_name):
-        delimeter =  self._joining_mapping[delimiter_name]
+        delimeter = self._joining_mapping[delimiter_name]
         for i, _ in enumerate(reversed(chunks)):
             break_point = len(chunks) - i
-            first_part  = chunks[:break_point]
-            last_part   = chunks[break_point:]
-            if len(last_part) == 0 or len(first_part) == 0: continue
+            first_part = chunks[:break_point]
+            last_part = chunks[break_point:]
+            if len(last_part) == 0 or len(first_part) == 0:
+                continue
 
-            try_first   = self._fast_reconstruct(first_part, delimeter)
-            try_last    = self._fast_reconstruct(last_part, delimeter)
+            try_first = self._fast_reconstruct(first_part, delimeter)
+            try_last = self._fast_reconstruct(last_part, delimeter)
 
-            if self._is_line_dirty(try_first): continue
+            if self._is_line_dirty(try_first):
+                continue
             elif self._is_line_dirty(try_last):
                 _ = self._breakable_chunks[delimiter_name]
                 self._breakable_chunks[delimiter_name] = break_point if _ is None else _

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -43,6 +43,7 @@ class CleanWriter(object):
     def __init__(self, words_per_line=79):
         self.words_per_line = words_per_line - 4
         self._breakable = {'commas': None, 'parens': None}
+        self._mapping = {'commas': ', ', 'parens': '( '}
 #
     def _clean_line(self, line, space):
         # break into chunks wherever it's possible to start a new line
@@ -89,8 +90,8 @@ class CleanWriter(object):
             last_part   = chunks[break_point:]
             if len(last_part) == 0 or len(first_part) == 0: continue
 #
-            try_first   = self._fast_reconstruct(first_part)
-            try_last    = self._fast_reconstruct(last_part)
+            try_first   = self._fast_reconstruct(first_part, self._mapping[chunk_name])
+            try_last    = self._fast_reconstruct(last_part, self._mapping[chunk_name])
 #
             if self._is_line_dirty(try_first): continue
             elif self._is_line_dirty(try_last):


### PR DESCRIPTION
I understand that there aren't any unit tests in this PR now. However this is just a checkpoint in order to get a review. I've verified the output of the clean method of the CleanWriter class for quite a few test files in the interactive shell.