### PR TITLE
Hid Django installation message when verbosity is 0.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -89,7 +89,8 @@ def get_installed():
 
 
 def setup(verbosity, test_labels):
-    print("Testing against Django installed in '%s'" % os.path.dirname(django.__file__))
+    if verbosity >= 1:
+        print("Testing against Django installed in '%s'" % os.path.dirname(django.__file__))
 
     # Force declaring available_apps in TransactionTestCase for faster tests.
     def no_available_apps(self):


### PR DESCRIPTION
This message was introduced to help people figure out quickly when they
aren't running the tests against the copy of Django they're editing.
There's no reason to display it when verbosity is set to 0. It defaults
to 1.