### PR TITLE
Fixed #24275 -- Used autopep8 to format migration files

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -190,8 +190,10 @@ class MigrationWriter(object):
         except ImportError:
             pass
         else:
-            migration_statement = autopep8.fix_code(migration_statement,
-                                    options=autopep8.parse_args(['--aggressive', '']))
+            migration_statement = autopep8.fix_code(
+                migration_statement,
+                options=autopep8.parse_args(['--aggressive', ''])
+            )
         return migration_statement
 
     @staticmethod

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -184,7 +184,15 @@ class MigrationWriter(object):
         if self.migration.replaces:
             items['replaces_str'] = "\n    replaces = %s\n" % self.serialize(self.migration.replaces)[0]
 
-        return (MIGRATION_TEMPLATE % items).encode("utf8")
+        migration_statement = (MIGRATION_TEMPLATE % items).encode("utf8")
+        try:
+            import autopep8
+        except ImportError:
+            pass
+        else:
+            migration_statement = autopep8.fix_code(migration_statement,
+                                    options=autopep8.parse_args(['--aggressive', '']))
+        return migration_statement
 
     @staticmethod
     def serialize_datetime(value):


### PR DESCRIPTION
After discussion on https://github.com/django/django/pull/4064