### PR TITLE
Fixed #24278 - Fixed serialization of migration operations.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -441,6 +441,7 @@ answer newbie questions, and generally made Django that much better:
     Mark Lavin <markdlavin@gmail.com>
     Mark Sandstrom <mark@deliciouslynerdy.com>
     Markus Holtermann <https://markusholtermann.eu>
+    Marten Kenbeek <marten.knbk+django@gmail.com>
     martin.glueck@gmail.com
     Martin Green
     Martin Kosír <martin@martinkosir.net>

--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -13,6 +13,8 @@ class SeparateDatabaseAndState(Operation):
     that affect the state or not the database, or so on.
     """
 
+    serialization_expand_args = ['database_operations', 'state_operations']
+
     def __init__(self, database_operations=None, state_operations=None):
         self.database_operations = database_operations or []
         self.state_operations = state_operations or []

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from django.apps import apps
 from django.db import migrations, models
 from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.operations.base import Operation
 from django.utils import datetime_safe, six
 from django.utils._os import upath
 from django.utils.encoding import force_text
@@ -423,6 +424,10 @@ class MigrationWriter(object):
                 return "%s.as_manager()" % name, imports
             else:
                 return cls.serialize_deconstructed(manager_path, args, kwargs)
+        elif isinstance(value, Operation):
+            string, imports = OperationWriter(value, indentation=0).serialize()
+            # Nested operation, trailing comma is handled in upper OperationWriter._write()
+            return string.rstrip(','), imports
         # Anything that knows how to deconstruct itself.
         elif hasattr(value, 'deconstruct'):
             return cls.serialize_deconstructed(*value.deconstruct())

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -39,11 +39,10 @@ class SettingsReference(str):
 
 
 class OperationWriter(object):
-    indentation = 2
-
-    def __init__(self, operation):
+    def __init__(self, operation, indentation=2):
         self.operation = operation
         self.buff = []
+        self.indentation = indentation
 
     def serialize(self):
 
@@ -56,7 +55,14 @@ class OperationWriter(object):
                     for key, value in _arg_value.items():
                         key_string, key_imports = MigrationWriter.serialize(key)
                         arg_string, arg_imports = MigrationWriter.serialize(value)
-                        self.feed('%s: %s,' % (key_string, arg_string))
+                        args = arg_string.splitlines()
+                        if len(args) > 1:
+                            self.feed('%s: %s' % (key_string, args[0]))
+                            for arg in args[1:-1]:
+                                self.feed(arg)
+                            self.feed('%s,' % args[-1])
+                        else:
+                            self.feed('%s: %s,' % (key_string, arg_string))
                         imports.update(key_imports)
                         imports.update(arg_imports)
                     self.unindent()
@@ -66,13 +72,26 @@ class OperationWriter(object):
                     self.indent()
                     for item in _arg_value:
                         arg_string, arg_imports = MigrationWriter.serialize(item)
-                        self.feed('%s,' % arg_string)
+                        args = arg_string.splitlines()
+                        if len(args) > 1:
+                            for arg in args[:-1]:
+                                self.feed(arg)
+                            self.feed('%s,' % args[-1])
+                        else:
+                            self.feed('%s,' % arg_string)
                         imports.update(arg_imports)
                     self.unindent()
                     self.feed('],')
             else:
                 arg_string, arg_imports = MigrationWriter.serialize(_arg_value)
-                self.feed('%s=%s,' % (_arg_name, arg_string))
+                args = arg_string.splitlines()
+                if len(args) > 1:
+                    self.feed('%s=%s' % (_arg_name, args[0]))
+                    for arg in args[1:-1]:
+                        self.feed(arg)
+                    self.feed('%s,' % args[-1])
+                else:
+                    self.feed('%s=%s,' % (_arg_name, arg_string))
                 imports.update(arg_imports)
 
         imports = set()

--- a/docs/releases/1.8.1.txt
+++ b/docs/releases/1.8.1.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Prevented ``TypeError`` in translation functions ``check_for_language()`` and
   ``get_language_bidi()`` when translations are deactivated (:ticket:`24569`).
+
+* Fixed :djadmin:`squashmigrations` command when using
+  :class:`~django.db.migrations.operations.SeparateDatabaseAndState` (:ticket:`24278`).

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -81,6 +81,27 @@ class OperationWriterTests(SimpleTestCase):
             '),'
         )
 
+    def test_nested_args_signature(self):
+        operation = custom_migration_operations.operations.ArgsOperation(
+            custom_migration_operations.operations.ArgsOperation(1, 2),
+            custom_migration_operations.operations.KwargsOperation(kwarg1=3, kwarg2=4)
+        )
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
+        self.assertEqual(imports, {'import custom_migration_operations.operations'})
+        self.assertEqual(
+            buff,
+            'custom_migration_operations.operations.ArgsOperation(\n'
+            '    arg1=custom_migration_operations.operations.ArgsOperation(\n'
+            '        arg1=1,\n'
+            '        arg2=2,\n'
+            '    ),\n'
+            '    arg2=custom_migration_operations.operations.KwargsOperation(\n'
+            '        kwarg1=3,\n'
+            '        kwarg2=4,\n'
+            '    ),\n'
+            '),'
+        )
+
     def test_multiline_args_signature(self):
         operation = custom_migration_operations.operations.ArgsOperation("test\n    arg1", "test\narg2")
         buff, imports = OperationWriter(operation, indentation=0).serialize()
@@ -103,6 +124,29 @@ class OperationWriterTests(SimpleTestCase):
             '    arg=[\n'
             '        1,\n'
             '        2,\n'
+            '    ],\n'
+            '),'
+        )
+
+    def test_nested_operation_expand_args_signature(self):
+        operation = custom_migration_operations.operations.ExpandArgsOperation(
+            arg=[
+                custom_migration_operations.operations.KwargsOperation(
+                    kwarg1=1,
+                    kwarg2=2,
+                ),
+            ]
+        )
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
+        self.assertEqual(imports, {'import custom_migration_operations.operations'})
+        self.assertEqual(
+            buff,
+            'custom_migration_operations.operations.ExpandArgsOperation(\n'
+            '    arg=[\n'
+            '        custom_migration_operations.operations.KwargsOperation(\n'
+            '            kwarg1=1,\n'
+            '            kwarg2=2,\n'
+            '        ),\n'
             '    ],\n'
             '),'
         )

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -37,9 +37,7 @@ class OperationWriterTests(SimpleTestCase):
 
     def test_empty_signature(self):
         operation = custom_migration_operations.operations.TestOperation()
-        writer = OperationWriter(operation)
-        writer.indentation = 0
-        buff, imports = writer.serialize()
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
@@ -49,9 +47,7 @@ class OperationWriterTests(SimpleTestCase):
 
     def test_args_signature(self):
         operation = custom_migration_operations.operations.ArgsOperation(1, 2)
-        writer = OperationWriter(operation)
-        writer.indentation = 0
-        buff, imports = writer.serialize()
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
@@ -63,9 +59,7 @@ class OperationWriterTests(SimpleTestCase):
 
     def test_kwargs_signature(self):
         operation = custom_migration_operations.operations.KwargsOperation(kwarg1=1)
-        writer = OperationWriter(operation)
-        writer.indentation = 0
-        buff, imports = writer.serialize()
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
@@ -76,9 +70,7 @@ class OperationWriterTests(SimpleTestCase):
 
     def test_args_kwargs_signature(self):
         operation = custom_migration_operations.operations.ArgsKwargsOperation(1, 2, kwarg2=4)
-        writer = OperationWriter(operation)
-        writer.indentation = 0
-        buff, imports = writer.serialize()
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
@@ -89,11 +81,21 @@ class OperationWriterTests(SimpleTestCase):
             '),'
         )
 
+    def test_multiline_args_signature(self):
+        operation = custom_migration_operations.operations.ArgsOperation("test\n    arg1", "test\narg2")
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
+        self.assertEqual(imports, {'import custom_migration_operations.operations'})
+        self.assertEqual(
+            buff,
+            "custom_migration_operations.operations.ArgsOperation(\n"
+            "    arg1='test\\n    arg1',\n"
+            "    arg2='test\\narg2',\n"
+            "),"
+        )
+
     def test_expand_args_signature(self):
         operation = custom_migration_operations.operations.ExpandArgsOperation([1, 2])
-        writer = OperationWriter(operation)
-        writer.indentation = 0
-        buff, imports = writer.serialize()
+        buff, imports = OperationWriter(operation, indentation=0).serialize()
         self.assertEqual(imports, {'import custom_migration_operations.operations'})
         self.assertEqual(
             buff,
@@ -158,6 +160,14 @@ class WriterTests(TestCase):
         self.assertSerializedEqual("föobár")
         string, imports = MigrationWriter.serialize("foobar")
         self.assertEqual(string, "'foobar'")
+
+    def test_serialize_multiline_strings(self):
+        self.assertSerializedEqual(b"foo\nbar")
+        string, imports = MigrationWriter.serialize(b"foo\nbar")
+        self.assertEqual(string, "b'foo\\nbar'")
+        self.assertSerializedEqual("föo\nbár")
+        string, imports = MigrationWriter.serialize("foo\nbar")
+        self.assertEqual(string, "'foo\\nbar'")
 
     def test_serialize_collections(self):
         self.assertSerializedEqual({1: 2})


### PR DESCRIPTION
Changed MigrationWriter _serialize_path to work with deconstructed
operations. Deconstruction of operations returns the name of the class
as the first value, not the full import path.