### PR TITLE
Fixed #24254 -- Don't return extra select columns for subquery

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -303,6 +303,10 @@ class SQLCompiler(object):
         return result
 
     def get_extra_select(self, order_by, select):
+        if self.subquery:
+            # For a subquery, we can't return more than one column, so we don't
+            # want any extra columns.
+            return []
         extra_select = []
         select_sql = [t[1] for t in select]
         if self.query.distinct and not self.query.distinct_fields:

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3669,3 +3669,12 @@ class TestTicket24279(TestCase):
         School.objects.create()
         qs = School.objects.filter(Q(pk__in=()) | Q())
         self.assertQuerysetEqual(qs, [])
+
+
+class TestTicket24254(TestCase):
+    def test_ticket_24254(self):
+        # This tests that the following queryset compiles to valid SQL.
+        qs = Person.objects.filter(
+            pk__in=Person.objects.order_by('name').distinct()[:10]
+        )
+        self.assertQuerysetEqual(qs, [])


### PR DESCRIPTION
For a subquery to be valid, it cannot return more than one column, so we
don't want any extra columns.