### PR TITLE
Revert #24075

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -11,7 +11,6 @@ from django.contrib.auth import get_permission_codename
 from django.core import exceptions
 from django.core.management.base import CommandError
 from django.db import DEFAULT_DB_ALIAS, router
-from django.db.migrations.loader import is_latest_migration_applied
 from django.utils.encoding import DEFAULT_LOCALE_ENCODING
 from django.utils import six
 
@@ -59,10 +58,6 @@ def _check_permission_clashing(custom, builtin, ctype):
 
 
 def create_permissions(app_config, verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs):
-    # TODO: Remove when migration plan / state is passed (#24100).
-    if not is_latest_migration_applied('auth'):
-        return
-
     if not app_config.models_module:
         return
 

--- a/django/contrib/auth/tests/test_management.py
+++ b/django/contrib/auth/tests/test_management.py
@@ -20,9 +20,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import checks, exceptions
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import (
-    TestCase, override_settings, override_system_checks, skipUnlessDBFeature,
-)
+from django.test import TestCase, override_settings, override_system_checks
 from django.utils import six
 from django.utils.encoding import force_str
 
@@ -575,21 +573,3 @@ class PermissionTestCase(TestCase):
         six.assertRaisesRegex(self, exceptions.ValidationError,
             "The verbose_name of auth.permission is longer than 244 characters",
             create_permissions, auth_app_config, verbosity=0)
-
-
-class MigrateTests(TestCase):
-
-    @skipUnlessDBFeature('can_rollback_ddl')
-    def test_unmigrating_first_migration_post_migrate_signal(self):
-        """
-        #24075 - When unmigrating an app before its first migration,
-        post_migrate signal handler must be aware of the missing tables.
-        """
-        try:
-            with override_settings(
-                INSTALLED_APPS=["django.contrib.auth", "django.contrib.contenttypes"],
-                MIGRATION_MODULES={'auth': 'django.contrib.auth.migrations'},
-            ):
-                call_command("migrate", "auth", "zero", stdout=six.StringIO())
-        finally:
-            call_command("migrate", stdout=six.StringIO())

--- a/django/contrib/auth/tests/test_management.py
+++ b/django/contrib/auth/tests/test_management.py
@@ -590,6 +590,6 @@ class MigrateTests(TestCase):
                 INSTALLED_APPS=["django.contrib.auth", "django.contrib.contenttypes"],
                 MIGRATION_MODULES={'auth': 'django.contrib.auth.migrations'},
             ):
-                call_command("migrate", "auth", "zero", verbosity=0)
+                call_command("migrate", "auth", "zero", stdout=six.StringIO())
         finally:
-            call_command("migrate", verbosity=0)
+            call_command("migrate", stdout=six.StringIO())

--- a/django/contrib/contenttypes/management.py
+++ b/django/contrib/contenttypes/management.py
@@ -1,6 +1,5 @@
 from django.apps import apps
 from django.db import DEFAULT_DB_ALIAS, router
-from django.db.migrations.loader import is_latest_migration_applied
 from django.utils import six
 from django.utils.six.moves import input
 
@@ -10,10 +9,6 @@ def update_contenttypes(app_config, verbosity=2, interactive=True, using=DEFAULT
     Creates content types for models in the given app, removing any model
     entries that no longer have a matching model class.
     """
-    # TODO: Remove when migration plan / state is passed (#24100).
-    if not is_latest_migration_applied('contenttypes'):
-        return
-
     if not app_config.models_module:
         return
 

--- a/django/contrib/contenttypes/tests/tests.py
+++ b/django/contrib/contenttypes/tests/tests.py
@@ -258,9 +258,9 @@ class ContentTypesTests(TestCase):
                 INSTALLED_APPS=["django.contrib.contenttypes"],
                 MIGRATION_MODULES={'contenttypes': 'django.contrib.contenttypes.migrations'},
             ):
-                call_command("migrate", "contenttypes", "zero", verbosity=0)
+                call_command("migrate", "contenttypes", "zero", stdout=six.StringIO())
         finally:
-            call_command("migrate", verbosity=0)
+            call_command("migrate", stdout=six.StringIO())
 
     def test_name_deprecation(self):
         """

--- a/django/contrib/contenttypes/tests/tests.py
+++ b/django/contrib/contenttypes/tests/tests.py
@@ -5,9 +5,8 @@ import warnings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.management import call_command
 from django.http import Http404, HttpRequest
-from django.test import TestCase, override_settings, skipUnlessDBFeature
+from django.test import TestCase, override_settings
 from django.utils import six
 
 from .models import (
@@ -246,21 +245,6 @@ class ContentTypesTests(TestCase):
         # Instead, just return the ContentType object and let the app detect stale states.
         ct_fetched = ContentType.objects.get_for_id(ct.pk)
         self.assertIsNone(ct_fetched.model_class())
-
-    @skipUnlessDBFeature('can_rollback_ddl')
-    def test_unmigrating_first_migration_post_migrate_signal(self):
-        """
-        #24075 - When unmigrating an app before its first migration,
-        post_migrate signal handler must be aware of the missing tables.
-        """
-        try:
-            with override_settings(
-                INSTALLED_APPS=["django.contrib.contenttypes"],
-                MIGRATION_MODULES={'contenttypes': 'django.contrib.contenttypes.migrations'},
-            ):
-                call_command("migrate", "contenttypes", "zero", stdout=six.StringIO())
-        finally:
-            call_command("migrate", stdout=six.StringIO())
 
     def test_name_deprecation(self):
         """

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,7 +6,6 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
-from django.db import connection
 from django.db.migrations.graph import MigrationGraph, NodeNotFoundError
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six
@@ -339,14 +338,3 @@ class AmbiguityError(Exception):
     Raised when more than one migration matches a name prefix
     """
     pass
-
-
-def is_latest_migration_applied(app_label):
-    # TODO: Remove when migration plan / state is passed (#24100).
-    loader = MigrationLoader(connection)
-    loader.load_disk()
-    leaf_nodes = loader.graph.leaf_nodes(app=app_label)
-    return (
-        leaf_nodes and leaf_nodes[0] in loader.applied_migrations or
-        app_label in loader.unmigrated_apps
-    )

--- a/docs/releases/1.7.5.txt
+++ b/docs/releases/1.7.5.txt
@@ -9,4 +9,7 @@ Django 1.7.5 fixes several bugs in 1.7.4.
 Bugfixes
 ========
 
-* ...
+* Reverted a fix that prevented a migration crash when unapplying
+  ``contrib.contenttypes``’s or ``contrib.auth``’s first migration
+  (:ticket:`24075`) due to severe impact on the test performance
+  (:ticket:`24251`) and problems in multi-database setups (:ticket:`24298`).


### PR DESCRIPTION
Reverted fix preventing a migration crash when unapplying `contrib.contenttypes`’s or `contrib.auth`’s first migration ([#24075](https://code.djangoproject.com/ticket/24075)) due to severe impact on test performance ([#24251](https://code.djangoproject.com/ticket/24251)) and problems in multi-database setups ([#24298](https://code.djangoproject.com/ticket/24298)).