### PR TITLE
Fix #24181 -- THOUSAND_SEPARATOR strings are reversed

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -47,7 +47,7 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
         int_part_gd = ''
         for cnt, digit in enumerate(int_part[::-1]):
             if cnt and not cnt % grouping:
-                int_part_gd += thousand_sep
+                int_part_gd += thousand_sep[::-1]
             int_part_gd += digit
         int_part = int_part_gd[::-1]
     return sign + int_part + dec_part

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -26,6 +26,9 @@ class TestNumberFormat(TestCase):
         self.assertEqual(nformat('1234', '.', grouping=2, thousand_sep=',',
                                  force_grouping=True), '12,34')
         self.assertEqual(nformat('-1234.33', '.', decimal_pos=1), '-1234.3')
+        self.assertEqual(nformat('10000', '.', grouping=3,
+                                 thousand_sep='comma', force_grouping=True),
+                         '10comma000')
 
     def test_large_number(self):
         most_max = ('{}179769313486231570814527423731704356798070567525844996'


### PR DESCRIPTION
Original patch by hannal. Fixes the reversed thousand_sep string bug with intcomma template tag in L10N.