### PR TITLE
Updates to mod_wsgi documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -280,6 +280,7 @@ answer newbie questions, and generally made Django that much better:
     Ian Clelland <clelland@gmail.com>
     Ian G. Kelly <ian.g.kelly@gmail.com>
     Ian Holsman <http://feh.holsman.net/>
+    Ian Lee <IanLee1521@gmail.com>
     Ibon <ibonso@gmail.com>
     Idan Gazit <idan@gazit.me>
     Igor Kolar <ike@email.si>

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -83,7 +83,9 @@ your Python path as well. To do this, add an additional path to your
 ``WSGIPythonPath`` directive, with multiple paths separated by a colon (``:``)
 if using a UNIX-like system, or a semicolon (``;``) if using Windows. If any
 part of a directory path contains a space character, the complete argument
-string to ``WSGIPythonPath`` must be quoted::
+string to ``WSGIPythonPath`` must be quoted:
+
+.. code-block:: apache
 
     WSGIPythonPath /path/to/mysite.com:/path/to/your/venv/lib/python3.X/site-packages
 
@@ -103,7 +105,9 @@ Django instance to run in it, you will need to add appropriate
 ``WSGIDaemonProcess`` and ``WSGIProcessGroup`` directives. A further change
 required to the above configuration if you use daemon mode is that you can't
 use ``WSGIPythonPath``; instead you should use the ``python-path`` option to
-``WSGIDaemonProcess``, for example::
+``WSGIDaemonProcess``, for example:
+
+.. code-block:: apache
 
     WSGIDaemonProcess example.com python-path=/path/to/mysite.com:/path/to/venv/lib/python2.7/site-packages
     WSGIProcessGroup example.com
@@ -143,7 +147,9 @@ static media, and others using the mod_wsgi interface to Django.
 This example sets up Django at the site root, but explicitly serves
 ``robots.txt``, ``favicon.ico``, any CSS file, and anything in the
 ``/static/`` and ``/media/`` URL space as a static file. All other URLs
-will be served using mod_wsgi::
+will be served using mod_wsgi:
+
+.. code-block:: apache
 
     Alias /robots.txt /path/to/mysite.com/static/robots.txt
     Alias /favicon.ico /path/to/mysite.com/static/favicon.ico

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -119,7 +119,10 @@ the Apache webserver, when combined with the ``WSGIScriptAlias`` directive.
 
     WSGIDaemonProcess example.com python-path=/path/to/mysite.com:/path/to/venv/lib/python2.7/site-packages
     WSGIProcessGroup example.com
-    WSGIScriptAlias /subdir /path/to/mysite.com/mysite/wsgi.py process-group=example.com
+    WSGIScriptAlias /mysite /path/to/mysite.com/mysite/wsgi.py process-group=example.com
+
+This configuration (when combined with the basic configuration from above) will
+allow access to a server such as ``http://example.com/mysite``.
 
 See the official mod_wsgi documentation for `details on setting up daemon
 mode`_.

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -108,6 +108,15 @@ use ``WSGIPythonPath``; instead you should use the ``python-path`` option to
     WSGIDaemonProcess example.com python-path=/path/to/mysite.com:/path/to/venv/lib/python2.7/site-packages
     WSGIProcessGroup example.com
 
+Additionally, daemon mode can be used to specify a non root subdirectory of
+the Apache webserver, when combined with the ``WSGIScriptAlias`` directive.
+
+.. code-block:: apache
+
+    WSGIDaemonProcess example.com python-path=/path/to/mysite.com:/path/to/venv/lib/python2.7/site-packages
+    WSGIProcessGroup example.com
+    WSGIScriptAlias /subdir /path/to/mysite.com/mysite/wsgi.py process-group=example.com
+
 See the official mod_wsgi documentation for `details on setting up daemon
 mode`_.
 


### PR DESCRIPTION
Added updates to mod_wsgi documentation. This was brought on by several days of my trying to figure out how to properly configure Apache to host a django site at a subdirectory ``http://example.com/mydjangosite`` and having everything work properly.

This ideally would become the defacto location to document this case for those seeking an answer:

http://stackoverflow.com/questions/18424852/configure-django-on-sub-directory/28244894 
http://serverfault.com/questions/563225/django-wsgi-application-in-a-subdirectory
http://stackoverflow.com/questions/1466708/run-django-with-url-prefix-subdirectory-app-works-but-urls-broken
http://stackoverflow.com/questions/1036186/django-apache-redirect-problem
...

In the end I was able to [answer](http://stackoverflow.com/questions/18424852/configure-django-on-sub-directory/28244894) this by stumbling upon [Graham Dumpleton's post](http://blog.dscpl.com.au/2012/10/requests-running-in-wrong-django.html).