### PR TITLE
Do not generate a new lazy wrapper on each invocation.

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -180,6 +180,8 @@ def allow_lazy(func, *resultclasses):
     immediately, otherwise a __proxy__ is returned that will evaluate the
     function when needed.
     """
+    lazy_func = lazy(func, *resultclasses)
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         for arg in list(args) + list(six.itervalues(kwargs)):
@@ -187,7 +189,7 @@ def allow_lazy(func, *resultclasses):
                 break
         else:
             return func(*args, **kwargs)
-        return lazy(func, *resultclasses)(*args, **kwargs)
+        return lazy_func(*args, **kwargs)
     return wrapper
 
 empty = object()


### PR DESCRIPTION
This dramatically improves performance on PyPy. The following benchmark:

```
python -mtimeit -s "from django.utils.functional import allow_lazy; from django.utils.translation import ugettext_lazy; f = allow_lazy(lambda s: s, str)" "f(ugettext_lazy('abc'))"
```
goes from 390us per loop to 165us.