### PR TITLE
[WIP] Fixed #24200 -- Cleared statement cache on Oracle

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -494,6 +494,14 @@ class BaseDatabaseWrapper(object):
             '_start_transaction_under_autocommit() method'
         )
 
+    def clear_old_columns(self):
+        """
+        Handler for database feature `connection_persists_old_columns = True`
+        """
+        if self.connection is None:
+            return
+        self.connection.close()
+
     def schema_editor(self, *args, **kwargs):
         """
         Returns a new instance of this backend's SchemaEditor.

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -415,7 +415,7 @@ class BaseDatabaseSchemaEditor(object):
             self.deferred_sql.append(self._create_fk_sql(model, field, "_fk_%(to_table)s_%(to_column)s"))
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
-            self.connection.close()
+            self.connection.clear_old_columns()
 
     def remove_field(self, model, field):
         """
@@ -441,7 +441,7 @@ class BaseDatabaseSchemaEditor(object):
         self.execute(sql)
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
-            self.connection.close()
+            self.connection.clear_old_columns()
 
     def alter_field(self, model, old_field, new_field, strict=False):
         """
@@ -736,7 +736,7 @@ class BaseDatabaseSchemaEditor(object):
             self.execute(sql)
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
-            self.connection.close()
+            self.connection.clear_old_columns()
 
     def _alter_column_type_sql(self, table, column, type):
         """

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -59,7 +59,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_table_description(self, cursor, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."
+        # disable statement caching incase tables or columns have been altered
+        self.connection.set_statement_cache_size(0)
         cursor.execute("SELECT * FROM %s WHERE ROWNUM < 2" % self.connection.ops.quote_name(table_name))
+        self.connection.set_statement_cache_size(20)
         description = []
         for desc in cursor.description:
             name = force_text(desc[0])  # cx_Oracle always returns a 'str' on both Python 2 and 3

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -87,9 +87,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         self.remove_field(model, old_field)
         # Rename the new field
         self.alter_field(model, new_temp_field, new_field)
-        # Close the connection to force cx_Oracle to get column types right
-        # on a new cursor
-        self.connection.close()
 
     def normalize_name(self, name):
         """


### PR DESCRIPTION
I've implemented statement cache purging for oracle, so we no longer have to close the connection when columns are altered. I didn't remove the feature incase other backends (third party) made use of it. Instead, I added an overridable function which backends can use to define the behaviour for what they do when django determines there are old columns that are being persisted.

I haven't done docs yet, but will do so if this is accepted.

As for testing, I couldn't figure out a way to write a test that stressed this function. I added a return statement to the top of `clear_old_columns` and ran most of the test suite (introspection, migrations, schema) and couldn't replicate any issues with stale column info.

If someone can give me an idea of how to write a test that'd fail without the persists old column feature, I'll add that in.

@shaib what are your thoughts here?