### PR TITLE
Disallowed importing concrete models without an application.

### DIFF
--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -24,9 +24,8 @@ Available ``Meta`` options
 
 .. attribute:: Options.app_label
 
-    If a model exists outside of an application in :setting:`INSTALLED_APPS` or
-    if it's imported before its application was loaded, it must define which
-    app it is part of::
+    If a model is defined outside of an application in
+    :setting:`INSTALLED_APPS`, it must declare which app it belongs to::
 
         app_label = 'myapp'
 

--- a/tests/test_runner/runner.py
+++ b/tests/test_runner/runner.py
@@ -1,0 +1,20 @@
+from django.test.runner import DiscoverRunner
+
+
+class CustomOptionsTestRunner(DiscoverRunner):
+
+    def __init__(self, verbosity=1, interactive=True, failfast=True, option_a=None, option_b=None, option_c=None, **kwargs):
+        super(CustomOptionsTestRunner, self).__init__(verbosity=verbosity, interactive=interactive,
+                                                      failfast=failfast)
+        self.option_a = option_a
+        self.option_b = option_b
+        self.option_c = option_c
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument('--option_a', '-a', action='store', dest='option_a', default='1'),
+        parser.add_argument('--option_b', '-b', action='store', dest='option_b', default='2'),
+        parser.add_argument('--option_c', '-c', action='store', dest='option_c', default='3'),
+
+    def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        print("%s:%s:%s" % (self.option_a, self.option_b, self.option_c))

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -151,30 +151,11 @@ class ManageCommandTests(unittest.TestCase):
                 testrunner='test_runner.NonExistentRunner')
 
 
-class CustomOptionsTestRunner(DiscoverRunner):
-
-    def __init__(self, verbosity=1, interactive=True, failfast=True, option_a=None, option_b=None, option_c=None, **kwargs):
-        super(CustomOptionsTestRunner, self).__init__(verbosity=verbosity, interactive=interactive,
-                                                      failfast=failfast)
-        self.option_a = option_a
-        self.option_b = option_b
-        self.option_c = option_c
-
-    @classmethod
-    def add_arguments(cls, parser):
-        parser.add_argument('--option_a', '-a', action='store', dest='option_a', default='1'),
-        parser.add_argument('--option_b', '-b', action='store', dest='option_b', default='2'),
-        parser.add_argument('--option_c', '-c', action='store', dest='option_c', default='3'),
-
-    def run_tests(self, test_labels, extra_tests=None, **kwargs):
-        print("%s:%s:%s" % (self.option_a, self.option_b, self.option_c))
-
-
 class CustomTestRunnerOptionsTests(AdminScriptTestCase):
 
     def setUp(self):
         settings = {
-            'TEST_RUNNER': '\'test_runner.tests.CustomOptionsTestRunner\'',
+            'TEST_RUNNER': '\'test_runner.runner.CustomOptionsTestRunner\'',
         }
         self.write_settings('settings.py', sdict=settings)
 


### PR DESCRIPTION
Removed fragile algorithm to find which application a model belongs to.

Fixed #21680, #21719. Refs #21794.