### PR TITLE
Fixed #24200 -- Made introspection bypass statement cache

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -35,7 +35,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_combined_alters = False
     nulls_order_largest = True
     requires_literal_defaults = True
-    connection_persists_old_columns = True
     closed_cursor_error_class = InterfaceError
     bare_select_suffix = " FROM DUAL"
     uppercases_column_names = True

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -33,6 +33,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     except AttributeError:
         pass
 
+    cache_bust_counter = 1
+
     def get_field_type(self, data_type, description):
         # If it's a NUMBER with scale == 0, consider it an IntegerField
         if data_type == cx_Oracle.NUMBER:
@@ -59,7 +61,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_table_description(self, cursor, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."
-        cursor.execute("SELECT * FROM %s WHERE ROWNUM < 2" % self.connection.ops.quote_name(table_name))
+        self.cache_bust_counter += 1
+        cursor.execute("SELECT * FROM {} WHERE ROWNUM < 2 AND {} > 0".format(
+            self.connection.ops.quote_name(table_name),
+            self.cache_bust_counter))
         description = []
         for desc in cursor.description:
             name = force_text(desc[0])  # cx_Oracle always returns a 'str' on both Python 2 and 3

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -87,9 +87,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         self.remove_field(model, old_field)
         # Rename the new field
         self.alter_field(model, new_temp_field, new_field)
-        # Close the connection to force cx_Oracle to get column types right
-        # on a new cursor
-        self.connection.close()
 
     def normalize_name(self, name):
         """

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -286,6 +286,10 @@ Database backends
 * The MySQL backend no longer creates explicit indexes for foreign keys when
   using the InnoDB storage engine, as MySQL already creates them automatically.
 
+* The Oracle backend no longer defines the ``connection_persists_old_columns``
+  feature as ``True``. Instead, Oracle will now include a cache busting clause
+  when getting the description of a table.
+
 Email
 ^^^^^
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24200

Oracle will no longer close connections when table columns have changed. Busting the cache with an increasing counter for `get_table_description` solves the stale table description problem.

The following tests fail when commenting out the line that increases the counter:

- test_add_field (migrations.test_operations.OperationTests)
- test_alter_order_with_respect_to (migrations.test_operations.OperationTests)
- test_remove_field (migrations.test_operations.OperationTests)
- test_remove_fk (migrations.test_operations.OperationTests)
- test_alter (schema.tests.SchemaTests)
