### PR TITLE
Subclass template.Node instead of Node, for consistency.

### DIFF
--- a/django/templatetags/static.py
+++ b/django/templatetags/static.py
@@ -1,5 +1,4 @@
 from django import template
-from django.template.base import Node
 from django.utils.encoding import iri_to_uri
 from django.utils.six.moves.urllib.parse import urljoin
 
@@ -90,7 +89,7 @@ def get_media_prefix(parser, token):
     return PrefixNode.handle_token(parser, token, "MEDIA_URL")
 
 
-class StaticNode(Node):
+class StaticNode(template.Node):
     def __init__(self, varname=None, path=None):
         if path is None:
             raise template.TemplateSyntaxError(


### PR DESCRIPTION
`PrefixNode` and `StaticNode` are both subclassing `Node` but with a different syntax. Are they actually sub-classing different parents? If not, we can consolidate this to one syntax.

It looks like `django.template.base.Node` and `django.template.Node` both point to the same class (https://github.com/django/django/blob/master/django/template/__init__.py#L62)