### PR TITLE
Fix `utils.http.same_origin` to comply with RFC6454 (Trac #24321)

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -36,7 +36,6 @@ RFC3986_SUBDELIMS = str("!$&'()*+,;=")
 PROTOCOL_TO_PORT = {
     'http': 80,
     'https': 443,
-    'ftp': 21,
 }
 
 
@@ -259,13 +258,10 @@ def same_origin(url1, url2):
     """
     p1, p2 = urlparse(url1), urlparse(url2)
     try:
-        return (
-            p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme]
-            ) == (
-            p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
-    except ValueError:
-        return False
-    except KeyError:
+        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
+        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
+        return o1 == o2
+    except (ValueError, KeyError):
         return False
 
 

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -33,6 +33,12 @@ ASCTIME_DATE = re.compile(r'^\w{3} %s %s %s %s$' % (__M, __D2, __T, __Y))
 RFC3986_GENDELIMS = str(":/?#[]@")
 RFC3986_SUBDELIMS = str("!$&'()*+,;=")
 
+PROTOCOL_TO_PORT = {
+    'http': 80,
+    'https': 443,
+    'ftp': 21,
+}
+
 
 def urlquote(url, safe='/'):
     """
@@ -253,8 +259,13 @@ def same_origin(url1, url2):
     """
     p1, p2 = urlparse(url1), urlparse(url2)
     try:
-        return (p1.scheme, p1.hostname, p1.port) == (p2.scheme, p2.hostname, p2.port)
+        return (
+            p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme]
+            ) == (
+            p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
     except ValueError:
+        return False
+    except KeyError:
         return False
 
 

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -18,6 +18,9 @@ class TestUtilsHttp(unittest.TestCase):
         self.assertTrue(http.same_origin('http://foo.com/', 'http://foo.com'))
         # With port
         self.assertTrue(http.same_origin('https://foo.com:8000', 'https://foo.com:8000/'))
+        # No port given but according to RFC6454 still the same origin
+        self.assertTrue(http.same_origin('http://foo.com', 'http://foo.com:80/'))
+        self.assertTrue(http.same_origin('https://foo.com', 'https://foo.com:443/'))
 
     def test_same_origin_false(self):
         # Different scheme
@@ -28,6 +31,9 @@ class TestUtilsHttp(unittest.TestCase):
         self.assertFalse(http.same_origin('http://foo.com', 'http://foo.com.evil.com'))
         # Different port
         self.assertFalse(http.same_origin('http://foo.com:8000', 'http://foo.com:8001'))
+        # No port given
+        self.assertFalse(http.same_origin('http://foo.com', 'http://foo.com:8000/'))
+        self.assertFalse(http.same_origin('https://foo.com', 'https://foo.com:8000/'))
 
     def test_urlencode(self):
         # 2-tuples (the norm)


### PR DESCRIPTION
Trac Ticket: https://code.djangoproject.com/ticket/24321#ticket

According to RFC6454 (http://tools.ietf.org/html/rfc6454#section-3.2.1) this should both be true:

```python
>>> from django.utils.http import same_origin
>>> same_origin('http://google.com', 'http://google.com')
True
>>> same_origin('http://google.com', 'http://google.com:80')
False
```

Quote:
> All of the following resources have the same origin:
>
>   http://example.com/
>   http://example.com:80/
>   http://example.com/path/file
>
>   Each of the URIs has the same scheme, host, and port components.

Django's `same_origin` uses the standard urllib, which will return an empty port if none is explicitly specified, which is why I have extended the `same_origin` method to use a protocol-to-port-mapping if no port is explicitly declared.