### PR TITLE
Custom Admin views documentation

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1406,8 +1406,22 @@ templates used by the :class:`ModelAdmin` views:
                 return my_urls + urls
 
             def my_view(self, request):
-                # custom view which should return an HttpResponse
-                pass
+                # Admin specific rendering
+                # This ensures all of the admin variables are included if you are using the Django
+                # Admin template
+                context = dict(
+                   self.each_context(),
+                   # Anything else you want in the context
+                )
+                context.update(extra_context or {})
+                return TemplateResponse(request, "sometemplate.html", context)
+
+    If you want to use the Django Admin template you should extend from ``admin/base_site.html``, like so::
+    
+       {% extends "admin/base_site.html" %}
+       {% block content %}
+       <!-- content -->
+       {% endblock %}
 
     .. note::
 


### PR DESCRIPTION
Slightly improved the documentation relating to adding custom admin views, directing people
to the way template variables are included and the base template.

This is against Django 1.7, so I'm not sure if it'll work with the dev branch