### PR TITLE
cache.txt: ``0`` forces to immediately expire

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -363,7 +363,7 @@ behavior. These arguments are provided as additional keys in the
 * :setting:`TIMEOUT <CACHES-TIMEOUT>`: The default timeout, in
   seconds, to use for the cache. This argument defaults to ``300`` seconds (5 minutes).
   You can set ``TIMEOUT`` to ``None`` so that, by default, cache keys never
-  expire.
+  expire. The value of ``0`` forces to immediately expire (effectively "don't cache").
 
 * :setting:`OPTIONS <CACHES-OPTIONS>`: Any options that should be
   passed to the cache backend. The list of valid options will vary
@@ -745,7 +745,8 @@ The basic interface is ``set(key, value, timeout)`` and ``get(key)``::
 The ``timeout`` argument is optional and defaults to the ``timeout`` argument
 of the appropriate backend in the :setting:`CACHES` setting (explained above).
 It's the number of seconds the value should be stored in the cache. Passing in
-``None`` for ``timeout`` will cache the value forever.
+``None`` for ``timeout`` will cache the value forever. The ``timeout`` of ``0``
+forces to immediately expire (effectively "don't cache").
 
 If the object doesn't exist in the cache, ``cache.get()`` returns ``None``::
 


### PR DESCRIPTION
More explicit docs: cache timeout:  ``0`` forces to immediately expire
Changed it at two places. Russ Magee:
https://groups.google.com/d/msg/django-users/iScpF2dSg98/-aFcj3mKhjIJ