### PR TITLE
Fixed #24161 -- Stored the user primary key as a serialized value in the session.

### DIFF
--- a/tests/auth_tests/models/__init__.py
+++ b/tests/auth_tests/models/__init__.py
@@ -5,9 +5,10 @@ from .invalid_models import (
     CustomUserBadRequiredFields,
 )
 from .with_foreign_key import CustomUserWithFK, Email
+from .uuid_pk import UUIDUser
 
 __all__ = (
     'CustomPermissionsUser', 'CustomUserNonUniqueUsername',
     'CustomUserNonListRequiredFields', 'CustomUserBadRequiredFields',
-    'CustomUserWithFK', 'Email', 'IsActiveTestUser1',
+    'CustomUserWithFK', 'Email', 'IsActiveTestUser1', 'UUIDUser',
 )

--- a/tests/auth_tests/models/uuid_pk.py
+++ b/tests/auth_tests/models/uuid_pk.py
@@ -1,0 +1,13 @@
+import uuid
+
+from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.tests.custom_user import RemoveGroupsAndPermissions
+from django.db import models
+
+with RemoveGroupsAndPermissions():
+    class UUIDUser(AbstractUser):
+        """A user with a UUID as primary key"""
+        id = models.UUIDField(default=uuid.uuid4, primary_key=True)
+
+        class Meta:
+            app_label = 'auth'


### PR DESCRIPTION
This allows using a UUIDField primary key along with the JSON session
serializer.

Thanks to Trac alias jamesbeith for the report and Simon Charette
for the initial patch.