### PR TITLE
Refs #14030 -- Added tests for Value aggregates

### DIFF
--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -8,7 +8,7 @@ from django.core.exceptions import FieldError
 from django.db import connection
 from django.db.models import (
     F, Aggregate, Avg, Count, DecimalField, FloatField, Func, IntegerField,
-    Max, Min, Sum,
+    Max, Min, Sum, Value,
 )
 from django.test import TestCase, ignore_warnings
 from django.test.utils import Approximate, CaptureQueriesContext
@@ -706,7 +706,9 @@ class ComplexAggregateTestCase(TestCase):
             Book.objects.aggregate(fail=F('price'))
 
     def test_nonfield_annotation(self):
-        book = Book.objects.annotate(val=Max(2, output_field=IntegerField()))[0]
+        book = Book.objects.annotate(val=Max(Value(2, output_field=IntegerField())))[0]
+        self.assertEqual(book.val, 2)
+        book = Book.objects.annotate(val=Max(Value(2), output_field=IntegerField()))[0]
         self.assertEqual(book.val, 2)
         book = Book.objects.annotate(val=Max(2, output_field=IntegerField()))[0]
         self.assertEqual(book.val, 2)


### PR DESCRIPTION
e2d6e14662d780383e18066a3182155fb5b7747b simplified Value expressions, but I was too aggressive when altering the tests.

@pope1ni pointed out (https://github.com/django/django/commit/e2d6e14662d780383e18066a3182155fb5b7747b#commitcomment-9712894) that two tests were refactored to be duplicates of each other. I've re-added the original tests and kept one of the refactored tests. This should provide full coverage of Value expression combinations.

