### PR TITLE
[1.8.x] Fixed #24320 - Use smart_text in serialization while handling FK field value

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.serializers import base
 from django.db import DEFAULT_DB_ALIAS, models
 from django.utils import six
-from django.utils.encoding import force_text, is_protected_type
+from django.utils.encoding import force_text, is_protected_type, smart_text
 
 
 class Serializer(base.Serializer):
@@ -62,7 +62,11 @@ class Serializer(base.Serializer):
             else:
                 value = None
         else:
-            value = getattr(obj, field.get_attname())
+            gotten_value = getattr(obj, field.get_attname())
+            if gotten_value is not None:
+                value = smart_text(gotten_value)
+            else:
+                value = gotten_value
         self._current[field.name] = value
 
     def handle_m2m_field(self, obj, field):

--- a/tests/serializers_regress/models.py
+++ b/tests/serializers_regress/models.py
@@ -284,6 +284,10 @@ class UUIDData(models.Model):
     data = models.UUIDField(primary_key=True)
 
 
+class FKToUUID(models.Model):
+    data = models.ForeignKey(UUIDData)
+
+
 class ComplexModel(models.Model):
     field1 = models.CharField(max_length=10)
     field2 = models.CharField(max_length=10)

--- a/tests/serializers_regress/tests.py
+++ b/tests/serializers_regress/tests.py
@@ -29,15 +29,16 @@ from .models import (
     BooleanData, BooleanPKData, CharData, CharPKData, ComplexModel, DateData,
     DateTimeData, DecimalData, DecimalPKData, EmailData, EmailPKData,
     ExplicitInheritBaseModel, FileData, FilePathData, FilePathPKData, FKData,
-    FKDataNaturalKey, FKDataToField, FKDataToO2O, FKSelfData, FloatData,
-    FloatPKData, GenericData, GenericIPAddressData, GenericIPAddressPKData,
-    InheritAbstractModel, InheritBaseModel, IntegerData, IntegerPKData,
-    Intermediate, IPAddressData, IPAddressPKData, LengthModel, M2MData,
-    M2MIntermediateData, M2MSelfData, ModifyingSaveData, NaturalKeyAnchor,
-    NullBooleanData, O2OData, PositiveIntegerData, PositiveIntegerPKData,
-    PositiveSmallIntegerData, PositiveSmallIntegerPKData, ProxyBaseModel,
-    ProxyProxyBaseModel, SlugData, SlugPKData, SmallData, SmallPKData, Tag,
-    TextData, TimeData, UniqueAnchor, UUIDData,
+    FKDataNaturalKey, FKDataToField, FKDataToO2O, FKSelfData, FKToUUID,
+    FloatData, FloatPKData, GenericData, GenericIPAddressData,
+    GenericIPAddressPKData, InheritAbstractModel, InheritBaseModel,
+    IntegerData, IntegerPKData, Intermediate, IPAddressData, IPAddressPKData,
+    LengthModel, M2MData, M2MIntermediateData, M2MSelfData, ModifyingSaveData,
+    NaturalKeyAnchor, NullBooleanData, O2OData, PositiveIntegerData,
+    PositiveIntegerPKData, PositiveSmallIntegerData,
+    PositiveSmallIntegerPKData, ProxyBaseModel, ProxyProxyBaseModel, SlugData,
+    SlugPKData, SmallData, SmallPKData, Tag, TextData, TimeData, UniqueAnchor,
+    UUIDData,
 )
 
 try:
@@ -203,6 +204,7 @@ im_obj = (im_create, im_compare)
 o2o_obj = (o2o_create, o2o_compare)
 pk_obj = (pk_create, pk_compare)
 inherited_obj = (inherited_create, inherited_compare)
+uuid_obj = uuid.uuid4()
 
 test_data = [
     # Format: (data type, PK value, Model Class, data)
@@ -361,7 +363,8 @@ The end."""),
     # The end."""),
     # (pk_obj, 770, TimePKData, datetime.time(10, 42, 37)),
     # (pk_obj, 790, XMLPKData, "<foo></foo>"),
-    (pk_obj, 791, UUIDData, uuid.uuid4()),
+    (pk_obj, 791, UUIDData, uuid_obj),
+    (fk_obj, 792, FKToUUID, uuid_obj),
 
     (data_obj, 800, AutoNowDateTimeData, datetime.datetime(2006, 6, 16, 10, 42, 37)),
     (data_obj, 810, ModifyingSaveData, 42),


### PR DESCRIPTION
I used the the same principle as it used in XML serialization (https://github.com/django/django/blob/47b23ca2ee4d26a50895adf0fba19020b27d8d84/django/core/serializers/xml_serializer.py#L104)