### PR TITLE
Fixed #24335: Range fields not supported in psycopg2 < 2.5

### DIFF
--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -1,155 +1,146 @@
 import json
 
-from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
+from django.contrib.postgres.forms import HAS_PSYCOPG2_RANGES
 
-from django.contrib.postgres import forms, lookups
-from django.db import models
-from django.utils import six
+__all__ = ['HAS_PSYCOPG2_RANGES']
 
-__all__ = [
-    'RangeField', 'IntegerRangeField', 'BigIntegerRangeField',
-    'FloatRangeField', 'DateTimeRangeField', 'DateRangeField',
-]
+if HAS_PSYCOPG2_RANGES:
 
+    from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
 
-class RangeField(models.Field):
-    empty_strings_allowed = False
+    from django.contrib.postgres import forms, lookups
+    from django.db import models
+    from django.utils import six
 
-    def get_prep_value(self, value):
-        if value is None:
-            return None
-        elif isinstance(value, Range):
+    __all__ += [
+        'RangeField', 'IntegerRangeField', 'BigIntegerRangeField',
+        'FloatRangeField', 'DateTimeRangeField', 'DateRangeField',
+    ]
+
+    class RangeField(models.Field):
+        empty_strings_allowed = False
+
+        def get_prep_value(self, value):
+            if value is None:
+                return None
+            elif isinstance(value, Range):
+                return value
+            elif isinstance(value, (list, tuple)):
+                return self.range_type(value[0], value[1])
             return value
-        elif isinstance(value, (list, tuple)):
-            return self.range_type(value[0], value[1])
-        return value
 
-    def to_python(self, value):
-        if isinstance(value, six.string_types):
-            value = self.range_type(**json.loads(value))
-        elif isinstance(value, (list, tuple)):
-            value = self.range_type(value[0], value[1])
-        return value
+        def to_python(self, value):
+            if isinstance(value, six.string_types):
+                value = self.range_type(**json.loads(value))
+            elif isinstance(value, (list, tuple)):
+                value = self.range_type(value[0], value[1])
+            return value
 
-    def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
-        if value is None:
-            return None
-        if value.isempty:
-            return json.dumps({"empty": True})
-        return json.dumps({
-            "lower": value.lower,
-            "upper": value.upper,
-            "bounds": value._bounds,
-        })
+        def value_to_string(self, obj):
+            value = self._get_val_from_obj(obj)
+            if value is None:
+                return None
+            if value.isempty:
+                return json.dumps({"empty": True})
+            return json.dumps({
+                "lower": value.lower,
+                "upper": value.upper,
+                "bounds": value._bounds,
+            })
 
-    def formfield(self, **kwargs):
-        kwargs.setdefault('form_class', self.form_field)
-        return super(RangeField, self).formfield(**kwargs)
+        def formfield(self, **kwargs):
+            kwargs.setdefault('form_class', self.form_field)
+            return super(RangeField, self).formfield(**kwargs)
 
+    class IntegerRangeField(RangeField):
+        base_field = models.IntegerField()
+        range_type = NumericRange
+        form_field = forms.IntegerRangeField
 
-class IntegerRangeField(RangeField):
-    base_field = models.IntegerField()
-    range_type = NumericRange
-    form_field = forms.IntegerRangeField
+        def db_type(self, connection):
+            return 'int4range'
 
-    def db_type(self, connection):
-        return 'int4range'
+    class BigIntegerRangeField(RangeField):
+        base_field = models.BigIntegerField()
+        range_type = NumericRange
+        form_field = forms.IntegerRangeField
 
+        def db_type(self, connection):
+            return 'int8range'
 
-class BigIntegerRangeField(RangeField):
-    base_field = models.BigIntegerField()
-    range_type = NumericRange
-    form_field = forms.IntegerRangeField
+    class FloatRangeField(RangeField):
+        base_field = models.FloatField()
+        range_type = NumericRange
+        form_field = forms.FloatRangeField
 
-    def db_type(self, connection):
-        return 'int8range'
+        def db_type(self, connection):
+            return 'numrange'
 
+    class DateTimeRangeField(RangeField):
+        base_field = models.DateTimeField()
+        range_type = DateTimeTZRange
+        form_field = forms.DateTimeRangeField
 
-class FloatRangeField(RangeField):
-    base_field = models.FloatField()
-    range_type = NumericRange
-    form_field = forms.FloatRangeField
+        def db_type(self, connection):
+            return 'tstzrange'
 
-    def db_type(self, connection):
-        return 'numrange'
+    class DateRangeField(RangeField):
+        base_field = models.DateField()
+        range_type = DateRange
+        form_field = forms.DateRangeField
 
+        def db_type(self, connection):
+            return 'daterange'
 
-class DateTimeRangeField(RangeField):
-    base_field = models.DateTimeField()
-    range_type = DateTimeTZRange
-    form_field = forms.DateTimeRangeField
+    RangeField.register_lookup(lookups.DataContains)
+    RangeField.register_lookup(lookups.ContainedBy)
+    RangeField.register_lookup(lookups.Overlap)
 
-    def db_type(self, connection):
-        return 'tstzrange'
+    @RangeField.register_lookup
+    class FullyLessThan(lookups.PostgresSimpleLookup):
+        lookup_name = 'fully_lt'
+        operator = '<<'
 
+    @RangeField.register_lookup
+    class FullGreaterThan(lookups.PostgresSimpleLookup):
+        lookup_name = 'fully_gt'
+        operator = '>>'
 
-class DateRangeField(RangeField):
-    base_field = models.DateField()
-    range_type = DateRange
-    form_field = forms.DateRangeField
+    @RangeField.register_lookup
+    class NotLessThan(lookups.PostgresSimpleLookup):
+        lookup_name = 'not_lt'
+        operator = '&>'
 
-    def db_type(self, connection):
-        return 'daterange'
+    @RangeField.register_lookup
+    class NotGreaterThan(lookups.PostgresSimpleLookup):
+        lookup_name = 'not_gt'
+        operator = '&<'
 
+    @RangeField.register_lookup
+    class AdjacentToLookup(lookups.PostgresSimpleLookup):
+        lookup_name = 'adjacent_to'
+        operator = '-|-'
 
-RangeField.register_lookup(lookups.DataContains)
-RangeField.register_lookup(lookups.ContainedBy)
-RangeField.register_lookup(lookups.Overlap)
+    @RangeField.register_lookup
+    class RangeStartsWith(lookups.FunctionTransform):
+        lookup_name = 'startswith'
+        function = 'lower'
 
+        @property
+        def output_field(self):
+            return self.lhs.output_field.base_field
 
-@RangeField.register_lookup
-class FullyLessThan(lookups.PostgresSimpleLookup):
-    lookup_name = 'fully_lt'
-    operator = '<<'
+    @RangeField.register_lookup
+    class RangeEndsWith(lookups.FunctionTransform):
+        lookup_name = 'endswith'
+        function = 'upper'
 
+        @property
+        def output_field(self):
+            return self.lhs.output_field.base_field
 
-@RangeField.register_lookup
-class FullGreaterThan(lookups.PostgresSimpleLookup):
-    lookup_name = 'fully_gt'
-    operator = '>>'
-
-
-@RangeField.register_lookup
-class NotLessThan(lookups.PostgresSimpleLookup):
-    lookup_name = 'not_lt'
-    operator = '&>'
-
-
-@RangeField.register_lookup
-class NotGreaterThan(lookups.PostgresSimpleLookup):
-    lookup_name = 'not_gt'
-    operator = '&<'
-
-
-@RangeField.register_lookup
-class AdjacentToLookup(lookups.PostgresSimpleLookup):
-    lookup_name = 'adjacent_to'
-    operator = '-|-'
-
-
-@RangeField.register_lookup
-class RangeStartsWith(lookups.FunctionTransform):
-    lookup_name = 'startswith'
-    function = 'lower'
-
-    @property
-    def output_field(self):
-        return self.lhs.output_field.base_field
-
-
-@RangeField.register_lookup
-class RangeEndsWith(lookups.FunctionTransform):
-    lookup_name = 'endswith'
-    function = 'upper'
-
-    @property
-    def output_field(self):
-        return self.lhs.output_field.base_field
-
-
-@RangeField.register_lookup
-class IsEmpty(lookups.FunctionTransform):
-    lookup_name = 'isempty'
-    function = 'isempty'
-    output_field = models.BooleanField()
+    @RangeField.register_lookup
+    class IsEmpty(lookups.FunctionTransform):
+        lookup_name = 'isempty'
+        function = 'isempty'
+        output_field = models.BooleanField()

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -1,79 +1,80 @@
-from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
+try:
+    from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
+    HAS_PSYCOPG2_RANGES = True
+except ImportError:
+    HAS_PSYCOPG2_RANGES = False
 
-from django import forms
-from django.core import exceptions
-from django.forms.widgets import MultiWidget
-from django.utils.translation import ugettext_lazy as _
+__all__ = ['HAS_PSYCOPG2_RANGES']
 
-__all__ = ['IntegerRangeField', 'FloatRangeField', 'DateTimeRangeField', 'DateRangeField']
+if HAS_PSYCOPG2_RANGES:
+    from django import forms
+    from django.core import exceptions
+    from django.forms.widgets import MultiWidget
+    from django.utils.translation import ugettext_lazy as _
 
+    __all__ += ['IntegerRangeField', 'FloatRangeField', 'DateTimeRangeField', 'DateRangeField']
 
-class BaseRangeField(forms.MultiValueField):
-    default_error_messages = {
-        'invalid': _('Enter two valid values.'),
-        'bound_ordering': _('The start of the range must not exceed the end of the range.'),
-    }
+    class BaseRangeField(forms.MultiValueField):
+        default_error_messages = {
+            'invalid': _('Enter two valid values.'),
+            'bound_ordering': _('The start of the range must not exceed the end of the range.'),
+        }
 
-    def __init__(self, **kwargs):
-        kwargs.setdefault('widget', RangeWidget(self.base_field.widget))
-        kwargs.setdefault('fields', [self.base_field(required=False), self.base_field(required=False)])
-        kwargs.setdefault('required', False)
-        kwargs.setdefault('require_all_fields', False)
-        super(BaseRangeField, self).__init__(**kwargs)
+        def __init__(self, **kwargs):
+            kwargs.setdefault('widget', RangeWidget(self.base_field.widget))
+            kwargs.setdefault('fields', [self.base_field(required=False), self.base_field(required=False)])
+            kwargs.setdefault('required', False)
+            kwargs.setdefault('require_all_fields', False)
+            super(BaseRangeField, self).__init__(**kwargs)
 
-    def prepare_value(self, value):
-        if isinstance(value, self.range_type):
-            return [value.lower, value.upper]
-        if value is None:
-            return [None, None]
-        return value
+        def prepare_value(self, value):
+            if isinstance(value, self.range_type):
+                return [value.lower, value.upper]
+            if value is None:
+                return [None, None]
+            return value
 
-    def compress(self, values):
-        if not values:
-            return None
-        lower, upper = values
-        if lower is not None and upper is not None and lower > upper:
-            raise exceptions.ValidationError(
-                self.error_messages['bound_ordering'],
-                code='bound_ordering',
-            )
-        try:
-            range_value = self.range_type(lower, upper)
-        except TypeError:
-            raise exceptions.ValidationError(
-                self.error_messages['invalid'],
-                code='invalid',
-            )
-        else:
-            return range_value
+        def compress(self, values):
+            if not values:
+                return None
+            lower, upper = values
+            if lower is not None and upper is not None and lower > upper:
+                raise exceptions.ValidationError(
+                    self.error_messages['bound_ordering'],
+                    code='bound_ordering',
+                )
+            try:
+                range_value = self.range_type(lower, upper)
+            except TypeError:
+                raise exceptions.ValidationError(
+                    self.error_messages['invalid'],
+                    code='invalid',
+                )
+            else:
+                return range_value
 
+    class IntegerRangeField(BaseRangeField):
+        base_field = forms.IntegerField
+        range_type = NumericRange
 
-class IntegerRangeField(BaseRangeField):
-    base_field = forms.IntegerField
-    range_type = NumericRange
+    class FloatRangeField(BaseRangeField):
+        base_field = forms.FloatField
+        range_type = NumericRange
 
+    class DateTimeRangeField(BaseRangeField):
+        base_field = forms.DateTimeField
+        range_type = DateTimeTZRange
 
-class FloatRangeField(BaseRangeField):
-    base_field = forms.FloatField
-    range_type = NumericRange
+    class DateRangeField(BaseRangeField):
+        base_field = forms.DateField
+        range_type = DateRange
 
+    class RangeWidget(MultiWidget):
+        def __init__(self, base_widget, attrs=None):
+            widgets = (base_widget, base_widget)
+            super(RangeWidget, self).__init__(widgets, attrs)
 
-class DateTimeRangeField(BaseRangeField):
-    base_field = forms.DateTimeField
-    range_type = DateTimeTZRange
-
-
-class DateRangeField(BaseRangeField):
-    base_field = forms.DateField
-    range_type = DateRange
-
-
-class RangeWidget(MultiWidget):
-    def __init__(self, base_widget, attrs=None):
-        widgets = (base_widget, base_widget)
-        super(RangeWidget, self).__init__(widgets, attrs)
-
-    def decompress(self, value):
-        if value:
-            return (value.lower, value.upper)
-        return (None, None)
+        def decompress(self, value):
+            if value:
+                return (value.lower, value.upper)
+            return (None, None)

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -420,6 +420,14 @@ All of the range fields translate to :ref:`psycopg2 Range objects
 information is necessary. The default is lower bound included, upper bound
 excluded.
 
+.. note::
+    The :class:`~psycopg2:psycopg2.extras.Range` was added to
+    psycopg2__ in version 2.5. These fields are unavailable for import if
+    using an earlier version of the package.
+
+__ http://initd.org/psycopg/
+
+
 IntegerRangeField
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -164,6 +164,14 @@ omitted value as an unbounded range. They also validate that the lower bound is
 not greater than the upper bound. All of these fields use
 :class:`~django.contrib.postgres.forms.RangeWidget`.
 
+.. note::
+    The :class:`~psycopg2:psycopg2.extras.Range` was added to
+    psycopg2__ in version 2.5. The following fields are unavailable for import if
+    using an earlier version of the package.
+
+__ http://initd.org/psycopg/
+
+
 IntegerRangeField
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
If the version of psycopg2 is smaller than 2.5, don't attempt to
define the django.contrib.postgres.fields.ranges.Range field and
associated subclasses.

Also, added documentation noting that the classes are unavailable