### PR TITLE
Fixed #24343 -- Ensure db converters are used for foreign keys.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -15,6 +15,7 @@ from django.db.models.fields import (
     BLANK_CHOICE_DASH, AutoField, Field, IntegerField, PositiveIntegerField,
     PositiveSmallIntegerField,
 )
+from django.db.models.expressions import Col
 from django.db.models.lookups import IsNull
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import PathInfo
@@ -2050,6 +2051,12 @@ class ForeignKey(ForeignObject):
 
     def db_parameters(self, connection):
         return {"type": self.db_type(connection), "check": []}
+
+    def get_db_converters(self, connection):
+        backend_converters = connection.ops.get_db_converters(Col(self.attname, self.related_field))
+        field_converters = self.related_field.get_db_converters(connection)
+        self_converters = super(ForeignKey, self).get_db_converters(connection)
+        return backend_converters + field_converters + self_converters
 
 
 class OneToOneField(ForeignKey):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2054,9 +2054,15 @@ class ForeignKey(ForeignObject):
 
     def get_db_converters(self, connection):
         backend_converters = connection.ops.get_db_converters(Col(self.attname, self.related_field))
+        backend_converters = [self._convert_backend_converter(func) for func in backend_converters]
         field_converters = self.related_field.get_db_converters(connection)
         self_converters = super(ForeignKey, self).get_db_converters(connection)
         return backend_converters + field_converters + self_converters
+
+    def _convert_backend_converter(self, converter):
+        def new_converter(value, connection, context):
+            return converter(value, self, context)
+        return new_converter
 
 
 class OneToOneField(ForeignKey):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2061,7 +2061,7 @@ class ForeignKey(ForeignObject):
 
     def _convert_backend_converter(self, converter):
         def new_converter(value, connection, context):
-            return converter(value, self, context)
+            return converter(value, Col(self.attname, self.related_field), context)
         return new_converter
 
 

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -11,11 +11,11 @@ from django.db import connection, connections, router, transaction
 from django.db.backends import utils
 from django.db.models import Q, signals
 from django.db.models.deletion import CASCADE, SET_DEFAULT, SET_NULL
+from django.db.models.expressions import Col
 from django.db.models.fields import (
     BLANK_CHOICE_DASH, AutoField, Field, IntegerField, PositiveIntegerField,
     PositiveSmallIntegerField,
 )
-from django.db.models.expressions import Col
 from django.db.models.lookups import IsNull
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import PathInfo

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -369,6 +369,10 @@ class PrimaryKeyUUIDModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
 
 
+class RelatedToUUIDModel(models.Model):
+    rel = models.ForeignKey('PrimaryKeyUUIDModel')
+
+
 ###############################################################################
 
 # See ticket #24215.

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -5,7 +5,9 @@ from django.core import exceptions, serializers
 from django.db import models
 from django.test import TestCase
 
-from .models import NullableUUIDModel, PrimaryKeyUUIDModel, RelatedToUUIDModel, UUIDModel
+from .models import (
+    NullableUUIDModel, PrimaryKeyUUIDModel, RelatedToUUIDModel, UUIDModel,
+)
 
 
 class TestSaveLoad(TestCase):
@@ -124,6 +126,6 @@ class TestAsPrimaryKey(TestCase):
 
     def test_underlying_field(self):
         pk_model = PrimaryKeyUUIDModel.objects.create()
-        related = RelatedToUUIDModel.objects.create(rel=pk_model)
+        RelatedToUUIDModel.objects.create(rel=pk_model)
         related = RelatedToUUIDModel.objects.get()
         self.assertEqual(related.rel.pk, related.rel_id)

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -5,7 +5,7 @@ from django.core import exceptions, serializers
 from django.db import models
 from django.test import TestCase
 
-from .models import NullableUUIDModel, PrimaryKeyUUIDModel, UUIDModel
+from .models import NullableUUIDModel, PrimaryKeyUUIDModel, RelatedToUUIDModel, UUIDModel
 
 
 class TestSaveLoad(TestCase):
@@ -121,3 +121,9 @@ class TestAsPrimaryKey(TestCase):
         self.assertTrue(u1_found)
         self.assertTrue(u2_found)
         self.assertEqual(PrimaryKeyUUIDModel.objects.count(), 2)
+
+    def test_underlying_field(self):
+        pk_model = PrimaryKeyUUIDModel.objects.create()
+        related = RelatedToUUIDModel.objects.create(rel=pk_model)
+        related = RelatedToUUIDModel.objects.get()
+        self.assertEqual(related.rel.pk, related.rel_id)


### PR DESCRIPTION
This may not be the best way of doing this.

@jarshwah - you made some changes to db_converters to use `Col` objects, I don't know whether it's appropriate to work out when we have a foreign key and set the output field to the correct (i.e. related) type.

I believe it will fix the ticket, it certainly fixes the added failing test.