### PR TITLE
Do not repoint relations on superclasses when migrating a subclass's name change

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -162,6 +162,7 @@ class RenameModel(Operation):
         all_related_objects = (
             f for f in model._meta.get_fields(include_hidden=True)
             if f.auto_created and not f.concrete and not (f.hidden or f.many_to_many)
+            and f.model is model
         )
         # Rename the model
         state.models[app_label, self.new_name_lower] = state.models[app_label, self.old_name_lower]

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -538,6 +538,22 @@ class OperationTests(OperationTestBase):
             self.assertFKExists("test_rmwsrf_rider", ["friend_id"], ("test_rmwsrf_rider", "id"))
             self.assertFKNotExists("test_rmwsrf_rider", ["friend_id"], ("test_rmwsrf_horserider", "id"))
 
+    def test_rename_model_with_superclass_fk(self):
+        """
+        Tests the RenameModel operation on model which has a superclass that has a foreign key
+        """
+
+        project_state = self.set_up_test_model("test_rmwsc", related_model=True, mti_model=True)
+        # Test the state alteration
+        operation = migrations.RenameModel("ShetlandPony", "LittleHorse")
+        self.assertEqual(operation.describe(), "Rename model ShetlandPony to LittleHorse")
+        new_state = project_state.clone()
+        operation.state_forwards("test_rmwsc", new_state)
+        self.assertNotIn(("test_rmwsc", "shetlandpony"), new_state.models)
+        self.assertIn(("test_rmwsc", "littlehorse"), new_state.models)
+        # RenameModel shouldn't repoint the superclass's relations, only local ones
+        self.assertEqual(project_state.models["test_rmwsc", "rider"].fields[1][1].rel.to, new_state.models["test_rmwsc", "rider"].fields[1][1].rel.to)
+
     def test_rename_model_with_self_referential_m2m(self):
         app_label = "test_rename_model_with_self_referential_m2m"
 


### PR DESCRIPTION
When renaming a class the migrations framework follows all references backwards in order to repoint their foreign keys to the new location. However, the current implementation doesn't differentiate between relations by virtue of a direct relation to the subclass and those that it inherits from a superclass.

This change explicitly checks that the model that each found relation field belongs to is the same one being renamed. Without this, any project that has a renamed subclass will generate superfluous migrations for the parent class on every invocation of makemigrations, leaving incorrect migrations in eggs and spurious database records if not caught.