### PR TITLE
Set context.template instead of context.engine while rendering.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -211,7 +211,7 @@ class ForNode(Node):
                     context[self.loopvars[0]] = item
                 # In debug mode provide the source of the node which raised
                 # the exception
-                if context.engine.debug:
+                if context.template.engine.debug:
                     for node in self.nodelist_loop:
                         try:
                             nodelist.append(node.render(context))
@@ -392,7 +392,7 @@ class SsiNode(Node):
     def render(self, context):
         filepath = self.filepath.resolve(context)
 
-        if not include_is_allowed(filepath, context.engine.allowed_include_roots):
+        if not include_is_allowed(filepath, context.template.engine.allowed_include_roots):
             if settings.DEBUG:
                 return "[Didn't have permission to include file]"
             else:
@@ -404,7 +404,7 @@ class SsiNode(Node):
             output = ''
         if self.parsed:
             try:
-                t = Template(output, name=filepath, engine=context.engine)
+                t = Template(output, name=filepath, engine=context.template.engine)
                 return t.render(context)
             except TemplateSyntaxError as e:
                 if settings.DEBUG:

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -107,7 +107,7 @@ class ExtendsNode(Node):
         if isinstance(getattr(parent, 'template', None), Template):
             # parent is a django.template.backends.django.Template
             return parent.template
-        return context.engine.get_template(parent)
+        return context.template.engine.get_template(parent)
 
     def render(self, context):
         compiled_parent = self.get_parent(context)
@@ -148,7 +148,7 @@ class IncludeNode(Node):
             # Does this quack like a Template?
             if not callable(getattr(template, 'render', None)):
                 # If not, we'll try get_template
-                template = context.engine.get_template(template)
+                template = context.template.engine.get_template(template)
             values = {
                 name: var.resolve(context)
                 for name, var in six.iteritems(self.extra_context)
@@ -158,7 +158,7 @@ class IncludeNode(Node):
             with context.push(**values):
                 return template.render(context)
         except Exception:
-            if context.engine.debug:
+            if context.template.engine.debug:
                 raise
             return ''
 

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -149,7 +149,7 @@ class BlockTranslateNode(Node):
                 result = translation.pgettext(message_context, singular)
             else:
                 result = translation.ugettext(singular)
-        default_value = context.engine.string_if_invalid
+        default_value = context.template.engine.string_if_invalid
 
         def render_value(key):
             if key in context:

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -756,10 +756,11 @@ Notes:
 * The ``render()`` method is where the work actually happens.
 
 * ``render()`` should generally fail silently, particularly in a production
-  environment. In some cases however, particularly if ``context.engine.debug``
-  is ``True``, this method may raise an exception to make debugging easier.
-  For example, several core tags raise ``django.template.TemplateSyntaxError``
-  if they receive the wrong number or type of arguments.
+  environment. In some cases however, particularly if
+  ``context.template.engine.debug`` is ``True``, this method may raise an
+  exception to make debugging easier. For example, several core tags raise
+  ``django.template.TemplateSyntaxError`` if they receive the wrong number or
+  type of arguments.
 
 Ultimately, this decoupling of compilation and rendering results in an
 efficient template system, because a template can render multiple contexts
@@ -795,16 +796,17 @@ This is not a very common situation, but it's useful if you're rendering a
 template yourself. For example::
 
     def render(self, context):
-        t = context.engine.get_template('small_fragment.html')
+        t = context.template.engine.get_template('small_fragment.html')
         return t.render(Context({'var': obj}, autoescape=context.autoescape))
 
 .. versionchanged:: 1.8
 
-    The ``engine`` attribute of ``Context`` objects was added in Django 1.8.
-    :meth:`context.engine.get_template <django.template.Engine.get_template>`
-    must be used instead of :func:`django.template.loader.get_template`
-    because the latter now returns a wrapper whose ``render`` method doesn't
-    accept a :class:`~django.template.Context`.
+    The ``template`` attribute of ``Context`` objects was added in Django 1.8.
+    :meth:`context.template.engine.get_template
+    <django.template.Engine.get_template>` must be used instead of
+    :func:`django.template.loader.get_template` because the latter now returns
+    a wrapper whose ``render`` method doesn't accept a
+    :class:`~django.template.Context`.
 
 If we had neglected to pass in the current ``context.autoescape`` value to our
 new ``Context`` in this example, the results would have *always* been

--- a/docs/ref/templates/upgrading.txt
+++ b/docs/ref/templates/upgrading.txt
@@ -162,7 +162,7 @@ instance in the ``render()`` method of a template tag, you can use the current
 
 You can write::
 
-    template = context.engine.get_template('included.html')
+    template = context.template.engine.get_template('included.html')
 
 This will load the template with the current engine without triggering the
 multiple template engines machinery, which is usually the desired behavior.
@@ -201,7 +201,7 @@ APIs. The multiple template engines machinery isn't involved here.
 Finally, if you have access to the current context, you can use the same trick
 as above::
 
-    template = context.engine.from_string(template_code)
+    template = context.template.engine.from_string(template_code)
 
 ``Template()``
 ==============

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -516,9 +516,6 @@ class RequestContextTests(unittest.TestCase):
         self.assertEqual(len(ctx.dicts), 3)
 
     def test_context_comparable(self):
-        # Create an engine without any context processors.
-        engine = Engine()
-
         test_data = {'x': 'y', 'v': 'z', 'd': {'o': object, 'a': 'b'}}
 
         # test comparing RequestContext to prevent problems if somebody
@@ -526,8 +523,8 @@ class RequestContextTests(unittest.TestCase):
         request = RequestFactory().get('/')
 
         self.assertEqual(
-            RequestContext(request, dict_=test_data, engine=engine),
-            RequestContext(request, dict_=test_data, engine=engine))
+            RequestContext(request, dict_=test_data),
+            RequestContext(request, dict_=test_data))
 
 
 @ignore_warnings(category=RemovedInDjango20Warning)


### PR DESCRIPTION
This opens more possibilities, like accessing context.template.origin.

It also follows the chain of objects instead of following a shortcut.