### PR TITLE
Fixed #20889 -- Prevented BadHeaderError when Python inserts newline

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -102,6 +102,9 @@ class HttpResponseBase(six.Iterator):
         """
         if not isinstance(value, (bytes, six.text_type)):
             value = str(value)
+        if ((isinstance(value, bytes) and (b'\n' in value or b'\r' in value)) or
+                isinstance(value, six.text_type) and ('\n' in value or '\r' in value)):
+            raise BadHeaderError("Header values can't contain newlines (got %r)" % value)
         try:
             if six.PY3:
                 if isinstance(value, str):
@@ -124,8 +127,6 @@ class HttpResponseBase(six.Iterator):
             else:
                 e.reason += ', HTTP response headers must be in %s format' % charset
                 raise
-        if str('\n') in value or str('\r') in value:
-            raise BadHeaderError("Header values can't contain newlines (got %r)" % value)
         return value
 
     def __setitem__(self, header, value):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -306,6 +306,9 @@ class HttpResponseTests(unittest.TestCase):
         f = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz a\xcc\x88'.encode('latin-1')
         f = f.decode('utf-8')
         h['Content-Disposition'] = 'attachment; filename="%s"' % f
+        # This one is triggering http://bugs.python.org/issue20747, that is Python
+        # will itself insert a newline in the header
+        h['Content-Disposition'] = 'attachement; filename="EdelRot_Blu\u0308te (3)-0.JPG"'
 
     def test_newlines_in_headers(self):
         # Bug #10188: Do not allow newlines in headers (CR or LF)


### PR DESCRIPTION
Workaround for http://bugs.python.org/issue20747.
In some corner cases, Python 2 inserts a newline in a header value
despite `maxlinelen` passed in Header constructor.