### PR TITLE
Remove unused foreign_key_re variables in MySQL/Oracle DB backends

### DIFF
--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -1,4 +1,3 @@
-import re
 from collections import namedtuple
 
 from MySQLdb.constants import FIELD_TYPE
@@ -11,7 +10,6 @@ from django.utils.encoding import force_text
 
 FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('extra', 'default'))
 InfoLine = namedtuple('InfoLine', 'col_name data_type max_len num_prec num_scale extra column_default')
-foreign_key_re = re.compile(r"\sCONSTRAINT `[^`]*` FOREIGN KEY \(`([^`]*)`\) REFERENCES `([^`]*)` \(`([^`]*)`\)")
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -1,13 +1,9 @@
-import re
-
 import cx_Oracle
 
 from django.db.backends.base.introspection import (
     BaseDatabaseIntrospection, FieldInfo, TableInfo,
 )
 from django.utils.encoding import force_text
-
-foreign_key_re = re.compile(r"\sCONSTRAINT `[^`]*` FOREIGN KEY \(`([^`]*)`\) REFERENCES `([^`]*)` \(`([^`]*)`\)")
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):


### PR DESCRIPTION
I saw these when researching how the backends work. They were last referenced in the outgoing code of commit 4536359887b34eea5e7b8cf6864d9092b46c2980 for MySQL and the Oracle one seems to have been copy/pasted in during the creation of the backend in cac7675f247da325cb862a312804fe64845d1155.