### PR TITLE
Fixed #24376 -- Added verbose_name arg to UUIDField.__init__

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2369,9 +2369,9 @@ class UUIDField(Field):
     description = 'Universally unique identifier'
     empty_strings_allowed = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, verbose_name=None, **kwargs):
         kwargs['max_length'] = 32
-        super(UUIDField, self).__init__(**kwargs)
+        super(UUIDField, self).__init__(verbose_name, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super(UUIDField, self).deconstruct()


### PR DESCRIPTION
@timgraham @claudep I tested this simple patch manually, locally.

https://code.djangoproject.com/ticket/24376