### PR TITLE
Fixed #24381 -- Fixed pickling of QuerySets that filter on reverse FKs.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1297,6 +1297,13 @@ class ForeignObjectRel(object):
         self.symmetrical = False
         self.multiple = True
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Avoid pickling the app cache.
+        for attr in ('opts', 'to_opts'):
+            state.pop(attr, None)
+        return state
+
     # Some of the following cached_properties can't be initialized in
     # __init__ as the field doesn't have its model yet. Calling these methods
     # before field.contribute_to_class() has been called will result in

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -43,6 +43,9 @@ class PickleabilityTestCase(TestCase):
     def test_membermethod_as_default(self):
         self.assert_pickles(Happening.objects.filter(number4=1))
 
+    def test_filter_reverse_fk(self):
+        self.assert_pickles(Group.objects.filter(event=1))
+
     def test_doesnotexist_exception(self):
         # Ticket #17776
         original = Event.DoesNotExist("Doesn't exist")


### PR DESCRIPTION
I am not suggesting this is the correct solution, but hopefully it will point someone in the correct direction.