### PR TITLE
Fixed #23762 -- clarified CACHE_MIDDLEWARE_ANONYMOUS_ONLY deprecation in...

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -395,7 +395,13 @@ details on these changes.
 * The module ``django.test._doctest`` will be removed. Instead use the doctest
   module from the Python standard library.
 
-* The ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting will be removed.
+* The ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting will be removed. This change
+  applies to both ``django.middleware.cache.CacheMiddleware`` and
+  ``django.middleware.cache.UpdateCacheMiddleware`` despite the missing
+  deprecation warning in ``django.middleware.cache.UpdateCacheMiddleware`` in
+  version 1.7. Please read `#15201`_ for more information.
+
+  .. _`#15201`: https://code.djangoproject.com/ticket/15201
 
 * Usage of the hard-coded *Hold down "Control", or "Command" on a Mac, to select
   more than one.* string to override or append to user-provided ``help_text`` in

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -1040,10 +1040,11 @@ If necessary, you can temporarily disable auto-escaping with
 ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``CacheMiddleware`` used to provide a way to cache requests only if they
-weren't made by a logged-in user. This mechanism was largely ineffective
-because the middleware correctly takes into account the ``Vary: Cookie`` HTTP
-header, and this header is being set on a variety of occasions, such as:
+``CacheMiddleware`` and ``UpdateCacheMiddleware`` used to provide a way to
+cache requests only if they weren't made by a logged-in user. This mechanism
+was largely ineffective because the middleware correctly takes into account the
+``Vary: Cookie`` HTTP header, and this header is being set on a variety of
+occasions, such as:
 
 * accessing the session, or
 * using CSRF protection, which is turned on by default, or

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1720,7 +1720,11 @@ removed in Django 1.8 (please see the :ref:`deprecation timeline
 
 * The module ``django.test._doctest`` is removed.
 
-* The ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting is removed.
+* The ``CACHE_MIDDLEWARE_ANONYMOUS_ONLY`` setting will be removed. This change
+  applies to both ``django.middleware.cache.CacheMiddleware`` and
+  ``django.middleware.cache.UpdateCacheMiddleware`` despite the missing
+  deprecation warning in ``django.middleware.cache.UpdateCacheMiddleware`` in
+  version 1.7.
 
 * Usage of the hard-coded *Hold down "Control", or "Command" on a Mac, to select
   more than one.* string to override or append to user-provided ``help_text`` in


### PR DESCRIPTION
Made changes to 1.8.txt and deprecation.txt to clarify that the CACHE_MIDDLEWARE_ANONYMOUS_ONLY setting deprecation warning only applied to ``CacheMiddleware`` but not ``UpdateCacheMiddleware`` to avoid confusing users when the setting was deprecated in 1.8