### PR TITLE
Break long lines in code examples.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -280,6 +280,7 @@ answer newbie questions, and generally made Django that much better:
     Ian Clelland <clelland@gmail.com>
     Ian G. Kelly <ian.g.kelly@gmail.com>
     Ian Holsman <http://feh.holsman.net/>
+    Ian Lee <IanLee1521@gmail.com>
     Ibon <ibonso@gmail.com>
     Idan Gazit <idan@gazit.me>
     Igor Kolar <ike@email.si>

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -690,9 +690,13 @@ object::
             # split_contents() knows not to split quoted strings.
             tag_name, format_string = token.split_contents()
         except ValueError:
-            raise template.TemplateSyntaxError("%r tag requires a single argument" % token.contents.split()[0])
+            raise template.TemplateSyntaxError(
+                "%r tag requires a single argument" % token.contents.split()[0]
+            )
         if not (format_string[0] == format_string[-1] and format_string[0] in ('"', "'")):
-            raise template.TemplateSyntaxError("%r tag's argument should be in quotes" % tag_name)
+            raise template.TemplateSyntaxError(
+                "%r tag's argument should be in quotes" % tag_name
+            )
         return CurrentTimeNode(format_string[1:-1])
 
 Notes:
@@ -961,9 +965,13 @@ Now your tag should begin to look like this::
             # split_contents() knows not to split quoted strings.
             tag_name, date_to_be_formatted, format_string = token.split_contents()
         except ValueError:
-            raise template.TemplateSyntaxError("%r tag requires exactly two arguments" % token.contents.split()[0])
+            raise template.TemplateSyntaxError(
+                "%r tag requires exactly two arguments" % token.contents.split()[0]
+            )
         if not (format_string[0] == format_string[-1] and format_string[0] in ('"', "'")):
-            raise template.TemplateSyntaxError("%r tag's argument should be in quotes" % tag_name)
+            raise template.TemplateSyntaxError(
+                "%r tag's argument should be in quotes" % tag_name
+            )
         return FormatTimeNode(date_to_be_formatted, format_string[1:-1])
 
 You also have to change the renderer to retrieve the actual contents of the
@@ -1059,13 +1067,17 @@ class, like so::
             # Splitting by None == splitting by spaces.
             tag_name, arg = token.contents.split(None, 1)
         except ValueError:
-            raise template.TemplateSyntaxError("%r tag requires arguments" % token.contents.split()[0])
+            raise template.TemplateSyntaxError(
+                "%r tag requires arguments" % token.contents.split()[0]
+            )
         m = re.search(r'(.*?) as (\w+)', arg)
         if not m:
             raise template.TemplateSyntaxError("%r tag had invalid arguments" % tag_name)
         format_string, var_name = m.groups()
         if not (format_string[0] == format_string[-1] and format_string[0] in ('"', "'")):
-            raise template.TemplateSyntaxError("%r tag's argument should be in quotes" % tag_name)
+            raise template.TemplateSyntaxError(
+                "%r tag's argument should be in quotes" % tag_name
+            )
         return CurrentTimeNode3(format_string[1:-1], var_name)
 
 The difference here is that ``do_current_time()`` grabs the format string and


### PR DESCRIPTION
The website only renders code blocks at 96 chars, and therefore long code lines get wrapped. Manually breaking the lines prevents the wrapping from occurring.