### PR TITLE
[1.7.x] Fixed 24352 -- Coercing ManyRelatedManager to string raises StopIteracion exception. 

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -855,6 +855,9 @@ def create_many_related_manager(superclass, rel):
             )
         do_not_call_in_templates = True
 
+        def __str__(self):
+            return repr(self)
+
         def _build_remove_filters(self, removed_vals):
             filters = Q(**{self.source_field_name: self.related_val})
             # No need to add a subquery condition if removed_vals is a QuerySet without

--- a/docs/releases/1.7.6.txt
+++ b/docs/releases/1.7.6.txt
@@ -9,4 +9,6 @@ Django 1.7.6 fixes several bugs in 1.7.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a ``StopIteration`` exception when using ``ManyRelatedManager``
+  with strings (:ticket:`24352`).
+

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -109,3 +109,7 @@ class M2MRegressionTests(TestCase):
         worksheet.lines = hi
         self.assertEqual(1, worksheet.lines.count())
         self.assertEqual(1, hi.count())
+
+    def test_many_related_manager_str(self):
+        worksheet = Worksheet.objects.create(id=1)
+        self.assertIn('ManyRelatedManager', str(worksheet.lines))


### PR DESCRIPTION
Fixed Coercing ManyRelatedManager to string raises Stopteration exception