### PR TITLE
Refs #24366 -- Fixed recursion depth error in migration graph.

### DIFF
--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -126,33 +126,35 @@ class MigrationGraph(object):
                 self.node_map[node].__dict__.pop('_descendants', None)
             self.cached = False
 
-    def forwards_plan(self, node):
+    def forwards_plan(self, target):
         """
         Given a node, returns a list of which previous nodes (dependencies)
         must be applied, ending with the node itself.
         This is the list you would follow if applying the migrations to
         a database.
         """
-        if node not in self.nodes:
-            raise NodeNotFoundError("Node %r not a valid node" % (node, ), node)
+        if target not in self.nodes:
+            raise NodeNotFoundError("Node %r not a valid node" % (target, ), target)
         # Use parent.key instead of parent to speed up the frequent hashing in ensure_not_cyclic
-        self.ensure_not_cyclic(node, lambda x: (parent.key for parent in self.node_map[x].parents))
+        self.ensure_not_cyclic(target, lambda x: (parent.key for parent in self.node_map[x].parents))
         self.cached = True
-        return self.node_map[node].ancestors()
+        node = self.node_map[target]
+        return node.ancestors()
 
-    def backwards_plan(self, node):
+    def backwards_plan(self, target):
         """
         Given a node, returns a list of which dependent nodes (dependencies)
         must be unapplied, ending with the node itself.
         This is the list you would follow if removing the migrations from
         a database.
         """
-        if node not in self.nodes:
-            raise NodeNotFoundError("Node %r not a valid node" % (node, ), node)
+        if target not in self.nodes:
+            raise NodeNotFoundError("Node %r not a valid node" % (target, ), target)
         # Use child.key instead of child to speed up the frequent hashing in ensure_not_cyclic
-        self.ensure_not_cyclic(node, lambda x: (child.key for child in self.node_map[x].children))
+        self.ensure_not_cyclic(target, lambda x: (child.key for child in self.node_map[x].children))
         self.cached = True
-        return self.node_map[node].descendants()
+        node = self.node_map[target]
+        return node.descendants()
 
     def root_nodes(self, app=None):
         """

--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -153,7 +153,7 @@ class GraphTests(TestCase):
             graph.forwards_plan, ('C', '0001')
         )
 
-    def test_deep_graph(self):
+    def test_graph_recursive(self):
         graph = MigrationGraph()
         root = ("app_a", "1")
         graph.add_node(root, None)
@@ -169,7 +169,7 @@ class GraphTests(TestCase):
         self.assertEqual(expected[::-1], actual)
 
     @expectedFailure
-    def test_recursion_depth(self):
+    def test_graph_iterative(self):
         graph = MigrationGraph()
         root = ("app_a", "1")
         graph.add_node(root, None)


### PR DESCRIPTION
Changed MigrationGraph.forwards_plan and MigrationGraph.backwards_plan
to cache values of subtrees and retry when generating the whole tree in
one run exceeded the maximum recursion depth. Worst-case this doubles the
effective maximum recursion depth, best case this allows for limitless
recursion, depending on the order of MigrationGraph.nodes. Provided a
cleaner stack trace and error message in case it still fails.

Partially fixed a regression introduced in #4173 and unmarked `migrations.test_graph.GraphTests.test_recursion_depth` as an expected failure. 

https://code.djangoproject.com/ticket/24366