### PR TITLE
allows ungettext_lazy to accept a long or an int as the number

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -89,7 +89,7 @@ ugettext_lazy = lazy(ugettext, six.text_type)
 pgettext_lazy = lazy(pgettext, six.text_type)
 
 def lazy_number(func, resultclass, number=None, **kwargs):
-    if isinstance(number, int):
+    if isinstance(number, (int, long)):
         kwargs['number'] = number
         proxy = lazy(func, resultclass)(**kwargs)
     else:

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -149,6 +149,10 @@ class TranslationTests(TransRealMixin, TestCase):
             with six.assertRaisesRegex(self, KeyError, 'Your dictionary lacks key.*'):
                 complex_context_deferred % {'name': 'Jim'}
 
+    def test_ungettext_lazy_long(self):
+        plural_with_long = ungettext_lazy('Hi %(name)s, %(num)d good result', 'Hi %(name)s, %(num)d good results', 4L)
+        self.assertEqual(plural_with_long % {'num': 4L, 'name': 'Jim'}, 'Hi Jim, 4 good results')
+
     @override_settings(LOCALE_PATHS=extended_locale_paths)
     def test_pgettext(self):
         trans_real._active = local()


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/24401