### PR TITLE
Added missing backtick

### DIFF
--- a/docs/ref/contrib/formtools/form-wizard.txt
+++ b/docs/ref/contrib/formtools/form-wizard.txt
@@ -319,7 +319,7 @@ The ``urls.py`` file would contain something like::
 
 .. versionchanged:: 1.6
 
-The ``condition_dict`` can be passed as attribute for the ``as_view()`
+The ``condition_dict`` can be passed as attribute for the ``as_view()``
 method or as a class attribute named ``condition_dict``::
 
     class OrderWizard(WizardView):


### PR DESCRIPTION
Nothing much to say, added the missing back tick. Only applies to version 1.7 as formwizard was removed in Django 1.8