### PR TITLE
Fixed #24406 -- Improved SelectFilter js to use click events

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -58,15 +58,27 @@ window.SelectFilter = {
         filter_input.id = field_id + '_input';
 
         selector_available.appendChild(from_box);
-        var choose_all = quickElement('a', selector_available, gettext('Choose all'), 'title', interpolate(gettext('Click to choose all %s at once.'), [field_name]), 'href', 'javascript: (function(){ SelectBox.move_all("' + field_id + '_from", "' + field_id + '_to"); SelectFilter.refresh_icons("' + field_id + '");})()', 'id', field_id + '_add_all_link');
+        var choose_all = quickElement('a', selector_available, gettext('Choose all'), 'title', interpolate(gettext('Click to choose all %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_add_all_link');
+        choose_all.addEventListener("click", function() {
+            SelectBox.move_all(field_id + "_from", field_id + "_to");
+            SelectFilter.refresh_icons(field_id);
+        });
         choose_all.className = 'selector-chooseall';
 
         // <ul class="selector-chooser">
         var selector_chooser = quickElement('ul', selector_div);
         selector_chooser.className = 'selector-chooser';
-        var add_link = quickElement('a', quickElement('li', selector_chooser), gettext('Choose'), 'title', gettext('Choose'), 'href', 'javascript: (function(){ SelectBox.move("' + field_id + '_from","' + field_id + '_to"); SelectFilter.refresh_icons("' + field_id + '");})()', 'id', field_id + '_add_link');
+        var add_link = quickElement('a', quickElement('li', selector_chooser), gettext('Choose'), 'title', gettext('Choose'), 'href', 'javascript:void(0);', 'id', field_id + '_add_link');
+        add_link.addEventListener("click", function() {
+            SelectBox.move(field_id + "_from", field_id + "_to");
+            SelectFilter.refresh_icons(field_id);
+        });
         add_link.className = 'selector-add';
-        var remove_link = quickElement('a', quickElement('li', selector_chooser), gettext('Remove'), 'title', gettext('Remove'), 'href', 'javascript: (function(){ SelectBox.move("' + field_id + '_to","' + field_id + '_from"); SelectFilter.refresh_icons("' + field_id + '");})()', 'id', field_id + '_remove_link');
+        var remove_link = quickElement('a', quickElement('li', selector_chooser), gettext('Remove'), 'title', gettext('Remove'), 'href', 'javascript:void(0);', 'id', field_id + '_remove_link');
+        remove_link.addEventListener("click", function() {
+            SelectBox.move(field_id + "_to", field_id + "_from");
+            SelectFilter.refresh_icons(field_id);
+        });
         remove_link.className = 'selector-remove';
 
         // <div class="selector-chosen">
@@ -77,7 +89,11 @@ window.SelectFilter = {
 
         var to_box = quickElement('select', selector_chosen, '', 'id', field_id + '_to', 'multiple', 'multiple', 'size', from_box.size, 'name', from_box.getAttribute('name'));
         to_box.className = 'filtered';
-        var clear_all = quickElement('a', selector_chosen, gettext('Remove all'), 'title', interpolate(gettext('Click to remove all chosen %s at once.'), [field_name]), 'href', 'javascript: (function() { SelectBox.move_all("' + field_id + '_to", "' + field_id + '_from"); SelectFilter.refresh_icons("' + field_id + '");})()', 'id', field_id + '_remove_all_link');
+        var clear_all = quickElement('a', selector_chosen, gettext('Remove all'), 'title', interpolate(gettext('Click to remove all chosen %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_remove_all_link');
+        clear_all.addEventListener("click", function() {
+            SelectBox.move_all(field_id + "_to", field_id + "_from");
+            SelectFilter.refresh_icons(field_id);
+        });
         clear_all.className = 'selector-clearall';
 
         from_box.setAttribute('name', from_box.getAttribute('name') + '_old');

--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -59,8 +59,8 @@ window.SelectFilter = {
 
         selector_available.appendChild(from_box);
         var choose_all = quickElement('a', selector_available, gettext('Choose all'), 'title', interpolate(gettext('Click to choose all %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_add_all_link');
-        choose_all.addEventListener("click", function() {
-            SelectBox.move_all(field_id + "_from", field_id + "_to");
+        choose_all.addEventListener('click', function() {
+            SelectBox.move_all(field_id + '_from', field_id + '_to');
             SelectFilter.refresh_icons(field_id);
         });
         choose_all.className = 'selector-chooseall';
@@ -69,14 +69,14 @@ window.SelectFilter = {
         var selector_chooser = quickElement('ul', selector_div);
         selector_chooser.className = 'selector-chooser';
         var add_link = quickElement('a', quickElement('li', selector_chooser), gettext('Choose'), 'title', gettext('Choose'), 'href', 'javascript:void(0);', 'id', field_id + '_add_link');
-        add_link.addEventListener("click", function() {
-            SelectBox.move(field_id + "_from", field_id + "_to");
+        add_link.addEventListener('click', function() {
+            SelectBox.move(field_id + '_from', field_id + '_to');
             SelectFilter.refresh_icons(field_id);
         });
         add_link.className = 'selector-add';
         var remove_link = quickElement('a', quickElement('li', selector_chooser), gettext('Remove'), 'title', gettext('Remove'), 'href', 'javascript:void(0);', 'id', field_id + '_remove_link');
-        remove_link.addEventListener("click", function() {
-            SelectBox.move(field_id + "_to", field_id + "_from");
+        remove_link.addEventListener('click', function() {
+            SelectBox.move(field_id + '_to', field_id + '_from');
             SelectFilter.refresh_icons(field_id);
         });
         remove_link.className = 'selector-remove';
@@ -90,8 +90,8 @@ window.SelectFilter = {
         var to_box = quickElement('select', selector_chosen, '', 'id', field_id + '_to', 'multiple', 'multiple', 'size', from_box.size, 'name', from_box.getAttribute('name'));
         to_box.className = 'filtered';
         var clear_all = quickElement('a', selector_chosen, gettext('Remove all'), 'title', interpolate(gettext('Click to remove all chosen %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_remove_all_link');
-        clear_all.addEventListener("click", function() {
-            SelectBox.move_all(field_id + "_to", field_id + "_from");
+        clear_all.addEventListener('click', function() {
+            SelectBox.move_all(field_id + '_to', field_id + '_from');
             SelectFilter.refresh_icons(field_id);
         });
         clear_all.className = 'selector-clearall';

--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -59,26 +59,14 @@ window.SelectFilter = {
 
         selector_available.appendChild(from_box);
         var choose_all = quickElement('a', selector_available, gettext('Choose all'), 'title', interpolate(gettext('Click to choose all %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_add_all_link');
-        choose_all.addEventListener('click', function() {
-            SelectBox.move_all(field_id + '_from', field_id + '_to');
-            SelectFilter.refresh_icons(field_id);
-        });
         choose_all.className = 'selector-chooseall';
 
         // <ul class="selector-chooser">
         var selector_chooser = quickElement('ul', selector_div);
         selector_chooser.className = 'selector-chooser';
         var add_link = quickElement('a', quickElement('li', selector_chooser), gettext('Choose'), 'title', gettext('Choose'), 'href', 'javascript:void(0);', 'id', field_id + '_add_link');
-        add_link.addEventListener('click', function() {
-            SelectBox.move(field_id + '_from', field_id + '_to');
-            SelectFilter.refresh_icons(field_id);
-        });
         add_link.className = 'selector-add';
         var remove_link = quickElement('a', quickElement('li', selector_chooser), gettext('Remove'), 'title', gettext('Remove'), 'href', 'javascript:void(0);', 'id', field_id + '_remove_link');
-        remove_link.addEventListener('click', function() {
-            SelectBox.move(field_id + '_to', field_id + '_from');
-            SelectFilter.refresh_icons(field_id);
-        });
         remove_link.className = 'selector-remove';
 
         // <div class="selector-chosen">
@@ -90,15 +78,15 @@ window.SelectFilter = {
         var to_box = quickElement('select', selector_chosen, '', 'id', field_id + '_to', 'multiple', 'multiple', 'size', from_box.size, 'name', from_box.getAttribute('name'));
         to_box.className = 'filtered';
         var clear_all = quickElement('a', selector_chosen, gettext('Remove all'), 'title', interpolate(gettext('Click to remove all chosen %s at once.'), [field_name]), 'href', 'javascript:void(0);', 'id', field_id + '_remove_all_link');
-        clear_all.addEventListener('click', function() {
-            SelectBox.move_all(field_id + '_to', field_id + '_from');
-            SelectFilter.refresh_icons(field_id);
-        });
         clear_all.className = 'selector-clearall';
 
         from_box.setAttribute('name', from_box.getAttribute('name') + '_old');
 
         // Set up the JavaScript event handlers for the select box filter interface
+        addEvent(choose_all, 'click', function() { SelectBox.move_all(field_id + '_from', field_id + '_to'); SelectFilter.refresh_icons(field_id); });
+        addEvent(add_link, 'click', function() { SelectBox.move(field_id + '_from', field_id + '_to'); SelectFilter.refresh_icons(field_id); });
+        addEvent(remove_link, 'click', function() { SelectBox.move(field_id + '_to', field_id + '_from'); SelectFilter.refresh_icons(field_id); });
+        addEvent(clear_all, 'click', function() { SelectBox.move_all(field_id + '_to', field_id + '_from'); SelectFilter.refresh_icons(field_id); });
         addEvent(filter_input, 'keypress', function(e) { SelectFilter.filter_key_press(e, field_id); });
         addEvent(filter_input, 'keyup', function(e) { SelectFilter.filter_key_up(e, field_id); });
         addEvent(filter_input, 'keydown', function(e) { SelectFilter.filter_key_down(e, field_id); });


### PR DESCRIPTION
The SelectFilter widget uses `<a href="javascript: function(){...}">` to execute javascript. This is problematic if one wishes to customize the widget, since the href javascript is executed after events are handled. This change modifies the javascript to use click events to handle button behavior: `someElement.addEventListener('click', function() {...});`