### PR TITLE
Fixed #24379 -- Documented that example for RemoteUser disables ModelUser

### DIFF
--- a/docs/howto/auth-remote-user.txt
+++ b/docs/howto/auth-remote-user.txt
@@ -50,6 +50,13 @@ With this setup, ``RemoteUserMiddleware`` will detect the username in
 ``request.META['REMOTE_USER']`` and will authenticate and auto-login that user
 using the :class:`~django.contrib.auth.backends.RemoteUserBackend`.
 
+Be aware that this particular setup disables authentication with the default
+``ModelBackend``. This means that if the ``REMOTE_USER`` value is not set
+then the user is unable to log in, even using Django's admin interface.
+Adding ``'django.contrib.auth.backends.ModelBackend'`` to the
+``AUTHENTICATION_BACKENDS`` list will use ``ModelBackend`` as a fallback
+if ``REMOTE_USER`` is absent, which will solve these issues.
+
 .. note::
    Since the ``RemoteUserBackend`` inherits from ``ModelBackend``, you will
    still have all of the same permissions checking that is implemented in


### PR DESCRIPTION
The example given in the howto for authenticating remote user gives an
example AUTHENTICATION_BACKENDS which lacks the default ModelBackend.

I added a paragraph explaining that this means that login forms will not
work without it.