### PR TITLE
Fixed #24416 -- uggettext_lazy in email addresses.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -101,7 +101,7 @@ def forbid_multi_line_headers(name, val, encoding):
 
 
 def sanitize_address(addr, encoding):
-    if isinstance(addr, six.string_types):
+    if not isinstance(addr, tuple):
         addr = parseaddr(force_text(addr))
     nm, addr = addr
     nm = Header(nm, encoding).encode()
@@ -262,11 +262,11 @@ class EmailMessage(object):
         msg = self._create_message(msg)
         msg['Subject'] = self.subject
         msg['From'] = self.extra_headers.get('From', self.from_email)
-        msg['To'] = self.extra_headers.get('To', ', '.join(self.to))
+        msg['To'] = self.extra_headers.get('To', ', '.join(map(force_text, self.to)))
         if self.cc:
-            msg['Cc'] = ', '.join(self.cc)
+            msg['Cc'] = ', '.join(map(force_text, self.cc))
         if self.reply_to:
-            msg['Reply-To'] = self.extra_headers.get('Reply-To', ', '.join(self.reply_to))
+            msg['Reply-To'] = self.extra_headers.get('Reply-To', ', '.join(map(force_text, self.reply_to)))
 
         # Email header names are case-insensitive (RFC 2045), so we have to
         # accommodate that when doing comparisons.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -665,6 +665,27 @@ class BaseEmailBackendTests(HeadersCheckMixin, object):
         self.assertEqual(message.get('from'), "tester")
         self.assertEqual(message.get('to'), "django")
 
+    def test_lazy_addresses(self):
+        """
+        Regression test for #24416
+        """
+        _ = ugettext_lazy
+        self.assertTrue(send_mail('Subject', 'Content', _('tester'), [_('django')]))
+        message = self.get_the_message()
+        self.assertEqual(message.get('from'), 'tester')
+        self.assertEqual(message.get('to'), 'django')
+
+        self.flush_mailbox()
+        m = EmailMessage('Subject', 'Content', _('tester'), [_('to1'), _('to2')],
+                         cc=[_('cc1'), _('cc2')], bcc=[_('bcc')], reply_to=[_('reply')])
+        m.send()
+        message = self.get_the_message()
+        self.assertEqual(message.get('from'), 'tester')
+        self.assertEqual(message.get('to'), 'to1, to2')
+        self.assertEqual(message.get('cc'), 'cc1, cc2')
+        self.assertEqual(m.recipients(), ['to1', 'to2', 'cc1', 'cc2', 'bcc'])  # bcc check
+        self.assertEqual(message.get('Reply-To'), 'reply')
+
     def test_close_connection(self):
         """
         Test that connection can be closed (even when not explicitly opened)


### PR DESCRIPTION
(An alternative fix in sanitize_address would be something like:

    if isinstance(addr, six.string_types) or isinstance(addr, Promise):

but I don't see any other Django code that tests for lazy strings in that way.) 