### PR TITLE
Fixed #24360 -- Delayed internal LocaleMiddleware variable initialization

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import (
 from django.http import HttpResponseRedirect
 from django.utils import translation
 from django.utils.cache import patch_vary_headers
+from django.utils.functional import cached_property
 
 
 class LocaleMiddleware(object):
@@ -19,17 +20,9 @@ class LocaleMiddleware(object):
     """
     response_redirect_class = HttpResponseRedirect
 
-    def __init__(self):
-        self._is_language_prefix_patterns_used = False
-        for url_pattern in get_resolver(None).url_patterns:
-            if isinstance(url_pattern, LocaleRegexURLResolver):
-                self._is_language_prefix_patterns_used = True
-                break
-
     def process_request(self, request):
-        check_path = self.is_language_prefix_patterns_used()
         language = translation.get_language_from_request(
-            request, check_path=check_path)
+            request, check_path=self.is_language_prefix_patterns_used)
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
 
@@ -37,7 +30,7 @@ class LocaleMiddleware(object):
         language = translation.get_language()
         language_from_path = translation.get_language_from_path(request.path_info)
         if (response.status_code == 404 and not language_from_path
-                and self.is_language_prefix_patterns_used()):
+                and self.is_language_prefix_patterns_used):
             urlconf = getattr(request, 'urlconf', None)
             language_path = '/%s%s' % (language, request.path_info)
             path_valid = is_valid_path(language_path, urlconf)
@@ -60,16 +53,20 @@ class LocaleMiddleware(object):
                 )
                 return self.response_redirect_class(language_url)
 
-        if not (self.is_language_prefix_patterns_used()
+        if not (self.is_language_prefix_patterns_used
                 and language_from_path):
             patch_vary_headers(response, ('Accept-Language',))
         if 'Content-Language' not in response:
             response['Content-Language'] = language
         return response
 
+    @cached_property
     def is_language_prefix_patterns_used(self):
         """
         Returns `True` if the `LocaleRegexURLResolver` is used
         at root level of the urlpatterns, else it returns `False`.
         """
-        return self._is_language_prefix_patterns_used
+        for url_pattern in get_resolver(None).url_patterns:
+            if isinstance(url_pattern, LocaleRegexURLResolver):
+                return True
+        return False


### PR DESCRIPTION
Failing in a middleware `__init__` is preventing proper debug view.