### PR TITLE
Fixed MySQL build failure introduced by refs #24390.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -798,7 +798,7 @@ class BaseDatabaseSchemaEditor(object):
             )
         # Else generate the name for the index using a different algorithm
         table_name = model._meta.db_table.replace('"', '').replace('.', '_')
-        index_unique_name = '_%s' % self._digest(*column_names)
+        index_unique_name = '_%s' % self._digest(table_name, *column_names)
         max_length = self.connection.ops.max_name_length() or 200
         # If the index name is too long, truncate it
         index_name = ('%s_%s%s%s' % (

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -21,7 +21,7 @@ class SchemaIndexesTests(TestCase):
                 column_names=("column1", "column2", "column3"),
                 suffix="123",
             )
-        self.assertEqual(index_name, "indexes_article_column1_856fe518123")
+        self.assertEqual(index_name, "indexes_article_column1_6bd61f85123")
 
     def test_index_together(self):
         editor = connection.schema_editor()


### PR DESCRIPTION
Added table_name back to _create_index_sql() to prevent
duplicate index names on MySQL.