### PR TITLE
Add padding to list items on debug.py - ticket_24440

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -636,9 +636,9 @@ TECHNICAL_500_TEMPLATE = ("""
     div.context ol { padding-left:30px; margin:0 10px; list-style-position: inside; }
     div.context ol li { font-family:monospace; white-space:pre; color:#777; cursor:pointer; }
     div.context ol li pre { display:inline; }
-    div.context ol.context-line li { color:#505050; background-color:#dfdfdf; }
+    div.context ol.context-line li { color:#505050; background-color:#dfdfdf; padding: 5px; }
     div.context ol.context-line li span { position:absolute; right:32px; }
-    .user div.context ol.context-line li { background-color:#bbb; color:#000; }
+    .user div.context ol.context-line li { background-color:#bbb; color:#000; padding: 5px; }
     .user div.context ol li { color:#666; }
     div.commands { margin-left: 40px; }
     div.commands a { color:#555; text-decoration:none; }


### PR DESCRIPTION
When viewing debug output, or any code which generates a stack trace, the CSS for debug.py does not contain enough padding for nested list items. This results in a dark grey border which directly touches the line of code it contains. This makes it difficult to read.

This ticket is a request, along with screenshots and patch, to add 5px of padding on two list item CSS declarations.

Before:
![debug-screenshot-before](https://cloud.githubusercontent.com/assets/563460/6448478/e1697108-c0df-11e4-9812-498b47c47cd9.png)

After:
![debug-screenshot-after](https://cloud.githubusercontent.com/assets/563460/6448481/e4b3e410-c0df-11e4-9d5e-7f43eca306ff.png)

Trac ticket link: https://code.djangoproject.com/ticket/24440#no1