### PR TITLE
Fix ordering of inner prefetch related lookups

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1797,7 +1797,7 @@ def prefetch_related_objects(result_cache, related_lookups):
                     done_queries[prefetch_to] = obj_list
                     new_lookups = normalize_prefetch_lookups(additional_lookups, prefetch_to)
                     auto_lookups.update(new_lookups)
-                    all_lookups.extendleft(new_lookups)
+                    all_lookups.extendleft(reversed(new_lookups))
                 followed_descriptors.add(descriptor)
             else:
                 # Either a singly related object that has already been fetched


### PR DESCRIPTION
Inner prefetch related lookups were shifted to `all_lookups` (in `prefetch_related_objects` function) in reverse order.
Fix shifts them in the correct order.

Assume this model diagram:
A -(m2m)-> B -(m2m)-> C -(m2m)-> D
Now have this code:
```python
A.objects.prefetch_related(
    'B',
    queryset=B.objects.prefetch_related(
        Prefetch(
            'C',
            to_attr='myC'
        ),
        'myC__D'
    )
)
```

`all_lookups` will have `['B__myC__D', 'B__myC']`. The B prefix is after normalizing.
But the correct order should be `['B__myC', 'B__myC__D']`.

Also see https://docs.python.org/2/library/collections.html#collections.deque.extendleft :
"Note, the series of left appends results in reversing the order of elements in the iterable argument."