### PR TITLE
Fixed #24447 Migrations do not add a FK constraint for an existing column

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -709,9 +709,9 @@ class BaseDatabaseSchemaEditor(object):
                 }
             )
         # Does it have a foreign key?
-        if new_field.rel and \
-           (fks_dropped or (old_field.rel and not old_field.db_constraint)) and \
-           new_field.db_constraint:
+        if (new_field.rel and
+           (fks_dropped or not old_field.rel or not old_field.db_constraint) and
+           new_field.db_constraint):
             self.execute(self._create_fk_sql(model, new_field, "_fk_%(to_table)s_%(to_column)s"))
         # Rebuild FKs that pointed to us if we previously had to drop them
         if old_field.primary_key and new_field.primary_key and old_type != new_type:

--- a/docs/releases/1.7.6.txt
+++ b/docs/releases/1.7.6.txt
@@ -9,4 +9,5 @@ Django 1.7.6 fixes several bugs in 1.7.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a bug that prevented migrations from adding a FK constraint
+  for an existing column. (:ticket:`24447`).


### PR DESCRIPTION
Migrations failed when introducting foreign keys. The code
didn't detect this case - if old_field.rel doesn't exist
alter_field() must always create the foreign key and ONLY if
.rel exists it must check .db_constraint, too. Since no .rel
also means there was no foreign key before.

Additional:
* I have this change for 1.7.x too
* If needed I can try to write a test