### PR TITLE
moved definition of chunks out of timesince function

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -6,6 +6,15 @@ from django.utils.html import avoid_wrapping
 from django.utils.timezone import is_aware, utc
 from django.utils.translation import ugettext, ungettext_lazy
 
+TIMESINCE_CHUNKS = (
+    (60 * 60 * 24 * 365, ungettext_lazy('%d year', '%d years')),
+    (60 * 60 * 24 * 30, ungettext_lazy('%d month', '%d months')),
+    (60 * 60 * 24 * 7, ungettext_lazy('%d week', '%d weeks')),
+    (60 * 60 * 24, ungettext_lazy('%d day', '%d days')),
+    (60 * 60, ungettext_lazy('%d hour', '%d hours')),
+    (60, ungettext_lazy('%d minute', '%d minutes'))
+)
+
 
 def timesince(d, now=None, reversed=False):
     """
@@ -21,14 +30,6 @@ def timesince(d, now=None, reversed=False):
     Adapted from
     http://web.archive.org/web/20060617175230/http://blog.natbat.co.uk/archive/2003/Jun/14/time_since
     """
-    chunks = (
-        (60 * 60 * 24 * 365, ungettext_lazy('%d year', '%d years')),
-        (60 * 60 * 24 * 30, ungettext_lazy('%d month', '%d months')),
-        (60 * 60 * 24 * 7, ungettext_lazy('%d week', '%d weeks')),
-        (60 * 60 * 24, ungettext_lazy('%d day', '%d days')),
-        (60 * 60, ungettext_lazy('%d hour', '%d hours')),
-        (60, ungettext_lazy('%d minute', '%d minutes'))
-    )
     # Convert datetime.date to datetime.datetime for comparison.
     if not isinstance(d, datetime.datetime):
         d = datetime.datetime(d.year, d.month, d.day)
@@ -44,14 +45,14 @@ def timesince(d, now=None, reversed=False):
     if since <= 0:
         # d is in the future compared to now, stop processing.
         return avoid_wrapping(ugettext('0 minutes'))
-    for i, (seconds, name) in enumerate(chunks):
+    for i, (seconds, name) in enumerate(TIMESINCE_CHUNKS):
         count = since // seconds
         if count != 0:
             break
     result = avoid_wrapping(name % count)
-    if i + 1 < len(chunks):
+    if i + 1 < len(TIMESINCE_CHUNKS):
         # Now get the second item
-        seconds2, name2 = chunks[i + 1]
+        seconds2, name2 = TIMESINCE_CHUNKS[i + 1]
         count2 = (since - (seconds * count)) // seconds2
         if count2 != 0:
             result += ugettext(', ') + avoid_wrapping(name2 % count2)


### PR DESCRIPTION
this speeds up the timesince function/filter substantially. With the following, completely unscientific, "benchmark", I measured a speed-up of roughly 300x

	import random
	import timeit
	import datetime
	from django.utils import timezone
	from django.utils.timesince import timesince

	random.seed(0)

	now = timezone.now()
	datetimes = [now - datetime.timedelta(seconds=random.randint(0, 2**16)) for n in range(1000)]

	def doit():
		for d in datetimes:
			timesince(d)
			
	timer = timeit.Timer(doit)

	print timer.repeat(5, number=10)

Before:

    [82.95916604995728, 78.85510802268982, 83.29391980171204, 81.92009782791138, 82.44019603729248]

After:

    [0.2534639835357666, 0.2476367950439453, 0.24594998359680176, 0.2475271224975586, 0.24568581581115723]

While this benchmark is completely synthetic and of little value, we do see measurable performance increases on real-world pages with lots of `timesince` filters