### PR TITLE
Remove rel usage

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -180,7 +180,7 @@ class BaseModelAdminChecks(object):
                 return []
             else:
                 if (isinstance(field, models.ManyToManyField) and
-                        not field.rel.through._meta.auto_created):
+                        not field.remote_field.through._meta.auto_created):
                     return [
                         checks.Error(
                             ("The value of '%s' cannot include the ManyToManyField '%s', "

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -9,12 +9,10 @@ import datetime
 
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import (
-    get_limit_choices_to_from_path, get_model_from_relation,
-    prepare_lookup_value, reverse_field_path,
+    get_model_from_relation, prepare_lookup_value, reverse_field_path,
 )
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
-from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
 from django.utils import timezone
 from django.utils.encoding import force_text, smart_text
 from django.utils.translation import ugettext_lazy as _
@@ -164,10 +162,7 @@ class FieldListFilter(ListFilter):
 class RelatedFieldListFilter(FieldListFilter):
     def __init__(self, field, request, params, model, model_admin, field_path):
         other_model = get_model_from_relation(field)
-        if hasattr(field, 'rel'):
-            rel_name = field.rel.get_related_field().name
-        else:
-            rel_name = other_model._meta.pk.name
+        rel_name = field.target_field.name
         self.lookup_kwarg = '%s__%s__exact' % (field_path, rel_name)
         self.lookup_kwarg_isnull = '%s__isnull' % field_path
         self.lookup_val = request.GET.get(self.lookup_kwarg)
@@ -182,9 +177,7 @@ class RelatedFieldListFilter(FieldListFilter):
         self.title = self.lookup_title
 
     def has_output(self):
-        if (isinstance(self.field, ForeignObjectRel) and
-                self.field.field.null or hasattr(self.field, 'rel') and
-                self.field.null):
+        if self.field.null:
             extra = 1
         else:
             extra = 0
@@ -212,9 +205,7 @@ class RelatedFieldListFilter(FieldListFilter):
                 }, [self.lookup_kwarg_isnull]),
                 'display': val,
             }
-        if (isinstance(self.field, ForeignObjectRel) and
-                (self.field.field.null or isinstance(self.field.field, ManyToManyField)) or
-                hasattr(self.field, 'rel') and (self.field.null or isinstance(self.field, ManyToManyField))):
+        if self.field.null:
             yield {
                 'selected': bool(self.lookup_val_isnull),
                 'query_string': cl.get_query_string({
@@ -223,9 +214,7 @@ class RelatedFieldListFilter(FieldListFilter):
                 'display': EMPTY_CHANGELIST_VALUE,
             }
 
-FieldListFilter.register(lambda f: (
-    bool(f.rel) if hasattr(f, 'rel') else
-    isinstance(f, ForeignObjectRel)), RelatedFieldListFilter)
+FieldListFilter.register(lambda f: f.remote_field, RelatedFieldListFilter)
 
 
 class BooleanFieldListFilter(FieldListFilter):
@@ -371,13 +360,6 @@ class AllValuesFieldListFilter(FieldListFilter):
             queryset = model_admin.get_queryset(request)
         else:
             queryset = parent_model._default_manager.all()
-
-        # optional feature: limit choices base on existing relationships
-        # queryset = queryset.complex_filter(
-        #    {'%s__isnull' % reverse_path: False})
-        limit_choices_to = get_limit_choices_to_from_path(model, field_path)
-        queryset = queryset.filter(limit_choices_to)
-
         self.lookup_choices = (queryset
                                .distinct()
                                .order_by(field.name)

--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -203,7 +203,7 @@ class AdminReadonlyField(object):
                     else:
                         result_repr = linebreaksbr(result_repr)
             else:
-                if isinstance(f.rel, ManyToManyRel) and value is not None:
+                if isinstance(f.remote_field, ManyToManyRel) and value is not None:
                     result_repr = ", ".join(map(six.text_type, value.all()))
                 else:
                     result_repr = display_for_field(value, f)

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -26,8 +26,6 @@ from django.core.urlresolvers import reverse
 from django.db import models, router, transaction
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields import BLANK_CHOICE_DASH
-from django.db.models.fields.related import ForeignObjectRel
-from django.db.models.sql.constants import QUERY_TERMS
 from django.forms.formsets import DELETION_FIELD_NAME, all_valid
 from django.forms.models import (
     BaseInlineFormSet, inlineformset_factory, modelform_defines_fields,
@@ -154,7 +152,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
             # rendered output. formfield can be None if it came from a
             # OneToOneField with parent_link=True or a M2M intermediary.
             if formfield and db_field.name not in self.raw_id_fields:
-                related_modeladmin = self.admin_site._registry.get(db_field.rel.to)
+                related_modeladmin = self.admin_site._registry.get(db_field.remote_field.model)
                 wrapper_kwargs = {}
                 if related_modeladmin:
                     wrapper_kwargs.update(
@@ -163,7 +161,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
                         can_delete_related=related_modeladmin.has_delete_permission(request),
                     )
                 formfield.widget = widgets.RelatedFieldWidgetWrapper(
-                    formfield.widget, db_field.rel, self.admin_site, **wrapper_kwargs
+                    formfield.widget, db_field.remote_field, self.admin_site, **wrapper_kwargs
                 )
 
             return formfield
@@ -202,11 +200,11 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         ordering.  Otherwise don't specify the queryset, let the field decide
         (returns None in that case).
         """
-        related_admin = self.admin_site._registry.get(db_field.rel.to, None)
+        related_admin = self.admin_site._registry.get(db_field.remote_field.model, None)
         if related_admin is not None:
             ordering = related_admin.get_ordering(request)
             if ordering is not None and ordering != ():
-                return db_field.rel.to._default_manager.using(db).order_by(*ordering)
+                return db_field.remote_field.model._default_manager.using(db).order_by(*ordering)
         return None
 
     def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
@@ -215,7 +213,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         """
         db = kwargs.get('using')
         if db_field.name in self.raw_id_fields:
-            kwargs['widget'] = widgets.ForeignKeyRawIdWidget(db_field.rel,
+            kwargs['widget'] = widgets.ForeignKeyRawIdWidget(db_field.remote_field,
                                     self.admin_site, using=db)
         elif db_field.name in self.radio_fields:
             kwargs['widget'] = widgets.AdminRadioSelect(attrs={
@@ -236,12 +234,12 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         """
         # If it uses an intermediary model that isn't auto created, don't show
         # a field in admin.
-        if not db_field.rel.through._meta.auto_created:
+        if not db_field.remote_field.through._meta.auto_created:
             return None
         db = kwargs.get('using')
 
         if db_field.name in self.raw_id_fields:
-            kwargs['widget'] = widgets.ManyToManyRawIdWidget(db_field.rel,
+            kwargs['widget'] = widgets.ManyToManyRawIdWidget(db_field.remote_field,
                                     self.admin_site, using=db)
             kwargs['help_text'] = ''
         elif db_field.name in (list(self.filter_vertical) + list(self.filter_horizontal)):
@@ -334,46 +332,32 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
                 if k == lookup and v == value:
                     return True
 
-        parts = lookup.split(LOOKUP_SEP)
-
-        # Last term in lookup is a query term (__exact, __startswith etc)
-        # This term can be ignored.
-        if len(parts) > 1 and parts[-1] in QUERY_TERMS:
-            parts.pop()
-
-        # Special case -- foo__id__exact and foo__id queries are implied
-        # if foo has been specifically included in the lookup list; so
-        # drop __id if it is the last part. However, first we need to find
-        # the pk attribute name.
-        rel_name = None
-        for part in parts[:-1]:
+        relation_parts = []
+        prev_field = None
+        for part in lookup.split(LOOKUP_SEP):
             try:
                 field = model._meta.get_field(part)
             except FieldDoesNotExist:
                 # Lookups on non-existent fields are ok, since they're ignored
                 # later.
-                return True
-            if hasattr(field, 'rel'):
-                if field.rel is None:
-                    # This property or relation doesn't exist, but it's allowed
-                    # since it's ignored in ChangeList.get_filters().
-                    return True
-                model = field.rel.to
-                if hasattr(field.rel, 'get_related_field'):
-                    rel_name = field.rel.get_related_field().name
-                else:
-                    rel_name = None
-            elif isinstance(field, ForeignObjectRel):
-                model = field.related_model
-                rel_name = model._meta.pk.name
-            else:
-                rel_name = None
-        if rel_name and len(parts) > 1 and parts[-1] == rel_name:
-            parts.pop()
+                break
+            # It is allowed to filter on values that would be found from local
+            # model anyways. For example, if you filter on employee__department__id,
+            # then the id value would be found already from employee__department_id.
+            if not prev_field or (prev_field.concrete and
+                                  field not in prev_field.get_path_info()[-1].target_fields):
+                relation_parts.append(part)
+            if not getattr(field, 'get_path_info', None):
+                # This is not a relational field, so further parts
+                # must be transforms.
+                break
+            prev_field = field
+            model = field.get_path_info()[-1].to_opts.model
 
-        if len(parts) == 1:
+        if len(relation_parts) <= 1:
+            # Either a local field filter, or no fields at all.
             return True
-        clean_lookup = LOOKUP_SEP.join(parts)
+        clean_lookup = LOOKUP_SEP.join(relation_parts)
         valid_lookups = [self.date_hierarchy]
         for filter_item in self.list_filter:
             if isinstance(filter_item, type) and issubclass(filter_item, SimpleListFilter):
@@ -422,7 +406,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         for related_object in related_objects:
             related_model = related_object.related_model
             if (any(issubclass(model, related_model) for model in registered_models) and
-                    related_object.field.rel.get_related_field() == field):
+                    related_object.field.remote_field.get_related_field() == field):
                 return True
 
         return False
@@ -1882,8 +1866,8 @@ class InlineModelAdmin(BaseModelAdmin):
             # The model was auto-created as intermediary for a
             # ManyToMany-relationship, find the target model
             for field in opts.fields:
-                if field.rel and field.rel.to != self.parent_model:
-                    opts = field.rel.to._meta
+                if field.remote_field and field.remote_field.model != self.parent_model:
+                    opts = field.remote_field.model._meta
                     break
         codename = get_permission_codename('change', opts)
         return request.user.has_perm("%s.%s" % (opts.app_label, codename))

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -215,7 +215,7 @@ def items_for_result(cl, result, form):
                 if isinstance(value, (datetime.date, datetime.time)):
                     row_classes.append('nowrap')
             else:
-                if isinstance(f.rel, models.ManyToOneRel):
+                if isinstance(f.remote_field, models.ManyToOneRel):
                     field_val = getattr(result, f.name)
                     if field_val is None:
                         result_repr = EMPTY_CHANGELIST_VALUE

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -446,7 +446,7 @@ def reverse_field_path(model, path):
         # Field should point to another model
         if field.is_relation and not (field.auto_created and not field.concrete):
             related_name = field.related_query_name()
-            parent = field.rel.to
+            parent = field.remote_field.model
         else:
             related_name = field.field.name
             parent = field.related_model
@@ -481,23 +481,3 @@ def remove_trailing_data_field(fields):
     except NotRelationField:
         fields = fields[:-1]
     return fields
-
-
-def get_limit_choices_to_from_path(model, path):
-    """ Return Q object for limiting choices if applicable.
-
-    If final model in path is linked via a ForeignKey or ManyToManyField which
-    has a ``limit_choices_to`` attribute, return it as a Q object.
-    """
-    fields = get_fields_from_path(model, path)
-    fields = remove_trailing_data_field(fields)
-    get_limit_choices_to = (
-        fields and hasattr(fields[-1], 'rel') and
-        getattr(fields[-1].rel, 'get_limit_choices_to', None))
-    if not get_limit_choices_to:
-        return models.Q()  # empty Q
-    limit_choices_to = get_limit_choices_to()
-    if isinstance(limit_choices_to, models.Q):
-        return limit_choices_to  # already a Q
-    else:
-        return models.Q(**limit_choices_to)  # convert dict to Q

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -383,7 +383,7 @@ class ChangeList(object):
             except FieldDoesNotExist:
                 pass
             else:
-                if isinstance(field.rel, models.ManyToOneRel):
+                if isinstance(field.remote_field, models.ManyToOneRel):
                     return True
         return False
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -151,7 +151,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
         super(ForeignKeyRawIdWidget, self).__init__(attrs)
 
     def render(self, name, value, attrs=None):
-        rel_to = self.rel.to
+        rel_to = self.rel.model
         if attrs is None:
             attrs = {}
         extra = []
@@ -196,9 +196,9 @@ class ForeignKeyRawIdWidget(forms.TextInput):
     def label_for_value(self, value):
         key = self.rel.get_related_field().name
         try:
-            obj = self.rel.to._default_manager.using(self.db).get(**{key: value})
+            obj = self.rel.model._default_manager.using(self.db).get(**{key: value})
             return '&nbsp;<strong>%s</strong>' % escape(Truncator(obj).words(14, truncate='...'))
-        except (ValueError, self.rel.to.DoesNotExist):
+        except (ValueError, self.rel.model.DoesNotExist):
             return ''
 
 
@@ -210,7 +210,7 @@ class ManyToManyRawIdWidget(ForeignKeyRawIdWidget):
     def render(self, name, value, attrs=None):
         if attrs is None:
             attrs = {}
-        if self.rel.to in self.admin_site._registry:
+        if self.rel.model in self.admin_site._registry:
             # The related object is registered with the same AdminSite
             attrs['class'] = 'vManyToManyRawIdAdminField'
         if value:
@@ -248,7 +248,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
         # Backwards compatible check for whether a user can add related
         # objects.
         if can_add_related is None:
-            can_add_related = rel.to in admin_site._registry
+            can_add_related = rel.model in admin_site._registry
         self.can_add_related = can_add_related
         # XXX: The UX does not support multiple selected values.
         multiple = getattr(widget, 'allow_multiple_selected', False)
@@ -280,7 +280,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
 
     def render(self, name, value, *args, **kwargs):
         from django.contrib.admin.views.main import IS_POPUP_VAR, TO_FIELD_VAR
-        rel_opts = self.rel.to._meta
+        rel_opts = self.rel.model._meta
         info = (rel_opts.app_label, rel_opts.model_name)
         self.widget.choices = self.choices
         url_params = '&'.join("%s=%s" % param for param in [

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -207,8 +207,8 @@ class ModelDetailView(BaseAdminDocsView):
             # ForeignKey is a special case since the field will actually be a
             # descriptor that returns the other object
             if isinstance(field, models.ForeignKey):
-                data_type = field.rel.to.__name__
-                app_label = field.rel.to._meta.app_label
+                data_type = field.remote_field.model.__name__
+                app_label = field.remote_field.model._meta.app_label
                 verbose = utils.parse_rst(
                     (_("the related `%(app_label)s.%(data_type)s` object") % {
                         'app_label': app_label, 'data_type': data_type,
@@ -228,8 +228,8 @@ class ModelDetailView(BaseAdminDocsView):
 
         # Gather many-to-many fields.
         for field in opts.many_to_many:
-            data_type = field.rel.to.__name__
-            app_label = field.rel.to._meta.app_label
+            data_type = field.remote_field.model.__name__
+            app_label = field.remote_field.model._meta.app_label
             verbose = _("related `%(app_label)s.%(object_name)s` objects") % {
                 'app_label': app_label,
                 'object_name': data_type,

--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -31,7 +31,7 @@ class GroupAdmin(admin.ModelAdmin):
 
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         if db_field.name == 'permissions':
-            qs = kwargs.get('queryset', db_field.rel.to.objects)
+            qs = kwargs.get('queryset', db_field.remote_field.model.objects)
             # Avoid a major performance hit resolving permission names which
             # triggers a content_type load:
             kwargs['queryset'] = qs.select_related('content_type')

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -90,11 +90,11 @@ class Command(BaseCommand):
                     input_msg = capfirst(verbose_field_name)
                     if default_username:
                         input_msg += " (leave blank to use '%s')" % default_username
-                    username_rel = self.username_field.rel
+                    username_rel = self.username_field.remote_field
                     input_msg = force_str('%s%s: ' % (
                         input_msg,
                         ' (%s.%s)' % (
-                            username_rel.to._meta.object_name,
+                            username_rel.model._meta.object_name,
                             username_rel.field_name
                         ) if username_rel else '')
                     )
@@ -115,7 +115,7 @@ class Command(BaseCommand):
                     user_data[field_name] = options.get(field_name)
                     while user_data[field_name] is None:
                         message = force_str('%s%s: ' % (capfirst(field.verbose_name),
-                            ' (%s.%s)' % (field.rel.to._meta.object_name, field.rel.field_name) if field.rel else ''))
+                            ' (%s.%s)' % (field.remote_field.model._meta.object_name, field.remote_field.field_name) if field.remote_field else ''))
                         user_data[field_name] = self.get_input_data(field, message)
 
                 # Get a password

--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -39,6 +39,7 @@ class GenericForeignKey(object):
     one_to_many = False
     one_to_one = False
     related_model = None
+    remote_field = None
 
     allow_unsaved_instance_assignment = False
 
@@ -135,7 +136,7 @@ class GenericForeignKey(object):
                         id='contenttypes.E003',
                     )
                 ]
-            elif field.rel.to != ContentType:
+            elif field.remote_field.model != ContentType:
                 return [
                     checks.Error(
                         "'%s.%s' is not a ForeignKey to 'contenttypes.ContentType'." % (
@@ -323,7 +324,7 @@ class GenericRelation(ForeignObject):
         return errors
 
     def _check_generic_foreign_key_existence(self):
-        target = self.rel.to
+        target = self.remote_field.model
         if isinstance(target, ModelBase):
             fields = target._meta.virtual_fields
             if any(isinstance(field, GenericForeignKey) and
@@ -348,16 +349,16 @@ class GenericRelation(ForeignObject):
 
     def resolve_related_fields(self):
         self.to_fields = [self.model._meta.pk.name]
-        return [(self.rel.to._meta.get_field(self.object_id_field_name), self.model._meta.pk)]
+        return [(self.remote_field.model._meta.get_field(self.object_id_field_name), self.model._meta.pk)]
 
     def get_path_info(self):
-        opts = self.rel.to._meta
+        opts = self.remote_field.model._meta
         target = opts.pk
-        return [PathInfo(self.model._meta, opts, (target,), self.rel, True, False)]
+        return [PathInfo(self.model._meta, opts, (target,), self.remote_field, True, False)]
 
     def get_reverse_path_info(self):
         opts = self.model._meta
-        from_opts = self.rel.to._meta
+        from_opts = self.remote_field.model._meta
         return [PathInfo(from_opts, opts, (opts.pk,), self, not self.unique, False)]
 
     def get_choices_default(self):
@@ -371,7 +372,7 @@ class GenericRelation(ForeignObject):
         kwargs['virtual_only'] = True
         super(GenericRelation, self).contribute_to_class(cls, name, **kwargs)
         self.model = cls
-        setattr(cls, self.name, ReverseGenericRelatedObjectsDescriptor(self.rel))
+        setattr(cls, self.name, ReverseGenericRelatedObjectsDescriptor(self.remote_field))
 
     def set_attributes_from_rel(self):
         pass
@@ -387,7 +388,7 @@ class GenericRelation(ForeignObject):
                                                  for_concrete_model=self.for_concrete_model)
 
     def get_extra_restriction(self, where_class, alias, remote_alias):
-        field = self.rel.to._meta.get_field(self.content_type_field_name)
+        field = self.remote_field.model._meta.get_field(self.content_type_field_name)
         contenttype_pk = self.get_content_type().pk
         cond = where_class()
         lookup = field.get_lookup('exact')(field.get_col(remote_alias), contenttype_pk)
@@ -398,7 +399,7 @@ class GenericRelation(ForeignObject):
         """
         Return all objects related to ``objs`` via this ``GenericRelation``.
         """
-        return self.rel.to._base_manager.db_manager(using).filter(**{
+        return self.remote_field.model._base_manager.db_manager(using).filter(**{
             "%s__pk" % self.content_type_field_name: ContentType.objects.db_manager(using).get_for_model(
                 self.model, for_concrete_model=self.for_concrete_model).pk,
             "%s__in" % self.object_id_field_name: [obj.pk for obj in objs]
@@ -421,7 +422,7 @@ class ReverseGenericRelatedObjectsDescriptor(ForeignRelatedObjectsDescriptor):
     @cached_property
     def related_manager_cls(self):
         return create_generic_related_manager(
-            self.rel.to._default_manager.__class__,
+            self.rel.model._default_manager.__class__,
             self.rel,
         )
 
@@ -439,7 +440,7 @@ def create_generic_related_manager(superclass, rel):
 
             self.instance = instance
 
-            self.model = rel.to
+            self.model = rel.model
 
             content_type = ContentType.objects.db_manager(instance._state.db).get_for_model(
                 instance, for_concrete_model=rel.field.for_concrete_model)

--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -68,7 +68,7 @@ def generic_inlineformset_factory(model, form=ModelForm,
     opts = model._meta
     # if there is no field called `ct_field` let the exception propagate
     ct_field = opts.get_field(ct_field)
-    if not isinstance(ct_field, models.ForeignKey) or ct_field.rel.to != ContentType:
+    if not isinstance(ct_field, models.ForeignKey) or ct_field.remote_field.model != ContentType:
         raise Exception("fk_name '%s' is not a ForeignKey to ContentType" % ct_field)
     fk_field = opts.get_field(fk_field)  # let the exception propagate
     if exclude is not None:

--- a/django/contrib/contenttypes/views.py
+++ b/django/contrib/contenttypes/views.py
@@ -48,7 +48,7 @@ def shortcut(request, content_type_id, object_id):
 
         # First, look for an many-to-many relationship to Site.
         for field in opts.many_to_many:
-            if field.rel.to is Site:
+            if field.remote_field.model is Site:
                 try:
                     # Caveat: In the case of multiple related Sites, this just
                     # selects the *first* one, which is arbitrary.
@@ -61,7 +61,7 @@ def shortcut(request, content_type_id, object_id):
         # Next, look for a many-to-one relationship to Site.
         if object_domain is None:
             for field in obj._meta.fields:
-                if field.rel and field.rel.to is Site:
+                if field.remote_field and field.remote_field.model is Site:
                     try:
                         object_domain = getattr(obj, field.name).domain
                     except Site.DoesNotExist:

--- a/django/contrib/gis/db/models/lookups.py
+++ b/django/contrib/gis/db/models/lookups.py
@@ -45,7 +45,7 @@ class GISLookup(Lookup):
             # model field associated with the next field in the list
             # until there's no more left.
             while len(field_list):
-                opts = geo_fld.rel.to._meta
+                opts = geo_fld.remote_field.model._meta
                 geo_fld = opts.get_field(field_list.pop())
         except (FieldDoesNotExist, AttributeError):
             return False

--- a/django/contrib/gis/utils/layermapping.py
+++ b/django/contrib/gis/utils/layermapping.py
@@ -229,7 +229,7 @@ class LayerMapping(object):
             elif isinstance(model_field, models.ForeignKey):
                 if isinstance(ogr_name, dict):
                     # Is every given related model mapping field in the Layer?
-                    rel_model = model_field.rel.to
+                    rel_model = model_field.remote_field.model
                     for rel_name, ogr_field in ogr_name.items():
                         idx = check_ogr_fld(ogr_field)
                         try:

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -33,7 +33,7 @@ class ArrayField(Field):
 
     def check(self, **kwargs):
         errors = super(ArrayField, self).check(**kwargs)
-        if self.base_field.rel:
+        if self.base_field.remote_field:
             errors.append(
                 checks.Error(
                     'Base field for array cannot be a related field.',

--- a/django/core/serializers/__init__.py
+++ b/django/core/serializers/__init__.py
@@ -184,16 +184,16 @@ def sort_dependencies(app_list):
             # Now add a dependency for any FK relation with a model that
             # defines a natural key
             for field in model._meta.fields:
-                if hasattr(field.rel, 'to'):
-                    rel_model = field.rel.to
+                if field.remote_field:
+                    rel_model = field.remote_field.model
                     if hasattr(rel_model, 'natural_key') and rel_model != model:
                         deps.append(rel_model)
             # Also add a dependency for any simple M2M relation with a model
             # that defines a natural key.  M2M relations with explicit through
             # models don't count as dependencies.
             for field in model._meta.many_to_many:
-                if field.rel.through._meta.auto_created:
-                    rel_model = field.rel.to
+                if field.remote_field.through._meta.auto_created:
+                    rel_model = field.remote_field.model
                     if hasattr(rel_model, 'natural_key') and rel_model != model:
                         deps.append(rel_model)
             model_dependencies.append((model, deps))

--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -49,7 +49,7 @@ class Serializer(object):
             concrete_model = obj._meta.concrete_model
             for field in concrete_model._meta.local_fields:
                 if field.serialize:
-                    if field.rel is None:
+                    if field.remote_field is None:
                         if self.selected_fields is None or field.attname in self.selected_fields:
                             self.handle_field(obj, field)
                     else:

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -125,7 +125,7 @@ class BaseDatabaseIntrospection(object):
                 for f in model._meta.local_many_to_many:
                     # If this is an m2m using an intermediate table,
                     # we don't need to reset the sequence.
-                    if f.rel.through is None:
+                    if f.remote_field.through is None:
                         sequence_list.append({'table': f.m2m_db_table(), 'column': None})
 
         return sequence_list

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -241,9 +241,9 @@ class BaseDatabaseSchemaEditor(object):
                 definition += " %s" % col_type_suffix
             params.extend(extra_params)
             # FK
-            if field.rel and field.db_constraint:
-                to_table = field.rel.to._meta.db_table
-                to_column = field.rel.to._meta.get_field(field.rel.field_name).column
+            if field.remote_field and field.db_constraint:
+                to_table = field.remote_field.model._meta.db_table
+                to_column = field.remote_field.model._meta.get_field(field.remote_field.field_name).column
                 if self.connection.features.supports_foreign_keys:
                     self.deferred_sql.append(self._create_fk_sql(model, field, "_fk_%(to_table)s_%(to_column)s"))
                 elif self.sql_create_inline_fk:
@@ -284,8 +284,8 @@ class BaseDatabaseSchemaEditor(object):
 
         # Make M2M tables
         for field in model._meta.local_many_to_many:
-            if field.rel.through._meta.auto_created:
-                self.create_model(field.rel.through)
+            if field.remote_field.through._meta.auto_created:
+                self.create_model(field.remote_field.through)
 
     def delete_model(self, model):
         """
@@ -293,8 +293,8 @@ class BaseDatabaseSchemaEditor(object):
         """
         # Handle auto-created intermediary models
         for field in model._meta.local_many_to_many:
-            if field.rel.through._meta.auto_created:
-                self.delete_model(field.rel.through)
+            if field.remote_field.through._meta.auto_created:
+                self.delete_model(field.remote_field.through)
 
         # Delete the table
         self.execute(self.sql_delete_table % {
@@ -377,8 +377,8 @@ class BaseDatabaseSchemaEditor(object):
         table instead (for M2M fields)
         """
         # Special-case implicit M2M tables
-        if field.many_to_many and field.rel.through._meta.auto_created:
-            return self.create_model(field.rel.through)
+        if field.many_to_many and field.remote_field.through._meta.auto_created:
+            return self.create_model(field.remote_field.through)
         # Get the column's definition
         definition, params = self.column_sql(model, field, include_default=True)
         # It might not actually have a column behind it
@@ -409,7 +409,7 @@ class BaseDatabaseSchemaEditor(object):
         if field.db_index and not field.unique:
             self.deferred_sql.append(self._create_index_sql(model, [field]))
         # Add any FK constraints later
-        if field.rel and self.connection.features.supports_foreign_keys and field.db_constraint:
+        if field.remote_field and self.connection.features.supports_foreign_keys and field.db_constraint:
             self.deferred_sql.append(self._create_fk_sql(model, field, "_fk_%(to_table)s_%(to_column)s"))
         # Reset connection if required
         if self.connection.features.connection_persists_old_columns:
@@ -421,13 +421,13 @@ class BaseDatabaseSchemaEditor(object):
         but for M2Ms may involve deleting a table.
         """
         # Special-case implicit M2M tables
-        if field.many_to_many and field.rel.through._meta.auto_created:
-            return self.delete_model(field.rel.through)
+        if field.many_to_many and field.remote_field.through._meta.auto_created:
+            return self.delete_model(field.remote_field.through)
         # It might not actually have a column behind it
         if field.db_parameters(connection=self.connection)['type'] is None:
             return
         # Drop any FK constraints, MySQL requires explicit deletion
-        if field.rel:
+        if field.remote_field:
             fk_names = self._constraint_names(model, [field.column], foreign_key=True)
             for fk_name in fk_names:
                 self.execute(self._delete_constraint_sql(self.sql_delete_fk, model, fk_name))
@@ -454,21 +454,21 @@ class BaseDatabaseSchemaEditor(object):
         old_type = old_db_params['type']
         new_db_params = new_field.db_parameters(connection=self.connection)
         new_type = new_db_params['type']
-        if (old_type is None and old_field.rel is None) or (new_type is None and new_field.rel is None):
+        if (old_type is None and old_field.remote_field is None) or (new_type is None and new_field.remote_field is None):
             raise ValueError(
                 "Cannot alter field %s into %s - they do not properly define "
                 "db_type (are you using PostGIS 1.5 or badly-written custom "
                 "fields?)" % (old_field, new_field),
             )
         elif old_type is None and new_type is None and (
-                old_field.rel.through and new_field.rel.through and
-                old_field.rel.through._meta.auto_created and
-                new_field.rel.through._meta.auto_created):
+                old_field.remote_field.through and new_field.remote_field.through and
+                old_field.remote_field.through._meta.auto_created and
+                new_field.remote_field.through._meta.auto_created):
             return self._alter_many_to_many(model, old_field, new_field, strict)
         elif old_type is None and new_type is None and (
-                old_field.rel.through and new_field.rel.through and
-                not old_field.rel.through._meta.auto_created and
-                not new_field.rel.through._meta.auto_created):
+                old_field.remote_field.through and new_field.remote_field.through and
+                not old_field.remote_field.through._meta.auto_created and
+                not new_field.remote_field.through._meta.auto_created):
             # Both sides have through models; this is a no-op.
             return
         elif old_type is None or new_type is None:
@@ -487,7 +487,7 @@ class BaseDatabaseSchemaEditor(object):
 
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
-        if old_field.rel and old_field.db_constraint:
+        if old_field.remote_field and old_field.db_constraint:
             fk_names = self._constraint_names(model, [old_field.column], foreign_key=True)
             if strict and len(fk_names) != 1:
                 raise ValueError("Found wrong number (%s) of foreign key constraints for %s.%s" % (
@@ -707,8 +707,8 @@ class BaseDatabaseSchemaEditor(object):
                 }
             )
         # Does it have a foreign key?
-        if (new_field.rel and
-                (fks_dropped or not old_field.rel or not old_field.db_constraint) and
+        if (new_field.remote_field and
+                (fks_dropped or not old_field.remote_field or not old_field.db_constraint) and
                 new_field.db_constraint):
             self.execute(self._create_fk_sql(model, new_field, "_fk_%(to_table)s_%(to_column)s"))
         # Rebuild FKs that pointed to us if we previously had to drop them
@@ -766,22 +766,22 @@ class BaseDatabaseSchemaEditor(object):
         Alters M2Ms to repoint their to= endpoints.
         """
         # Rename the through table
-        if old_field.rel.through._meta.db_table != new_field.rel.through._meta.db_table:
-            self.alter_db_table(old_field.rel.through, old_field.rel.through._meta.db_table,
-                                new_field.rel.through._meta.db_table)
+        if old_field.remote_field.through._meta.db_table != new_field.remote_field.through._meta.db_table:
+            self.alter_db_table(old_field.remote_field.through, old_field.remote_field.through._meta.db_table,
+                                new_field.remote_field.through._meta.db_table)
         # Repoint the FK to the other side
         self.alter_field(
-            new_field.rel.through,
+            new_field.remote_field.through,
             # We need the field that points to the target model, so we can tell alter_field to change it -
             # this is m2m_reverse_field_name() (as opposed to m2m_field_name, which points to our model)
-            old_field.rel.through._meta.get_field(old_field.m2m_reverse_field_name()),
-            new_field.rel.through._meta.get_field(new_field.m2m_reverse_field_name()),
+            old_field.remote_field.through._meta.get_field(old_field.m2m_reverse_field_name()),
+            new_field.remote_field.through._meta.get_field(new_field.m2m_reverse_field_name()),
         )
         self.alter_field(
-            new_field.rel.through,
+            new_field.remote_field.through,
             # for self-referential models we need to alter field from the other end too
-            old_field.rel.through._meta.get_field(old_field.m2m_field_name()),
-            new_field.rel.through._meta.get_field(new_field.m2m_field_name()),
+            old_field.remote_field.through._meta.get_field(old_field.m2m_field_name()),
+            new_field.remote_field.through._meta.get_field(new_field.m2m_field_name()),
         )
 
     def _create_index_name(self, model, column_names, suffix=""):
@@ -860,8 +860,8 @@ class BaseDatabaseSchemaEditor(object):
     def _create_fk_sql(self, model, field, suffix):
         from_table = model._meta.db_table
         from_column = field.column
-        to_table = field.related_field.model._meta.db_table
-        to_column = field.related_field.column
+        to_table = field.target_field.model._meta.db_table
+        to_column = field.target_field.column
         suffix = suffix % {
             "to_table": to_table,
             "to_column": to_column,

--- a/django/db/backends/mysql/validation.py
+++ b/django/db/backends/mysql/validation.py
@@ -14,7 +14,7 @@ class DatabaseValidation(BaseDatabaseValidation):
         errors = super(DatabaseValidation, self).check_field(field, **kwargs)
 
         # Ignore any related fields.
-        if getattr(field, 'rel', None) is None:
+        if getattr(field, 'remote_field', None) is None:
             field_type = field.db_type(connection)
 
             # Ignore any non-concrete fields

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -346,7 +346,7 @@ WHEN (new.%(col_name)s IS NULL)
                     # continue to loop
                     break
             for f in model._meta.many_to_many:
-                if not f.rel.through:
+                if not f.remote_field.through:
                     table_name = self.quote_name(f.m2m_db_table())
                     sequence_name = self._get_sequence_name(f.m2m_db_table())
                     column_name = self.quote_name('id')

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -172,7 +172,7 @@ class DatabaseOperations(BaseDatabaseOperations):
                     )
                     break  # Only one AutoField is allowed per model, so don't bother continuing.
             for f in model._meta.many_to_many:
-                if not f.rel.through:
+                if not f.remote_field.through:
                     output.append(
                         "%s setval(pg_get_serial_sequence('%s','%s'), "
                         "coalesce(max(%s), 1), max(%s) %s null) %s %s;" % (

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -78,7 +78,7 @@ class MigrationAutodetector(object):
         fields_def = []
         for name, field in fields:
             deconstruction = self.deep_deconstruct(field)
-            if field.rel and field.rel.to:
+            if field.remote_field and field.remote_field.model:
                 del deconstruction[2]['to']
             fields_def.append(deconstruction)
         return fields_def
@@ -163,11 +163,11 @@ class MigrationAutodetector(object):
             old_model_state = self.from_state.models[app_label, old_model_name]
             for field_name, field in old_model_state.fields:
                 old_field = self.old_apps.get_model(app_label, old_model_name)._meta.get_field(field_name)
-                if (hasattr(old_field, "rel") and getattr(old_field.rel, "through", None)
-                        and not old_field.rel.through._meta.auto_created):
+                if (hasattr(old_field, "remote_field") and getattr(old_field.remote_field, "through", None)
+                        and not old_field.remote_field.through._meta.auto_created):
                     through_key = (
-                        old_field.rel.through._meta.app_label,
-                        old_field.rel.through._meta.model_name,
+                        old_field.remote_field.through._meta.app_label,
+                        old_field.remote_field.through._meta.model_name,
                     )
                     self.through_users[through_key] = (app_label, old_model_name, field_name)
 
@@ -460,20 +460,20 @@ class MigrationAutodetector(object):
             related_fields = {}
             primary_key_rel = None
             for field in model_opts.local_fields:
-                if field.rel:
-                    if field.rel.to:
+                if field.remote_field:
+                    if field.remote_field.model:
                         if field.primary_key:
-                            primary_key_rel = field.rel.to
-                        elif not field.rel.parent_link:
+                            primary_key_rel = field.remote_field.model
+                        elif not field.remote_field.parent_link:
                             related_fields[field.name] = field
                     # through will be none on M2Ms on swapped-out models;
                     # we can treat lack of through as auto_created=True, though.
-                    if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+                    if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                         related_fields[field.name] = field
             for field in model_opts.local_many_to_many:
-                if field.rel.to:
+                if field.remote_field.model:
                     related_fields[field.name] = field
-                if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+                if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                     related_fields[field.name] = field
             # Are there unique/index_together to defer?
             unique_together = model_state.options.pop('unique_together', None)
@@ -522,13 +522,13 @@ class MigrationAutodetector(object):
                     dep_app_label = "__setting__"
                     dep_object_name = swappable_setting
                 else:
-                    dep_app_label = field.rel.to._meta.app_label
-                    dep_object_name = field.rel.to._meta.object_name
+                    dep_app_label = field.remote_field.model._meta.app_label
+                    dep_object_name = field.remote_field.model._meta.object_name
                 dependencies = [(dep_app_label, dep_object_name, None, True)]
-                if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+                if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                     dependencies.append((
-                        field.rel.through._meta.app_label,
-                        field.rel.through._meta.object_name,
+                        field.remote_field.through._meta.app_label,
+                        field.remote_field.through._meta.object_name,
                         None,
                         True
                     ))
@@ -639,17 +639,17 @@ class MigrationAutodetector(object):
             # Gather related fields
             related_fields = {}
             for field in model._meta.local_fields:
-                if field.rel:
-                    if field.rel.to:
+                if field.remote_field:
+                    if field.remote_field.model:
                         related_fields[field.name] = field
                     # through will be none on M2Ms on swapped-out models;
                     # we can treat lack of through as auto_created=True, though.
-                    if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+                    if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                         related_fields[field.name] = field
             for field in model._meta.local_many_to_many:
-                if field.rel.to:
+                if field.remote_field.model:
                     related_fields[field.name] = field
-                if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+                if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                     related_fields[field.name] = field
             # Generate option removal first
             unique_together = model_state.options.pop('unique_together', None)
@@ -736,7 +736,7 @@ class MigrationAutodetector(object):
             for rem_app_label, rem_model_name, rem_field_name in sorted(self.old_field_keys - self.new_field_keys):
                 if rem_app_label == app_label and rem_model_name == model_name:
                     old_field_dec = self.deep_deconstruct(old_model_state.get_field_by_name(rem_field_name))
-                    if field.rel and field.rel.to and 'to' in old_field_dec[2]:
+                    if field.remote_field and field.remote_field.model and 'to' in old_field_dec[2]:
                         old_rel_to = old_field_dec[2]['to']
                         if old_rel_to in self.renamed_models_rel:
                             old_field_dec[2]['to'] = self.renamed_models_rel[old_rel_to]
@@ -766,20 +766,20 @@ class MigrationAutodetector(object):
         field = self.new_apps.get_model(app_label, model_name)._meta.get_field(field_name)
         # Fields that are foreignkeys/m2ms depend on stuff
         dependencies = []
-        if field.rel and field.rel.to:
+        if field.remote_field and field.remote_field.model:
             # Account for FKs to swappable models
             swappable_setting = getattr(field, 'swappable_setting', None)
             if swappable_setting is not None:
                 dep_app_label = "__setting__"
                 dep_object_name = swappable_setting
             else:
-                dep_app_label = field.rel.to._meta.app_label
-                dep_object_name = field.rel.to._meta.object_name
+                dep_app_label = field.remote_field.model._meta.app_label
+                dep_object_name = field.remote_field.model._meta.object_name
             dependencies = [(dep_app_label, dep_object_name, None, True)]
-            if getattr(field.rel, "through", None) and not field.rel.through._meta.auto_created:
+            if getattr(field.remote_field, "through", None) and not field.remote_field.through._meta.auto_created:
                 dependencies.append((
-                    field.rel.through._meta.app_label,
-                    field.rel.through._meta.object_name,
+                    field.remote_field.through._meta.app_label,
+                    field.remote_field.through._meta.object_name,
                     None,
                     True,
                 ))
@@ -838,13 +838,13 @@ class MigrationAutodetector(object):
             new_field = self.new_apps.get_model(app_label, model_name)._meta.get_field(field_name)
             # Implement any model renames on relations; these are handled by RenameModel
             # so we need to exclude them from the comparison
-            if hasattr(new_field, "rel") and getattr(new_field.rel, "to", None):
+            if hasattr(new_field, "remote_field") and getattr(new_field.remote_field, "model", None):
                 rename_key = (
-                    new_field.rel.to._meta.app_label,
-                    new_field.rel.to._meta.model_name,
+                    new_field.remote_field.model._meta.app_label,
+                    new_field.remote_field.model._meta.model_name,
                 )
                 if rename_key in self.renamed_models:
-                    new_field.rel.to = old_field.rel.to
+                    new_field.remote_field.model = old_field.remote_field.model
             old_field_dec = self.deep_deconstruct(old_field)
             new_field_dec = self.deep_deconstruct(new_field)
             if old_field_dec != new_field_dec:

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -191,11 +191,11 @@ class AlterField(Operation):
             # If the field is a relatedfield with an unresolved rel.to, just
             # set it equal to the other field side. Bandaid fix for AlterField
             # migrations that are part of a RenameModel change.
-            if from_field.rel and from_field.rel.to:
-                if isinstance(from_field.rel.to, six.string_types):
-                    from_field.rel.to = to_field.rel.to
-                elif to_field.rel and isinstance(to_field.rel.to, six.string_types):
-                    to_field.rel.to = from_field.rel.to
+            if from_field.remote_field and from_field.remote_field.model:
+                if isinstance(from_field.remote_field.model, six.string_types):
+                    from_field.remote_field.model = to_field.remote_field.model
+                elif to_field.remote_field and isinstance(to_field.remote_field.model, six.string_types):
+                    to_field.remote_field.model = from_field.remote_field.model
             if not self.preserve_default:
                 to_field.default = self.field.default
             schema_editor.alter_field(from_model, from_field, to_field)

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -74,9 +74,9 @@ class CreateModel(Operation):
                 strings_to_check.append(base.split(".")[-1])
         # Check we have no FKs/M2Ms with it
         for fname, field in self.fields:
-            if field.rel:
-                if isinstance(field.rel.to, six.string_types):
-                    strings_to_check.append(field.rel.to.split(".")[-1])
+            if field.remote_field:
+                if isinstance(field.remote_field.model, six.string_types):
+                    strings_to_check.append(field.remote_field.model.split(".")[-1])
         # Now go over all the strings and compare them
         for string in strings_to_check:
             if string.lower() == name.lower():
@@ -181,7 +181,7 @@ class RenameModel(Operation):
             for name, field in state.models[related_key].fields:
                 if name == related_object.field.name:
                     field = field.clone()
-                    field.rel.to = "%s.%s" % (app_label, self.new_name)
+                    field.remote_field.model = "%s.%s" % (app_label, self.new_name)
                 new_fields.append((name, field))
             state.models[related_key].fields = new_fields
             state.reload_model(*related_key)
@@ -220,11 +220,11 @@ class RenameModel(Operation):
             fields = zip(old_model._meta.local_many_to_many, new_model._meta.local_many_to_many)
             for (old_field, new_field) in fields:
                 # Skip self-referential fields as these are renamed above.
-                if new_field.model == new_field.related_model or not new_field.rel.through._meta.auto_created:
+                if new_field.model == new_field.related_model or not new_field.remote_field.through._meta.auto_created:
                     continue
                 # Rename the M2M table that's based on this model's name.
-                old_m2m_model = old_field.rel.through
-                new_m2m_model = new_field.rel.through
+                old_m2m_model = old_field.remote_field.through
+                new_m2m_model = new_field.remote_field.through
                 schema_editor.alter_db_table(
                     new_m2m_model,
                     old_m2m_model._meta.db_table,
@@ -296,11 +296,11 @@ class AlterModelTable(Operation):
             )
             # Rename M2M fields whose name is based on this model's db_table
             for (old_field, new_field) in zip(old_model._meta.local_many_to_many, new_model._meta.local_many_to_many):
-                if new_field.rel.through._meta.auto_created:
+                if new_field.remote_field.through._meta.auto_created:
                     schema_editor.alter_db_table(
-                        new_field.rel.through,
-                        old_field.rel.through._meta.db_table,
-                        new_field.rel.through._meta.db_table,
+                        new_field.remote_field.through,
+                        old_field.remote_field.through._meta.db_table,
+                        new_field.remote_field.through._meta.db_table,
                     )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/optimizer.py
+++ b/django/db/migrations/optimizer.py
@@ -230,15 +230,15 @@ class MigrationOptimizer(object):
     def reduce_create_model_add_field(self, operation, other, in_between):
         if operation.name_lower == other.model_name_lower:
             # Don't allow optimizations of FKs through models they reference
-            if hasattr(other.field, "rel") and other.field.rel:
+            if hasattr(other.field, "remote_field") and other.field.remote_field:
                 for between in in_between:
                     # Check that it doesn't point to the model
-                    app_label, object_name = self.model_to_key(other.field.rel.to)
+                    app_label, object_name = self.model_to_key(other.field.remote_field.model)
                     if between.references_model(object_name, app_label):
                         return None
                     # Check that it's not through the model
-                    if getattr(other.field.rel, "through", None):
-                        app_label, object_name = self.model_to_key(other.field.rel.through)
+                    if getattr(other.field.remote_field, "through", None):
+                        app_label, object_name = self.model_to_key(other.field.remote_field.through)
                         if between.references_model(object_name, app_label):
                             return None
             # OK, that's fine

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -94,9 +94,9 @@ class ProjectState(object):
             model_state = self.models[(app_label, model_name)]
             for name, field in model_state.fields:
                 if field.is_relation:
-                    if field.rel.to == RECURSIVE_RELATIONSHIP_CONSTANT:
+                    if field.remote_field.model == RECURSIVE_RELATIONSHIP_CONSTANT:
                         continue
-                    rel_app_label, rel_model_name = _get_app_label_and_model_name(field.rel.to, app_label)
+                    rel_app_label, rel_model_name = _get_app_label_and_model_name(field.remote_field.model, app_label)
                     related_models.add((rel_app_label, rel_model_name.lower()))
 
             # Unregister all related models
@@ -328,7 +328,7 @@ class ModelState(object):
         # Deconstruct the fields
         fields = []
         for field in model._meta.local_fields:
-            if getattr(field, "rel", None) and exclude_rels:
+            if getattr(field, "remote_field", None) and exclude_rels:
                 continue
             if isinstance(field, OrderWrt):
                 continue

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -593,10 +593,10 @@ class Model(six.with_metaclass(ModelBase)):
                 continue
             setattr(self, field.attname, getattr(db_instance, field.attname))
             # Throw away stale foreign key references.
-            if field.rel and field.get_cache_name() in self.__dict__:
+            if field.is_relation and field.get_cache_name() in self.__dict__:
                 rel_instance = getattr(self, field.get_cache_name())
                 local_val = getattr(db_instance, field.attname)
-                related_val = None if rel_instance is None else getattr(rel_instance, field.related_field.attname)
+                related_val = None if rel_instance is None else getattr(rel_instance, field.target_field.attname)
                 if local_val != related_val:
                     del self.__dict__[field.get_cache_name()]
         self._state.db = db_instance._state.db

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -199,7 +199,7 @@ class ModelBase(type):
             # Locate OneToOneField instances.
             for field in base._meta.local_fields:
                 if isinstance(field, OneToOneField):
-                    parent_links[field.rel.to] = field
+                    parent_links[field.remote_field.model] = field
 
         # Do the appropriate setup for any model parents.
         for base in parents:
@@ -307,19 +307,19 @@ class ModelBase(type):
             # certain it has been created
             def make_foreign_order_accessors(field, model, cls):
                 setattr(
-                    field.rel.to,
+                    field.remote_field.model,
                     'get_%s_order' % cls.__name__.lower(),
                     curry(method_get_order, cls)
                 )
                 setattr(
-                    field.rel.to,
+                    field.remote_field.model,
                     'set_%s_order' % cls.__name__.lower(),
                     curry(method_set_order, cls)
                 )
             add_lazy_relation(
                 cls,
                 opts.order_with_respect_to,
-                opts.order_with_respect_to.rel.to,
+                opts.order_with_respect_to.remote_field.model,
                 make_foreign_order_accessors
             )
 
@@ -382,7 +382,7 @@ class Model(six.with_metaclass(ModelBase)):
                 setattr(self, field.attname, val)
                 kwargs.pop(field.name, None)
                 # Maintain compatibility with existing calls.
-                if isinstance(field.rel, ManyToOneRel):
+                if isinstance(field.remote_field, ManyToOneRel):
                     kwargs.pop(field.attname, None)
 
         # Now we're left with the unprocessed fields that *must* come from
@@ -399,7 +399,7 @@ class Model(six.with_metaclass(ModelBase)):
                 # This field will be populated on request.
                 continue
             if kwargs:
-                if isinstance(field.rel, ForeignObjectRel):
+                if isinstance(field.remote_field, ForeignObjectRel):
                     try:
                         # Assume object instance was passed in.
                         rel_obj = kwargs.pop(field.name)
@@ -879,7 +879,7 @@ class Model(six.with_metaclass(ModelBase)):
     def prepare_database_save(self, field):
         if self.pk is None:
             raise ValueError("Unsaved model instance %r cannot be used in an ORM query." % self)
-        return getattr(self, field.rel.field_name)
+        return getattr(self, field.remote_field.field_name)
 
     def clean(self):
         """
@@ -1238,20 +1238,20 @@ class Model(six.with_metaclass(ModelBase)):
         fields = cls._meta.local_many_to_many
 
         # Skip when the target model wasn't found.
-        fields = (f for f in fields if isinstance(f.rel.to, ModelBase))
+        fields = (f for f in fields if isinstance(f.remote_field.model, ModelBase))
 
         # Skip when the relationship model wasn't found.
-        fields = (f for f in fields if isinstance(f.rel.through, ModelBase))
+        fields = (f for f in fields if isinstance(f.remote_field.through, ModelBase))
 
         for f in fields:
-            signature = (f.rel.to, cls, f.rel.through)
+            signature = (f.remote_field.model, cls, f.remote_field.through)
             if signature in seen_intermediary_signatures:
                 errors.append(
                     checks.Error(
                         "The model has two many-to-many relations through "
                         "the intermediate model '%s.%s'." % (
-                            f.rel.through._meta.app_label,
-                            f.rel.through._meta.object_name
+                            f.remote_field.through._meta.app_label,
+                            f.remote_field.through._meta.object_name
                         ),
                         hint=None,
                         obj=cls,
@@ -1448,7 +1448,7 @@ class Model(six.with_metaclass(ModelBase)):
                     )
                 )
             else:
-                if isinstance(field.rel, models.ManyToManyRel):
+                if isinstance(field.remote_field, models.ManyToManyRel):
                     errors.append(
                         checks.Error(
                             "'%s' refers to a ManyToManyField '%s', but "
@@ -1595,7 +1595,7 @@ class Model(six.with_metaclass(ModelBase)):
         for f in cls._meta.local_many_to_many:
             # Check if auto-generated name for the M2M field is too long
             # for the database.
-            for m2m in f.rel.through._meta.local_fields:
+            for m2m in f.remote_field.through._meta.local_fields:
                 _, rel_name = m2m.get_attname_column()
                 if (m2m.db_column is None and rel_name is not None
                         and len(rel_name) > allowed_len):
@@ -1624,7 +1624,7 @@ class Model(six.with_metaclass(ModelBase)):
 def method_set_order(ordered_obj, self, id_list, using=None):
     if using is None:
         using = DEFAULT_DB_ALIAS
-    rel_val = getattr(self, ordered_obj._meta.order_with_respect_to.rel.field_name)
+    rel_val = getattr(self, ordered_obj._meta.order_with_respect_to.remote_field.field_name)
     order_name = ordered_obj._meta.order_with_respect_to.name
     # FIXME: It would be nice if there was an "update many" version of update
     # for situations like this.
@@ -1634,7 +1634,7 @@ def method_set_order(ordered_obj, self, id_list, using=None):
 
 
 def method_get_order(ordered_obj, self):
-    rel_val = getattr(self, ordered_obj._meta.order_with_respect_to.rel.field_name)
+    rel_val = getattr(self, ordered_obj._meta.order_with_respect_to.remote_field.field_name)
     order_name = ordered_obj._meta.order_with_respect_to.name
     pk_name = ordered_obj._meta.pk.name
     return [r[pk_name] for r in

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1343,6 +1343,16 @@ class ForeignObjectRel(object):
     def get_prep_lookup(self, lookup_name, value):
         return self.field.get_prep_lookup(lookup_name, value)
 
+    @cached_property
+    def target_field(self):
+        target_fields = self.get_path_info().target_fields
+        if len(target_fields) > 1:
+            raise RuntimeError("Multicolumn relations do not have a single target_field")
+        return target_fields[0]
+
+    def get_lookup(self, lookup_name):
+        return self.field.get_lookup(lookup_name)
+
     def get_internal_type(self):
         return self.field.get_internal_type()
 

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -15,6 +15,10 @@ from django.db.models.fields import (
     BLANK_CHOICE_DASH, AutoField, Field, IntegerField, PositiveIntegerField,
     PositiveSmallIntegerField,
 )
+from django.db.models.fields.related_lookups import (
+    RelatedExact, RelatedGreaterThan, RelatedGreaterThanOrEqual, RelatedIn,
+    RelatedLessThan, RelatedLessThanOrEqual,
+)
 from django.db.models.lookups import IsNull
 from django.db.models.query import QuerySet
 from django.db.models.query_utils import PathInfo
@@ -1336,6 +1340,16 @@ class ForeignObjectRel(object):
     def one_to_one(self):
         return self.field.one_to_one
 
+    def get_prep_lookup(self, lookup_name, value):
+        return self.field.get_prep_lookup(lookup_name, value)
+
+    def get_internal_type(self):
+        return self.field.get_internal_type()
+
+    @property
+    def db_type(self):
+        return self.field.db_type
+
     def __repr__(self):
         return '<%s: %s.%s>' % (
             type(self).__name__,
@@ -1760,67 +1774,25 @@ class ForeignObject(RelatedField):
         pathinfos = [PathInfo(from_opts, opts, (opts.pk,), self.rel, not self.unique, False)]
         return pathinfos
 
-    def get_lookup_constraint(self, constraint_class, alias, targets, sources, lookups,
-                              raw_value):
-        from django.db.models.sql.where import SubqueryConstraint, AND, OR
-        root_constraint = constraint_class()
-        assert len(targets) == len(sources)
-        if len(lookups) > 1:
-            raise exceptions.FieldError(
-                "Cannot resolve keyword %r into field. Choices are: %s" % (
-                    lookups[0],
-                    ", ".join(f.name for f in self.model._meta.get_fields()),
-                )
-            )
-        lookup_type = lookups[0]
+    def get_lookup(self, lookup_name):
+        if lookup_name == 'in':
+            return RelatedIn
+        elif lookup_name == 'exact':
+            return RelatedExact
+        elif lookup_name == 'gt':
+            return RelatedGreaterThan
+        elif lookup_name == 'gte':
+            return RelatedGreaterThanOrEqual
+        elif lookup_name == 'lt':
+            return RelatedLessThan
+        elif lookup_name == 'lte':
+            return RelatedLessThanOrEqual
+        elif lookup_name != 'isnull':
+            raise TypeError('Related Field got invalid lookup: %s' % lookup_name)
+        return super(ForeignObject, self).get_lookup(lookup_name)
 
-        def get_normalized_value(value):
-            from django.db.models import Model
-            if isinstance(value, Model):
-                value_list = []
-                for source in sources:
-                    # Account for one-to-one relations when sent a different model
-                    while not isinstance(value, source.model) and source.rel:
-                        source = source.rel.to._meta.get_field(source.rel.field_name)
-                    value_list.append(getattr(value, source.attname))
-                return tuple(value_list)
-            elif not isinstance(value, tuple):
-                return (value,)
-            return value
-
-        is_multicolumn = len(self.related_fields) > 1
-        if (hasattr(raw_value, '_as_sql') or
-                hasattr(raw_value, 'get_compiler')):
-            root_constraint.add(SubqueryConstraint(alias, [target.column for target in targets],
-                                                   [source.name for source in sources], raw_value),
-                                AND)
-        elif lookup_type == 'isnull':
-            root_constraint.add(IsNull(targets[0].get_col(alias, sources[0]), raw_value), AND)
-        elif (lookup_type == 'exact' or (lookup_type in ['gt', 'lt', 'gte', 'lte']
-                                         and not is_multicolumn)):
-            value = get_normalized_value(raw_value)
-            for target, source, val in zip(targets, sources, value):
-                lookup_class = target.get_lookup(lookup_type)
-                root_constraint.add(
-                    lookup_class(target.get_col(alias, source), val), AND)
-        elif lookup_type in ['range', 'in'] and not is_multicolumn:
-            values = [get_normalized_value(value) for value in raw_value]
-            value = [val[0] for val in values]
-            lookup_class = targets[0].get_lookup(lookup_type)
-            root_constraint.add(lookup_class(targets[0].get_col(alias, sources[0]), value), AND)
-        elif lookup_type == 'in':
-            values = [get_normalized_value(value) for value in raw_value]
-            root_constraint.connector = OR
-            for value in values:
-                value_constraint = constraint_class()
-                for source, target, val in zip(sources, targets, value):
-                    lookup_class = target.get_lookup('exact')
-                    lookup = lookup_class(target.get_col(alias, source), val)
-                    value_constraint.add(lookup, AND)
-                root_constraint.add(value_constraint, OR)
-        else:
-            raise TypeError('Related Field got invalid lookup: %s' % lookup_type)
-        return root_constraint
+    def get_transform(self, *args, **kwargs):
+        raise NotImplementedError('Relational fields do not support transforms')
 
     @property
     def attnames(self):
@@ -2016,6 +1988,9 @@ class ForeignKey(ForeignObject):
             return None
         else:
             return self.related_field.get_db_prep_save(value, connection=connection)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        return self.related_field.get_db_prep_value(value, connection, prepared)
 
     def value_to_string(self, obj):
         if not obj:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1083,7 +1083,7 @@ def create_many_related_manager(superclass, rel, reverse):
                     self.clear()
                     self.add(*objs)
                 else:
-                    old_ids = set(self.using(db).values_list(self.target_field.related_field.attname, flat=True))
+                    old_ids = set(self.using(db).values_list(self.target_field.target_field.attname, flat=True))
 
                     new_objs = []
                     for obj in objs:
@@ -1225,7 +1225,7 @@ def create_many_related_manager(superclass, rel, reverse):
                 target_model_qs = super(ManyRelatedManager, self).get_queryset()
                 if target_model_qs._has_filters():
                     old_vals = target_model_qs.using(db).filter(**{
-                        '%s__in' % self.target_field.related_field.attname: old_ids})
+                        '%s__in' % self.target_field.target_field.attname: old_ids})
                 else:
                     old_vals = old_ids
                 filters = self._build_remove_filters(old_vals)
@@ -1942,7 +1942,7 @@ class ForeignKey(ForeignObject):
         return name, path, args, kwargs
 
     @property
-    def related_field(self):
+    def target_field(self):
         return self.foreign_related_fields[0]
 
     def get_reverse_path_info(self):
@@ -1988,19 +1988,19 @@ class ForeignKey(ForeignObject):
         "Here we check if the default value is an object and return the to_field if so."
         field_default = super(ForeignKey, self).get_default()
         if isinstance(field_default, self.rel.to):
-            return getattr(field_default, self.related_field.attname)
+            return getattr(field_default, self.target_field.attname)
         return field_default
 
     def get_db_prep_save(self, value, connection):
         if value is None or (value == '' and
-                             (not self.related_field.empty_strings_allowed or
+                             (not self.target_field.empty_strings_allowed or
                               connection.features.interprets_empty_strings_as_nulls)):
             return None
         else:
-            return self.related_field.get_db_prep_save(value, connection=connection)
+            return self.target_field.get_db_prep_save(value, connection=connection)
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        return self.related_field.get_db_prep_value(value, connection, prepared)
+        return self.target_field.get_db_prep_value(value, connection, prepared)
 
     def value_to_string(self, obj):
         if not obj:
@@ -2040,7 +2040,7 @@ class ForeignKey(ForeignObject):
         # in which case the column type is simply that of an IntegerField.
         # If the database needs similar types for key fields however, the only
         # thing we can do is making AutoField an IntegerField.
-        rel_field = self.related_field
+        rel_field = self.target_field
         if (isinstance(rel_field, AutoField) or
                 (not connection.features.related_fields_match_type and
                 isinstance(rel_field, (PositiveIntegerField,
@@ -2063,7 +2063,7 @@ class ForeignKey(ForeignObject):
         return converters
 
     def get_col(self, alias, output_field=None):
-        return super(ForeignKey, self).get_col(alias, output_field or self.related_field)
+        return super(ForeignKey, self).get_col(alias, output_field or self.target_field)
 
 
 class OneToOneField(ForeignKey):

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -26,8 +26,8 @@ def get_normalized_value(value, lhs):
         # Account for one-to-one relations when sent a different model
         sources = lhs.output_field.get_path_info()[-1].target_fields
         for source in sources:
-            while not isinstance(value, source.model) and source.rel:
-                source = source.rel.to._meta.get_field(source.rel.field_name)
+            while not isinstance(value, source.model) and source.remote_field:
+                source = source.remote_field.model._meta.get_field(source.remote_field.field_name)
             value_list.append(getattr(value, source.attname))
         return tuple(value_list)
     if not isinstance(value, tuple):

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -1,0 +1,128 @@
+from django.db.models.lookups import (
+    Exact, GreaterThan, GreaterThanOrEqual, In, LessThan, LessThanOrEqual,
+)
+
+
+class MultiColSource(object):
+    contains_aggregate = False
+
+    def __init__(self, alias, targets, sources, field):
+        self.targets, self.sources, self.field, self.alias = targets, sources, field, alias
+        self.output_field = self.field
+
+    def __repr__(self):
+        return "{}({}, {})".format(
+            self.__class__.__name__, self.alias, self.field)
+
+    def relabeled_clone(self, relabels):
+        return self.__class__(relabels.get(self.alias, self.alias),
+                              self.targets, self.sources, self.field)
+
+
+def get_normalized_value(value, lhs):
+    from django.db.models import Model
+    if isinstance(value, Model):
+        value_list = []
+        # Account for one-to-one relations when sent a different model
+        sources = lhs.output_field.get_path_info()[-1].target_fields
+        for source in sources:
+            while not isinstance(value, source.model) and source.rel:
+                source = source.rel.to._meta.get_field(source.rel.field_name)
+            value_list.append(getattr(value, source.attname))
+        return tuple(value_list)
+    if not isinstance(value, tuple):
+        return (value,)
+    return value
+
+
+class RelatedIn(In):
+    def get_prep_lookup(self):
+        if not isinstance(self.lhs, MultiColSource) and self.rhs_is_direct_value():
+            # Note that if we get here, we are dealing with single-column relations
+            self.rhs = [get_normalized_value(val, self.lhs)[0] for val in self.rhs]
+            # We need to run the related field's get_prep_lookup(). Consider case
+            # ForeignKey to IntegerField given value 'abc'. The ForeignKey itself
+            # doesn't have validation for non-integers, so we must run validation
+            # using the target field.
+            if hasattr(self.lhs.output_field, 'get_path_info'):
+                # Run the target field's get_prep_lookup. We can safely assume there is
+                # only one as we don't get to the direct value branch otherwise.
+                self.rhs = self.lhs.output_field.get_path_info()[-1].target_fields[-1].get_prep_lookup(self.lookup_name, self.rhs)
+        return super(RelatedIn, self).get_prep_lookup()
+
+    def as_sql(self, compiler, connection):
+        if isinstance(self.lhs, MultiColSource):
+            # For multicolumn lookups we need to build a multicolumn where clause
+            # This clause is either a SubqueryConstraint (for values that need to be compiled to
+            # SQL), or a OR-combined list of (col1 = val1 AND col2 = val2 AND ...) clauses.
+            from django.db.models.sql.where import WhereNode, SubqueryConstraint, AND, OR
+
+            root_constraint = WhereNode(connector=OR)
+            if self.rhs_is_direct_value():
+                values = [get_normalized_value(value, self.lhs) for value in self.rhs]
+                for value in values:
+                    value_constraint = WhereNode()
+                    for source, target, val in zip(self.lhs.sources, self.lhs.targets, value):
+                        lookup_class = target.get_lookup('exact')
+                        lookup = lookup_class(target.get_col(self.lhs.alias, source), val)
+                        value_constraint.add(lookup, AND)
+                    root_constraint.add(value_constraint, OR)
+            else:
+                root_constraint.add(
+                    SubqueryConstraint(
+                        self.lhs.alias, [target.column for target in self.lhs.targets],
+                        [source.name for source in self.lhs.sources], self.rhs),
+                    AND)
+            return root_constraint.as_sql(compiler, connection)
+        else:
+            return super(RelatedIn, self).as_sql(compiler, connection)
+
+
+class RelatedLookupMixin(object):
+    def get_prep_lookup(self):
+        if not isinstance(self.lhs, MultiColSource) and self.rhs_is_direct_value():
+            # Note that if we get here, we are dealing with single-column relations
+            self.rhs = get_normalized_value(self.rhs, self.lhs)[0]
+            # We need to run the related field's get_prep_lookup(). Consider case
+            # ForeignKey to IntegerField given value 'abc'. The ForeignKey itself
+            # doesn't have validation for non-integers, so we must run validation
+            # using the target field.
+            if hasattr(self.lhs.output_field, 'get_path_info'):
+                # Get the target field. We can safely assume there is only one
+                # as we don't get to the direct value branch otherwise.
+                self.rhs = self.lhs.output_field.get_path_info()[-1].target_fields[-1].get_prep_lookup(self.lookup_name, self.rhs)
+
+        return super(RelatedLookupMixin, self).get_prep_lookup()
+
+    def as_sql(self, compiler, connection):
+        if isinstance(self.lhs, MultiColSource):
+            assert self.rhs_is_direct_value()
+            self.rhs = get_normalized_value(self.rhs, self.lhs)
+            from django.db.models.sql.where import WhereNode, AND
+            root_constraint = WhereNode()
+            for target, source, val in zip(self.lhs.targets, self.lhs.sources, self.rhs):
+                lookup_class = target.get_lookup(self.lookup_name)
+                root_constraint.add(
+                    lookup_class(target.get_col(self.lhs.alias, source), val), AND)
+            return root_constraint.as_sql(compiler, connection)
+        return super(RelatedLookupMixin, self).as_sql(compiler, connection)
+
+
+class RelatedExact(RelatedLookupMixin, Exact):
+    pass
+
+
+class RelatedLessThan(RelatedLookupMixin, LessThan):
+    pass
+
+
+class RelatedGreaterThan(RelatedLookupMixin, GreaterThan):
+    pass
+
+
+class RelatedGreaterThanOrEqual(RelatedLookupMixin, GreaterThanOrEqual):
+    pass
+
+
+class RelatedLessThanOrEqual(RelatedLookupMixin, LessThanOrEqual):
+    pass

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1645,12 +1645,12 @@ class RelatedPopulator(object):
         reverse = klass_info['reverse']
         self.reverse_cache_name = None
         if reverse:
-            self.cache_name = field.rel.get_cache_name()
+            self.cache_name = field.remote_field.get_cache_name()
             self.reverse_cache_name = field.get_cache_name()
         else:
             self.cache_name = field.get_cache_name()
             if field.unique:
-                self.reverse_cache_name = field.rel.get_cache_name()
+                self.reverse_cache_name = field.remote_field.get_cache_name()
 
     def get_deferred_cls(self, klass_info, init_list):
         model_cls = klass_info['model']

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -260,3 +260,11 @@ def refs_aggregate(lookup_parts, aggregates):
         if level_n_lookup in aggregates and aggregates[level_n_lookup].contains_aggregate:
             return aggregates[level_n_lookup], lookup_parts[n:]
     return False, ()
+
+
+def refs_expression(lookup_parts, annotations):
+    for n in range(len(lookup_parts) + 1):
+        level_n_lookup = LOOKUP_SEP.join(lookup_parts[0:n])
+        if level_n_lookup in annotations and annotations[level_n_lookup]:
+            return annotations[level_n_lookup], lookup_parts[n:]
+    return False, ()

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -181,9 +181,9 @@ def select_related_descend(field, restricted, requested, load_fields, reverse=Fa
      * load_fields - the set of fields to be loaded on this model
      * reverse - boolean, True if we are checking a reverse select related
     """
-    if not field.rel:
+    if not field.remote_field:
         return False
-    if field.rel.parent_link and not reverse:
+    if field.remote_field.parent_link and not reverse:
         return False
     if restricted:
         if reverse and field.related_query_name() not in requested:
@@ -250,7 +250,7 @@ deferred_class_factory.__safe_for_unpickling__ = True
 
 def refs_aggregate(lookup_parts, aggregates):
     """
-    A little helper method to check if the lookup_parts contains references
+    A helper method to check if the lookup_parts contains references
     to the given aggregates set. Because the LOOKUP_SEP is contained in the
     default annotation names we must check each prefix of the lookup_parts
     for a match.
@@ -263,6 +263,12 @@ def refs_aggregate(lookup_parts, aggregates):
 
 
 def refs_expression(lookup_parts, annotations):
+    """
+    A little helper method to check if the lookup_parts contains references
+    to the given annotations set. Because the LOOKUP_SEP is contained in the
+    default annotation names we must check each prefix of the lookup_parts
+    for a match.
+    """
     for n in range(len(lookup_parts) + 1):
         level_n_lookup = LOOKUP_SEP.join(lookup_parts[0:n])
         if level_n_lookup in annotations and annotations[level_n_lookup]:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -542,7 +542,9 @@ class SQLCompiler(object):
         name, order = get_order_dir(name, default_order)
         descending = True if order == 'DESC' else False
         pieces = name.split(LOOKUP_SEP)
-        field, targets, alias, joins, path, opts = self._setup_joins(pieces, opts, alias)
+        field, targets, alias, joins, path, opts = self._setup_joins(
+            pieces, opts, alias,
+        )
 
         # If we get to this point and the field is a relation to another model,
         # append the default ordering for that model unless the attribute name

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -549,7 +549,7 @@ class SQLCompiler(object):
         # If we get to this point and the field is a relation to another model,
         # append the default ordering for that model unless the attribute name
         # of the field is specified.
-        if field.rel and path and opts.ordering and name != field.attname:
+        if field.is_relation and path and opts.ordering and name != field.attname:
             # Firstly, avoid infinite loops.
             if not already_seen:
                 already_seen = set()

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -678,7 +678,7 @@ class SQLCompiler(object):
                                           only_load.get(field_model)):
                 continue
             klass_info = {
-                'model': f.rel.to,
+                'model': f.remote_field.model,
                 'field': f,
                 'reverse': False,
                 'from_parent': False,
@@ -688,13 +688,13 @@ class SQLCompiler(object):
             _, _, _, joins, _ = self.query.setup_joins(
                 [f.name], opts, root_alias)
             alias = joins[-1]
-            columns = self.get_default_columns(start_alias=alias, opts=f.rel.to._meta)
+            columns = self.get_default_columns(start_alias=alias, opts=f.remote_field.model._meta)
             for col in columns:
                 select_fields.append(len(select))
                 select.append((col, None))
             klass_info['select_fields'] = select_fields
             next_klass_infos = self.get_related_selections(
-                select, f.rel.to._meta, alias, cur_depth + 1, next, restricted)
+                select, f.remote_field.model._meta, alias, cur_depth + 1, next, restricted)
             get_related_klass_infos(klass_info, next_klass_infos)
 
         if restricted:
@@ -1005,7 +1005,7 @@ class SQLUpdateCompiler(SQLCompiler):
                 if val.contains_aggregate:
                     raise FieldError("Aggregate functions are not allowed in this query")
             elif hasattr(val, 'prepare_database_save'):
-                if field.rel:
+                if field.remote_field:
                     val = val.prepare_database_save(field)
                 else:
                     raise TypeError("Database is trying to update a relational field "

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -608,7 +608,7 @@ class Query(object):
                 if is_reverse_o2o(source):
                     cur_model = source.related_model
                 else:
-                    cur_model = source.rel.to
+                    cur_model = source.remote_field.model
                 opts = cur_model._meta
                 # Even if we're "just passing through" this model, we must add
                 # both the current model's pk and the related reference field
@@ -1303,7 +1303,7 @@ class Query(object):
                         opts = int_model._meta
                     else:
                         final_field = opts.parents[int_model]
-                        targets = (final_field.rel.get_related_field(),)
+                        targets = (final_field.remote_field.get_related_field(),)
                         opts = int_model._meta
                         path.append(PathInfo(final_field.model._meta, opts, targets, final_field, False, True))
                         cur_names_with_path[1].append(

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1038,7 +1038,7 @@ class Query(object):
         """
         Checks the type of object passed to query relations.
         """
-        if field.rel:
+        if field.is_relation:
             # QuerySets implement is_compatible_query_object_type() to
             # determine compatibility with the given field.
             if hasattr(value, 'is_compatible_query_object_type'):
@@ -1164,16 +1164,10 @@ class Query(object):
             # No support for transforms for relational fields
             assert len(lookups) == 1
             lookup_class = field.get_lookup(lookups[0])
-            # Undo the changes done in setup_joins() if hasattr(final_field, 'field') branch
-            # This hack is needed as long as the field.rel isn't like a real field.
-            if field.get_path_info()[-1].target_fields != sources:
-                target_field = field.rel
-            else:
-                target_field = field
             if len(targets) == 1:
-                lhs = targets[0].get_col(alias, target_field)
+                lhs = targets[0].get_col(alias, field)
             else:
-                lhs = MultiColSource(alias, targets, sources, target_field)
+                lhs = MultiColSource(alias, targets, sources, field)
             condition = lookup_class(lhs, value)
             lookup_type = lookup_class.lookup_name
         else:
@@ -1384,8 +1378,6 @@ class Query(object):
             reuse = can_reuse if join.m2m else None
             alias = self.join(connection, reuse=reuse)
             joins.append(alias)
-        if hasattr(final_field, 'field'):
-            final_field = final_field.field
         return final_field, targets, opts, joins, path
 
     def trim_joins(self, targets, joins, path):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -26,6 +26,11 @@ details on these changes.
   compatibility layer which allows absolute URLs to be considered equal to
   relative ones when the path is identical will also be removed.
 
+* ``Field.rel`` will be removed. Use ``Field.remote_field`` instead.
+
+* ``Field.remote_field.to`` attribute will be removed. Use the
+  ``model`` attribute instead.
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -348,6 +348,15 @@ versions:
 Its parsing caused bugs with the current syntax, so support for the old syntax
 will be removed in Django 2.0 following an accelerated deprecation.
 
+``Field.rel`` changes
+~~~~~~~~~~~~~~~~~~~~~
+
+``Field.rel`` and its methods and attributes are changed to match related fields
+API. ``Field.rel`` is renamed to ``remote_field``, and many of its methods and
+attributes are either changed or renamed.
+
+The aim of these changes is to provide a documented API for relation fields.
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -437,7 +437,7 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
         band.album_set.create(
             name='Hybrid Theory', cover_art=r'albums\hybrid_theory.jpg'
         )
-        rel = models.Album._meta.get_field('band').rel
+        rel = models.Album._meta.get_field('band').remote_field
 
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
@@ -456,7 +456,7 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
         core = models.Inventory.objects.create(
             barcode=87, name='Core', parent=apple
         )
-        rel = models.Inventory._meta.get_field('parent').rel
+        rel = models.Inventory._meta.get_field('parent').remote_field
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('test', core.parent_id, attrs={}), (
@@ -471,7 +471,7 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
         # have no magnifying glass link. See #16542
         big_honeycomb = models.Honeycomb.objects.create(location='Old tree')
         big_honeycomb.bee_set.create()
-        rel = models.Bee._meta.get_field('honeycomb').rel
+        rel = models.Bee._meta.get_field('honeycomb').remote_field
 
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
@@ -484,7 +484,7 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
         # no magnifying glass link. See #16542
         subject1 = models.Individual.objects.create(name='Subject #1')
         models.Individual.objects.create(name='Child', parent=subject1)
-        rel = models.Individual._meta.get_field('parent').rel
+        rel = models.Individual._meta.get_field('parent').remote_field
 
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
@@ -494,7 +494,7 @@ class ForeignKeyRawIdWidgetTest(DjangoTestCase):
 
     def test_proper_manager_for_label_lookup(self):
         # see #9258
-        rel = models.Inventory._meta.get_field('parent').rel
+        rel = models.Inventory._meta.get_field('parent').remote_field
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
 
         hidden = models.Inventory.objects.create(
@@ -521,7 +521,7 @@ class ManyToManyRawIdWidgetTest(DjangoTestCase):
         m1 = models.Member.objects.create(name='Chester')
         m2 = models.Member.objects.create(name='Mike')
         band.members.add(m1, m2)
-        rel = models.Band._meta.get_field('members').rel
+        rel = models.Band._meta.get_field('members').remote_field
 
         w = widgets.ManyToManyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
@@ -546,7 +546,7 @@ class ManyToManyRawIdWidgetTest(DjangoTestCase):
         c1 = models.Company.objects.create(name='Doodle')
         c2 = models.Company.objects.create(name='Pear')
         consultor1.companies.add(c1, c2)
-        rel = models.Advisor._meta.get_field('companies').rel
+        rel = models.Advisor._meta.get_field('companies').remote_field
 
         w = widgets.ManyToManyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
@@ -562,14 +562,14 @@ class ManyToManyRawIdWidgetTest(DjangoTestCase):
 
 class RelatedFieldWidgetWrapperTests(DjangoTestCase):
     def test_no_can_add_related(self):
-        rel = models.Individual._meta.get_field('parent').rel
+        rel = models.Individual._meta.get_field('parent').remote_field
         w = widgets.AdminRadioSelect()
         # Used to fail with a name error.
         w = widgets.RelatedFieldWidgetWrapper(w, rel, widget_admin_site)
         self.assertFalse(w.can_add_related)
 
     def test_select_multiple_widget_cant_change_delete_related(self):
-        rel = models.Individual._meta.get_field('parent').rel
+        rel = models.Individual._meta.get_field('parent').remote_field
         widget = forms.SelectMultiple()
         wrapper = widgets.RelatedFieldWidgetWrapper(
             widget, rel, widget_admin_site,
@@ -582,7 +582,7 @@ class RelatedFieldWidgetWrapperTests(DjangoTestCase):
         self.assertFalse(wrapper.can_delete_related)
 
     def test_on_delete_cascade_rel_cant_delete_related(self):
-        rel = models.Individual._meta.get_field('soulmate').rel
+        rel = models.Individual._meta.get_field('soulmate').remote_field
         widget = forms.Select()
         wrapper = widgets.RelatedFieldWidgetWrapper(
             widget, rel, widget_admin_site,

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -1058,7 +1058,7 @@ class DBConstraintTestCase(TestCase):
         self.assertEqual(models.Object.objects.count(), 2)
         self.assertEqual(obj.related_objects.count(), 1)
 
-        intermediary_model = models.Object._meta.get_field("related_objects").rel.through
+        intermediary_model = models.Object._meta.get_field("related_objects").remote_field.through
         intermediary_model.objects.create(from_object_id=obj.id, to_object_id=12345)
         self.assertEqual(obj.related_objects.count(), 1)
         self.assertEqual(intermediary_model.objects.count(), 2)

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -766,5 +766,5 @@ class TestRelatedObjectDeprecation(TestCase):
             self.assertEqual(len(warns), 1)
             self.assertEqual(
                 str(warns.pop().message),
-                'Usage of field.related has been deprecated. Use field.rel instead.'
+                'Usage of field.related has been deprecated. Use field.remote_field instead.'
             )

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -153,7 +153,7 @@ class DeletionTests(TestCase):
         r = R.objects.create()
         m.m2m.add(r)
         r.delete()
-        through = M._meta.get_field('m2m').rel.through
+        through = M._meta.get_field('m2m').remote_field.through
         self.assertFalse(through.objects.exists())
 
         r = R.objects.create()

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -178,8 +178,8 @@ class FieldDeconstructionTests(TestCase):
         # Test basic pointing
         from django.contrib.auth.models import Permission
         field = models.ForeignKey("auth.Permission")
-        field.rel.to = Permission
-        field.rel.field_name = "id"
+        field.remote_field.model = Permission
+        field.remote_field.field_name = "id"
         name, path, args, kwargs = field.deconstruct()
         self.assertEqual(path, "django.db.models.ForeignKey")
         self.assertEqual(args, [])

--- a/tests/foreign_object/models.py
+++ b/tests/foreign_object/models.py
@@ -109,7 +109,7 @@ class ArticleTranslationDescriptor(ReverseSingleRelatedObjectDescriptor):
         if instance is None:
             raise AttributeError("%s must be accessed via instance" % self.field.name)
         setattr(instance, self.cache_name, value)
-        if value is not None and not self.field.rel.multiple:
+        if value is not None and not self.field.remote_field.multiple:
             setattr(value, self.field.related.get_cache_name(), instance)
 
 

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -144,22 +144,26 @@ class GenericRelationTests(TestCase):
         tag.save()
 
     def test_ticket_20378(self):
+        # Create a couple of extra HasLinkThing so that the autopk value
+        # isn't the same for Link and HasLinkThing.
         hs1 = HasLinkThing.objects.create()
         hs2 = HasLinkThing.objects.create()
-        l1 = Link.objects.create(content_object=hs1)
-        l2 = Link.objects.create(content_object=hs2)
+        hs3 = HasLinkThing.objects.create()
+        hs4 = HasLinkThing.objects.create()
+        l1 = Link.objects.create(content_object=hs3)
+        l2 = Link.objects.create(content_object=hs4)
         self.assertQuerysetEqual(
             HasLinkThing.objects.filter(links=l1),
-            [hs1], lambda x: x)
+            [hs3], lambda x: x)
         self.assertQuerysetEqual(
             HasLinkThing.objects.filter(links=l2),
-            [hs2], lambda x: x)
+            [hs4], lambda x: x)
         self.assertQuerysetEqual(
             HasLinkThing.objects.exclude(links=l2),
-            [hs1], lambda x: x)
+            [hs1, hs2, hs3], lambda x: x, ordered=False)
         self.assertQuerysetEqual(
             HasLinkThing.objects.exclude(links=l1),
-            [hs2], lambda x: x)
+            [hs1, hs2, hs4], lambda x: x, ordered=False)
 
     def test_ticket_20564(self):
         b1 = B.objects.create()

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -65,7 +65,7 @@ class RelativeFieldTests(IsolatedModelsTestCase):
             name = models.CharField(max_length=20)
 
         class ModelM2M(models.Model):
-            m2m = models.ManyToManyField(Model, null=True, validators=[''])
+            m2m = models.ManyToManyField(Model, null=False, validators=[''])
 
         errors = ModelM2M.check()
         field = ModelM2M._meta.get_field('m2m')

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -565,12 +565,12 @@ class ManyToOneTests(TestCase):
         p = Parent()
         with self.assertRaisesMessage(ValueError,
                 'Cannot assign "%r": "%s" instance isn\'t saved in the database.'
-                % (p, Child.parent.field.rel.to._meta.object_name)):
+                % (p, Child.parent.field.remote_field.model._meta.object_name)):
             Child(parent=p)
 
         with self.assertRaisesMessage(ValueError,
                 'Cannot assign "%r": "%s" instance isn\'t saved in the database.'
-                % (p, Child.parent.field.rel.to._meta.object_name)):
+                % (p, Child.parent.field.remote_field.model._meta.object_name)):
             ToFieldChild(parent=p)
 
         # Creation using attname keyword argument and an id will cause the
@@ -610,7 +610,7 @@ class ManyToOneTests(TestCase):
         # Regression for #12190 -- Should be able to instantiate a FK outside
         # of a model, and interrogate its related field.
         cat = models.ForeignKey(Category)
-        self.assertEqual('id', cat.rel.get_related_field().name)
+        self.assertEqual('id', cat.remote_field.get_related_field().name)
 
     def test_relation_unsaved(self):
         # Test that the <field>_set manager does not join on Null value fields (#17541)

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1068,7 +1068,7 @@ class AutodetectorTests(TestCase):
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # The field name the FK on the book model points to
-        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].rel.field_name, 'id')
+        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].remote_field.field_name, 'id')
 
         # Now, we test the custom pk field name
         before = self.make_project_state([])
@@ -1076,7 +1076,7 @@ class AutodetectorTests(TestCase):
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # The field name the FK on the book model points to
-        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].rel.field_name, 'pk_field')
+        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].remote_field.field_name, 'pk_field')
 
     def test_unmanaged_create(self):
         """Tests that the autodetector correctly deals with managed models."""
@@ -1126,7 +1126,7 @@ class AutodetectorTests(TestCase):
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # The field name the FK on the book model points to
-        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].rel.field_name, 'id')
+        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].remote_field.field_name, 'id')
 
         # Now, we test the custom pk field name
         before = self.make_project_state([])
@@ -1134,7 +1134,7 @@ class AutodetectorTests(TestCase):
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # The field name the FK on the book model points to
-        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].rel.field_name, 'pk_field')
+        self.assertEqual(changes['otherapp'][0].operations[0].fields[2][1].remote_field.field_name, 'pk_field')
 
     @override_settings(AUTH_USER_MODEL="thirdapp.CustomUser")
     def test_swappable(self):
@@ -1159,7 +1159,7 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
         self.assertOperationAttributes(changes, 'testapp', 0, 0, model_name="author", name='user')
         fk_field = changes['testapp'][0].operations[0].field
-        to_model = '%s.%s' % (fk_field.rel.to._meta.app_label, fk_field.rel.to._meta.object_name)
+        to_model = '%s.%s' % (fk_field.remote_field.model._meta.app_label, fk_field.remote_field.model._meta.object_name)
         self.assertEqual(to_model, 'thirdapp.CustomUser')
 
     def test_add_field_with_default(self):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -479,7 +479,7 @@ class OperationTests(OperationTestBase):
         self.assertNotIn(("test_rnmo", "pony"), new_state.models)
         self.assertIn(("test_rnmo", "horse"), new_state.models)
         # RenameModel also repoints all incoming FKs and M2Ms
-        self.assertEqual("test_rnmo.Horse", new_state.models["test_rnmo", "rider"].fields[1][1].rel.to)
+        self.assertEqual("test_rnmo.Horse", new_state.models["test_rnmo", "rider"].fields[1][1].remote_field.model)
         self.assertTableNotExists("test_rnmo_pony")
         self.assertTableExists("test_rnmo_horse")
         if connection.features.supports_foreign_keys:
@@ -490,7 +490,7 @@ class OperationTests(OperationTestBase):
         # Test original state and database
         self.assertIn(("test_rnmo", "pony"), original_state.models)
         self.assertNotIn(("test_rnmo", "horse"), original_state.models)
-        self.assertEqual("Pony", original_state.models["test_rnmo", "rider"].fields[1][1].rel.to)
+        self.assertEqual("Pony", original_state.models["test_rnmo", "rider"].fields[1][1].remote_field.model)
         self.assertTableExists("test_rnmo_pony")
         self.assertTableNotExists("test_rnmo_horse")
         if connection.features.supports_foreign_keys:
@@ -515,7 +515,7 @@ class OperationTests(OperationTestBase):
         self.assertNotIn(("test_rmwsrf", "rider"), new_state.models)
         self.assertIn(("test_rmwsrf", "horserider"), new_state.models)
         # Remember, RenameModel also repoints all incoming FKs and M2Ms
-        self.assertEqual("test_rmwsrf.HorseRider", new_state.models["test_rmwsrf", "horserider"].fields[2][1].rel.to)
+        self.assertEqual("test_rmwsrf.HorseRider", new_state.models["test_rmwsrf", "horserider"].fields[2][1].remote_field.model)
         # Test the database alteration
         self.assertTableExists("test_rmwsrf_rider")
         self.assertTableNotExists("test_rmwsrf_horserider")
@@ -553,8 +553,8 @@ class OperationTests(OperationTestBase):
         self.assertIn(("test_rmwsc", "littlehorse"), new_state.models)
         # RenameModel shouldn't repoint the superclass's relations, only local ones
         self.assertEqual(
-            project_state.models["test_rmwsc", "rider"].fields[1][1].rel.to,
-            new_state.models["test_rmwsc", "rider"].fields[1][1].rel.to
+            project_state.models["test_rmwsc", "rider"].fields[1][1].remote_field.model,
+            new_state.models["test_rmwsc", "rider"].fields[1][1].remote_field.model
         )
         # Before running the migration we have a table for Shetland Pony, not Little Horse
         self.assertTableExists("test_rmwsc_shetlandpony")
@@ -612,7 +612,7 @@ class OperationTests(OperationTestBase):
         pony.riders.add(rider)
         self.assertEqual(Pony.objects.count(), 2)
         self.assertEqual(Rider.objects.count(), 2)
-        self.assertEqual(Pony._meta.get_field('riders').rel.through.objects.count(), 2)
+        self.assertEqual(Pony._meta.get_field('riders').remote_field.through.objects.count(), 2)
 
     def test_add_field(self):
         """

--- a/tests/model_fields/test_field_flags.py
+++ b/tests/model_fields/test_field_flags.py
@@ -155,7 +155,7 @@ class FieldFlagsTests(test.TestCase):
 
         # Ensure all m2m reverses are m2m
         for field in m2m_type_fields:
-            reverse_field = field.rel
+            reverse_field = field.remote_field
             self.assertTrue(reverse_field.is_relation)
             self.assertTrue(reverse_field.many_to_many)
             self.assertTrue(reverse_field.related_model)
@@ -171,7 +171,7 @@ class FieldFlagsTests(test.TestCase):
         # Ensure all o2m reverses are m2o
         for field in o2m_type_fields:
             if field.concrete:
-                reverse_field = field.rel
+                reverse_field = field.remote_field
                 self.assertTrue(reverse_field.is_relation and reverse_field.many_to_one)
 
     def test_cardinality_m2o(self):
@@ -213,6 +213,6 @@ class FieldFlagsTests(test.TestCase):
         for field in AllFieldsModel._meta.get_fields():
             is_concrete_forward_field = field.concrete and field.related_model
             if is_concrete_forward_field:
-                reverse_field = field.rel
+                reverse_field = field.remote_field
                 self.assertEqual(field.model, reverse_field.related_model)
                 self.assertEqual(field.related_model, reverse_field.model)

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -199,7 +199,7 @@ class ForeignKeyTests(test.TestCase):
         self.assertEqual(warnings, expected_warnings)
 
     def test_related_name_converted_to_text(self):
-        rel_name = Bar._meta.get_field('a').rel.related_name
+        rel_name = Bar._meta.get_field('a').remote_field.related_name
         self.assertIsInstance(rel_name, six.text_type)
 
     def test_abstract_model_pending_lookups(self):

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -226,7 +226,7 @@ class RelationTreeTests(TestCase):
         # Testing non hidden related objects
         self.assertEqual(
             sorted([field.related_query_name() for field in Relation._meta._relation_tree
-                   if not field.rel.field.rel.is_hidden()]),
+                   if not field.remote_field.field.remote_field.is_hidden()]),
             sorted([
                 'fk_abstract_rel', 'fk_base_rel', 'fk_concrete_rel', 'fo_abstract_rel',
                 'fo_base_rel', 'fo_concrete_rel', 'm2m_abstract_rel',

--- a/tests/model_options/models/tablespaces.py
+++ b/tests/model_options/models/tablespaces.py
@@ -42,8 +42,8 @@ class Article(models.Model):
 
 # Also set the tables for automatically created models
 
-Authors = Article._meta.get_field('authors').rel.through
+Authors = Article._meta.get_field('authors').remote_field.through
 Authors._meta.db_table = 'model_options_articleref_authors'
 
-Reviewers = Article._meta.get_field('reviewers').rel.through
+Reviewers = Article._meta.get_field('reviewers').remote_field.through
 Reviewers._meta.db_table = 'model_options_articleref_reviewers'

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -136,7 +136,7 @@ class OneToOneTests(TestCase):
         place = Place(name='User', address='London')
         with self.assertRaisesMessage(ValueError,
                             'Cannot assign "%r": "%s" instance isn\'t saved in the database.'
-                            % (place, Restaurant.place.field.rel.to._meta.object_name)):
+                            % (place, Restaurant.place.field.remote_field.model._meta.object_name)):
             Restaurant.objects.create(place=place, serves_hot_dogs=True, serves_pizza=False)
         bar = UndergroundBar()
         p = Place(name='User', address='London')
@@ -410,7 +410,7 @@ class OneToOneTests(TestCase):
         be added to the related model.
         """
         self.assertFalse(
-            hasattr(Target, HiddenPointer._meta.get_field('target').rel.get_accessor_name())
+            hasattr(Target, HiddenPointer._meta.get_field('target').remote_field.get_accessor_name())
         )
 
     def test_related_object(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -3678,3 +3678,11 @@ class TestTicket24279(TestCase):
         School.objects.create()
         qs = School.objects.filter(Q(pk__in=()) | Q())
         self.assertQuerysetEqual(qs, [])
+
+
+class TestInvalidValuesRelation(TestCase):
+    def test_invalid_values(self):
+        with self.assertRaises(ValueError):
+            Annotation.objects.filter(tag='abc')
+        with self.assertRaises(ValueError):
+            Annotation.objects.filter(tag__in=[123, 'abc'])

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -82,7 +82,7 @@ class PickleabilityTestCase(TestCase):
         m1 = M2MModel.objects.create()
         g1 = Group.objects.create(name='foof')
         m1.groups.add(g1)
-        m2m_through = M2MModel._meta.get_field('groups').rel.through
+        m2m_through = M2MModel._meta.get_field('groups').remote_field.through
         original = m2m_through.objects.get()
         dumped = pickle.dumps(original)
         reloaded = pickle.loads(dumped)

--- a/tests/schema/fields.py
+++ b/tests/schema/fields.py
@@ -35,12 +35,12 @@ class CustomManyToManyField(RelatedField):
         super(CustomManyToManyField, self).__init__(**kwargs)
 
     def contribute_to_class(self, cls, name, **kwargs):
-        if self.rel.symmetrical and (self.rel.to == "self" or self.rel.to == cls._meta.object_name):
-            self.rel.related_name = "%s_rel_+" % name
+        if self.remote_field.symmetrical and (self.remote_field.model == "self" or self.remote_field.model == cls._meta.object_name):
+            self.remote_field.related_name = "%s_rel_+" % name
         super(CustomManyToManyField, self).contribute_to_class(cls, name, **kwargs)
-        if not self.rel.through and not cls._meta.abstract and not cls._meta.swapped:
-            self.rel.through = create_many_to_many_intermediary_model(self, cls)
-        setattr(cls, self.name, ManyRelatedObjectsDescriptor(self.rel))
+        if not self.remote_field.through and not cls._meta.abstract and not cls._meta.swapped:
+            self.remote_field.through = create_many_to_many_intermediary_model(self, cls)
+        setattr(cls, self.name, ManyRelatedObjectsDescriptor(self.remote_field))
         self.m2m_db_table = curry(self._get_m2m_db_table, cls._meta)
 
     def get_internal_type(self):


### PR DESCRIPTION
Start making Rel objects like real field instances. First steps are:
  - Some attribute and method changes on Rel objects
  - Introduce remote_field, the idea is that self.remote_field.remote_field == self
  - Deprecate field.rel

The reason why I introduced remote_field and deprecated rel is that currently hasattr(field.rel, 'rel') is False, and there exists code that relies on this. After the change, field.remote_field.remote_field == field, that is the Rel object has remote_field just like other relational fields.

The changes cascade to all sorts of smaller and bigger fixes in Django. Most notably some badly bit-rotted code in Admin was refactored.

I'd like to get this included in Django as soon as possible. This patch changes lines all over Django, and I'm afraid this one will get a lot of rebase conflicts if left to linger.

Refs #23417