### PR TITLE
Fixed #20488 -- Added copy and move methods to the storage API

### DIFF
--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -1,0 +1,43 @@
+"""
+Copy a file in the safest way possible::
+
+    >>> from django.core.files.copy import file_copy_safe
+    >>> file_copy_safe("/tmp/old_file", "/tmp/new_file")
+"""
+
+import os
+from shutil import copystat
+
+from django.core.files import locks
+
+
+__all__ = ['file_copy_safe']
+
+
+def file_copy_safe(old_file_name, new_file_name, chunk_size=1024 * 64,
+                   allow_overwrite=False):
+    """
+    Copy a file from one location to another in the safest way possible.
+
+    If the destination file exists and ``allow_overwrite`` is ``False``, this
+    function will throw an ``IOError``.
+    """
+    # first open the old file, so that it won't go away
+    with open(old_file_name, 'rb') as old_file:
+        # now open the new file, not forgetting allow_overwrite
+        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT |
+                     getattr(os, 'O_BINARY', 0) |
+                     (not allow_overwrite and os.O_EXCL or 0))
+        try:
+            locks.lock(fd, locks.LOCK_EX)
+            current_chunk = None
+            while current_chunk != b'':
+                current_chunk = old_file.read(chunk_size)
+                os.write(fd, current_chunk)
+        except OSError:
+            os.remove(new_file_name)
+            raise
+        finally:
+            locks.unlock(fd)
+            os.close(fd)
+    copystat(old_file_name, new_file_name)

--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -10,7 +10,6 @@ from shutil import copystat
 
 from django.core.files import locks
 
-
 __all__ = ['file_copy_safe']
 
 

--- a/django/core/files/move.py
+++ b/django/core/files/move.py
@@ -6,9 +6,8 @@ Move a file in the safest way possible::
 """
 
 import os
-from shutil import copystat
 
-from django.core.files import locks
+from django.core.files.copy import file_copy_safe
 
 __all__ = ['file_move_safe']
 
@@ -53,21 +52,7 @@ def file_move_safe(old_file_name, new_file_name, chunk_size=1024 * 64, allow_ove
         # or when moving opened files on certain operating systems
         pass
 
-    # first open the old file, so that it won't go away
-    with open(old_file_name, 'rb') as old_file:
-        # now open the new file, not forgetting allow_overwrite
-        fd = os.open(new_file_name, (os.O_WRONLY | os.O_CREAT | getattr(os, 'O_BINARY', 0) |
-                                     (os.O_EXCL if not allow_overwrite else 0)))
-        try:
-            locks.lock(fd, locks.LOCK_EX)
-            current_chunk = None
-            while current_chunk != b'':
-                current_chunk = old_file.read(chunk_size)
-                os.write(fd, current_chunk)
-        finally:
-            locks.unlock(fd)
-            os.close(fd)
-    copystat(old_file_name, new_file_name)
+    file_copy_safe(old_file_name, new_file_name, chunk_size, allow_overwrite)
 
     try:
         os.remove(old_file_name)

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -7,6 +7,7 @@ from inspect import getargspec
 from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
 from django.core.files import File, locks
+from django.core.files.copy import file_copy_safe
 from django.core.files.move import file_move_safe
 from django.utils._os import abspathu, safe_join
 from django.utils.crypto import get_random_string
@@ -171,6 +172,20 @@ class Storage(object):
         """
         raise NotImplementedError('subclasses of Storage must provide a modified_time() method')
 
+    def move(self, src_name, dst_name):
+        """
+        Move the file specified by src_name to dst_name. This method will raise
+        ValueError if dst_name already exists.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a move() method')
+
+    def copy(self, src_name, dst_name):
+        """
+        Copy the file specified by src_name to dst_name. This method will raise
+        ValueError if dst_name already exists.
+        """
+        raise NotImplementedError('subclasses of Storage must provide a copy() method')
+
 
 @deconstructible
 class FileSystemStorage(Storage):
@@ -323,6 +338,25 @@ class FileSystemStorage(Storage):
 
     def modified_time(self, name):
         return datetime.fromtimestamp(os.path.getmtime(self.path(name)))
+
+    def _do_safe_operation(self, operation, src_path, dst_path):
+        try:
+            operation(src_path, dst_path)
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                raise ValueError('Destination already exists')
+            else:
+                raise
+
+    def move(self, src_name, dst_name):
+        src_path = self.path(src_name)
+        dst_path = self.path(dst_name)
+        self._do_safe_operation(file_move_safe, src_path, dst_path)
+
+    def copy(self, src_name, dst_name):
+        src_path = self.path(src_name)
+        dst_path = self.path(dst_name)
+        self._do_safe_operation(file_copy_safe, src_path, dst_path)
 
 
 def get_storage_class(import_path=None):

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -86,12 +86,12 @@ The Storage Class
 
     .. method:: copy(src_name, dst_name)
 
-        Copy the file specified by ``src_name`` to ``dst_name``. If
-        ``dst_name`` already exists ``ValueError`` will be raised. For
+        .. versionadded:: 1.9
+
+        Copies the file specified by ``src_name`` to ``dst_name``. If
+        ``dst_name`` already exists ``ValueError`` should be raised. For
         storage systems that don't support copy this will raise
         ``NotImplementedError`` instead.
-
-        .. versionadded:: 1.9
 
     .. method:: created_time(name)
 
@@ -152,12 +152,12 @@ The Storage Class
 
     .. method:: move(src_name, dst_name)
 
-        Move the file specified by ``src_name`` to ``dst_name``. If
-        ``dst_name`` already exists ``ValueError`` will be raised. For storage
+        .. versionadded:: 1.9
+
+        Moves the file specified by ``src_name`` to ``dst_name``. If
+        ``dst_name`` already exists ``ValueError`` should be raised. For storage
         systems that don't support move this will raise ``NotImplementedError``
         instead.
-
-        .. versionadded:: 1.9
 
     .. method:: open(name, mode='rb')
 

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -84,6 +84,15 @@ The Storage Class
         able to return the last accessed time this will raise
         ``NotImplementedError`` instead.
 
+    .. method:: copy(src_name, dst_name)
+
+        Copy the file specified by ``src_name`` to ``dst_name``. If
+        ``dst_name`` already exists ``ValueError`` will be raised. For
+        storage systems that don't support copy this will raise
+        ``NotImplementedError`` instead.
+
+        .. versionadded:: 1.9
+
     .. method:: created_time(name)
 
         Returns a naive ``datetime`` object containing the creation
@@ -140,6 +149,15 @@ The Storage Class
         modified time. For storage systems that aren't able to return
         the last modified time, this will raise
         ``NotImplementedError`` instead.
+
+    .. method:: move(src_name, dst_name)
+
+        Move the file specified by ``src_name`` to ``dst_name``. If
+        ``dst_name`` already exists ``ValueError`` will be raised. For storage
+        systems that don't support move this will raise ``NotImplementedError``
+        instead.
+
+        .. versionadded:: 1.9
 
     .. method:: open(name, mode='rb')
 

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -308,7 +308,6 @@ Email
 
 File Storage
 ^^^^^^^^^^^^
-
 * :meth:`Storage.get_available_name()
   <django.core.files.storage.Storage.get_available_name>` and
   :meth:`Storage.save() <django.core.files.storage.Storage.save>`

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -308,6 +308,7 @@ Email
 
 File Storage
 ^^^^^^^^^^^^
+
 * :meth:`Storage.get_available_name()
   <django.core.files.storage.Storage.get_available_name>` and
   :meth:`Storage.save() <django.core.files.storage.Storage.save>`

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -104,7 +104,10 @@ Email
 File Storage
 ^^^^^^^^^^^^
 
-* ...
+* :class:`~django.core.files.storage.Storage` and
+  :class:`~django.core.files.storage.FileSystemStorage` now have
+  :meth:`~django.core.files.storage.Storage.move()` and
+  :meth:`~django.core.files.storage.Storage.copy()` methods
 
 File Uploads
 ^^^^^^^^^^^^

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -81,7 +81,7 @@ class FileStorageDeconstructionTests(unittest.TestCase):
         self.assertEqual(kwargs, kwargs_orig)
 
 
-class FileStorageTestsBase(unittest.TestCase):
+class FileStorageTestsBase(SimpleTestCase):
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
@@ -415,14 +415,20 @@ class FileStorageTests(FileStorageTestsBase):
     def test_copy_file_no_suspicious_operation(self):
         f = ContentFile('content content')
         src_name = self.storage.save('initial.file', f)
-        with self.assertRaises(SuspiciousOperation):
+        with self.assertRaisesMessage(
+                SuspiciousOperation,
+                'The joined path (/tmp/passwd) is located '
+                'outside of the base path '
+                'component ({})'.format(self.storage.location)):
             self.storage.copy(src_name, '/tmp/passwd')
 
     def test_copy_raise_on_overwrite(self):
         f = ContentFile('content content')
         existing_name = self.storage.save('existing.file', f)
         src_name = self.storage.save('src.file', f)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesMessage(
+                ValueError,
+                'Destination already exists'):
             self.storage.copy(src_name, existing_name)
 
     def test_move_file(self):
@@ -436,13 +442,21 @@ class FileStorageTests(FileStorageTestsBase):
     def test_move_file_no_suspicious_operation(self):
         f = ContentFile('content content')
         src_name = self.storage.save('initial.file', f)
-        with self.assertRaises(SuspiciousOperation):
+        with self.assertRaisesMessage(
+                SuspiciousOperation,
+                'The joined path (/tmp/passwd) is located '
+                'outside of the base path '
+                'component ({})'.format(self.storage.location)):
             self.storage.move(src_name, '/tmp/passwd')
 
     def test_move_file_no_directory_traversal(self):
         f = ContentFile('content content')
         src_name = self.storage.save('initial.file', f)
-        with self.assertRaises(SuspiciousOperation):
+        with self.assertRaisesMessage(
+                SuspiciousOperation,
+                'The joined path (/tmp/passwd) is located '
+                'outside of the base path '
+                'component ({})'.format(self.storage.location)):
             self.storage.move(src_name, '../../../../../../../../tmp/passwd')
 
 

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -81,8 +81,7 @@ class FileStorageDeconstructionTests(unittest.TestCase):
         self.assertEqual(kwargs, kwargs_orig)
 
 
-class FileStorageTests(unittest.TestCase):
-    storage_class = FileSystemStorage
+class FileStorageTestsBase(unittest.TestCase):
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
@@ -96,7 +95,11 @@ class FileStorageTests(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
         shutil.rmtree(self.temp_dir2)
 
-    def test_empty_location(self):
+
+class FileStorageTests(FileStorageTestsBase):
+    storage_class = FileSystemStorage
+
+    def test_emtpy_location(self):
         """
         Makes sure an exception is raised if the location is empty
         """
@@ -401,6 +404,47 @@ class FileStorageTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.storage.delete('')
 
+    def test_copy_file(self):
+        f = ContentFile('content content')
+        src_name = self.storage.save('initial.file', f)
+        dst_name = self.storage.get_available_name('destination.file')
+        self.storage.copy(src_name, dst_name)
+        self.assertTrue(self.storage.exists(src_name))
+        self.assertTrue(self.storage.exists(dst_name))
+
+    def test_copy_file_no_suspicious_operation(self):
+        f = ContentFile('content content')
+        src_name = self.storage.save('initial.file', f)
+        with self.assertRaises(SuspiciousOperation):
+            self.storage.copy(src_name, '/tmp/passwd')
+
+    def test_copy_raise_on_overwrite(self):
+        f = ContentFile('content content')
+        existing_name = self.storage.save('existing.file', f)
+        src_name = self.storage.save('src.file', f)
+        with self.assertRaises(ValueError):
+            self.storage.copy(src_name, existing_name)
+
+    def test_move_file(self):
+        f = ContentFile('content content')
+        src_name = self.storage.save('initial.file', f)
+        dst_name = self.storage.get_available_name('destination.file')
+        self.storage.move(src_name, dst_name)
+        self.assertFalse(self.storage.exists(src_name))
+        self.assertTrue(self.storage.exists(dst_name))
+
+    def test_move_file_no_suspicious_operation(self):
+        f = ContentFile('content content')
+        src_name = self.storage.save('initial.file', f)
+        with self.assertRaises(SuspiciousOperation):
+            self.storage.move(src_name, '/tmp/passwd')
+
+    def test_move_file_no_directory_traversal(self):
+        f = ContentFile('content content')
+        src_name = self.storage.save('initial.file', f)
+        with self.assertRaises(SuspiciousOperation):
+            self.storage.move(src_name, '../../../../../../../../tmp/passwd')
+
 
 class CustomStorage(FileSystemStorage):
     def get_available_name(self, name, max_length=None):
@@ -417,7 +461,8 @@ class CustomStorage(FileSystemStorage):
         return name
 
 
-class CustomStorageTests(FileStorageTests):
+class CustomStorageTests(FileStorageTestsBase):
+
     storage_class = CustomStorage
 
     def test_custom_get_available_name(self):


### PR DESCRIPTION
 * implemented these methods in the default FileSystemStorage
 * fix issue with storage tests: each test from FileStorageTests was run twice (when inheriting from a TestCase class all test_ methods are ran in the subclass as well)
