### PR TITLE
Fixed test_notafile_error to pass on Windows.

### DIFF
--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -262,7 +262,7 @@ class FileSystemLoaderTests(SimpleTestCase):
                     self.engine.get_template(tmpfile.name)
 
     def test_notafile_error(self):
-        with self.assertRaisesMessage(IOError, 'Is a directory'):
+        with self.assertRaises(IOError):
             self.engine.get_template('first')
 
 


### PR DESCRIPTION
This test failed because a different error code is raised on Windows when
opening a directory. Since the particular message isn't as important to this
test as the fact that the original IOError is reraised, this fixes the test
by making the assertion more generic.