### PR TITLE
Docs example failed to close StringIO.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1623,7 +1623,9 @@ redirected into a ``StringIO`` instance::
         def test_command_output(self):
             out = StringIO()
             call_command('closepoll', stdout=out)
-            self.assertIn('Expected output', out.getvalue())
+            command_output = out.getvalue()
+            out.close()
+            self.assertIn('Expected output', command_output)
 
 .. _skipping-tests:
 


### PR DESCRIPTION
Trivial pull request updating docs. Given example in docs does not close StringIO() which should be closed before assertion.