### PR TITLE
Simplified command to display path to Django source files

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -530,11 +530,7 @@ template directory in the source code of Django itself
 
     .. code-block:: console
 
-        $ python -c "
-        import sys
-        sys.path = sys.path[1:]
-        import django
-        print(django.__path__)"
+        $ python -c "import django; print(django.__path__)"
 
 Then, just edit the file and replace
 ``{{ site_header|default:_('Django administration') }}`` (including the curly


### PR DESCRIPTION
In my opinion there is no need for the sys imports and that stuff. All it does, is removing the current directory from the sys.path for the lookup. But when you are in your site-packages directory, the django installation from this site package is the one that python would use. Also: one liners are nicer to copy and paste.