### PR TITLE
Fixed #24427 -- Stopped writing migration files in dry-run mode when merging

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -239,7 +239,18 @@ class Command(BaseCommand):
                 })
                 new_migration = subclass("%04i_merge" % (biggest_number + 1), app_label)
                 writer = MigrationWriter(new_migration)
-                with open(writer.path, "wb") as fh:
-                    fh.write(writer.as_string())
-                if self.verbosity > 0:
-                    self.stdout.write("\nCreated new merge migration %s" % writer.path)
+
+                if not self.dry_run:
+                    # Write the merge migrations file to the disk
+                    with open(writer.path, "wb") as fh:
+                        fh.write(writer.as_string())
+                    if self.verbosity > 0:
+                        self.stdout.write("\nCreated new merge migration %s" % writer.path)
+                elif self.verbosity == 3:
+                    # Alternatively, makemigrations --merge --dry-run --verbosity 3
+                    # will output the merge migrations to stdout rather than saving
+                    # the file to the disk.
+                    self.stdout.write(self.style.MIGRATE_HEADING(
+                        "Full merge migrations file '%s':" % writer.filename) + "\n"
+                    )
+                    self.stdout.write("%s\n" % writer.as_string())

--- a/docs/releases/1.7.6.txt
+++ b/docs/releases/1.7.6.txt
@@ -28,3 +28,7 @@ Bugfixes
 
 * Fixed a bug that prevented migrations from adding a foreign key constraint
   when converting an existing field to a foreign key (:ticket:`24447`).
+
+* Stopped writing migration files in dry-run mode when merging migration
+  conflicts. When ``--merge`` is called with ``verbosity=3`` migration file
+  is written to stdout (:ticket: `24427`).

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -620,6 +620,49 @@ class MakeMigrationsTests(MigrationTestBase):
         self.assertIn("Branch 0002_conflicting_second", output)
         self.assertIn("Created new merge migration", output)
 
+    def test_makemigration_merge_dry_run(self):
+        """
+        Ticket #24427 - Makes sure that makemigrations respects --dry-run option when fixing
+        migration conflicts.
+        """
+        out = six.StringIO()
+        with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
+            call_command("makemigrations", "migrations", dry_run=True, merge=True, interactive=False, stdout=out)
+            merge_file = os.path.join(migration_dir, '0003_merge.py')
+            self.assertFalse(os.path.exists(merge_file))
+        output = force_text(out.getvalue())
+        self.assertIn("Merging migrations", output)
+        self.assertIn("Branch 0002_second", output)
+        self.assertIn("Branch 0002_conflicting_second", output)
+        self.assertNotIn("Created new merge migration", output)
+
+    def test_makemigration_merge_dry_run_verbosity_3(self):
+        """
+        Ticket #24427 - Makes sure that `makemigrations --merge --dry-run` writes the merge
+        migration file to stdout with `verbosity == 3`.
+        """
+        out = six.StringIO()
+        with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
+            call_command("makemigrations", "migrations", dry_run=True, merge=True, interactive=False,
+                         stdout=out, verbosity=3)
+            merge_file = os.path.join(migration_dir, '0003_merge.py')
+            self.assertFalse(os.path.exists(merge_file))
+        output = force_text(out.getvalue())
+        self.assertIn("Merging migrations", output)
+        self.assertIn("Branch 0002_second", output)
+        self.assertIn("Branch 0002_conflicting_second", output)
+        self.assertNotIn("Created new merge migration", output)
+
+        # Additional output caused by verbosity 3
+        # The complete merge migration file that would be written
+        self.assertIn("# -*- coding: utf-8 -*-", output)
+        self.assertIn("class Migration(migrations.Migration):", output)
+        self.assertIn("dependencies = [", output)
+        self.assertIn("('migrations', '0002_second')", output)
+        self.assertIn("('migrations', '0002_conflicting_second')", output)
+        self.assertIn("operations = [", output)
+        self.assertIn("]", output)
+
     def test_makemigrations_dry_run(self):
         """
         Ticket #22676 -- `makemigrations --dry-run` should not ask for defaults.


### PR DESCRIPTION
* Avoid writing migration to file when dry_run=True
* Write migration to stdout when verbosity=3

https://code.djangoproject.com/ticket/24427