### PR TITLE
Fixed #23986 -- Collectstatic --clear fails if the static dir doesn't ex...

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -199,6 +199,9 @@ class Command(BaseCommand):
         """
         Deletes the given relative path using the destination storage backend.
         """
+        if not self.storage.exists(path):
+            return
+
         dirs, files = self.storage.listdir(path)
         for f in files:
             fpath = os.path.join(path, f)

--- a/tests/staticfiles_tests/tests.py
+++ b/tests/staticfiles_tests/tests.py
@@ -301,6 +301,10 @@ class TestCollectionClear(CollectionTestCase):
     def test_cleared_not_found(self):
         self.assertFileNotFound('cleared.txt')
 
+    def test_dir_not_exists(self, **kwargs):
+        shutil.rmtree(settings.STATIC_ROOT)
+        super(TestCollectionClear, self).run_collectstatic(clear=True)
+
 
 class TestCollectionExcludeNoDefaultIgnore(CollectionTestCase, TestDefaults):
     """


### PR DESCRIPTION
...ist yet