### PR TITLE
Fixed #23838: added missing `__iter__` to LazyObject

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -298,11 +298,11 @@ class LazyObject(object):
     __ne__ = new_method_proxy(operator.ne)
     __hash__ = new_method_proxy(hash)
 
-    # Dictionary methods support
+    # List/Tuple/Dictionary methods support
     __getitem__ = new_method_proxy(operator.getitem)
     __setitem__ = new_method_proxy(operator.setitem)
     __delitem__ = new_method_proxy(operator.delitem)
-
+    __iter__ = new_method_proxy(iter)
     __len__ = new_method_proxy(len)
     __contains__ = new_method_proxy(operator.contains)
 

--- a/tests/utils_tests/test_lazyobject.py
+++ b/tests/utils_tests/test_lazyobject.py
@@ -165,11 +165,22 @@ class LazyObjectTestCase(TestCase):
             del obj_dict['f']
 
     def test_iter(self):
-        # LazyObjects don't actually implements __iter__ but you can still
-        # iterate over them because they implement __getitem__
-        obj = self.lazy_wrap([1, 2, 3])
-        for expected, actual in zip([1, 2, 3], obj):
-            self.assertEqual(expected, actual)
+        # Tests whether an object's custom `__iter__` method is being
+        # used when iterating over it.
+
+        class IterObject(object):
+
+            def __init__(self, values):
+                self.values = values
+
+            def __iter__(self):
+                return iter(self.values)
+
+        original_list = ['test', '123']
+        self.assertEqual(
+            list(self.lazy_wrap(IterObject(original_list))),
+            original_list
+        )
 
     def test_pickle(self):
         # See ticket #16563


### PR DESCRIPTION
Adds the `__iter__` method to `LazyObject`.

I changed the `test_iter` unittest, because before my change it was relying on `__getitem__`, which python uses when `__iter__` is not available, but since I implemented `__iter__`, the `__getitem__` method isn't used anymore, but to test if `__iter__` really works (and it doesn't fall back to `__getitem__`), I had to create a custom object that only implements `__iter__` and not `__getitem__`.

Ticket:
https://code.djangoproject.com/ticket/23838