### PR TITLE
Fixed #23784. -- Added reminder to add AdminEmailHandler to LOGGING

### DIFF
--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -46,7 +46,9 @@ To activate this behavior, put the email addresses of the recipients in the
 
     Server error emails are sent using the logging framework, so you can
     customize this behavior by :doc:`customizing your logging configuration
-    </topics/logging>`.
+    </topics/logging>`. Note that you do need to add an
+    :class:`django.utils.log.AdminEmailHandler` to your logger to ensure that
+    emails will be sent.
 
 404 errors
 ~~~~~~~~~~

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -47,7 +47,7 @@ To activate this behavior, put the email addresses of the recipients in the
     Server error emails are sent using the logging framework, so you can
     customize this behavior by :doc:`customizing your logging configuration
     </topics/logging>`. Note that you do need to add an
-    :class:`django.utils.log.AdminEmailHandler` to your logger to ensure that
+    :class:`~django.utils.log.AdminEmailHandler` to your logger to ensure that
     emails will be sent.
 
 404 errors


### PR DESCRIPTION
Docs state that you need an AdminEmailHandler in your LOGGING to ensure that
emails are being sent to the project admins