### PR TITLE
Fixed #24013 -- Fixed escaping of reverse prefix.

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -445,16 +445,15 @@ class RegexURLResolver(LocaleRegexProvider):
                 )
         possibilities = self.reverse_dict.getlist(lookup_view)
 
-        prefix_norm, prefix_args = normalize(urlquote(_prefix))[0]
         for possibility, pattern, defaults in possibilities:
             for result, params in possibility:
                 if args:
-                    if len(args) != len(params) + len(prefix_args):
+                    if len(args) != len(params):
                         continue
-                    candidate_subs = dict(zip(prefix_args + params, text_args))
+                    candidate_subs = dict(zip(params, text_args))
                 else:
                     if (set(kwargs.keys()) | set(defaults.keys()) != set(params) |
-                            set(defaults.keys()) | set(prefix_args)):
+                            set(defaults.keys())):
                         continue
                     matches = True
                     for k, v in defaults.items():
@@ -469,12 +468,10 @@ class RegexURLResolver(LocaleRegexProvider):
                 # without quoting to build a decoded URL and look for a match.
                 # Then, if we have a match, redo the substitution with quoted
                 # arguments in order to return a properly encoded URL.
-                candidate_pat = prefix_norm.replace('%', '%%') + result
-                if re.search('^%s%s' % (prefix_norm, pattern), candidate_pat % candidate_subs, re.UNICODE):
+                candidate_pat = _prefix.replace('%', '%%') + result
+                if re.search('^%s%s' % (re.escape(_prefix), pattern), candidate_pat % candidate_subs, re.UNICODE):
                     # safe characters from `pchar` definition of RFC 3986
-                    candidate_subs = dict((k, urlquote(v, safe=RFC3986_SUBDELIMS + str('/~:@')))
-                                          for (k, v) in candidate_subs.items())
-                    url = candidate_pat % candidate_subs
+                    url = urlquote(candidate_pat % candidate_subs, safe=RFC3986_SUBDELIMS + str('/~:@'))
                     # Don't allow construction of scheme relative urls.
                     if url.startswith('//'):
                         url = '/%%2F%s' % url[2:]

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -171,11 +171,13 @@ class NoURLPatternsTests(TestCase):
         """
         resolver = RegexURLResolver(r'^$', settings.ROOT_URLCONF)
 
-        self.assertRaisesMessage(ImproperlyConfigured,
+        self.assertRaisesMessage(
+            ImproperlyConfigured,
             "The included urlconf 'urlpatterns_reverse.no_urls' does not "
             "appear to have any patterns in it. If you see valid patterns in "
             "the file then the issue is probably caused by a circular import.",
-            getattr, resolver, 'url_patterns')
+            getattr, resolver, 'url_patterns'
+        )
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
@@ -196,25 +198,33 @@ class URLPatternReverse(TestCase):
         self.assertRaises(NoReverseMatch, reverse, None)
 
     def test_prefix_braces(self):
-        self.assertEqual('/%7B%7Binvalid%7D%7D/includes/non_path_include/',
-               reverse('non_path_include', prefix='/{{invalid}}/'))
+        self.assertEqual(
+            '/%7B%7Binvalid%7D%7D/includes/non_path_include/',
+            reverse('non_path_include', prefix='/{{invalid}}/')
+        )
 
     def test_prefix_parenthesis(self):
         # Parentheses are allowed and should not cause errors or be escaped
-        self.assertEqual('/bogus)/includes/non_path_include/',
-               reverse('non_path_include', prefix='/bogus)/'))
+        self.assertEqual(
+            '/bogus)/includes/non_path_include/',
+            reverse('non_path_include', prefix='/bogus)/')
+        )
         self.assertEqual('/(bogus)/includes/non_path_include/',
                          reverse('non_path_include', prefix='/(bogus)/'))
 
     def test_prefix_format_char(self):
-        self.assertEqual('/bump%2520map/includes/non_path_include/',
-               reverse('non_path_include', prefix='/bump%20map/'))
+        self.assertEqual(
+            '/bump%2520map/includes/non_path_include/',
+            reverse('non_path_include', prefix='/bump%20map/')
+        )
 
     def test_non_urlsafe_prefix_with_args(self):
         # Regression for #20022, adjusted for #24013 because ~ is an unreserved
         # character. Tests whether % is escaped.
-        self.assertEqual('/%257Eme/places/1/',
-                reverse('places', args=[1], prefix='/%7Eme/'))
+        self.assertEqual(
+            '/%257Eme/places/1/',
+            reverse('places', args=[1], prefix='/%7Eme/')
+        )
 
     def test_patterns_reported(self):
         # Regression for #17076
@@ -545,8 +555,10 @@ class RequestURLconfTests(TestCase):
     def test_urlconf(self):
         response = self.client.get('/test/me/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'outer:/test/me/,'
-                                           b'inner:/inner_urlconf/second_test/')
+        self.assertEqual(
+            response.content, b'outer:/test/me/,'
+            b'inner:/inner_urlconf/second_test/'
+        )
         response = self.client.get('/inner_urlconf/second_test/')
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/second_test/')
@@ -745,8 +757,10 @@ class ErroneousViewTests(TestCase):
 
 class ViewLoadingTests(TestCase):
     def test_view_loading(self):
-        self.assertEqual(get_callable('urlpatterns_reverse.views.empty_view'),
-                         empty_view)
+        self.assertEqual(
+            get_callable('urlpatterns_reverse.views.empty_view'),
+            empty_view
+        )
 
         # passing a callable should return the callable
         self.assertEqual(get_callable(empty_view), empty_view)
@@ -754,14 +768,17 @@ class ViewLoadingTests(TestCase):
     def test_exceptions(self):
         # A missing view (identified by an AttributeError) should raise
         # ViewDoesNotExist, ...
-        six.assertRaisesRegex(self, ViewDoesNotExist,
-                              ".*View does not exist in.*",
-                              get_callable,
-                              'urlpatterns_reverse.views.i_should_not_exist')
+        six.assertRaisesRegex(
+            self, ViewDoesNotExist,
+            ".*View does not exist in.*", get_callable,
+            'urlpatterns_reverse.views.i_should_not_exist'
+        )
         # ... but if the AttributeError is caused by something else don't
         # swallow it.
-        self.assertRaises(AttributeError, get_callable,
-                          'urlpatterns_reverse.views_broken.i_am_broken')
+        self.assertRaises(
+            AttributeError, get_callable,
+            'urlpatterns_reverse.views_broken.i_am_broken'
+        )
 
 
 class IncludeTests(SimpleTestCase):


### PR DESCRIPTION
Prefix was treated as a part of the url pattern, which it is not.
Improved tests to conform with RFC 3986 which allows certain
characters in path segments without being escaped.