### PR TITLE
Fixed #24349 --email domain validation regex will accept upto 63 on gTLD

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -144,7 +144,9 @@ class EmailValidator(object):
     domain_regex = re.compile(
         # max length of the domain is 249: 254 (max email length) minus one
         # period, two characters for the TLD, @ sign, & one character before @.
-        r'(?:[A-Z0-9](?:[A-Z0-9-]{0,247}[A-Z0-9])?\.)+(?:[A-Z]{2,6}|[A-Z0-9-]{2,}(?<!-))$',
+        # max length of the gTDs is 63 
+        # Ref: http://en.wikipedia.org/wiki/Domain_Name_System#cite_ref-rfc1034_1-2
+        r'(?:[A-Z0-9](?:[A-Z0-9-]{0,247}[A-Z0-9])?\.)+(?:[A-Z0-9-]{2,63}(?<!-))$',
         re.IGNORECASE)
     literal_regex = re.compile(
         # literal form, ipv4 or ipv6 address (SMTP 4.1.3)

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -45,6 +45,7 @@ TEST_DATA = [
     (validate_email, 'email@localhost', None),
     (EmailValidator(whitelist=['localdomain']), 'email@localdomain', None),
     (validate_email, '"test@test"@example.com', None),
+    (validate_email, 'example@atm.longgtldfortesting', None),
 
     (validate_email, None, ValidationError),
     (validate_email, '', ValidationError),


### PR DESCRIPTION
@timgraham please find cleaned up commit here for merging. replacing previous pull request https://github.com/django/django/pull/4149/

email domain validation regex will accept upto 63 on gTLDs and also simplified the regular expression