### PR TITLE
Fixed #24460, improved HttpRequest.build_absolute_uri documentation

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -249,6 +249,14 @@ Methods
 
     Example: ``"http://example.com/music/bands/the_beatles/?print=true"``
 
+    .. note::
+
+        Mixing HTTP and HTTPS on the same site is discouraged, therefore
+        :meth:`~HttpRequest.build_absolute_uri()` will always generate an
+        absolute URI with the same scheme the current request has. If you need
+        to redirect users to HTTPS, it's best to let your webserver redirect
+        all HTTP traffic to HTTPS.
+
 .. method:: HttpRequest.get_signed_cookie(key, default=RAISE_ERROR, salt='', max_age=None)
 
     Returns a cookie value for a signed cookie, or raises a


### PR DESCRIPTION
To explain why it doesn't allow scheme switching (HTTP/HTTPS)
Ticket:
https://code.djangoproject.com/ticket/24460#comment:4