### PR TITLE
Fixed #9596 -- Added date transform for DateTimeField

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -99,6 +99,12 @@ class BaseDatabaseOperations(object):
         """
         return "%s"
 
+    def datetime_cast_date_sql(self, field_name, tzname):
+        """
+        Returns the SQL necessary to cast a datetime value to date value.
+        """
+        raise NotImplementedError('subclasses of BaseDatabaseOperations may require a datetime_cast_date() method')
+
     def datetime_extract_sql(self, lookup_type, field_name, tzname):
         """
         Given a lookup_type of 'year', 'month', 'day', 'hour', 'minute' or

--- a/django/db/backends/postgresql_psycopg2/operations.py
+++ b/django/db/backends/postgresql_psycopg2/operations.py
@@ -32,26 +32,26 @@ class DatabaseOperations(BaseDatabaseOperations):
         # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
-    def datetime_extract_sql(self, lookup_type, field_name, tzname):
+    def _convert_field_to_tz(self, field_name, tzname):
         if settings.USE_TZ:
             field_name = "%s AT TIME ZONE %%s" % field_name
             params = [tzname]
         else:
             params = []
-        # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
-        if lookup_type == 'week_day':
-            # For consistency across backends, we return Sunday=1, Saturday=7.
-            sql = "EXTRACT('dow' FROM %s) + 1" % field_name
-        else:
-            sql = "EXTRACT('%s' FROM %s)" % (lookup_type, field_name)
+        return field_name, params
+
+    def datetime_cast_date_sql(self, field_name, tzname):
+        field_name, params = self._convert_field_to_tz(field_name, tzname)
+        sql = '(%s)::date' % field_name
+        return sql, params
+
+    def datetime_extract_sql(self, lookup_type, field_name, tzname):
+        field_name, params = self._convert_field_to_tz(field_name, tzname)
+        sql = self.date_extract_sql(lookup_type, field_name)
         return sql, params
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
-        if settings.USE_TZ:
-            field_name = "%s AT TIME ZONE %%s" % field_name
-            params = [tzname]
-        else:
-            params = []
+        field_name, params = self._convert_field_to_tz(field_name, tzname)
         # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         sql = "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
         return sql, params

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -68,21 +68,23 @@ class DatabaseOperations(BaseDatabaseOperations):
         # cause a collision with a field name).
         return "django_date_trunc('%s', %s)" % (lookup_type.lower(), field_name)
 
+    def _require_pytz(self):
+        if settings.USE_TZ and pytz is None:
+            raise ImproperlyConfigured("This query requires pytz, but it isn't installed.")
+
+    def datetime_cast_date_sql(self, field_name, tzname):
+        self._require_pytz()
+        return "django_datetime_cast_date(%s, %%s)" % field_name, [tzname]
+
     def datetime_extract_sql(self, lookup_type, field_name, tzname):
         # Same comment as in date_extract_sql.
-        if settings.USE_TZ:
-            if pytz is None:
-                raise ImproperlyConfigured("This query requires pytz, "
-                                           "but it isn't installed.")
+        self._require_pytz()
         return "django_datetime_extract('%s', %s, %%s)" % (
             lookup_type.lower(), field_name), [tzname]
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
         # Same comment as in date_trunc_sql.
-        if settings.USE_TZ:
-            if pytz is None:
-                raise ImproperlyConfigured("This query requires pytz, "
-                                           "but it isn't installed.")
+        self._require_pytz()
         return "django_datetime_trunc('%s', %s, %%s)" % (
             lookup_type.lower(), field_name), [tzname]
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1463,6 +1463,22 @@ class DateTimeField(DateField):
         return super(DateTimeField, self).formfield(**defaults)
 
 
+@DateTimeField.register_lookup
+class DateTimeDateTransform(Transform):
+    lookup_name = 'date'
+
+    @cached_property
+    def output_field(self):
+        return DateField()
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = compiler.compile(self.lhs)
+        tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
+        sql, tz_params = connection.ops.datetime_cast_date_sql(lhs, tzname)
+        lhs_params.extend(tz_params)
+        return sql, lhs_params
+
+
 class DecimalField(Field):
     empty_strings_allowed = False
     default_error_messages = {

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2463,6 +2463,27 @@ numbers and even characters.
 
     Generally speaking, you can't mix dates and datetimes.
 
+.. fieldlookup:: date
+
+date
+~~~~
+
+.. versionadded:: 1.9
+
+For datetime fields, casts the value as date. Allows chaining additional field
+lookups. Takes a date value.
+
+Example::
+
+    Entry.objects.filter(pub_date__date=datetime.date(2005, 1, 1))
+    Entry.objects.filter(pub_date__date__gt=datetime.date(2005, 1, 1))
+
+(No equivalent SQL code fragment is included for this lookup because
+implementation of the relevant query varies among different database engines.)
+
+When :setting:`USE_TZ` is ``True``, fields are converted to the current time
+zone before filtering.
+
 .. fieldlookup:: year
 
 year

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -233,6 +233,9 @@ Models
   :class:`~django.db.models.Avg` aggregate in order to aggregate over
   non-numeric columns, such as ``DurationField``.
 
+* Added :lookup:`date` lookup to :class:`~django.db.models.DateTimeField`,
+  which allows querying a ``DateTimeField`` by only the date portion.
+
 CSRF
 ^^^^
 
@@ -345,6 +348,9 @@ Database backend API
 * The ``DatabaseOperations.value_to_db_<type>()`` methods were renamed to
   ``adapt_<type>field_value()`` to mirror the ``convert_<type>field_value()``
   methods.
+
+* To use the new ``date`` lookup, third-party database backends may need to
+  implement the ``BaseDatabaseOperations.datetime_cast_date_sql()`` method.
 
 Default settings that were tuples are now lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This change allows querying `DateTimeField`s by the date portion. Such as:

```
Articles.objects.filter(published_at__date=datetime.date.today())
```

Some concerns and questions:

1. I do not use Oracle DB. The Oracle implementation was created by reading Oracle documentation and other web searches. It has not been tested, nor is it known to be correct. Feedback from Oracle developers would be appreciated. All other built-in backends were tested.
2. Should I add a `TimeTransform` while I'm at it? To allow users to query on the time portion of a `DateTimeField`. If others think it is a good idea, I wouldn't mind adding it.
3. In DB backend `operations.py`, when converting a column to a timezone, should the timezone be returned as a format parameter to the SQL string (as in MySQL and Postgres) or should the timezone be embedded in the returned SQL string (as in Oracle)?

Thanks. All feedback appreciated.