### PR TITLE
Refs #23559: warned about letting users edit User model in admin interface

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -100,6 +100,14 @@ You should see a few types of editable content: groups and users. They are
 provided by :mod:`django.contrib.auth`, the authentication framework shipped
 by Django.
 
+.. admonition:: Warning
+
+    You will see that you can modify the permissions of your users. Generally,
+    only superusers have the ability to do this, but you can give other users
+    permission to change the User model. This is ultimately the same as giving
+    them superuser status, because they will be able to elevate permissions of
+    users including themselves!
+
 Make the poll app modifiable in the admin
 =========================================
 


### PR DESCRIPTION
This adds a warning to the beginner tutorial that you shouldn't give normal users permission to edit the User model, as that amounts to giving them superuser rights. Some more work should be done to completely solve issue #23559, because there should also be more detailed information elsewhere in the documentation about how to safely let regular users administer the User model.