### PR TITLE
Include template filename in case of TemplateSyntaxError

### DIFF
--- a/django/template/loader.py
+++ b/django/template/loader.py
@@ -58,9 +58,8 @@ class BaseLoader(object):
             return source, display_name
         except TemplateSyntaxError:
             excp_class, excp_inst, stack_trace = sys.exc_info()
-            error = "Error in file: %s\n%s"%(display_name, excp_inst.message)
+            error = "Error in file: %s\n%s" % (display_name, excp_inst.message)
             six.reraise(excp_class, excp_class(error), stack_trace)
-
 
     def load_template_source(self, template_name, template_dirs=None):
         """

--- a/django/template/loader.py
+++ b/django/template/loader.py
@@ -26,10 +26,11 @@
 # installed, because pkg_resources is necessary to read eggs.
 
 from django.core.exceptions import ImproperlyConfigured
-from django.template.base import Origin, Template, Context, TemplateDoesNotExist
+from django.template.base import Origin, Template, Context, TemplateDoesNotExist, TemplateSyntaxError
 from django.conf import settings
 from django.utils.module_loading import import_string
 from django.utils import six
+import sys
 
 template_source_loaders = None
 
@@ -55,6 +56,11 @@ class BaseLoader(object):
             # This allows for correct identification (later) of the actual template that does
             # not exist.
             return source, display_name
+        except TemplateSyntaxError:
+            excp_class, excp_inst, stack_trace = sys.exc_info()
+            error = "Error in file: %s\n%s"%(display_name, excp_inst.message)
+            six.reraise(excp_class, excp_class(error), stack_trace)
+
 
     def load_template_source(self, template_name, template_dirs=None):
         """


### PR DESCRIPTION
If a template inherit from another templates, its very difficult to tell which template is causing the syntax error.
This commit show the file name of the template causing the syntaxt error