### PR TITLE
Fixed #24469 -- Fixed escaping of forms, fields, and media in non-Django templates.

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -97,6 +97,9 @@ class BaseForm(object):
         self.fields = copy.deepcopy(self.base_fields)
         self._bound_fields_cache = {}
 
+    def __html__(self):
+        return force_text(self)
+
     def __str__(self):
         return self.as_table()
 
@@ -492,6 +495,9 @@ class BoundField(object):
             self.label = self.field.label
         self.help_text = field.help_text or ''
         self._initial_value = UNSET
+
+    def __html__(self):
+        return force_text(self)
 
     def __str__(self):
         """Renders this field as an HTML widget."""

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -51,6 +51,9 @@ class Media(object):
         for name in MEDIA_TYPES:
             getattr(self, 'add_' + name)(media_attrs.get(name, None))
 
+    def __html__(self):
+        return force_text(self)
+
     def __str__(self):
         return self.render()
 

--- a/tests/template_backends/jinja2/template_backends/django_escaping.html
+++ b/tests/template_backends/jinja2/template_backends/django_escaping.html
@@ -1,0 +1,5 @@
+{{ media }}
+
+{{ test_form }}
+
+{{ test_form.test_field }}

--- a/tests/template_backends/templates/template_backends/django_escaping.html
+++ b/tests/template_backends/templates/template_backends/django_escaping.html
@@ -1,0 +1,5 @@
+{{ media }}
+
+{{ test_form }}
+
+{{ test_form.test_field }}


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/24469 for more information