### PR TITLE
Fixed escaping regression in urlize filter.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -337,7 +337,7 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
                 if autoescape and not safe_input:
                     lead, trail = escape(lead), escape(trail)
                     trimmed = escape(trimmed)
-                middle = '<a href="%s"%s>%s</a>' % (url, nofollow_attr, trimmed)
+                middle = '<a href="%s"%s>%s</a>' % (escape(url), nofollow_attr, trimmed)
                 words[i] = mark_safe('%s%s%s' % (lead, middle, trail))
             else:
                 if safe_input:

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -18,8 +18,8 @@ class UrlizeTests(SimpleTestCase):
         )
         self.assertEqual(
             output,
-            '<a href="http://example.com/?x=&y=" rel="nofollow">http://example.com/?x=&y=</a> '
-            '<a href="http://example.com?x=&y=%3C2%3E" rel="nofollow">http://example.com?x=&amp;y=&lt;2&gt;</a>'
+            '<a href="http://example.com/?x=&amp;y=" rel="nofollow">http://example.com/?x=&y=</a> '
+            '<a href="http://example.com?x=&amp;y=%3C2%3E" rel="nofollow">http://example.com?x=&amp;y=&lt;2&gt;</a>'
         )
 
     @setup({'urlize02': '{{ a|urlize }} {{ b|urlize }}'})
@@ -30,8 +30,8 @@ class UrlizeTests(SimpleTestCase):
         )
         self.assertEqual(
             output,
-            '<a href="http://example.com/?x=&y=" rel="nofollow">http://example.com/?x=&amp;y=</a> '
-            '<a href="http://example.com?x=&y=" rel="nofollow">http://example.com?x=&amp;y=</a>'
+            '<a href="http://example.com/?x=&amp;y=" rel="nofollow">http://example.com/?x=&amp;y=</a> '
+            '<a href="http://example.com?x=&amp;y=" rel="nofollow">http://example.com?x=&amp;y=</a>'
         )
 
     @setup({'urlize03': '{% autoescape off %}{{ a|urlize }}{% endautoescape %}'})
@@ -78,7 +78,7 @@ class UrlizeTests(SimpleTestCase):
         output = self.engine.render_to_string('urlize09', {'a': "http://example.com/?x=&amp;y=&lt;2&gt;"})
         self.assertEqual(
             output,
-            '<a href="http://example.com/?x=&y=%3C2%3E" rel="nofollow">http://example.com/?x=&amp;y=&lt;2&gt;</a>',
+            '<a href="http://example.com/?x=&amp;y=%3C2%3E" rel="nofollow">http://example.com/?x=&amp;y=&lt;2&gt;</a>',
         )
 
 

--- a/tests/template_tests/filter_tests/test_urlizetrunc.py
+++ b/tests/template_tests/filter_tests/test_urlizetrunc.py
@@ -19,8 +19,8 @@ class UrlizetruncTests(SimpleTestCase):
         )
         self.assertEqual(
             output,
-            '"Unsafe" <a href="http://example.com/x=&y=" rel="nofollow">http:...</a> '
-            '&quot;Safe&quot; <a href="http://example.com?x=&y=" rel="nofollow">http:...</a>'
+            '"Unsafe" <a href="http://example.com/x=&amp;y=" rel="nofollow">http:...</a> '
+            '&quot;Safe&quot; <a href="http://example.com?x=&amp;y=" rel="nofollow">http:...</a>'
         )
 
     @setup({'urlizetrunc02': '{{ a|urlizetrunc:"8" }} {{ b|urlizetrunc:"8" }}'})
@@ -34,8 +34,8 @@ class UrlizetruncTests(SimpleTestCase):
         )
         self.assertEqual(
             output,
-            '&quot;Unsafe&quot; <a href="http://example.com/x=&y=" rel="nofollow">http:...</a> '
-            '&quot;Safe&quot; <a href="http://example.com?x=&y=" rel="nofollow">http:...</a>'
+            '&quot;Unsafe&quot; <a href="http://example.com/x=&amp;y=" rel="nofollow">http:...</a> '
+            '&quot;Safe&quot; <a href="http://example.com?x=&amp;y=" rel="nofollow">http:...</a>'
         )
 
 
@@ -72,7 +72,7 @@ class FunctionTests(SimpleTestCase):
     def test_query_string(self):
         self.assertEqual(
             urlizetrunc('http://www.google.co.uk/search?hl=en&q=some+long+url&btnG=Search&meta=', 20),
-            '<a href="http://www.google.co.uk/search?hl=en&q=some+long+url&btnG=Search&'
+            '<a href="http://www.google.co.uk/search?hl=en&amp;q=some+long+url&amp;btnG=Search&amp;'
             'meta=" rel="nofollow">http://www.google...</a>',
         )
 


### PR DESCRIPTION
Now that the URL is always unescaped as of refs #22267,
we should re-escape it before inserting it into the anchor.