### PR TITLE
Update models.py

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1254,7 +1254,7 @@ class ModelMultipleChoiceField(ModelChoiceField):
         # Since this overrides the inherited ModelChoiceField.clean
         # we run custom validators here
         self.run_validators(value)
-        return qs
+        return value
 
     def _check_values(self, value):
         """


### PR DESCRIPTION
When editing an object from the admin, the initial selection does not correspond to the selections stored in the database. Returning value instead of qs solves the problem.