### PR TITLE
Fixed #24467. Always include prepopulate.js to avoid JS errors

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -574,12 +574,12 @@ class ModelAdmin(BaseModelAdmin):
             'core.js',
             'admin/RelatedObjectLookups.js',
             'jquery%s.js' % extra,
-            'jquery.init.js'
+            'jquery.init.js',
+            'urlify.js',
+            'prepopulate%s.js' % extra
         ]
         if self.actions is not None:
             js.append('actions%s.js' % extra)
-        if self.prepopulated_fields:
-            js.extend(['urlify.js', 'prepopulate%s.js' % extra])
         return forms.Media(js=[static('admin/js/%s' % url) for url in js])
 
     def get_model_perms(self, request):

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -575,11 +575,10 @@ class ModelAdmin(BaseModelAdmin):
             'admin/RelatedObjectLookups.js',
             'jquery%s.js' % extra,
             'jquery.init.js',
+            'actions%s.js' % extra,
             'urlify.js',
             'prepopulate%s.js' % extra
         ]
-        if self.actions is not None:
-            js.append('actions%s.js' % extra)
         return forms.Media(js=[static('admin/js/%s' % url) for url in js])
 
     def get_model_perms(self, request):


### PR DESCRIPTION
As I mentioned in https://code.djangoproject.com/ticket/24467 - we need to include "prepopulate.js" file always.

This bug is in Django 1.7.5 and maybe in older releases. I use 1.7.5 and fixed this bug in development branch. If I need to do this fix in other branch (for example 1.7.x) please assist me on this way.

Thank you.
Anton