### PR TITLE
Fixed typo in ModelForm's documentation

### DIFF
--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -691,7 +691,7 @@ and values from an attached model instance. For example::
     >>> article.headline
     'My headline'
     >>> form = ArticleForm(initial={'headline': 'Initial headline'), instance=article)
-    >>> form['pub_date'].value()
+    >>> form['headline'].value()
     'Initial headline'
 
 .. _modelforms-factory:


### PR DESCRIPTION
I found this typo in a code example in ModelForm's documentation . I think many moons ago the code example used to be the 'pub_date' field. But then it was changed to 'headline' and one line got missed!