### PR TITLE
Fixed #24394 -- Fixed ImproperlyConfigured Error

### DIFF
--- a/django/db/backends/dummy/base.py
+++ b/django/db/backends/dummy/base.py
@@ -11,10 +11,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.base.client import BaseDatabaseClient
 from django.db.backends.base.creation import BaseDatabaseCreation
-from django.db.backends.base.features import BaseDatabaseFeatures
 from django.db.backends.base.introspection import BaseDatabaseIntrospection
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.backends.base.validation import BaseDatabaseValidation
+from django.db.backends.dummy.features import DummyDatabaseFeatures
 
 
 def complain(*args, **kwargs):
@@ -75,7 +75,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def __init__(self, *args, **kwargs):
         super(DatabaseWrapper, self).__init__(*args, **kwargs)
 
-        self.features = BaseDatabaseFeatures(self)
+        self.features = DummyDatabaseFeatures(self)
         self.ops = DatabaseOperations(self)
         self.client = DatabaseClient(self)
         self.creation = DatabaseCreation(self)

--- a/django/db/backends/dummy/features.py
+++ b/django/db/backends/dummy/features.py
@@ -1,0 +1,5 @@
+from django.db.backends.base.features import BaseDatabaseFeatures
+
+
+class DummyDatabaseFeatures(BaseDatabaseFeatures):
+    supports_transactions = False

--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -153,6 +153,9 @@ class ConnectionHandler(object):
                     'ENGINE': 'django.db.backends.dummy',
                 },
             }
+        if self._databases[DEFAULT_DB_ALIAS] == {}:
+            self._databases[DEFAULT_DB_ALIAS]['ENGINE'] = 'django.db.backends.dummy'
+
         if DEFAULT_DB_ALIAS not in self._databases:
             raise ImproperlyConfigured("You must define a '%s' database" % DEFAULT_DB_ALIAS)
         return self._databases

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -6,14 +6,13 @@ from __future__ import unicode_literals
 import unittest
 
 from admin_scripts.tests import AdminScriptTestCase
-
 from django import db
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.db.backends.dummy.base import DatabaseCreation
 from django.test import (
-    TestCase, TransactionTestCase, mock, skipUnlessDBFeature,
+    TestCase, TransactionTestCase, mock, skipUnlessDBFeature, testcases,
 )
 from django.test.runner import DiscoverRunner, dependency_ordered
 from django.test.testcases import connections_support_transactions
@@ -404,3 +403,18 @@ class AutoIncrementResetTest(TransactionTestCase):
     def test_autoincrement_reset2(self):
         p = Person.objects.create(first_name='Jack', last_name='Smith')
         self.assertEqual(p.pk, 1)
+
+
+class EmptyDefaultDatabaseTest(unittest.TestCase):
+    def test_empty_default_database(self):
+        """
+        Test that an empty default database in settings does not raise an ImproperlyConfigured
+        error when running a unit test that does not use a database.
+        """
+        testcases.connections = db.ConnectionHandler({'default': {}})
+        connection = testcases.connections[db.utils.DEFAULT_DB_ALIAS]
+        self.assertEqual(connection.settings_dict['ENGINE'], 'django.db.backends.dummy')
+        try:
+            connections_support_transactions()
+        except Exception as e:
+            self.fail("connections_support_transactions() unexpectedly raised an error: %s" % e)


### PR DESCRIPTION
Fixed ImproperlyConfigured Error when running any unit test
and the default database entry in settings is an empty dictionary.