### PR TITLE
Deleted stray tick mark in docs

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1584,7 +1584,7 @@ Field API reference
 
     All of Django's built-in fields, such as :class:`CharField`, are particular
     implementations of ``Field``. If you need a custom field, you can either
-    subclass any of the built-in fields or write a ``Field``` from scratch. In
+    subclass any of the built-in fields or write a ``Field`` from scratch. In
     either case, see :doc:`/howto/custom-model-fields`.
 
     .. attribute:: description


### PR DESCRIPTION
This is causing the following to show up in the docs (https://docs.djangoproject.com/en/1.7/ref/models/fields/#django.db.models.Field):

"...you can either subclass any of the built-in fields or write a Field` from scratch."