### PR TITLE
Fixed #23034 -- Added migration support for ManyToMany through model.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -465,11 +465,8 @@ class BaseDatabaseSchemaEditor(object):
                 old_field.remote_field.through._meta.auto_created and
                 new_field.remote_field.through._meta.auto_created):
             return self._alter_many_to_many(model, old_field, new_field, strict)
-        elif old_type is None and new_type is None and (
-                old_field.remote_field.through and new_field.remote_field.through and
-                not old_field.remote_field.through._meta.auto_created and
-                not new_field.remote_field.through._meta.auto_created):
-            # Both sides have through models; this is a no-op.
+        elif old_type is None and new_type is None and old_field.remote_field.through and new_field.remote_field.through:
+            # Both sides are many-to-many; this is a no-op.
             return
         elif old_type is None or new_type is None:
             raise ValueError(

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -68,6 +68,20 @@ class MigrationAutodetector(object):
             },
         )
 
+    def m2m_field_compare(self, through, rem_through):
+        """
+        Compare if two many-to-many fields describe the same through model,
+        i.e. define a relation between the same from and to models and have
+        the same field name.
+        Used to detect through model renames, regardless of how much the
+        model has changed.
+        """
+        return (
+            through["from"] == rem_through["from"]
+            and through["to"] == rem_through["to"]
+            and through["field"] == rem_through["field"]
+        )
+
     def only_relation_agnostic_fields(self, fields):
         """
         Return a definition of the fields that ignores field names and
@@ -140,6 +154,53 @@ class MigrationAutodetector(object):
 
         # Renames have to come first
         self.generate_renamed_models()
+
+        self.old_through_models = {}
+        self.new_through_models = {}
+        # Prepare a list of all m2m fields in the old and new models.
+        # This is used to detect changes to through models.
+        for app_label, model_name in sorted(set(self.old_model_keys).intersection(self.new_model_keys)):
+            old_model_name = self.renamed_models.get((app_label, model_name), model_name)
+            old_model_state = self.from_state.models[app_label, old_model_name]
+            for field_name, field in old_model_state.fields:
+                # We need the through model, even if it is auto-created and
+                # through is None in the deconstructed field.
+                old_field = self.old_apps.get_model(app_label, old_model_name)._meta.get_field(field_name)
+                if old_field.remote_field and getattr(old_field.remote_field, "through", None):
+                    # Get the through key from the rendered field.
+                    through_key = (
+                        old_field.remote_field.through._meta.app_label,
+                        old_field.remote_field.through._meta.model_name
+                    )
+                    # Get the to key from the deconstructed field.
+                    to_key = field.related_model.split('.')
+                    self.old_through_models[through_key] = {
+                        "from": (app_label, model_name),
+                        "to": to_key,
+                        "through": through_key,
+                        "field": field_name
+                    }
+            new_model_state = self.to_state.models[app_label, model_name]
+            for field_name, field in new_model_state.fields:
+                # We need the through model, even if it is auto-created and
+                # through is None in the deconstructed field.
+                new_field = self.new_apps.get_model(app_label, model_name)._meta.get_field(field_name)
+                if new_field.remote_field and getattr(new_field.remote_field, "through", None):
+                    # Get the through key from the rendered field.
+                    through_key = (
+                        new_field.remote_field.through._meta.app_label,
+                        new_field.remote_field.through._meta.model_name
+                    )
+                    # Get the to key from the deconstructed field.
+                    to_key = field.remote_field.model.split('.')
+                    self.new_through_models[through_key] = {
+                        "from": (app_label, model_name),
+                        "to": to_key,
+                        "through": through_key,
+                        "field": field_name,
+                    }
+
+        self.generate_renamed_through_models()
 
         # Prepare field lists, and prepare a list of the fields that used
         # through models in the old state so we can make dependencies
@@ -415,12 +476,16 @@ class MigrationAutodetector(object):
         for app_label, model_name in sorted(added_models):
             model_state = self.to_state.models[app_label, model_name]
             model_fields_def = self.only_relation_agnostic_fields(model_state.fields)
+            if 'auto_created' in model_state.options:
+                continue
 
             removed_models = set(self.old_model_keys) - set(self.new_model_keys)
             for rem_app_label, rem_model_name in removed_models:
                 if rem_app_label == app_label:
                     rem_model_state = self.from_state.models[rem_app_label, rem_model_name]
                     rem_model_fields_def = self.only_relation_agnostic_fields(rem_model_state.fields)
+                    if 'auto_created' in rem_model_state.options:
+                        continue
                     if model_fields_def == rem_model_fields_def:
                         if self.questioner.ask_rename_model(rem_model_state, model_state):
                             self.add_operation(
@@ -435,6 +500,32 @@ class MigrationAutodetector(object):
                             self.old_model_keys.remove((rem_app_label, rem_model_name))
                             self.old_model_keys.append((app_label, model_name))
                             break
+
+    def generate_renamed_through_models(self):
+        for (app_label, model_name), through in sorted(self.new_through_models.items()):
+            through_state = self.to_state.models[app_label, model_name]
+            for (rem_app_label, rem_model_name), rem_through in sorted(self.old_through_models.items()):
+                if self.m2m_field_compare(through, rem_through):
+                    if through["through"] == rem_through["through"]:
+                        break
+                    rem_through_state = self.from_state.models[rem_app_label, rem_model_name]
+                    self.add_operation(
+                        app_label,
+                        operations.RenameModel(
+                            old_name=rem_through_state.name,
+                            new_name=through_state.name,
+                        )
+                    )
+                    self.renamed_models[app_label, model_name] = rem_model_name
+                    self.renamed_models_rel['%s.%s' % (rem_through_state.app_label, rem_through_state.name)] = '%s.%s' % (through_state.app_label, through_state.name)
+                    self.old_model_keys.remove((rem_app_label, rem_model_name))
+                    self.old_model_keys.append((app_label, model_name))
+                    break
+                elif through["field"] == rem_through["field"] and through["from"] == rem_through["from"]:
+                    self.old_model_keys.remove(rem_through["through"])
+                    del self.old_through_models[rem_through["through"]]
+                    self.new_model_keys.remove(through["through"])
+                    del self.new_through_models[through["through"]]
 
     def generate_created_models(self):
         """
@@ -456,6 +547,8 @@ class MigrationAutodetector(object):
         for app_label, model_name in all_added_models:
             model_state = self.to_state.models[app_label, model_name]
             model_opts = self.new_apps.get_model(app_label, model_name)._meta
+            if model_opts.auto_created:
+                continue
             # Gather related fields
             related_fields = {}
             primary_key_rel = None
@@ -632,8 +725,9 @@ class MigrationAutodetector(object):
         for app_label, model_name in all_deleted_models:
             model_state = self.from_state.models[app_label, model_name]
             model = self.old_apps.get_model(app_label, model_name)
-            if not model._meta.managed:
+            if model._meta.auto_created or not model._meta.managed:
                 # Skip here, no need to handle fields for unmanaged models
+                # Auto-created models are handled when the creating model is processed
                 continue
 
             # Gather related fields

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -142,7 +142,8 @@ class ProjectState(object):
                 except KeyError:
                     pass
                 else:
-                    states_to_be_rendered.append(model_state)
+                    if "auto_created" not in model_state.options:
+                        states_to_be_rendered.append(model_state)
 
             # Render all models
             self.apps.render_multiple(states_to_be_rendered)
@@ -170,7 +171,7 @@ class ProjectState(object):
     def from_apps(cls, apps):
         "Takes in an Apps and returns a ProjectState matching it"
         app_models = {}
-        for model in apps.get_models(include_swapped=True):
+        for model in apps.get_models(include_swapped=True, include_auto_created=True):
             model_state = ModelState.from_model(model)
             app_models[(model_state.app_label, model_state.name_lower)] = model_state
         return cls(app_models)

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -127,6 +127,13 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher")),
     ])
+    author_publisher_m2m = ModelState("testapp", "Author_publishers", [
+        ("id", models.AutoField(primary_key=True, auto_created=True, verbose_name="ID")),
+        ("author", models.ForeignKey("testapp.Author", related_name="Author_publishers+")),
+        ("publisher", models.ForeignKey("testapp.Publisher", related_name="Author_publishers+")),
+    ], {
+        "auto_created": "testapp.Author",
+    })
     author_with_m2m_blank = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher", blank=True)),
@@ -138,6 +145,15 @@ class AutodetectorTests(TestCase):
     author_with_former_m2m = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("publishers", models.CharField(max_length=100)),
+    ])
+    author_with_repointed_m2m = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("publishers", models.ManyToManyField("otherapp.Book")),
+    ])
+    author_book_m2m = ModelState("testapp", "Author_publishers", [
+        ("id", models.AutoField(primary_key=True, auto_created=True, verbose_name="ID")),
+        ("author", models.ForeignKey("testapp.Author", related_name="Author_publishers+")),
+        ("book", models.ForeignKey("otherapp.Book", related_name="Author_publishers+")),
     ])
     author_with_options = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
@@ -1290,7 +1306,7 @@ class AutodetectorTests(TestCase):
                 raise Exception("Should not have prompted for not null addition")
 
         before = self.make_project_state([self.author_empty, self.publisher])
-        after = self.make_project_state([self.author_with_m2m, self.publisher])
+        after = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m])
         autodetector = MigrationAutodetector(before, after, CustomQuestioner())
         changes = autodetector._detect_changes()
         # Right number/type of migrations?
@@ -1299,8 +1315,8 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, 'testapp', 0, 0, name="publishers")
 
     def test_alter_many_to_many(self):
-        before = self.make_project_state([self.author_with_m2m, self.publisher])
-        after = self.make_project_state([self.author_with_m2m_blank, self.publisher])
+        before = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m])
+        after = self.make_project_state([self.author_with_m2m_blank, self.publisher, self.author_publisher_m2m])
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # Right number/type of migrations?
@@ -1394,13 +1410,65 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, "testapp", 0, 3, name="Author")
         self.assertOperationAttributes(changes, "testapp", 0, 4, name="Contract")
 
+    def test_m2m_add_through_model(self):
+        """
+        Tests that the auto-created through model is correctly renamed to the
+        new custom through model.
+        """
+        before = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m])
+        after = self.make_project_state([self.author_with_m2m_through, self.publisher, self.contract])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, [
+            "RenameModel", "AlterModelOptions", "AlterField", "AlterField", "AlterField", "AlterField",
+        ])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, old_name="Author_publishers", new_name="Contract")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="contract", options={})
+        self.assertOperationAttributes(changes, "testapp", 0, 2, name="publishers", model_name="author")
+        self.assertOperationAttributes(changes, "testapp", 0, 3, name="author", model_name="contract")
+        self.assertOperationAttributes(changes, "testapp", 0, 4, name="id", model_name="contract")
+        self.assertOperationAttributes(changes, "testapp", 0, 5, name="publisher", model_name="contract")
+
+    def test_m2m_remove_through_model(self):
+        """
+        Tests that the custom through model is correctly renamed to the
+        auto-created through model.
+        """
+        before = self.make_project_state([self.author_with_m2m_through, self.publisher, self.contract])
+        after = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, [
+            "RenameModel", "AlterModelOptions", "AlterField", "AlterField", "AlterField", "AlterField",
+        ])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, old_name="Contract", new_name="Author_publishers")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="author_publishers", options={
+            "auto_created": "testapp.Author"
+        })
+        self.assertOperationAttributes(changes, "testapp", 0, 2, name="publishers", model_name="author")
+        self.assertOperationAttributes(changes, "testapp", 0, 3, name="author", model_name="author_publishers")
+        self.assertOperationAttributes(changes, "testapp", 0, 4, name="id", model_name="author_publishers")
+        self.assertOperationAttributes(changes, "testapp", 0, 5, name="publisher", model_name="author_publishers")
+
+    def test_repoint_m2m_field(self):
+        before = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m, self.book])
+        after = self.make_project_state([self.author_with_repointed_m2m, self.book, self.author_book_m2m, self.publisher])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, [
+            "AlterField",
+        ])
+
     def test_concrete_field_changed_to_many_to_many(self):
         """
         #23938 - Tests that changing a concrete field into a ManyToManyField
         first removes the concrete field and then adds the m2m field.
         """
         before = self.make_project_state([self.author_with_former_m2m])
-        after = self.make_project_state([self.author_with_m2m, self.publisher])
+        after = self.make_project_state([self.author_with_m2m, self.publisher, self.author_publisher_m2m])
         autodetector = MigrationAutodetector(before, after)
         changes = autodetector._detect_changes()
         # Right number/type of migrations?


### PR DESCRIPTION
Added auto-created models to project state, while preventing
conventional creation/deletion as this is handled elsewhere.
This allows the auto-detector to pick up any changes to custom
or auto-created through models. Added support for switching
between the two by explicitly renaming through models in a specific
many-to-many field.

https://code.djangoproject.com/ticket/23034