### PR TITLE
Fixed #23746 -- Added a pre_capture_queries signal that clears query caches.

### DIFF
--- a/django/contrib/auth/tests/test_management.py
+++ b/django/contrib/auth/tests/test_management.py
@@ -499,7 +499,6 @@ class PermissionTestCase(TestCase):
         models.Permission._meta.permissions = self._original_permissions
         models.Permission._meta.default_permissions = self._original_default_permissions
         models.Permission._meta.verbose_name = self._original_verbose_name
-        ContentType.objects.clear_cache()
 
     def test_duplicated_permissions(self):
         """

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 from django.apps import apps
 from django.db import models
 from django.db.utils import OperationalError, ProgrammingError
+from django.test.signals import pre_capture_queries
+from django.utils.encoding import force_text, python_2_unicode_compatible, smart_text
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import smart_text, force_text
-from django.utils.encoding import python_2_unicode_compatible
 
 
 class ContentTypeManager(models.Manager):
@@ -199,3 +199,11 @@ class ContentType(models.Model):
 
     def natural_key(self):
         return (self.app_label, self.model)
+
+
+def clear_content_types_cache(**kwargs):
+    """
+    Resets the cache to allow ``assertNumQueries`` to count all queries.
+    """
+    ContentType.objects.clear_cache()
+pre_capture_queries.connect(clear_content_types_cache)

--- a/django/contrib/contenttypes/tests/tests.py
+++ b/django/contrib/contenttypes/tests/tests.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.models import ContentType, clear_content_types_cache
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpRequest, Http404
 from django.test import TestCase, override_settings
+from django.test.signals import pre_capture_queries
 from django.utils import six
 
 from .models import ConcreteModel, ProxyModel, FooWithoutUrl, FooWithUrl, FooWithBrokenAbsoluteUrl
@@ -13,10 +14,12 @@ from .models import ConcreteModel, ProxyModel, FooWithoutUrl, FooWithUrl, FooWit
 class ContentTypesTests(TestCase):
 
     def setUp(self):
+        pre_capture_queries.disconnect(clear_content_types_cache)
         ContentType.objects.clear_cache()
 
     def tearDown(self):
         ContentType.objects.clear_cache()
+        pre_capture_queries.connect(clear_content_types_cache)
 
     def test_lookup_cache(self):
         """

--- a/django/contrib/sites/models.py
+++ b/django/contrib/sites/models.py
@@ -6,6 +6,7 @@ import warnings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.db.models.signals import pre_save, pre_delete
+from django.test.signals import pre_capture_queries
 from django.utils.deprecation import RemovedInDjango19Warning
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
@@ -122,3 +123,11 @@ def clear_site_cache(sender, **kwargs):
         pass
 pre_save.connect(clear_site_cache, sender=Site)
 pre_delete.connect(clear_site_cache, sender=Site)
+
+
+def clear_sites_cache(**kwargs):
+    """
+    Resets the whole cache to allow ``assertNumQueries`` to count all queries.
+    """
+    Site.objects.clear_cache()
+pre_capture_queries.connect(clear_sites_cache)

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -13,6 +13,8 @@ template_rendered = Signal(providing_args=["template", "context"])
 
 setting_changed = Signal(providing_args=["setting", "value", "enter"])
 
+pre_capture_queries = Signal()
+
 # Most setting_changed receivers are supposed to be added below,
 # except for cases where the receiver is related to a contrib app.
 

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -16,7 +16,7 @@ from django.db import reset_queries
 from django.http import request
 from django.template import Template
 from django.template.loaders import locmem
-from django.test.signals import template_rendered, setting_changed
+from django.test.signals import pre_capture_queries, setting_changed, template_rendered
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango19Warning, RemovedInDjango20Warning
 from django.utils.encoding import force_str
@@ -422,6 +422,7 @@ class CaptureQueriesContext(object):
         self.initial_queries = len(self.connection.queries_log)
         self.final_queries = None
         request_started.disconnect(reset_queries)
+        pre_capture_queries.send(sender=self.__class__)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -704,6 +704,22 @@ Arguments sent with this signal:
     The :class:`~django.template.Context` with which the template was
     rendered.
 
+pre_capture_queries
+-------------------
+
+.. data:: django.test.signals.pre_capture_queries
+   :module:
+
+Sent on entering a query capturing context, such as
+:meth:`~django.test.TransactionTestCase.assertNumQueries`. Holders of caches
+that may prevent execution of queries should connect to the signal and clear
+them when it's received.
+
+Arguments sent with this signal:
+
+``sender``
+    The context manager that will be capturing queries.
+
 Database Wrappers
 =================
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1569,6 +1569,13 @@ your test suite.
             Person.objects.create(name="Aaron")
             Person.objects.create(name="Daniel")
 
+    .. versionchanged:: 1.8
+
+        Internal caches that prevent execution of some queries are cleared on
+        entering the context. You may temporarily disconnect some receivers
+        from the :data:`~django.test.signals.pre_capture_queries` signal if
+        you're testing cache priming.
+
 .. _topics-testing-email:
 
 Email services

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4165,9 +4165,6 @@ class UserAdminTest(TestCase):
     def test_user_permission_performance(self):
         u = User.objects.all()[0]
 
-        # Don't depend on a warm cache, see #17377.
-        ContentType.objects.clear_cache()
-
         with self.assertNumQueries(10):
             response = self.client.get('/test_admin/admin/auth/user/%s/' % u.pk)
             self.assertEqual(response.status_code, 200)
@@ -4205,10 +4202,6 @@ class GroupAdminTest(TestCase):
 
     def test_group_permission_performance(self):
         g = Group.objects.create(name="test_group")
-
-        # Ensure no queries are skipped due to cached content type for Group.
-        ContentType.objects.clear_cache()
-
         with self.assertNumQueries(8):
             response = self.client.get('/test_admin/admin/auth/group/%s/' % g.pk)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
The signal is sent before entering a capturing context (assertNumQueries /
CaptureQueriesContext), letting listeners pre-clear some query caches.
Thanks to that the number of queries doesn't depend on execution history.

Disabled the cache clearing (by disconnected the signal temporarily) for
contenttypes tests that actually test cache priming.

Increased the expected number of queries in a few prefetch_related tests
as they now can't rely on having content types cached.

Reverted fixes from #17377, #20432 and #23746 as they are no longer needed.