### PR TITLE
Fix router examples allow_migrate crash

### DIFF
--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -314,7 +314,7 @@ send queries for the ``auth`` app to ``auth_db``::
                return True
             return None
 
-        def allow_migrate(self, db, app_label, model, **hints):
+        def allow_migrate(self, db, app_label, model=None, **hints):
             """
             Make sure the auth app only appears in the 'auth_db'
             database.
@@ -352,7 +352,7 @@ from::
                 return True
             return None
 
-        def allow_migrate(self, db, app_label, model, **hints):
+        def allow_migrate(self, db, app_label, model=None, **hints):
             """
             All non-auth models end up in this pool.
             """


### PR DESCRIPTION
allow_migrate requires model parameter to have default value None, as described in reference documentation (same file but before examples):
https://docs.djangoproject.com/en/1.8/topics/db/multi-db/#allow_migrate

Otherwise it crashes with error:

File "c:\...\site-packages\django\db\utils.py", line 347, in allow_migrate
    allow = method(db, app_label, **hints)
TypeError: allow_migrate() takes exactly 4 arguments (3 given)