### PR TITLE
Fixed #24476 -- Added context manager/decorator for overriding prefix.

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -527,15 +527,14 @@ def resolve(path, urlconf=None):
     return get_resolver(urlconf).resolve(path)
 
 
-def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None, current_app=None):
+def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
     if urlconf is None:
         urlconf = get_urlconf()
     resolver = get_resolver(urlconf)
     args = args or []
     kwargs = kwargs or {}
 
-    if prefix is None:
-        prefix = get_script_prefix()
+    prefix = get_script_prefix()
 
     if not isinstance(viewname, six.string_types):
         view = viewname

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -12,11 +12,13 @@ from django.apps import apps
 from django.conf import UserSettingsHolder, settings
 from django.core import mail
 from django.core.signals import request_started
+from django.core.urlresolvers import get_script_prefix, set_script_prefix
 from django.db import reset_queries
 from django.http import request
 from django.template import Template
 from django.test.signals import setting_changed, template_rendered
 from django.utils import six
+from django.utils.decorators import ContextDecorator
 from django.utils.encoding import force_str
 from django.utils.translation import deactivate
 
@@ -595,3 +597,22 @@ def require_jinja2(test_func):
         'OPTIONS': {'keep_trailing_newline': True},
     }])(test_func)
     return test_func
+
+
+class ScriptPrefix(ContextDecorator):
+    def __enter__(self):
+        set_script_prefix(self.prefix)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        set_script_prefix(self.old_prefix)
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+        self.old_prefix = get_script_prefix()
+
+
+def override_script_prefix(prefix):
+    """
+    Decorator or context manager to temporary override the script prefix.
+    """
+    return ScriptPrefix(prefix)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -22,15 +22,13 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core import mail
 from django.core.checks import Error
 from django.core.files import temp as tempfile
-from django.core.urlresolvers import (
-    NoReverseMatch, get_script_prefix, resolve, reverse, set_script_prefix,
-)
+from django.core.urlresolvers import NoReverseMatch, resolve, reverse
 from django.forms.utils import ErrorList
 from django.template.response import TemplateResponse
 from django.test import (
     TestCase, modify_settings, override_settings, skipUnlessDBFeature,
 )
-from django.test.utils import patch_logger
+from django.test.utils import override_script_prefix, patch_logger
 from django.utils import formats, six, translation
 from django.utils._os import upath
 from django.utils.cache import get_max_age
@@ -5822,16 +5820,12 @@ class AdminKeepChangeListFiltersTests(TestCase):
             add_preserved_filters(context, url),
         )
 
-        original_prefix = get_script_prefix()
-        try:
-            set_script_prefix('/prefix/')
+        with override_script_prefix('/prefix/'):
             url = reverse('admin:auth_user_changelist', current_app=self.admin_site.name)
             self.assertURLEqual(
                 self.get_changelist_url(),
                 add_preserved_filters(context, url),
             )
-        finally:
-            set_script_prefix(original_prefix)
 
 
 class NamespacedAdminKeepChangeListFiltersTests(AdminKeepChangeListFiltersTests):

--- a/tests/flatpages_tests/test_models.py
+++ b/tests/flatpages_tests/test_models.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from django.contrib.flatpages.models import FlatPage
-from django.core.urlresolvers import clear_script_prefix, set_script_prefix
 from django.test import TestCase
+from django.test.utils import override_script_prefix
 
 
 class FlatpageModelTests(TestCase):
@@ -13,10 +13,7 @@ class FlatpageModelTests(TestCase):
         pf = FlatPage(title="Café!", url='/café/')
         self.assertEqual(pf.get_absolute_url(), '/caf%C3%A9/')
 
+    @override_script_prefix('/beverages/')
     def test_get_absolute_url_honors_script_prefix(self):
         pf = FlatPage(title="Tea!", url='/tea/')
-        set_script_prefix('/beverages/')
-        try:
-            self.assertEqual(pf.get_absolute_url(), '/beverages/tea/')
-        finally:
-            clear_script_prefix()
+        self.assertEqual(pf.get_absolute_url(), '/beverages/tea/')


### PR DESCRIPTION
Tests were using an undocumented keyword argument for easily overriding
script prefix while reversing. This is now changed into a test utility
which can be used as decorator or context manager.