### PR TITLE
Fixed #13750 - Added documentation for image field behavior and added re...

### DIFF
--- a/docs/topics/files.txt
+++ b/docs/topics/files.txt
@@ -55,6 +55,10 @@ it has all the methods and attributes described below.
     file name used on disk cannot be relied on until after the model has been
     saved.
 
+.. note::
+    Accessing an image field (or other file-like field) on a model returns
+    a closed file reference. 
+
 
 The ``File`` object
 ===================

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -384,3 +384,7 @@ class AbstractForeignFieldsModel(models.Model):
 
     class Meta:
         abstract = True
+
+
+class Profile(models.Model):
+    image = models.ImageField()

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -181,6 +181,21 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
         loaded_p = pickle.loads(dump)
         self.assertEqual(p.mugshot, loaded_p.mugshot)
 
+    def test_image_field_io_closed_file(self):
+        """
+        Opening 'image' property as Image object of a model's ImageField will fail
+        with an 'I/O operation on closed file' error. Regression for #13750
+
+        Accessing the image after saving it should return a closed file reference.
+        """
+        from .models import Profile
+        profile = Profile()
+        profile.image = self.file1
+
+        profile.save()
+
+        self.assertTrue(profile.image.closed)
+
 
 @skipIf(Image is None, "Pillow is required to test ImageField")
 class ImageFieldTwoDimensionsTests(ImageFieldTestMixin, TestCase):


### PR DESCRIPTION
Added documentation for image field behavior and added regression test

Added a regression test that verifies that accessing an image field on a model
returns a closed file reference. Also added documentation to docs/topics/fiels.txt
that mentions this behavior.