### PR TITLE
Fixed #24483 -- Greedily consume choices iterators

### DIFF
--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -595,6 +595,28 @@ class StateTests(TestCase):
         self.assertIsNot(old_model.food_mgr.model, new_model.food_mgr.model)
         self.assertIsNot(old_model.food_qs.model, new_model.food_qs.model)
 
+    def test_choices_iterator(self):
+        """
+        #24483 ProjectState.from_apps should not destructively consume choice
+        iterators
+        """
+
+        new_apps = Apps(["migrations"])
+
+        choices = [('a', 'A'), ('b', 'B')]
+
+        class Author(models.Model):
+            name = models.CharField(max_length=255)
+            choice = models.CharField(max_length=255, choices=iter(choices))
+
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+
+        ProjectState.from_apps(new_apps)
+        choices_field = Author._meta.get_field('choice')
+        self.assertEqual(list(choices_field.choices), choices)
+
 
 class ModelStateTests(TestCase):
     def test_custom_model_base(self):

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -411,13 +411,6 @@ class ChoicesTests(test.TestCase):
         self.assertEqual(WhizIterEmpty(c=None).c, None)    # Blank value
         self.assertEqual(WhizIterEmpty(c='').c, '')        # Empty value
 
-    def test_charfield_get_choices_with_blank_iterator(self):
-        """
-        Check that get_choices works with an empty Iterator
-        """
-        f = models.CharField(choices=(x for x in []))
-        self.assertEqual(f.get_choices(include_blank=True), [('', '---------')])
-
 
 class SlugFieldTests(test.TestCase):
     def test_slugfield_max_length(self):


### PR DESCRIPTION
If Field.choices is provided as an iterator, consume in `__init__` instead
of using itertools.tee (which ends up holding everything in memory
anyway). Fixes bug where deconstruct was consuming iterator but
bypassing the call to `tee`.