### PR TITLE
Fixed #24488 -- Made `create_default_site` use default pk of 1.

### DIFF
--- a/django/contrib/sites/management.py
+++ b/django/contrib/sites/management.py
@@ -25,7 +25,7 @@ def create_default_site(app_config, verbosity=2, interactive=True, using=DEFAULT
         # can also crop up outside of tests - see #15346.
         if verbosity >= 2:
             print("Creating example.com Site object")
-        Site(pk=settings.SITE_ID, domain="example.com", name="example.com").save(using=using)
+        Site(pk=getattr(settings, "SITE_ID", 1), domain="example.com", name="example.com").save(using=using)
 
         # We set an explicit pk instead of relying on auto-incrementation,
         # so we need to reset the database sequence. See #17415.

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -209,6 +209,16 @@ class CreateDefaultSiteTests(TestCase):
         create_default_site(self.app_config, verbosity=0)
         self.assertEqual(Site.objects.get().pk, 35696)
 
+    def test_no_site_id(self):
+        """
+        #24488 - The pk should default to 1 if no ``SITE_ID`` is configured.
+        """
+        # Restore original ``SITE_ID`` afterwards.
+        with override_settings():
+            del settings.SITE_ID
+            create_default_site(self.app_config, verbosity=0)
+            self.assertEqual(Site.objects.get().pk, 1)
+
 
 class MiddlewareTest(TestCase):
 


### PR DESCRIPTION
Fixed `create_default_site` to use a default value in case
`settings.SITE_ID` is not set.

https://code.djangoproject.com/ticket/24488