### PR TITLE
Fixed #24486 -- Documented method to provide output_field to mixed F expressions

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -274,6 +274,17 @@ should define the desired ``output_field``. For example, adding an
 ``IntegerField()`` and a ``FloatField()`` together should probably have
 ``output_field=FloatField()`` defined.
 
+.. note::
+
+    When you need to define the ``output_field`` for ``F`` expression
+    arithmetic between different types it's necessary to surround the
+    expression in another expression::
+
+        from django.db.models import DateTimeField, ExpressionNode, F
+
+        Race.objects.annotate(finish=ExpressionNode(
+            F('start') + F('duration'), output_field=DateTimeField()))
+
 .. versionchanged:: 1.8
 
     ``output_field`` is a new parameter.


### PR DESCRIPTION
This should probably be back ported to avoid redundant tickets being created since the solution is non-obvious to someone without internal knowledge.

When `F(datetime) + F(delta)` are combined in a query, the expression is unable to determine the output type without special casing the code. Since F expressions do not accept an output_field argument, another type is required to provide an output_field at a higher layer.

The other option would be:

```
finish = F('start') + F('duration')
finish.output_field = DateTimeField()
Race.objects.annotate(finish=finish)
```

But I find that less palatable.