### PR TITLE
Refs #24485 -- Renamed some expression types

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -2,7 +2,7 @@ from django.contrib.gis import forms
 from django.contrib.gis.db.models.lookups import gis_lookups
 from django.contrib.gis.db.models.proxy import GeometryProxy
 from django.contrib.gis.geometry.backend import Geometry, GeometryException
-from django.db.models.expressions import ExpressionNode
+from django.db.models.expressions import Expression
 from django.db.models.fields import Field
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
@@ -188,7 +188,7 @@ class GeometryField(GeoSelectFormatMixin, Field):
         returning to the caller.
         """
         value = super(GeometryField, self).get_prep_value(value)
-        if isinstance(value, ExpressionNode):
+        if isinstance(value, Expression):
             return value
         elif isinstance(value, (tuple, list)):
             geom = value[0]
@@ -282,7 +282,7 @@ class GeometryField(GeoSelectFormatMixin, Field):
                     pass
                 else:
                     params += value[1:]
-            elif isinstance(value, ExpressionNode):
+            elif isinstance(value, Expression):
                 params = []
             else:
                 params = [connection.ops.Adapter(value)]

--- a/django/contrib/gis/db/models/lookups.py
+++ b/django/contrib/gis/db/models/lookups.py
@@ -4,7 +4,7 @@ import re
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import Col, ExpressionNode
+from django.db.models.expressions import Col, Expression
 from django.db.models.lookups import Lookup
 from django.utils import six
 
@@ -80,7 +80,7 @@ class GISLookup(Lookup):
             if not hasattr(geo_fld, 'srid'):
                 raise ValueError('No geographic field found in expression.')
             self.rhs.srid = geo_fld.srid
-        elif isinstance(self.rhs, ExpressionNode):
+        elif isinstance(self.rhs, Expression):
             raise ValueError('Complex expressions not supported for GeometryField')
         elif isinstance(self.rhs, (list, tuple)):
             geom = self.rhs[0]

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from django.core.exceptions import ObjectDoesNotExist, ImproperlyConfigured  # NOQA
 from django.db.models.query import Q, QuerySet, Prefetch  # NOQA
-from django.db.models.expressions import ExpressionNode, F, Value, Func, Case, When  # NOQA
+from django.db.models.expressions import Expression, F, Value, Func, Case, When  # NOQA
 from django.db.models.manager import Manager  # NOQA
 from django.db.models.base import Model  # NOQA
 from django.db.models.aggregates import *  # NOQA

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -280,9 +280,9 @@ should define the desired ``output_field``. For example, adding an
     arithmetic between different types, it's necessary to surround the
     expression in another expression::
 
-        from django.db.models import DateTimeField, ExpressionNode, F
+        from django.db.models import DateTimeField, Expression, F
 
-        Race.objects.annotate(finish=ExpressionNode(
+        Race.objects.annotate(finish=Expression(
             F('start') + F('duration'), output_field=DateTimeField()))
 
 .. versionchanged:: 1.8
@@ -365,13 +365,13 @@ Expression API
 
 Query expressions implement the :ref:`query expression API <query-expression>`,
 but also expose a number of extra methods and attributes listed below. All
-query expressions must inherit from ``ExpressionNode()`` or a relevant
+query expressions must inherit from ``Expression()`` or a relevant
 subclass.
 
 When a query expression wraps another expression, it is responsible for
 calling the appropriate methods on the wrapped expression.
 
-.. class:: ExpressionNode
+.. class:: Expression
 
     .. attribute:: contains_aggregate
 
@@ -485,9 +485,9 @@ We'll start by defining the template to be used for SQL generation and
 an ``__init__()`` method to set some attributes::
 
   import copy
-  from django.db.models import ExpressionNode
+  from django.db.models import Expression
 
-  class Coalesce(ExpressionNode):
+  class Coalesce(Expression):
       template = 'COALESCE( %(expressions)s )'
 
       def __init__(self, expressions, output_field, **extra):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -845,7 +845,7 @@ class ReprTests(TestCase):
         self.assertEqual(repr(Date('published', 'exact')), "Date(published, exact)")
         self.assertEqual(repr(DateTime('published', 'exact', utc)), "DateTime(published, exact, %s)" % utc)
         self.assertEqual(repr(F('published')), "F(published)")
-        self.assertEqual(repr(F('cost') + F('tax')), "<Expression: F(cost) + F(tax)>")
+        self.assertEqual(repr(F('cost') + F('tax')), "<CombinedExpression: F(cost) + F(tax)>")
         self.assertEqual(repr(Func('published', function='TO_CHAR')), "Func(F(published), function=TO_CHAR)")
         self.assertEqual(repr(OrderBy(Value(1))), 'OrderBy(Value(1), descending=False)')
         self.assertEqual(repr(Random()), "Random()")


### PR DESCRIPTION
Renamed ExpressionNode -> Expression to provide a friendlier base name that is semi-public.
Renamed Expression -> CombinedExpression to avoid the name clash, and to better describe the purpose of the type.

Thanks to Carl, Tim, and yoyoma from Trac for providing input.