### PR TITLE
Fixed #24496 -- Checked CSRF Referer against CSRF_COOKIE_DOMAIN.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -16,6 +16,7 @@ from django.utils.datastructures import ImmutableList, MultiValueDict
 from django.utils.encoding import (
     escape_uri_path, force_bytes, force_str, force_text, iri_to_uri,
 )
+from django.utils.http import is_same_domain
 from django.utils.six.moves.urllib.parse import (
     parse_qsl, quote, urlencode, urljoin, urlsplit,
 )
@@ -527,15 +528,7 @@ def validate_host(host, allowed_hosts):
     host = host[:-1] if host.endswith('.') else host
 
     for pattern in allowed_hosts:
-        pattern = pattern.lower()
-        match = (
-            pattern == '*' or
-            pattern.startswith('.') and (
-                host.endswith(pattern) or host == pattern[1:]
-            ) or
-            pattern == host
-        )
-        if match:
+        if pattern == '*' or is_same_domain(host, pattern):
             return True
 
     return False

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -14,7 +14,8 @@ from django.core.urlresolvers import get_callable
 from django.utils.cache import patch_vary_headers
 from django.utils.crypto import constant_time_compare, get_random_string
 from django.utils.encoding import force_text
-from django.utils.http import same_origin
+from django.utils.http import is_same_domain
+from django.utils.six.moves.urllib.parse import urlparse
 
 logger = logging.getLogger('django.request')
 
@@ -22,6 +23,8 @@ REASON_NO_REFERER = "Referer checking failed - no Referer."
 REASON_BAD_REFERER = "Referer checking failed - %s does not match %s."
 REASON_NO_CSRF_COOKIE = "CSRF cookie not set."
 REASON_BAD_TOKEN = "CSRF token missing or incorrect."
+REASON_MALFORMED_REFERER = "Referer checking failed - Referer is malformed."
+REASON_INSECURE_REFERER = "Referer checking failed - Referer is insecure while host is secure."
 
 CSRF_KEY_LENGTH = 32
 
@@ -154,9 +157,28 @@ class CsrfViewMiddleware(object):
                 if referer is None:
                     return self._reject(request, REASON_NO_REFERER)
 
-                # Note that request.get_host() includes the port.
-                good_referer = 'https://%s/' % request.get_host()
-                if not same_origin(referer, good_referer):
+                referer = urlparse(referer)
+
+                # Make sure we have a valid URL for Referer.
+                if '' in (referer.scheme, referer.netloc):
+                    return self._reject(request, REASON_MALFORMED_REFERER)
+
+                # Ensure that our Referer is also secure.
+                if referer.scheme != 'https':
+                    return self._reject(request, REASON_INSECURE_REFERER)
+
+                # If there isn't a CSRF_COOKIE_DOMAIN, assume we need an exact
+                # match on host:port. If not, obey the cookie rules.
+                if settings.CSRF_COOKIE_DOMAIN is None:
+                    # request.get_host() includes the port.
+                    good_referer = request.get_host()
+                else:
+                    good_referer = settings.CSRF_COOKIE_DOMAIN
+                    server_port = request.META['SERVER_PORT']
+                    if server_port not in ('443', '80'):
+                        good_referer = '%s:%s' % (good_referer, server_port)
+
+                if not is_same_domain(referer.netloc, good_referer):
                     reason = REASON_BAD_REFERER % (referer, good_referer)
                     return self._reject(request, reason)
 

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -253,17 +253,23 @@ def quote_etag(etag):
     return '"%s"' % etag.replace('\\', '\\\\').replace('"', '\\"')
 
 
-def same_origin(url1, url2):
+def is_same_domain(host, pattern):
     """
-    Checks if two URLs are 'same-origin'
+    Return ``True`` if the host is either an exact match or a match
+    to the wildcard pattern.
+
+    Any pattern beginning with a period matches a domain and all of its
+    subdomains. (e.g. ``.example.com`` matches ``example.com`` and
+    ``foo.example.com``). Anything else is an exact string match.
     """
-    p1, p2 = urlparse(url1), urlparse(url2)
-    try:
-        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
-        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
-        return o1 == o2
-    except (ValueError, KeyError):
+    if not pattern:
         return False
+
+    pattern = pattern.lower()
+    return (
+        pattern[0] == '.' and (host.endswith(pattern) or host == pattern[1:]) or
+        pattern == host
+    )
 
 
 def is_safe_url(url, host=None):

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -257,9 +257,14 @@ The CSRF protection is based on the following things:
    due to the fact that HTTP 'Set-Cookie' headers are (unfortunately) accepted
    by clients that are talking to a site under HTTPS.  (Referer checking is not
    done for HTTP requests because the presence of the Referer header is not
-   reliable enough under HTTP.)
+   reliable enough under HTTP.)  The referer is compared against the
+   :setting:`CSRF_COOKIE_DOMAIN` setting.  The :setting:`CSRF_COOKIE_DOMAIN`
+   setting supports subdomains.  For example, ".example.com" will allow
+   post requests from "www.example.com" and "api.example.com." If
+   :setting:`CSRF_COOKIE_DOMAIN` is not set, the referer must match the
+   ``Host`` header.
 
-This ensures that only forms that have originated from your Web site can be used
+This ensures that only forms that have originated from trusted domains can be used
 to POST data back.
 
 It deliberately ignores GET requests (and other requests that are defined as

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -10,31 +10,6 @@ from django.utils.datastructures import MultiValueDict
 
 class TestUtilsHttp(unittest.TestCase):
 
-    def test_same_origin_true(self):
-        # Identical
-        self.assertTrue(http.same_origin('http://foo.com/', 'http://foo.com/'))
-        # One with trailing slash - see #15617
-        self.assertTrue(http.same_origin('http://foo.com', 'http://foo.com/'))
-        self.assertTrue(http.same_origin('http://foo.com/', 'http://foo.com'))
-        # With port
-        self.assertTrue(http.same_origin('https://foo.com:8000', 'https://foo.com:8000/'))
-        # No port given but according to RFC6454 still the same origin
-        self.assertTrue(http.same_origin('http://foo.com', 'http://foo.com:80/'))
-        self.assertTrue(http.same_origin('https://foo.com', 'https://foo.com:443/'))
-
-    def test_same_origin_false(self):
-        # Different scheme
-        self.assertFalse(http.same_origin('http://foo.com', 'https://foo.com'))
-        # Different host
-        self.assertFalse(http.same_origin('http://foo.com', 'http://goo.com'))
-        # Different host again
-        self.assertFalse(http.same_origin('http://foo.com', 'http://foo.com.evil.com'))
-        # Different port
-        self.assertFalse(http.same_origin('http://foo.com:8000', 'http://foo.com:8001'))
-        # No port given
-        self.assertFalse(http.same_origin('http://foo.com', 'http://foo.com:8000/'))
-        self.assertFalse(http.same_origin('https://foo.com', 'https://foo.com:8000/'))
-
     def test_urlencode(self):
         # 2-tuples (the norm)
         result = http.urlencode((('a', 1), ('b', 2), ('c', 3)))
@@ -156,6 +131,25 @@ class TestUtilsHttp(unittest.TestCase):
         self.assertEqual(
             http.urlunquote_plus('Paris+&+Orl%C3%A9ans'),
             'Paris & Orl\xe9ans')
+
+    def test_is_same_domain_good(self):
+        for pair in (
+            ('example.com', 'example.com'),
+            ('example.com', '.example.com'),
+            ('foo.example.com', '.example.com'),
+            ('example.com:8888', 'example.com:8888'),
+            ('example.com:8888', '.example.com:8888'),
+            ('foo.example.com:8888', '.example.com:8888'),
+        ):
+            self.assertTrue(http.is_same_domain(*pair))
+
+    def test_is_same_domain_bad(self):
+        for pair in (
+            ('example2.com', 'example.com'),
+            ('foo.example.com', 'example.com'),
+            ('example.com:9999', 'example.com:8888'),
+        ):
+            self.assertFalse(http.is_same_domain(*pair))
 
 
 class ETagProcessingTests(unittest.TestCase):


### PR DESCRIPTION
Right now, if you try to share a CSRF token across a subdomain without https, everything works great since the Referer header isn't validated.

But over https, we want to be a bit more strict and make sure that the Referer is from another secure site, and also that the Referer matches where we think it should be coming from. The canonical source for where we think it should be from is `CSRF_COOKIE_DOMAIN`.

If we set our `CSRF_COOKIE_DOMAIN` to `.example.com`, that means our CSRF validation should work for `www.example.com` and `foo.example.com`. Not just strictly the domain the request is coming from.