### PR TITLE
Fixed ticket_24498 - Remove migration db config while running unit tests

### DIFF
--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -80,6 +80,10 @@ class Command(BaseCommand):
         from django.conf import settings
         from django.test.utils import get_runner
 
+        # Don't run migrations for tests
+        if settings.DATABASES.get('migration') is not None:
+            del settings.DATABASES['migration']
+
         TestRunner = get_runner(settings, options.get('testrunner'))
 
         if options.get('liveserver') is not None:


### PR DESCRIPTION
While running tests it should ignore migration database settings if specified.