### PR TITLE
Fixed #24508 -- Made annotations reflective

### DIFF
--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -182,6 +182,14 @@ class NonAggregateAnnotationTestCase(TestCase):
                 sum_rating=Sum('rating')
             ).filter(sum_rating=F('nope')))
 
+    def test_combined_annotation_commutative(self):
+        book1 = Book.objects.annotate(adjusted_rating=F('rating') + 2).get(pk=self.b1.pk)
+        book2 = Book.objects.annotate(adjusted_rating=2 + F('rating')).get(pk=self.b1.pk)
+        self.assertEqual(book1.adjusted_rating, book2.adjusted_rating)
+        book1 = Book.objects.annotate(adjusted_rating=F('rating') + None).get(pk=self.b1.pk)
+        book2 = Book.objects.annotate(adjusted_rating=None + F('rating')).get(pk=self.b1.pk)
+        self.assertEqual(book1.adjusted_rating, book2.adjusted_rating)
+
     def test_update_with_annotation(self):
         book_preupdate = Book.objects.get(pk=self.b2.pk)
         Book.objects.annotate(other_rating=F('rating') - 1).update(rating=F('other_rating'))


### PR DESCRIPTION
We should backport this to 1.8 to be consistent with `filter(a=2+F())`.