### PR TITLE
Fixed #23814 -- Edit localflavor documentation

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -12,10 +12,11 @@ This document contains all the API references of :class:`Field` including the
 
 .. seealso::
 
-    If the built-in fields don't do the trick, you can try :doc:`localflavor
-    </topics/localflavor>`, which contains assorted pieces of code
-    that are useful for particular countries or cultures. Also, you can easily
-    :doc:`write your own custom model fields </howto/custom-model-fields>`.
+    If the built-in fields don't do the trick, you can try `django-localflavor
+    <https://django-localflavor.readthedocs.org/>`_, which contains assorted
+    pieces of code that are useful for particular countries or cultures. Also,
+    you can easily :doc:`write your own custom model fields
+    </howto/custom-model-fields>`.
 
 .. note::
 

--- a/docs/topics/localflavor.txt
+++ b/docs/topics/localflavor.txt
@@ -11,6 +11,10 @@ See the official documentation for more information:
 
     https://django-localflavor.readthedocs.org/
 
+.. _localflavor-packages:
+
+Code is hosted on github at https://github.com/django/django-localflavor
+
 .. _localflavor-how-to-migrate:
 
 How to migrate
@@ -35,3 +39,15 @@ update your code:
 The code in the new package is the same (it was copied directly from Django),
 so you don't have to worry about backwards compatibility in terms of
 functionality. Only the imports have changed.
+
+.. _localflavor-deprecation-policy:
+
+Deprecation policy
+==================
+
+In Django 1.5, importing from ``django.contrib.localflavor`` will result in a
+``DeprecationWarning``. This means your code will still work, but you should
+change it as soon as possible.
+
+In Django 1.6, importing from ``django.contrib.localflavor`` will no longer
+work.

--- a/docs/topics/localflavor.txt
+++ b/docs/topics/localflavor.txt
@@ -13,7 +13,7 @@ See the official documentation for more information:
 
 .. _localflavor-packages:
 
-Code is hosted on github at https://github.com/django/django-localflavor
+Code is hosted on github at https://github.com/django/django-localflavor.
 
 .. _localflavor-how-to-migrate:
 

--- a/docs/topics/localflavor.txt
+++ b/docs/topics/localflavor.txt
@@ -7,48 +7,9 @@ assorted pieces of code that are useful for particular countries or cultures.
 This code is now distributed separately from Django, for easier maintenance
 and to trim the size of Django's codebase.
 
-The new localflavor package is named ``django-localflavor``, with a main
-module called ``localflavor`` and many subpackages using an
-`ISO 3166 country code`_. For example: ``localflavor.us`` is the
-localflavor package for the U.S.A.
-
-Most of these ``localflavor`` add-ons are country-specific fields for the
-:doc:`forms </topics/forms/index>` framework -- for example, a
-``USStateField`` that knows how to validate U.S. state abbreviations and a
-``FISocialSecurityNumber`` that knows how to validate Finnish social security
-numbers.
-
-To use one of these localized components, just import the relevant subpackage.
-For example, here's how you can create a form with a field representing a
-French telephone number::
-
-    from django import forms
-    from localflavor.fr.forms import FRPhoneNumberField
-
-    class MyForm(forms.Form):
-        my_french_phone_no = FRPhoneNumberField()
-
-For documentation on a given country's localflavor helpers, see its README
-file.
-
-.. _ISO 3166 country code: http://www.iso.org/iso/country_codes.htm
-
-.. _localflavor-packages:
-
-Supported countries
-===================
-
 See the official documentation for more information:
 
     https://django-localflavor.readthedocs.org/
-
-Internationalization of localflavors
-====================================
-
-To activate translations for the ``localflavor`` application, you must include
-the application's name in the :setting:`INSTALLED_APPS` setting, so the
-internationalization system can find the catalog, as explained in
-:ref:`how-django-discovers-translations`.
 
 .. _localflavor-how-to-migrate:
 
@@ -74,15 +35,3 @@ update your code:
 The code in the new package is the same (it was copied directly from Django),
 so you don't have to worry about backwards compatibility in terms of
 functionality. Only the imports have changed.
-
-.. _localflavor-deprecation-policy:
-
-Deprecation policy
-==================
-
-In Django 1.5, importing from ``django.contrib.localflavor`` will result in a
-``DeprecationWarning``. This means your code will still work, but you should
-change it as soon as possible.
-
-In Django 1.6, importing from ``django.contrib.localflavor`` will no longer
-work.


### PR DESCRIPTION
Edited localflavor doc to point to the external package documentation,
leaving just the 'How to migrate' section in Django.