### PR TITLE
Fixed #23666 -- Added note for running unit tests on Windows

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -34,6 +34,12 @@ sample settings module that uses the SQLite database. To run the tests::
    $ cd django-repo/tests
    $ PYTHONPATH=..:$PYTHONPATH ./runtests.py
 
+.. admonition:: Windows users
+
+    It is recommended that you use something like
+    `Git Bash <https://msysgit.github.io/>`_ to successfully run the tests with
+    the above approach.
+
 You can avoid typing the ``PYTHONPATH`` bit each time by adding your Django
 checkout to your ``PYTHONPATH`` or by installing the source checkout using pip.
 See :ref:`installing-development-version`.


### PR DESCRIPTION
This is a simple addition to the [unit test documentation page](https://docs.djangoproject.com/en/1.7/internals/contributing/writing-code/unit-tests/) with a note about Windows users.