### PR TITLE
#23764 cache.SessionStore does not respect settings.SESSION_SERIALIZER

### DIFF
--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -26,7 +26,7 @@ class SessionStore(SessionBase):
             # cache keys. If this happens, reset the session. See #17810.
             session_data = None
         if session_data is not None:
-            return session_data
+            return self.decode(session_data)
         self.create()
         return {}
 
@@ -54,7 +54,7 @@ class SessionStore(SessionBase):
         else:
             func = self._cache.set
         result = func(self.cache_key,
-                      self._get_session(no_load=must_create),
+                      self.encode(self._get_session(no_load=must_create)),
                       self.get_expiry_age())
         if must_create and not result:
             raise CreateError


### PR DESCRIPTION
Have fixed `cache.SessionStore` to respect the SESSION_SERIALIZER setting.
The `django.contrib.sessions.backends.cache` now `.encode`s in the .save method and `.decode`s in the load method.

I'm not sure how to add regression tests for this. One option is to add this to the test.session_tests.tests.SessionTestsMixin:
```python
    def test_save_encodes(self):
        # regression test for #23764
        session = self.backend()
        session.encode = mock.MagicMock(return_value='encoded')
        session['some key'] = 'some unencoded value'
        session.save()
        session.encode.assert_called_with({'some key': 'some unencoded value'})
```
but this tests for breaks `tests.sessions_tests.tests.CookieSessionTests` because that backend gives self.serializer to the signer instead of using it directly. I don't want to put an ugly 

```python
def test_save_encdoes(self):
  pass
```
in there.