### PR TITLE
Fixed #23697 -- Improved field filtering error

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1766,7 +1766,9 @@ class ForeignObject(RelatedField):
         root_constraint = constraint_class()
         assert len(targets) == len(sources)
         if len(lookups) > 1:
-            raise exceptions.FieldError('Relation fields do not support nested lookups')
+            available = [f.name for f in self.model._meta.get_fields()]
+            raise exceptions.FieldError("Cannot resolve keyword %r into field. "
+                                     "Choices are: %s" % (lookups[0], ", ".join(available)))
         lookup_type = lookups[0]
 
         def get_normalized_value(value):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1164,6 +1164,14 @@ class Queries1Tests(BaseQuerysetTest):
             ['<Author: a1>', '<Author: a2>', '<Author: a3>', '<Author: a4>']
         )
 
+    def test_ticket_23697(self):
+        # Better error message upon unknown field in queryset filter argument
+        with self.assertRaisesMessage(FieldError,
+                "Cannot resolve keyword 'unknown_field' into field."
+                " Choices are: annotation, category, category_id, children,"
+                " id, item, managedmodel, name, parent, parent_id"):
+            Tag.objects.filter(unknown_field__name='generic')
+
 
 class Queries2Tests(TestCase):
     @classmethod


### PR DESCRIPTION
Previous message indicated that 'Relation fields do not support nested
lookups'; replaced this with a message more like the pre-1.7 error
message, that instead lists the fields which are available.

Added test for new error message