### PR TITLE
Fixes #24484 -- Add helpful message when running tests with models changes without migrations

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -13,10 +13,9 @@ from django.core.management.sql import (
     emit_post_migrate_signal, emit_pre_migrate_signal,
 )
 from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
-from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.loader import AmbiguityError
-from django.db.migrations.state import ProjectState
+from django.db.migrations.utils import has_unmigrated_models
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.module_loading import module_has_submodule
 
@@ -174,12 +173,7 @@ class Command(BaseCommand):
             if self.verbosity >= 1:
                 self.stdout.write("  No migrations to apply.")
                 # If there's changes that aren't in migrations yet, tell them how to fix it.
-                autodetector = MigrationAutodetector(
-                    executor.loader.project_state(),
-                    ProjectState.from_apps(apps),
-                )
-                changes = autodetector.changes(graph=executor.loader.graph)
-                if changes:
+                if has_unmigrated_models():
                     self.stdout.write(self.style.NOTICE(
                         "  Your models have changes that are not yet reflected "
                         "in a migration, and so won't be applied."

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -4,6 +4,7 @@ import sys
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db.migrations.utils import has_unmigrated_models
 from django.test.utils import get_runner
 
 
@@ -79,6 +80,18 @@ class Command(BaseCommand):
     def handle(self, *test_labels, **options):
         from django.conf import settings
         from django.test.utils import get_runner
+
+        if has_unmigrated_models():
+            self.stdout.write(self.style.NOTICE(
+                "  Your models have changes that are not yet reflected "
+                "in a migration."
+            ))
+            self.stdout.write(self.style.NOTICE(
+                "  Run 'manage.py makemigrations' to make new "
+                "migrations, and then re-run 'manage.py test'"
+            ))
+
+            return
 
         TestRunner = get_runner(settings, options.get('testrunner'))
 

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -1,0 +1,16 @@
+from django.apps import apps
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.state import ProjectState
+
+
+def has_unmigrated_models(loader=None, connection=None):
+    """
+    Returns True if the currently registered models have changes that are not
+    yet represented in a migration
+    """
+    if loader is None:
+        loader = MigrationLoader(connection)
+
+    autodetector = MigrationAutodetector(loader.project_state(), ProjectState.from_apps(apps))
+    return bool(autodetector.changes(graph=loader.graph))

--- a/tests/gis_tests/geoapp/models.py
+++ b/tests/gis_tests/geoapp/models.py
@@ -64,6 +64,7 @@ class MultiFields(NamedModel):
     class Meta:
         unique_together = ('city', 'point')
         required_db_features = ['gis_enabled']
+        app_label = 'geoapp'
 
 
 class Truth(models.Model):

--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -98,3 +98,18 @@ class School(models.Model):
 
 class Student(models.Model):
     school = models.ForeignKey(School)
+
+
+class UnsavedForeignKey(models.ForeignKey):
+    # A ForeignKey which can point to an unsaved object
+    allow_unsaved_instance_assignment = True
+
+
+class Band(models.Model):
+    name = models.CharField(max_length=50)
+
+
+class BandMember(models.Model):
+    band = UnsavedForeignKey(Band)
+    first_name = models.CharField(max_length=50)
+    last_name = models.CharField(max_length=50)

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -8,8 +8,8 @@ from django.utils import six
 from django.utils.translation import ugettext_lazy
 
 from .models import (
-    Article, Category, Child, First, Parent, Record, Relation, Reporter,
-    School, Student, Third, ToFieldChild,
+    Article, Band, BandMember, Category, Child, First, Parent, Record, Relation,
+    Reporter, School, Student, Third, ToFieldChild,
 )
 
 
@@ -165,18 +165,6 @@ class ManyToOneTests(TestCase):
         should be allowed when the allow_unsaved_instance_assignment
         attribute has been set to True.
         """
-        class UnsavedForeignKey(models.ForeignKey):
-            # A ForeignKey which can point to an unsaved object
-            allow_unsaved_instance_assignment = True
-
-        class Band(models.Model):
-            name = models.CharField(max_length=50)
-
-        class BandMember(models.Model):
-            band = UnsavedForeignKey(Band)
-            first_name = models.CharField(max_length=50)
-            last_name = models.CharField(max_length=50)
-
         beatles = Band(name='The Beatles')
         john = BandMember(first_name='John', last_name='Lennon')
         # This should not raise an exception as the ForeignKey between member

--- a/tests/one_to_one/models.py
+++ b/tests/one_to_one/models.py
@@ -118,3 +118,18 @@ class Director(models.Model):
     is_temp = models.BooleanField(default=False)
     school = models.OneToOneField(School)
     objects = DirectorManager()
+
+
+class UnsavedOneToOneField(models.OneToOneField):
+    # A OneToOneField which can point to an unsaved object
+    allow_unsaved_instance_assignment = True
+
+
+class Band(models.Model):
+    name = models.CharField(max_length=50)
+
+
+class BandManager(models.Model):
+    band = UnsavedOneToOneField(Band)
+    first_name = models.CharField(max_length=50)
+    last_name = models.CharField(max_length=50)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -4,8 +4,9 @@ from django.db import IntegrityError, connection, models, transaction
 from django.test import TestCase
 
 from .models import (
-    Bar, Director, Favorites, HiddenPointer, ManualPrimaryKey, MultiModel,
-    Place, RelatedModel, Restaurant, School, Target, UndergroundBar, Waiter,
+    Band, BandManager, Bar, Director, Favorites, HiddenPointer,
+    ManualPrimaryKey, MultiModel, Place, RelatedModel, Restaurant, School,
+    Target, UndergroundBar, Waiter,
 )
 
 
@@ -151,18 +152,6 @@ class OneToOneTests(TestCase):
         should be allowed when the allow_unsaved_instance_assignment
         attribute has been set to True.
         """
-        class UnsavedOneToOneField(models.OneToOneField):
-            # A OneToOneField which can point to an unsaved object
-            allow_unsaved_instance_assignment = True
-
-        class Band(models.Model):
-            name = models.CharField(max_length=50)
-
-        class BandManager(models.Model):
-            band = UnsavedOneToOneField(Band)
-            first_name = models.CharField(max_length=50)
-            last_name = models.CharField(max_length=50)
-
         band = Band(name='The Beatles')
         manager = BandManager(first_name='Brian', last_name='Epstein')
         # This should not raise an exception as the OneToOneField between


### PR DESCRIPTION
This PR adds a check into the ``test`` management command which looks for model changes that are not reflected in a migration. If it finds any, it will close the tests with an error.

I think it would be useful to turn this into a system check so it gets run on other management commands. One issue with that though is we would need to find a way to prevent this check from running on the ``makemigrations`` command. Let me know if you think that would be useful and I'll look into it.