### PR TITLE
Fixed #24134 -- Document short options for django-admin.py

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -81,8 +81,7 @@ The output follows the schema described in :pep:`386`::
     1.4a1
     1.4
 
-Displaying debug output
------------------------
+.. django-admin-option:: --verbosity, -v
 
 Use :djadminopt:`--verbosity` to specify the amount of notification and debug information
 that ``django-admin`` should print to the console. For more details, see the
@@ -111,7 +110,7 @@ a list of app labels as arguments::
 
 If you do not specify any app, all apps will be checked.
 
-.. django-admin-option:: --tag <tagname>
+.. django-admin-option:: --tag <tagname>, -t <tagname>
 
 The :doc:`system check framework </ref/checks>` performs many different
 types of checks. These check types are categorized with tags. You can use these tags
@@ -151,14 +150,19 @@ compilemessages
 Compiles .po files created by :djadmin:`makemessages` to .mo files for use with
 the builtin gettext support. See :doc:`/topics/i18n/index`.
 
-Use the :djadminopt:`--locale` option (or its shorter version ``-l``) to
-specify the locale(s) to process. If not provided, all locales are processed.
+.. django-admin-option:: --locale, -l
 
-Use the :djadminopt:`--exclude` option (or its shorter version ``-x``) to
-specify the locale(s) to exclude from processing. If not provided, no locales
-are excluded.
+Use the :djadminopt:`--locale` option to specify the locale(s) to process. If
+not provided, all locales are processed.
 
-You can pass ``--use-fuzzy`` option (or ``-f``) to include fuzzy translations
+.. django-admin-option:: --exclude, -x
+
+Use the :djadminopt:`--exclude` option to specify the locale(s) to exclude from
+processing. If not provided, no locales are excluded.
+
+.. django-admin-option:: --use-fuzzy, -f
+
+You can pass ``--use-fuzzy`` option to include fuzzy translations
 into compiled files.
 
 .. versionchanged:: 1.8
@@ -243,6 +247,8 @@ records to dump. If you're using a :ref:`custom manager <custom-managers>` as
 the default manager and it filters some of the available records, not all of the
 objects will be dumped.
 
+.. django-admin-option:: --all, -a
+
 The :djadminopt:`--all` option may be provided to specify that
 ``dumpdata`` should use Django's base manager, dumping records which
 might otherwise be filtered or modified by a custom manager.
@@ -259,11 +265,15 @@ By default, ``dumpdata`` will output all data on a single line. This isn't
 easy for humans to read, so you can use the ``--indent`` option to
 pretty-print the output with a number of indentation spaces.
 
+.. django-admin-option:: --exclude, -e
+
 The :djadminopt:`--exclude` option may be provided to prevent specific
 applications or models (specified as in the form of ``app_label.ModelName``)
 from being dumped. If you specify a model name to ``dumpdata``, the dumped
 output will be restricted to that model, rather than the entire application.
 You can also mix application names and model names.
+
+.. django-admin-option:: --database
 
 The :djadminopt:`--database` option can be used to specify the database
 from which data will be dumped.
@@ -306,8 +316,12 @@ flush
 Removes all data from the database, re-executes any post-synchronization
 handlers, and reinstalls any initial data fixtures.
 
+.. django-admin-option:: --noinput
+
 The :djadminopt:`--noinput` option may be provided to suppress all user
 prompts.
+
+.. django-admin-option:: --database
 
 The :djadminopt:`--database` option may be used to specify the database
 to flush.
@@ -385,10 +399,11 @@ Searches for and loads the contents of the named fixture into the database.
 The :djadminopt:`--database` option can be used to specify the database
 onto which the data will be loaded.
 
-.. django-admin-option:: --ignorenonexistent
+.. django-admin-option:: --ignorenonexistent, -i
 
-The :djadminopt:`--ignorenonexistent` option can be used to ignore fields and
-models that may have been removed since the fixture was originally generated.
+The :djadminopt:`--ignorenonexistent` option (or its shorter version -i) can
+be used to ignore fields and models that may have been removed since the
+fixture was originally generated.
 
 .. django-admin-option:: --app
 
@@ -539,19 +554,24 @@ directory. After making changes to the messages files you need to compile them
 with :djadmin:`compilemessages` for use with the builtin gettext support. See
 the :ref:`i18n documentation <how-to-create-language-files>` for details.
 
-.. django-admin-option:: --all
+.. django-admin-option:: --all, -a
 
-Use the ``--all`` or ``-a`` option to update the message files for all
+Use the ``--all`` option to update the message files for all
 available languages.
 
 Example usage::
 
     django-admin makemessages --all
 
-.. django-admin-option:: --extension
+.. django-admin-option:: --extension, -e
 
-Use the ``--extension`` or ``-e`` option to specify a list of file extensions
+Use the ``--extension`` option to specify a list of file extensions
 to examine (default: ".html", ".txt").
+
+.. django-admin-option:: --locale, -l
+
+Use the :djadminopt:`--locale` option to
+specify the locale(s) to process.
 
 Example usage::
 
@@ -561,8 +581,6 @@ Separate multiple extensions with commas or use -e or --extension multiple times
 
     django-admin makemessages --locale=de --extension=html,txt --extension xml
 
-Use the :djadminopt:`--locale` option (or its shorter version ``-l``) to
-specify the locale(s) to process.
 
 .. versionadded:: 1.8
 
@@ -581,26 +599,26 @@ Example usage::
     django-admin makemessages -x pt_BR
     django-admin makemessages -x pt_BR -x fr
 
-.. django-admin-option:: --domain
+.. django-admin-option:: --domain, -d
 
-Use the ``--domain`` or ``-d`` option to change the domain of the messages files.
+Use the ``--domain`` option to change the domain of the messages files.
 Currently supported:
 
 * ``django`` for all ``*.py``, ``*.html`` and ``*.txt`` files (default)
 * ``djangojs`` for ``*.js`` files
 
-.. django-admin-option:: --symlinks
+.. django-admin-option:: --symlinks, -s
 
-Use the ``--symlinks`` or ``-s`` option to follow symlinks to directories when
+Use the ``--symlinks`` option to follow symlinks to directories when
 looking for new translation strings.
 
 Example usage::
 
     django-admin makemessages --locale=de --symlinks
 
-.. django-admin-option:: --ignore
+.. django-admin-option:: --ignore, -i
 
-Use the ``--ignore`` or ``-i`` option to ignore files or directories matching
+Use the ``--ignore`` option to ignore files or directories matching
 the given :mod:`glob`-style pattern. Use multiple times to ignore more.
 
 These patterns are used by default: ``'CVS'``, ``'.*'``, ``'*~'``, ``'*.pyc'``
@@ -900,9 +918,11 @@ use the ``--plain`` option, like so::
 
     django-admin shell --plain
 
+.. django-admin-option:: --interface <interpreter>, -i <interpreter>
+
 If you would like to specify either IPython or bpython as your interpreter if
 you have both installed you can specify an alternative interpreter interface
-with the ``-i`` or ``--interface`` options like so:
+with the ``--interface`` option like so:
 
 IPython::
 
@@ -1164,7 +1184,7 @@ information.
 The ``--failfast`` option can be used to stop running tests and report the
 failure immediately after a test fails.
 
-.. django-admin-option:: --testrunner
+.. django-admin-option:: --testrunner, -t
 
 The ``--testrunner`` option can be used to control the test runner class that
 is used to execute tests. If this value is provided, it overrides the value

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -81,7 +81,7 @@ The output follows the schema described in :pep:`386`::
     1.4a1
     1.4
 
-.. django-admin-option:: --verbosity, -v
+.. django-admin-verbosity:: --verbosity, -v
 
 Use :djadminopt:`--verbosity` to specify the amount of notification and debug information
 that ``django-admin`` should print to the console. For more details, see the
@@ -150,17 +150,17 @@ compilemessages
 Compiles .po files created by :djadmin:`makemessages` to .mo files for use with
 the builtin gettext support. See :doc:`/topics/i18n/index`.
 
-.. django-admin-option:: --locale, -l
+.. django-admin-compilemessage:: --locale, -l
 
 Use the :djadminopt:`--locale` option to specify the locale(s) to process. If
 not provided, all locales are processed.
 
-.. django-admin-option:: --exclude, -x
+.. django-admin-compilemessage:: --exclude, -x
 
 Use the :djadminopt:`--exclude` option to specify the locale(s) to exclude from
 processing. If not provided, no locales are excluded.
 
-.. django-admin-option:: --use-fuzzy, -f
+.. django-admin-compilemessage:: --use-fuzzy, -f
 
 You can pass ``--use-fuzzy`` option to include fuzzy translations
 into compiled files.
@@ -247,7 +247,7 @@ records to dump. If you're using a :ref:`custom manager <custom-managers>` as
 the default manager and it filters some of the available records, not all of the
 objects will be dumped.
 
-.. django-admin-option:: --all, -a
+.. django-admin-dumpdata:: --all, -a
 
 The :djadminopt:`--all` option may be provided to specify that
 ``dumpdata`` should use Django's base manager, dumping records which
@@ -259,13 +259,13 @@ By default, ``dumpdata`` will format its output in JSON, but you can use the
 ``--format`` option to specify another format. Currently supported formats
 are listed in :ref:`serialization-formats`.
 
-.. django-admin-option:: --indent <num>
+.. django-admin-dumpdata:: --indent <num>
 
 By default, ``dumpdata`` will output all data on a single line. This isn't
 easy for humans to read, so you can use the ``--indent`` option to
 pretty-print the output with a number of indentation spaces.
 
-.. django-admin-option:: --exclude, -e
+.. django-admin-dumpdata:: --exclude, -e
 
 The :djadminopt:`--exclude` option may be provided to prevent specific
 applications or models (specified as in the form of ``app_label.ModelName``)
@@ -273,12 +273,12 @@ from being dumped. If you specify a model name to ``dumpdata``, the dumped
 output will be restricted to that model, rather than the entire application.
 You can also mix application names and model names.
 
-.. django-admin-option:: --database
+.. django-admin-dumpdata:: --database
 
 The :djadminopt:`--database` option can be used to specify the database
 from which data will be dumped.
 
-.. django-admin-option:: --natural-foreign
+.. django-admin-dumpdata:: --natural-foreign
 
 When this option is specified, Django will use the ``natural_key()`` model
 method to serialize any foreign key and many-to-many relationship to objects of
@@ -288,20 +288,20 @@ should probably be using this flag. See the :ref:`natural keys
 <topics-serialization-natural-keys>` documentation for more details on this
 and the next option.
 
-.. django-admin-option:: --natural-primary
+.. django-admin-dumpdata:: --natural-primary
 
 When this option is specified, Django will not provide the primary key in the
 serialized data of this object since it can be calculated during
 deserialization.
 
-.. django-admin-option:: --pks
+.. django-admin-dumpdata:: --pks
 
 By default, ``dumpdata`` will output all the records of the model, but
 you can use the ``--pks`` option to specify a comma separated list of
 primary keys on which to filter.  This is only available when dumping
 one model.
 
-.. django-admin-option:: --output
+.. django-admin-dumpdata:: --output
 
 .. versionadded:: 1.8
 
@@ -316,12 +316,12 @@ flush
 Removes all data from the database, re-executes any post-synchronization
 handlers, and reinstalls any initial data fixtures.
 
-.. django-admin-option:: --noinput
+.. django-admin-flush:: --noinput
 
 The :djadminopt:`--noinput` option may be provided to suppress all user
 prompts.
 
-.. django-admin-option:: --database
+.. django-admin-flush:: --database
 
 The :djadminopt:`--database` option may be used to specify the database
 to flush.


### PR DESCRIPTION
I added some missing short options to the documentation page of django-admin.py.
I also improved the consistency by putting the short and long version of the command into section headline (and removing it, when needed, from the description text).