### PR TITLE
Changed model file field to not save the whole instance

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -109,7 +109,7 @@ class FieldFile(File):
 
         # Save the object because it has changed, unless save is False
         if save:
-            self.instance.save()
+            self.instance.save(update_fields=[self.field.name])
     save.alters_data = True
 
     def delete(self, save=True):
@@ -132,7 +132,7 @@ class FieldFile(File):
         self._committed = False
 
         if save:
-            self.instance.save()
+            self.instance.save(update_fields=[self.field.name])
     delete.alters_data = True
 
     def _get_closed(self):


### PR DESCRIPTION
Model.file.save() and Model.file.delete() would update the whole instance, which feels a bit unexpected to me and could lead to errors.

~~~~{.python}
# Example 1
article = Article.objects.get(pk=1)
article.title = "Bad title"
# ... many lines later ...
article.image.save(image_file)  # will save image AND overwrite title

# Example 2
article = Article.objects.get(pk=1)
image_file = get_image_file()  # download image, could take awhile..
# at the same time in different place
article.title = "Updated title"
article.save()
# back to our file, download just finished
article.image.save(image_file)  # will overwrite "Updated title"
~~~~