### PR TITLE
Fixed #24505 -- Multiple m2m fields to same 'to' with disabled related_name

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2621,6 +2621,14 @@ class ManyToManyField(RelatedField):
         if self.remote_field.symmetrical and (
                 self.remote_field.model == "self" or self.remote_field.model == cls._meta.object_name):
             self.remote_field.related_name = "%s_rel_+" % name
+        else:
+            # If the backwards relation is disabled, replace the original
+            # related_name with one generated from the m2m field name.
+            # This is because Django still uses backwards relations internally
+            # and we need to avoid clashes (multiple m2m fields with
+            # related_name == '+').
+            if self.remote_field.is_hidden():
+                self.remote_field.related_name = "_%s_+" % name
 
         super(ManyToManyField, self).contribute_to_class(cls, name, **kwargs)
 

--- a/tests/m2m_regress/models.py
+++ b/tests/m2m_regress/models.py
@@ -87,3 +87,18 @@ class RegressionModelSplit(BadModelWithSplit):
     Model with a split method should not cause an error in add_lazy_relation
     """
     others = models.ManyToManyField('self')
+
+
+# Regression for #24505 -- Multiple ManyToManyFields to same "to" model
+# with related_name set to '+' mix up badly.
+class Category(models.Model):
+    def __str__(self):
+        return str(self.pk)
+
+
+class Post(models.Model):
+    primary_categories = models.ManyToManyField(Category, related_name='+')
+    secondary_categories = models.ManyToManyField(Category, related_name='+')
+
+    def __str__(self):
+        return str(self.pk)

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.utils import six
 
 from .models import (
-    Entry, RegressionModelSplit, SelfRefer, SelfReferChild,
+    Category, Entry, Post, RegressionModelSplit, SelfRefer, SelfReferChild,
     SelfReferChildSibling, Tag, TagCollection, Worksheet,
 )
 
@@ -111,3 +111,16 @@ class M2MRegressionTests(TestCase):
 
         c1.refresh_from_db()
         self.assertQuerysetEqual(c1.tags.order_by('name'), ["<Tag: t1>", "<Tag: t2>"])
+
+    def test_multiple_forwards_only_m2m(self):
+        # Regression for #24505 - Multiple ManyToManyFields to same "to"
+        # model with related_name set to '+' mix up badly
+        category = Category.objects.create()
+        post = Post.objects.create()
+
+        post.primary_categories.add(category)
+
+        self.assertQuerysetEqual(
+            post.primary_categories.all(),
+            ['<Category: %s>' % category.pk]
+        )

--- a/tests/model_meta/results.py
+++ b/tests/model_meta/results.py
@@ -319,7 +319,7 @@ TEST_RESULTS = {
     'get_all_related_objects_with_model_hidden_local': {
         Person: (
             ('+', None),
-            ('+', None),
+            ('_people_hidden_+', None),
             ('Person_following_inherited+', None),
             ('Person_following_inherited+', None),
             ('Person_friends_inherited+', None),
@@ -334,7 +334,7 @@ TEST_RESULTS = {
         ),
         BasePerson: (
             ('+', None),
-            ('+', None),
+            ('_basepeople_hidden_+', None),
             ('BasePerson_following_abstract+', None),
             ('BasePerson_following_abstract+', None),
             ('BasePerson_following_base+', None),
@@ -381,9 +381,9 @@ TEST_RESULTS = {
     'get_all_related_objects_with_model_hidden': {
         Person: (
             ('+', BasePerson),
-            ('+', BasePerson),
             ('+', None),
-            ('+', None),
+            ('_basepeople_hidden_+', BasePerson),
+            ('_people_hidden_+', None),
             ('BasePerson_following_abstract+', BasePerson),
             ('BasePerson_following_abstract+', BasePerson),
             ('BasePerson_following_base+', BasePerson),
@@ -416,7 +416,7 @@ TEST_RESULTS = {
         ),
         BasePerson: (
             ('+', None),
-            ('+', None),
+            ('_basepeople_hidden_+', None),
             ('BasePerson_following_abstract+', None),
             ('BasePerson_following_abstract+', None),
             ('BasePerson_following_base+', None),
@@ -730,7 +730,7 @@ TEST_RESULTS = {
             ('friends_base_rel_+', None),
             ('followers_base', None),
             ('relating_basepeople', None),
-            ('+', None),
+            ('_basepeople_hidden_+', None),
         ),
         Person: (
             ('friends_abstract_rel_+', BasePerson),
@@ -738,11 +738,11 @@ TEST_RESULTS = {
             ('friends_base_rel_+', BasePerson),
             ('followers_base', BasePerson),
             ('relating_basepeople', BasePerson),
-            ('+', BasePerson),
+            ('_basepeople_hidden_+', BasePerson),
             ('friends_inherited_rel_+', None),
             ('followers_concrete', None),
             ('relating_people', None),
-            ('+', None),
+            ('_people_hidden_+', None),
         ),
         Relation: (
             ('m2m_abstract_rel', None),
@@ -757,13 +757,13 @@ TEST_RESULTS = {
             'friends_base_rel_+',
             'followers_base',
             'relating_basepeople',
-            '+',
+            '_basepeople_hidden_+',
         ],
         Person: [
             'friends_inherited_rel_+',
             'followers_concrete',
             'relating_people',
-            '+',
+            '_people_hidden_+',
         ],
         Relation: [
             'm2m_abstract_rel',

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -237,7 +237,7 @@ class RelationTreeTests(TestCase):
         self.assertEqual(
             sorted([field.related_query_name() for field in BasePerson._meta._relation_tree]),
             sorted([
-                '+', '+', 'BasePerson_following_abstract+', 'BasePerson_following_abstract+',
+                '+', '_basepeople_hidden_+', 'BasePerson_following_abstract+', 'BasePerson_following_abstract+',
                 'BasePerson_following_base+', 'BasePerson_following_base+', 'BasePerson_friends_abstract+',
                 'BasePerson_friends_abstract+', 'BasePerson_friends_base+', 'BasePerson_friends_base+',
                 'BasePerson_m2m_abstract+', 'BasePerson_m2m_base+', 'Relating_basepeople+',


### PR DESCRIPTION
This fixes a bug with multiple many to many fields to the same `to` model and `related_name` set to `+`.

This happens because Django is still using backwards relations internally so multiple fields with the same `related_name` are sometimes overridden and the last field defined wins.

There is still a bug with Django not throwing an exception when defining m2m fields with the same `related_name` and backwards relation enabled but I think it's slightly different from this one and should be managed differently.

Ideally we would refactor the ORM so that it doesn't use backwards relations internally when disabled but this particular fix was easy to implement (although hard to find) so I would be happy with it.

I had to change a few tests so I would like somebody to take a look at them and double-check that it makes sense if possible.