### PR TITLE
Fixed #19910 -- Added slash to i18n redirect if APPEND_SLASH is set.

### DIFF
--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -34,12 +34,12 @@ class RedirectFallbackMiddleware(object):
             r = Redirect.objects.get(site=current_site, old_path=full_path)
         except Redirect.DoesNotExist:
             pass
-        if settings.APPEND_SLASH and not request.path.endswith('/'):
-            # Try appending a trailing slash.
-            path_len = len(request.path)
-            full_path = full_path[:path_len] + '/' + full_path[path_len:]
+        if r is None and settings.APPEND_SLASH and not request.path.endswith('/'):
             try:
-                r = Redirect.objects.get(site=current_site, old_path=full_path)
+                r = Redirect.objects.get(
+                    site=current_site,
+                    old_path=request.get_full_path(force_append_slash=True),
+                )
             except Redirect.DoesNotExist:
                 pass
         if r is not None:

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -99,11 +99,12 @@ class HttpRequest(object):
                 msg += " The domain name provided is not valid according to RFC 1034/1035."
             raise DisallowedHost(msg)
 
-    def get_full_path(self):
+    def get_full_path(self, force_append_slash=False):
         # RFC 3986 requires query string arguments to be in the ASCII range.
         # Rather than crash if this doesn't happen, we encode defensively.
-        return '%s%s' % (
+        return '%s%s%s' % (
             escape_uri_path(self.path),
+            '/' if force_append_slash and not self.path.endswith('/') else '',
             ('?' + iri_to_uri(self.META.get('QUERY_STRING', ''))) if self.META.get('QUERY_STRING', '') else ''
         )
 

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -34,15 +34,18 @@ class LocaleMiddleware(object):
             urlconf = getattr(request, 'urlconf', None)
             language_path = '/%s%s' % (language, request.path_info)
             path_valid = is_valid_path(language_path, urlconf)
-            if (not path_valid and settings.APPEND_SLASH
-                    and not language_path.endswith('/')):
-                path_valid = is_valid_path("%s/" % language_path, urlconf)
+            path_needs_slash = (
+                not path_valid and (
+                    settings.APPEND_SLASH and not language_path.endswith('/')
+                    and is_valid_path('%s/' % language_path, urlconf)
+                )
+            )
 
-            if path_valid:
+            if path_valid or path_needs_slash:
                 script_prefix = get_script_prefix()
                 # Insert language after the script prefix and before the
                 # rest of the URL
-                language_url = request.get_full_path().replace(
+                language_url = request.get_full_path(force_append_slash=path_needs_slash).replace(
                     script_prefix,
                     '%s%s/' % (script_prefix, language),
                     1

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -247,8 +247,8 @@ class URLRedirectWithoutTrailingSlashTests(URLTestCaseBase):
 
     def test_en_redirect(self):
         response = self.client.get('/account/register', HTTP_ACCEPT_LANGUAGE='en', follow=True)
-        # target status code of 301 because of CommonMiddleware redirecting
-        self.assertIn(('/en/account/register/', 301), response.redirect_chain)
+        # We only want one redirect, bypassing CommonMiddleware
+        self.assertListEqual(response.redirect_chain, [('/en/account/register/', 302)])
         self.assertRedirects(response, '/en/account/register/', 302)
 
         response = self.client.get('/prefixed.xml', HTTP_ACCEPT_LANGUAGE='en', follow=True)

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -35,7 +35,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_have_slash(self):
         """
-        Tests that URLs with slashes go unmolested.
+        URLs with slashes should go unmolested.
         """
         request = self.rf.get('/slash/')
         self.assertEqual(CommonMiddleware().process_request(request), None)
@@ -43,7 +43,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_slashless_resource(self):
         """
-        Tests that matches to explicit slashless URLs go unmolested.
+        Matches to explicit slashless URLs should go unmolested.
         """
         request = self.rf.get('/noslash')
         self.assertEqual(CommonMiddleware().process_request(request), None)
@@ -51,7 +51,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_slashless_unknown(self):
         """
-        Tests that APPEND_SLASH doesn't redirect to unknown resources.
+        APPEND_SLASH should not redirect to unknown resources.
         """
         request = self.rf.get('/unknown')
         self.assertEqual(CommonMiddleware().process_request(request), None)
@@ -59,12 +59,21 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_redirect(self):
         """
-        Tests that APPEND_SLASH redirects slashless URLs to a valid pattern.
+        APPEND_SLASH should redirect slashless URLs to a valid pattern.
         """
         request = self.rf.get('/slash')
         r = CommonMiddleware().process_request(request)
         self.assertEqual(r.status_code, 301)
         self.assertEqual(r.url, '/slash/')
+
+    @override_settings(APPEND_SLASH=True)
+    def test_append_slash_redirect_querystring(self):
+        """
+        APPEND_SLASH should preserve querystrings when redirecting.
+        """
+        request = self.rf.get('/slash?test=1')
+        r = CommonMiddleware().process_request(request)
+        self.assertEqual(r.url, '/slash/?test=1')
 
     @override_settings(APPEND_SLASH=True, DEBUG=True)
     def test_append_slash_no_redirect_on_POST_in_DEBUG(self):
@@ -90,7 +99,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=False)
     def test_append_slash_disabled(self):
         """
-        Tests disabling append slash functionality.
+        Disabling append slash functionality should leave slashless URLs alone.
         """
         request = self.rf.get('/slash')
         self.assertEqual(CommonMiddleware().process_request(request), None)
@@ -98,8 +107,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_quoted(self):
         """
-        Tests that URLs which require quoting are redirected to their slash
-        version ok.
+        URLs which require quoting should be redirected to their slash version ok.
         """
         request = self.rf.get(quote('/needsquoting#'))
         r = CommonMiddleware().process_request(request)
@@ -139,7 +147,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_have_slash_custom_urlconf(self):
         """
-        Tests that URLs with slashes go unmolested.
+        URLs with slashes should go unmolested.
         """
         request = self.rf.get('/customurlconf/slash/')
         request.urlconf = 'middleware.extra_urls'
@@ -148,7 +156,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_slashless_resource_custom_urlconf(self):
         """
-        Tests that matches to explicit slashless URLs go unmolested.
+        Matches to explicit slashless URLs should go unmolested.
         """
         request = self.rf.get('/customurlconf/noslash')
         request.urlconf = 'middleware.extra_urls'
@@ -157,7 +165,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_slashless_unknown_custom_urlconf(self):
         """
-        Tests that APPEND_SLASH doesn't redirect to unknown resources.
+        APPEND_SLASH should not redirect to unknown resources.
         """
         request = self.rf.get('/customurlconf/unknown')
         request.urlconf = 'middleware.extra_urls'
@@ -166,7 +174,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_redirect_custom_urlconf(self):
         """
-        Tests that APPEND_SLASH redirects slashless URLs to a valid pattern.
+        APPEND_SLASH should redirect slashless URLs to a valid pattern.
         """
         request = self.rf.get('/customurlconf/slash')
         request.urlconf = 'middleware.extra_urls'
@@ -192,7 +200,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=False)
     def test_append_slash_disabled_custom_urlconf(self):
         """
-        Tests disabling append slash functionality.
+        Disabling append slash functionality should leave slashless URLs alone.
         """
         request = self.rf.get('/customurlconf/slash')
         request.urlconf = 'middleware.extra_urls'
@@ -201,8 +209,7 @@ class CommonMiddlewareTest(TestCase):
     @override_settings(APPEND_SLASH=True)
     def test_append_slash_quoted_custom_urlconf(self):
         """
-        Tests that URLs which require quoting are redirected to their slash
-        version ok.
+        URLs which require quoting should be redirected to their slash version ok.
         """
         request = self.rf.get(quote('/customurlconf/needsquoting#'))
         request.urlconf = 'middleware.extra_urls'


### PR DESCRIPTION
This introduced a force_append_slash argument for request.get_full_path which
is now also used by RedirectFallbackMiddleware and CommonMiddleware when
handling redirects for settings.APPEND_SLASH.