### PR TITLE
partial fix for issue#11390

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1387,7 +1387,7 @@ class ModelAdmin(BaseModelAdmin):
             if add:
                 initial = self.get_changeform_initial_data(request)
                 form = ModelForm(initial=initial)
-                formsets, inline_instances = self._create_formsets(request, self.model(), change=False)
+                formsets, inline_instances = self._create_formsets(request, form.instance, change=False)
             else:
                 form = ModelForm(instance=obj)
                 formsets, inline_instances = self._create_formsets(request, obj, change=True)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/11390

Avoid creating another model instance, with the associated recreation of default field values. For example, with the field below, this PR reduces the calls to get_default_title from 3 to 2 when viewing the "add item" admin page.
```
class Article(models.Model):
    title = models.CharField(max_length=50, default=get_default_title)
```
See [sample Django project](https://github.com/tomviner/callable_as_default) to reproduce this.