### PR TITLE
Fixed #22938 -- Modified session expiry date to allow cleanup of file based sessions

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -71,6 +71,16 @@ class SessionStore(SessionBase):
             modification = datetime.datetime.fromtimestamp(modification)
         return modification
 
+    def _expiry_date(self, session_data):
+        """
+        Return the expiry time of the file storing the session's content.
+        """
+        expiry = session_data.get('_session_expiry', None)
+        if expiry is None:
+            expiry = self._last_modification() + \
+                datetime.timedelta(seconds=settings.SESSION_COOKIE_AGE)
+        return expiry
+
     def load(self):
         session_data = {}
         try:
@@ -90,8 +100,7 @@ class SessionStore(SessionBase):
 
                 # Remove expired sessions.
                 expiry_age = self.get_expiry_age(
-                    modification=self._last_modification(),
-                    expiry=session_data.get('_session_expiry'))
+                    expiry=self._expiry_date(session_data))
                 if expiry_age < 0:
                     session_data = {}
                     self.delete()

--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -75,8 +75,8 @@ class SessionStore(SessionBase):
         """
         Return the expiry time of the file storing the session's content.
         """
-        expiry = session_data.get('_session_expiry', None)
-        if expiry is None:
+        expiry = session_data.get('_session_expiry')
+        if not expiry:
             expiry = self._last_modification() + \
                 datetime.timedelta(seconds=settings.SESSION_COOKIE_AGE)
         return expiry


### PR DESCRIPTION
This PR fix https://code.djangoproject.com/ticket/22938

set SESSION_ENGINE to use django.contrib.sessions.backends.file
- create few sessions, wait untill they expire (you may use set_expiry, to reduce the waiting time)
- try ```django-admin.py clearsessions``` directly to clean out expired sessions.

Files should be deleted from your temp dir.