### PR TITLE
Removed the null handler in Django's default logging config.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1,12 +1,12 @@
 import hashlib
+import logging
 
 from django.db.backends.utils import truncate_name
 from django.db.transaction import atomic
 from django.utils import six
 from django.utils.encoding import force_bytes
-from django.utils.log import getLogger
 
-logger = getLogger('django.db.backends.schema')
+logger = logging.getLogger('django.db.backends.schema')
 
 
 def _related_non_m2m_objects(opts):

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -34,9 +34,6 @@ DEFAULT_LOGGING = {
             'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
         },
-        'null': {
-            'class': 'logging.NullHandler',
-        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -12,8 +12,6 @@ from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 from django.views.debug import ExceptionReporter, get_exception_reporter_filter
 
-getLogger = logging.getLogger
-
 # Default logging for Django. This sends an email to the site admins on every
 # HTTP 500 error. Depending on DEBUG, all other log records are either sent to
 # the console (DEBUG=True) or discarded by mean of the NullHandler (DEBUG=False).

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import decimal
+import logging
 import sys
 
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
@@ -9,7 +10,6 @@ from django.core.urlresolvers import get_resolver
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render, render_to_response
 from django.template import TemplateDoesNotExist
-from django.utils.log import getLogger
 from django.views.debug import (
     SafeExceptionReporterFilter, technical_500_response,
 )
@@ -102,7 +102,7 @@ def render_no_template(request):
 
 
 def send_log(request, exc_info):
-    logger = getLogger('django.request')
+    logger = logging.getLogger('django.request')
     # The default logging config has a logging filter to ensure admin emails are
     # only sent with DEBUG=False, but since someone might choose to remove that
     # filter, we still want to be able to test the behavior of error emails


### PR DESCRIPTION
It's unused since f0f327bb.