### PR TITLE
Fixed #13750 - Added regression test and patch

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -23,28 +23,29 @@ class ImageFile(File):
 
     def _get_image_dimensions(self):
         if not hasattr(self, '_dimensions_cache'):
-            close = self.closed
             self.open()
-            self._dimensions_cache = get_image_dimensions(self, close=close)
+            self._dimensions_cache = get_image_dimensions(self)
         return self._dimensions_cache
 
 
-def get_image_dimensions(file_or_path, close=False):
+def get_image_dimensions(file_or_path):
     """
-    Returns the (width, height) of an image, given an open file or a path.  Set
-    'close' to True to close the file at the end if it is initially in an open
-    state.
+    Returns the (width, height) of an image, given an open file or a path. If a
+    file is opened it is closed at the end of the function.
     """
     from PIL import ImageFile as PillowImageFile
 
     p = PillowImageFile.Parser()
+
     if hasattr(file_or_path, 'read'):
         file = file_or_path
         file_pos = file.tell()
         file.seek(0)
+        close = False
     else:
         file = open(file_or_path, 'rb')
         close = True
+
     try:
         # Most of the time Pillow only needs a small chunk to parse the image
         # and get the dimensions, but with some TIFF files Pillow needs to

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -384,3 +384,7 @@ class AbstractForeignFieldsModel(models.Model):
 
     class Meta:
         abstract = True
+
+
+class Profile(models.Model):
+    image = models.ImageField()

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -181,6 +181,23 @@ class ImageFieldTests(ImageFieldTestMixin, TestCase):
         loaded_p = pickle.loads(dump)
         self.assertEqual(p.mugshot, loaded_p.mugshot)
 
+    def test_image_field_io_closed_file(self):
+        """
+        Opening 'image' property as Image object of a model's ImageField will fail
+        with an 'I/O operation on closed file' error. Regression for #13750
+        """
+        from .models import Profile
+        profile = Profile()
+        profile.image = self.file1
+
+        profile.save()
+
+        self.assertTrue(profile.image.closed)
+
+        profile.image.width
+
+        Image.open(profile.image)
+
 
 @skipIf(Image is None, "Pillow is required to test ImageField")
 class ImageFieldTwoDimensionsTests(ImageFieldTestMixin, TestCase):


### PR DESCRIPTION
Added a regression test that verifies that accessing an image field on a model
returns a closed file reference. Also added a patch that correctly determines whether
a file should be closed or not.