### PR TITLE
Fixed #19259 -- Added group by selected primary keys support.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -6,6 +6,7 @@ from django.utils.functional import cached_property
 class BaseDatabaseFeatures(object):
     gis_enabled = False
     allows_group_by_pk = False
+    allows_group_by_selected_pks = False
     # True if django.db.backends.utils.typecast_timestamp is used on values
     # returned from dates() calls.
     needs_datetime_string_cast = True

--- a/django/db/backends/postgresql_psycopg2/features.py
+++ b/django/db/backends/postgresql_psycopg2/features.py
@@ -3,6 +3,7 @@ from django.db.utils import InterfaceError
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
+    allows_group_by_selected_pks = True
     needs_datetime_string_cast = False
     can_return_id_from_insert = True
     has_real_datatype = True

--- a/django/test/__init__.py
+++ b/django/test/__init__.py
@@ -6,7 +6,7 @@ from django.test.client import Client, RequestFactory
 from django.test.testcases import (
     TestCase, TransactionTestCase,
     SimpleTestCase, LiveServerTestCase, skipIfDBFeature,
-    skipUnlessDBFeature
+    skipUnlessAnyDBFeature, skipUnlessDBFeature
 )
 from django.test.utils import (ignore_warnings, modify_settings,
     override_settings, override_system_checks)
@@ -14,8 +14,8 @@ from django.test.utils import (ignore_warnings, modify_settings,
 __all__ = [
     'Client', 'RequestFactory', 'TestCase', 'TransactionTestCase',
     'SimpleTestCase', 'LiveServerTestCase', 'skipIfDBFeature',
-    'skipUnlessDBFeature', 'ignore_warnings', 'modify_settings',
-    'override_settings', 'override_system_checks'
+    'skipUnlessAnyDBFeature', 'skipUnlessDBFeature', 'ignore_warnings',
+    'modify_settings', 'override_settings', 'override_system_checks'
 ]
 
 # To simplify Django's test suite; not meant as a public API

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1051,6 +1051,16 @@ def skipUnlessDBFeature(*features):
     )
 
 
+def skipUnlessAnyDBFeature(*features):
+    """
+    Skip a test unless a database has any of the named features.
+    """
+    return _deferredSkip(
+        lambda: not any(getattr(connection.features, feature, False) for feature in features),
+        "Database doesn't support any of the feature(s): %s" % ", ".join(features)
+    )
+
+
 class QuietWSGIRequestHandler(WSGIRequestHandler):
     """
     Just a regular WSGIRequestHandler except it doesn't log to the standard

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -7,10 +7,11 @@ from operator import attrgetter
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
+from django.db import connection
 from django.db.models import (
     F, Q, Avg, Count, Max, StdDev, Sum, Value, Variance,
 )
-from django.test import TestCase, skipUnlessDBFeature
+from django.test import TestCase, skipUnlessAnyDBFeature, skipUnlessDBFeature
 from django.test.utils import Approximate
 from django.utils import six
 
@@ -1011,7 +1012,7 @@ class AggregationTests(TestCase):
         # Check that the query executes without problems.
         self.assertEqual(len(qs.exclude(publisher=-1)), 6)
 
-    @skipUnlessDBFeature("allows_group_by_pk")
+    @skipUnlessAnyDBFeature('allows_group_by_pk', 'allows_group_by_selected_pks')
     def test_aggregate_duplicate_columns(self):
         # Regression test for #17144
 
@@ -1041,7 +1042,7 @@ class AggregationTests(TestCase):
             ]
         )
 
-    @skipUnlessDBFeature("allows_group_by_pk")
+    @skipUnlessAnyDBFeature('allows_group_by_pk', 'allows_group_by_selected_pks')
     def test_aggregate_duplicate_columns_only(self):
         # Works with only() too.
         results = Author.objects.only('id', 'name').annotate(num_contacts=Count('book_contact_set'))
@@ -1067,13 +1068,14 @@ class AggregationTests(TestCase):
             ]
         )
 
-    @skipUnlessDBFeature("allows_group_by_pk")
+    @skipUnlessAnyDBFeature('allows_group_by_pk', 'allows_group_by_selected_pks')
     def test_aggregate_duplicate_columns_select_related(self):
         # And select_related()
         results = Book.objects.select_related('contact').annotate(
             num_authors=Count('authors'))
         _, _, grouping = results.query.get_compiler(using='default').pre_sql_setup()
-        self.assertEqual(len(grouping), 1)
+        # In the case of `group_by_selected_pks` we also group by contact.id because of the select_related.
+        self.assertEqual(len(grouping), 1 if connection.features.allows_group_by_pk else 2)
         self.assertIn('id', grouping[0][0])
         self.assertNotIn('name', grouping[0][0])
         self.assertNotIn('contact', grouping[0][0])


### PR DESCRIPTION
- [x] Enable the `allows_group_by_selected_pks` feature flag only for PostgreSQL 9.1+
- [x] Avoid unnecessary group by foreign keys