### PR TITLE
Fix image dimension detection exception checking

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -4,6 +4,7 @@ Utility functions for handling images.
 Requires Pillow as you might imagine.
 """
 import zlib
+import struct
 
 from django.core.files import File
 
@@ -63,6 +64,10 @@ def get_image_dimensions(file_or_path, close=False):
                     pass
                 else:
                     raise
+            except struct.error as e:
+                # ignore struct complaining when the header is truncated,
+                # continue feeding chunks to the parser (ticket #24544)
+                pass
             if p.image:
                 return p.image.size
             chunk_size *= 2


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/24544
The code is broken at least in these alive django versions: 1.4, 1.6, 1.7 and 1.8
Does not need tests since it's a test per se.