### PR TITLE
Fixed #24544 -- Fixed get_image_dimensions() on image buffers that Pillow fails to parse

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -3,6 +3,7 @@ Utility functions for handling images.
 
 Requires Pillow as you might imagine.
 """
+import struct
 import zlib
 
 from django.core.files import File
@@ -63,6 +64,11 @@ def get_image_dimensions(file_or_path, close=False):
                     pass
                 else:
                     raise
+            except struct.error as e:
+                # ignore PIL failing on a too short buffer, when reads
+                # return less bytes than expected. skip and feed more data
+                # to the parser (ticket #24544)
+                pass
             if p.image:
                 return p.image.size
             chunk_size *= 2

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import gzip
 import os
+import struct
 import tempfile
 import unittest
 import zlib
@@ -13,6 +14,7 @@ from django.core.files.base import ContentFile
 from django.core.files.move import file_move_safe
 from django.core.files.temp import NamedTemporaryFile
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
+from django.test import mock
 from django.utils import six
 from django.utils._os import upath
 
@@ -239,8 +241,14 @@ class InconsistentGetImageDimensionsBug(unittest.TestCase):
             self.assertEqual(size, Image.open(fh).size)
 
 
-class GetImageDimensionsOnInvalidImages(unittest.TestCase):
-    @unittest.skipUnless(Image, "Pillow not installed")
+@unittest.skipUnless(Image, "Pillow not installed")
+class GetImageDimensionsExceptionBug(unittest.TestCase):
+    """
+    Test that get_image_dimensions() always returns a tuple
+    which can be (0, 0) for invalid images, and test that it
+    catches all exceptions raised by PIL/Pillow
+    (#24441, #24544)
+    """
     def test_invalid_image(self):
         """
         get_image_dimensions() should return (None, None) for the dimensions of
@@ -253,6 +261,21 @@ class GetImageDimensionsOnInvalidImages(unittest.TestCase):
         with open(img_path, 'rb') as fh:
             size = images.get_image_dimensions(fh)
             self.assertEqual(size, (None, None))
+
+    def test_valid_image(self):
+        """
+        get_image_dimensions() should catch struct.error while feeding
+        the PIL Image parser (#24544).
+
+        uses the test.png image and emulates the Parser feed error
+        since the error is raised on every feed attempt, the resulting image
+        size should be invalid, that is (0, 0)
+        """
+        img_path = os.path.join(os.path.dirname(upath(__file__)), "test.png")
+        with mock.patch('PIL.ImageFile.Parser.feed', side_effect=struct.error):
+            with open(img_path, 'rb') as fh:
+                size = images.get_image_dimensions(fh)
+                self.assertEqual(size, (0, 0))
 
 
 class FileMoveSafeTests(unittest.TestCase):


### PR DESCRIPTION
Fix django/core/files/images.py `get_image_dimensions` not catching a `struct.error` exception on a too short buffer fed to the PIL Image parser. Tests and faulty valid image provided. Fixes #24544