### PR TITLE
Documentation trivial fix: 2 blocks of code weren't highlighted

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -305,7 +305,9 @@ of :class:`~django.contrib.auth.models.AnonymousUser`, otherwise it will be an
 instance of :class:`~django.contrib.auth.models.User`.
 
 You can tell them apart with
-:meth:`~django.contrib.auth.models.User.is_authenticated()`, like so::
+:meth:`~django.contrib.auth.models.User.is_authenticated()`, like so:
+
+.. code-block:: python
 
     if request.user.is_authenticated():
         # Do something for authenticated users.
@@ -333,7 +335,9 @@ If you have an authenticated user you want to attach to the current session
 
     This example shows how you might use both
     :func:`~django.contrib.auth.authenticate()` and
-    :func:`~django.contrib.auth.login()`::
+    :func:`~django.contrib.auth.login()`:
+
+    .. code-block:: python
 
         from django.contrib.auth import authenticate, login
 


### PR DESCRIPTION
Hello,

For whatever reason, those 2 blocks weren't highlighted in the documentation. This patch fix this. You can see the current version of documentation regarding those 2 blocks here: https://docs.djangoproject.com/en/dev/topics/auth/default/#authentication-in-web-requests

This also affect stable/1.7.x and stable/1.8.x. I don't know what is the policy for this situation: should I open 2 others pull requests? If you want to do it by hand, just do a cherry-pick in those 2 branchs:

    git cherry-pick be1a0432dc76ae861a828c5976e93c7e19f33b4e

Kind regards,