### PR TITLE
Fixed #24537 -- Ignored field order in RenameModel detection

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -76,7 +76,7 @@ class MigrationAutodetector(object):
         change during renames)
         """
         fields_def = []
-        for name, field in fields:
+        for name, field in sorted(fields):
             deconstruction = self.deep_deconstruct(field)
             if field.remote_field and field.remote_field.model:
                 del deconstruction[2]['to']

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -657,6 +657,37 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'otherapp', 0, ["RenameField"])
         self.assertOperationAttributes(changes, 'otherapp', 0, 0, old_name="author", new_name="writer")
 
+    def test_rename_model_with_fks_in_different_position(self):
+        """
+        #24537 - Tests that the order of fields in a model does not influence
+        the RenameModel detection.
+        """
+        before = self.make_project_state([
+            ModelState("testapp", "EntityA", [
+                ("id", models.AutoField(primary_key=True)),
+            ]),
+            ModelState("testapp", "EntityB", [
+                ("id", models.AutoField(primary_key=True)),
+                ("some_label", models.CharField(max_length=255)),
+                ("entity_a", models.ForeignKey("testapp.EntityA")),
+            ]),
+        ])
+        after = self.make_project_state([
+            ModelState("testapp", "EntityA", [
+                ("id", models.AutoField(primary_key=True)),
+            ]),
+            ModelState("testapp", "RenamedEntityB", [
+                ("id", models.AutoField(primary_key=True)),
+                ("entity_a", models.ForeignKey("testapp.EntityA")),
+                ("some_label", models.CharField(max_length=255)),
+            ]),
+        ])
+        autodetector = MigrationAutodetector(before, after, MigrationQuestioner({"ask_rename_model": True}))
+        changes = autodetector._detect_changes()
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RenameModel"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, old_name="EntityB", new_name="RenamedEntityB")
+
     def test_fk_dependency(self):
         """Tests that having a ForeignKey automatically adds a dependency."""
         # Make state


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24537