### PR TITLE
Fixed #24556 -- Added note about transport security to passwords documentation

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -228,3 +228,16 @@ from the ``User`` model.
 
    Checks if the given string is a hashed password that has a chance
    of being verified against :func:`check_password`.
+
+Passwords are sent in plain text to your server unless you use HTTPS
+====================================================================
+
+You should always use :ref:`HTTPS <security-recommendation-ssl>` for your site.
+This is especially true if you require the user to send any sensitive
+information using a HTML form, such as login details. With plain HTTP, the
+password will be sent in plaintext from the user's computer to your server,
+making it vulnerable to *password sniffing*. With :ref:`HTTPS
+<security-recommendation-ssl>` the entire HTTP request will be encrypted so
+that only you (the holder of the certificate's private key) can decrypt it.
+This is true with self-signed SSL certificates as well as those supplied by a
+trusted root authority.


### PR DESCRIPTION
The 'Password management in Django' page is comprehensive on the subject
of storing passwords in the server. But was missing out a key point
about password security: traffic between client and server needs to be
encrypted when sending user's login details.

Personally, I found the existing documentation so comprehensive that I
thought 'great, someone has thought about all this for me and I don't
need to worry about password security' and forgot all about the need for
HTTPS until someone reminded me (several weeks later). So I think there
needs to be a note on this page about HTTPS.