### PR TITLE
Refs #23643 -- Added plain text report of exception chain.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -889,10 +889,15 @@ In template {{ template_info.name }}, error at line {{ template_info.line }}
 {% else %}
    {{ source_line.0 }} : {{ source_line.1 }}
 {% endifequal %}{% endfor %}{% endif %}
-Traceback:
-{% for frame in frames %}File "{{ frame.filename|escape }}" in {{ frame.function|escape }}
-{% if frame.context_line %}  {{ frame.lineno }}. {{ frame.context_line|escape }}{% endif %}
-{% endfor %}
+Traceback:{% for frame in frames %}
+{% ifchanged frame.exc_cause %}{% if frame.exc_cause %}{% if frame.exc_cause_explicit %}
+The above exception ({{ frame.exc_cause }}) was the direct cause of the following exception:
+{% else %}
+During handling of the above exception ({{ frame.exc_cause }}), another exception occurred:
+{% endif %}{% endif %}{% endifchanged %}
+File "{{ frame.filename|escape }}" in {{ frame.function|escape }}
+{% if frame.context_line %}  {{ frame.lineno }}. {{ frame.context_line|escape }}{% endif %}{% endfor %}
+
 Exception Type: {{ exception_type|escape }}{% if request %} at {{ request.path_info|escape }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}
 </textarea>

--- a/tests/view_tests/tests/py3_test_debug.py
+++ b/tests/view_tests/tests/py3_test_debug.py
@@ -32,10 +32,13 @@ class Py3ExceptionReporterTests(TestCase):
 
         explicit_exc = 'The above exception ({0}) was the direct cause of the following exception:'
         implicit_exc = 'During handling of the above exception ({0}), another exception occurred:'
+
         reporter = ExceptionReporter(request, exc_type, exc_value, tb)
         html = reporter.get_traceback_html()
-        self.assertIn(explicit_exc.format("Top level"), html)
-        self.assertIn(implicit_exc.format("Second exception"), html)
+        # Both messages are twice on page -- one rendered as html,
+        # one as plain text (for pastebin)
+        self.assertEqual(2, html.count(explicit_exc.format("Top level")))
+        self.assertEqual(2, html.count(implicit_exc.format("Second exception")))
 
         text = reporter.get_traceback_text()
         self.assertIn(explicit_exc.format("Top level"), text)


### PR DESCRIPTION
As mentioned in #3535, I've forgot to update the plain-text output in copy&paste box. Here's the fix. It produces following output:

```
Traceback:

File "/Users/tricoder/Projects/django/testdebug/testdebug/urls.py" in view
  7.         raise AttributeError('Top level')

The above exception (Top level) was the direct cause of the following exception:

File "/Users/tricoder/Projects/django/testdebug/testdebug/urls.py" in view
  10.             raise ValueError('Second exception') from explicit

During handling of the above exception (Second exception), another exception occurred:

File "/Users/tricoder/Projects/django/django/core/handlers/base.py" in get_response
  131.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)


File "/Users/tricoder/Projects/django/testdebug/testdebug/urls.py" in view
  12.             raise IndexError('Final exception')

Exception Type: IndexError at /
Exception Value: Final exception
```

I haven't created new ticket for this PR. Is it OK?