### PR TITLE
Fixed #24538 -- Allow self in Jinja context

### DIFF
--- a/django/template/backends/jinja2.py
+++ b/django/template/backends/jinja2.py
@@ -60,4 +60,4 @@ class Template(object):
             context['request'] = request
             context['csrf_input'] = csrf_input_lazy(request)
             context['csrf_token'] = csrf_token_lazy(request)
-        return self.template.render(**context)
+        return self.template.render(context)

--- a/tests/template_backends/test_jinja2.py
+++ b/tests/template_backends/test_jinja2.py
@@ -21,3 +21,21 @@ class Jinja2Tests(TemplateStringsTests):
     engine_class = Jinja2
     backend_name = 'jinja2'
     options = {'keep_trailing_newline': True}
+
+    def test_self_context(self):
+        """
+        #24538 -- Using 'self' in the context should not throw errors
+        """
+        engine = Jinja2({
+            'DIRS': [],
+            'APP_DIRS': False,
+            'NAME': 'django',
+            'OPTIONS': {},
+        })
+
+        # self will be overridden to be a TemplateReference, so the self
+        # variable will not come through. Attempting to use one though should
+        # not throw an error.
+        template = engine.from_string('hello {{ foo }}!')
+        content = template.render(context={'self': 'self', 'foo': 'world'})
+        self.assertEqual(content, 'hello world!')


### PR DESCRIPTION
Rendering a Jinja template with self in the context threw an error. While self is a reserved variable in Jinja, including self in the context is not an error, so Django should respect that.

The bug report can be found at https://code.djangoproject.com/ticket/24538