### PR TITLE
Fixed #22598 -- Allowed make_aware to work with ambiguous datetime

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -347,7 +347,7 @@ def is_naive(value):
     return value.tzinfo is None or value.tzinfo.utcoffset(value) is None
 
 
-def make_aware(value, timezone=None):
+def make_aware(value, timezone=None, is_dst=None):
     """
     Makes a naive datetime.datetime in a given time zone aware.
     """
@@ -355,7 +355,7 @@ def make_aware(value, timezone=None):
         timezone = get_current_timezone()
     if hasattr(timezone, 'localize'):
         # This method is available for pytz time zones.
-        return timezone.localize(value, is_dst=None)
+        return timezone.localize(value, is_dst=is_dst)
     else:
         # Check that we won't overwrite the timezone of an aware datetime.
         if is_aware(value):

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -947,19 +947,36 @@ appropriate entities.
     Returns ``True`` if ``value`` is naive, ``False`` if it is aware. This
     function assumes that ``value`` is a :class:`~datetime.datetime`.
 
-.. function:: make_aware(value, timezone=None)
+.. function:: make_aware(value, timezone=None, is_dst=None)
 
     Returns an aware :class:`~datetime.datetime` that represents the same
     point in time as ``value`` in ``timezone``, ``value`` being a naive
     :class:`~datetime.datetime`. If ``timezone`` is set to ``None``, it
     defaults to the :ref:`current time zone <default-current-time-zone>`.
 
-    This function can raise an exception if ``value`` doesn't exist or is
-    ambiguous because of DST transitions.
+    When pytz_ is installed, the exception ``pytz.AmbiguousTimeError``
+    will be raised if you try to make ``value`` aware during a DST transition
+    where the same time occurs twice (when reverting from DST). Setting
+    ``is_dst`` to ``True`` or ``False`` will avoid the exception by choosing if
+    the time is pre-transition or post-transition respectively. ``is_dst`` has
+    no effect when ``pytz`` is not installed.
+
+    When pytz_ is installed, the exception ``pytz.NonExistentTimeError``
+    will be raised if you try to make ``value`` aware during a DST transition
+    such that the time never occurred (when entering into DST). Setting
+    ``is_dst`` to ``True`` or ``False`` will avoid the exception by moving the
+    hour backwards or forwards by 1 respectively. For example, ``is_dst=True``
+    would change a non-existent time of 2:30 to 1:30 and ``is_dst=False``
+    would change the time to 3:30. ``is_dst`` has no effect when ``pytz`` is
+    not installed.
 
     .. versionchanged:: 1.8
 
         In older versions of Django, ``timezone`` was a required argument.
+
+    .. versionchanged:: 1.9
+
+        The ``is_dst`` argument was added.
 
 .. function:: make_naive(value, timezone=None)
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -159,6 +159,9 @@ Internationalization
 * The :func:`django.views.i18n.javascript_catalog` view now works correctly
   if used multiple times with different configurations on the same page.
 
+* The :func:`django.utils.timezone.make_aware` function gained an ``is_dst``
+  argument to help resolve ambiguous times during DST transitions.
+
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I wrote this patch before discovering the ticket (which was wontfixed), but I believe this patch takes a different approach. https://code.djangoproject.com/ticket/22598

Where the original reporter wanted to try different settings until it worked, this patch allows the user to resolve the ambiguity if they choose.

Still need to finish off the tests (and docs), and I need to work out whether or not make_naive would need similar options.