### PR TITLE
Reusable apps don't use AUTH_USER_PROFILE

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -407,7 +407,13 @@ use as your User model.
    have a ForeignKey to each other and seeing how ``makemigrations`` resolves that
    circular dependency if you want to see how it's usually done)
 
+.. warning::
 
+   Reusable apps don't use this feature. Remember: One project has N app. If 
+   app `fooapp` needs a custom `AUTH_USER_MODEL` `FooUser` and app `barapp` needs
+   `BarUser` you can't install both apps at once.
+   If you want to store per user information in your app, use a OneToOneField or inheritance.
+   
 Referencing the User model
 --------------------------
 


### PR DESCRIPTION
Please add a third warning to the AUTH_USER_PROFILE docs. Many developers new to django get this wrong: use a OneToOneField or inheritance.