### PR TITLE
Refs #24215 -- Improved error message for unhandled lazy ops.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -232,9 +232,44 @@ class StateApps(Apps):
         if ignore_swappable:
             pending_models -= {make_model_tuple(settings.AUTH_USER_MODEL)}
         if pending_models:
-            msg = "Unhandled pending operations for models: %s"
-            labels = (".".join(model_key) for model_key in self._pending_operations)
-            raise ValueError(msg % ", ".join(labels))
+            raise ValueError(self._pending_models_error(pending_models))
+
+    def _pending_models_error(self, pending_models):
+        """
+        Almost all internal uses of lazy operations in Django are to resolve
+        string model references in related fields. We can extract the fields
+        from those operations and use them to provide a nicer error message.
+
+        This will work for any function passed to lazy_related_operation that
+        has a keyword argument called 'field'.
+        """
+
+        def extract_field(operation):
+            # Expect a functools.partial with a kwarg called 'field' applied.
+            try:
+                return operation.func.keywords['field']
+            except (AttributeError, KeyError):
+                return None
+
+        def extract_field_names(operations):
+            return (str(field) for field in map(extract_field, operations) if field)
+
+        get_ops = self._pending_operations.__getitem__
+
+        # Ordered list of pairs of the form
+        # ((app_label, model_name), [field_name_1, field_name_2, ...])
+        models_fields = sorted(
+            (model_key, sorted(extract_field_names(get_ops(model_key))))
+            for model_key in pending_models
+        )
+
+        def model_text(model_key, fields):
+            field_list = ", ".join(fields)
+            field_text = " (referred to by fields: %s)" % field_list if fields else ""
+            return ("%s.%s" % model_key) + field_text
+
+        msg = "Unhandled pending operations for models:"
+        return "\n  ".join([msg] + [model_text(*i) for i in models_fields])
 
     @contextmanager
     def bulk_update(self):


### PR DESCRIPTION
Before #4130, the condition in ``StateApps`` where lazy field operations were pending after all models loaded gave an error message which listed the field pointing at the missing model. Due to the refactor that introspection into the lazy operation was lost, and the error message was simplified to simply show the name of the missing model.

This restores the more informative error message, and lists all missing models and related fields, not just the first encountered.