### PR TITLE
Fixed behavior of InclusionNode.

### DIFF
--- a/tests/template_tests/templates/inclusion_base.html
+++ b/tests/template_tests/templates/inclusion_base.html
@@ -1,0 +1,1 @@
+{% block content %}base{% endblock %}

--- a/tests/template_tests/templates/inclusion_extends1.html
+++ b/tests/template_tests/templates/inclusion_extends1.html
@@ -1,0 +1,2 @@
+{% extends 'inclusion_base.html' %}
+{% block content %}one{% endblock %}

--- a/tests/template_tests/templates/inclusion_extends2.html
+++ b/tests/template_tests/templates/inclusion_extends2.html
@@ -1,0 +1,2 @@
+{% extends 'inclusion_base.html' %}
+{% block content %}two{% endblock %}

--- a/tests/template_tests/templatetags/inclusion.py
+++ b/tests/template_tests/templatetags/inclusion.py
@@ -164,3 +164,13 @@ def inclusion_tag_without_context_parameter(arg):
     """Expected inclusion_tag_without_context_parameter __doc__"""
     return {}
 inclusion_tag_without_context_parameter.anything = "Expected inclusion_tag_without_context_parameter __dict__"
+
+
+@register.inclusion_tag('inclusion_extends1.html')
+def inclusion_extends1():
+    return {}
+
+
+@register.inclusion_tag('inclusion_extends2.html')
+def inclusion_extends2():
+    return {}


### PR DESCRIPTION
This makes the InclusionNode cache-safe by removing the render-time
side effects to it's nodelist. Further, this changes usage of
NodeList.render to Template.render to ensure values are properly cleaned
up from the render_context stack.

Refs #23441 and #24555.