### PR TITLE
Fix typo in 1.9 release notes

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -304,7 +304,7 @@ details on these changes.
 * ``django.db.backends.DatabaseValidation.validate_field`` will be removed in
   favor of the ``check_field`` method.
 
-* The ``check`` management command will be removed.
+* The ``validate`` management command will be removed.
 
 * ``django.utils.module_loading.import_by_path`` will be removed in favor of
   ``django.utils.module_loading.import_string``.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -493,7 +493,7 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
 * ``django.db.backends.DatabaseValidation.validate_field`` is removed in
   favor of the ``check_field`` method.
 
-* The ``check`` management command is removed.
+* The ``validate`` management command is removed.
 
 * ``django.utils.module_loading.import_by_path`` is removed in favor of
   ``django.utils.module_loading.import_string``.


### PR DESCRIPTION
"validate" was superseded by "check", not the other way round. This is a correction to 20e4e8fc79.