### PR TITLE
Fixed #9739 - Made Admin prefill DateTimeField from URL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -586,6 +586,7 @@ answer newbie questions, and generally made Django that much better:
     Richard Davies <richard.davies@elastichosts.com>
     Richard House <Richard.House@i-logue.com>
     Rick Wagner <rwagner@physics.ucsd.edu>
+    Ridley Larsen <ridley@velocitywebworks.com>
     Robert Coup
     Robert Myers <myer0052@gmail.com>
     Roberto Aguilar <roberto@baremetal.io>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1312,9 +1312,6 @@ class ModelAdmin(BaseModelAdmin):
             # We have to special-case M2Ms as a list of comma-separated PKs.
             if isinstance(f, models.ManyToManyField):
                 initial[k] = initial[k].split(",")
-            # Populate DateTimeFields with a comma-separated date and time.
-            if isinstance(f, models.DateTimeField):
-                initial[k] = initial[k].split(",")
         return initial
 
     @csrf_protect_m

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1312,6 +1312,9 @@ class ModelAdmin(BaseModelAdmin):
             # We have to special-case M2Ms as a list of comma-separated PKs.
             if isinstance(f, models.ManyToManyField):
                 initial[k] = initial[k].split(",")
+            # Populate DateTimeFields with a comma-separated date and time.
+            if isinstance(f, models.DateTimeField):
+                initial[k] = initial[k].split(",")
         return initial
 
     @csrf_protect_m

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -891,7 +891,10 @@ class SplitDateTimeWidget(MultiWidget):
 
     def decompress(self, value):
         if value:
-            value = to_current_timezone(value)
+            if isinstance(value, six.string_types):
+                return value.split(',')
+            else:
+                value = to_current_timezone(value)
             return [value.date(), value.time().replace(microsecond=0)]
         return [None, None]
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1736,7 +1736,9 @@ templates used by the :class:`ModelAdmin` views:
     A hook for the initial data on admin change forms. By default, fields are
     given initial values from ``GET`` parameters. For instance,
     ``?name=initial_value`` will set the ``name`` field's initial value to be
-    ``initial_value``.
+    ``initial_value``. ManyToManyFields can be populated with a comma-separated
+    list of PKs, and DateTimeFields can be populated with comma-separated
+    date, time.
 
     This method should return a dictionary in the form
     ``{'fieldname': 'fieldval'}``::

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4331,6 +4331,26 @@ class PrePopulatedTest(TestCase):
         response = self.client.get(reverse('admin:admin_views_prepopulatedpostlargeslug_add'))
         self.assertContains(response, "maxLength: 1000")  # instead of 1,000
 
+    def test_changeform_intial_data(self):
+        """
+        Regression test for #9739
+        Tests the prepopulation of fields within the admin site.
+        """
+        # Add sections for testing <select>.
+        s1 = Section.objects.create(name='Section 1')
+        # Prepopulate the Article add page with GET data.
+        querystring = '?title=TestTitle&content=Lorem%20Ipsum&date=2011-06-01,18:21:53&section=1'
+        response = self.client.get(
+            reverse('admin:admin_views_article_add') + querystring
+        )
+        self.assertEqual(response.status_code, 200)
+        # test if the prepopulated values are within the response and in the correct fields
+        self.assertContains(response, text='value="TestTitle"')
+        self.assertContains(response, text='Lorem Ipsum')
+        self.assertContains(response, text='value="2011-06-01"')
+        self.assertContains(response, text='value="18:21:53"')
+        self.assertContains(response, text='<option value="%s" selected="selected">' % (s1.pk))
+
 
 @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'],
     ROOT_URLCONF="admin_views.urls")


### PR DESCRIPTION
Added the ability to prepopulate SplitDateTimeWidgets from a URL.
Added a test for ModelAdmin.get_changeform_initial_data. Added
documentation for prepopulating ManyToManyFields and DateTimeFields.