### PR TITLE
Fixed #24562 -- Renamed get_major_version() to get_main_version()

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -12,11 +12,11 @@ def get_version(version=None):
     version = get_complete_version(version)
 
     # Now build the two parts of the version number:
-    # major = X.Y[.Z]
+    # main = X.Y[.Z]
     # sub = .devN - for pre-alpha releases
     #     | {a|b|c}N - for alpha, beta and rc releases
 
-    major = get_major_version(version)
+    main = get_main_version(version)
 
     sub = ''
     if version[3] == 'alpha' and version[4] == 0:
@@ -28,15 +28,14 @@ def get_version(version=None):
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
         sub = mapping[version[3]] + str(version[4])
 
-    return str(major + sub)
+    return str(main + sub)
 
 
-def get_major_version(version=None):
-    "Returns major version from VERSION."
+def get_main_version(version=None):
+    "Returns main version (X.Y[.Z]) from VERSION."
     version = get_complete_version(version)
     parts = 2 if version[2] == 0 else 3
-    major = '.'.join(str(x) for x in version[:parts])
-    return major
+    return '.'.join(str(x) for x in version[:parts])
 
 
 def get_complete_version(version=None):


### PR DESCRIPTION
This reflects the actual behavior of the method.