### PR TITLE
Fixed #24564 - Moved AbstractBaseUser and BaseUserManager so they can be...

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -1,0 +1,116 @@
+"""
+This module contains an AbstractBaseUser (moved from models.py) that is
+importable even when django.contrib.auth is not in INSTALLED_APPS.
+"""
+from __future__ import unicode_literals
+
+from django.contrib.auth.hashers import (
+    check_password, is_password_usable, make_password,
+)
+from django.db import models
+from django.utils.crypto import get_random_string, salted_hmac
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
+
+
+class BaseUserManager(models.Manager):
+
+    @classmethod
+    def normalize_email(cls, email):
+        """
+        Normalize the address by lowercasing the domain part of the email
+        address.
+        """
+        email = email or ''
+        try:
+            email_name, domain_part = email.strip().rsplit('@', 1)
+        except ValueError:
+            pass
+        else:
+            email = '@'.join([email_name, domain_part.lower()])
+        return email
+
+    def make_random_password(self, length=10,
+                             allowed_chars='abcdefghjkmnpqrstuvwxyz'
+                                           'ABCDEFGHJKLMNPQRSTUVWXYZ'
+                                           '23456789'):
+        """
+        Generates a random password with the given length and given
+        allowed_chars. Note that the default value of allowed_chars does not
+        have "I" or "O" or letters and digits that look similar -- just to
+        avoid confusion.
+        """
+        return get_random_string(length, allowed_chars)
+
+    def get_by_natural_key(self, username):
+        return self.get(**{self.model.USERNAME_FIELD: username})
+
+
+@python_2_unicode_compatible
+class AbstractBaseUser(models.Model):
+    password = models.CharField(_('password'), max_length=128)
+    last_login = models.DateTimeField(_('last login'), blank=True, null=True)
+
+    is_active = True
+
+    REQUIRED_FIELDS = []
+
+    class Meta:
+        abstract = True
+
+    def get_username(self):
+        "Return the identifying username for this User"
+        return getattr(self, self.USERNAME_FIELD)
+
+    def __str__(self):
+        return self.get_username()
+
+    def natural_key(self):
+        return (self.get_username(),)
+
+    def is_anonymous(self):
+        """
+        Always returns False. This is a way of comparing User objects to
+        anonymous users.
+        """
+        return False
+
+    def is_authenticated(self):
+        """
+        Always return True. This is a way to tell if the user has been
+        authenticated in templates.
+        """
+        return True
+
+    def set_password(self, raw_password):
+        self.password = make_password(raw_password)
+
+    def check_password(self, raw_password):
+        """
+        Returns a boolean of whether the raw_password was correct. Handles
+        hashing formats behind the scenes.
+        """
+        def setter(raw_password):
+            self.set_password(raw_password)
+            self.save(update_fields=["password"])
+        return check_password(raw_password, self.password, setter)
+
+    def set_unusable_password(self):
+        # Sets a value that will never be a valid hash
+        self.password = make_password(None)
+
+    def has_usable_password(self):
+        return is_password_usable(self.password)
+
+    def get_full_name(self):
+        raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_full_name() method')
+
+    def get_short_name(self):
+        raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_short_name() method.')
+
+    def get_session_auth_hash(self):
+        """
+        Returns an HMAC of the password field.
+        """
+        key_salt = "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash"
+        return salted_hmac(key_salt, self.password).hexdigest()

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import auth
-from django.contrib.auth.hashers import (
-    check_password, is_password_usable, make_password,
-)
+from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.signals import user_logged_in
 from django.contrib.contenttypes.models import ContentType
 from django.core import validators
@@ -12,7 +10,6 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models.manager import EmptyManager
 from django.utils import six, timezone
-from django.utils.crypto import get_random_string, salted_hmac
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -129,39 +126,6 @@ class Group(models.Model):
         return (self.name,)
 
 
-class BaseUserManager(models.Manager):
-
-    @classmethod
-    def normalize_email(cls, email):
-        """
-        Normalize the address by lowercasing the domain part of the email
-        address.
-        """
-        email = email or ''
-        try:
-            email_name, domain_part = email.strip().rsplit('@', 1)
-        except ValueError:
-            pass
-        else:
-            email = '@'.join([email_name, domain_part.lower()])
-        return email
-
-    def make_random_password(self, length=10,
-                             allowed_chars='abcdefghjkmnpqrstuvwxyz'
-                                           'ABCDEFGHJKLMNPQRSTUVWXYZ'
-                                           '23456789'):
-        """
-        Generates a random password with the given length and given
-        allowed_chars. Note that the default value of allowed_chars does not
-        have "I" or "O" or letters and digits that look similar -- just to
-        avoid confusion.
-        """
-        return get_random_string(length, allowed_chars)
-
-    def get_by_natural_key(self, username):
-        return self.get(**{self.model.USERNAME_FIELD: username})
-
-
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
@@ -189,76 +153,6 @@ class UserManager(BaseUserManager):
     def create_superuser(self, username, email, password, **extra_fields):
         return self._create_user(username, email, password, True, True,
                                  **extra_fields)
-
-
-@python_2_unicode_compatible
-class AbstractBaseUser(models.Model):
-    password = models.CharField(_('password'), max_length=128)
-    last_login = models.DateTimeField(_('last login'), blank=True, null=True)
-
-    is_active = True
-
-    REQUIRED_FIELDS = []
-
-    class Meta:
-        abstract = True
-
-    def get_username(self):
-        "Return the identifying username for this User"
-        return getattr(self, self.USERNAME_FIELD)
-
-    def __str__(self):
-        return self.get_username()
-
-    def natural_key(self):
-        return (self.get_username(),)
-
-    def is_anonymous(self):
-        """
-        Always returns False. This is a way of comparing User objects to
-        anonymous users.
-        """
-        return False
-
-    def is_authenticated(self):
-        """
-        Always return True. This is a way to tell if the user has been
-        authenticated in templates.
-        """
-        return True
-
-    def set_password(self, raw_password):
-        self.password = make_password(raw_password)
-
-    def check_password(self, raw_password):
-        """
-        Returns a boolean of whether the raw_password was correct. Handles
-        hashing formats behind the scenes.
-        """
-        def setter(raw_password):
-            self.set_password(raw_password)
-            self.save(update_fields=["password"])
-        return check_password(raw_password, self.password, setter)
-
-    def set_unusable_password(self):
-        # Sets a value that will never be a valid hash
-        self.password = make_password(None)
-
-    def has_usable_password(self):
-        return is_password_usable(self.password)
-
-    def get_full_name(self):
-        raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_full_name() method')
-
-    def get_short_name(self):
-        raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_short_name() method.')
-
-    def get_session_auth_hash(self):
-        """
-        Returns an HMAC of the password field.
-        """
-        key_salt = "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash"
-        return salted_hmac(key_salt, self.password).hexdigest()
 
 
 # A few helper functions for common logic between User and AnonymousUser.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -428,6 +428,10 @@ Miscellaneous
 
 * Support for PostGIS 1.5 has been dropped.
 
+* ``AbstractBaseUser`` and ``BaseUserManager`` were moved to a new
+  ``django.contrib.auth.base_user`` module so they can be imported without
+  including ``django.contrib.auth`` in :setting:`INSTALLED_APPS`.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -711,6 +711,13 @@ utility methods:
         * ``o``, ``O``, and ``0`` (lowercase letter o, uppercase letter o,
           and zero)
 
+.. versionchanged:: 1.9
+
+    ``AbstractBaseUser`` and ``BaseUserManager`` were moved to a new
+    ``django.contrib.auth.base_user`` module so they can be imported without
+    including ``django.contrib.auth`` in :setting:`INSTALLED_APPS`.
+
+
 Extending Django's default User
 -------------------------------
 


### PR DESCRIPTION
... used without auth in INSTALLED_APPS. I left the docs as-is, referring to `django.contrib.auth.models.AbstractBaseUser`. Not sure if you want to bless this new location, or just leave it as an implementation detail for the (probably rare) times someone needs it.