### PR TITLE
Fixed #24569 -- Made some translation functions accept None value

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -248,8 +248,12 @@ def get_language_bidi():
     * False = left-to-right layout
     * True = right-to-left layout
     """
-    base_lang = get_language().split('-')[0]
-    return base_lang in settings.LANGUAGES_BIDI
+    lang = get_language()
+    if lang is None:
+        return False
+    else:
+        base_lang = get_language().split('-')[0]
+        return base_lang in settings.LANGUAGES_BIDI
 
 
 def catalog():
@@ -394,7 +398,7 @@ def check_for_language(lang_code):
     <https://www.djangoproject.com/weblog/2007/oct/26/security-fix/>.
     """
     # First, a quick check to make sure lang_code is well-formed (#21458)
-    if not language_code_re.search(lang_code):
+    if lang_code is None or not language_code_re.search(lang_code):
         return False
     for path in all_locale_paths():
         if gettext_module.find('django', path, [to_locale(lang_code)]) is not None:

--- a/docs/releases/1.8.1.txt
+++ b/docs/releases/1.8.1.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Restored proper parsing of the :djadmin:`testserver` command's positional
   arguments (fixture names) (:ticket:`24571`).
+
+* Prevented ``TypeError`` in translation functions ``check_for_language()`` and
+  ``get_language_bidi()`` when translations are deactivated (:ticket:`24569`).

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -27,10 +27,10 @@ from django.utils.safestring import SafeBytes, SafeString, SafeText, mark_safe
 from django.utils.six import PY3
 from django.utils.translation import (
     LANGUAGE_SESSION_KEY, activate, check_for_language, deactivate,
-    get_language, get_language_from_request, get_language_info, gettext,
-    gettext_lazy, ngettext_lazy, npgettext, npgettext_lazy, pgettext,
-    pgettext_lazy, string_concat, to_locale, trans_real, ugettext,
-    ugettext_lazy, ungettext, ungettext_lazy,
+    get_language, get_language_bidi, get_language_from_request,
+    get_language_info, gettext, gettext_lazy, ngettext_lazy, npgettext,
+    npgettext_lazy, pgettext, pgettext_lazy, string_concat, to_locale,
+    trans_real, ugettext, ugettext_lazy, ungettext, ungettext_lazy,
 )
 
 from .forms import CompanyForm, I18nForm, SelectDateForm
@@ -397,6 +397,11 @@ class TranslationTests(TestCase):
         """
         self.assertEqual(trans_real.to_language('en_US'), 'en-us')
         self.assertEqual(trans_real.to_language('sr_Lat'), 'sr-lat')
+
+    def test_language_bidi(self):
+        self.assertEqual(get_language_bidi(), False)
+        with translation.override(None):
+            self.assertEqual(get_language_bidi(), False)
 
     @override_settings(LOCALE_PATHS=[os.path.join(here, 'other', 'locale')])
     def test_bad_placeholder_1(self):
@@ -1417,6 +1422,7 @@ class CountrySpecificLanguageTests(TestCase):
         self.assertTrue(check_for_language('en-US'))
         self.assertFalse(check_for_language('en-ü'))
         self.assertFalse(check_for_language('en\x00'))
+        self.assertFalse(check_for_language(None))
 
     def test_get_language_from_request(self):
         # issue 19919


### PR DESCRIPTION
get_language() can return None when translations are deactivated.
Thanks Nicola Peduzzi for the report.