### PR TITLE
Fixed #24581 -- Added an exception when ManyToManyField._get_m2m_attr() fails to match

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2566,6 +2566,7 @@ class ManyToManyField(RelatedField):
                     (link_field_name is None or link_field_name == f.name)):
                 setattr(self, cache_attr, getattr(f, attr))
                 return getattr(self, cache_attr)
+        raise AttributeError('Failed to resolve m2m attribute %r', (attr,))
 
     def _get_m2m_reverse_attr(self, related, attr):
         """

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -244,6 +244,25 @@ class ManyToManyFieldTests(test.TestCase):
             "Pending lookup added for a many-to-many field on an abstract model"
         )
 
+    def test_attribute_lookup_on_an_invalid_relation(self):
+        """
+        Tests that calling _get_m2m_attr fails properly when the relation is
+        inconsistent (through model does not point back to the origin).
+        """
+        class A(models.Model):
+            class Meta:
+                app_label = "something"
+
+        class B(models.Model):
+            class Meta:
+                app_label = "something"
+
+        field = models.ManyToManyField('A', through=B)
+        field.contribute_to_class(A, 'to_a')
+        self.assertRaises(
+            AttributeError,
+            lambda: field._get_m2m_attr(field.related, 'name'))
+
 
 class DateTimeFieldTests(unittest.TestCase):
     def test_datetimefield_to_python_usecs(self):


### PR DESCRIPTION
This fixes https://code.djangoproject.com/ticket/24581