### PR TITLE
Fixed #24590 -- Cached calls to swappable_setting.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -255,6 +255,17 @@ class Apps(object):
                 "Model '%s.%s' not registered." % (app_label, model_name))
         return model
 
+    @lru_cache.lru_cache(maxsize=None)
+    def get_swappable_setting(self, to_string):
+        # See if anything swapped/swappable matches
+        for model in self.get_models(include_swapped=True):
+            if model._meta.swapped:
+                if model._meta.swapped == to_string:
+                    return model._meta.swappable
+            if ("%s.%s" % (model._meta.app_label, model._meta.object_name)) == to_string and model._meta.swappable:
+                return model._meta.swappable
+        return None
+
     def set_available_apps(self, available):
         """
         Restricts the set of installed apps used by get_app_config[s].

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -309,13 +309,7 @@ class RelatedField(Field):
                     self.remote_field.model._meta.app_label,
                     self.remote_field.model._meta.object_name,
                 )
-            # See if anything swapped/swappable matches
-            for model in apps.get_models(include_swapped=True):
-                if model._meta.swapped:
-                    if model._meta.swapped == to_string:
-                        return model._meta.swappable
-                if ("%s.%s" % (model._meta.app_label, model._meta.object_name)) == to_string and model._meta.swappable:
-                    return model._meta.swappable
+            return apps.get_swappable_setting(to_string)
         return None
 
     def set_attributes_from_rel(self):

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -178,10 +178,3 @@ def static_finders_changed(**kwargs):
     }:
         from django.contrib.staticfiles.finders import get_finder
         get_finder.cache_clear()
-
-
-@receiver(setting_changed)
-def auth_user_model_changed(**kwargs):
-    if kwargs['setting'] == 'AUTH_USER_MODEL':
-        from django.apps import apps
-        apps.get_swappable_setting.cache_clear()

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -178,3 +178,10 @@ def static_finders_changed(**kwargs):
     }:
         from django.contrib.staticfiles.finders import get_finder
         get_finder.cache_clear()
+
+
+@receiver(setting_changed)
+def auth_user_model_changed(**kwargs):
+    if kwargs['setting'] == 'AUTH_USER_MODEL':
+        from django.apps import apps
+        apps.get_swappable_setting.cache_clear()

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.apps import apps
 from django.db import models
 from django.test import TestCase, override_settings
 from django.utils import six
@@ -219,6 +220,8 @@ class FieldDeconstructionTests(TestCase):
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_foreign_key_swapped(self):
+        # Clear cache for mapping models to swappable setting
+        apps.get_swappable_setting.cache_clear()
         # It doesn't matter that we swapped out user for permission;
         # there's no validation. We just want to check the setting stuff works.
         field = models.ForeignKey("auth.Permission")
@@ -227,6 +230,8 @@ class FieldDeconstructionTests(TestCase):
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission"})
         self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
+        # And reset cache again
+        apps.get_swappable_setting.cache_clear()
 
     def test_image_field(self):
         field = models.ImageField(upload_to="foo/barness", width_field="width", height_field="height")
@@ -297,6 +302,8 @@ class FieldDeconstructionTests(TestCase):
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_many_to_many_field_swapped(self):
+        # Clear cache for mapping models to swappable setting
+        apps.get_swappable_setting.cache_clear()
         # It doesn't matter that we swapped out user for permission;
         # there's no validation. We just want to check the setting stuff works.
         field = models.ManyToManyField("auth.Permission")
@@ -305,6 +312,8 @@ class FieldDeconstructionTests(TestCase):
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission"})
         self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
+        # And clear cache again
+        apps.get_swappable_setting.cache_clear()
 
     def test_null_boolean_field(self):
         field = models.NullBooleanField()


### PR DESCRIPTION
Moved the lookup in `Field.swappable_setting` to `Apps`, and added
an `lru_cache` to cache the results.

https://code.djangoproject.com/ticket/24590