### PR TITLE
Fixed #24591 -- Optimized cloning of ModelState objects.

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -402,7 +402,8 @@ You can take this template and work from it, though we suggest looking at the
 built-in Django operations in ``django.db.migrations.operations`` - they're
 easy to read and cover a lot of the example usage of semi-internal aspects
 of the migration framework like ``ProjectState`` and the patterns used to get
-historical models.
+historical models, as well as ``ModelState`` and the patterns used to mutate
+historical models in ``state_forwards()``.
 
 Some things to note:
 
@@ -420,6 +421,16 @@ Some things to note:
 * You might see implementations of ``references_model`` on the built-in
   operations; this is part of the autodetection code and does not matter for
   custom operations.
+
+.. warning::
+
+    For performance reasons, the :class:`~django.db.models.Field` instances in
+    ``ModelState.fields`` are reused across migrations. You must never change
+    the attributes on these instances. If you need to mutate a field in
+    ``state_forwards()``, you must remove the old instance from
+    ``ModelState.fields`` and add a new instance in its place. The same is true
+    for the :class:`~django.db.models.Manager` instances in
+    ``ModelState.managers``.
 
 As a simple example, let's make an operation that loads PostgreSQL extensions
 (which contain some of PostgreSQL's more exciting features). It's simple enough;

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -10,6 +10,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 
 from .models import (
     FoodManager, FoodQuerySet, ModelWithCustomBase, NoMigrationFoodManager,
+    UnicodeModel,
 )
 
 
@@ -677,6 +678,21 @@ class ModelStateTests(TestCase):
         field.model = models.Model
         with self.assertRaisesMessage(ValueError,
                 'ModelState.fields cannot be bound to a model - "field" is.'):
+            ModelState('app', 'Model', [('field', field)])
+
+    def test_sanity_check_to(self):
+        field = models.ForeignKey(UnicodeModel)
+        with self.assertRaisesMessage(ValueError,
+                'ModelState.fields cannot refer to a model class - "field.to" does. '
+                'Use a string reference instead.'):
+            ModelState('app', 'Model', [('field', field)])
+
+    def test_sanity_check_through(self):
+        field = models.ManyToManyField('UnicodeModel')
+        field.remote_field.through = UnicodeModel
+        with self.assertRaisesMessage(ValueError,
+                'ModelState.fields cannot refer to a model class - "field.through" does. '
+                'Use a string reference instead.'):
             ModelState('app', 'Model', [('field', field)])
 
     def test_fields_immutability(self):


### PR DESCRIPTION
Changed ModelState.clone() to create a shallow copy of self.fields
and self.managers.

https://code.djangoproject.com/ticket/24591