### PR TITLE
Fixed #24544 -- Fixed get_image_dimensions() on image buffers that Pillow fails to parse (based on artscoop work)

### DIFF
--- a/django/core/files/images.py
+++ b/django/core/files/images.py
@@ -3,6 +3,7 @@ Utility functions for handling images.
 
 Requires Pillow as you might imagine.
 """
+import struct
 import zlib
 
 from django.core.files import File
@@ -63,6 +64,11 @@ def get_image_dimensions(file_or_path, close=False):
                     pass
                 else:
                     raise
+            except struct.error as e:
+                # ignore PIL failing on a too short buffer, when reads
+                # return less bytes than expected. skip and feed more data
+                # to the parser (ticket #24544)
+                pass
             if p.image:
                 return p.image.size
             chunk_size *= 2


### PR DESCRIPTION
It looks like https://github.com/django/django/pull/4401 haven't been updated in a few days.
Since I need this fix as well, I updated @artscoop PR from @timgraham feedback.
The tests should now pass.