### PR TITLE
Fixes #24598 -- Allowed overriding default content type in responses

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -54,8 +54,9 @@ class HttpResponseBase(six.Iterator):
         self._reason_phrase = reason
         self._charset = charset
         if content_type is None:
-            content_type = '%s; charset=%s' % (settings.DEFAULT_CONTENT_TYPE,
-                                               self.charset)
+            content_type = getattr(self, 'default_content_type',
+                                   settings.DEFAULT_CONTENT_TYPE)
+            content_type = '%s; charset=%s' % (content_type, self.charset)
         self['Content-Type'] = content_type
 
     @property
@@ -470,11 +471,11 @@ class JsonResponse(HttpResponse):
     :param safe: Controls if only ``dict`` objects may be serialized. Defaults
       to ``True``.
     """
+    default_content_type = 'application/json'
 
     def __init__(self, data, encoder=DjangoJSONEncoder, safe=True, **kwargs):
         if safe and not isinstance(data, dict):
             raise TypeError('In order to allow non-dict objects to be '
                 'serialized set the safe parameter to False')
-        kwargs.setdefault('content_type', 'application/json')
         data = json.dumps(data, cls=encoder)
         super(JsonResponse, self).__init__(content=data, **kwargs)

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -217,6 +217,14 @@ Requests and Responses
 
 * The debug view now shows details of chained exceptions on Python 3.
 
+* When no content_type argument is passed ``HttpResponseBase`` will now check
+  for a `default_content_type` property, and fall back to
+  settings.DEFAULT_CONTENT_TYPE if one is not defined.
+
+  This allows sub-classes (e.g.
+  :class:`JsonResponse <django.http.JsonResponse>`) to override the default
+  content type without losing the automatic appending of "; charset=encoding".
+
 Tests
 ^^^^^
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -219,7 +219,7 @@ Requests and Responses
 
 * When no content_type argument is passed ``HttpResponseBase`` will now check
   for a ``default_content_type`` property, and fall back to
-  :settings:`DEFAULT_CONTENT_TYPE` if one is not defined.
+  :setting:`DEFAULT_CONTENT_TYPE` if one is not defined.
 
   This allows sub-classes (e.g.
   :class:`JsonResponse <django.http.JsonResponse>`) to override the default

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -218,12 +218,13 @@ Requests and Responses
 * The debug view now shows details of chained exceptions on Python 3.
 
 * When no content_type argument is passed ``HttpResponseBase`` will now check
-  for a `default_content_type` property, and fall back to
-  settings.DEFAULT_CONTENT_TYPE if one is not defined.
+  for a ``default_content_type`` property, and fall back to
+  :settings:`DEFAULT_CONTENT_TYPE` if one is not defined.
 
   This allows sub-classes (e.g.
   :class:`JsonResponse <django.http.JsonResponse>`) to override the default
-  content type without losing the automatic appending of "; charset=encoding".
+  content type without losing the automatic appending of
+  ``"; charset=encoding"``.
 
 Tests
 ^^^^^

--- a/tests/view_tests/tests/test_json.py
+++ b/tests/view_tests/tests/test_json.py
@@ -13,7 +13,7 @@ class JsonResponseTests(TestCase):
         response = self.client.get('/json/response/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response['content-type'], 'application/json')
+            response['content-type'], 'application/json; charset=utf-8')
         self.assertEqual(json.loads(response.content.decode()), {
             'a': [1, 2, 3],
             'foo': {'bar': 'baz'},


### PR DESCRIPTION
Allows a HttpResponseBase sub-class to override the default content type without losing the auto-appended charset= value.