### PR TITLE
[documentation] improve a bit registration/login.html

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -873,6 +873,8 @@ implementation details see :ref:`using-the-views`.
         <input type="hidden" name="next" value="{{ next }}" />
         </form>
 
+        <p><a href="{% url 'password_reset' %}">Lost password</a>.</p>
+
         {% endblock %}
 
     If you have customized authentication (see

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -847,6 +847,15 @@ implementation details see :ref:`using-the-views`.
         <p>Your username and password didn't match. Please try again.</p>
         {% endif %}
 
+        {% if next %}
+            {% if user.is_authenticated %}
+            <p>You account doesn't have access to this page, please login with
+            an account that has access to it to proceed.</p>
+            {% else %}
+            <p>Please login to see this page.</p>
+            {% endif %}
+        {% endif %}
+
         <form method="post" action="{% url 'django.contrib.auth.views.login' %}">
         {% csrf_token %}
         <table>


### PR DESCRIPTION
Hello,

In the example template here https://docs.djangoproject.com/en/1.8/topics/auth/default/#django.contrib.auth.views.login two extremely common patterns are missing:

* inform the user that he has been redirected to this page because he doesn't have the rights to see it
* link to password reset workflow

I can only see very few situations where those two features aren't wanted, thus, it seems a reasonable idea to include them in the reference example.

This pull request is split into two commits, this allow cherry-picking if only a part of it is accepted.

Kind regards,