### PR TITLE
Use mock.patch in migrations tests

### DIFF
--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 from datetime import date, timedelta
 
@@ -6,6 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.test import TestCase
+from django.utils.six import PY3
 
 
 class TokenGeneratorTest(TestCase):
@@ -54,7 +54,7 @@ class TokenGeneratorTest(TestCase):
         p2 = Mocked(date.today() + timedelta(settings.PASSWORD_RESET_TIMEOUT_DAYS + 1))
         self.assertFalse(p2.check_token(user, tk1))
 
-    @unittest.skipIf(sys.version_info[:2] >= (3, 0), "Unnecessary test with Python 3")
+    @unittest.skipIf(PY3, "Unnecessary test with Python 3")
     def test_date_length(self):
         """
         Make sure we don't allow overly long dates, causing a potential DoS.


### PR DESCRIPTION
Currently some of the migrations tests rely on the fact 'input' is aliased
because of six, instead of using mock.patch.  Replace this code with proper
use of mock.patch.

Also, replace one case of excessively specific python version check with
testing six.PY3