### PR TITLE
Fixed #24474 -- Make empty_value_diplay a property in admin

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -174,6 +174,7 @@ class RelatedFieldListFilter(FieldListFilter):
         else:
             self.lookup_title = other_model._meta.verbose_name
         self.title = self.lookup_title
+        self.empty_value_display = model_admin.get_empty_value_display()
 
     def has_output(self):
         if self.field.null:
@@ -189,7 +190,6 @@ class RelatedFieldListFilter(FieldListFilter):
         return field.get_choices(include_blank=False)
 
     def choices(self, cl):
-        from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
         yield {
             'selected': self.lookup_val is None and not self.lookup_val_isnull,
             'query_string': cl.get_query_string({},
@@ -210,7 +210,7 @@ class RelatedFieldListFilter(FieldListFilter):
                 'query_string': cl.get_query_string({
                     self.lookup_kwarg_isnull: 'True',
                 }, [self.lookup_kwarg]),
-                'display': EMPTY_CHANGELIST_VALUE,
+                'display': self.empty_value_display,
             }
 
 FieldListFilter.register(lambda f: f.remote_field, RelatedFieldListFilter)
@@ -353,6 +353,7 @@ class AllValuesFieldListFilter(FieldListFilter):
         self.lookup_val = request.GET.get(self.lookup_kwarg, None)
         self.lookup_val_isnull = request.GET.get(self.lookup_kwarg_isnull,
                                                  None)
+        self.empty_value_display = model_admin.get_empty_value_display()
         parent_model, reverse_path = reverse_field_path(model, field_path)
         # Obey parent ModelAdmin queryset when deciding which options to show
         if model == parent_model:
@@ -370,7 +371,6 @@ class AllValuesFieldListFilter(FieldListFilter):
         return [self.lookup_kwarg, self.lookup_kwarg_isnull]
 
     def choices(self, cl):
-        from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
         yield {
             'selected': (self.lookup_val is None
                 and self.lookup_val_isnull is None),
@@ -397,7 +397,7 @@ class AllValuesFieldListFilter(FieldListFilter):
                 'query_string': cl.get_query_string({
                     self.lookup_kwarg_isnull: 'True',
                 }, [self.lookup_kwarg]),
-                'display': EMPTY_CHANGELIST_VALUE,
+                'display': self.empty_value_display,
             }
 
 FieldListFilter.register(lambda f: True, AllValuesFieldListFilter)

--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -174,6 +174,7 @@ class AdminReadonlyField(object):
         self.is_first = is_first
         self.is_checkbox = False
         self.is_readonly = True
+        self.empty_value_display = model_admin.get_empty_value_display()
 
     def label_tag(self):
         attrs = {}
@@ -186,12 +187,11 @@ class AdminReadonlyField(object):
 
     def contents(self):
         from django.contrib.admin.templatetags.admin_list import _boolean_icon
-        from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
         field, obj, model_admin = self.field['field'], self.form.instance, self.model_admin
         try:
             f, attr, value = lookup_field(field, obj, model_admin)
         except (AttributeError, ValueError, ObjectDoesNotExist):
-            result_repr = EMPTY_CHANGELIST_VALUE
+            result_repr = self.empty_value_display
         else:
             if f is None:
                 boolean = getattr(attr, "boolean", False)
@@ -207,7 +207,8 @@ class AdminReadonlyField(object):
                 if isinstance(f.remote_field, ManyToManyRel) and value is not None:
                     result_repr = ", ".join(map(six.text_type, value.all()))
                 else:
-                    result_repr = display_for_field(value, f)
+                    empty_value_display = self.model_admin.get_empty_value_display()
+                    result_repr = display_for_field(value, f, empty_value_display)
         return conditional_escape(result_repr)
 
 

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -814,6 +814,15 @@ class ModelAdmin(BaseModelAdmin):
             description = capfirst(action.replace('_', ' '))
         return func, action, description
 
+    def get_empty_value_display(self):
+        """
+        Return the empty_value_display set on ModelAdmin or AdminSite.
+        """
+        try:
+            return mark_safe(self.empty_value_display)
+        except AttributeError:
+            return mark_safe(self.admin_site.empty_value_display)
+
     def get_list_display(self, request):
         """
         Return a sequence containing the fields to be displayed on the

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -48,6 +48,8 @@ class AdminSite(object):
     # URL for the "View site" link at the top of each admin page.
     site_url = '/'
 
+    _empty_value_display = '-'
+
     login_form = None
     index_template = None
     app_index_template = None
@@ -153,6 +155,14 @@ class AdminSite(object):
         Get all the enabled actions as an iterable of (name, func).
         """
         return six.iteritems(self._actions)
+
+    @property
+    def empty_value_display(self):
+        return self._empty_value_display
+
+    @empty_value_display.setter
+    def empty_value_display(self, empty_value_display):
+        self._empty_value_display = empty_value_display
 
     def has_permission(self, request):
         """

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -8,7 +8,7 @@ from django.contrib.admin.utils import (
     display_for_field, display_for_value, label_for_field, lookup_field,
 )
 from django.contrib.admin.views.main import (
-    ALL_VAR, EMPTY_CHANGELIST_VALUE, ORDER_VAR, PAGE_VAR, SEARCH_VAR,
+    ALL_VAR, ORDER_VAR, PAGE_VAR, SEARCH_VAR,
 )
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import NoReverseMatch
@@ -194,20 +194,22 @@ def items_for_result(cl, result, form):
     first = True
     pk = cl.lookup_opts.pk.attname
     for field_name in cl.list_display:
+        empty_value_display = cl.model_admin.get_empty_value_display()
         row_classes = ['field-%s' % field_name]
         try:
             f, attr, value = lookup_field(field_name, result, cl.model_admin)
         except ObjectDoesNotExist:
-            result_repr = EMPTY_CHANGELIST_VALUE
+            result_repr = empty_value_display
         else:
+            empty_value_display = getattr(attr, 'empty_value_display', empty_value_display)
             if f is None:
                 if field_name == 'action_checkbox':
                     row_classes = ['action-checkbox']
                 allow_tags = getattr(attr, 'allow_tags', False)
                 boolean = getattr(attr, 'boolean', False)
-                if boolean:
+                if boolean or not value:
                     allow_tags = True
-                result_repr = display_for_value(value, boolean)
+                result_repr = display_for_value(value, empty_value_display, boolean)
                 # Strip HTML tags in the resulting text, except if the
                 # function has an "allow_tags" attribute set to True.
                 if allow_tags:
@@ -218,11 +220,11 @@ def items_for_result(cl, result, form):
                 if isinstance(f.remote_field, models.ManyToOneRel):
                     field_val = getattr(result, f.name)
                     if field_val is None:
-                        result_repr = EMPTY_CHANGELIST_VALUE
+                        result_repr = empty_value_display
                     else:
                         result_repr = field_val
                 else:
-                    result_repr = display_for_field(value, f)
+                    result_repr = display_for_field(value, f, empty_value_display)
                 if isinstance(f, (models.DateField, models.TimeField, models.ForeignKey)):
                     row_classes.append('nowrap')
         if force_text(result_repr) == '':

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -367,18 +367,17 @@ def help_text_for_field(name, model):
     return smart_text(help_text)
 
 
-def display_for_field(value, field):
+def display_for_field(value, field, empty_value_display):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
-    from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
 
     if field.flatchoices:
-        return dict(field.flatchoices).get(value, EMPTY_CHANGELIST_VALUE)
+        return dict(field.flatchoices).get(value, empty_value_display)
     # NullBooleanField needs special-case null-handling, so it comes
     # before the general null test.
     elif isinstance(field, models.BooleanField) or isinstance(field, models.NullBooleanField):
         return _boolean_icon(value)
     elif value is None:
-        return EMPTY_CHANGELIST_VALUE
+        return empty_value_display
     elif isinstance(field, models.DateTimeField):
         return formats.localize(timezone.template_localtime(value))
     elif isinstance(field, (models.DateField, models.TimeField)):
@@ -393,14 +392,13 @@ def display_for_field(value, field):
         return smart_text(value)
 
 
-def display_for_value(value, boolean=False):
+def display_for_value(value, empty_value_display, boolean=False):
     from django.contrib.admin.templatetags.admin_list import _boolean_icon
-    from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
 
     if boolean:
         return _boolean_icon(value)
     elif value is None:
-        return EMPTY_CHANGELIST_VALUE
+        return empty_value_display
     elif isinstance(value, datetime.datetime):
         return formats.localize(timezone.template_localtime(value))
     elif isinstance(value, (datetime.date, datetime.time)):

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -33,9 +33,6 @@ ERROR_FLAG = 'e'
 IGNORED_PARAMS = (
     ALL_VAR, ORDER_VAR, ORDER_TYPE_VAR, SEARCH_VAR, IS_POPUP_VAR, TO_FIELD_VAR)
 
-# Text to display within change-list table cells if the value is blank.
-EMPTY_CHANGELIST_VALUE = '-'
-
 
 class ChangeList(object):
     def __init__(self, request, model, list_display, list_display_links,

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -205,6 +205,40 @@ subclass::
         to its documentation for some caveats when time zone support is
         enabled (:setting:`USE_TZ = True <USE_TZ>`).
 
+.. attribute:: ModelAdmin.empty_value_display
+
+    .. versionadded:: 1.9
+
+    This attribute overrides the default display value for record fields that
+    are empty (None, empty string or an empty list or tuple). The default value
+    is ``-`` (a dash).
+
+    In this example we override the ``empty_value_display`` for give ``ModelAdmin``::
+
+        from django.contrib import admin
+
+        class AuthorAdmin(admin.ModelAdmin):
+            fields = ('name', 'title', 'birth_date',)
+
+            empty_value_display = '-empty-'
+
+    You could also override ``empty_value_display`` for all admin pages with::
+
+        AdminSite.empty_value_display = '-none-'
+
+    or for specific fields like this::
+
+        from django.contrib import admin
+
+        class AuthorAdmin(admin.ModelAdmin):
+            fields = ('name', 'title', 'view_birth_date',)
+
+            def view_birth_date(self, obj):
+                return obj.birth_date
+
+            view_birth_date.short_name = 'birth_date'
+            view_birth_date.empty_value_display = '???'
+
 .. attribute:: ModelAdmin.exclude
 
     This attribute, if given, should be a list of field names to exclude from
@@ -583,6 +617,37 @@ subclass::
           class PersonAdmin(admin.ModelAdmin):
               list_display = ('first_name', 'last_name', 'colored_name')
 
+    * If the value of a field is ``None``, an empty string, or a list without
+      elements then Django will display ``-`` (a dash). You can override this by
+      setting another `empty_value_display` on `AdminSite` like::
+
+          from django.contrib import admin
+
+          admin.site.empty_value_display = '(None)'
+
+      You can also override it on ``ModelAdmin`` level like this::
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display = ('name', 'birth_date_view')
+
+              empty_value_display = 'unknown'
+
+      Or on a field level::
+
+          class PersonAdmin(admin.ModelAdmin):
+              list_display = ('name', 'birth_date_view')
+
+              def birth_date_view(self, obj):
+                   return obj.birth_date
+
+              birth_date_view.empty_value_display = 'unknown'
+
+    .. versionadded:: 1.9
+
+    ``ModelAdmin`` and ``AdminSite`` now both have a ``empty_value_display``
+    attribute. Likewise it can be set to a custom ``ModelAdmin``
+    field specification.
+
     * If the string given is a method of the model, ``ModelAdmin`` or a
       callable that returns True or False Django will display a pretty
       "on" or "off" icon if you give the method a ``boolean`` attribute
@@ -603,7 +668,6 @@ subclass::
 
           class PersonAdmin(admin.ModelAdmin):
               list_display = ('name', 'born_in_fifties')
-
 
     * The ``__str__()`` (``__unicode__()`` on Python 2) method is just
       as valid in ``list_display`` as any other model method, so it's
@@ -2467,6 +2531,14 @@ Templates can override or extend base admin templates as described in
 .. attribute:: AdminSite.app_index_template
 
     Path to a custom template that will be used by the admin site app index view.
+
+.. attribute:: AdminSite.empty_value_display
+
+    .. versionadded:: 1.9
+
+    The string to use for displaying empty values in the admin site change list.
+    The value can be overridden as an attribute on ``AdminSite``, on a per
+    ``ModelAdmin`` basis, or on a custom field within ``ModelAdmin``.
 
 .. attribute:: AdminSite.login_template
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -48,6 +48,15 @@ Minor features
   changing the ``select_related()`` values used in the admin's changelist query
   based on the request.
 
+* :attr:`AdminSite.empty_value_display
+  <django.contrib.admin.AdminSite.empty_value_display>` was added to override
+  the display of empty values in ``admin change list``.
+
+* :attr:`ModelAdmin.empty_value_display
+  <django.contrib.admin.ModelAdmin.empty_value_display>` was added to have
+  ModelAdmin specific overrides for the display of empty values in ``admin
+  change list``. These overrides can also be set on a field level.
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -125,3 +125,14 @@ class DynamicSearchFieldsChildAdmin(admin.ModelAdmin):
         search_fields = super(DynamicSearchFieldsChildAdmin, self).get_search_fields(request)
         search_fields += ('age',)
         return search_fields
+
+
+class EmptyValueChildAdmin(admin.ModelAdmin):
+    list_display = ('name', 'age_display', 'age')
+
+    def age_display(self, obj):
+        return obj.age
+
+    age_display.empty_value_display = '&dagger;'
+
+    empty_value_display = '-empty-'


### PR DESCRIPTION
Add param to ModelAdmin to set the empty value display:
ModelAdmin.empty_value_display.

Add property on ModelAdmin custom fields to set
empty_value_display for individual fields.

Add method to set empty value display on admin site level:
AdminSite.set_empty_value_display().