### PR TITLE
Fixed #24607 -- Fixed handling of natural keys in models that use inheritance

### DIFF
--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -46,6 +46,8 @@ class Serializer(object):
         self.selected_fields = options.pop("fields", None)
         self.use_natural_foreign_keys = options.pop('use_natural_foreign_keys', False)
         self.use_natural_primary_keys = options.pop('use_natural_primary_keys', False)
+        if self.use_natural_primary_keys:
+            self.use_natural_foreign_keys = True
 
         self.start_serialization()
         self.first = True

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -43,11 +43,11 @@ class Serializer(base.Serializer):
         pk = obj._meta.pk
         if pk.remote_field:
             if self.use_natural_foreign_keys:
-                return self.get_dump_pk(getattr(obj, pk.remote_field.field.name), level+1)
+                return self.get_dump_pk(getattr(obj, pk.remote_field.field.name), level + 1)
             else:
                 return force_text(obj.pk, strings_only=True)
         elif self.use_natural_primary_keys and hasattr(obj, "natural_key"):
-            return _NONE if level==0 else obj.natural_key()
+            return _NONE if level == 0 else obj.natural_key()
         else:
             return force_text(obj.pk, strings_only=True)
 
@@ -126,7 +126,7 @@ def Deserializer(object_list, **options):
         data = {}
         if 'pk' in d:
             pk = d.get("pk", None)
-            if isinstance(pk, (list,tuple)):
+            if isinstance(pk, (list, tuple)):
                 pk = _get_by_natural_pk(Model, pk)
             else:
                 try:

--- a/tests/fixtures_inheritance/models.py
+++ b/tests/fixtures_inheritance/models.py
@@ -1,0 +1,19 @@
+from django.db import models
+
+class UserManager(models.Manager):
+
+    def get_by_natural_key(self, username):
+        return self.get(username=username)
+
+class User(models.Model):
+    objects = UserManager()
+    username = models.CharField(max_length=10)
+
+    def natural_key(self):
+        return (self.username,)
+
+class Person(User):
+    label = models.CharField(max_length=10)
+
+class Customer(Person):
+    num = models.IntegerField()

--- a/tests/fixtures_inheritance/models.py
+++ b/tests/fixtures_inheritance/models.py
@@ -1,9 +1,11 @@
 from django.db import models
 
+
 class UserManager(models.Manager):
 
     def get_by_natural_key(self, username):
         return self.get(username=username)
+
 
 class User(models.Model):
     objects = UserManager()
@@ -12,8 +14,10 @@ class User(models.Model):
     def natural_key(self):
         return (self.username,)
 
+
 class Person(User):
     label = models.CharField(max_length=10)
+
 
 class Customer(Person):
     num = models.IntegerField()

--- a/tests/fixtures_inheritance/tests.py
+++ b/tests/fixtures_inheritance/tests.py
@@ -2,9 +2,11 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-from django.test import TestCase
-from .models import User, Person, Customer
+
 from django.core import management
+from django.test import TestCase
+
+from .models import User, Person, Customer
 
 
 class TempJSONFile(object):

--- a/tests/fixtures_inheritance/tests.py
+++ b/tests/fixtures_inheritance/tests.py
@@ -4,8 +4,8 @@ import os
 import tempfile
 from django.test import TestCase
 from .models import User, Person, Customer
-from django.apps import apps
 from django.core import management
+
 
 class TempJSONFile(object):
 
@@ -28,8 +28,8 @@ class TestNaturalKeysAndInheritance(TestCase):
     def setUp(self):
         Customer.objects.create(username="toto", label="ping", num=23)
         Customer.objects.create(username="titi", label="pong", num=34)
-        Person  .objects.create(username="tata", label="pang"        )
-        User    .objects.create(username="tutu"                      )
+        Person  .objects.create(username="tata", label="pang")
+        User    .objects.create(username="tutu")
 
     def clear_tables(self):
         Customer.objects.all().delete()

--- a/tests/fixtures_inheritance/tests.py
+++ b/tests/fixtures_inheritance/tests.py
@@ -1,0 +1,79 @@
+from __future__ import unicode_literals
+
+import os
+import tempfile
+from django.test import TestCase
+from .models import User, Person, Customer
+from django.apps import apps
+from django.core import management
+
+class TempJSONFile(object):
+
+    def __init__(self):
+        fd, self.filename = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+
+    def __enter__(self):
+        return self.filename
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            os.unlink(self.filename)
+        except:
+            pass
+
+
+class TestNaturalKeysAndInheritance(TestCase):
+
+    def setUp(self):
+        Customer.objects.create(username="toto", label="ping", num=23)
+        Customer.objects.create(username="titi", label="pong", num=34)
+        Person  .objects.create(username="tata", label="pang"        )
+        User    .objects.create(username="tutu"                      )
+
+    def clear_tables(self):
+        Customer.objects.all().delete()
+        Person  .objects.all().delete()
+        User    .objects.all().delete()
+
+    def dumpdata(self, args, filename,
+                 natural_foreign_keys=False,
+                 natural_primary_keys=False):
+        management.call_command('dumpdata', *args,
+                                **{'format': 'json',
+                                   'output': filename,
+                                   'use_natural_foreign_keys': natural_foreign_keys,
+                                   'use_natural_primary_keys': natural_primary_keys})
+
+    def readdata(self, filename):
+        with open(filename, "r") as f:
+            return f.read()
+
+    def loaddata(self, filename):
+        management.call_command('loaddata', filename, verbosity=0)
+
+    def dump_and_load(self,
+                      natural_foreign_keys=False,
+                      natural_primary_keys=False):
+        with TempJSONFile() as filename:
+            self.dumpdata(["fixtures_inheritance"], filename,
+                          natural_foreign_keys=natural_foreign_keys,
+                          natural_primary_keys=natural_primary_keys)
+            self.clear_tables()
+            self.loaddata(filename)
+        self.assertEqual(4, len(User    .objects.all()))
+        self.assertEqual(3, len(Person  .objects.all()))
+        self.assertEqual(2, len(Customer.objects.all()))
+
+    def test_neither(self):
+        self.dump_and_load()
+
+    def test_primary(self):
+        self.dump_and_load(natural_primary_keys=True)
+
+    def test_foreign(self):
+        self.dump_and_load(natural_foreign_keys=True)
+
+    def test_both(self):
+        self.dump_and_load(natural_primary_keys=True,
+                           natural_foreign_keys=True)


### PR DESCRIPTION
this PR concerns my bug report https://code.djangoproject.com/ticket/24607

@timgraham I have rebased it on master and added tests, as you asked in my previous PR https://github.com/django/django/pull/4473

In the last commit, I have also explained (and fixed) why it must be the case that use_natural_primary_keys => use_natural_foreign_keys.