### PR TITLE
Fixed #24374 -- Called Template._render in IncludeNode

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -154,9 +154,9 @@ class IncludeNode(Node):
                 for name, var in six.iteritems(self.extra_context)
             }
             if self.isolated_context:
-                return template.render(context.new(values))
+                return template._render(context.new(values))
             with context.push(**values):
-                return template.render(context)
+                return template._render(context)
         except Exception:
             if context.template.engine.debug:
                 raise


### PR DESCRIPTION
Is it this simple?

I didn't replace the check for the `render` method on line 149.

This patch does not change my results from running the tests with sqlite.