### PR TITLE
[WIP] Fixed #24629 -- Allowed Func to be used as Transform

### DIFF
--- a/django/db/models/functions.py
+++ b/django/db/models/functions.py
@@ -1,7 +1,7 @@
 """
 Classes that represent database functions.
 """
-from django.db.models import IntegerField
+from django.db.models import CharField, IntegerField, TextField
 from django.db.models.expressions import Func, Value
 
 
@@ -86,6 +86,8 @@ class Concat(Func):
 class Length(Func):
     """Returns the number of characters in the expression"""
     function = 'LENGTH'
+    lookup_name = 'length'
+    transform = True
 
     def __init__(self, expression, **extra):
         output_field = extra.pop('output_field', IntegerField())
@@ -98,6 +100,8 @@ class Length(Func):
 
 class Lower(Func):
     function = 'LOWER'
+    lookup_name = 'lower'
+    transform = True
 
     def __init__(self, expression, **extra):
         super(Lower, self).__init__(expression, **extra)
@@ -134,6 +138,8 @@ class Substr(Func):
 
 class Upper(Func):
     function = 'UPPER'
+    lookup_name = 'upper'
+    transform = True
 
     def __init__(self, expression, **extra):
         super(Upper, self).__init__(expression, **extra)

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -37,7 +37,7 @@ class RegisterLookupMixin(object):
         found = self._get_lookup(lookup_name)
         if found is None and hasattr(self, 'output_field'):
             return self.output_field.get_transform(lookup_name)
-        if found is not None and not issubclass(found, Transform):
+        if found is not None and not hasattr(found, 'transform'):
             return None
         return found
 
@@ -60,6 +60,7 @@ class RegisterLookupMixin(object):
 class Transform(RegisterLookupMixin):
 
     bilateral = False
+    transform = True
 
     def __init__(self, lhs, lookups):
         self.lhs = lhs

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -311,3 +311,45 @@ class FunctionTests(TestCase):
             ],
             lambda a: a.name
         )
+
+    def test_length_transform(self):
+        try:
+            CharField.register_lookup(Length.transformer())
+            Author.objects.create(name='John Smith', alias='smithj')
+            Author.objects.create(name='Rhonda')
+            authors = Author.objects.filter(name__length__gt=7)
+            self.assertQuerysetEqual(
+                authors.order_by('name'), [
+                    'John Smith'
+                ],
+                lambda a: a.name)
+        finally:
+            CharField._unregister_lookup(Length)
+
+    def test_lower_transform(self):
+        try:
+            CharField.register_lookup(Lower.transformer())
+            Author.objects.create(name='John Smith', alias='smithj')
+            Author.objects.create(name='Rhonda')
+            authors = Author.objects.filter(name__lower__exact='john smith')
+            self.assertQuerysetEqual(
+                authors.order_by('name'), [
+                    'John Smith'
+                ],
+                lambda a: a.name)
+        finally:
+            CharField._unregister_lookup(Lower)
+
+    def test_upper_transform(self):
+        try:
+            CharField.register_lookup(Upper.transformer())
+            Author.objects.create(name='John Smith', alias='smithj')
+            Author.objects.create(name='Rhonda')
+            authors = Author.objects.filter(name__upper__exact='JOHN SMITH')
+            self.assertQuerysetEqual(
+                authors.order_by('name'), [
+                    'John Smith'
+                ],
+                lambda a: a.name)
+        finally:
+            CharField._unregister_lookup(Upper)


### PR DESCRIPTION
This is an experiment to see how a backwards compatible translation layer could help with the disconnect between Func and Transform.

The basic idea is that Funcs can return themselves wrapped in a Transform that proxies methods back to the Func. I'm not in love with this idea, but I think it might have a place if we decide we'd like to not break the Transform API so soon after it has been released.