### PR TITLE
bugfix: support defaults which are unhashable (e.g. JsonField default={}...

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -43,7 +43,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         super(DatabaseSchemaEditor, self).add_field(model, field)
 
         # Simulate the effect of a one-off default.
-        if self.skip_default(field) and field.default not in {None, NOT_PROVIDED}:
+        if self.skip_default(field) and field.default not in [None, NOT_PROVIDED]:
             effective_default = self.effective_default(field)
             self.execute('UPDATE %(table)s SET %(column)s = %%s' % {
                 'table': self.quote_name(model._meta.db_table),


### PR DESCRIPTION
bugfix: support defaults which are unhashable.
As an example now JsonField(default={}) causes an exception while executing the migration.