### PR TITLE
Fix 24424: migration autodetector won't remove last field on models being deleted

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -636,6 +636,8 @@ class MigrationAutodetector(object):
                 # Skip here, no need to handle fields for unmanaged models
                 continue
 
+            local_field_count = len(model._meta.local_concrete_fields)
+
             # Gather related fields
             related_fields = {}
             for field in model._meta.local_fields:
@@ -672,6 +674,10 @@ class MigrationAutodetector(object):
                 )
             # Then remove each related field
             for name, field in sorted(related_fields.items()):
+                # don't remove the last field, since that produces an invalid table
+                # on some backends.
+                if local_field_count == 1:
+                    break
                 self.add_operation(
                     app_label,
                     operations.RemoveField(
@@ -679,6 +685,8 @@ class MigrationAutodetector(object):
                         name=name,
                     )
                 )
+                local_field_count -= 1
+
             # Finally, remove the model.
             # This depends on both the removal/alteration of all incoming fields
             # and the removal of all its own related fields, and if it's

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1652,6 +1652,20 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, 'testapp', 0, 0, name="Author")
         self.assertOperationAttributes(changes, 'testapp', 0, 1, name="Aardvark")
 
+    def test_model_with_only_relation_fields_is_removed(self):
+        """
+        Tests that a model with only relation fields is removed.
+        """
+        # Make state
+        before = self.make_project_state([self.aardvark_pk_fk_author, self.author_empty])
+        after = self.make_project_state([self.author_empty])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["DeleteModel"])
+        self.assertOperationAttributes(changes, 'testapp', 0, 0, name="Aardvark")
+
     def test_first_dependency(self):
         """
         Tests that a dependency to an app with no migrations uses __first__.

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1388,8 +1388,8 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, "testapp", 0, [
             "RemoveField", "RemoveField", "DeleteModel", "DeleteModel"
         ])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="author",  model_name='contract')
-        self.assertOperationAttributes(changes, "testapp", 0, 1, name="publisher",  model_name='contract')
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="author", model_name='contract')
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="publisher", model_name='contract')
         self.assertOperationAttributes(changes, "testapp", 0, 2, name="Author")
         self.assertOperationAttributes(changes, "testapp", 0, 3, name="Contract")
 

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1386,13 +1386,12 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(changes, "testapp", 0, [
-            "RemoveField", "RemoveField", "RemoveField", "DeleteModel", "DeleteModel"
+            "RemoveField", "RemoveField", "DeleteModel", "DeleteModel"
         ])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="publishers", model_name='author')
-        self.assertOperationAttributes(changes, "testapp", 0, 1, name="author", model_name='contract')
-        self.assertOperationAttributes(changes, "testapp", 0, 2, name="publisher", model_name='contract')
-        self.assertOperationAttributes(changes, "testapp", 0, 3, name="Author")
-        self.assertOperationAttributes(changes, "testapp", 0, 4, name="Contract")
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="author",  model_name='contract')
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="publisher",  model_name='contract')
+        self.assertOperationAttributes(changes, "testapp", 0, 2, name="Author")
+        self.assertOperationAttributes(changes, "testapp", 0, 3, name="Contract")
 
     def test_concrete_field_changed_to_many_to_many(self):
         """


### PR DESCRIPTION
Previously the migration auto-detector would produce transition states with invalid tables (for some backends) when removing models with only relation fields. The `generate_deleted_models()` method would first generate a RemoveField operation for each relation field, and then generate a DeleteModel operation at the end. 

In the case where the model being removed only has relation fields, this produces a state where there are no fields on the model, or a table without any columns. This breaks on SQLite (and MySQL, from what I gather).

This patch uses a simple field counter to make sure the last field on a model is not removed before the DeleteModel operation.