### PR TITLE
Fixed #24603 - Allowed Context.update() to be used as a context manager.

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -171,8 +171,7 @@ class Context(BaseContext):
         "Pushes other_dict to the stack of dictionaries in the Context"
         if not hasattr(other_dict, '__getitem__'):
             raise TypeError('other_dict must be a mapping (dictionary-like) object.')
-        self.dicts.append(other_dict)
-        return other_dict
+        return ContextDict(self, other_dict)
 
 
 class RenderContext(BaseContext):

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -479,7 +479,7 @@ used to build the new context level.
     >>> c['foo']
     'first level'
 
-.. method:: update(other_dict)
+.. method:: Context.update(other_dict)
 
 In addition to ``push()`` and ``pop()``, the ``Context``
 object also defines an ``update()`` method. This works like ``push()``
@@ -494,6 +494,19 @@ the stack instead of an empty one.
     'updated'
     >>> c.pop()
     {'foo': 'updated'}
+    >>> c['foo']
+    'first level'
+
+.. versionadded:: 1.9
+
+Like ``push()``, you can use ``update()`` as a context manager to ensure a
+matching ``pop()`` is called.
+
+    >>> c = Context()
+    >>> c['foo'] = 'first level'
+    >>> with c.update({'foo': 'second level'}):
+    >>>     c['foo']
+    'second level'
     >>> c['foo']
     'first level'
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -208,6 +208,9 @@ Templates
 * A warning will now be logged for missing context variables. These messages
   will be logged to the :ref:`django.template <django-template-logger>` logger.
 
+* :meth:`Context.update() <django.template.Context.update>` can now be used as
+  a context manager.
+
 Requests and Responses
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -21,12 +21,25 @@ class ContextTests(SimpleTestCase):
         self.assertEqual(c["a"], 1)
         self.assertEqual(c.get("foo", 42), 42)
 
+    def test_push_context_mgr(self):
+        c = Context({"a": 1})
         with c.push():
             c['a'] = 2
             self.assertEqual(c['a'], 2)
         self.assertEqual(c['a'], 1)
 
         with c.push(a=3):
+            self.assertEqual(c['a'], 3)
+        self.assertEqual(c['a'], 1)
+
+    def test_update_context_mgr(self):
+        c = Context({"a": 1})
+        with c.update({}):
+            c['a'] = 2
+            self.assertEqual(c['a'], 2)
+        self.assertEqual(c['a'], 1)
+
+        with c.update({'a': 3}):
             self.assertEqual(c['a'], 3)
         self.assertEqual(c['a'], 1)
 


### PR DESCRIPTION
This changed Context.update() to act similarly to Context.push() when used as a
context manager.