### PR TITLE
Refs #24625 -- Filtered docutils warnings output in tests

### DIFF
--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
 from django.test import TestCase, modify_settings, override_settings
+from django.test.utils import captured_stderr
 
 from .models import Company, Person
 
@@ -220,9 +221,8 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
 
     def setUp(self):
         self.client.login(username='super', password='secret')
-        self.response = self.client.get(
-            reverse('django-admindocs-models-detail',
-                    args=['admin_docs', 'person']))
+        with captured_stderr() as self.docutils_stderr:
+            self.response = self.client.get(reverse('django-admindocs-models-detail', args=['admin_docs', 'person']))
 
     def test_method_excludes(self):
         """
@@ -295,6 +295,9 @@ class TestModelDetailView(TestDataMixin, AdminDocsTestCase):
         self.assertContains(self.response, '.. raw:: html\n    :file: admin_docs/evilfile.txt')
         self.assertContains(self.response, '<p>&quot;include&quot; directive disabled.</p>',)
         self.assertContains(self.response, '.. include:: admin_docs/evilfile.txt')
+        out = self.docutils_stderr.getvalue()
+        self.assertIn('"raw" directive disabled', out)
+        self.assertIn('"include" directive disabled', out)
 
     def test_model_with_many_to_one(self):
         link = '<a class="reference external" href="/admindocs/models/%s/">%s</a>'


### PR DESCRIPTION
Instead of setting ``warning_stream`` in the docutils config overrides
to ``False`` I opted for filtering the stderr in the tests to keep the
error output showing up in server logs.