### PR TITLE
Update related.py

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -635,7 +635,7 @@ class ReverseSingleRelatedObjectDescriptor(object):
             )
         elif value is not None and not isinstance(value, self.field.remote_field.model):
             raise ValueError(
-                'Cannot assign "%r": "%s.%s" must be a "%s" instance.' % (
+                u'Cannot assign "%r": "%s.%s" must be a "%s" instance.' % (
                     value,
                     instance._meta.object_name,
                     self.field.name,


### PR DESCRIPTION
Changed error message template to be unicode, so that if the interpolated variable "self.field.remote_field.model._meta.object_name" is unicode, the ValueError is properly raised, rather than throwing an error about trying to encode the error message itself.