### PR TITLE
Fixed #12952 -- Made admin history messages use model verbose name

### DIFF
--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -35,9 +35,9 @@ class Article(models.Model):
     """
     A simple article to test admin views. Test backwards compatibility.
     """
-    title = models.CharField(max_length=100)
+    title = models.CharField(max_length=100, verbose_name='¿Name?')
     content = models.TextField()
-    date = models.DateTimeField()
+    date = models.DateTimeField(verbose_name='¿Date published?')
     section = models.ForeignKey(Section, null=True, blank=True)
     sub_section = models.ForeignKey(Section, null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1739,6 +1739,32 @@ class AdminViewPermissionsTest(TestCase):
 
             self.client.get(reverse('admin:logout'))
 
+    def test_history_view_verbose_model_name(self):
+        login_url = '%s?next=%s' % (
+            reverse('admin:login'), reverse('admin:index')
+        )
+        change_dict = {
+            'title': 'Ikke fordømt',
+            'content': '<p>edited article</p>',
+            'date_0': '2008-03-18', 'date_1': '10:54:39',
+            'section': self.s1.pk
+        }
+        article_change_url = reverse(
+            'admin:admin_views_article_change', args=(self.a1.pk,)
+        )
+
+        self.client.post(login_url, self.changeuser_login)
+        self.client.post(article_change_url, change_dict)
+
+        response = self.client.get(
+            reverse('admin:admin_views_article_history', args=(self.a1.pk,))
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, u'<td>changeuser (Change User)</td>')
+        self.assertContains(
+            response, u'<td>Changed ¿Name?, content and ¿Date published?.</td>'
+        )
+
     def test_history_view_bad_url(self):
         self.client.post(reverse('admin:login'), self.changeuser_login)
         response = self.client.get(reverse('admin:admin_views_article_history', args=('foo',)))

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -932,7 +932,7 @@ class ChangelistTests(AuthViewsTestCase):
         )
         self.assertRedirects(response, reverse('auth_test_admin:auth_user_changelist'))
         row = LogEntry.objects.latest('id')
-        self.assertEqual(row.change_message, 'Changed email.')
+        self.assertEqual(row.change_message, 'Changed email address.')
 
     def test_user_not_change(self):
         response = self.client.post(


### PR DESCRIPTION
[Ticket: Models history doesn't use verbose names](https://code.djangoproject.com/ticket/12952)

This was a ticket which had a patch that needed improvement. The latest patch was attached 4years ago.

While there has been some effort to maintain consistency in the original author's code for the feature there was a test rewrite.