### PR TITLE
Fixed #21652: Added notification when processing objects in loaddata

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -144,6 +144,8 @@ class Command(BaseCommand):
                         self.models.add(obj.object.__class__)
                         try:
                             obj.save(using=self.using)
+                            if self.verbosity == 3:
+                                self.stdout.write('Processed %i object(s).' % loaded_objects_in_fixture)
                         except (DatabaseError, IntegrityError) as e:
                             e.args = ("Could not load %(app_label)s.%(object_name)s(pk=%(pk)s): %(error_msg)s" % {
                                 'app_label': obj.object._meta.app_label,

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -342,6 +342,18 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             '<Article: Who needs more than one database?>',
         ])
 
+    def test_loaddata_verbose(self):
+        # Load db fixture 1 with high verbosity level
+        new_io = six.StringIO()
+        management.call_command('loaddata', 'fixture1.json', verbosity=3, stdout=new_io, stderr=new_io)
+        command_output = new_io.getvalue().strip()
+
+        # Check the output, that all objects were processed
+        self.assertIn("Processed 1 object(s).\nProcessed 2 object(s).\n"
+                      "Processed 3 object(s).\nProcessed 4 object(s).\n",
+                      command_output
+        )
+
     def test_loading_using(self):
         # Load db fixtures 1 and 2. These will load using the 'default' database identifier explicitly
         management.call_command('loaddata', 'db_fixture_1', verbosity=0, using='default')

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -351,8 +351,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
         # Check the output, that all objects were processed
         self.assertIn("Processed 1 object(s).\nProcessed 2 object(s).\n"
                       "Processed 3 object(s).\nProcessed 4 object(s).\n",
-                      command_output
-        )
+                      command_output)
 
     def test_loading_using(self):
         # Load db fixtures 1 and 2. These will load using the 'default' database identifier explicitly


### PR DESCRIPTION
Added an output to verbose==3 level to output a running count of the
objects processed per fixture.