### PR TITLE
Fixed #12199 -- Added the ability to use "as" with the {% firstof %} template tag.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -249,6 +249,7 @@ Sample usage::
     for blocks of template code.
 
 .. templatetag:: firstof
+.. versionadded: 1.9
 
 firstof
 ^^^^^^^
@@ -284,6 +285,9 @@ This tag auto-escapes variable values. You can disable auto-escaping with::
 Or if only some variables should be escaped, you can use::
 
     {% firstof var1 var2|safe var3 "<strong>fallback value</strong>"|safe %}
+
+You can also use the syntax ``{% firstof var1 var2 var3 as value %}`` to store the
+output inside a variable. 
 
 .. templatetag:: for
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -208,6 +208,8 @@ Templates
 * A warning will now be logged for missing context variables. These messages
   will be logged to the :ref:`django.template <django-template-logger>` logger.
 
+* ``{% firstof %}`` tag supports storing the output in a variable using 'as'
+
 Requests and Responses
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/template_tests/syntax_tests/test_firstof.py
+++ b/tests/template_tests/syntax_tests/test_firstof.py
@@ -81,3 +81,10 @@ class FirstOfTagTests(SimpleTestCase):
     def test_firstof14(self):
         output = self.engine.render_to_string('firstof14', {'a': '<'})
         self.assertEqual(output, '<')
+
+    @setup({'firstof15': '{% firstof a b c as myvar %}'})
+    def test_firstof15(self):
+        ctx = {'a': 0, 'b': 2, 'c': 3}
+        output = self.engine.render_to_string('firstof15', ctx)
+        self.assertEqual(ctx['myvar'], '2')
+        self.assertEqual(output, '')


### PR DESCRIPTION
Updated from https://github.com/django/django/pull/4490