### PR TITLE
Update builtins.txt - formatting style

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2450,7 +2450,7 @@ If ``value`` is ``Joel is a slug``, the output would be::
 yesno
 ^^^^^
 
-Maps values for true, false and (optionally) None, to the strings "yes", "no",
+Maps values for ``True``, ``False`` and (optionally) ``None``, to the strings "yes", "no",
 "maybe", or a custom mapping passed as a comma-separated list, and
 returns one of those strings according to the value:
 
@@ -2465,7 +2465,7 @@ Value       Argument                Outputs
 ``True``    ``"yeah,no,maybe"``     ``yeah``
 ``False``   ``"yeah,no,maybe"``     ``no``
 ``None``    ``"yeah,no,maybe"``     ``maybe``
-``None``    ``"yeah,no"``           ``"no"`` (converts None to False
+``None``    ``"yeah,no"``           ``no`` (converts None to False
                                     if no mapping for None is given)
 ==========  ======================  ==================================
 


### PR DESCRIPTION
Change true/false to the corresponding True/False Python notation and remove quotations marks around the last "no", which can be confusing, since they are not present on previous examples