### PR TITLE
Fixed #16609 -- Fixed duplicate admin results when searching nested M2M relations

### DIFF
--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -60,6 +60,11 @@ class GroupAdmin(admin.ModelAdmin):
     list_filter = ['members']
 
 
+class ConcertAdmin(admin.ModelAdmin):
+    list_filter = ['group__members']
+    search_fields = ['group__members__name']
+
+
 class QuartetAdmin(admin.ModelAdmin):
     list_filter = ['members']
 

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -44,6 +44,11 @@ class Group(models.Model):
         return self.name
 
 
+class Concert(models.Model):
+    name = models.CharField(max_length=30)
+    group = models.ForeignKey(Group)
+
+
 class Membership(models.Model):
     music = models.ForeignKey(Musician)
     group = models.ForeignKey(Group)


### PR DESCRIPTION
Admin change lists contains duplicate results when searching/filtering with M2M traversals. This was fixed earlier in issue #16609 but only when the M2M relation was at the first level on the displayed object.
This commit fixes the issue even when the M2M is at deeper levels behind a foreign key.