### PR TITLE
Correcting migrate help

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             default=DEFAULT_DB_ALIAS, help='Nominates a database to synchronize. '
                 'Defaults to the "default" database.')
         parser.add_argument('--fake', action='store_true', dest='fake', default=False,
-            help='Mark migrations as run without actually running them')
+            help='Mark migrations as run without actually running them.')
         parser.add_argument('--fake-initial', action='store_true', dest='fake_initial', default=False,
             help='Detect if tables already exist and fake-apply initial migrations if so. Make sure '
                  'that the current database schema matches your initial migration before using this '


### PR DESCRIPTION
The help for migrate fake did not have a full stop after, which makes it quite difficult to read in the terminal.