### PR TITLE
Fixed #23727 - Change TEST_NON_SERIALIZED_APPS to include contenttypes.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -590,7 +590,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Apps that don't need to be serialized at test database creation time
 # (only apps with migrations are to start with)
-TEST_NON_SERIALIZED_APPS = []
+TEST_NON_SERIALIZED_APPS = ['django.contrib.contenttypes']
 
 ############
 # FIXTURES #

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2354,7 +2354,7 @@ The name of the class to use for starting the test suite. See
 TEST_NON_SERIALIZED_APPS
 ------------------------
 
-Default: ``[]``
+Default: ``['django.contrib.contenttypes']``
 
 In order to restore the database state between tests for
 ``TransactionTestCase``\s and database backends without transactions, Django
@@ -2363,9 +2363,8 @@ when it starts the test run so it can then reload from that copy before tests
 that need it.
 
 This slows down the startup time of the test runner; if you have apps that
-you know don't need this feature, you can add their full names in here (e.g.
-``'django.contrib.contenttypes'``) to exclude them from this serialization
-process.
+you know don't need this feature, you can add their full names in here to
+exclude them from this serialization process.
 
 .. setting:: THOUSAND_SEPARATOR
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -223,7 +223,8 @@ Requests and Responses
 Tests
 ^^^^^
 
-* ...
+* The default value for :setting:`TEST_NON_SERIALIZED_APPS` has been changed to
+  include ``django.contrib.contenttypes``.
 
 URLs
 ^^^^


### PR DESCRIPTION
When using a TransactionTestCase-based class with serialized_rollback set to
True and without this fix, then starting the second or any subsequent test
cases in a suite would cause _fixture_setup to attempt to insert the rows in
the django_content_type table that already exist there, causing an
IntegrityError.  This was because the contenttypes app registers a
post_migrate signal to repopulate its table.  However,
TransactionTestCase._fixture_setup, would call deserialize_db_from_string,
which would attempt to re-add those same rows.  This change was added so that
deserialize_db_from_string would not attempt to re-add those rows.

This is simple to reproduce with the following app test code:
class TestIt(TransactionTestCase):
   serialized_rollback = True

   def test_one(self):
       self.assertTrue(True)

   def test_two(self):
       self.assertTrue(True)

However, this proved to be very difficult to write a test case for in the
django unit tests framework because the framework requires that the test case
class's 'available_apps' attribute be non-None, but doing so causes a different
code path to be executed (the post_migrate signal is not sent during the
database flush) and the bug is not exposed.