### PR TITLE
Fixed #23727 -- Inhibited the post_migrate signals when using serialized...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -679,6 +679,7 @@ answer newbie questions, and generally made Django that much better:
     Tome Cvitan <tome@cvitan.com>
     Tomek Paczkowski <tomek@hauru.eu>
     Tom Insam
+    Tommy Beadle <tbeadle@gmail.com>
     Tom Tobin
     torne-django@wolfpuppy.org.uk
     Travis Cline <travis.cline@gmail.com>

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -883,10 +883,19 @@ class TransactionTestCase(SimpleTestCase):
         # when flushing only a subset of the apps
         for db_name in self._databases_names(include_mirrors=False):
             # Flush the database
+            inhibit_post_migrate = (
+                self.available_apps is not None
+                or (
+                    self.serialized_rollback
+                    and hasattr(
+                        connections[db_name],
+                        "_test_serialized_contents")
+                )
+            )
             call_command('flush', verbosity=0, interactive=False,
                          database=db_name, reset_sequences=False,
                          allow_cascade=self.available_apps is not None,
-                         inhibit_post_migrate=self.available_apps is not None)
+                         inhibit_post_migrate=inhibit_post_migrate)
 
     def assertQuerysetEqual(self, qs, values, transform=repr, ordered=True, msg=None):
         items = six.moves.map(transform, qs)


### PR DESCRIPTION
When using a TransactionTestCase-based class with serialized_rollback set to
True, after creating the database and running its migrations (along with
emitting the post_migration signal), the content of the database is serialized
to _test_serialized_contents.  Without this fix, after the first test case,
_fixture_teardown would flush the tables but then the post_migrate signal would be
emitted and new rows (with new PK's) would be created in the django_content_type
table.  Then, when starting the second or any subsequent test cases in a suite,
_fixture_setup attempts to deserialize the content of _test_serialized_contents,
but these rows are identical to the rows already in the database, except for
their PK's.  This causes an IntegrityError due to a uniqueness constraint in the
django_content_type table.
This change made it so that, in the above scenario, the post_migrate signal is
not emitted after flushing the tables, since it will be repopulated during
_fixture_setup.

The problem is simple to reproduce with the following app test code:

    class TestIt(TransactionTestCase):
        serialized_rollback = True
    
       def test_one(self):
           self.assertTrue(True)
    
       def test_two(self):
           self.assertTrue(True)

however this proved to be very difficult to write a test case for in the
django unit tests framework because the framework requires that the test case
class's 'available_apps' attribute be non-None, but doing so would cause the
suppression of the post_migrate signal to be emitted anyway.