### PR TITLE
Fixed #24349 -- Limited domain name labels to 63 characters in EmailValidator

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -142,9 +142,9 @@ class EmailValidator(object):
         r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"$)',  # quoted-string
         re.IGNORECASE)
     domain_regex = re.compile(
-        # max length of the domain is 249: 254 (max email length) minus one
-        # period, two characters for the TLD, @ sign, & one character before @.
-        r'(?:[A-Z0-9](?:[A-Z0-9-]{0,247}[A-Z0-9])?\.)+(?:[A-Z]{2,6}|[A-Z0-9-]{2,}(?<!-))$',
+        # max length for DNS labels and TLD is 63 characters
+        # Ref: http://en.wikipedia.org/wiki/Domain_Name_System#cite_ref-rfc1034_1-2
+        r'((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+)(?:[A-Z0-9-]{2,63}(?<!-))$',
         re.IGNORECASE)
     literal_regex = re.compile(
         # literal form, ipv4 or ipv6 address (SMTP 4.1.3)

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -236,6 +236,9 @@ Validators
 * Added :func:`django.core.validators.int_list_validator` to generate
   validators of strings containing integers separated with a custom character.
 
+* :class:`validators.EmailValidator <django.core.validators.EmailValidator>` now
+  limits DNS labels and TLD length to 63 characters.
+
 Backwards incompatible changes in 1.9
 =====================================
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -45,7 +45,12 @@ TEST_DATA = [
     (validate_email, 'email@localhost', None),
     (EmailValidator(whitelist=['localdomain']), 'email@localdomain', None),
     (validate_email, '"test@test"@example.com', None),
+    (validate_email, 'example@atm.%s' % ('a' * 63), None),
+    (validate_email, 'example@%s.atm' % ('a' * 63), None),
+    (validate_email, 'example@%s.%s.atm' % ('a' * 63, 'b' * 10), None),
 
+    (validate_email, 'example@atm.%s' % ('a' * 64), ValidationError),
+    (validate_email, 'example@%s.atm.%s' % ('b' * 64, 'a' * 63), ValidationError),
     (validate_email, None, ValidationError),
     (validate_email, '', ValidationError),
     (validate_email, 'abc', ValidationError),
@@ -69,9 +74,9 @@ TEST_DATA = [
     (validate_email, '"\\\011"@here.com', None),
     (validate_email, '"\\\012"@here.com', ValidationError),
     (validate_email, 'trailingdot@shouldfail.com.', ValidationError),
-    # Max length of domain name in email is 249 (see validator for calculation)
-    (validate_email, 'a@%s.us' % ('a' * 249), None),
-    (validate_email, 'a@%s.us' % ('a' * 250), ValidationError),
+    # Max length of domain name in email is 63 (see validator for calculation)
+    (validate_email, 'a@%s.us' % ('a' * 63), None),
+    (validate_email, 'a@%s.us' % ('a' * 64), ValidationError),
 
     (validate_slug, 'slug-ok', None),
     (validate_slug, 'longer-slug-still-ok', None),


### PR DESCRIPTION
@timgraham Ref: [pull request](https://github.com/django/django/pull/4273)