### PR TITLE
Fixed #24159 -- compilemessages runs across apps.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -462,7 +462,7 @@ answer newbie questions, and generally made Django that much better:
     Matt Deacalion Stevens <matt@dirtymonkey.co.uk>
     Matt Dennenbaum
     Matthew Flanagan <http://wadofstuff.blogspot.com>
-    Matthew Somerville <matthew-github@dracos.co.uk>
+    Matthew Somerville <matthew-django@dracos.co.uk>
     Matthew Tretter <m@tthewwithanm.com>
     Matthias Kestenholz <mk@406.ch>
     Matthias Pronk <django@masida.nl>

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -61,6 +61,12 @@ class Command(BaseCommand):
             from django.conf import settings
             basedirs.extend(upath(path) for path in settings.LOCALE_PATHS)
 
+        # Walk entire tree, looking for locale directories
+        for dirpath, dirnames, filenames in os.walk('.', topdown=True):
+            for dirname in dirnames:
+                if dirname == 'locale':
+                    basedirs.insert(0, os.path.join(dirpath, dirname))
+
         # Gather existing directories.
         basedirs = set(map(os.path.abspath, filter(os.path.isdir, basedirs)))
 

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
         for dirpath, dirnames, filenames in os.walk('.', topdown=True):
             for dirname in dirnames:
                 if dirname == 'locale':
-                    basedirs.insert(0, os.path.join(dirpath, dirname))
+                    basedirs.append(os.path.join(dirpath, dirname))
 
         # Gather existing directories.
         basedirs = set(map(os.path.abspath, filter(os.path.isdir, basedirs)))

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -161,6 +161,11 @@ are excluded.
 You can pass ``--use-fuzzy`` option (or ``-f``) to include fuzzy translations
 into compiled files.
 
+.. versionchanged:: 1.9
+
+    ``compilemessages`` now matches the operation of :djadmin:`makemessages`,
+    scanning the project tree for ``.po`` files to compile.
+
 .. versionchanged:: 1.8
 
     Added ``--exclude`` and ``--use-fuzzy`` options.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -191,6 +191,10 @@ Internationalization
   :ttag:`get_language_info` template tag. Also added a corresponding template
   filter: :tfilter:`language_name_translated`.
 
+* You can now run :djadmin:`compilemessages` from the root directory of your
+  project and it will find all the app message files that were created by
+  :djadmin:`makemessages`.
+
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1583,6 +1583,11 @@ which you ran :djadmin:`django-admin makemessages <makemessages>`, run
 
 That's it. Your translations are ready for use.
 
+.. versionchanged:: 1.9
+
+    ``compilemessages`` now matches the operation of :djadmin:`makemessages`,
+    scanning the project tree for ``.po`` files to compile.
+
 .. admonition:: Working on Windows?
 
    If you're using Windows and need to install the GNU gettext utilities so

--- a/tests/i18n/commands/app_with_locale/locale/ru/LC_MESSAGES/django.po
+++ b/tests/i18n/commands/app_with_locale/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-03-30 12:51+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#
+msgid "Lenin"
+msgstr "Ленин"
+
+#, fuzzy
+msgid "Vodka"
+msgstr "Водка"


### PR DESCRIPTION
This updates the command to match the documentation, which states it runs over all .po files.
https://code.djangoproject.com/ticket/24159