### PR TITLE
Fixed #24655 -- RelatedFieldWidgetWrapper admin widget JS static url

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -272,7 +272,7 @@ class RelatedFieldWidgetWrapper(forms.Widget):
 
     @property
     def media(self):
-        media = Media(js=['admin/js/related-widget-wrapper.js'])
+        media = Media(js=[static('admin/js/related-widget-wrapper.js')])
         return self.widget.media + media
 
     def get_related_url(self, info, action, *args):


### PR DESCRIPTION
RelatedFieldWidgetWrapper now uses a call to static to resolve 'admin/js/related-widget-wrapper.js'