### PR TITLE
Fixed #24657 - Fixed incorrect context in include tag example

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -678,7 +678,7 @@ context. This allows you to reference a compiled ``Template`` in your context.
 An included template is rendered within the context of the template that
 includes it. This example produces the output ``"Hello, John"``:
 
-* Context: variable ``person`` is set to ``"john"``.
+* Context: variable ``person`` is set to ``"John"``.
 * Template::
 
     {% include "name_snippet.html" %}


### PR DESCRIPTION
Before the example, the expected output is: `"Hello, John"`, but
the value of the `person` variable in the context is `john` (lowercase)