### PR TITLE
Remove cases of six.iter* wrapped in a list()

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -353,8 +353,8 @@ class AdminErrorList(forms.utils.ErrorList):
         super(AdminErrorList, self).__init__()
 
         if form.is_bound:
-            self.extend(list(six.itervalues(form.errors)))
+            self.extend(form.errors.values())
             for inline_formset in inline_formsets:
                 self.extend(inline_formset.non_form_errors())
                 for errors_in_inline_form in inline_formset.errors:
-                    self.extend(list(six.itervalues(errors_in_inline_form)))
+                    self.extend(errors_in_inline_form.values())

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -271,7 +271,7 @@ class AdminSite(object):
         # Add in each model's views, and create a list of valid URLS for the
         # app_index
         valid_app_labels = []
-        for model, model_admin in six.iteritems(self._registry):
+        for model, model_admin in self._registry.items():
             urlpatterns += [
                 url(r'^%s/%s/' % (model._meta.app_label, model._meta.model_name), include(model_admin.urls)),
             ]
@@ -470,8 +470,7 @@ class AdminSite(object):
         app_dict = self._build_app_dict(request)
 
         # Sort the apps alphabetically.
-        app_list = list(six.itervalues(app_dict))
-        app_list.sort(key=lambda x: x['name'].lower())
+        app_list = sorted(app_dict.values(), key=lambda x: x['name'].lower())
 
         # Sort the models alphabetically within each app.
         for app in app_list:

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -17,7 +17,6 @@ from django.template.base import (
     libraries,
 )
 from django.template.engine import Engine
-from django.utils import six
 from django.utils._os import upath
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -64,7 +63,7 @@ class TemplateTagIndexView(BaseAdminDocsView):
         load_all_installed_template_libraries()
 
         tags = []
-        app_libs = list(six.iteritems(libraries))
+        app_libs = list(libraries.items())
         builtin_libs = [(None, lib) for lib in builtins]
         for module_name, library in builtin_libs + app_libs:
             for tag_name, tag_func in library.tags.items():
@@ -97,7 +96,7 @@ class TemplateFilterIndexView(BaseAdminDocsView):
         load_all_installed_template_libraries()
 
         filters = []
-        app_libs = list(six.iteritems(libraries))
+        app_libs = list(libraries.items())
         builtin_libs = [(None, lib) for lib in builtins]
         for module_name, library in builtin_libs + app_libs:
             for filter_name, filter_func in library.filters.items():

--- a/django/contrib/sitemaps/views.py
+++ b/django/contrib/sitemaps/views.py
@@ -7,7 +7,6 @@ from django.core import urlresolvers
 from django.core.paginator import EmptyPage, PageNotAnInteger
 from django.http import Http404
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.http import http_date
 
 
@@ -56,7 +55,7 @@ def sitemap(request, sitemaps, section=None,
             raise Http404("No sitemap available for section: %r" % section)
         maps = [sitemaps[section]]
     else:
-        maps = list(six.itervalues(sitemaps))
+        maps = sitemaps.values()
     page = request.GET.get("p", 1)
 
     urls = []

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -13,7 +13,7 @@ from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
 from django.db.backends import utils
 from django.db.models.constants import LOOKUP_SEP
-from django.utils import six, tree
+from django.utils import tree
 
 # PathInfo is used when converting lookups (fk__somecol). The contents
 # describe the relation in Model terms (model Options and Fields for both
@@ -53,7 +53,7 @@ class Q(tree.Node):
     default = AND
 
     def __init__(self, *args, **kwargs):
-        super(Q, self).__init__(children=list(args) + list(six.iteritems(kwargs)))
+        super(Q, self).__init__(children=list(args) + list(kwargs.items()))
 
     def _combine(self, other, conn):
         if not isinstance(other, Q):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -988,7 +988,7 @@ class SelectDateWidget(Widget):
         html = {}
         choices = [(i, i) for i in self.years]
         html['year'] = self.create_select(name, self.year_field, value, year_val, choices, self.year_none_value)
-        choices = list(six.iteritems(self.months))
+        choices = list(self.months.items())
         html['month'] = self.create_select(name, self.month_field, value, month_val, choices, self.month_none_value)
         choices = [(i, i) for i in range(1, 32)]
         html['day'] = self.create_select(name, self.day_field, value, day_val, choices, self.day_none_value)

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -1097,7 +1097,7 @@ def parse_bits(parser, bits, params, varargs, varkw, defaults,
         kwarg = token_kwargs([bit], parser)
         if kwarg:
             # The kwarg was successfully extracted
-            param, value = list(six.iteritems(kwarg))[0]
+            param, value = kwarg.popitem()
             if param not in params and varkw is None:
                 # An unexpected keyword argument was supplied
                 raise TemplateSyntaxError(

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -466,7 +466,7 @@ def do_block_translate(parser, token):
         options[option] = value
 
     if 'count' in options:
-        countervar, counter = list(six.iteritems(options['count']))[0]
+        countervar, counter = list(options['count'].items())[0]
     else:
         countervar, counter = None, None
     if 'context' in options:

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -184,7 +184,7 @@ def allow_lazy(func, *resultclasses):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        for arg in list(args) + list(six.itervalues(kwargs)):
+        for arg in list(args) + list(kwargs.values()):
             if isinstance(arg, Promise):
                 break
         else:

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -127,7 +127,7 @@ class ExceptionReporterFilter(object):
             return request.POST
 
     def get_traceback_frame_variables(self, request, tb_frame):
-        return list(six.iteritems(tb_frame.f_locals))
+        return list(tb_frame.f_locals.items())
 
 
 class SafeExceptionReporterFilter(ExceptionReporterFilter):


### PR DESCRIPTION
There's absolutely no advantage [and a mild performance hit] to using six.iter*
in these cases.  The list immediately consumes the iterator.