### PR TITLE
Fixed #24660 -- Reduced interdependencies between gCBV methods

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -100,6 +100,11 @@ class SingleObjectMixin(ContextMixin):
         Insert the single object into the context dict.
         """
         context = {}
+        # when self.object value is None, we should NOT run get_object()
+        # method; this value means object will be created by ModelForm (in
+        # CreateView)
+        if not hasattr(self, "object"):
+            self.object = self.get_object()
         if self.object:
             context['object'] = self.object
             context_object_name = self.get_context_object_name(self.object)
@@ -143,14 +148,14 @@ class SingleObjectTemplateResponseMixin(TemplateResponseMixin):
             # If self.template_name_field is set, grab the value of the field
             # of that name from the object; this is the most specific template
             # name, if given.
-            if self.object and self.template_name_field:
+            if hasattr(self, "object") and self.object and self.template_name_field:
                 name = getattr(self.object, self.template_name_field, None)
                 if name:
                     names.insert(0, name)
 
             # The least-specific option is the default <app>/<model>_detail.html;
             # only use this if the object in question is a model.
-            if isinstance(self.object, models.Model):
+            if hasattr(self, "object") and isinstance(self.object, models.Model):
                 object_meta = self.object._meta
                 if self.object._deferred:
                     object_meta = self.object._meta.proxy_for_model._meta

--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -127,6 +127,8 @@ class MultipleObjectMixin(ContextMixin):
         """
         Get the context for this view.
         """
+        self.object_list = getattr(self, "object_list", self.get_queryset())
+
         queryset = kwargs.pop('object_list', self.object_list)
         page_size = self.get_paginate_by(queryset)
         context_object_name = self.get_context_object_name(queryset)
@@ -197,7 +199,7 @@ class MultipleObjectTemplateResponseMixin(TemplateResponseMixin):
         # app and model name. This name gets put at the end of the template
         # name list so that user-supplied names override the automatically-
         # generated ones.
-        if hasattr(self.object_list, 'model'):
+        if hasattr(self, "object_list") and hasattr(self.object_list, 'model'):
             opts = self.object_list.model._meta
             names.append("%s/%s%s.html" % (opts.app_label, opts.model_name, self.template_name_suffix))
 

--- a/docs/ref/class-based-views/mixins-multiple-object.txt
+++ b/docs/ref/class-based-views/mixins-multiple-object.txt
@@ -176,6 +176,15 @@ MultipleObjectMixin
 
         Returns context data for displaying the list of objects.
 
+        If the ``object_list`` attribute is not set, ``get_queryset()`` will be
+        used to get the object list.
+
+        .. versionchanged:: 1.9
+
+            In order to reduce interdependencies of different methods, this
+            method no longer requires ``object_list`` attribute to be set in
+            the ``get()`` method.
+
     **Context**
 
     * ``object_list``: The list of objects that this view is displaying. If
@@ -224,3 +233,10 @@ MultipleObjectTemplateResponseMixin
 
         * the value of ``template_name`` on the view (if provided)
         * ``<app_label>/<model_name><template_name_suffix>.html``
+
+        .. versionchanged:: 1.9
+
+            In order to reduce interdependencies of different methods, this
+            method no longer requires ``object_list`` attribute to be set in
+            the ``get()`` method.
+

--- a/docs/ref/class-based-views/mixins-single-object.txt
+++ b/docs/ref/class-based-views/mixins-single-object.txt
@@ -104,11 +104,18 @@ SingleObjectMixin
 
     .. method:: get_context_data(**kwargs)
 
-        Returns context data for displaying the list of objects.
+        Returns context data for displaying a single object.
 
-        The base implementation of this method requires that the ``object``
-        attribute be set by the view (even if ``None``). Be sure to do this if
-        you are using this mixin without one of the built-in views that does so.
+        If the ``object`` attribute is not set, ``get_object()`` will be used to
+        get the object. If the ``object`` attribute is set to ``None`` value, it
+        will not be inserted in context (this behavior is used by
+        :class:`~django.views.generic.edit.CreateView`).
+
+        .. versionchanged:: 1.9
+
+            In order to reduce interdependencies of different methods, this
+            method no longer requires ``object`` attribute to be set in
+            ``get()`` and ``post()`` methods.
 
     .. method:: get_slug_field()
 
@@ -160,3 +167,10 @@ SingleObjectTemplateResponseMixin
         * the contents of the ``template_name_field`` field on the
           object instance that the view is operating upon (if available)
         * ``<app_label>/<model_name><template_name_suffix>.html``
+
+        .. versionchanged:: 1.9
+
+            In order to reduce interdependencies of different methods, this
+            method no longer requires ``object`` attribute to be set in
+            ``get()`` and ``post()`` methods.
+

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -505,6 +505,19 @@ Miscellaneous
 * The ``django.contrib.sites.models.Site.domain`` field was changed to be
   :attr:`~django.db.models.Field.unique`.
 
+* Changes were made to a few methods in generic Class Based Views to reduce
+  interdependencies between methods.
+  :meth:`SingleObjectMixin.get_context_data <django.views.generic.detail.SingleObjectMixin.get_context_data>`
+  and
+  :meth:`MultipleObjectMixin.get_context_data <django.views.generic.list.MultipleObjectMixin.get_context_data>`
+  will now get the object or object list from respective methods if they are
+  not set in ``get()`` or ``post()`` methods.
+  :meth:`SingleObjectTemplateResponseMixin.get_template_names <django.views.generic.detail.SingleObjectTemplateResponseMixin.get_template_names>`
+  and
+  :meth:`MultipleObjectTemplateResponseMixin.get_template_names <django.views.generic.list.MultipleObjectTemplateResponseMixin.get_template_names>`
+  will also no longer raise an ``AttributeError`` if the object or object list
+  are not set.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -5,8 +5,10 @@ import datetime
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
+from django.test.client import RequestFactory
 from django.utils.encoding import force_str
 from django.views.generic.base import View
+from django.views.generic.list import ListView
 
 from .models import Artist, Author, Book, Page
 
@@ -244,3 +246,13 @@ class ListViewTests(TestCase):
         Author.objects.all().delete()
         for i in range(n):
             Author.objects.create(name='Author %02i' % i, slug='a%s' % i)
+
+    def test_methods_do_not_depend_on_self_objectlist(self):
+        class TestListView(ListView):
+            model = Artist
+            request = RequestFactory().get('/')
+        try:
+            TestListView().get_context_data()
+            TestListView().get_template_names()
+        except AttributeError as e:
+            self.fail("ListView method raised AttributeError unexpectedly: %s !" % e)


### PR DESCRIPTION
Generic class based views method interdependencies are reduced
by changing get_context_data() and get_template_names() to make
them not depend on object and object_list attributes.