### PR TITLE
Add link to the code of conduct from contributing guides.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,3 +24,9 @@ Django uses Trac to keep track of bugs, feature requests, and associated
 patches because GitHub doesn't provide adequate tooling for its community.
 Patches can be submitted as pull requests, but if you don't file a ticket,
 it's unlikely that we'll notice your contribution.
+
+Code of conduct
+===============
+
+As a contributor, you can help us keep the Django community open and inclusive.
+Please read and follow our `Code of Conduct <https://www.djangoproject.com/conduct/>`_.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -68,6 +68,12 @@ It contains lots of great information and is a must read for anyone who'd like
 to become a regular contributor to Django. If you've got questions, it's
 probably got the answers.
 
+Conduct
+=======
+
+As a contributor, you can help us keep the Django community open and inclusive.
+Please read and follow our `Code of Conduct <https://www.djangoproject.com/conduct/>`_.
+
 Installing Git
 ==============
 


### PR DESCRIPTION
This is inspired by Angluar.js
(https://github.com/angular/angular/blob/master/CONTRIBUTING.md), among others.
Thanks to Jeff Triplett for the prod.