### PR TITLE
Encapsulate SECRET_KEY generation logic

### DIFF
--- a/django/core/management/commands/startproject.py
+++ b/django/core/management/commands/startproject.py
@@ -2,7 +2,8 @@ from importlib import import_module
 
 from django.core.management.base import CommandError
 from django.core.management.templates import TemplateCommand
-from django.utils.crypto import get_random_string
+
+from .utils import get_random_secret_key
 
 
 class Command(TemplateCommand):
@@ -27,7 +28,6 @@ class Command(TemplateCommand):
                                project_name)
 
         # Create a random SECRET_KEY to put it in the main settings.
-        chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-        options['secret_key'] = get_random_string(50, chars)
+        options['secret_key'] = get_random_secret_key()
 
         super(Command, self).handle('project', project_name, target, **options)

--- a/django/core/management/commands/startproject.py
+++ b/django/core/management/commands/startproject.py
@@ -3,7 +3,7 @@ from importlib import import_module
 from django.core.management.base import CommandError
 from django.core.management.templates import TemplateCommand
 
-from .utils import get_random_secret_key
+from ..utils import get_random_secret_key
 
 
 class Command(TemplateCommand):

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -80,10 +80,9 @@ def find_command(cmd, path=None, pathext=None):
     return None
 
 
-def get_random_secret_key()
+def get_random_secret_key():
     """
     Reusable logic to create a valid random SECRET_KEY value.
-    
     Returns a 50 characters long random string usable as a SECRET_KEY setting
     value.
     """

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -5,6 +5,7 @@ import sys
 from subprocess import PIPE, Popen
 
 from django.utils import six
+from django.utils.crypto import get_random_string
 from django.utils.encoding import DEFAULT_LOCALE_ENCODING, force_text
 
 from .base import CommandError
@@ -77,3 +78,14 @@ def find_command(cmd, path=None, pathext=None):
             if os.path.isfile(fext):
                 return fext
     return None
+
+
+def get_random_secret_key()
+    """
+    Reusable logic to create a valid random SECRET_KEY value.
+    
+    Returns a 50 characters long random string usable as a SECRET_KEY setting
+    value.
+    """
+    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+    return get_random_string(50, chars)


### PR DESCRIPTION
Move the logic of generating the SECRET_KEY value to django/core/management/utils.py so it can be reused by projects doing their own custom project initialization. This avoids copy/pasting the SECRET KEY logic and allows for backwards compatibility if the logic is ever updated.

The code is inside the startproject's command handle method (/django/core/management/commands/startproject.py) and is not used or imported anywhere else.

Example project benefiting from this change: https://github.com/mayan-edms/mayan-edms/blob/master/mayan/apps/main/management/commands/initialsetup.py