### PR TITLE
Refs #23643-- Fixed exception.__traceback__ AttributeError in debug view for py2

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -409,7 +409,7 @@ class ExceptionReporter(object):
         # sometimes in Python 3), take the traceback from self.tb (Python 2
         # doesn't have a __traceback__ attribute on Exception)
         exc_value = exceptions.pop()
-        tb = self.tb if not exceptions else exc_value.__traceback__
+        tb = self.tb if sys.version_info < (3,) else exc_value.__traceback__
 
         while tb is not None:
             # Support for __traceback_hide__ which is used by a few libraries
@@ -444,7 +444,9 @@ class ExceptionReporter(object):
 
             # If the traceback for current exception is consumed, try the
             # other exception.
-            if not tb.tb_next and exceptions:
+            if sys.version_info < (3,):
+                tb = tb.tb_next
+            elif not tb.tb_next and exceptions:
                 exc_value = exceptions.pop()
                 tb = exc_value.__traceback__
             else:

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -409,7 +409,7 @@ class ExceptionReporter(object):
         # sometimes in Python 3), take the traceback from self.tb (Python 2
         # doesn't have a __traceback__ attribute on Exception)
         exc_value = exceptions.pop()
-        tb = self.tb if sys.version_info < (3,) else exc_value.__traceback__
+        tb = self.tb if six.PY2 or not exceptions else exc_value.__traceback__
 
         while tb is not None:
             # Support for __traceback_hide__ which is used by a few libraries
@@ -444,7 +444,7 @@ class ExceptionReporter(object):
 
             # If the traceback for current exception is consumed, try the
             # other exception.
-            if sys.version_info < (3,):
+            if six.PY2:
                 tb = tb.tb_next
             elif not tb.tb_next and exceptions:
                 exc_value = exceptions.pop()

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -243,7 +243,7 @@ class DebugViewTests(LoggingCaptureMixin, SimpleTestCase):
         from django.db import connection 
         import sys
 
-        cu = connection.cursor()
+        cu = connection.cursor.wrapped()
 
         try:
             cu.execute('INSERT INTAO "pippo" VALUES (1,2)')
@@ -255,7 +255,7 @@ class DebugViewTests(LoggingCaptureMixin, SimpleTestCase):
 
             #--- Saved exc_info to be used in the debug view
             pass
-
+        
         #-- call the debug view with the DB exception
         rf = RequestFactory()
         response = technical_500_response(rf.get('/'), *exc_info_rv)

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -20,7 +20,7 @@ from django.test.utils import LoggingCaptureMixin
 from django.utils import six
 from django.utils.encoding import force_bytes, force_text
 from django.utils.functional import SimpleLazyObject
-from django.views.debug import CallableSettingWrapper, ExceptionReporter
+from django.views.debug import CallableSettingWrapper, ExceptionReporter, technical_500_response
 
 from .. import BrokenException, except_args
 from ..views import (
@@ -193,6 +193,77 @@ class DebugViewTests(LoggingCaptureMixin, SimpleTestCase):
             status_code=404
         )
 
+    def test_regression_23643_by_hand(self):
+        """
+        Regression test for bug #23643.
+
+        The debug view does not work when an Integrity error is raised.
+
+        Here I create an IntegrityError with a __cause__ attribute
+        and call the debug view with it and a generic traceback
+        """
+
+        from django.db.utils import IntegrityError
+        import sys, copy
+
+        i_exc = IntegrityError('NOT NULL constraint failed: bla bla bla',)
+
+        #NOTE: django/db/utils.py sets __cause__ when database exception occurs
+        i_exc.__cause__ = copy.copy(i_exc)
+        # as weird as I can... ;)
+        try:
+            raise
+        except Exception as e:
+            tb = sys.exc_info()[2]
+            pass
+
+        exc_info_rv = [IntegrityError, i_exc, tb]
+
+        #-- call the debug view with the DB exception forged by hand
+        rf = RequestFactory()
+        response = technical_500_response(rf.get('/'), *exc_info_rv)
+        self.assertContains(
+            response,
+            "IntegrityError at /",
+            status_code=500
+        )
+
+    def test_regression_23643_handling_dbexception_in_the_debugview(self):
+        """
+        Regression test for bug #23643.
+
+        The debug view does not work when a DBException is raised.
+
+        Here I perform a wrong SQL query to let the DBWrapper raise an Exception
+        and set the __cause__ attribute. Then call the debug view with the catched exception
+        and its traceback to simulate the error
+
+        SQL syntax used does not matter, OperationalError is raised anyway.
+        """
+        from django.db import connection 
+        import sys
+
+        cu = connection.cursor()
+
+        try:
+            cu.execute('INSERT INTAO "pippo" VALUES (1,2)')
+        except Exception as e:
+            exc_info_rv = sys.exc_info()
+            # print("EXCEPTION INFO %s" % list(exc_info_rv))
+            cu.close()
+            connection.close()
+
+            #--- Saved exc_info to be used in the debug view
+            pass
+
+        #-- call the debug view with the DB exception
+        rf = RequestFactory()
+        response = technical_500_response(rf.get('/'), *exc_info_rv)
+        self.assertContains(
+            response,
+            "OperationalError at /",
+            status_code=500
+        )
 
 @override_settings(
     DEBUG=True,


### PR DESCRIPTION
This is just a raw fix I have not investigated how it can be possibile that python2 has 2 exceptions in that point of execution. 

If the exceptions behaviour is wrong then the fix could do, else we have to manage multiple exceptions other than __traceback__ attribute retrieval. 

I don't know enough python now, but I have preferred to give a raw patch because of the "release critical" severity.