### PR TITLE
Fixed #23271 -- unicode exception on makemessages

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -32,18 +32,22 @@ def check_programs(*programs):
                     "gettext tools 0.15 or newer installed." % program)
 
 
-def gettext_popen_wrapper(args, os_err_exc_type=CommandError, stdout_encoding="utf-8"):
+def gettext_popen_wrapper(args, os_err_exc_type=CommandError, stdout_encoding="utf-8",
+                          universal_newlines=True):
     """
     Makes sure text obtained from stdout of gettext utilities is Unicode.
     """
-    stdout, stderr, status_code = popen_wrapper(args, os_err_exc_type=os_err_exc_type)
-    if os.name == 'nt' and six.PY3 and stdout_encoding != DEFAULT_LOCALE_ENCODING:
-        # This looks weird because it's undoing what
-        # subprocess.Popen(universal_newlines=True).communicate()
-        # does when capturing PO files contents from stdout of gettext command
-        # line programs. No need to do anything on Python 2 because it's
-        # already a byte-string there (#23271).
-        stdout = stdout.encode(DEFAULT_LOCALE_ENCODING).decode(stdout_encoding)
+    # This both decodes utf-8 and cleans line ends.
+    # Simply using popen_wrapper(universal_newlines=True) messes up with the encoding.
+    # This goes back to Popen flaky support for encoding (https://bugs.python.org/issue6135)
+    # This is a solution for #23271, #21928.
+    # No need to do anything on Python 2 because it's already a byte-string there.
+    manual_io_wrapper = six.PY3 and stdout_encoding != DEFAULT_LOCALE_ENCODING
+
+    stdout, stderr, status_code = popen_wrapper(args, os_err_exc_type=os_err_exc_type,
+                                                universal_newlines=not manual_io_wrapper)
+    if manual_io_wrapper:
+        stdout = io.TextIOWrapper(io.BytesIO(stdout), encoding=stdout_encoding).read()
     if six.PY2:
         stdout = stdout.decode(stdout_encoding)
     return stdout, stderr, status_code

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -10,7 +10,7 @@ from django.utils.encoding import DEFAULT_LOCALE_ENCODING, force_text
 from .base import CommandError
 
 
-def popen_wrapper(args, os_err_exc_type=CommandError):
+def popen_wrapper(args, os_err_exc_type=CommandError, universal_newlines=True):
     """
     Friendly wrapper around Popen.
 
@@ -18,7 +18,7 @@ def popen_wrapper(args, os_err_exc_type=CommandError):
     """
     try:
         p = Popen(args, shell=False, stdout=PIPE, stderr=PIPE,
-                close_fds=os.name != 'nt', universal_newlines=True)
+                close_fds=os.name != 'nt', universal_newlines=universal_newlines)
     except OSError as e:
         strerror = force_text(e.strerror, DEFAULT_LOCALE_ENCODING,
                               strings_only=True)


### PR DESCRIPTION
In makemassages, not using universal_newlines in Popen call.
Popen(universal_newlines=True) encodes the gettext output
using DEFAULT_LOCALE_ENCODING, which may through
Unicode exception.

This also solves a test failure in some configurations
(i18n.test_extraction.BasicExtractorTests)