### PR TITLE
[1.8.x] Refs #24591 -- Optimized cloning of ModelState objects.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -496,7 +496,7 @@ class ModelState(object):
         return self.__class__(
             app_label=self.app_label,
             name=self.name,
-            fields=list(self.construct_fields()),
+            fields=[(name, copy.deepcopy(field)) for name, field in self.fields],
             options=dict(self.options),
             bases=self.bases,
             managers=list(self.construct_managers()),

--- a/docs/releases/1.8.1.txt
+++ b/docs/releases/1.8.1.txt
@@ -4,7 +4,8 @@ Django 1.8.1 release notes
 
 *Under development*
 
-Django 1.8.1 fixes several bugs in 1.8.
+Django 1.8.1 fixes several bugs in 1.8 and includes some optimizations in the
+migration framework.
 
 Bugfixes
 ========
@@ -61,3 +62,11 @@ Bugfixes
 
 * Fixed JavaScript path of ``contrib.admin``’s related field widget when using
   alternate static file storages (:ticket:`24655`).
+
+Optimizations
+=============
+
+* Changed ``ModelState`` to deepcopy fields instead of deconstructing and
+  reconstructing (:ticket:`24591`). This speeds up the rendering of
+  model states and reduces memory usage when running
+  :djadmin:`manage.py migrate <migrate>` with unapplied migrations.


### PR DESCRIPTION
Changed ModelState.clone() to create a deepcopy of self.fields.

https://code.djangoproject.com/ticket/24591