### PR TITLE
get_all_related_objects backwards compatible replacement: doc amendment

### DIFF
--- a/docs/ref/models/meta.txt
+++ b/docs/ref/models/meta.txt
@@ -240,7 +240,7 @@ can be made to convert your code to the new API:
 
       [
           f for f in MyModel._meta.get_fields()
-          if f.one_to_many and f.auto_created
+          if (f.one_to_many or f.one_to_one) and f.auto_created
       ]
 
 * ``MyModel._meta.get_all_related_objects_with_model()``::
@@ -248,7 +248,7 @@ can be made to convert your code to the new API:
       [
           (f, f.model if f.model != MyModel else None)
           for f in MyModel._meta.get_fields()
-          if f.one_to_many and f.auto_created
+          if (f.one_to_many or f.one_to_one) and f.auto_created
       ]
 
 * ``MyModel._meta.get_all_related_many_to_many_objects()``::


### PR DESCRIPTION
The example backwards compatible replacement for `Model._meta.get_all_related_objects` doesn't include a check for OneToOneFields so isn't fully 100% backwards compatible. This PR includes that check (would also be appropriate for the stable/1.8.x branch).

To illustrate:

```
class A(models.Model):
    pass
class B(models.Model):
    a = models.ForeignKey('A')
class C(models.Model):
    a = models.OneToOneField('A')

A._meta.get_all_related_objects()
[<ManyToOneRel: core.b>, <OneToOneRel: core.c>]

[f for f in A._meta.get_fields() if f.one_to_many and f.auto_created]
[<ManyToOneRel: core.b>]

 [f for f in A._meta.get_fields() if (f.one_to_many or f.one_to_one) and f.auto_created]
[<ManyToOneRel: core.b>, <OneToOneRel: core.c>]
```