### PR TITLE
Fixed #24667 --- Repaired cardinality test

### DIFF
--- a/tests/model_fields/test_field_flags.py
+++ b/tests/model_fields/test_field_flags.py
@@ -146,12 +146,13 @@ class FieldFlagsTests(test.TestCase):
                 self.assertEqual(1, true_cardinality_flags)
 
     def test_cardinality_m2m(self):
-        m2m_type_fields = (
+        m2m_type_fields = [
             f for f in self.all_fields
             if f.is_relation and f.many_to_many
-        )
+        ]
         # Test classes are what we expect
         self.assertEqual(MANY_TO_MANY_CLASSES, {f.__class__ for f in m2m_type_fields})
+        self.assertTrue(len(m2m_type_fields) > 0)
 
         # Ensure all m2m reverses are m2m
         for field in m2m_type_fields:


### PR DESCRIPTION
One of the tests in model_fields was broken due to the use of
generators. List comprehension was used to make this particular
test working.