### PR TITLE
Fixed oneword misstype in intro.txt

### DIFF
--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -252,7 +252,7 @@ Decorating class-based views
 ============================
 
 The extension of class-based views isn't limited to using mixins. You
-can use also use decorators. Since class-based views aren't functions,
+can also use decorators. Since class-based views aren't functions,
 decorating them works differently depending on if you're using ``as_view`` or
 creating a subclass.
 


### PR DESCRIPTION
Just a oneword misstype in [class-based-views/intro#Decorating class-based views](https://docs.djangoproject.com/en/dev/topics/class-based-views/intro/#decorating-class-based-views) documentation.