### PR TITLE
Fixed #24675 --Implemented an option to avoid unnecessary queries to MySQL since MySQL 5.6

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -279,12 +279,16 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return conn
 
     def init_connection_state(self):
-        with self.cursor() as cursor:
-            # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
-            # on a recently-inserted row will return when the field is tested for
-            # NULL.  Disabling this value brings this aspect of MySQL in line with
-            # SQL standards.
-            cursor.execute('SET SQL_AUTO_IS_NULL = 0')
+        if getattr(settings, 'SET_MYSQL_AUTO_IS_NULL', True):
+            with self.cursor() as cursor:
+                # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
+                # on a recently-inserted row will return when the field is tested for
+                # NULL.  Disabling this value brings this aspect of MySQL in line with
+                # SQL standards.
+                # The default from MySQL 5.6 is 0, so this can be disabled in
+                # settings if using MySQL>5.6 or having it set in server
+                # variables to avoid unnecessary database queries
+                cursor.execute('SET SQL_AUTO_IS_NULL = 0')
 
     def create_cursor(self):
         cursor = self.connection.cursor()

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -279,15 +279,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return conn
 
     def init_connection_state(self):
-        if getattr(settings, 'SET_MYSQL_AUTO_IS_NULL', True):
+        # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
+        # on a recently-inserted row will return when the field is tested for
+        # NULL. Disabling this value brings this aspect of MySQL in line with
+        # SQL standards.
+        # Check the sql_auto_is_null status on the MySQL server and if necessary
+        # set it to False.
+        if self.features.sql_auto_is_null:
             with self.cursor() as cursor:
-                # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
-                # on a recently-inserted row will return when the field is tested for
-                # NULL.  Disabling this value brings this aspect of MySQL in line with
-                # SQL standards.
-                # The default from MySQL 5.6 is 0, so this can be disabled in
-                # settings if using MySQL>5.6 or having it set in server
-                # variables to avoid unnecessary database queries
                 cursor.execute('SET SQL_AUTO_IS_NULL = 0')
 
     def create_cursor(self):

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -285,7 +285,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # SQL standards.
         # Check the sql_auto_is_null status on the MySQL server and if necessary
         # set it to False.
-        if self.features.sql_auto_is_null:
+        if self.features.sql_auto_is_null():
             with self.cursor() as cursor:
                 cursor.execute('SET SQL_AUTO_IS_NULL = 0')
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -68,3 +68,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     def introspected_boolean_field_type(self, *args, **kwargs):
         return 'IntegerField'
+
+    @cached_property
+    def sql_auto_is_null(self):
+        "Return if server global variable sql_auto_is_null is set to True"
+        with self.connection.cursor() as cursor:
+            cursor.execute("SHOW GLOBAL VARIABLES LIKE 'sql_auto_is_null'")
+            return cursor.fetchone()[1] == 'ON'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24675#ticket

Since MySQL 5.6 setting MYSQL_AUTO_IS_NULL is unnecessary. Implementing this eliminates one query in every connection resulting in better performance.

http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_sql_auto_is_null

System Variable	Name	sql_auto_is_null
Variable Scope	Global, Session
Dynamic Variable	Yes
Permitted Values	Type	boolean
Default	0
