### PR TITLE
Fixed #24665 - Model field relational attributes are None by default, not False

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -121,10 +121,10 @@ class Field(RegisterLookupMixin):
     # Field flags
     hidden = False
 
-    many_to_many = None
-    many_to_one = None
-    one_to_many = None
-    one_to_one = None
+    many_to_many = False
+    many_to_one = False
+    one_to_many = False
+    one_to_one = False
     related_model = None
 
     # Generic field type description, usually overridden by subclasses

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -95,12 +95,6 @@ class RelatedField(Field):
     Base class that all relational fields inherit from.
     """
 
-    # Field flags
-    one_to_many = False
-    one_to_one = False
-    many_to_many = False
-    many_to_one = False
-
     @cached_property
     def related_model(self):
         # Can't cache this property until all the models are loaded.

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1882,9 +1882,9 @@ Attributes for fields with relations
 ====================================
 
 These attributes are used to query for the cardinality and other details of a
-relation. These attribute are present on all fields; however, they will only
-have meaningful values if the field is a relation type
-(:attr:`Field.is_relation=True <Field.is_relation>`).
+relation. These attributes are present on all fields and are ``False``
+by default; however, the values in these attributes are useful only if the field
+is a relation type (:attr:`Field.is_relation=True <Field.is_relation>`).
 
 .. attribute:: Field.many_to_many
 


### PR DESCRIPTION
The values in the attributes for fields with relations were `True` or `False` for relational fields, but `None` by default for non-relational fields. Now, these values are always `False` by default for all fields (incl. non-relational). 
The documentation now says, that all fields (incl. non-relational) will have values in the relational attributes set to `False`, instead of saying, that the values will be meaningful only for relational fields.