### PR TITLE
Fixed #24682 -- update generic editing view links

### DIFF
--- a/docs/ref/class-based-views/flattened-index.txt
+++ b/docs/ref/class-based-views/flattened-index.txt
@@ -184,7 +184,7 @@ CreateView
 * :attr:`~django.views.generic.base.TemplateResponseMixin.content_type`
 * :attr:`~django.views.generic.detail.SingleObjectMixin.context_object_name` [:meth:`~django.views.generic.detail.SingleObjectMixin.get_context_object_name`]
 * :attr:`~django.views.generic.edit.ModelFormMixin.fields`
-* :attr:`~django.views.generic.edit.FormMixin.form_class` [:meth:`~django.views.generic.edit.FormMixin.get_form_class`]
+* :attr:`~django.views.generic.edit.FormMixin.form_class` [:meth:`~django.views.generic.edit.ModelFormMixin.get_form_class`]
 * :attr:`~django.views.generic.base.View.http_method_names`
 * :attr:`~django.views.generic.edit.FormMixin.initial` [:meth:`~django.views.generic.edit.FormMixin.get_initial`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.model`
@@ -194,7 +194,7 @@ CreateView
 * :attr:`~django.views.generic.base.TemplateResponseMixin.response_class` [:meth:`~django.views.generic.base.TemplateResponseMixin.render_to_response`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.slug_field` [:meth:`~django.views.generic.detail.SingleObjectMixin.get_slug_field`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.slug_url_kwarg`
-* :attr:`~django.views.generic.edit.FormMixin.success_url` [:meth:`~django.views.generic.edit.FormMixin.get_success_url`]
+* :attr:`~django.views.generic.edit.FormMixin.success_url` [:meth:`~django.views.generic.edit.ModelFormMixin.get_success_url`]
 * :attr:`~django.views.generic.base.TemplateResponseMixin.template_engine`
 * :attr:`~django.views.generic.base.TemplateResponseMixin.template_name` [:meth:`~django.views.generic.base.TemplateResponseMixin.get_template_names`]
 * :attr:`~django.views.generic.detail.SingleObjectTemplateResponseMixin.template_name_field`
@@ -205,11 +205,11 @@ CreateView
 * :meth:`~django.views.generic.base.View.as_view`
 * :meth:`~django.views.generic.base.View.dispatch`
 * :meth:`~django.views.generic.edit.FormMixin.form_invalid`
-* :meth:`~django.views.generic.edit.FormMixin.form_valid`
+* :meth:`~django.views.generic.edit.ModelFormMixin.form_valid`
 * :meth:`~django.views.generic.edit.ProcessFormView.get`
 * :meth:`~django.views.generic.base.ContextMixin.get_context_data`
 * :meth:`~django.views.generic.edit.FormMixin.get_form`
-* :meth:`~django.views.generic.edit.FormMixin.get_form_kwargs`
+* :meth:`~django.views.generic.edit.ModelFormMixin.get_form_kwargs`
 * :meth:`~django.views.generic.detail.SingleObjectMixin.get_object`
 * ``head()``
 * :meth:`~django.views.generic.base.View.http_method_not_allowed`
@@ -226,7 +226,7 @@ UpdateView
 * :attr:`~django.views.generic.base.TemplateResponseMixin.content_type`
 * :attr:`~django.views.generic.detail.SingleObjectMixin.context_object_name` [:meth:`~django.views.generic.detail.SingleObjectMixin.get_context_object_name`]
 * :attr:`~django.views.generic.edit.ModelFormMixin.fields`
-* :attr:`~django.views.generic.edit.FormMixin.form_class` [:meth:`~django.views.generic.edit.FormMixin.get_form_class`]
+* :attr:`~django.views.generic.edit.FormMixin.form_class` [:meth:`~django.views.generic.edit.ModelFormMixin.get_form_class`]
 * :attr:`~django.views.generic.base.View.http_method_names`
 * :attr:`~django.views.generic.edit.FormMixin.initial` [:meth:`~django.views.generic.edit.FormMixin.get_initial`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.model`
@@ -236,7 +236,7 @@ UpdateView
 * :attr:`~django.views.generic.base.TemplateResponseMixin.response_class` [:meth:`~django.views.generic.base.TemplateResponseMixin.render_to_response`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.slug_field` [:meth:`~django.views.generic.detail.SingleObjectMixin.get_slug_field`]
 * :attr:`~django.views.generic.detail.SingleObjectMixin.slug_url_kwarg`
-* :attr:`~django.views.generic.edit.FormMixin.success_url` [:meth:`~django.views.generic.edit.FormMixin.get_success_url`]
+* :attr:`~django.views.generic.edit.FormMixin.success_url` [:meth:`~django.views.generic.edit.ModelFormMixin.get_success_url`]
 * :attr:`~django.views.generic.base.TemplateResponseMixin.template_engine`
 * :attr:`~django.views.generic.base.TemplateResponseMixin.template_name` [:meth:`~django.views.generic.base.TemplateResponseMixin.get_template_names`]
 * :attr:`~django.views.generic.detail.SingleObjectTemplateResponseMixin.template_name_field`
@@ -247,11 +247,11 @@ UpdateView
 * :meth:`~django.views.generic.base.View.as_view`
 * :meth:`~django.views.generic.base.View.dispatch`
 * :meth:`~django.views.generic.edit.FormMixin.form_invalid`
-* :meth:`~django.views.generic.edit.FormMixin.form_valid`
+* :meth:`~django.views.generic.edit.ModelFormMixin.form_valid`
 * :meth:`~django.views.generic.edit.ProcessFormView.get`
 * :meth:`~django.views.generic.base.ContextMixin.get_context_data`
 * :meth:`~django.views.generic.edit.FormMixin.get_form`
-* :meth:`~django.views.generic.edit.FormMixin.get_form_kwargs`
+* :meth:`~django.views.generic.edit.ModelFormMixin.get_form_kwargs`
 * :meth:`~django.views.generic.detail.SingleObjectMixin.get_object`
 * ``head()``
 * :meth:`~django.views.generic.base.View.http_method_not_allowed`


### PR DESCRIPTION
Updated links for CreateView and UpdateView in _Class-based generic views flattened index_ to point to `ModelFormMixin` instead of `FormMixin`.