### PR TITLE
Match admin URL reverse documentation

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -537,11 +537,11 @@ class ModelAdmin(BaseModelAdmin):
         urlpatterns = [
             url(r'^$', wrap(self.changelist_view), name='%s_%s_changelist' % info),
             url(r'^add/$', wrap(self.add_view), name='%s_%s_add' % info),
-            url(r'^(.+)/history/$', wrap(self.history_view), name='%s_%s_history' % info),
-            url(r'^(.+)/delete/$', wrap(self.delete_view), name='%s_%s_delete' % info),
-            url(r'^(.+)/change/$', wrap(self.change_view), name='%s_%s_change' % info),
+            url(r'^(?P<object_id>.+)/history/$', wrap(self.history_view), name='%s_%s_history' % info),
+            url(r'^(?P<object_id>.+)/delete/$', wrap(self.delete_view), name='%s_%s_delete' % info),
+            url(r'^(?P<object_id>.+)/change/$', wrap(self.change_view), name='%s_%s_change' % info),
             # For backwards compatibility (was the change url before 1.9)
-            url(r'^(.+)/$', wrap(RedirectView.as_view(
+            url(r'^(?P<object_id>.+)/$', wrap(RedirectView.as_view(
                 pattern_name='%s:%s_%s_change' % ((self.admin_site.name,) + info)
             ))),
         ]


### PR DESCRIPTION
The docs at https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#admin-reverse-urls
states that admin URLs take the parameter "object_id"