### PR TITLE
Support role based permission management

### DIFF
--- a/django/contrib/userrole/admin.py
+++ b/django/contrib/userrole/admin.py
@@ -1,0 +1,52 @@
+from django.contrib import admin
+from models import UserRole
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+# Register your models here.
+
+class UserRoleAdmin(admin.ModelAdmin):
+    filter_horizontal = ('users', 'admins', 'permissions', 'groups',)
+    non_superuser_disabled_fields = ('name', 'admins', 'permissions', 'groups',)
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_superuser:
+            return []
+        else:
+            return self.non_superuser_disabled_fields
+
+    def queryset(self, request):
+        """
+        UserRole admin has 'change' permission to UserRoles managed by him/her
+        """
+        qs = super(UserRoleAdmin, self).queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(admins=request.user)
+
+    def response_add(self, request, obj, post_url_continue='../%s/'):
+        ret = super(UserRoleAdmin, self).response_add(request, obj, post_url_continue)
+        self.add_admin_permission(obj)
+        return ret
+
+    def response_change(self, request, obj):
+        ret = super(UserRoleAdmin, self).response_change(request, obj)
+        self.add_admin_permission(obj)
+        return ret
+
+    def add_admin_permission(self, obj):
+        """
+        Add change permission to UserRole admins
+        :param obj:
+        :return:
+        """
+        content_type = ContentType.objects.get_for_model(obj)
+        codename = "change_%s" % content_type.model
+        perms = Permission.objects.filter(content_type=content_type, codename=codename)
+        if not perms:
+            raise Exception('failed to get permission: %s, %s' % (content_type, codename))
+        for admin in obj.admins.all():
+            admin.user_permissions.add(perms[0])
+
+
+admin.site.register(UserRole, UserRoleAdmin)

--- a/django/contrib/userrole/admin.py
+++ b/django/contrib/userrole/admin.py
@@ -1,9 +1,12 @@
-from django.contrib import admin
 from models import UserRole
+
+from django.contrib import admin
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 
+
 # Register your models here.
+
 
 class UserRoleAdmin(admin.ModelAdmin):
     filter_horizontal = ('users', 'admins', 'permissions', 'groups',)
@@ -45,8 +48,8 @@ class UserRoleAdmin(admin.ModelAdmin):
         perms = Permission.objects.filter(content_type=content_type, codename=codename)
         if not perms:
             raise Exception('failed to get permission: %s, %s' % (content_type, codename))
-        for admin in obj.admins.all():
-            admin.user_permissions.add(perms[0])
+        for role_admin in obj.admins.all():
+            role_admin.user_permissions.add(perms[0])
 
 
 admin.site.register(UserRole, UserRoleAdmin)

--- a/django/contrib/userrole/backends.py
+++ b/django/contrib/userrole/backends.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from django.contrib.auth.models import User, Permission
 from models import UserRole
+
+from django.contrib.auth.models import Permission, User
 
 
 class UserRoleBackend(object):
@@ -63,4 +64,3 @@ class UserRoleBackend(object):
             return User.objects.get(pk=user_id)
         except User.DoesNotExist:
             return None
-

--- a/django/contrib/userrole/backends.py
+++ b/django/contrib/userrole/backends.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from django.contrib.auth.models import User, Permission
+from models import UserRole
+
+
+class UserRoleBackend(object):
+    '''
+    UserRoleBackend does not Authenticates User. It only  Authorise permissions
+    '''
+    supports_object_permissions = False
+    supports_anonymous_user = False
+    supports_inactive_user = False
+
+    def authenticate(self, username=None, password=None):
+        return None
+
+    def get_group_permissions(self, user_obj, obj=None):
+        """
+        Returns a set of permission strings that this user has through his/her
+        user roles.
+        """
+        if not hasattr(user_obj, '_user_role_group_perm_cache'):
+            # find all user groups the user belongs to
+            user_roles = UserRole.objects.filter(users=user_obj)
+            perms = []
+            for ur in user_roles:
+                perm_queryset = Permission.objects.filter(group__userrole=ur)
+                perms += perm_queryset.values_list('content_type__app_label', 'codename').order_by()
+            user_obj._user_role_group_perm_cache = set(["%s.%s" % (ct, name) for ct, name in perms])
+        return user_obj._user_role_group_perm_cache
+
+    def get_all_permissions(self, user_obj, obj=None):
+        if not hasattr(user_obj, '_user_role_perm_cache'):
+            user_roles = UserRole.objects.filter(users=user_obj)
+            user_obj._user_role_perm_cache = set()
+            for ur in user_roles:
+                user_obj._userrole_perm_cache.update(
+                    set([u"%s.%s" % (p.content_type.app_label, p.codename) for p in ur.permissions.select_related()])
+                )
+            user_obj._userrole_perm_cache.update(self.get_group_permissions(user_obj))
+        return user_obj._user_role_perm_cache
+
+    def has_perm(self, user_obj, perm, obj=None):
+        if not user_obj.is_active:
+            return False
+        return perm in self.get_all_permissions(user_obj)
+
+    def has_module_perms(self, user_obj, app_label):
+        """
+        Returns True if user_obj has any permissions in the given app_label.
+        """
+        if not user_obj.is_active:
+            return False
+        for perm in self.get_all_permissions(user_obj):
+            if perm[:perm.index('.')] == app_label:
+                return True
+        return False
+
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None
+

--- a/django/contrib/userrole/models.py
+++ b/django/contrib/userrole/models.py
@@ -1,0 +1,22 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth.models import User, Group, Permission
+
+# Create your models here.
+
+class UserRole(models.Model):
+    '''
+    UserRole provides role based access control for django. It helps to decouple User management and permission management,
+    which is desirable for enterprises with more than 500 employees.
+    A User can be assigned to zero-to-many UserRoles and a UserRole can have zero-to-many users
+    '''
+
+    name = models.CharField(max_length=128, unique=True, help_text=_("role's name, be globally unique"))
+    users = models.ManyToManyField(User, related_name='users', help_text=_('users assigned to this role'), blank=True)
+    admins = models.ManyToManyField(User, related_name='admins', help_text=_(
+        'admins of this role, who can add users to and remove users from this role'), blank=True)
+    permissions = models.ManyToManyField(Permission, help_text=_('permissions assigned to this role'), blank=True)
+    groups = models.ManyToManyField(Group, help_text=_('groups assigned to this role'), blank=True)
+
+    def __unicode__(self):
+        return self.name

--- a/django/contrib/userrole/models.py
+++ b/django/contrib/userrole/models.py
@@ -1,8 +1,10 @@
+from django.contrib.auth.models import Group, Permission, User
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth.models import User, Group, Permission
+
 
 # Create your models here.
+
 
 class UserRole(models.Model):
     '''

--- a/django/contrib/userrole/views.py
+++ b/django/contrib/userrole/views.py
@@ -1,0 +1,1 @@
+# Create your views here.


### PR DESCRIPTION
Decouple User management and Permission management is terribly necessary for large enterprise. Role based permission management saves django admins from assign permissions for every employee, and let other staffs, such as team leaders to define roles and assign members to and move members between different roles. Django admins will only focus on permission management for roles.

This commit supplies an app that manage UserRole and a backend as AUTH_BACKEND.

