### PR TITLE
Fixed #24689 -- Fixed DetailView methods with deferred QuerySet

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -89,6 +89,9 @@ class SingleObjectMixin(ContextMixin):
         if self.context_object_name:
             return self.context_object_name
         elif isinstance(obj, models.Model):
+            if self.object._deferred:
+                obj = obj._meta.proxy_for_model
+
             return obj._meta.model_name
         else:
             return None
@@ -149,9 +152,14 @@ class SingleObjectTemplateResponseMixin(TemplateResponseMixin):
             # The least-specific option is the default <app>/<model>_detail.html;
             # only use this if the object in question is a model.
             if isinstance(self.object, models.Model):
+                object_meta = self.object._meta
+
+                if self.object._deferred:
+                    object_meta = self.object._meta.proxy_for_model._meta
+
                 names.append("%s/%s%s.html" % (
-                    self.object._meta.app_label,
-                    self.object._meta.model_name,
+                    object_meta.app_label,
+                    object_meta.model_name,
                     self.template_name_suffix
                 ))
             elif hasattr(self, 'model') and self.model is not None and issubclass(self.model, models.Model):

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -5,7 +5,10 @@ import datetime
 
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.test import TestCase, override_settings
+from django.test.client import RequestFactory
 from django.views.generic.base import View
+from django.views.generic.detail import SingleObjectTemplateResponseMixin
+from django.views.generic.edit import ModelFormMixin
 
 from .models import Artist, Author, Book, Page
 
@@ -136,6 +139,32 @@ class DetailViewTest(TestCase):
         self.assertEqual(res.context['object'], self.author1)
         self.assertNotIn('author', res.context)
         self.assertTemplateUsed(res, 'generic_views/author_detail.html')
+
+    def test_deferred_queryset_template_name(self):
+        class FormContext(SingleObjectTemplateResponseMixin):
+            request = RequestFactory().get('/')
+            model = Author
+            object = Author.objects.get(pk=self.author1.pk)
+
+        class FormDeferredContext(SingleObjectTemplateResponseMixin):
+            request = RequestFactory().get('/')
+            model = Author
+            object = Author.objects.defer('name').get(pk=self.author1.pk)
+
+        self.assertEqual(FormContext().get_template_names(), FormDeferredContext().get_template_names())
+        self.assertEqual(FormContext().get_template_names()[0], 'generic_views/author_detail.html')
+
+    def test_deferred_queryset_context_object_name(self):
+        class FormContext(ModelFormMixin):
+            request = RequestFactory().get('/')
+            model = Author
+            object = Author.objects.defer('name').get(pk=self.author1.pk)
+            fields = ('name', )
+
+        form_context_data = FormContext().get_context_data()
+
+        self.assertEqual(form_context_data['object'], self.author1)
+        self.assertEqual(form_context_data['author'], self.author1)
 
     def test_invalid_url(self):
         self.assertRaises(AttributeError, self.client.get, '/detail/author/invalid/url/')


### PR DESCRIPTION
When using DetailView with a deferred queryset get_template_names would construct template name from a proxied model. This pull request implements a check if an object is deferred uses `proxy_for_model` in case of deferred objects.