### PR TITLE
Fixed #24649 -- Allowed using Avg aggregate on non-numeric field types.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -160,6 +160,9 @@ class BaseDatabaseFeatures(object):
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 
+    # Can the backend use an Avg aggregate on DurationField?
+    can_avg_on_durationfield = True
+
     # Does the backend decide to commit before SAVEPOINT statements
     # when autocommit is disabled? http://bugs.python.org/issue8145#msg109965
     autocommits_when_autocommit_is_off = False

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -40,6 +40,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     uppercases_column_names = True
     # select for update with limit can be achieved on Oracle, but not with the current backend.
     supports_select_for_update_with_limit = False
+    can_avg_on_durationfield = False  # Pending implementation (#24699).
 
     def introspected_boolean_field_type(self, field=None, created_separately=False):
         """

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -75,12 +75,8 @@ class Avg(Aggregate):
     name = 'Avg'
 
     def __init__(self, expression, **extra):
-        super(Avg, self).__init__(expression, output_field=FloatField(), **extra)
-
-    def convert_value(self, value, expression, connection, context):
-        if value is None:
-            return value
-        return float(value)
+        output_field = extra.pop('output_field', FloatField())
+        super(Avg, self).__init__(expression, output_field=output_field, **extra)
 
 
 class Count(Aggregate):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2802,12 +2802,19 @@ by the aggregate.
 Avg
 ~~~
 
-.. class:: Avg(expression, output_field=None, **extra)
+.. class:: Avg(expression, output_field=FloatField(), **extra)
 
-    Returns the mean value of the given expression, which must be numeric.
+    Returns the mean value of the given expression, which must be numeric
+    unless you specify a different ``output_field``.
 
     * Default alias: ``<field>__avg``
-    * Return type: ``float``
+    * Return type: ``float`` (or the type of whatever ``output_field`` is
+      specified)
+
+    .. versionchanged:: 1.9
+
+        The ``output_field`` parameter was added to allow aggregating over
+        non-numeric columns, such as ``DurationField``.
 
 Count
 ~~~~~

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -200,6 +200,10 @@ Models
   (such as :lookup:`exact`, :lookup:`gt`, :lookup:`lt`, etc.). For example:
   ``Entry.objects.filter(pub_date__month__gt=6)``.
 
+* You can specify the ``output_field`` parameter of the
+  :class:`~django.db.models.Avg` aggregate in order to aggregate over
+  non-numeric columns, such as ``DurationField``.
+
 CSRF
 ^^^^
 

--- a/tests/aggregation/models.py
+++ b/tests/aggregation/models.py
@@ -17,6 +17,7 @@ class Author(models.Model):
 class Publisher(models.Model):
     name = models.CharField(max_length=255)
     num_awards = models.IntegerField()
+    duration = models.DurationField(blank=True, null=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24649