### PR TITLE
Updated standard MIDDLEWARE_CLASSES in docs.

### DIFF
--- a/docs/topics/http/middleware.txt
+++ b/docs/topics/http/middleware.txt
@@ -32,8 +32,10 @@ here's the default value created by :djadmin:`django-admin startproject
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware',
     ]
 
 A Django installation doesn't require any middleware —


### PR DESCRIPTION
The documentation for the default value of `MIDDLEWARE_CLASSES` set by `django-admin startproject` was out of date.  Updated it to match what is in `django/conf/project_template/project_name/settings.py`.