### PR TITLE
Dep 191: Composite fields

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -32,6 +32,7 @@ class GenericForeignKey(object):
     concrete = False
     editable = False
     hidden = False
+    is_composite = False
 
     is_relation = True
     many_to_many = False

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -44,7 +44,7 @@ class Serializer(base.Serializer):
         return data
 
     def handle_field(self, obj, field):
-        value = field._get_val_from_obj(obj)
+        value = getattr(obj, field.attname)
         # Protected types (i.e., primitives like None, numbers, dates,
         # and Decimals) are passed through as is. All other values are
         # converted to string first.

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -11,6 +11,7 @@ from django.db.models.aggregates import *  # NOQA
 from django.db.models.fields import *  # NOQA
 from django.db.models.fields.subclassing import SubfieldBase        # NOQA
 from django.db.models.fields.files import FileField, ImageField  # NOQA
+from django.db.models.fields.composite import CompositeField, constrain    # NOQA
 from django.db.models.fields.related import (  # NOQA
     ForeignKey, ForeignObject, OneToOneField, ManyToManyField,
     ManyToOneRel, ManyToManyRel, OneToOneRel)

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -346,6 +346,9 @@ class ModelState(object):
         # Necessary for correct validation of new instances of objects with explicit (non-auto) PKs.
         # This impacts validation only; it has no effect on the actual save.
         self.adding = True
+        # Field observers that are being kept alive for the lifetime of this
+        # instance.
+        self.field_observers = list()
 
 
 class Model(six.with_metaclass(ModelBase)):
@@ -1612,6 +1615,7 @@ class Model(six.with_metaclass(ModelBase)):
                     )
 
         return errors
+
 
 
 ############################################

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -348,7 +348,7 @@ class ModelState(object):
         self.adding = True
         # Field observers that are being kept alive for the lifetime of this
         # instance.
-        self.field_observers = list()
+        self.field_observers = dict()
 
 
 class Model(six.with_metaclass(ModelBase)):
@@ -1615,7 +1615,6 @@ class Model(six.with_metaclass(ModelBase)):
                     )
 
         return errors
-
 
 
 ############################################

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -125,6 +125,8 @@ class BaseExpression(object):
 
     # aggregate specific fields
     is_summary = False
+    # The number of result cols that the field takes up in a result row
+    width = 1
 
     def __init__(self, output_field=None):
         self._output_field = output_field

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -142,6 +142,8 @@ class Field(RegisterLookupMixin):
     one_to_one = None
     related_model = None
 
+    is_composite = False
+
     # Generic field type description, usually overridden by subclasses
     def _description(self):
         return _('Field of type: %(field_type)s') % {
@@ -864,18 +866,12 @@ class Field(RegisterLookupMixin):
         first_choice = blank_choice if include_blank else []
         return first_choice + list(self.flatchoices)
 
-    def _get_val_from_obj(self, obj):
-        if obj is not None:
-            return getattr(obj, self.attname)
-        else:
-            return self.get_default()
-
     def value_to_string(self, obj):
         """
         Returns a string value of this field from the passed obj.
         This is used by the serialization framework.
         """
-        return smart_text(self._get_val_from_obj(obj))
+        return smart_text(getattr(obj, self.attname))
 
     def _get_flatchoices(self):
         """Flattened version of choices tuple."""
@@ -1341,7 +1337,7 @@ class DateField(DateTimeCheckMixin, Field):
         return connection.ops.value_to_db_date(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -1501,7 +1497,7 @@ class DateTimeField(DateField):
         return connection.ops.value_to_db_datetime(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -1707,7 +1703,7 @@ class DurationField(Field):
         return converters + super(DurationField, self).get_db_converters(connection)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else duration_string(val)
 
     def formfield(self, **kwargs):
@@ -2307,7 +2303,7 @@ class TimeField(DateTimeCheckMixin, Field):
         return connection.ops.value_to_db_time(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -2374,7 +2370,7 @@ class BinaryField(Field):
 
     def value_to_string(self, obj):
         """Binary data is serialized as base64"""
-        return b64encode(force_bytes(self._get_val_from_obj(obj))).decode('ascii')
+        return b64encode(force_bytes(getattr(obj, self.attname))).decode('ascii')
 
     def to_python(self, value):
         # If it's a string, it should be base64-encoded data

--- a/django/db/models/fields/composite.py
+++ b/django/db/models/fields/composite.py
@@ -1,0 +1,404 @@
+import copy
+import re
+import weakref
+from collections import OrderedDict
+from itertools import chain
+
+from django.core import checks
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models.fields import Field
+from django.db.models.fields.composite_lookups import (
+    CompositeExact, CompositeIn, CompositeIsNull, SubfieldTransform,
+)
+from django.utils import six
+from django.utils.functional import cached_property
+from django.utils.observables import Observable, ObservableDict
+
+__all__ = ('constrain', 'CompositeField')
+
+
+def constrain(*fields, **kwargs):
+    """
+    Add a database constraint which applies to the given fields, and adds a
+    descriptor to the model which returns the values of fields as a dict.
+
+    Currently supported kwargs are:
+        - unique: Applies a UNIQUE constraint to the model's table, ensuring
+          that any combination of the fields values on the database table
+          is unique. Default is `False`
+        - db_index: Adds an index to the model's table, which indexes
+
+    If 'fields' is empty, a composite field will still be created on the model,
+    but it will have no data.
+    If 'fields' contains a single element, then the constraints are still
+    applied to the field, even if that field is not unique or indexed.
+
+    eg.
+
+    class Model(Model):
+        x = IntegerField(unique=False)
+        x_unique = models.constrain(x, unique=True)
+
+    The presence of x_unique will still add a unique constraint on x to the
+    table, even though the field has unique=False.
+
+
+    It is possible to constrain fields specified on a base class, by passing
+    in the field as a string.
+
+    eg.
+
+    class Base(Model):
+        x = IntegerField(unique=False)
+
+    class Concrete(Base):
+        y = IntegerField()
+        _ = models.constrain('x', y, unique=True)
+
+    The previous example also demonstrates how to add an unnamed constraint
+    to a model. CompositeFields whose name consist solely of a string of
+    underscore characters will not contribute an accessor to the containing
+    class, nor will they be available via the query API.
+    """
+    unique = kwargs.pop('unique', False)
+    db_index = kwargs.pop('db_index', True)
+    composite_field = CompositeField(unique=unique, db_index=db_index)
+
+    # Loads subfields. This isn't called until the app registry is ready,
+    # so all fields are guaranteed to exist on the model.
+    def lazy_subfields(model_cls):
+        subfields = OrderedDict()
+        for field in fields:
+            # If the field is defined on a supertype, there is no field
+            # available in the current scope to pass the field into `constrain`
+            # (and SuperType.field_name doesn't work because metaclasses).
+            #
+            # Thus constrained fields can be passed in by their name on the
+            # model.
+            if isinstance(field, six.string_types):
+                field = model_cls._meta.get_field(field)
+                subfields[field.name] = Subfield(
+                    composite_field, field, managed=False
+                )
+                continue
+            # The field may be copied from a parent model during inheritance
+            # The subfield should use the copied model
+            for model_field in model_cls._meta.fields:
+                if field == model_field:
+                    assert hasattr(field, 'model'), 'Not all modules loaded'
+                    subfields[field.name] = Subfield(
+                        composite_field, model_field, managed=False
+                    )
+                    break
+            else:
+                # The field was declared inside the parameter list of
+                # constrain
+                # eg. models.constrain(IntegerField(), ...)
+                #
+                # It can also happen if the field is declared outside
+                # the class definition
+                raise FieldDoesNotExist(
+                    'Field cannot be declared inside call to `constrain`'
+                )
+        return subfields
+    composite_field._lazy_subfields = lazy_subfields
+
+    return composite_field
+
+
+class CompositeFieldBase(type):
+    # The composite field metaclass isn't required until DEP 192, but it doesn't
+    # do any harm to add it now.
+
+    def __new__(cls, name, bases, attrs):
+        return super(CompositeFieldBase, cls).__new__(cls, name, bases, attrs)
+
+
+class CompositeField(six.with_metaclass(CompositeFieldBase, Field)):
+    is_composite = True
+    concrete = False
+
+    _UNNAMED_FIELD_REGEX = re.compile('_+$')
+
+    def __init__(self, **kwargs):
+        super(CompositeField, self).__init__(**kwargs)
+
+    @cached_property
+    def subfields(self):
+        if not hasattr(self, 'model'):
+            raise AttributeError(
+                'CompositeField does not have `subfields` until '
+                'contribute_to_class has been called'
+            )
+        # We don't actually need the entire app registry to load, but  we do
+        # need all the other fields on the model to be fully finalized, in order
+        # for it to be possible to populate the subfields with the correct
+        # model names. Waiting for the app registry to be loaded might be late,
+        # but at least we can be confident that everything has loaded by then
+        self.model._meta.apps.get_models()
+
+        if hasattr(self, '_lazy_subfields'):
+            return self._lazy_subfields(self.model)
+        else:
+            # DEP 192
+            raise NotImplementedError('standalone fields')
+
+    @cached_property
+    def is_unnamed(self):
+        return bool(self._UNNAMED_FIELD_REGEX.match(self.name))
+
+    def contribute_to_class(self, model_cls, name, virtual_only=False):
+        super(CompositeField, self).contribute_to_class(
+            model_cls, name, virtual_only=True
+        )
+        if not self.is_unnamed:
+            setattr(model_cls, name, CompositeFieldDescriptor(self))
+
+    def get_subfield(self, subfield_name):
+        if subfield_name in self.subfields:
+            return self.subfields[subfield_name]
+        raise FieldDoesNotExist(subfield_name)
+
+    def get_lookup(self, lookup_name):
+        if self.is_unnamed:
+            raise LookupError(
+                'Cannot perform lookup on unnamed composite field'
+            )
+        if lookup_name == 'exact':
+            return CompositeExact
+        elif lookup_name == 'isnull':
+            return CompositeIsNull
+        elif lookup_name == 'in':
+            return CompositeIn
+
+    def get_transform(self, lookup_name):
+        if lookup_name in self.subfields:
+            return SubfieldTransform
+
+    def value_to_dict(self, value):
+        """
+        Takes an arbitrary python object and returns a mapping of subfield
+        names to values. If the `CompositeField` is nullable and the value
+        is null, this method is expected to still return a python dict.
+
+        By default, just returns value unchanged. The method should be overriden
+        by CompositeField subclasses
+        """
+        return value
+
+    def value_from_dict(self, field_dict):
+        """
+        Takes a mapping of subfield names to their current model values and
+        returns a custom object instance. The argument will never be `None`.
+
+        The returned value must be one of:
+            - None
+            - A tuple of field values
+            - ObservableDict/ObservableOrderedDict
+            - A python object which mixes in Observable
+
+        The values of the composite field's subfields are bound to the values
+        returned by this method to the returned value, so any change record
+        emitted by the observable will update the subfield with the same name
+        as the record's key.
+
+        By default, just wraps the field dict in an ObservableDict. This method
+        should be overriden by CompositeField subclasses
+        """
+        return ObservableDict(field_dict)
+
+    def check(self, **kwargs):
+        return chain(
+            super(CompositeField, self).check(**kwargs),
+            self._check_subfields
+        )
+
+    def _check_subfields(self, **kwargs):
+        for subfield in self.subfields.values:
+            # TODO: Field error codes
+            if subfield.is_relation:
+                yield checks.Error(
+                    'Subfield %s cannot be a relation field' % subfield.name,
+                    hint=None,
+                    obj=self,
+                    id='fields.E401'
+                )
+            if subfield.is_composite:
+                yield checks.Error(
+                    'Subfield %s cannot be a composite field' % subfield.name,
+                    hint=None,
+                    obj=self,
+                    id='fields.E402'
+                )
+        subfield_messages = chain.from_iterable(
+            field.check(**kwargs) for field in self.subfields.values
+        )
+        for msg in chain.from_iterable(subfield_messages):
+            yield msg
+
+    def _check_field_name(self):
+        for err in super(CompositeField, self)._check_field_name():
+            if err.id in ('fields.E001', 'fields.E002') and self.is_unnamed:
+                continue
+            yield err
+
+    def __deepcopy__(self, memodict):
+        obj = super(CompositeField, self).__deepcopy__(memodict)
+        if hasattr(self, '_subfields'):
+            # DEP 192
+            raise NotImplementedError('Standalone composite field')
+        elif hasattr(self, '_lazy_subfields'):
+            obj._lazy_subfields = self._lazy_subfields
+        return obj
+
+    def get_attname_column(self):
+        return self.get_attname(), None
+
+    def get_col(self, alias, output_field=None):
+        assert (output_field is None or output_field is self)
+        from django.db.models.fields.composite_lookups import CompositeCol
+        return CompositeCol(alias, self)
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.value_from_dict(dict(zip(self.subfields, value)))
+
+
+class Subfield(Field):
+    """
+    A Subfield is a field which stores the value of another field. The subfield
+    is an implementation detail of the composite field API and may be removed
+    without warning.
+
+    Subfields can either be managed or unmanaged. An unmanaged subfield exists
+    independently of the composite field, on the model's definition, a
+    managed subfield is created as part of a standalone composite field
+    definition and is contributed to the model by the composite field
+    """
+    _OWN_ATTRS = ('composite_field', 'delegate_field', 'managed')
+
+    def __init__(self, composite_field, delegate_field, managed=False):
+        self.composite_field = composite_field
+        self.delegate_field = delegate_field
+        self.managed = managed
+
+    @cached_property
+    def attname(self):
+        if not self.managed:
+            return self.delegate_field.attname
+        return '%s__%s' % (self.composite_field.name, self.delegate_field.name)
+
+    @property
+    def creation_counter(self):
+        return self.composite_field.creation_counter
+
+    @property
+    def subfield_creation_counter(self):
+        return self.delegate_field.creation_counter
+
+    def check(self, **kwargs):
+        if not self.managed:
+            return self.delegate_field.check(**kwargs)
+        # An unmanaged subfield is already checked by the model
+        return []
+
+    # TODO: A subfield cannot have any of the names 'exact', 'isnull', 'in'
+
+    def __getattr__(self, attr):
+        if attr in Subfield._OWN_ATTRS:
+            return self.__dict__[attr]
+        return getattr(self.delegate_field, attr)
+
+    def __setattr__(self, attr, value):
+        if attr in Subfield._OWN_ATTRS:
+            self.__dict__[attr] = value
+        else:
+            setattr(self.delegate_field, attr, value)
+
+    def __deepcopy__(self, memodict):
+        obj = copy.copy(self)
+        obj.composite_field = memodict[id(self.composite_field)]
+        obj.delegate_field = copy.deepcopy(self.delegate_field)
+        return obj
+
+
+class CompositeFieldDescriptor(object):
+    def __init__(self, field):
+        self.field = field
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        subfield_dict = dict()
+        for subfield_name, subfield in self.field.subfields.items():
+            value = getattr(instance, subfield.attname)
+            subfield_dict[subfield_name] = value
+        result = self.field.value_from_dict(subfield_dict)
+
+        if isinstance(result, Observable):
+            self.bind_observer(instance, result)
+            return result
+        elif result is None or isinstance(result, tuple):
+            return result
+        else:
+            # We should just return here, rather than raising an error.
+            # A functionally-minded developer might prefer immutable composite
+            # field instances, in which case Observable is not required
+            # Useful sanity check for the moment.
+            raise AttributeError(
+                'CompositeField.value_from_dict must return an observable '
+                'instance')
+
+    def __set__(self, instance, value):
+        # Update all subfield values immediately
+        subfield_dict = self.field.value_to_dict(value)
+        for subfield_name, subfield_value in subfield_dict.items():
+            subfield = self.field.get_subfield(subfield_name)
+            setattr(instance, subfield.attname, subfield_value)
+        if isinstance(value, Observable):
+            value = self.field.value_from_dict(
+                self.field.value_to_dict(value)
+            )
+            self.bind_observer(instance, value)
+
+    def bind_observer(self, instance, observable):
+        """
+        Adds an observer of the observable subfield value to the given instance
+        The observers of an observable are stored as weak references, so attach
+        a reference to the observer to the ModelState.
+
+        This causes the observer to get gc'd when the model instance is gc'd,
+        and the observer to try to update a non-existent model instance.
+        """
+        observers = instance._state.field_observers.setdefault(self.field, [])
+
+        observer = SubfieldObserver(self.field, instance)
+        observable.add_observer(observer)
+        observers.append(observer)
+
+
+class SubfieldObserver(object):
+    def __init__(self, composite_field, model_instance):
+        self.field = composite_field
+        # Avoid a circular reference to the model instance which would prevent
+        # a gc.
+        self.instance_ref = weakref.ref(model_instance)
+
+    def handle_changes(self, change_records):
+        instance = self.instance_ref()
+        if instance is None:
+            return
+        for record in change_records:
+            try:
+                subfield = self.field.get_subfield(record.key)
+            except FieldDoesNotExist:
+                continue
+
+            # FIXME: We only have one-way binding, so a subfield value is
+            # allowed to be updated without affecting the state of the model
+            # instance. As a sanity check until this gets ready for production,
+            # ensure that the value remains in sync
+            assert getattr(instance, subfield.attname) == record.old, (
+                'Subfield value is not synchronized'
+            )
+
+            setattr(instance, subfield.attname, record.new)

--- a/django/db/models/fields/composite_lookups.py
+++ b/django/db/models/fields/composite_lookups.py
@@ -1,0 +1,113 @@
+from django.db.models.expressions import Expression
+from django.db.models.lookups import Exact, In, IsNull, Transform
+from django.utils import six
+from django.utils.functional import cached_property
+
+
+class CompositeCol(Expression):
+
+    contains_aggregate = False
+
+    def __init__(self, alias, target):
+        self.alias, self.target = alias, target
+        super(CompositeCol, self).__init__(output_field=target)
+
+    def relabeled_clone(self, relabels):
+        return self._class__(relabels.get(self.alias, self.alias), self.field)
+
+    @cached_property
+    def subcols(self):
+        return [
+            field.get_col(self.alias)
+            for field in self.target.subfields.values()
+        ]
+
+    @cached_property
+    def width(self):
+        return len(self.subcols)
+
+    @property
+    def aliased_subcols(self):
+        prefix = self.target.name
+        for col in self.subcols:
+            yield col, '%s_%s' % (prefix, col.target.name)
+
+    def as_sql(self, compiler, connection):
+        sql = []
+        prefix = self.target.name + '_'
+        for subcol in self.subcols:
+            s_sql, s_params = subcol.as_sql(compiler, connection)
+            sql.append('%s AS %s' % (s_sql, prefix + subcol.target.name))
+        return ','.join(sql), []
+
+    def __repr__(self):
+        return "{}({}, {})".format(
+            self.__class__.__name__, self.alias, self.target)
+
+    def get_db_converters(self, connection):
+        return self.target.get_db_converters(connection)
+
+
+class CompositeExact(Exact):
+    def as_sql(self, compiler, connection):
+        from django.db.models.sql.where import WhereNode, AND
+        constraint = WhereNode()
+
+        subfields = six.iteritems(self.lhs.field.subfields)
+        subfield_values = self.lhs.field.value_to_dict(self.rhs)
+
+        for subfield_name, subfield in subfields:
+            try:
+                subfield_value = subfield_values[subfield_name]
+            except KeyError:
+                # TODO: Raise more appropriate error
+                raise
+            subfield_col = subfield.get_col(self.lhs.alias)
+            constraint.add(
+                subfield.get_lookup('exact')(subfield_col, subfield_value),
+                AND
+            )
+        return constraint.as_sql(compiler, connection)
+
+
+class CompositeIsNull(IsNull):
+    def as_sql(self, compiler, connection):
+        from django.db.models.sql.where import WhereNode, NothingNode
+
+        if not self.lhs.field.null:
+            # Avoid sending a deserialization of `None` on composite fields
+            # which can't support it.
+            constraint = NothingNode() if self.rhs else WhereNode()
+        else:
+            # Perform an exact lookup on whichever combination of subfields
+            # corresponds to a python `None` value for the object. We assume
+            # that value_to_dict is deterministic.
+            constraint = self.lhs.get_lookup('exact')(self.lhs, None)
+            constraint.negated = not self.rhs
+        return constraint
+
+
+class CompositeIn(In):
+    def as_sql(self, compiler, connection):
+        from django.db.models.sql.where import WhereNode, OR
+        constraint = WhereNode()
+        if not self.rhs_is_direct_value():
+            for value in self.rhs:
+                exact_lookup = self.lhs.get_lookup('exact')(self.lhs, value)
+                constraint.add(exact_lookup.as_sql(compiler, connection), OR)
+        else:
+            raise NotImplementedError(
+                'Only direct lookups are supported on composite fields'
+            )
+        return constraint
+
+
+class SubfieldTransform(Transform):
+    def __init__(self, lhs, init_lookups):
+        self.output_field = lhs.target.get_subfield(init_lookups[0])
+        lhs = self.output_field.get_col(lhs.alias)
+        super(SubfieldTransform, self).__init__(lhs, init_lookups)
+
+    def as_sql(self, compiler, connection):
+        lhs, params = compiler.compile(self.lhs)
+        return '%s' % lhs, params

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -195,7 +195,7 @@ class Options(object):
             in self.managers if not abstract
         ]
 
-    def contribute_to_class(self, cls, name):
+    def contribute_to_class(self, cls, name, deferred=False):
         from django.db import connection
         from django.db.backends.utils import truncate_name
 
@@ -249,6 +249,7 @@ class Options(object):
         if not self.db_table:
             self.db_table = "%s_%s" % (self.app_label, self.model_name)
             self.db_table = truncate_name(self.db_table, connection.ops.max_name_length())
+        return True
 
     def _prepare(self, model):
         if self.order_with_respect_to:
@@ -467,6 +468,14 @@ class Options(object):
             "related_objects",
             (obj for obj in all_related_fields
             if not obj.hidden or obj.field.many_to_many)
+        )
+
+    @cached_property
+    def composite_fields(self):
+        return make_immutable_fields_list(
+            "composite_fields",
+            (f for f in self.virtual_fields if f.is_composite)
+
         )
 
     @raise_deprecation(suggested_alternative="get_fields()")

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -17,6 +17,7 @@ from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Col, Ref
+from django.db.models.fields.composite_lookups import CompositeCol
 from django.db.models.fields.related_lookups import MultiColSource
 from django.db.models.query_utils import Q, PathInfo, refs_expression
 from django.db.models.sql.constants import (
@@ -1170,6 +1171,12 @@ class Query(object):
                 lhs = targets[0].get_col(alias, field)
             else:
                 lhs = MultiColSource(alias, targets, sources, field)
+            condition = lookup_class(lhs, value)
+            lookup_type = lookup_class.lookup_name
+        elif field.is_composite and field.get_lookup(lookups[0]):
+            # A lookup directly on the field
+            lookup_class = field.get_lookup(lookups[0])
+            lhs = CompositeCol(alias, field)
             condition = lookup_class(lhs, value)
             lookup_type = lookup_class.lookup_name
         else:

--- a/django/utils/observables.py
+++ b/django/utils/observables.py
@@ -1,0 +1,373 @@
+import weakref
+import collections
+import inspect
+from django.utils import six
+
+
+class _NoValue:
+    def __repr__(self):
+        return 'NO_VALUE'
+
+NO_VALUE = _NoValue()
+
+
+def _is_descriptor(attribute):
+    return any(hasattr(attribute, method)
+               for method in {'__get__', '__set__', '__delete__'})
+
+
+class ChangeRecord(collections.namedtuple(
+    'ChangeRecord',
+    ('type', 'observable', 'key', 'old', 'new')
+)):
+    def __new__(cls, type, observable, key, old=NO_VALUE, new=NO_VALUE):
+        return super(ChangeRecord, cls).__new__(
+            cls, type, observable, key, old, new
+        )
+
+    @classmethod
+    def item(cls, observable, key, old=NO_VALUE, new=NO_VALUE):
+        return cls('item', observable, key, old=old, new=new)
+
+    @classmethod
+    def attribute(cls, observable, key, old=NO_VALUE, new=NO_VALUE):
+        return cls('attribute', observable, key, old=old, new=new)
+
+    @property
+    def type(self):
+        """ The type of the change record. Value must be one of:
+        - 'item':
+            The 'key' of the record represents an index into a sequence or
+            a key of a mapping
+        - 'attribute':
+            The 'key' of the record represents an attribute of an object.
+        """
+        return super(ChangeRecord, self).type
+
+    @property
+    def insert(self):
+        return self.old is NO_VALUE
+
+    @property
+    def remove(self):
+        return self.new is NO_VALUE
+
+
+class Observable(object):
+
+    def add_observer(self, observer):
+        if not hasattr(observer, 'handle_changes'):
+            raise TypeError("observer must have a 'handl_changes' method")
+        observer_ref = weakref.ref(observer, self._remove_observer_ref)
+        self.observer_refs.append(observer_ref)
+
+    @property
+    def observer_refs(self):
+        """
+        Returns a list of weak references to the observers of the observable
+        """
+        return self.__dict__.setdefault('_observer_refs', list())
+
+    def _remove_observer_ref(self, observer_ref):
+        self.observer_refs.remove(observer_ref)
+
+    @property
+    def _resolved_attribute_descriptors(self):
+        return self.__dict__.setdefault('_attribute_setters', {})
+
+    @property
+    def _change_notifier(self):
+        return self.__dict__.setdefault(
+            '_change_notifier_', ChangeNotifier(self)
+        )
+
+    def _resolve_descriptor(self, attr_name):
+        for cls in inspect.getmro(type(self)):
+            attr = cls.__dict__.get(attr_name, None)
+            if attr is None:
+                continue
+            return attr if _is_descriptor(attr) else None
+
+    def __setattr__(self, attr_name, value):
+        old_value = getattr(self, attr_name, NO_VALUE)
+        if attr_name not in self.__dict__:
+            descriptor = self._resolve_descriptor(attr_name)
+            if descriptor is not None:
+                if hasattr(descriptor, '__set__'):
+                    descriptor.__set__(self, value)
+                    return self._attribute_changed(attr_name, old_value, value)
+                else:
+                    raise AttributeError(
+                        "Cannot set attribute '{0}'".format(attr_name)
+                    )
+        self._attribute_changed(attr_name, old_value, value)
+        self.__dict__[attr_name] = value
+
+    def __delattr__(self, attr_name):
+        raise NotImplementedError('ObservableMixin.__delattr__')
+
+    def _attribute_changed(self, attr_name, old, new):
+        self._change_notifier.deliver(ChangeRecord.attribute(
+            self, attr_name, old=old, new=new
+        ))
+
+
+class ObservableList(list, Observable):
+
+    def __setitem__(self, index, value):
+        if isinstance(index, slice):
+            return self._setitem_slice(index, value)
+        with ChangeNotifier(self) as notifier:
+            index = self._positive_index(index)
+            notifier.deliver(self._mutate_record(index, value))
+            super(ObservableList, self).__setitem__(index, value)
+
+    def _setitem_slice(self, slice, value):
+        start, stop, step = slice.indices(len(self))
+        if step == 1:
+            with ChangeNotifier(self) as notifier:
+                r = range(start, stop, step)
+                # Clear out the list in reverse order so that we don't mess
+                # with the indexes of items we remove later
+                for i in reversed(r):
+                    notifier.deliver(self._remove_record(i))
+                # Add all the items back into the list in reversed order
+                for item in reversed(value):
+                    notifier.deliver(self._insert_record(start, item))
+                super(ObservableList, self).__setitem__(slice, value)
+        else:
+            # If the step isn't one, then the value must be the same length
+            # as the slice
+            r = range(start, stop, step)
+            if len(value) != len(r):
+                # Just delegate to super to throw the correct error
+                super(ObservableList, self).__setitem__(slice, value)
+            # Otherwise just __setitem__ on each value in turn. Zip could return
+            # an unexpected error (zip argument #2 does not support iteration)
+            # but meh. Who in their right mind uses assignment to a range
+            # anyway?
+            for i, item in zip(r, value):
+                self.__setitem__(i, item)
+
+    def __delitem__(self, index):
+        if isinstance(index, slice):
+            return self._delitem_slice(index)
+        index = self._positive_index(index)
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._remove_record(index))
+            super(ObservableList, self).__delitem__(index)
+
+    def _delitem_slice(self, slice):
+        start, stop, step = slice.indices(len(self))
+        r = range(start, stop, step)
+        if step > 0:
+            # Reverse the range so that we don't remove lower indexes before
+            # higher ones
+            r = reversed(r)
+        with ChangeNotifier(self) as notifier:
+            for i in r:
+                notifier.deliver(self._remove_record(i))
+            super(ObservableList, self).__delitem__(slice)
+
+    def __iadd__(self, li):
+        if not isinstance(li, list):
+            raise TypeError(
+                'Can only concatenate "list" (not "{0}") to list'
+                .format(type(li))
+            )
+        with ChangeNotifier(self) as notifier:
+            _len = len(self)
+            for index, item in enumerate(li):
+                notifier.deliver(self._insert_record(_len + index, item))
+            return super(ObservableList, self).__iadd__(li)
+
+    def __imul__(self, value):
+        if not isinstance(value, six.integer_types):
+            raise TypeError(
+                "Cannot multiply sequence by non-int of type '{0}'"
+                .format(type(value))
+            )
+        if value <= 0:
+            self.clear()
+        with ChangeNotifier(self) as notifier:
+            for i in range(1, value):
+                start = i * len(self)
+                for index, item in enumerate(self):
+                    notifier.deliver(self._insert_record(start + index, item))
+            return super(ObservableList, self).__imul__(value)
+
+    def append(self, item):
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._insert_record(len(self), item))
+            super(ObservableList, self).append(item)
+
+    def insert(self, index, item):
+        index = self._positive_index(index)
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._insert_record(index, item))
+            super(ObservableList, self).insert(index, item)
+
+    def extend(self, iterable):
+        with ChangeNotifier(self) as notifier:
+            for index, item in enumerate(iterable):
+                notifier.deliver(self._insert_record(len(self) + index, item))
+            super(ObservableList, self).extend(iterable)
+
+    def clear(self):
+        with ChangeNotifier(self) as notifier:
+            for i in reversed(range(len(self))):
+                notifier.deliver(self._remove_record(i))
+            super(ObservableList, self).clear()
+
+    def pop(self, index=None):
+        if index is None:
+            index = len(self) - 1
+        index = self._positive_index(index)
+        if not isinstance(index, six.integer_types):
+            raise TypeError("'{0}' cannot be interpreted as integer"
+                            .format(type(index)))
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._remove_record(index))
+            return super(ObservableList, self).pop(index)
+
+    def remove(self, value):
+        with ChangeNotifier(self) as notifier:
+            for i, item in enumerate(self):
+                if item == value:
+                    notifier.deliver(self._remove_record(i))
+            super(ObservableList, self).remove(value)
+
+    def reverse(self):
+        """ Reverse *IN PLACE* """
+        with ChangeNotifier(self) as notifier:
+            last = len(self) - 1
+            for i in range(int(len(self) / 2)):
+                notifier.deliver(self._mutate_record(i, self[last - i]))
+                notifier.deliver(self._mutate_record(last - i, self[i]))
+            super(ObservableList, self).reverse()
+
+    def sort(self):
+        raise NotImplementedError(
+            "in-place sort not implemented for observable lists. "
+            "Copy the list using the builtin `sorted` instead"
+        )
+
+    def _positive_index(self, index):
+        if not isinstance(index, six.integer_types):
+            raise TypeError(
+                "list indices must be 'int', not '{0}'".format(type(index))
+            )
+        return len(self) + index if index < 0 else index
+
+    def _mutate_record(self, index, new_value):
+        return ChangeRecord.item(self, index, old=self[index], new=new_value)
+
+    def _insert_record(self, index, value):
+        return ChangeRecord.item(self, index, new=value)
+
+    def _remove_record(self, index):
+        return ChangeRecord.item(self, index, old=self[index])
+
+
+class _ObservableMapping(Observable):
+    def __delitem__(self, key):
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._remove_record(key))
+            super(_ObservableMapping, self).__delitem__(key)
+
+    def __setitem__(self, key, value):
+        with ChangeNotifier(self) as notifier:
+            if key in self:
+                notifier.deliver(self._mutate_record(key, value))
+            else:
+                notifier.deliver(self._insert_record(key, value))
+            super(_ObservableMapping, self).__setitem__(key, value)
+
+    def clear(self):
+        with ChangeNotifier(self) as notifier:
+            for key, value in self.items():
+                notifier.deliver(self._remove_record(key, value))
+            super(_ObservableMapping, self).clear()
+
+    def pop(self, key):
+        with ChangeNotifier(self) as notifier:
+            notifier.deliver(self._remove_record(key))
+            return super(_ObservableMapping, self).pop(key)
+
+    def popitem(self):
+        with ChangeNotifier(self) as notifier:
+            k, v = super(_ObservableMapping, self).popitem()
+            notifier.deliver(self._remove_record(k, value=v))
+            return (k, v)
+
+    def setdefault(self, key, value):
+        with ChangeNotifier(self) as notifier:
+            if key not in self:
+                notifier.deliver(self._insert_record(key, value))
+            super(_ObservableMapping, self).setdefault(key, value)
+
+    def update(self, *args, **kwargs):
+        # to_update is an OrderedDict so that ObservableOrderedDict doesn't
+        # lose the order on update
+        to_update = collections.OrderedDict(*args, **kwargs)
+        with ChangeNotifier(self) as notifier:
+            for k, v in to_update.items():
+                if k in self:
+                    notifier.deliver(self._mutate_record(k, v))
+                else:
+                    notifier.deliver(self._insert_record(k, v))
+            super(_ObservableMapping, self).update(to_update)
+
+    def _mutate_record(self, key, new):
+        return ChangeRecord.item(self, key, old=self[key], new=new)
+
+    def _insert_record(self, key, value):
+        return ChangeRecord.item(self, key, new=value)
+
+    def _remove_record(self, key, value=NO_VALUE):
+        value = self[key] if value is NO_VALUE else value
+        return ChangeRecord.item(self, key, old=value)
+
+
+class ObservableDict(_ObservableMapping, dict):
+    pass
+
+
+class ObservableOrderedDict(_ObservableMapping, collections.OrderedDict):
+    pass
+
+
+class ChangeNotifier(object):
+    """
+    An obect which collects and delivers changes for an observable.
+
+    When used as a context manager, this class will batch all delivered requests
+    and deliver them as a single group of changes
+    """
+    def __init__(self, observable):
+        self.observable = observable
+        self._batch = None
+
+    def __enter__(self):
+        self._batch = list()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is None:
+            self._send_changes(self._batch)
+        self._batch = None
+        # Don't suppress any exceptions
+        return False
+
+    def deliver(self, change_record):
+        if self._batch is None:
+            self._send_changes([change_record, ])
+        else:
+            self._batch.append(change_record)
+
+    def _send_changes(self, changes):
+        for observer_ref in self.observable.observer_refs:
+            observer = observer_ref()
+            if observer is None:
+                continue
+            observer.handle_changes(changes)

--- a/django/utils/observables.py
+++ b/django/utils/observables.py
@@ -1,6 +1,7 @@
-import weakref
 import collections
 import inspect
+import weakref
+
 from django.utils import six
 
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -188,6 +188,23 @@ class GenericIPAddress(models.Model):
 
 
 ###############################################################################
+# Composite fields
+
+class ConstraintField(models.Model):
+    x = models.IntegerField()
+    y = models.IntegerField()
+
+    point = models.constrain(x, y)
+
+
+class UnnamedConstraintField(models.Model):
+    x = models.IntegerField()
+    y = models.IntegerField()
+
+    _ = models.constrain(x, y)
+
+
+###############################################################################
 # These models aren't used in any test, just here to ensure they validate
 # successfully.
 

--- a/tests/model_fields/test_composite_field.py
+++ b/tests/model_fields/test_composite_field.py
@@ -1,0 +1,82 @@
+from django.db.models import CompositeField
+from django.db.models.fields.composite import Subfield
+from django.test import TestCase
+
+from .models import ConstraintField
+
+
+class TestUniqueConstraint(TestCase):
+    def setUp(self):
+        self.objs = [
+            ConstraintField.objects.create(point={'x': 0, 'y': 0}),
+            ConstraintField.objects.create(point={'x': 0, 'y': 1}),
+            ConstraintField.objects.create(point={'x': 0, 'y': -1}),
+            ConstraintField.objects.create(point={'x': 1, 'y': 0}),
+            ConstraintField.objects.create(point={'x': 1, 'y': 1})
+        ]
+        self.meta = ConstraintField._meta
+        self.field = self.meta.get_field('point')
+
+    def test_composite_fields_subfields(self):
+        self.assertIsInstance(
+            self.field, CompositeField
+        )
+        self.assertEqual(
+            self.field.subfields, {
+                'x': Subfield(self.field, self.meta.get_field('x')),
+                'y': Subfield(self.field, self.meta.get_field('y'))
+            }
+        )
+
+    def test_subfield_params(self):
+        x_subfield = self.field.subfields['x']
+        self.assertEqual(x_subfield.attname, 'x')
+        self.assertEqual(
+            x_subfield.creation_counter,
+            self.field.creation_counter
+        )
+        self.assertEqual(
+            x_subfield.subfield_creation_counter,
+            self.meta.get_field('x').creation_counter
+        )
+
+    def test_subfield_mutation(self):
+        obj = self.objs[0]
+        obj.point['x'] = 14
+        self.assertEqual(obj.x, 14)
+
+        obj.x = 15
+        self.assertEqual(obj.point['x'], 15)
+
+    def test_composite_transform_lookup(self):
+        objs = ConstraintField.objects.filter(point__x=0).all()
+        self.assertEquals(
+            sorted(obj.pk for obj in objs),
+            [self.objs[0].pk, self.objs[1].pk, self.objs[2].pk]
+        )
+
+        objs = ConstraintField.objects.filter(
+            point__x=0, point__y__gte=0, point__y__lte=1
+        ).all()
+        self.assertEqual(
+            sorted(obj.pk for obj in objs),
+            [self.objs[0].pk, self.objs[1].pk]
+        )
+
+    def test_query_constraint(self):
+        obj = ConstraintField.objects.get(point={'x': 0, 'y': 0})
+        self.assertEquals(obj.pk, self.objs[0].pk)
+
+    def test_values(self):
+        objs = (
+            ConstraintField.objects.filter(point__x=0)
+            .values('point', 'y').all()
+        )
+        objs = list(objs)
+        self.assertEqual(
+            objs, [
+                {'point': {'x': 0, 'y': 0}, 'y': 0},
+                {'point': {'x': 0, 'y': 1}, 'y': 1},
+                {'point': {'x': 0, 'y': -1}, 'y': -1}
+            ]
+        )

--- a/tests/model_meta/models.py
+++ b/tests/model_meta/models.py
@@ -27,6 +27,9 @@ class AbstractPerson(models.Model):
         related_name='fo_abstract_rel',
     )
 
+    # COMPOSITE fields
+    constrain_abstract = models.constrain(data_abstract)
+
     # GFK fields
     content_type_abstract = models.ForeignKey(ContentType, related_name='+')
     object_id_abstract = models.PositiveIntegerField()
@@ -57,6 +60,9 @@ class BasePerson(AbstractPerson):
         related_name='fo_base_rel',
     )
 
+    # COMPOSITE fields
+    constrain_base = models.constrain('data_abstract', data_base)
+
     # GFK fields
     content_type_base = models.ForeignKey(ContentType, related_name='+')
     object_id_base = models.PositiveIntegerField()
@@ -82,6 +88,11 @@ class Person(BasePerson):
         from_fields=['model_non_concrete_id'],
         to_fields=['id'],
         related_name='fo_concrete_rel',
+    )
+
+    # COMPOSITE fields
+    constrain_concrete = models.constrain(
+        data_inherited, 'data_base', 'data_abstract'
     )
 
     # GFK fields

--- a/tests/model_meta/results.py
+++ b/tests/model_meta/results.py
@@ -5,6 +5,9 @@ TEST_RESULTS = {
         Person: [
             'baseperson_ptr',
             'baseperson_ptr_id',
+            'constrain_abstract',
+            'constrain_base',
+            'constrain_concrete',
             'content_type_abstract',
             'content_type_abstract_id',
             'content_type_base',
@@ -48,6 +51,8 @@ TEST_RESULTS = {
             'relating_person',
         ],
         BasePerson: [
+            'constrain_abstract',
+            'constrain_base',
             'content_type_abstract',
             'content_type_abstract_id',
             'content_type_base',
@@ -78,6 +83,7 @@ TEST_RESULTS = {
             'relating_baseperson'
         ],
         AbstractPerson: [
+            'constrain_abstract',
             'content_type_abstract',
             'content_type_abstract_id',
             'data_abstract',
@@ -129,6 +135,9 @@ TEST_RESULTS = {
             'data_not_concrete_inherited',
             'content_type_concrete_id',
             'object_id_concrete',
+            'constrain_concrete',
+            'constrain_base',
+            'constrain_abstract',
         ],
         BasePerson: [
             'id',
@@ -142,6 +151,8 @@ TEST_RESULTS = {
             'data_not_concrete_base',
             'content_type_base_id',
             'object_id_base',
+            'constrain_base',
+            'constrain_abstract',
         ],
         AbstractPerson: [
             'data_abstract',
@@ -149,6 +160,7 @@ TEST_RESULTS = {
             'data_not_concrete_abstract',
             'content_type_abstract_id',
             'object_id_abstract',
+            'constrain_abstract',
         ],
         Relating: [
             'id',
@@ -265,6 +277,25 @@ TEST_RESULTS = {
             'people',
             'people_hidden',
         ],
+    },
+    'composite_fields': {
+        Person: [
+            'constrain_concrete',
+            'constrain_base',
+            'constrain_abstract',
+        ],
+        BasePerson: [
+            'constrain_base',
+            'constrain_abstract',
+        ],
+        AbstractPerson: [
+            'constrain_abstract'
+        ]
+    },
+    'composite_field_subfields': {
+        'constrain_abstract': ['data_abstract'],
+        'constrain_base': ['data_abstract', 'data_base'],
+        'constrain_concrete': ['data_abstract', 'data_base', 'data_inherited']
     },
     'many_to_many_with_model': {
         Person: [
@@ -773,16 +804,22 @@ TEST_RESULTS = {
     },
     'virtual_fields': {
         AbstractPerson: [
+            'constrain_abstract',
             'generic_relation_abstract',
             'content_object_abstract',
         ],
         BasePerson: [
+            'constrain_abstract',
+            'constrain_base',
             'generic_relation_base',
             'content_object_base',
             'generic_relation_abstract',
             'content_object_abstract',
         ],
         Person: [
+            'constrain_abstract',
+            'constrain_base',
+            'constrain_concrete',
             'content_object_concrete',
             'generic_relation_concrete',
             'generic_relation_base',

--- a/tests/model_meta/test_legacy.py
+++ b/tests/model_meta/test_legacy.py
@@ -1,7 +1,6 @@
 import warnings
 
 from django import test
-from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.fields import CharField, related
 from django.utils.deprecation import RemovedInDjango20Warning
@@ -133,11 +132,6 @@ class GetFieldByNameTests(OptionsBaseTests):
         field_info = Person._meta.get_field_by_name('relating_people')
         self.assertEqual(field_info[1:], (None, False, True))
         self.assertTrue(field_info[0].auto_created)
-
-    def test_get_generic_relation(self):
-        field_info = Person._meta.get_field_by_name('generic_relation_base')
-        self.assertEqual(field_info[1:], (None, True, False))
-        self.assertIsInstance(field_info[0], GenericRelation)
 
     def test_get_m2m_field_invalid(self):
         with warnings.catch_warnings(record=True) as warning:

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -73,6 +73,14 @@ class DataTests(OptionsBaseTests):
             for f in fields:
                 self.assertIsNotNone(f.column)
 
+    def test_composite_fields(self):
+        for model, expected_result in TEST_RESULTS['composite_fields'].items():
+            fields = model._meta.composite_fields
+            self.assertEqual([f.attname for f in fields], expected_result)
+            for f in fields:
+                subfields = TEST_RESULTS['composite_field_subfields'][f.name]
+                self.assertEqual(sorted(f.subfields), subfields)
+
 
 class M2MTests(OptionsBaseTests):
 

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -141,7 +141,7 @@ class TeamField(models.CharField):
         return Team(value)
 
     def value_to_string(self, obj):
-        return self._get_val_from_obj(obj).to_string()
+        return getattr(obj, self.attname).to_string()
 
     def deconstruct(self):
         name, path, args, kwargs = super(TeamField, self).deconstruct()

--- a/tests/utils_tests/observables/test_change_notifier.py
+++ b/tests/utils_tests/observables/test_change_notifier.py
@@ -1,0 +1,82 @@
+from django.test import TestCase
+
+from django.utils.observables import (
+    ChangeNotifier, ChangeRecord, Observable
+)
+
+
+class Observer(object):
+    def __init__(self):
+        self.changes = list()
+
+    def handle_changes(self, change_records):
+        self.changes.extend(change_records)
+
+
+class MockObservable(Observable):
+    pass
+
+
+class TestChangeNotifier(TestCase):
+    def setUp(self):
+        self.observer_one = Observer()
+        self.observer_two = Observer()
+        self.observable = MockObservable()
+
+    def _emit_record(self, notifier):
+        record = ChangeRecord('key', self.observable, 'key')
+        notifier.deliver(record)
+        return record
+
+    def test_no_observers(self):
+        with ChangeNotifier(self.observable) as notifier:
+            self._emit_record(notifier)
+
+        self.assertEqual(self.observer_one.changes, [])
+        self.assertEqual(self.observer_two.changes, [])
+
+    def test_single_observer(self):
+        self.observable.add_observer(self.observer_one)
+        with ChangeNotifier(self.observable) as notifier:
+            record = self._emit_record(notifier)
+            # Should not deliver changes until context has exited
+            self.assertEqual(self.observer_one.changes, [])
+
+        self.assertEqual(self.observer_one.changes, [record, ])
+        self.assertEqual(self.observer_two.changes, [])
+
+    def test_multiple_observers(self):
+        self.observable.add_observer(self.observer_one)
+        self.observable.add_observer(self.observer_two)
+
+        with ChangeNotifier(self.observable) as notifier:
+            record = self._emit_record(notifier)
+
+        self.assertEqual(self.observer_one.changes, [record, ])
+        self.assertEqual(self.observer_two.changes, [record, ])
+
+    def test_exception_handling(self):
+        self.observable.add_observer(self.observer_one)
+        cn = ChangeNotifier(self.observable)
+        try:
+            with cn as notifier:
+                self._emit_record(notifier)
+                raise NotImplementedError()
+        except NotImplementedError:
+            # Changes should not have been delivered
+            self.assertEqual(self.observer_one.changes, [])
+        else:
+            self.fail('Exception not passed out of context')
+
+        # Can reuse a notifier
+        with cn as notifier:
+            record = self._emit_record(notifier)
+
+        self.assertEqual(self.observer_one.changes, [record, ])
+
+    def test_no_context(self):
+        self.observable.add_observer(self.observer_one)
+        notifier = ChangeNotifier(self.observable)
+        record = self._emit_record(notifier)
+
+        self.assertEqual(self.observer_one.changes, [record, ])

--- a/tests/utils_tests/observables/test_change_notifier.py
+++ b/tests/utils_tests/observables/test_change_notifier.py
@@ -1,8 +1,5 @@
 from django.test import TestCase
-
-from django.utils.observables import (
-    ChangeNotifier, ChangeRecord, Observable
-)
+from django.utils.observables import ChangeNotifier, ChangeRecord, Observable
 
 
 class Observer(object):

--- a/tests/utils_tests/observables/test_observable_dict.py
+++ b/tests/utils_tests/observables/test_observable_dict.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.utils.observables import ObservableDict, ChangeRecord
+from django.utils.observables import ChangeRecord, ObservableDict
 
 
 class Observer(object):

--- a/tests/utils_tests/observables/test_observable_dict.py
+++ b/tests/utils_tests/observables/test_observable_dict.py
@@ -1,0 +1,94 @@
+from django.test import TestCase
+from django.utils.observables import ObservableDict, ChangeRecord
+
+
+class Observer(object):
+    def __init__(self):
+        self.changes = list()
+
+    def handle_changes(self, change_records):
+        self.changes = list(change_records)
+
+
+class TestObservableDict(TestCase):
+    def setUp(self):
+        self.observer = Observer()
+        self._mkdict()
+
+    def _mkdict(self):
+        self.observer.changes.clear()
+        self.dict = ObservableDict({
+            'a': 1,
+            'b': 2,
+            'c': 3
+        })
+        self.dict.add_observer(self.observer)
+
+    def assertItemsEqual(self, iterable1, iterable2):
+        self.assert_(sorted(iterable1) == sorted(iterable2))
+
+    def test_delitem(self):
+        del self.dict['a']
+        self.assertEquals(self.dict, {'b': 2, 'c': 3})
+        self.assertEquals(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'a', old=1)
+        ])
+
+    def test_setitem(self):
+        self.dict['a'] = 26
+        self.assertEquals(self.dict, {'a': 26, 'b': 2, 'c': 3})
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'a', old=1, new=26),
+        ])
+
+        self._mkdict()
+        self.dict['d'] = 4
+        self.assertEquals(self.dict, {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'd', new=4)
+        ])
+
+    def test_clear(self):
+        self.dict.clear()
+        self.assertEquals(self.dict, {})
+        # We don't know in which order the items are cleared
+        self.assertItemsEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'a', old=1),
+            ChangeRecord.item(self.dict, 'b', old=2),
+            ChangeRecord.item(self.dict, 'c', old=3)
+        ])
+
+    def test_pop(self):
+        result = self.dict.pop('a')
+        self.assertEqual(result, 1)
+        self.assertEqual(self.dict, {'b': 2, 'c': 3})
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'a', old=1)
+        ])
+
+    def test_popitem(self):
+        k, v = self.dict.popitem()
+        self.assertFalse(k in self.dict)
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, k, old=v)
+        ])
+
+    def test_setdefault(self):
+        self.dict.setdefault('a', 4)
+        self.assertEqual(self.dict, {'a': 1, 'b': 2, 'c': 3})
+        self.assertEqual(self.observer.changes, [])
+
+        self.dict.setdefault('d', 4)
+        self.assertEqual(self.dict, {'a': 1, 'b': 2, 'c': 3, 'd': 4})
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'd', new=4)
+        ])
+
+    def test_update(self):
+        self.dict.update({'d': 5}, c=6, f=7)
+        self.assertEqual(self.dict, {'a': 1, 'b': 2, 'c': 6, 'd': 5, 'f': 7})
+        self.assertItemsEqual(self.observer.changes, [
+            ChangeRecord.item(self.dict, 'c', old=3, new=6),
+            ChangeRecord.item(self.dict, 'd', new=5),
+            ChangeRecord.item(self.dict, 'f', new=7)
+        ])

--- a/tests/utils_tests/observables/test_observable_list.py
+++ b/tests/utils_tests/observables/test_observable_list.py
@@ -1,0 +1,278 @@
+from django.test import TestCase
+from django.utils.observables import ObservableList, ChangeRecord
+
+
+class Observer(object):
+    def __init__(self):
+        self.changes = list()
+
+    def handle_changes(self, change_records):
+        self.changes.extend(change_records)
+
+
+class TestObservableList(TestCase):
+    def setUp(self):
+        self.observer = Observer()
+        self._mklist(range(3))
+
+    def _mklist(self, li):
+        self.observer.changes.clear()
+        self.list = ObservableList(li)
+        self.list.add_observer(self.observer)
+
+    def test_setitem(self):
+        self.list[1] = 'hello'
+        self.assertEqual(self.list, [0, 'hello', 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 1, old=1, new='hello')
+            ]
+        )
+
+        # Using a negative.item should create records with a positive.item
+        self._mklist(range(3))
+        self.list[-2] = 'world'
+        self.assertEqual(self.list, [0, 'world', 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 1, old=1, new='world'),
+            ]
+        )
+
+    def test_setitem_slice(self):
+        self._mklist(range(10))
+
+        self.list[3:8] = ['a', 'b']
+        self.assertEqual(self.list, [0, 1, 2, 'a', 'b', 8, 9])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 7, old=7),
+                ChangeRecord.item(self.list, 6, old=6),
+                ChangeRecord.item(self.list, 5, old=5),
+                ChangeRecord.item(self.list, 4, old=4),
+                ChangeRecord.item(self.list, 3, old=3),
+                ChangeRecord.item(self.list, 3, new='b'),
+                ChangeRecord.item(self.list, 3, new='a')
+            ]
+        )
+
+        self._mklist(range(10))
+        self.list[0:10:2] = ['a', 'b', 'c', 'd', 'e']
+        self.assertEqual(self.list, ['a', 1, 'b', 3, 'c', 5, 'd', 7, 'e', 9])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 0, old=0, new='a'),
+                ChangeRecord.item(self.list, 2, old=2, new='b'),
+                ChangeRecord.item(self.list, 4, old=4, new='c'),
+                ChangeRecord.item(self.list, 6, old=6, new='d'),
+                ChangeRecord.item(self.list, 8, old=8, new='e'),
+            ]
+        )
+
+        self._mklist(range(10))
+        self.list[10:0:-2] = ['a', 'b', 'c', 'd', 'e']
+        self.assertEqual(self.list, [0, 'e', 2, 'd', 4, 'c', 6, 'b', 8, 'a'])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 9, old=9, new='a'),
+                ChangeRecord.item(self.list, 7, old=7, new='b'),
+                ChangeRecord.item(self.list, 5, old=5, new='c'),
+                ChangeRecord.item(self.list, 3, old=3, new='d'),
+                ChangeRecord.item(self.list, 1, old=1, new='e'),
+            ]
+        )
+
+    def test_delitem(self):
+        del self.list[1]
+        self.assertEqual(self.list, [0, 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 1, old=1)
+            ]
+        )
+
+    def test_delitem_slice(self):
+        self._mklist(range(10))
+
+        # contiguous items
+        del self.list[5:]
+        self.assertEqual(self.list, [0, 1, 2, 3, 4])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 9, old=9),
+                ChangeRecord.item(self.list, 8, old=8),
+                ChangeRecord.item(self.list, 7, old=7),
+                ChangeRecord.item(self.list, 6, old=6),
+                ChangeRecord.item(self.list, 5, old=5)
+            ]
+        )
+
+        # non-unit step
+        self._mklist(range(10))
+        del self.list[0:10:3]
+        self.assertEqual(self.list, [1, 2, 4, 5, 7, 8])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 9, old=9),
+                ChangeRecord.item(self.list, 6, old=6),
+                ChangeRecord.item(self.list, 3, old=3),
+                ChangeRecord.item(self.list, 0, old=0)
+            ]
+        )
+
+        # backwards range. Should still delete items from highest to lowest
+        self._mklist(range(10))
+        del self.list[10:0:-3]
+        self.assertEqual(self.list, [0, 1, 2, 4, 5, 7, 8])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 9, old=9),
+                ChangeRecord.item(self.list, 6, old=6),
+                ChangeRecord.item(self.list, 3, old=3)
+            ]
+        )
+
+    def test_inplace_add(self):
+        with self.assertRaises(TypeError):
+            self.list += ('a', 'b', 'c')
+
+        self.list += ['a', 'b', 'c']
+        self.assertEqual(self.list, [0, 1, 2, 'a', 'b', 'c'])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 3, new='a'),
+                ChangeRecord.item(self.list, 4, new='b'),
+                ChangeRecord.item(self.list, 5, new='c')
+            ]
+        )
+
+    def test_add(self):
+        self.list = self.list + ['a', 'b', 'c']
+        self.assertEqual(self.list, [0, 1, 2, 'a', 'b', 'c'])
+        self.assertEqual(self.observer.changes, [])
+
+    def test_inplace_mul(self):
+        with self.assertRaises(TypeError):
+            self.list *= 'a'
+        self.list *= 2
+        self.assertEqual(self.list, [0, 1, 2, 0, 1, 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 3, new=0),
+                ChangeRecord.item(self.list, 4, new=1),
+                ChangeRecord.item(self.list, 5, new=2)
+            ])
+        self.observer.changes.clear()
+        self.list *= -1
+        self.assertEqual(self.list, [])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 5, old=2),
+                ChangeRecord.item(self.list, 4, old=1),
+                ChangeRecord.item(self.list, 3, old=0),
+                ChangeRecord.item(self.list, 2, old=2),
+                ChangeRecord.item(self.list, 1, old=1),
+                ChangeRecord.item(self.list, 0, old=0)
+            ]
+        )
+
+    def test_mul(self):
+        self.list = self.list * 2
+        self.assertEqual(self.list, [0, 1, 2, 0, 1, 2])
+        self.assertEqual(self.observer.changes, [])
+
+    def test_append(self):
+        self.list.append('hello')
+        self.assertEqual(self.list, [0, 1, 2, 'hello'])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 3, new='hello')
+            ]
+        )
+
+    def test_insert(self):
+        self.list.insert(1, 'hello')
+        self.assertEqual(self.list, [0, 'hello', 1, 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 1, new='hello')
+            ]
+        )
+
+    def test_extend(self):
+        self.list.extend(('a', 'b', 'c'))
+        self.assertEqual(self.list, [0, 1, 2, 'a', 'b', 'c'])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 3, new='a'),
+                ChangeRecord.item(self.list, 4, new='b'),
+                ChangeRecord.item(self.list, 5, new='c')
+            ]
+        )
+
+    def test_clear(self):
+        self.list.clear()
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 2, old=2),
+                ChangeRecord.item(self.list, 1, old=1),
+                ChangeRecord.item(self.list, 0, old=0)
+            ]
+        )
+
+    def test_pop(self):
+        result = self.list.pop(0)
+        self.assertEqual(result, 0)
+        self.assertEqual(self.list, [1, 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 0, old=0)
+            ]
+        )
+
+    def test_remove(self):
+        with self.assertRaises(ValueError):
+            self.list.remove(14)
+        self.list.remove(1)
+        self.assertEqual(self.list, [0, 2])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 1, old=1)
+            ]
+        )
+
+    def test_inplace_reverse(self):
+        self.list.reverse()
+        self.assertEqual(self.list, [2, 1, 0])
+        self.assertEqual(
+            self.observer.changes,
+            [
+                ChangeRecord.item(self.list, 0, old=0, new=2),
+                ChangeRecord.item(self.list, 2, old=2, new=0),
+            ])
+
+
+
+
+
+
+
+

--- a/tests/utils_tests/observables/test_observable_list.py
+++ b/tests/utils_tests/observables/test_observable_list.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.utils.observables import ObservableList, ChangeRecord
+from django.utils.observables import ChangeRecord, ObservableList
 
 
 class Observer(object):
@@ -268,11 +268,3 @@ class TestObservableList(TestCase):
                 ChangeRecord.item(self.list, 0, old=0, new=2),
                 ChangeRecord.item(self.list, 2, old=2, new=0),
             ])
-
-
-
-
-
-
-
-

--- a/tests/utils_tests/observables/test_observable_mixin.py
+++ b/tests/utils_tests/observables/test_observable_mixin.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.utils.observables import Observable, ChangeRecord
+from django.utils.observables import ChangeRecord, Observable
 
 
 class Observer(object):

--- a/tests/utils_tests/observables/test_observable_mixin.py
+++ b/tests/utils_tests/observables/test_observable_mixin.py
@@ -1,0 +1,136 @@
+from django.test import TestCase
+from django.utils.observables import Observable, ChangeRecord
+
+
+class Observer(object):
+    def __init__(self):
+        self.changes = list()
+
+    def handle_changes(self, change_records):
+        self.changes.extend(change_records)
+
+
+class MyObservableBase(Observable):
+    def __init__(self):
+        self._prop_base_value = '70 rpm'
+
+    def _get_prop_base(self):
+        return self._prop_base_value
+
+    def _set_prop_base(self, value):
+        self._prop_base_value = value
+
+    inherited_property = property(_get_prop_base, _set_prop_base)
+    shadowed_property = property(_get_prop_base, _set_prop_base)
+
+
+class MyObservable(MyObservableBase):
+    class_field = None
+
+    def __init__(self):
+        self.instance_field = None
+        self._property_value = None
+        super(MyObservable, self).__init__()
+
+    def _get_prop(self):
+        return self._property_value
+
+    def _set_prop(self, value):
+        self._property_value = value
+
+    def _del_prop(self, value):
+        del self._property_value
+
+    instance_property = property(_get_prop, _set_prop)
+    unsettable_property = property(_get_prop)
+    deletable_property = property(_get_prop, _set_prop, _del_prop)
+    shadowed_property = property(_get_prop, _set_prop)
+
+    def __str__(self):
+        return '<my_observable at {0}>'.format(id(self))
+
+
+class ObservableMixinTest(TestCase):
+    def setUp(self):
+        self.observer = Observer()
+        self._mkinstance()
+
+    def _mkinstance(self):
+        self.observer.changes.clear()
+        self.instance = MyObservable()
+        self.instance.add_observer(self.observer)
+
+    def test_set_class_field(self):
+        self.instance.class_field = 42
+        # The class field value should change on the instance, but not on
+        # the class
+        self.assertEqual(self.instance.class_field, 42)
+        self.assertIs(MyObservable.class_field, None)
+
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, 'class_field',
+                                   old=None, new=42)
+        ])
+
+        self.observer.changes.clear()
+        # Changing the value on the class should not fire an event.
+        MyObservable.class_field = 64
+        # Just like python, setting the class field doesn't update any instance
+        # which has a value for the field in it's __dict__
+        self.assertEqual(self.instance.class_field, 42)
+        self.assertEqual(self.observer.changes, [])
+
+    def test_set_instance_field(self):
+        self.instance.instance_field = 'hello'
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, 'instance_field',
+                                   old=None, new='hello')
+        ])
+        self.observer.changes.clear()
+
+        self.instance.new_instance_field = 'world'
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, 'new_instance_field',
+                                   new='world')
+        ])
+        self.assertTrue(self.observer.changes[0].insert)
+
+    def test_set_property(self):
+        self.instance.instance_property = 'Rolling stones'
+        # setting an instance property should actually call the descriptor
+        # not just set it in the dict.
+        self.assertEqual(self.instance.instance_property, 'Rolling stones')
+        self.assertEqual(self.instance._property_value, 'Rolling stones')
+
+        # It's easier if the changes to both attributes are recorded.
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, '_property_value',
+                         old=None, new='Rolling stones'),
+            ChangeRecord.attribute(self.instance, 'instance_property',
+                         old=None, new='Rolling stones')
+        ])
+
+        # Trying to set an unsettable property should raise an attribute error
+        self.observer.changes.clear()
+        with self.assertRaises(AttributeError):
+            self.instance.unsettable_property = 'The beatles'
+        self.assertEqual(self.observer.changes, [])
+
+    def test_set_property_inherited(self):
+        self.instance.inherited_property = '45 rpm'
+        self.assertEqual(self.instance.inherited_property, '45 rpm')
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, '_prop_base_value',
+                                   old='70 rpm', new='45 rpm'),
+            ChangeRecord.attribute(self.instance, 'inherited_property',
+                                   old='70 rpm', new='45 rpm'),
+        ])
+        self.observer.changes.clear()
+
+        self.instance.shadowed_property = '1600 rpm'
+        self.assertEqual(self.observer.changes, [
+            ChangeRecord.attribute(self.instance, '_property_value',
+                                   old=None, new='1600 rpm'),
+            ChangeRecord.attribute(self.instance, 'shadowed_property',
+                                   old=None, new='1600 rpm')
+        ])


### PR DESCRIPTION
An early cut of the implementation of [DEP 191](https://github.com/django/deps/blob/master/draft/0191-composite-fields.rst) for composite fields. DEP192 will be implemented separately, although some partial implementation of various hooks which will be required for the implementation of standalone composite fields is included, appropriately commented.

Please feel free to review even though implementation is incomplete, it is complete enough for your comments to be valuable (otherwise I wouldn't have submitted the PR). This is a rather large change which will require community consensus.

Done

- Observables and some standard observable collection implementations
- Serialization/deserialization of composite fields
- Implementation of `django.db.models.constrain` factory method
- Custom lookup and transform implementation
- Refactoring of sql compiler to support `values` and expressions spanning multiple columns in a row of a result set

Still to do:

- Serialization
- Apply composite field constraints and indexes to the database table
- Migrations
- Update proposal