### PR TITLE
Fixed a typo and formatting consistency in testing tools docs

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1362,7 +1362,7 @@ your test suite.
 .. method:: SimpleTestCase.assertNotContains(response, text, status_code=200, msg_prefix='', html=False)
 
     Asserts that a ``Response`` instance produced the given ``status_code`` and
-    that ``text`` does not appears in the content of the response.
+    that ``text`` does *not* appear in the content of the response.
 
     Set ``html`` to ``True`` to handle ``text`` as HTML. The comparison with
     the response content will be based on HTML semantics instead of


### PR DESCRIPTION
I changed "appears" to "appear" and emphasized the word "not" to match
the rest of the document.