### PR TITLE
Fixed #24716 -- Deprecated Field._get_val_from_obj()

### DIFF
--- a/django/contrib/gis/serializers/geojson.py
+++ b/django/contrib/gis/serializers/geojson.py
@@ -60,7 +60,7 @@ class Serializer(JSONSerializer):
 
     def handle_field(self, obj, field):
         if field.name == self.geometry_field:
-            self._geometry = field._get_val_from_obj(obj)
+            self._geometry = getattr(obj, field.attname)
         else:
             super(Serializer, self).handle_field(obj, field)
 

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -93,7 +93,7 @@ class ArrayField(Field):
 
     def value_to_string(self, obj):
         values = []
-        vals = self._get_val_from_obj(obj)
+        vals = getattr(obj, self.attname)
         base_field = self.base_field
 
         for val in vals:

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -42,8 +42,7 @@ class HStoreField(Field):
         return value
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
-        return json.dumps(value)
+        return json.dumps(getattr(obj, self.attname))
 
     def formfield(self, **kwargs):
         defaults = {

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -32,7 +32,7 @@ class RangeField(models.Field):
         return value
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = getattr(obj, self.attname)
         if value is None:
             return None
         if value.isempty:

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -44,7 +44,7 @@ class Serializer(base.Serializer):
         return data
 
     def handle_field(self, obj, field):
-        value = field._get_val_from_obj(obj)
+        value = getattr(obj, field.attname)
         # Protected types (i.e., primitives like None, numbers, dates,
         # and Decimals) are passed through as is. All other values are
         # converted to string first.

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -23,7 +23,7 @@ from django.utils.duration import duration_string
 from django.utils.functional import cached_property, curry, total_ordering, Promise
 from django.utils.text import capfirst
 from django.utils import timezone
-from django.utils.deprecation import RemovedInDjango21Warning
+from django.utils.deprecation import RemovedInDjango21Warning, warn_about_renamed_method
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import (smart_text, force_text, force_bytes,
     python_2_unicode_compatible)
@@ -828,18 +828,17 @@ class Field(RegisterLookupMixin):
         first_choice = blank_choice if include_blank else []
         return first_choice + list(self.flatchoices)
 
+    @warn_about_renamed_method('Field', '_get_val_from_obj', 'value_from_object',
+                               RemovedInDjango21Warning)
     def _get_val_from_obj(self, obj):
-        if obj is not None:
-            return getattr(obj, self.attname)
-        else:
-            return self.get_default()
+        return self.value_from_object(obj)
 
     def value_to_string(self, obj):
         """
         Returns a string value of this field from the passed obj.
         This is used by the serialization framework.
         """
-        return smart_text(self._get_val_from_obj(obj))
+        return smart_text(getattr(obj, self.attname))
 
     def _get_flatchoices(self):
         """Flattened version of choices tuple."""
@@ -1298,7 +1297,7 @@ class DateField(DateTimeCheckMixin, Field):
         return connection.ops.value_to_db_date(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -1458,7 +1457,7 @@ class DateTimeField(DateField):
         return connection.ops.value_to_db_datetime(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -1664,7 +1663,7 @@ class DurationField(Field):
         return converters + super(DurationField, self).get_db_converters(connection)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else duration_string(val)
 
     def formfield(self, **kwargs):
@@ -2264,7 +2263,7 @@ class TimeField(DateTimeCheckMixin, Field):
         return connection.ops.value_to_db_time(value)
 
     def value_to_string(self, obj):
-        val = self._get_val_from_obj(obj)
+        val = getattr(obj, self.attname)
         return '' if val is None else val.isoformat()
 
     def formfield(self, **kwargs):
@@ -2331,7 +2330,7 @@ class BinaryField(Field):
 
     def value_to_string(self, obj):
         """Binary data is serialized as base64"""
-        return b64encode(force_bytes(self._get_val_from_obj(obj))).decode('ascii')
+        return b64encode(force_bytes(getattr(obj, self.attname))).decode('ascii')
 
     def to_python(self, value):
         # If it's a string, it should be base64-encoded data

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -705,15 +705,16 @@ Converting field data for serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To customize how the values are serialized by a serializer, you can override
-:meth:`~Field.value_to_string`. Calling ``Field._get_val_from_obj(obj)`` is the
-best way to get the value serialized. For example, since our ``HandField`` uses
-strings for its data storage anyway, we can reuse some existing conversion code::
+:meth:`~Field.value_to_string`. Using ``value_from_object`` is the
+best way to get the field's value prior to serialization. For example, since
+our ``HandField`` uses strings for its data storage anyway, we can reuse some
+existing conversion code::
 
     class HandField(models.Field):
         # ...
 
         def value_to_string(self, obj):
-            value = self._get_val_from_obj(obj)
+            value = self.value_from_object(obj)
             return self.get_prep_value(value)
 
 Some general advice

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -58,6 +58,8 @@ details on these changes.
 * The ``django.template.loaders.base.Loader.__call__()`` method will be
   removed.
 
+* ``Field._get_val_from_obj()`` will be renamed to ``Field.value_from_object()``
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -502,6 +502,8 @@ Miscellaneous
   Therefore, the ``@skipIfCustomUser`` decorator is no longer needed to
   decorate tests in ``django.contrib.auth``.
 
+* ``Field._get_val_from_obj`` was renamed to ``Field.value_from_object``.
+
 .. removed-features-1.9:
 
 Features removed in 1.9

--- a/tests/serializers/models.py
+++ b/tests/serializers/models.py
@@ -141,7 +141,7 @@ class TeamField(models.CharField):
         return Team(value)
 
     def value_to_string(self, obj):
-        return self._get_val_from_obj(obj).to_string()
+        return self.value_from_object(obj).to_string()
 
     def deconstruct(self):
         name, path, args, kwargs = super(TeamField, self).deconstruct()


### PR DESCRIPTION
The method duplicates the functionality of `Field.value_from_object`
and has the additional downside of being a privately named public
API method.

All usage of the method in django.* libraries have been replaced
with a call to getattr, to reduce the overhead of an additional,
unecessary function call.

No unittests are added, since this is just the removal of a single method, 
which was already amply tested by the serialization tests.