### PR TITLE
Fix #24707 - url resolution: uncallable views passed via import raise a better error

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -12,6 +12,7 @@ import functools
 import re
 import warnings
 from importlib import import_module
+from six import string_types
 from threading import local
 
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
@@ -92,6 +93,11 @@ def get_callable(lookup_view, can_fail=False):
     """
     if callable(lookup_view):
         return lookup_view
+
+    if not isinstance(lookup_view, string_types):
+        raise ViewDoesNotExist(
+            "'%s' was not a callable or a dot-notation path" % lookup_view
+        )
 
     mod_name, func_name = get_mod_func(lookup_view)
     if not func_name:  # No '.' in lookup_view

--- a/tests/urlpatterns_reverse/erroneous_urls.py
+++ b/tests/urlpatterns_reverse/erroneous_urls.py
@@ -19,8 +19,10 @@ with warnings.catch_warnings():
         url(r'erroneous_unqualified/$', 'unqualified_view'),
         # View does not exist
         url(r'missing_inner/$', 'urlpatterns_reverse.views.missing_view'),
-        # View is not callable
-        url(r'uncallable/$', 'urlpatterns_reverse.views.uncallable'),
+        # View is not callable (dot-notation)
+        url(r'uncallable-dotted/$', 'urlpatterns_reverse.views.uncallable'),
+        # View is not callable (view object)
+        url(r'uncallable-object/$', views.uncallable),
         # Module does not exist
         url(r'missing_outer/$', 'urlpatterns_reverse.missing_module.missing_view'),
         # Regex contains an error (refs #6170)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -735,7 +735,8 @@ class ErroneousViewTests(TestCase):
         self.assertRaises(ImportError, self.client.get, '/erroneous_outer/')
         self.assertRaises(ViewDoesNotExist, self.client.get, '/missing_inner/')
         self.assertRaises(ViewDoesNotExist, self.client.get, '/missing_outer/')
-        self.assertRaises(ViewDoesNotExist, self.client.get, '/uncallable/')
+        self.assertRaises(ViewDoesNotExist, self.client.get, '/uncallable-dotted/')
+        self.assertRaises(ViewDoesNotExist, self.client.get, '/uncallable-object/')
 
         # Regression test for #21157
         self.assertRaises(ImportError, self.client.get, '/erroneous_unqualified/')

--- a/tests/urlpatterns_reverse/views.py
+++ b/tests/urlpatterns_reverse/views.py
@@ -35,7 +35,7 @@ def pass_resolver_match_view(request, *args, **kwargs):
     response.resolver_match = request.resolver_match
     return response
 
-uncallable = "Can I be a view? Pleeeease?"
+uncallable = None  # neither a callable nor a string
 
 
 class ViewClass(object):


### PR DESCRIPTION
Wasn't sure to make the PR against master or 1.8.x, but it applies cleanly and merges on both...