### PR TITLE
Fixed #24715 -- Renamed Oracle Sequence and Triggers when renaming table.

### DIFF
--- a/docs/releases/1.7.9.txt
+++ b/docs/releases/1.7.9.txt
@@ -1,15 +1,11 @@
 ==========================
-Django 1.8.2 release notes
+Django 1.7.9 release notes
 ==========================
 
 *Under development*
-
-Django 1.8.2 fixes several bugs in 1.8.1.
 
 Bugfixes
 ========
 
 * Added renaming of Oracle triggers and sequences when using
   ``RenameModel`` (:ticket:`24715`).
-
-* Fixed check for template engine alias unicity (:ticket:`24685`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -41,6 +41,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.7.9
    1.7.8
    1.7.7
    1.7.6

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -3,6 +3,7 @@ import itertools
 import unittest
 from copy import copy
 
+from django.core.management.color import no_style
 from django.db import (
     DatabaseError, IntegrityError, OperationalError, connection,
 )
@@ -1161,6 +1162,11 @@ class SchemaTests(TransactionTestCase):
         Author._meta.db_table = "schema_otherauthor"
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], "CharField")
+        # Ensure we can still reset sequence and sequence was renamed properly
+        sql_list = connection.ops.sequence_reset_sql(no_style(), [Author, ])
+        with connection.schema_editor() as editor:
+            for sql in sql_list:
+                editor.execute(sql)
         # Alter the table again
         with connection.schema_editor() as editor:
             editor.alter_db_table(Author, "schema_otherauthor", "schema_author")


### PR DESCRIPTION
When the migration renames an Oracle table, it does not currently rename the sequences and triggers.  This renames them also if there is an auto_field.