### PR TITLE
Fixed #24708 -- Handled non-string values in GenericIPAddressField.to_python()

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1963,7 +1963,12 @@ class GenericIPAddressField(Field):
         return "GenericIPAddressField"
 
     def to_python(self, value):
-        if value and ':' in value:
+        if value is None:
+            return None
+        if not isinstance(value, six.string_types):
+            value = force_text(value)
+        value = value.strip()
+        if ':' in value:
             return clean_ipv6_address(value,
                 self.unpack_ipv4, self.error_messages['invalid'])
         return value

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.test import TestCase
+from django.utils.functional import lazy
 
 from . import ValidationTestCase
 from .models import (
@@ -129,6 +130,10 @@ class GenericIPAddressFieldTests(ValidationTestCase):
     def test_correct_generic_ip_passes(self):
         giptm = GenericIPAddressTestModel(generic_ip="1.2.3.4")
         self.assertIsNone(giptm.full_clean())
+        giptm = GenericIPAddressTestModel(generic_ip=" 1.2.3.4 ")
+        self.assertIsNone(giptm.full_clean())
+        giptm = GenericIPAddressTestModel(generic_ip="1.2.3.4\n")
+        self.assertIsNone(giptm.full_clean())
         giptm = GenericIPAddressTestModel(generic_ip="2001::2")
         self.assertIsNone(giptm.full_clean())
 
@@ -136,6 +141,10 @@ class GenericIPAddressFieldTests(ValidationTestCase):
         giptm = GenericIPAddressTestModel(generic_ip="294.4.2.1")
         self.assertFailsValidation(giptm.full_clean, ['generic_ip'])
         giptm = GenericIPAddressTestModel(generic_ip="1:2")
+        self.assertFailsValidation(giptm.full_clean, ['generic_ip'])
+        giptm = GenericIPAddressTestModel(generic_ip=1)
+        self.assertFailsValidation(giptm.full_clean, ['generic_ip'])
+        giptm = GenericIPAddressTestModel(generic_ip=lazy(lambda: 1, int))
         self.assertFailsValidation(giptm.full_clean, ['generic_ip'])
 
     def test_correct_v4_ip_passes(self):


### PR DESCRIPTION
Handled a case of GenericIPAddressField raising an exception if non
strings are passed in.