### PR TITLE
Fixed #24720 -- Moved append slash checking in CommonMiddleware to process_response()

### DIFF
--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -39,7 +39,7 @@ class CommonMiddlewareTest(TestCase):
         """
         request = self.rf.get('/slash/')
         self.assertEqual(CommonMiddleware().process_request(request), None)
-        response = HttpResponseNotFound
+        response = HttpResponseNotFound()
         self.assertEqual(CommonMiddleware().process_response(request, response), response)
 
     @override_settings(APPEND_SLASH=True)
@@ -162,7 +162,7 @@ class CommonMiddlewareTest(TestCase):
         request = self.rf.get('/customurlconf/slash/')
         request.urlconf = 'middleware.extra_urls'
         self.assertEqual(CommonMiddleware().process_request(request), None)
-        response = HttpResponseNotFound
+        response = HttpResponseNotFound()
         self.assertEqual(CommonMiddleware().process_response(request, response), response)
 
     @override_settings(APPEND_SLASH=True)
@@ -184,7 +184,7 @@ class CommonMiddlewareTest(TestCase):
         request = self.rf.get('/customurlconf/unknown')
         request.urlconf = 'middleware.extra_urls'
         self.assertEqual(CommonMiddleware().process_request(request), None)
-        response = HttpResponseNotFound
+        response = HttpResponseNotFound()
         self.assertEqual(CommonMiddleware().process_response(request, response), response)
 
     @override_settings(APPEND_SLASH=True)

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -66,7 +66,7 @@ def nested_view(request):
     """
     setup_test_environment()
     c = Client()
-    c.get("/no_template_view")
+    c.get("/no_template_view/")
     return render_to_response('base.html', {'nested': 'yes'})
 
 


### PR DESCRIPTION
Addresses issue #24720 - using middleware.common to append slashes causes extra overhead to all requests that do not end in a slash

https://code.djangoproject.com/ticket/24720

To avoid resolving the url twice for all urls that do not end in a
slash - only check if we should add the slash if we receive a 404
response in *process_response* (if we are prepending www  it still does
the check in *process_request* to avoid multiple redirects)

Avoiding this double url resolution speeds up the affected requests by about 5%

This pull request exposes a bug(?!?) in the TestClient (see
*test_client_regress.tests.ContextTests.test_nested_requests*).  It
appears that returning a redirect from process_response behaves
differently than returning a redirect from process_request that leads
to extra context being added to the response.context when making 
nested calls.  Possibly related to the *template_rendered* signal (or not).
