### PR TITLE
Fixed #24717 -- Fixed test failures for RHEL6 SCL

### DIFF
--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -7,7 +7,8 @@ import warnings
 
 from django.core.files.temp import NamedTemporaryFile
 from django.db import DJANGO_VERSION_PICKLE_KEY, models
-from django.test import TestCase
+from django.test import TestCase, mock
+from django.utils._os import upath
 from django.utils.encoding import force_text
 from django.utils.version import get_version
 
@@ -62,8 +63,8 @@ class ModelPickleTestCase(TestCase):
 
     def test_unpickling_when_appregistrynotready(self):
         """
-        #24007 -- Verifies that a pickled model can be unpickled without having
-        to manually setup the apps registry beforehand.
+        #24007 -- Verifies that a pickled model can be unpickled without
+        having to manually setup the apps registry beforehand.
         """
         script_template = """#!/usr/bin/env python
 import pickle
@@ -84,19 +85,21 @@ print(article.headline)"""
         with NamedTemporaryFile(mode='w+', suffix=".py") as script:
             script.write(script_template % pickle.dumps(a))
             script.flush()
-            pythonpath = [os.path.dirname(script.name)] + sys.path
-            env = {
-                # Needed to run test outside of tests directory
-                str('PYTHONPATH'): os.pathsep.join(pythonpath),
-                # Needed on Windows because http://bugs.python.org/issue8557
-                str('PATH'): os.environ['PATH'],
-                str('TMPDIR'): os.environ['TMPDIR'],
-                str('LANG'): os.environ.get('LANG', ''),
-            }
-            if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-                env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
-            try:
-                result = subprocess.check_output([sys.executable, script.name], env=env)
-            except subprocess.CalledProcessError:
-                self.fail("Unable to reload model pickled data")
+
+            # A path to model_regress must be set in PYTHONPATH
+            model_regress_dir = os.path.dirname(upath(__file__))
+            model_regress_path = os.path.abspath(model_regress_dir)
+
+            tests_path = os.path.split(model_regress_path)[0]
+            pythonpath = os.environ.get('PYTHONPATH', '')
+            pythonpath = os.pathsep.join([tests_path, pythonpath])
+
+            with mock.patch.dict('os.environ', {'PYTHONPATH': pythonpath}):
+                try:
+                    result = subprocess.check_output([
+                        sys.executable,
+                        script.name
+                    ])
+                except subprocess.CalledProcessError:
+                    self.fail("Unable to reload model pickled data")
         self.assertEqual(result.strip().decode(), "Some object")


### PR DESCRIPTION
The test test_unpickling_when_appregistrynotready in the package
model_regress.test_pickle fails on RHEL6 systems running python 2.7
from a RedHat Software Collection (SCL) because this test runs an
external python script with a stripped system environment. RedHat SCLs
work by setting a number of system environment variables when these are
stripped out by this test the python 2.7 interpreter is no longer able
to function properly because it can not find the system libraries needed
from the SCL. The solution I propose is to use mock to modify the system
environment directly instead of passing a stripped environment. I tested
this commit using using python 3.4.3 on Windows 7, and python 2.7 on
Windows 7, Debian 7.8, and RHEL6 with SCLs enabled.

Note that on Unix/Linux systems the code as it was before could also
break on local installs of python to a home directory or /usr/local for
example since it was not passing variables such as LD_LIBRARY_PATH to
the python script it executes.