### PR TITLE
Fixed #24727 -- Prevented ClearableFileInput from masking exceptions on Python 2

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -377,6 +377,15 @@ class ClearableFileInput(FileInput):
         """
         Return whether value is considered to be initial value.
         """
+        # hasattr() masks exceptions on Python 2: getattr + try..catch
+        # is more consistent across versions.
+        if six.PY2:
+            try:
+                getattr(value, 'url')
+            except AttributeError:
+                return False
+            else:
+                return bool(value)
         return bool(value and hasattr(value, 'url'))
 
     def get_template_substitution_values(self, value):

--- a/tests/forms_tests/tests/test_widgets.py
+++ b/tests/forms_tests/tests/test_widgets.py
@@ -1345,6 +1345,25 @@ class ClearableFileInputTests(TestCase):
         self.assertIn('my&lt;div&gt;file', output)
         self.assertNotIn('my<div>file', output)
 
+    def test_html_does_not_mask_exceptions(self):
+        """
+        A ClearableFileInput should not mask exceptions produced while
+        checking that it has a value.
+        """
+        @python_2_unicode_compatible
+        class FailingURLFieldFile(object):
+            def _get_url(self):
+                raise RuntimeError("Something went wrong")
+            url = property(_get_url)
+
+            def __str__(self):
+                return "value"
+
+        widget = ClearableFileInput()
+        field = FailingURLFieldFile()
+        with self.assertRaises(RuntimeError):
+            widget.render('myfile', field)
+
     def test_clear_input_renders_only_if_not_required(self):
         """
         A ClearableFileInput with is_required=False does not render a clear


### PR DESCRIPTION
Please see the following Trac ticket:

https://code.djangoproject.com/ticket/24727#ticket