### PR TITLE
Mention `translation.override()` context manager in docs

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1774,6 +1774,15 @@ which returns the language used in the current thread,
 for the current thread, and ``django.utils.translation.check_for_language()``
 which checks if the given language is supported by Django.
 
+For your convenience there is a context manager
+``django.utils.translation.override()`` that stores the current language on
+enter and restores it on exit. With it, the above example becomes::
+
+    from django.utils import tranlations
+    def welcome_translated(language):
+        with translation.override(language):
+            return translation.ugettext('welcome')
+
 Language cookie
 ---------------
 


### PR DESCRIPTION
The only example on using translations outside of views and templates
uses the clumsy try/finally and doesn't mention the convenient
`override` context manager.

I think this is pretty trivial thus no ticket. If it needs one, please let me know.