### PR TITLE
Add WKT geometry types

### DIFF
--- a/django/contrib/gis/geometry/regex.py
+++ b/django/contrib/gis/geometry/regex.py
@@ -7,7 +7,8 @@ hex_regex = re.compile(r'^[0-9A-F]+$', re.I)
 wkt_regex = re.compile(r'^(SRID=(?P<srid>\-?\d+);)?'
                        r'(?P<wkt>'
                        r'(?P<type>POINT|LINESTRING|LINEARRING|POLYGON|MULTIPOINT|'
-                       r'MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)'
+                       r'MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION|'
+                       r'CURVEPOLYGON|CIRCULARSTRING)'
                        r'[ACEGIMLONPSRUTYZ\d,\.\-\(\) ]+)$',
                        re.I)
 json_regex = re.compile(r'^(\s+)?\{.*}(\s+)?$', re.DOTALL)


### PR DESCRIPTION
CURVEPOLYGON and CIRCULARSTRING are commonly supported geometry types that are missing from this expression. This causes the Geometry constructor to fail when trying to read them from a database.