### PR TITLE
Only insert cache item into the database when there is no item already i...

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -137,7 +137,7 @@ class DatabaseCache(BaseDatabaseCache):
                         cursor.execute("UPDATE %s SET value = %%s, expires = %%s "
                                        "WHERE cache_key = %%s" % table,
                                        [b64encoded, exp, key])
-                    else:
+                    elif not result:
                         cursor.execute("INSERT INTO %s (cache_key, value, expires) "
                                        "VALUES (%%s, %%s, %%s)" % table,
                                        [key, b64encoded, exp])

--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -141,6 +141,8 @@ class DatabaseCache(BaseDatabaseCache):
                         cursor.execute("INSERT INTO %s (cache_key, value, expires) "
                                        "VALUES (%%s, %%s, %%s)" % table,
                                        [key, b64encoded, exp])
+                    else:
+                        return False
             except DatabaseError:
                 # To be threadsafe, updates/inserts are allowed to fail silently
                 return False


### PR DESCRIPTION
I made a change to the cache db backend to only do an insert when it's needed.

When there is already an result and its not expired the insert is going to fail so it could be skipped.

Or am I missing something?