### PR TITLE
Fixed #24857 -- Added "python -m django" entry point.

### DIFF
--- a/django/__main__.py
+++ b/django/__main__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Alias to allow the django module to be run as a script.
+
+Example:
+
+    python -m django collectstatic
+"""
+from django.core import management
+
+if __name__ == "__main__":
+    management.execute_from_command_line()

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -33,7 +33,8 @@ Django settings files, use ``django-admin`` with
 option.
 
 The command-line examples throughout this document use ``django-admin`` to
-be consistent, but any example can use ``manage.py`` just as well.
+be consistent, but any example can use ``python -m django`` or ``manage.py``
+just as well.
 
 Usage
 =====
@@ -41,6 +42,7 @@ Usage
 .. code-block:: console
 
     $ django-admin <command> [options]
+    $ python -m django <command> [options]
     $ manage.py <command> [options]
 
 ``command`` should be one of the commands listed in this document.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -411,7 +411,7 @@ Management Commands
   requiring it to be manually entered).
 
 * The ``django`` package may be run as a script, i.e. ``python -m django``,
-  which will behave the same as ``python django-admin.py``.
+  which will behave the same as ``django-admin``.
 
 Migrations
 ^^^^^^^^^^

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -410,6 +410,9 @@ Management Commands
   to the database using the password from your settings file (instead of
   requiring it to be manually entered).
 
+* The ``django`` package may be run as a script, i.e. ``python -m django``,
+  which will behave the same as ``python django-admin.py``.
+
 Migrations
 ^^^^^^^^^^
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2041,3 +2041,12 @@ class Dumpdata(AdminScriptTestCase):
         out, err = self.run_manage(args)
         self.assertOutput(err, "You can only use --pks option with one model")
         self.assertNoOutput(out)
+
+
+class MainModule(AdminScriptTestCase):
+    """Tests that python -m django works like django-admin.py."""
+
+    def test_runs_django_admin(self):
+        cmd_out, _ = self.run_django_admin(['--version'])
+        mod_out, _ = self.run_test('-m', ['django', '--version'])
+        self.assertEqual(mod_out, cmd_out)


### PR DESCRIPTION
The entry point `django` would be a more obvious name than `django-admin`, and `python -m django` is a pretty obvious way to run the primary django command (`django-admin`). Add those methods of use as valid points of entry.

Note that I'm using "obvious" in my above description to mean that it's likely guessable by a newcomer to Django, not that it should have been so obvious that I'm complaining that it's not already added.