### PR TITLE
Updated capitalization in the word "JavaScript" for consistency

### DIFF
--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -242,16 +242,16 @@ Once you have completed these steps, you are finished with the deprecation.
 In each major release, all ``RemovedInDjangoXXWarning``\s matching the new
 version are removed.
 
-Javascript patches
+JavaScript patches
 ------------------
 
 Django's admin system leverages the jQuery framework to increase the
 capabilities of the admin interface. In conjunction, there is an emphasis on
-admin javascript performance and minimizing overall admin media file size.
-Serving compressed or "minified" versions of javascript files is considered
+admin JavaScript performance and minimizing overall admin media file size.
+Serving compressed or "minified" versions of JavaScript files is considered
 best practice in this regard.
 
-To that end, patches for javascript files should include both the original
+To that end, patches for JavaScript files should include both the original
 code for future development (e.g. ``foo.js``), and a compressed version for
 production use (e.g. ``foo.min.js``). Any links to the file in the codebase
 should point to the compressed version.
@@ -259,7 +259,7 @@ should point to the compressed version.
 Compressing JavaScript
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To simplify the process of providing optimized javascript code, Django
+To simplify the process of providing optimized JavaScript code, Django
 includes a handy python script which should be used to create a "minified"
 version. To run it::
 
@@ -268,11 +268,11 @@ version. To run it::
 Behind the scenes, ``compress.py`` is a front-end for Google's
 `Closure Compiler`_ which is written in Java. However, the Closure Compiler
 library is not bundled with Django directly, so those wishing to contribute
-complete javascript patches will need to download and install the library
+complete JavaScript patches will need to download and install the library
 independently. The Closure Compiler library requires `Java`_ 7 or higher.
 
 Please don't forget to run ``compress.py`` and include the ``diff`` of the
-minified scripts when submitting patches for Django's javascript.
+minified scripts when submitting patches for Django's JavaScript.
 
 .. _Closure Compiler: https://developers.google.com/closure/compiler/
 .. _list of tickets with patches: https://code.djangoproject.com/query?status=new&status=assigned&status=reopened&has_patch=1&order=priority

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1827,7 +1827,7 @@ definitions on forms <form-asset-paths>`.
 jQuery
 ~~~~~~
 
-Django admin Javascript makes use of the `jQuery`_ library.
+Django admin JavaScript makes use of the `jQuery`_ library.
 
 To avoid conflicts with user-supplied scripts or libraries, Django's jQuery
 (version 1.11.2) is namespaced as ``django.jQuery``. If you want to use jQuery

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2673,7 +2673,7 @@ Index                      ``index``
 Logout                     ``logout``
 Password change            ``password_change``
 Password change done       ``password_change_done``
-i18n javascript            ``jsi18n``
+i18n JavaScript            ``jsi18n``
 Application index page     ``app_list``              ``app_label``
 Redirect to object's page  ``view_on_site``          ``content_type_id``, ``object_id``
 =========================  ========================  ==================================

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -7,7 +7,7 @@ Cross Site Request Forgery protection
 
 The CSRF middleware and template tag provides easy-to-use protection against
 `Cross Site Request Forgeries`_.  This type of attack occurs when a malicious
-Web site contains a link, a form button or some javascript that is intended to
+Web site contains a link, a form button or some JavaScript that is intended to
 perform some action on your Web site, using the credentials of a logged-in user
 who visits the malicious site in their browser.  A related type of attack,
 'login CSRF', where an attacking site tricks a user's browser into logging into
@@ -80,7 +80,7 @@ While the above method can be used for AJAX POST requests, it has some
 inconveniences: you have to remember to pass the CSRF token in as POST data with
 every POST request. For this reason, there is an alternative method: on each
 XMLHttpRequest, set a custom ``X-CSRFToken`` header to the value of the CSRF
-token. This is often easier, because many javascript frameworks provide hooks
+token. This is often easier, because many JavaScript frameworks provide hooks
 that allow headers to be set on every request.
 
 As a first step, you must get the CSRF token itself. The recommended source for

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -252,7 +252,7 @@ sites with improperly configured servers, it can also pose a security
 risk.
 
 If your site serves user-uploaded files, a malicious user could upload a
-specially-crafted file that would be interpreted as HTML or Javascript by
+specially-crafted file that would be interpreted as HTML or JavaScript by
 the browser when you expected it to be something harmless.
 
 To learn more about this header and how the browser treats it, you can
@@ -280,8 +280,8 @@ setting will be useful.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some browsers have the ability to block content that appears to be an `XSS
-attack`_. They work by looking for Javascript content in the GET or POST
-parameters of a page. If the Javascript is replayed in the server's response,
+attack`_. They work by looking for JavaScript content in the GET or POST
+parameters of a page. If the JavaScript is replayed in the server's response,
 the page is blocked from rendering and an error page is shown instead.
 
 The `X-XSS-Protection header`_ is used to control the operation of the

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2862,7 +2862,7 @@ protected cookie data.
 Turning it on makes it less trivial for an attacker to escalate a cross-site
 scripting vulnerability into full hijacking of a user's session. There's not
 much excuse for leaving this off, either: if your code depends on reading
-session cookies from Javascript, you're probably doing it wrong.
+session cookies from JavaScript, you're probably doing it wrong.
 
 .. _HTTPOnly: https://www.owasp.org/index.php/HTTPOnly
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1146,7 +1146,7 @@ verbatim
 
 Stops the template engine from rendering the contents of this block tag.
 
-A common use is to allow a Javascript template layer that collides with
+A common use is to allow a JavaScript template layer that collides with
 Django's syntax. For example::
 
     {% verbatim %}

--- a/docs/releases/1.1.2.txt
+++ b/docs/releases/1.1.2.txt
@@ -36,7 +36,7 @@ browsers, our encoding of cookie values was changed so that the characters
 comma and semi-colon are treated as non-safe characters, and are therefore
 encoded as ``\054`` and ``\073`` respectively.  This could produce backwards
 incompatibilities, especially if you are storing comma or semi-colon in
-cookies and have javascript code that parses and manipulates cookie values
+cookies and have JavaScript code that parses and manipulates cookie values
 client-side.
 
 One new feature

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -686,7 +686,7 @@ other browsers, our encoding of cookie values was changed so that the
 comma and semicolon are treated as non-safe characters, and are
 therefore encoded as ``\054`` and ``\073`` respectively.  This could
 produce backwards incompatibilities, especially if you are storing
-comma or semi-colon in cookies and have javascript code that parses
+comma or semi-colon in cookies and have JavaScript code that parses
 and manipulates cookie values client-side.
 
 ``ModelForm.is_valid()`` and ``ModelForm.errors``

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -101,7 +101,7 @@ Extended static files handling
 
 Django 1.3 ships with a new contrib app --
 ``django.contrib.staticfiles`` -- to help developers handle the static
-media files (images, CSS, Javascript, etc.) that are needed to render
+media files (images, CSS, JavaScript, etc.) that are needed to render
 a complete web page.
 
 In previous versions of Django, it was common to place static assets
@@ -588,7 +588,7 @@ gettext domain):
   translations). See the `corresponding deprecated features section`_
   of this document.
 
-For translatable literals found in Javascript code (``'djangojs'`` gettext
+For translatable literals found in JavaScript code (``'djangojs'`` gettext
 domain):
 
 * Similarly to the ``'django'`` domain translations: Overriding of

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -194,7 +194,7 @@ more information.
 ``{% verbatim %}`` template tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To make it easier to deal with javascript templates which collide with Django's
+To make it easier to deal with JavaScript templates which collide with Django's
 syntax, you can now use the :ttag:`verbatim` block tag to avoid parsing the
 tag's content.
 

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -857,7 +857,7 @@ Miscellaneous
   :meth:`~django.db.models.query.QuerySet.none` has been called:
   ``isinstance(qs.none(), EmptyQuerySet)``
 
-* If your CSS/Javascript code used to access HTML input widgets by type, you
+* If your CSS/JavaScript code used to access HTML input widgets by type, you
   should review it as ``type='text'`` widgets might be now output as
   ``type='email'``, ``type='url'`` or ``type='number'`` depending on their
   corresponding field type.

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1747,7 +1747,7 @@ whose implementation was changed to make use of ``json.dumps()`` instead.
 If you were relying on this function to provide safe output from untrusted
 strings, you should use ``django.utils.html.escapejs`` or the
 :tfilter:`escapejs` template filter.
-If all you need is to generate valid javascript strings, you can simply use
+If all you need is to generate valid JavaScript strings, you can simply use
 ``json.dumps()``.
 
 ``fix_ampersands`` utils method and template filter

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -390,7 +390,7 @@ itunes
 iTunes
 ize
 Jannis
-javascript
+JavaScript
 Jinja
 jQuery
 JServ

--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -207,7 +207,7 @@ be prepended with the value of the appropriate prefix.
 
 As part of the introduction of the
 :doc:`staticfiles app </ref/contrib/staticfiles>` two new settings were added
-to refer to "static files" (images, CSS, Javascript, etc.) that are needed
+to refer to "static files" (images, CSS, JavaScript, etc.) that are needed
 to render a complete web page: :setting:`STATIC_URL` and :setting:`STATIC_ROOT`.
 
 To find the appropriate prefix to use, Django will check if the

--- a/docs/topics/i18n/formatting.txt
+++ b/docs/topics/i18n/formatting.txt
@@ -64,7 +64,7 @@ will try to use a locale specific format whenever it outputs a value
 in a template.
 
 However, it may not always be appropriate to use localized values --
-for example, if you're outputting Javascript or XML that is designed
+for example, if you're outputting JavaScript or XML that is designed
 to be machine-readable, you will always want unlocalized values. You
 may also want to use localization in selected templates, rather than
 using localization everywhere.

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1187,7 +1187,7 @@ whenever you restart your application server.
     def cached_javascript_catalog(request, domain='djangojs', packages=None):
         return javascript_catalog(request, domain, packages)
 
-You can even pre-generate the javascript catalog as part of your deployment
+You can even pre-generate the JavaScript catalog as part of your deployment
 procedure and serve it as a static file. This radical technique is implemented
 in django-statici18n_.
 


### PR DESCRIPTION
A simple documentation update, amending the word "JavaScript" in places where it has a lower case "J" or "S".