### PR TITLE
Fixed #24713 -- Redirect loop detection in test client is incorrect

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -661,9 +661,9 @@ class Client(RequestFactory):
             response = self.get(url.path, QueryDict(url.query), follow=False, **extra)
             response.redirect_chain = redirect_chain
 
-            if redirect_chain[-1] in redirect_chain[:-1]:
+            if redirect_chain[:-1].count(redirect_chain[-1]) > 2:
                 # Check that we're not redirecting to somewhere we've already
-                # been to, to prevent loops.
+                # been to more than twice, to prevent loops.
                 raise RedirectCycleError("Redirect loop detected.", last_response=response)
             if len(redirect_chain) > 20:
                 # Such a lengthy chain likely also means a loop, but one with


### PR DESCRIPTION
Raising RedirectCycleError only when already on the same view more than twice.
If the count should be other than 2 please let me know.