### PR TITLE
Fixed #24676 -- Fixed help text positioning in ``contrib.admin`` filter_* widgets.

### DIFF
--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -609,6 +609,9 @@ ul.orderer li.deleted:hover, ul.orderer li.deleted a.selector:hover {
 }
 
 /* RELATED WIDGET WRAPPER */
+.related-widget-wrapper {
+    overflow: hidden;  /* clear floated contents */
+}
 
 .related-widget-wrapper-link {
     opacity: 0.3;

--- a/docs/releases/1.8.1.txt
+++ b/docs/releases/1.8.1.txt
@@ -80,6 +80,10 @@ Bugfixes
 
 * Fixed ``makemessages`` crash in some locales (:ticket:`23271`).
 
+* Fixed help text positioning of ``contrib.admin`` fields that use the
+  ``ModelAdmin.filter_horizontal`` and ``filter_vertical`` options
+  (:ticket:`24676`).
+
 Optimizations
 =============
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24676