### PR TITLE
Moved migration exception classes to shared module

### DIFF
--- a/django/db/migrations/exceptions.py
+++ b/django/db/migrations/exceptions.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+
+from django.utils.encoding import python_2_unicode_compatible
+
+
+class AmbiguityError(Exception):
+    """
+    Raised when more than one migration matches a name prefix.
+    """
+    pass
+
+
+class BadMigrationError(Exception):
+    """
+    Raised when there's a bad migration (unreadable/bad format/etc.).
+    """
+    pass
+
+
+class CircularDependencyError(Exception):
+    """
+    Raised when there's an impossible-to-resolve circular dependency.
+    """
+    pass
+
+
+class InvalidBasesError(ValueError):
+    """
+    Raised when a model's base classes can't be resolved.
+    """
+    pass
+
+
+class IrreversibleError(RuntimeError):
+    """
+    Raised when a irreversible migration is about to be reversed.
+    """
+    pass
+
+
+@python_2_unicode_compatible
+class NodeNotFoundError(LookupError):
+    """
+    Raised when an attempt on a node is made that is not available in the graph.
+    """
+
+    def __init__(self, message, node):
+        self.message = message
+        self.node = node
+
+    def __str__(self):
+        return self.message
+
+    def __repr__(self):
+        return "NodeNotFoundError(%r)" % self.node

--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -8,6 +8,8 @@ from django.utils.datastructures import OrderedSet
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import total_ordering
 
+from .exceptions import CircularDependencyError, NodeNotFoundError
+
 RECURSION_DEPTH_WARNING = (
     "Maximum recursion depth exceeded while generating migration graph, "
     "falling back to iterative approach. If you're experiencing performance issues, "
@@ -276,27 +278,3 @@ class MigrationGraph(object):
 
     def __contains__(self, node):
         return node in self.nodes
-
-
-class CircularDependencyError(Exception):
-    """
-    Raised when there's an impossible-to-resolve circular dependency.
-    """
-    pass
-
-
-@python_2_unicode_compatible
-class NodeNotFoundError(LookupError):
-    """
-    Raised when an attempt on a node is made that is not available in the graph.
-    """
-
-    def __init__(self, message, node):
-        self.message = message
-        self.node = node
-
-    def __str__(self):
-        return self.message
-
-    def __repr__(self):
-        return "NodeNotFoundError(%r)" % self.node

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,9 +6,11 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
-from django.db.migrations.graph import MigrationGraph, NodeNotFoundError
+from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six
+
+from .exceptions import AmbiguityError, BadMigrationError, NodeNotFoundError
 
 MIGRATIONS_MODULE_NAME = 'migrations'
 
@@ -324,17 +326,3 @@ class MigrationLoader(object):
         See graph.make_state for the meaning of "nodes" and "at_end"
         """
         return self.graph.make_state(nodes=nodes, at_end=at_end, real_apps=list(self.unmigrated_apps))
-
-
-class BadMigrationError(Exception):
-    """
-    Raised when there's a bad migration (unreadable/bad format/etc.)
-    """
-    pass
-
-
-class AmbiguityError(Exception):
-    """
-    Raised when more than one migration matches a name prefix
-    """
-    pass

--- a/django/db/migrations/migration.py
+++ b/django/db/migrations/migration.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 from django.db.transaction import atomic
 from django.utils.encoding import python_2_unicode_compatible
 
+from .exceptions import IrreversibleError
+
 
 @python_2_unicode_compatible
 class Migration(object):
@@ -38,10 +40,6 @@ class Migration(object):
     # non-empty, this migration will only be applied if all these migrations
     # are not applied.
     replaces = []
-
-    # Error class which is raised when a migration is irreversible
-    class IrreversibleError(RuntimeError):
-        pass
 
     def __init__(self, name, app_label):
         self.name = name
@@ -138,7 +136,7 @@ class Migration(object):
         for operation in self.operations:
             # If it's irreversible, error out
             if not operation.reversible:
-                raise Migration.IrreversibleError("Operation %s in %s is not reversible" % (operation, self))
+                raise IrreversibleError("Operation %s in %s is not reversible" % (operation, self))
             # Preserve new state from previous run to not tamper the same state
             # over all operations
             new_state = new_state.clone()

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -18,9 +18,7 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.version import get_docs_version
 
-
-class InvalidBasesError(ValueError):
-    pass
+from .exceptions import InvalidBasesError
 
 
 def _get_app_label_and_model_name(model, app_label=''):

--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -1,9 +1,9 @@
 import warnings
 
-from django.db.migrations.graph import (
-    RECURSION_DEPTH_WARNING, CircularDependencyError, MigrationGraph,
-    NodeNotFoundError,
+from django.db.migrations.exceptions import (
+    CircularDependencyError, NodeNotFoundError,
 )
+from django.db.migrations.graph import RECURSION_DEPTH_WARNING, MigrationGraph
 from django.test import TestCase
 from django.utils.encoding import force_text
 

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 from unittest import skipIf
 
 from django.db import connection, connections
-from django.db.migrations.graph import NodeNotFoundError
-from django.db.migrations.loader import AmbiguityError, MigrationLoader
+from django.db.migrations.exceptions import AmbiguityError, NodeNotFoundError
+from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, modify_settings, override_settings
 from django.utils import six

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -1,10 +1,11 @@
 from django.apps.registry import Apps
 from django.db import models
+from django.db.migrations.exceptions import InvalidBasesError
 from django.db.migrations.operations import (
     AddField, AlterField, DeleteModel, RemoveField,
 )
 from django.db.migrations.state import (
-    InvalidBasesError, ModelState, ProjectState, get_related_models_recursive,
+    ModelState, ProjectState, get_related_models_recursive,
 )
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import six


### PR DESCRIPTION
This PR aims to provide a base cleanup before introducing more helpful exceptions in migrations when something fails.