### PR TITLE
Fixed #24736 - Replaced magic Sitemap max items

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -540,6 +540,12 @@ PASSWORD_HASHERS = [
 
 SIGNING_BACKEND = 'django.core.signing.TimestampSigner'
 
+############
+# SITEMAPS #
+############
+
+SITEMAP_MAX_ITEMS = 50000
+
 ########
 # CSRF #
 ########

--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -47,7 +47,7 @@ def ping_google(sitemap_url=None, ping_url=PING_URL):
 class Sitemap(object):
     # This limit is defined by Google. See the index documentation at
     # http://sitemaps.org/protocol.php#index.
-    limit = 50000
+    limit = settings.SITEMAP_MAX_ITEMS
 
     # If protocol is None, the URLs in the sitemap will use the protocol
     # with which the sitemap was requested.

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -362,7 +362,8 @@ dict don't change at all.
 
 You should create an index file if one of your sitemaps has more than 50,000
 URLs. In this case, Django will automatically paginate the sitemap, and the
-index will reflect that.
+index will reflect that. You can lower the number of items per page by defining
+ :setting:`SITEMAP_MAX_ITEMS` in your settings.
 
 If you're not using the vanilla sitemap view -- for example, if it's wrapped
 with a caching decorator -- you must name your sitemap view and pass

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2992,6 +2992,25 @@ table. This is used so that application data can hook into specific sites
 and a single database can manage content for multiple sites.
 
 
+.. _settings-sitemaps:
+
+Sitemaps
+=====
+
+Settings for :mod:`django.contrib.sitemaps`.
+
+.. setting:: SITEMAP_MAX_ITEMS
+
+SITEMAP_MAX_ITEMS
+-------
+
+Default: ``50000``
+
+The maximum number of items, as an integer, per page of indexed sitemap pages.
+``50000`` is the maximum number of items recommended by the sitemap protocol, but you
+may want to lower this number for performance purposes.
+
+
 .. _settings-staticfiles:
 
 Static files


### PR DESCRIPTION
This is a small change which turns the 50000 Sitemap max item
limit into a customizable value in the default global settings.