### PR TITLE
Simplify timezone.is_aware/naive

### DIFF
--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -29,7 +29,6 @@ from django.utils import datetime_safe, six
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.six import StringIO
 from django.utils.six.moves.urllib.parse import urlparse
-from django.utils.timezone import is_aware
 from django.utils.xmlutils import SimplerXMLGenerator
 
 
@@ -46,13 +45,14 @@ def rfc2822_date(date):
     time_str = date.strftime('%s, %%d %s %%Y %%H:%%M:%%S ' % (dow, month))
     if six.PY2:             # strftime returns a byte string in Python 2
         time_str = time_str.decode('utf-8')
-    if is_aware(date):
-        offset = date.tzinfo.utcoffset(date)
+    offset = date.utcoffset()
+    # Historically, this function assumes that naive datetimes are in UTC.
+    if offset is None:
+        return time_str + '-0000'
+    else:
         timezone = (offset.days * 24 * 60) + (offset.seconds // 60)
         hour, minute = divmod(timezone, 60)
         return time_str + '%+03d%02d' % (hour, minute)
-    else:
-        return time_str + '-0000'
 
 
 def rfc3339_date(date):
@@ -61,13 +61,14 @@ def rfc3339_date(date):
     time_str = date.strftime('%Y-%m-%dT%H:%M:%S')
     if six.PY2:             # strftime returns a byte string in Python 2
         time_str = time_str.decode('utf-8')
-    if is_aware(date):
-        offset = date.tzinfo.utcoffset(date)
+    offset = date.utcoffset()
+    # Historically, this function assumes that naive datetimes are in UTC.
+    if offset is None:
+        return time_str + 'Z'
+    else:
         timezone = (offset.days * 24 * 60) + (offset.seconds // 60)
         hour, minute = divmod(timezone, 60)
         return time_str + '%+03d:%02d' % (hour, minute)
-    else:
-        return time_str + 'Z'
 
 
 def get_tag_uri(url, date):

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -331,20 +331,26 @@ def is_aware(value):
     """
     Determines if a given datetime.datetime is aware.
 
-    The logic is described in Python's docs:
+    The concept is defined in Python's docs:
     http://docs.python.org/library/datetime.html#datetime.tzinfo
+
+    Assuming value.tzinfo is either None or a proper datetime.tzinfo,
+    value.utcoffset() implements the appropriate logic.
     """
-    return value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None
+    return value.utcoffset() is not None
 
 
 def is_naive(value):
     """
     Determines if a given datetime.datetime is naive.
 
-    The logic is described in Python's docs:
+    The concept is defined in Python's docs:
     http://docs.python.org/library/datetime.html#datetime.tzinfo
+
+    Assuming value.tzinfo is either None or a proper datetime.tzinfo,
+    value.utcoffset() implements the appropriate logic.
     """
-    return value.tzinfo is None or value.tzinfo.utcoffset(value) is None
+    return value.utcoffset() is None
 
 
 def make_aware(value, timezone=None, is_dst=None):


### PR DESCRIPTION
While working on something else, I noticed that I could simplify the code in places where Django manipulates UTC offsets, hence this drive-by PR.

If the tests pass, and perhaps if someone :+1: it, it should be good to go.