### PR TITLE
accept callable storage function

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import warnings
-from inspect import getargspec
+from inspect import getargspec, isfunction
 
 from django import forms
 from django.core import checks
@@ -243,6 +243,8 @@ class FileField(Field):
         self._unique_set_explicitly = 'unique' in kwargs
 
         self.storage = storage or default_storage
+        if isfunction(self.storage):
+            self.storage = self.storage()
         self.upload_to = upload_to
         if callable(upload_to):
             self.generate_filename = upload_to


### PR DESCRIPTION
To dynamically determin and set the storage class in FileField,
that possible inside the callable function, so we can safely access the settings without influencing
the migrations.