### PR TITLE
Avoid server failure on absence of _sqlite3.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -1,4 +1,3 @@
-import _sqlite3  # isort:skip
 import codecs
 import contextlib
 import copy
@@ -34,6 +33,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             c.execute('PRAGMA foreign_keys = %s' % int(self._initial_pragma_fk))
 
     def quote_value(self, value):
+        # Inner import to allow nice failure for backend if not present
+        import _sqlite3
         try:
             value = _sqlite3.adapt(value)
         except _sqlite3.ProgrammingError:


### PR DESCRIPTION
The nice behaviour for import was dropped during reorganizing
of db classes in commit 28308078f397d1de36fd0da417ac7da2544ba12d.
This reverts the original behaviour.

This could happen for example if running on a server with hardened security where python was compiled without sqlite3 libs/headers.