### PR TITLE
Backport Ticket #21357 -- Fixed test client session initialization to Django 1.7

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -396,6 +396,11 @@ class Client(RequestFactory):
             cookie = self.cookies.get(settings.SESSION_COOKIE_NAME, None)
             if cookie:
                 return engine.SessionStore(cookie.value)
+            else:
+                s = engine.SessionStore()
+                s.save()
+                self.cookies[settings.SESSION_COOKIE_NAME] = s.session_key
+                return s
         return {}
     session = property(_session)
 

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1014,6 +1014,14 @@ class SessionTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'YES')
 
+    def test_session_initiated(self):
+        session = self.client.session
+        session['session_var'] = 'foo'
+        session.save()
+
+        response = self.client.get('/check_session/')
+        self.assertEqual(response.content, b'foo')
+
     def test_logout(self):
         """Logout should work whether the user is logged in or not (#9978)."""
         self.client.logout()


### PR DESCRIPTION
The test client will now create a session when it is first accessed
if no session already exists. This is the behavior as documented in the 1.7 Docs.
https://docs.djangoproject.com/en/1.7/topics/testing/tools/#persistent-state