### PR TITLE
Fixed #24748 -- incorrect GROUP BY on MySQL in some queries

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -143,8 +143,14 @@ class SQLCompiler(object):
             # then also add having expressions to group by.
             pk = None
             for expr in expressions:
-                if (expr.output_field.primary_key and
-                        getattr(expr.output_field, 'model') == self.query.model):
+                # Is this a reference to query's base table primary key? If the expression
+                # isn't a Col-like, then skip the expression.
+                try:
+                    target = expr.target
+                    alias = expr.alias
+                except AttributeError:
+                    continue
+                if target == self.query.model._meta.pk and alias == self.query.tables[0]:
                     pk = expr
             if pk:
                 # MySQLism: Columns in HAVING clause must be added to the GROUP BY.

--- a/docs/releases/1.8.2.txt
+++ b/docs/releases/1.8.2.txt
@@ -10,3 +10,6 @@ Bugfixes
 ========
 
 * Fixed check for template engine alias uniqueness (:ticket:`24685`).
+
+* Fixed incorrect GROUP BY clause generation on MySQL when the query's model
+  had a self-referential foreign key (:ticket:`24748`).

--- a/tests/aggregation_regress/models.py
+++ b/tests/aggregation_regress/models.py
@@ -104,3 +104,8 @@ class Bravo(models.Model):
 class Charlie(models.Model):
     alfa = models.ForeignKey(Alfa, null=True)
     bravo = models.ForeignKey(Bravo, null=True)
+
+
+class Thing(models.Model):
+    name = models.CharField(max_length=50)
+    parent = models.ForeignKey('self', null=True, blank=True, related_name='children')

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -17,7 +17,7 @@ from django.utils import six
 
 from .models import (
     Alfa, Author, Book, Bravo, Charlie, Clues, Entries, HardbackBook, ItemTag,
-    Publisher, Store, WithManualPK,
+    Publisher, Store, Thing, WithManualPK,
 )
 
 
@@ -1277,3 +1277,15 @@ class JoinPromotionTests(TestCase):
     def test_non_nullable_fk_not_promoted(self):
         qs = Book.objects.annotate(Count('contact__name'))
         self.assertIn(' INNER JOIN ', str(qs.query))
+
+
+class Ticket24748Tests(TestCase):
+    def test_ticket_24748(self):
+        t1 = Thing.objects.create(name='t1')
+        Thing.objects.create(name='t2', parent=t1)
+        Thing.objects.create(name='t3', parent=t1)
+        self.assertQuerysetEqual(
+            Thing.objects.annotate(num_children=Count('children')).order_by('name'),
+            [('t1', 2), ('t2', 0), ('t3', 0)],
+            lambda x: (x.name, x.num_children)
+        )


### PR DESCRIPTION
When the query's model had a self-referential foreign key, the 1.8
compiler.get_group_by() code incorrectly used the self-referential
foreign key's column (for example parent_id) as GROUP BY clause
when it should have used the model's primary key column (id).