### PR TITLE
Fixed #24763 - Docs incorrectly state that DoesNotExist is in django.core.exceptions

### DIFF
--- a/docs/ref/exceptions.txt
+++ b/docs/ref/exceptions.txt
@@ -12,25 +12,17 @@ Django Core Exceptions
 
 Django core exception classes are defined in ``django.core.exceptions``.
 
-``ObjectDoesNotExist`` and ``DoesNotExist``
+``ObjectDoesNotExist``
 -------------------------------------------
-
-.. exception:: DoesNotExist
-
-    The ``DoesNotExist`` exception is raised when an object is not found for
-    the given parameters of a query. Django provides a ``DoesNotExist``
-    exception as an attribute of each model class to identify the class of
-    object that could not be found and to allow you to catch a particular model
-    class with ``try/except``.
 
 .. exception:: ObjectDoesNotExist
 
-    The base class for ``DoesNotExist`` exceptions; a ``try/except`` for
-    ``ObjectDoesNotExist`` will catch ``DoesNotExist`` exceptions for all
-    models.
+    The base class for :exc:`~django.db.models.Model.DoesNotExist` exceptions;
+    a ``try/except`` for ``ObjectDoesNotExist`` will catch
+    :exc:`~django.db.models.Model.DoesNotExist` exceptions for all models.
 
     See :meth:`~django.db.models.query.QuerySet.get()` for further information
-    on :exc:`ObjectDoesNotExist` and :exc:`DoesNotExist`.
+    on :exc:`ObjectDoesNotExist` and :exc:`~django.db.models.Model.DoesNotExist`.
 
 ``FieldDoesNotExist``
 ---------------------

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -824,7 +824,7 @@ For every :class:`~django.db.models.DateField` and
 <django.db.models.Field.null>`, the object will have ``get_next_by_FOO()`` and
 ``get_previous_by_FOO()`` methods, where ``FOO`` is the name of the field. This
 returns the next and previous object with respect to the date field, raising
-a :exc:`~django.core.exceptions.DoesNotExist` exception when appropriate.
+a :exc:`~django.db.models.Model.DoesNotExist` exception when appropriate.
 
 Both of these methods will perform their queries using the default
 manager for the model. If you need to emulate filtering used by a

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1543,15 +1543,15 @@ than one object was found. The
 :exc:`~django.core.exceptions.MultipleObjectsReturned` exception is an
 attribute of the model class.
 
-``get()`` raises a :exc:`~django.core.exceptions.DoesNotExist` exception if an
-object wasn't found for the given parameters. This exception is also an
-attribute of the model class. Example::
+``get()`` raises a :exc:`~django.db.models.Model.DoesNotExist` exception if an
+object wasn't found for the given parameters. This exception is an attribute
+of the model class. Example::
 
     Entry.objects.get(id='foo') # raises Entry.DoesNotExist
 
-The :exc:`~django.core.exceptions.DoesNotExist` exception inherits from
+The :exc:`~django.db.models.Model.DoesNotExist` exception inherits from
 :exc:`django.core.exceptions.ObjectDoesNotExist`, so you can target multiple
-:exc:`~django.core.exceptions.DoesNotExist` exceptions. Example::
+:exc:`~django.db.models.Model.DoesNotExist` exceptions. Example::
 
     from django.core.exceptions import ObjectDoesNotExist
     try:
@@ -1559,6 +1559,18 @@ The :exc:`~django.core.exceptions.DoesNotExist` exception inherits from
         b = Blog.objects.get(id=1)
     except ObjectDoesNotExist:
         print("Either the entry or blog doesn't exist.")
+
+.. currentmodule:: django.db.models.Model
+
+.. exception:: DoesNotExist
+
+    QuerySets raise a ``DoesNotExist`` exception when an object is not found for
+    the given parameters of a query. Django provides a ``DoesNotExist``
+    exception as an attribute of each model class to identify the class of
+    object that could not be found and to allow you to catch a particular model
+    class with ``try/except``.
+
+.. currentmodule:: django.db.models.query.QuerySet
 
 create
 ~~~~~~
@@ -1868,7 +1880,7 @@ If your model's :ref:`Meta <meta-options>` specifies
 field specified in :attr:`~django.db.models.Options.get_latest_by` by default.
 
 Like :meth:`get()`, ``earliest()`` and ``latest()`` raise
-:exc:`~django.core.exceptions.DoesNotExist` if there is no object with the
+:exc:`~django.db.models.Model.DoesNotExist` if there is no object with the
 given parameters.
 
 Note that ``earliest()`` and ``latest()`` exist purely for convenience and

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -712,7 +712,7 @@ Miscellaneous
 
 * Accessing reverse one-to-one relations fetched via
   :meth:`~django.db.models.query.QuerySet.select_related` now raises
-  :exc:`~django.core.exceptions.DoesNotExist` instead of returning ``None``.
+  :exc:`~django.db.models.Model.DoesNotExist` instead of returning ``None``.
 
 .. _deprecated-features-1.5:
 

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -315,7 +315,7 @@ Minor features
   a ``SuspiciousOperation`` reaches the WSGI handler to return an
   ``HttpResponseBadRequest``.
 
-* The :exc:`~django.core.exceptions.DoesNotExist` exception now includes a
+* The :exc:`~django.db.models.Model.DoesNotExist` exception now includes a
   message indicating the name of the attribute used for the lookup.
 
 * The :meth:`~django.db.models.query.QuerySet.get_or_create` method no longer

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -279,7 +279,7 @@ will be returned::
 
    Calls :meth:`~django.db.models.query.QuerySet.get()` on a given model manager,
    but it raises :class:`~django.http.Http404` instead of the model's
-   :class:`~django.core.exceptions.DoesNotExist` exception.
+   :class:`~django.db.models.Model.DoesNotExist` exception.
 
 Required arguments
 ------------------


### PR DESCRIPTION
Attempting to address ticket: https://code.djangoproject.com/ticket/24763

Previously, the documentation had references to exception
django.core.exceptions.DoesNotExist.  This exception is
actually created in django.db.models.ModelBase.

This change updates references in the docs to
django.core.exceptions.DoesNotExist to instead point at
 django.db.models.Model.DoesNotExist.  Additionally,
the ModelDoesNotExist details were moved out of the
django.core.exceptions section because that's not where
they live.