### PR TITLE
Fixed #24769 -- Added integer casting of "verbosity" option with optparse parser.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -257,6 +257,9 @@ class BaseCommand(object):
 
         """
         if not self.use_argparse:
+            def store_as_int(option, opt_str, value, parser):
+                setattr(parser.values, option.dest, int(value))
+
             # Backwards compatibility: use deprecated optparse module
             warnings.warn("OptionParser usage for Django management commands "
                           "is deprecated, use ArgumentParser instead",
@@ -264,8 +267,8 @@ class BaseCommand(object):
             parser = OptionParser(prog=prog_name,
                                 usage=self.usage(subcommand),
                                 version=self.get_version())
-            parser.add_option('-v', '--verbosity', action='store', dest='verbosity', default='1',
-                type='choice', choices=['0', '1', '2', '3'],
+            parser.add_option('-v', '--verbosity', action='callback', dest='verbosity', default='1',
+                type='choice', choices=['0', '1', '2', '3'], callback=store_as_int,
                 help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output')
             parser.add_option('--settings',
                 help=(


### PR DESCRIPTION
The optparse parser is being used if `BaseCommand.options_list` is being
used, which might be the case for apps like django-pdb or django-ipdb.

This regressed in 85686386 (#19973).

It would be nice to have some test for this.
I've looked at https://github.com/django/django/pull/4449, which attempted to fix this in another way, but the tests do not really apply here, do they?

Initial report for Django: https://code.djangoproject.com/ticket/24769