### PR TITLE
Added SSL support to the `runserver` development server.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
-from django.core.servers.basehttp import get_internal_wsgi_application, run
+from django.core.servers.basehttp import SecureWSGIRequestHandler, SecureWSGIServer, get_internal_wsgi_application, run
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.executor import MigrationExecutor
 from django.utils import autoreload, six
@@ -41,6 +41,11 @@ class Command(BaseCommand):
             help='Tells Django to NOT use threading.')
         parser.add_argument('--noreload', action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.')
+        parser.add_argument('--certfile', dest='certfile',
+            help='Tells Django to serve over HTTPS with the specified SSL certificate. Must be specified if `keyfile` \
+            is set.')
+        parser.add_argument('--keyfile', dest='keyfile',
+            help='Tells Django to server over HTTPS with the specified SSL key.')
 
     def execute(self, *args, **options):
         if options.get('no_color'):
@@ -87,6 +92,13 @@ class Command(BaseCommand):
         if not self.addr:
             self.addr = '::1' if self.use_ipv6 else '127.0.0.1'
             self._raw_ipv6 = bool(self.use_ipv6)
+
+        self.keyfile = options.get('keyfile')
+        self.certfile = options.get('certfile')
+        self.use_ssl = True if self.keyfile or self.certfile else False
+        if self.keyfile and not self.certfile:
+                raise CommandError('The `certfile` argument must be specified with a key file.')
+
         self.run(**options)
 
     def run(self, **options):
@@ -117,11 +129,12 @@ class Command(BaseCommand):
         self.stdout.write(now)
         self.stdout.write((
             "Django version %(version)s, using settings %(settings)r\n"
-            "Starting development server at http://%(addr)s:%(port)s/\n"
+            "Starting development server at %(scheme)s://%(addr)s:%(port)s/\n"
             "Quit the server with %(quit_command)s.\n"
         ) % {
             "version": self.get_version(),
             "settings": settings.SETTINGS_MODULE,
+            "scheme": 'https' if self.use_ssl else 'http',
             "addr": '[%s]' % self.addr if self._raw_ipv6 else self.addr,
             "port": self.port,
             "quit_command": quit_command,
@@ -129,8 +142,18 @@ class Command(BaseCommand):
 
         try:
             handler = self.get_handler(*args, **options)
+            if self.use_ssl:
+                extra_kwargs = {
+                    'server_class': SecureWSGIServer,
+                    'handler_class': SecureWSGIRequestHandler,
+                    'certfile': self.certfile,
+                    'keyfile': self.keyfile
+                }
+            else:
+                extra_kwargs = {}
+
             run(self.addr, int(self.port), handler,
-                ipv6=self.use_ipv6, threading=threading)
+                ipv6=self.use_ipv6, threading=threading, **extra_kwargs)
         except socket.error as e:
             # Use helpful error messages instead of ugly tracebacks.
             ERRORS = {

--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -17,6 +17,11 @@ class Command(BaseCommand):
             help='Port number or ipaddr:port to run the server on.')
         parser.add_argument('--ipv6', '-6', action='store_true', dest='use_ipv6', default=False,
             help='Tells Django to use an IPv6 address.')
+        parser.add_argument('--certfile', dest='certfile',
+            help='Tells Django to serve over HTTPS with the specified SSL certificate. Must be specified if `keyfile` \
+            is set.')
+        parser.add_argument('--keyfile', dest='keyfile',
+            help='Tells Django to server over HTTPS with the specified SSL key.')
 
     def handle(self, *fixture_labels, **options):
         verbosity = options.get('verbosity')
@@ -42,5 +47,7 @@ class Command(BaseCommand):
             shutdown_message=shutdown_message,
             use_reloader=False,
             use_ipv6=options['use_ipv6'],
-            use_threading=use_threading
+            use_threading=use_threading,
+            certfile=options.get('certfile'),
+            keyfile=options.get('keyfile')
         )

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -838,6 +838,32 @@ Example usage::
 
     django-admin runserver --ipv6
 
+.. django-admin-option:: --certfile
+
+With the  ``--certfile`` option you can specify an SSL certificate file that
+will be used to serve your application over HTTPS. The certificate file can
+contain the certificate chain alone or the certificate chain concatenated
+with the private key. If the ``--certfile`` option is specified without
+specifying the ``--keyfile`` option, it is assumed that the certificate and
+private key are concatenated in a single file.
+
+Example Usage::
+
+    django-admin runserver --certfile server.pem
+    django-admin runserver --certfile server.crt --keyfile server.key
+
+.. django-admin-option:: --keyfile
+
+With the ``--keyfile`` option you can specify an SSL key file that will be
+used to serve your application over HTTPS in conjunction with the specified
+certificate file. If the ``--keyfile`` is specified then a certificate must
+also be provided with the ``--certfile`` option.
+
+Example Usage::
+
+    django-admin runserver --keyfile server.key --certfile server.crt
+
+
 Examples of using different ports and addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -840,6 +840,8 @@ Example usage::
 
 .. django-admin-option:: --certfile
 
+.. versionadded:: 1.9
+
 With the  ``--certfile`` option you can specify an SSL certificate file that
 will be used to serve your application over HTTPS. The certificate file can
 contain the certificate chain alone or the certificate chain concatenated
@@ -853,6 +855,8 @@ Example Usage::
     django-admin runserver --certfile server.crt --keyfile server.key
 
 .. django-admin-option:: --keyfile
+
+.. versionadded:: 1.9
 
 With the ``--keyfile`` option you can specify an SSL key file that will be
 used to serve your application over HTTPS in conjunction with the specified

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -191,6 +191,10 @@ Management Commands
 * The :djadmin:`createcachetable` command now has a ``--dry-run`` flag to
   print out the SQL rather than execute it.
 
+* The :djadmin:`runserver` command now supports serving over SSL. This does
+  not change the development server's intended scope. Use in a production
+  environment remains highly discouraged.
+
 Models
 ^^^^^^
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1306,7 +1306,9 @@ class ManageRunserver(AdminScriptTestCase):
         self.assertServerSettings('127.0.0.1', '8000', certfile="server.crt", use_ssl=True)
 
     def test_runner_keyfile(self):
-        self.assertRaises(CommandError, self.cmd.handle, keyfile="server.key")
+        with self.assertRaises(CommandError) as context_manager:
+            self.cmd.handle(keyfile="server.key")
+        self.assertEqual(str(context_manager.exception), 'The `certfile` argument must be specified with a key file.')
 
     def test_runner_certfile_keyfile(self):
         self.cmd.handle(certfile="server.crt", keyfile="server.key")

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1250,11 +1250,14 @@ class ManageRunserver(AdminScriptTestCase):
         self.cmd = Command()
         self.cmd.run = monkey_run
 
-    def assertServerSettings(self, addr, port, ipv6=None, raw_ipv6=False):
+    def assertServerSettings(self, addr, port, ipv6=None, raw_ipv6=False, certfile=None, keyfile=None, use_ssl=False):
         self.assertEqual(self.cmd.addr, addr)
         self.assertEqual(self.cmd.port, port)
         self.assertEqual(self.cmd.use_ipv6, ipv6)
         self.assertEqual(self.cmd._raw_ipv6, raw_ipv6)
+        self.assertEqual(self.cmd.certfile, certfile)
+        self.assertEqual(self.cmd.keyfile, keyfile)
+        self.assertEqual(self.cmd.use_ssl, use_ssl)
 
     def test_runserver_addrport(self):
         self.cmd.handle()
@@ -1298,6 +1301,17 @@ class ManageRunserver(AdminScriptTestCase):
         self.cmd.handle(addrport="deadbeef:7654")
         self.assertServerSettings('deadbeef', '7654')
 
+    def test_runner_certfile(self):
+        self.cmd.handle(certfile="server.crt")
+        self.assertServerSettings('127.0.0.1', '8000', certfile="server.crt", use_ssl=True)
+
+    def test_runner_keyfile(self):
+        self.assertRaises(CommandError, self.cmd.handle, keyfile="server.key")
+
+    def test_runner_certfile_keyfile(self):
+        self.cmd.handle(certfile="server.crt", keyfile="server.key")
+        self.assertServerSettings('127.0.0.1', '8000', certfile="server.crt", keyfile="server.key", use_ssl=True)
+
 
 class ManageRunserverEmptyAllowedHosts(AdminScriptTestCase):
     def setUp(self):
@@ -1326,7 +1340,7 @@ class ManageTestserver(AdminScriptTestCase):
             'blah.json',
             stdout=out, settings=None, pythonpath=None, verbosity=1,
             traceback=False, addrport='', no_color=False, use_ipv6=False,
-            skip_checks=True, interactive=True,
+            skip_checks=True, interactive=True, certfile=None, keyfile=None,
         )
 
 


### PR DESCRIPTION
The Django admin `runserver` command now optionally supports SSL. The
server key and certificate files can be specified independently or as a
concatenated certfile. The admin command documentation and test cases
have been updated accordingly.

Some changes were necessary in the django.core.servers.basehttp module.
Specifically SecureWSGIServer and SecureWSGIRequestHandler were added as
SSL-enabled versions of their similarly named parent classes. The run
function needed to be abstracted slightly to support variable server and
handler classes originating in the `runserver` command itself. Rather
than adding additional parameters for the certfile and keyfile
arguments, the explicit ipv6 parameter was removed in favor of a kwargs
dict to make the run function more generic.

The SecureWSGIServer class deliberately uses an ssl_version of
ssl.PROTOCOL_SSLv23. With the socket thusly wrapped, a more permissive
set of SSL/TLS versions are accepted by the development server. This
flagrantly disregards the security recommendations made in response to
the discovery of the POODLE vulnerability. However, the development
server is not intended for production use, so this not of serious
concern.

Furthermore, the ssl package is imported within the `__init__` method of
the SecureWSGIServer so as not to contribute to the overhead of
importing the basehttp module elsewhere.