### PR TITLE
UUIDField: Don't redundantly remove hyphens

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2366,7 +2366,7 @@ class UUIDField(Field):
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if isinstance(value, six.string_types):
-            value = uuid.UUID(value.replace('-', ''))
+            value = uuid.UUID(value)
         if isinstance(value, uuid.UUID):
             if connection.features.has_native_uuid_field:
                 return value


### PR DESCRIPTION
This works just fine in any version of python.

```
$ python
Python 2.7.9 (default, Dec 13 2014, 22:20:22)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import uuid; uuid.UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
>>> exit()
$ python2.6
Python 2.6.9 (unknown, Sep  9 2014, 15:05:12)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.39)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import uuid; uuid.UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
$ python3
Python 3.4.3 (default, Feb 25 2015, 21:28:45)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import uuid; uuid.UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
$ pypy
Python 2.7.9 (9c4588d731b7fe0b08669bd732c2b676cb0a8233, Mar 31 2015, 07:55:22)
[PyPy 2.5.1 with GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> import uuid; uuid.UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
UUID('a6bdbb77-a2d7-4989-bf16-eb1b147141b4')
```

Also worth noting the docstring in cpython's source: https://github.com/python/cpython/blob/2.7/Lib/uuid.py#L103-L126

Technically, a bunch of different string formats are acceptable.