### PR TITLE
Fixed #24698 and #24712: Implement get_db_prep_value for ForeignKey

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1939,6 +1939,9 @@ class ForeignKey(ForeignObject):
         else:
             return self.related_field.get_db_prep_save(value, connection=connection)
 
+    def get_db_prep_value(self, value, connection, prepared=False):
+        return self.related_field.get_db_prep_value(value, connection, prepared)
+
     def value_to_string(self, obj):
         if not obj:
             # In required many-to-one fields with only one available choice,

--- a/docs/releases/1.8.2.txt
+++ b/docs/releases/1.8.2.txt
@@ -20,3 +20,7 @@ Bugfixes
 
 * Fixed incorrect GROUP BY clause generation on MySQL when the query's model
   has a self-referential foreign key (:ticket:`24748`).
+
+* Implemented ``get_db_prep_value`` on :class:`~django.db.models.ForeignKey` 
+  so that ForeignKeys pointing to :class:`~django.db.models.UUIDField` work
+  correctly (:ticket:`24698` :ticket:`24712`).

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -375,3 +375,12 @@ class PrimaryKeyUUIDModel(models.Model):
 
 class RelatedToUUIDModel(models.Model):
     uuid_fk = models.ForeignKey('PrimaryKeyUUIDModel')
+
+
+# Following two models are for #24712 & #24698
+class FirstLevelInheritFromUUIDModel(PrimaryKeyUUIDModel):
+    pass
+
+
+class SecondLevelInheritFromUUIDModel(FirstLevelInheritFromUUIDModel):
+    pass

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -6,7 +6,8 @@ from django.db import models
 from django.test import TestCase
 
 from .models import (
-    NullableUUIDModel, PrimaryKeyUUIDModel, RelatedToUUIDModel, UUIDModel,
+    NullableUUIDModel, PrimaryKeyUUIDModel, RelatedToUUIDModel,
+    SecondLevelInheritFromUUIDModel, UUIDModel
 )
 
 
@@ -146,3 +147,8 @@ class TestAsPrimaryKey(TestCase):
         RelatedToUUIDModel.objects.update(uuid_fk=u2.pk)
         r.refresh_from_db()
         self.assertEqual(r.uuid_fk, u2)
+
+    def test_two_level_foreign_keys(self):
+        # For #24698 and #24712
+        # exercises the get_db_prep_value of ForeignKey
+        SecondLevelInheritFromUUIDModel.objects.create()


### PR DESCRIPTION
ForeignKey was not deferring to related field for get_db_prep_lookup. As a result, the db_prep_save value would differ from db_prep_lookup value for foreign keys pointing to fields that implement a custom get_db_prep_value.

Add a tests checking specifically for a ForeignKey to a UUIDField.