### PR TITLE
Fixed #24789 -- Example code positional arguments

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -450,7 +450,7 @@ different User model.
         from django.conf import settings
         from django.db.models.signals import post_save
 
-        def post_save_receiver(signal, sender, instance, **kwargs):
+        def post_save_receiver(sender, instance, created, **kwargs):
             pass
 
         post_save.connect(post_save_receiver, sender=settings.AUTH_USER_MODEL)


### PR DESCRIPTION
Corrected positional parameter order for example post_save signal 
receiver.

Arguments shown in example code (signal, sender, instance) appeared to 
be the incorrect positional arguments for a post_save signal (which 
might start as: sender, instance, created), as documented:
​https://docs.djangoproject.com/en/1.8/ref/signals/#post-save