### PR TITLE
Tidy spacing in generated migrations.

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -504,12 +504,11 @@ class MigrationWriter(object):
 
 MIGRATION_TEMPLATE = """\
 # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 %(imports)s
-
-class Migration(migrations.Migration):
-%(replaces_str)s
+class Migration(migrations.Migration):%(replaces_str)s
     dependencies = [
 %(dependencies)s\
     ]


### PR DESCRIPTION
```
# -*- coding: utf-8 -*-
from __future__ import unicode_literals

import datetime
from django.conf import settings
from django.db import migrations, models


class Migration(migrations.Migration):

    dependencies = [
        ('clients', '__first__'),
        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
    ]

    operations = [
```

vs

```
# -*- coding: utf-8 -*-

from __future__ import unicode_literals

import datetime
from django.conf import settings
from django.db import migrations, models

class Migration(migrations.Migration):
    dependencies = [
        ('clients', '__first__'),
        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
    ]

    operations = [
```

(MIght be tempting to further separate imports that start with "import " for ultimate niceness.)