### PR TITLE
Fixed #24813 -- Documented {% include %} debug behavior variance

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -699,6 +699,13 @@ available to the included template::
 
     {% include "name_snippet.html" with greeting="Hi" only %}
 
+If the included template is missing or has syntax errors, the behavior varies
+depending on the template engine's ``debug`` option (if not set, this option
+defaults to the value of :setting:`DEBUG`).  When debug mode is turned on,
+:exc:`~django.template.TemplateDoesNotExist` or
+:exc:`~django.template.TemplateSyntaxError` exception will be raised; otherwise
+``{% include %}`` silences the exception and returns an empty string.
+
 .. note::
     The :ttag:`include` tag should be considered as an implementation of
     "render this subtemplate and include the HTML", not as "parse this


### PR DESCRIPTION
Added doc note about difference in handling of missing template by
include tag based on DEBUG setting.