### PR TITLE
Refs #24553 -- Stopped overriding contrib.auth.urlpatterns in auth_tests

### DIFF
--- a/tests/auth_tests/urls.py
+++ b/tests/auth_tests/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.contrib.auth import views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
-from django.contrib.auth.urls import urlpatterns
+from django.contrib.auth.urls import urlpatterns as auth_urlpatterns
 from django.contrib.messages.api import info
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
@@ -65,7 +65,7 @@ def custom_request_auth_login(request):
     return views.login(request, authentication_form=CustomRequestAuthenticationForm)
 
 # special urls for auth test cases
-urlpatterns += [
+urlpatterns = auth_urlpatterns + [
     url(r'^logout/custom_query/$', views.logout, dict(redirect_field_name='follow')),
     url(r'^logout/next_page/$', views.logout, dict(next_page='/somewhere/')),
     url(r'^logout/next_page/named/$', views.logout, dict(next_page='password_reset')),

--- a/tests/auth_tests/urls_custom_user_admin.py
+++ b/tests/auth_tests/urls_custom_user_admin.py
@@ -2,7 +2,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.urls import urlpatterns
 
 site = admin.AdminSite(name='custom_user_admin')
 
@@ -16,6 +15,6 @@ class CustomUserAdmin(UserAdmin):
 
 site.register(get_user_model(), CustomUserAdmin)
 
-urlpatterns += [
+urlpatterns = [
     url(r'^admin/', include(site.urls)),
 ]


### PR DESCRIPTION
This avoid leakage of urls between tests. The perils of mutable data structures :)