### PR TITLE
Fixed #24705 -- Fixed negated Q objects in expressions.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -90,7 +90,7 @@ class Q(tree.Node):
         # We must promote any new joins to left outer joins so that when Q is
         # used as an expression, rows aren't filtered due to joins.
         joins_before = query.tables[:]
-        clause, joins = query._add_q(self, reuse, allow_joins=allow_joins)
+        clause, joins = query._add_q(self, reuse, allow_joins=allow_joins, split_subq=False)
         joins_to_promote = [j for j in joins if j not in joins_before]
         query.promote_joins(joins_to_promote)
         return clause

--- a/docs/releases/1.8.2.txt
+++ b/docs/releases/1.8.2.txt
@@ -18,6 +18,11 @@ Bugfixes
   query with a  ``Case`` expression could unexpectedly filter out results
   (:ticket:`24766`).
 
+* Fixed negated Q-objects as expressions. Negated Q-objects tried to generate
+  a subquery when the Q-object was used as an expression (for example
+  `Case(When(~Q(friends__age__lte=30)))`). This resulted in crash
+  (:ticket:`24705`).
+
 * Fixed incorrect GROUP BY clause generation on MySQL when the query's model
   has a self-referential foreign key (:ticket:`24748`).
 


### PR DESCRIPTION
Avoided split_exclude() for Q when used as an expression.