### PR TITLE
Clear floats with clear rather than overflow.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -217,6 +217,35 @@ p img, h1 img, h2 img, h3 img, h4 img, td img {
     clear: both;
 }
 
+/**
+ * http://nicolasgallagher.com/micro-clearfix-hack/
+ *
+ * For modern browsers
+ * 1. The space content is one way to avoid an Opera bug when the
+ *    contenteditable attribute is included anywhere else in the document.
+ *    Otherwise it causes space to appear at the top and bottom of elements
+ *    that are clearfixed.
+ * 2. The use of `table` rather than `block` is only necessary if using
+ *    `:before` to contain the top-margins of child elements.
+ */
+.clearfix:before,
+.clearfix:after {
+    content: " "; /* 1 */
+    display: table; /* 2 */
+}
+
+.clearfix:after {
+    clear: both;
+}
+
+/**
+ * For IE 6/7 only
+ * Include this rule to trigger hasLayout and contain floats.
+ */
+.clearfix {
+    *zoom: 1;
+}
+
 .align-left {
     text-align: left;
 }

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -3,7 +3,6 @@
 /* FORM ROWS */
 
 .form-row {
-    overflow: hidden;
     padding: 8px 12px;
     font-size: 11px;
     border-bottom: 1px solid #eee;

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -24,6 +24,7 @@
                     {% endif %}
                 </div>
             {% endfor %}
+                <div class="clear"></div>
         </div>
     {% endfor %}
 </fieldset>

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -4,7 +4,7 @@
         <div class="description">{{ fieldset.description|safe }}</div>
     {% endif %}
     {% for line in fieldset %}
-        <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+        <div class="form-row clearfix{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
             {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
             {% for field in line %}
                 <div{% if not line.fields|length_is:'1' %} class="field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="checkbox-row"{% endif %}>
@@ -24,7 +24,6 @@
                     {% endif %}
                 </div>
             {% endfor %}
-                <div class="clear"></div>
         </div>
     {% endfor %}
 </fieldset>


### PR DESCRIPTION
I've been dissecting Django admin's model choice widget changes recently ( https://github.com/jpic/test_input_relation it has a bit of history too because it was initially related to [#24784](https://code.djangoproject.com/ticket/24784) ) and found something a bit weird in the new CSS, which kind of breaks the ability to have a dynamic widget (ie. a javascript menu or autocompletion) in a clean manner (without fixing the flow with custom JS).

Shouldn't we use the .clear class defined in base.css to clear floats instead ?

Isn't .form-row is meant to contain .field-box which have float:left ?

In this case, shouldn't we need .form-row to contain an element that will clear
the floats ?

This would remove the need to hide overflow and enable rich dynamic widgets
(ie. js menus) without hacks.

Let me know what you think.