### PR TITLE
Fixed #24834 -- Fixed get_current_site() when Host header contains port.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -517,6 +517,7 @@ answer newbie questions, and generally made Django that much better:
     Niall Kelly <duke.sam.vimes@gmail.com>
     Nick Efford <nick@efford.org>
     Nick Lane <nick.lane.au@gmail.com>
+    Nick Pope <nick@nickpope.me.uk>
     Nick Presta <nick@nickpresta.ca>
     Nick Sandford <nick.sandford@gmail.com>
     Niclas Olofsson <n@niclasolofsson.se>

--- a/django/contrib/sites/models.py
+++ b/django/contrib/sites/models.py
@@ -5,6 +5,7 @@ import string
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.db.models.signals import pre_delete, pre_save
+from django.http.request import split_domain_port
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -37,10 +38,11 @@ class SiteManager(models.Manager):
 
     def _get_site_by_request(self, request):
         host = request.get_host()
-        if host not in SITE_CACHE:
-            site = self.get(domain__iexact=host)
-            SITE_CACHE[host] = site
-        return SITE_CACHE[host]
+        domain, port = split_domain_port(host)
+        if domain not in SITE_CACHE:
+            site = self.get(domain__iexact=domain)
+            SITE_CACHE[domain] = site
+        return SITE_CACHE[domain]
 
     def get_current(self, request=None):
         """

--- a/django/contrib/sites/requests.py
+++ b/django/contrib/sites/requests.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.http.request import split_domain_port
 from django.utils.encoding import python_2_unicode_compatible
 
 
@@ -13,7 +14,9 @@ class RequestSite(object):
     The save() and delete() methods raise NotImplementedError.
     """
     def __init__(self, request):
-        self.domain = self.name = request.get_host()
+        host = request.get_host()
+        domain, port = split_domain_port(host)
+        self.domain = self.name = domain
 
     def __str__(self):
         return self.domain

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -9,4 +9,5 @@ Django 1.8.3 fixes several bugs in 1.8.2.
 Bugfixes
 ========
 
-* ...
+* Fixed ``get_current_site()`` failure in the case where a port is
+  present in the value returned by ``HttpRequest.get_host()``.

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -75,6 +75,26 @@ class SitesFrameworkTests(TestCase):
             self.assertIsInstance(site, RequestSite)
             self.assertEqual(site.name, "example.com")
 
+    @override_settings(ALLOWED_HOSTS=['example.com'])
+    def test_get_current_site_host_header_with_port(self):
+        # Test that the correct Site object is returned
+        request = HttpRequest()
+        request.META = {"HTTP_HOST": "example.com:80"}
+        site = get_current_site(request)
+        self.assertIsInstance(site, Site)
+        self.assertEqual(site.id, settings.SITE_ID)
+
+        # Test that an exception is raised if the sites framework is installed
+        # but there is no matching Site
+        site.delete()
+        self.assertRaises(ObjectDoesNotExist, get_current_site, request)
+
+        # A RequestSite is returned if the sites framework is not installed
+        with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
+            site = get_current_site(request)
+            self.assertIsInstance(site, RequestSite)
+            self.assertEqual(site.name, "example.com")
+
     @override_settings(SITE_ID='', ALLOWED_HOSTS=['example.com'])
     def test_get_current_site_no_site_id(self):
         request = HttpRequest()


### PR DESCRIPTION
When the Host header contains a port, looking up the Site record fails
as the host will never match the domain.