### PR TITLE
index.txt basic grammar edits and SQL statements

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1097,8 +1097,8 @@ subclass::
     ``['first_name', 'last_name']`` and a user searches for ``john lennon``,
     Django will do the equivalent of this SQL ``WHERE`` clause::
 
-        WHERE (first_name LIKE '%john%' OR last_name LIKE '%john%')
-        AND (first_name LIKE '%lennon%' OR last_name LIKE '%lennon%')
+        WHERE (first_name ILIKE '%john%' OR last_name ILIKE '%john%')
+        AND (first_name ILIKE '%lennon%' OR last_name ILIKE '%lennon%')
 
     For faster and/or more restrictive searches, prefix the field name
     with an operator:
@@ -1110,8 +1110,8 @@ subclass::
         ``john lennon``, Django will do the equivalent of this SQL ``WHERE``
         clause::
 
-            WHERE (first_name LIKE 'john%' OR last_name LIKE 'john%')
-            AND (first_name LIKE 'lennon%' OR last_name LIKE 'lennon%')
+            WHERE (first_name ILIKE 'john%' OR last_name ILIKE 'john%')
+            AND (first_name ILIKE 'lennon%' OR last_name ILIKE 'lennon%')
 
         This query is more efficient than the normal ``'%john%'`` query,
         because the database only needs to check the beginning of a column's
@@ -1126,8 +1126,8 @@ subclass::
         ``john lennon``, Django will do the equivalent of this SQL 
         ``WHERE`` clause::
 
-            WHERE (first_name LIKE 'john' OR last_name LIKE 'john')
-            AND (first_name LIKE 'lennon' OR last_name LIKE 'lennon')
+            WHERE (first_name ILIKE 'john' OR last_name ILIKE 'john')
+            AND (first_name ILIKE 'lennon' OR last_name ILIKE 'lennon')
 
         Note that the query input is split by spaces, so, following this
         example, it's currently not possible to search for all records in which

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -237,13 +237,13 @@ subclass::
 
 .. attribute:: ModelAdmin.fields
 
-    If you need to achieve simple changes in the layout of fields in the forms
-    of the "add" and "change" pages like only showing a subset of the available
-    fields, modifying their order or grouping them in rows you can use the
-    ``fields`` option (for more complex layout needs see the
-    :attr:`~ModelAdmin.fieldsets` option described in the next section). For
-    example, you could define a simpler version of the admin form for the
-    :class:`django.contrib.flatpages.models.FlatPage` model as follows::
+    Use the ``fields`` option to make simple layout changes in the forms on
+    the “add” and “change” pages (i.e., show only a subset of available
+    fields, modify their order, or group into rows). For more complex layout
+    needs see the :attr:`~ModelAdmin.fieldsets` option described in the 
+    next section. For example, you could define a simpler version of the
+    admin form for the :class:`django.contrib.flatpages.models.FlatPage` 
+    model as follows::
 
         class FlatPageAdmin(admin.ModelAdmin):
             fields = ('url', 'title', 'content')
@@ -260,7 +260,7 @@ subclass::
 
     To display multiple fields on the same line, wrap those fields in their own
     tuple. In this example, the ``url`` and ``title`` fields will display on the
-    same line and the ``content`` field will be displayed below them in its
+    same line and the ``content`` field will be displayed below them on its
     own line::
 
         class FlatPageAdmin(admin.ModelAdmin):
@@ -344,7 +344,7 @@ subclass::
         listed in :attr:`~ModelAdmin.readonly_fields`.
 
     * ``classes``
-        A list containing extra CSS classes to apply to the fieldset.
+        A tuple containing extra CSS classes to apply to the fieldset.
 
         Example::
 
@@ -1085,8 +1085,8 @@ subclass::
         search_fields = ['foreign_key__related_fieldname']
 
     For example, if you have a blog entry with an author, the following
-    definition would enable search blog entries by the email address of the
-    author::
+    definition would enable searching blog entries by the email address
+    of the author::
 
         search_fields = ['user__email']
 
@@ -1097,20 +1097,21 @@ subclass::
     ``['first_name', 'last_name']`` and a user searches for ``john lennon``,
     Django will do the equivalent of this SQL ``WHERE`` clause::
 
-        WHERE (first_name ILIKE '%john%' OR last_name ILIKE '%john%')
-        AND (first_name ILIKE '%lennon%' OR last_name ILIKE '%lennon%')
+        WHERE (first_name LIKE '%john%' OR last_name LIKE '%john%')
+        AND (first_name LIKE '%lennon%' OR last_name LIKE '%lennon%')
 
     For faster and/or more restrictive searches, prefix the field name
     with an operator:
 
     ``^``
-        Matches the beginning of the field. For example, if ``search_fields``
-        is set to ``['^first_name', '^last_name']`` and a user searches for
+        Use the '^' operator to match starting at the beginning of the
+        field. For example, if ``search_fields`` is set to 
+        ``['^first_name', '^last_name']`` and a user searches for
         ``john lennon``, Django will do the equivalent of this SQL ``WHERE``
         clause::
 
-            WHERE (first_name ILIKE 'john%' OR last_name ILIKE 'john%')
-            AND (first_name ILIKE 'lennon%' OR last_name ILIKE 'lennon%')
+            WHERE (first_name LIKE 'john%' OR last_name LIKE 'john%')
+            AND (first_name LIKE 'lennon%' OR last_name LIKE 'lennon%')
 
         This query is more efficient than the normal ``'%john%'`` query,
         because the database only needs to check the beginning of a column's
@@ -1119,21 +1120,23 @@ subclass::
         index for this query, even though it's a ``LIKE`` query.
 
     ``=``
-        Matches exactly, case-insensitive. For example, if
-        ``search_fields`` is set to ``['=first_name', '=last_name']`` and
-        a user searches for ``john lennon``, Django will do the equivalent
-        of this SQL ``WHERE`` clause::
+        Use the '=' operator for case-insensitive exact matching. For 
+        example, if ``search_fields`` is set to 
+        ``['=first_name', '=last_name']`` and a user searches for 
+        ``john lennon``, Django will do the equivalent of this SQL 
+        ``WHERE`` clause::
 
-            WHERE (first_name ILIKE 'john' OR last_name ILIKE 'john')
-            AND (first_name ILIKE 'lennon' OR last_name ILIKE 'lennon')
+            WHERE (first_name LIKE 'john' OR last_name LIKE 'john')
+            AND (first_name LIKE 'lennon' OR last_name LIKE 'lennon')
 
         Note that the query input is split by spaces, so, following this
         example, it's currently not possible to search for all records in which
         ``first_name`` is exactly ``'john winston'`` (containing a space).
 
     ``@``
-        Performs a full-text match. This is like the default search method but
-        uses an index. Currently this is only available for MySQL.
+        Using the '@' operator performs a full text match. This is like 
+        the default search method but uses an index. Currently this is 
+        only available for MySQL.
 
     If you need to customize search you can use
     :meth:`ModelAdmin.get_search_results` to provide additional or alternate
@@ -1284,8 +1287,8 @@ templates used by the :class:`ModelAdmin` views:
 
 .. method:: ModelAdmin.get_search_results(request, queryset, search_term)
 
-    The ``get_search_results`` method modifies the list of objects displayed in
-    to those that match the provided search term. It accepts the request, a
+    The ``get_search_results`` method modifies the list of objects displayed 
+    into those that match the provided search term. It accepts the request, a
     queryset that applies the current filters, and the user-provided search term.
     It returns a tuple containing a queryset modified to implement the search, and
     a boolean indicating if the results may contain duplicates.
@@ -1354,7 +1357,7 @@ templates used by the :class:`ModelAdmin` views:
 .. method:: ModelAdmin.get_fields(request, obj=None)
 
     The ``get_fields`` method is given the ``HttpRequest`` and the ``obj``
-    being edited (or ``None`` on an add form) and is expected to return a list
+    being edited (or ``None`` on an add form) and is expected to return a tuple
     of fields, as described above in the :attr:`ModelAdmin.fields` section.
 
 .. method:: ModelAdmin.get_fieldsets(request, obj=None)
@@ -1576,9 +1579,9 @@ templates used by the :class:`ModelAdmin` views:
 
     .. admonition:: Note
 
-        Any ``choices`` attribute set on the formfield will limited to the form
-        field only. If the corresponding field on the model has choices set,
-        the choices provided to the form must be a valid subset of those
+        Any ``choices`` attributes set on the formfield will be limited to the 
+        form field only. If the corresponding field on the model has choices 
+        set, the choices provided to the form must be a valid subset of those
         choices, otherwise the form submission will fail with
         a :exc:`~django.core.exceptions.ValidationError` when the model itself
         is validated before saving.
@@ -2023,7 +2026,7 @@ The ``InlineModelAdmin`` class adds:
     overhead of having to select all the related instances to display in the
     drop-down.
 
-    ``raw_id_fields`` is a list of fields you would like to change into a
+    ``raw_id_fields`` is a list of fields you would like to change into an
     ``Input`` widget for either a ``ForeignKey`` or ``ManyToManyField``::
 
         class BookInline(admin.TabularInline):
@@ -2276,11 +2279,11 @@ you have the following models::
     class Product(models.Model):
         name = models.CharField(max_length=100)
 
-If you want to allow editing and creating ``Image`` instance on the ``Product``
+If you want to allow editing and creating an ``Image`` instance on the ``Product``
 add/change views you can use :class:`~django.contrib.contenttypes.admin.GenericTabularInline`
 or :class:`~django.contrib.contenttypes.admin.GenericStackedInline` (both
 subclasses of :class:`~django.contrib.contenttypes.admin.GenericInlineModelAdmin`)
-provided by :mod:`~django.contrib.contenttypes.admin`, they implement tabular and
+provided by :mod:`~django.contrib.contenttypes.admin`. They implement tabular and
 stacked visual layouts for the forms representing the inline objects
 respectively just like their non-generic counterparts and behave just like any
 other inline. In your ``admin.py`` for this example app::


### PR DESCRIPTION
For your review and consideration please find basic edits to this document, and two topics for discussion below. 

The two topics which require clarification: 
1)  In the 'fieldsets' and 'get_fieldsets' discussions on lines: 284 and 1367; the text suggests 'a list of two-tuples', but technically this is a 'two-tuple tuple'. I left it as is, because a list of two-tuples actually sounds less confusing, but seems to be technically wrong. Please weigh in on this issue. 

2) SQL statements on lines 1100-1101; 1113-1114; and 1129-1130 
Of the primary SQL flavors regularly referenced through the documentation (PostgreSQL, sqLite and MySQL), only PostgreSQL has the ILIKE statement. Unless clarification is added to the document at the point where ILIKE statements are referenced which explains the statement is exclusive to PostgreSQL when constructing case-insensitive searches, LIKE is a better representation of a SQL statement (even novices know the LIKE statement). Below please find the references to case-sensitivity searching in SQL by their respective sources.  

PostgreSQL:
"The key word ILIKE can be used instead of LIKE to make the match case-insensitive according to the active locale. This is not in the SQL standard but is a PostgreSQL extension." (http://www.postgresql.org/docs/8.3/static/functions-matching.html)

sqLite:
"The default configuration of SQLite only supports case-insensitive comparisons of ASCII characters." (https://www.sqlite.org/faq.html)

MySQL
"  string comparisons are case insensitive by default. This means that if you search with col_name LIKE 'a%', you get all column values that start with A or a." (https://dev.mysql.com/doc/refman/5.0/en/case-sensitivity.html)

I do not have write privileges to the repo, so if these changes are appropriate, please commit.  
Thank you.