### PR TITLE
Fixed documentation to match changes in #24149.

### DIFF
--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -166,8 +166,8 @@ Django apps. Just follow these conventions:
 * Setting names are in all uppercase.
 * Don't reinvent an already-existing setting.
 
-For settings that are sequences, Django itself uses tuples, rather than lists,
-but this is only a convention.
+For settings that are sequences, Django itself uses lists, but this is only
+a convention.
 
 .. _settings-without-django-settings-module:
 


### PR DESCRIPTION
With ticket #24149 (commit
9ec8aa5e5d42ac4529846f7eae6bf4982800abff), Django uses lists instead
of tuples for settings.