### PR TITLE
BaseRangeField should use base_field's prepare_value method. Ref: #24841

### DIFF
--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -26,12 +26,12 @@ class BaseRangeField(forms.MultiValueField):
         if isinstance(value, self.range_type):
             return [
                 lower_base.prepare_value(value.lower),
-                upper_base.prepare_value(value.upper)
+                upper_base.prepare_value(value.upper),
             ]
         if value is None:
             return [
                 lower_base.prepare_value(None),
-                upper_base.prepare_value(None)
+                upper_base.prepare_value(None),
             ]
         return value
 

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -22,10 +22,17 @@ class BaseRangeField(forms.MultiValueField):
         super(BaseRangeField, self).__init__(**kwargs)
 
     def prepare_value(self, value):
+        lower_base, upper_base = self.fields
         if isinstance(value, self.range_type):
-            return [value.lower, value.upper]
+            return [
+                lower_base.prepare_value(value.lower),
+                upper_base.prepare_value(value.upper)
+            ]
         if value is None:
-            return [None, None]
+            return [
+                lower_base.prepare_value(None),
+                upper_base.prepare_value(None)
+            ]
         return value
 
     def compress(self, values):

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -9,4 +9,6 @@ Django 1.8.3 fixes several bugs in 1.8.2.
 Bugfixes
 ========
 
+* Fixed ``BaseRangeField.prepare_value`` to use ``base_field``'s prepare value method. (:ticket `24841`).
+
 * ...

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -11,7 +11,7 @@ from django.contrib.postgres.validators import (
 )
 from django.core import exceptions, serializers
 from django.db import connection
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from .models import RangesModel
@@ -466,6 +466,14 @@ class TestFormField(TestCase):
         self.assertEqual(cm.exception.messages[0], 'This field is required.')
         value = field.clean(['2013-04-09 11:45', ''])
         self.assertEqual(value, DateTimeTZRange(datetime.datetime(2013, 4, 9, 11, 45), None))
+
+    @override_settings(USE_TZ=True, TIME_ZONE='Africa/Johannesburg')
+    def test_datetime_prepare_value(self):
+        field = pg_forms.DateTimeRangeField()
+        value = field.prepare_value(DateTimeTZRange(
+            datetime.datetime(2015, 5, 22, 16, 6, 33, tzinfo=timezone.utc), None))
+        print value
+        self.assertEqual(value, [datetime.datetime(2015, 5, 22, 18, 6, 33), None])
 
     def test_model_field_formfield_integer(self):
         model_field = pg_fields.IntegerRangeField()

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -472,7 +472,6 @@ class TestFormField(TestCase):
         field = pg_forms.DateTimeRangeField()
         value = field.prepare_value(DateTimeTZRange(
             datetime.datetime(2015, 5, 22, 16, 6, 33, tzinfo=timezone.utc), None))
-        print value
         self.assertEqual(value, [datetime.datetime(2015, 5, 22, 18, 6, 33), None])
 
     def test_model_field_formfield_integer(self):


### PR DESCRIPTION
The `BaseRangeField` doesn't do the `base_field`'s `prepare_value` method on the submitted range values, so the base field preparations are not applied to the values.

For the basic types, this isn't a problem, but for `DateTimeRangeField` it is, because the `DateTimeField` (`DateTimeRangeField`'s `base_field`) does a timezone conversion on the submitted values, but `DateTimeRangeField` leaves the timezone as is.

What then happens is that datetimes displayed by the field are in UTC, but they are submitted as the local timezone.