### PR TITLE
formsets.txt datetime vs string examples

### DIFF
--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -209,6 +209,7 @@ this management data, an exception will be raised::
     ...     'form-0-pub_date': '',
     ... }
     >>> formset = ArticleFormSet(data)
+    >>> formset.is_valid()
     Traceback (most recent call last):
     ...
     django.forms.utils.ValidationError: ['ManagementForm data is missing or has been tampered with']
@@ -454,7 +455,7 @@ Lets you create a formset with the ability to select forms for deletion::
     ... ])
     >>> for form in formset:
     ....    print(form.as_table())
-    <input type="hidden" name="form-TOTAL_FORMS" value="3" id="id_form-TOTAL_FORMS" /><input type="hidden" name="form-INITIAL_FORMS" value="2" id="id_form-INITIAL_FORMS" /><input type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS" />
+
     <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Article #1" id="id_form-0-title" /></td></tr>
     <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-10" id="id_form-0-pub_date" /></td></tr>
     <tr><th><label for="id_form-0-DELETE">Delete:</label></th><td><input type="checkbox" name="form-0-DELETE" id="id_form-0-DELETE" /></td></tr>


### PR DESCRIPTION
For your review and consideration;

1) View this doc as it renders on the website you will see that line 456 is the wrong font color/weight. I wonder if line 457 an extraneous  <hidden tag> is causing this issue. Also line 457 does not make sense, and is out of place without an explanation being provided for it. So I clipped it. Hope it fixes the issue.

2) The significant, repeating issue in this document relates to the example code blocks, which demonstrate setting the pub_date value to a string:

>>> data = {
...     # clipped code
...     'form-0-pub_date': '1904-06-16',
...     # clipped code

This causes is_valid() to return False for each example it occurs in,  because pub_date actually requires a datetime object, as is established in the first block of code: 

>>> class ArticleForm(forms.Form):
...     title = forms.CharField()
...     pub_date = forms.DateField()

The simple solution is to change each instance from a string to a datetime object: 

>>> data = {
...     # clipped code
...     'form-0-pub_date': datetime.date(1904-06-16),
...     # clipped code

... and then everything works. 

I am happy to suggest this, but have not made the changes. I searched this history of this doc to see if there was a discussion as to why this might be intentionally 'wrong' (i.e., for some aesthetic reason), but can't find anything along those lines. To complicate this issue, about half of the references in this document are properly referencing the datetime object. 

Lines with proper datetime.date syntax: 
line(s): 68, 392, 393, 428, 429, 435, 436, 437, 452, 453, 488, 489, 492, 

Lines with improper 'string' syntax: 
line(s): 154, 276, 278, 318, 320, 360, 362, 417, 420, 423, 477, 480,