### PR TITLE
Fixed #24699 -- Added aggregate support for DurationField on Oracle

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -157,9 +157,6 @@ class BaseDatabaseFeatures(object):
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 
-    # Can the backend use an Avg aggregate on DurationField?
-    can_avg_on_durationfield = True
-
     # Does the backend decide to commit before SAVEPOINT statements
     # when autocommit is disabled? http://bugs.python.org/issue8145#msg109965
     autocommits_when_autocommit_is_off = False

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -39,7 +39,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     uppercases_column_names = True
     # select for update with limit can be achieved on Oracle, but not with the current backend.
     supports_select_for_update_with_limit = False
-    can_avg_on_durationfield = False  # Pending implementation (#24699).
 
     def introspected_boolean_field_type(self, field=None, created_separately=False):
         """

--- a/django/db/backends/oracle/functions.py
+++ b/django/db/backends/oracle/functions.py
@@ -1,0 +1,24 @@
+from django.db.models import DecimalField, DurationField, Func
+
+
+class IntervalToSeconds(Func):
+    function = ''
+    template = """
+    EXTRACT(day from %(expressions)s) * 86400 +
+    EXTRACT(hour from %(expressions)s) * 3600 +
+    EXTRACT(minute from %(expressions)s) * 60 +
+    EXTRACT(second from %(expressions)s)
+    """
+
+    def __init__(self, expression, **extra):
+        output_field = extra.pop('output_field', DecimalField())
+        super(IntervalToSeconds, self).__init__(expression, output_field=output_field, **extra)
+
+
+class SecondsToInterval(Func):
+    function = 'NUMTODSINTERVAL'
+    template = "%(function)s(%(expressions)s, 'SECOND')"
+
+    def __init__(self, expression, **extra):
+        output_field = extra.pop('output_field', DurationField())
+        super(SecondsToInterval, self).__init__(expression, output_field=output_field, **extra)

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -78,6 +78,15 @@ class Avg(Aggregate):
         output_field = extra.pop('output_field', FloatField())
         super(Avg, self).__init__(expression, output_field=output_field, **extra)
 
+    def as_oracle(self, compiler, connection):
+        if self.output_field.get_internal_type() == 'DurationField':
+            expression = self.get_source_expressions()[0]
+            from django.db.backends.oracle.functions import IntervalToSeconds, SecondsToInterval
+            return compiler.compile(
+                SecondsToInterval(Avg(IntervalToSeconds(expression)))
+            )
+        return super(Avg, self).as_sql(compiler, connection)
+
 
 class Count(Aggregate):
     function = 'COUNT'
@@ -136,6 +145,15 @@ class StdDev(Aggregate):
 class Sum(Aggregate):
     function = 'SUM'
     name = 'Sum'
+
+    def as_oracle(self, compiler, connection):
+        if self.output_field.get_internal_type() == 'DurationField':
+            expression = self.get_source_expressions()[0]
+            from django.db.backends.oracle.functions import IntervalToSeconds, SecondsToInterval
+            return compiler.compile(
+                SecondsToInterval(Sum(IntervalToSeconds(expression)))
+            )
+        return super(Sum, self).as_sql(compiler, connection)
 
 
 class Variance(Aggregate):


### PR DESCRIPTION
This works, but I'd like to hear some thoughts on putting "private" expressions in `backends.<vendor>.functions`. 

The `IntervalToNumber` and `NumberToInterval` expressions are extremely bare bones. If they were going to be public then I'd probably build them out a little better. As a quick example, I'd add support for changing the second argument of `NumberToInterval` from `SECOND` to something user supplied.

But mainly, I'm wondering whether we should add expressions into each of the backends, and then reference them from the public API as I'm doing below. Is this where they belong? If yes, should we default to making everything public?

My thoughts on this are that expressions in the backend are fine, but they should be documented and rugged enough for public API.