### PR TITLE
Trac #7835: Test only models doc

### DIFF
--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -307,6 +307,53 @@ running your tests, you can define test-only models in its ``models.py``
 file.
 
 
+Test-only models
+==========================================================
+
+Test-only models are models that are only created while running unit tests. This is particularly useful when writing :doc:`reusable applications </intro/reusable-apps>` that do not contain any models of their own.
+
+Consider the following structure::
+
+    polls/
+        migrations/
+            0001_initial.py
+            __init__.py
+        tests/
+            __init__.py
+            models.py
+            test_polls.py
+            ...
+        __init__.py
+        models.py
+        views.py
+        urls.py
+        ...
+
+The ``models.py`` file in the test module contains your test-only model definitions. It is important to leave the original ``models.py`` file in the app module even if it is empty.
+
+Create a migration for your test-models in the migrations module. You will need to adapt the migration to only execute during unit tests. You can do this by checking if the database name::
+
+    from django.db import migrations
+    from django.conf import settings
+
+
+    def is_test_db():
+        return settings.DATABASES.get(
+            'default', {}).get('NAME', '').startswith('test_')
+
+    class Migration(migrations.Migration):
+
+        dependencies = []
+
+        if is_test_db():
+            operations = [
+                migrations.CreateModel(...),
+                ...
+            ]
+
+That's it! The test-models will now be usable in your unit tests.
+
+
 .. _other-testing-frameworks:
 
 Using different testing frameworks

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -331,7 +331,7 @@ Consider the following structure::
 
 The ``models.py`` file in the test module contains your test-only model definitions. It is important to leave the original ``models.py`` file in the app module even if it is empty.
 
-Create a migration for your test-models in the migrations module. You will need to adapt the migration to only execute during unit tests. You can do this by checking if the database name::
+Create a migration for your test-models in the migrations module. You will need to adapt the migration to only execute during unit tests. You can do this by checking the database name::
 
     from django.db import migrations
     from django.conf import settings


### PR DESCRIPTION
The following pull request is purely to add some documentation on how to add models that will only get created during unit tests.

Trac Ticket: https://code.djangoproject.com/ticket/7835

One concern that I have is that I have added this below [Using the Django test runner to test reusable applications](https://docs.djangoproject.com/en/1.8/topics/testing/advanced/#using-the-django-test-runner-to-test-reusable-applications). To me, I feel that both sections are talking about different ways of creating test only models but I understand if the community feels that this is a duplicate.