### PR TITLE
Implement has_changed in HStoreField to correctly handle empty one

### DIFF
--- a/django/contrib/postgres/forms/hstore.py
+++ b/django/contrib/postgres/forms/hstore.py
@@ -34,3 +34,13 @@ class HStoreField(forms.CharField):
         for key, val in value.items():
             value[key] = six.text_type(val)
         return value
+
+    def has_changed(self, initial, data):
+        """
+        Return True if data differs from initial.
+        """
+        # For purposes of seeing whether something has changed, None is
+        # the same as an empty dict, if the data or initial value we get
+        # is None, replace it w/ {}.
+        initial_value = self.to_python(initial)
+        return super(forms.HStoreField, self).has_changed(initial_value, data)

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -178,6 +178,12 @@ class TestFormField(PostgresSQLTestCase):
         form_field = model_field.formfield()
         self.assertIsInstance(form_field, forms.HStoreField)
 
+    def test_empty_field_has_not_changed(self):
+        class HStoreFormTest(forms.Form):
+            f1 = HStoreField()
+        form_w_hstore = HStoreFormTest()
+        self.assertFalse(form_w_hstore.has_changed())
+
 
 class TestValidator(PostgresSQLTestCase):
 


### PR DESCRIPTION
HStore Form Field falsely report has_changed. Implementing a custom has_changed method for this kind of field, we avoid comparing a default empty string '' with an empty dict {}