### PR TITLE
Fixed #24835 - exists() incorrect after annotation with Count()

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -489,6 +489,9 @@ class Query(object):
     def has_results(self, using):
         q = self.clone()
         if not q.distinct:
+            if q.group_by is True:
+                q.add_fields((f.attname for f in self.model._meta.concrete_fields), False)
+                q.set_group_by()
             q.clear_select_clause()
         q.clear_ordering(True)
         q.set_limits(high=1)

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Fixed crash during :djadmin:`makemigrations` if a migrations module either
   is missing ``__init__.py`` or is a file (:ticket:`24848`).
+
+* Fixed ``exists()`` returning incorrect results after annotation with
+  ``Count()`` (:ticket:`24835`).

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -325,6 +325,10 @@ class NonAggregateAnnotationTestCase(TestCase):
             lambda a: (a['age'], a['age_count'])
         )
 
+    def test_annotate_exists(self):
+        authors = Author.objects.annotate(c=Count('id')).filter(c__gt=1)
+        self.assertFalse(authors.exists())
+
     def test_column_field_ordering(self):
         """
         Test that columns are aligned in the correct order for


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24835

I followed the same approach as in `QuerySet._values()`. Seems hacky but I couldn't figure out a better way.