### PR TITLE
Fixed #24848 -- Fixed ValueError for faulty migrations module.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -79,9 +79,11 @@ class MigrationLoader(object):
             else:
                 # PY3 will happily import empty dirs as namespaces.
                 if not hasattr(module, '__file__'):
+                    self.unmigrated_apps.add(app_config.label)
                     continue
                 # Module is not a package (e.g. migrations.py).
                 if not hasattr(module, '__path__'):
+                    self.unmigrated_apps.add(app_config.label)
                     continue
                 # Force a reload if it's already loaded (tests need this)
                 if was_loaded:

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -9,4 +9,5 @@ Django 1.8.3 fixes several bugs in 1.8.2.
 Bugfixes
 ========
 
-* ...
+* Fixed crash during :djadmin:`makemigrations` if a migrations module
+  either was missing ``__init__.py`` or was a file (:ticket:`24848`).

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -164,12 +164,20 @@ class LoaderTests(TestCase):
 
     def test_load_module_file(self):
         with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.file"}):
-            MigrationLoader(connection)
+            loader = MigrationLoader(connection)
+            self.assertIn(
+                "migrations", loader.unmigrated_apps,
+                "App with migrations module file not in unmigrated apps."
+            )
 
     @skipIf(six.PY2, "PY2 doesn't load empty dirs.")
     def test_load_empty_dir(self):
         with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.namespace"}):
-            MigrationLoader(connection)
+            loader = MigrationLoader(connection)
+            self.assertIn(
+                "migrations", loader.unmigrated_apps,
+                "App missing __init__.py in migrations module not in unmigrated apps."
+            )
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
     def test_loading_squashed(self):


### PR DESCRIPTION
Added apps to unmigrated apps if they had a migrations.py file
or an empty migrations folder.

https://code.djangoproject.com/ticket/24848