### PR TITLE
Fixed #24847 -- Items set on a RequestContext after creation get lost

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -226,7 +226,13 @@ class RequestContext(Context):
         self.request = request
         self._processors = () if processors is None else tuple(processors)
         self._processors_index = len(self.dicts)
-        self.update({})         # placeholder for context processors output
+
+        # placeholder for context processors output
+        self.update({})
+
+        # empty dict for any new modifications
+        # (so that context processors don't overwrite them)
+        self.update({})
 
     @contextmanager
     def bind_template(self, template):

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -19,3 +19,6 @@ Bugfixes
   ``Count()`` (:ticket:`24835`).
 
 * Corrected ``HStoreField.has_changed()`` (:ticket:`24844`).
+
+* Fixed template context processors overwriting variables set after
+  ``RequestContext`` creation (:ticket:`24847`).

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -2,7 +2,7 @@
 
 from django.http import HttpRequest
 from django.template import (
-    Context, Engine, RequestContext, Variable, VariableDoesNotExist,
+    Context, Engine, RequestContext, Template, Variable, VariableDoesNotExist,
 )
 from django.template.context import RenderContext
 from django.test import RequestFactory, SimpleTestCase
@@ -153,8 +153,8 @@ class RequestContextTests(SimpleTestCase):
         request = RequestFactory().get('/')
         ctx = RequestContext(request, {})
         # The stack should now contain 3 items:
-        # [builtins, supplied context, context processor]
-        self.assertEqual(len(ctx.dicts), 3)
+        # [builtins, supplied context, context processor, empty dict]
+        self.assertEqual(len(ctx.dicts), 4)
 
     def test_context_comparable(self):
         # Create an engine without any context processors.
@@ -168,3 +168,10 @@ class RequestContextTests(SimpleTestCase):
             RequestContext(request, dict_=test_data),
             RequestContext(request, dict_=test_data),
         )
+
+    def test_modify_context_and_render(self):
+        template = Template('{{ foo }}')
+        request = RequestFactory().get('/')
+        context = RequestContext(request, {})
+        context['foo'] = 'foo'
+        self.assertEqual(template.render(context), 'foo')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24847