### PR TITLE
Fixed #24817 - Prevented loss of null info in MySQL field renaming

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -542,12 +542,7 @@ class BaseDatabaseSchemaEditor(object):
                 self.execute(self._delete_constraint_sql(self.sql_delete_check, model, constraint_name))
         # Have they renamed the column?
         if old_field.column != new_field.column:
-            self.execute(self.sql_rename_column % {
-                "table": self.quote_name(model._meta.db_table),
-                "old_column": self.quote_name(old_field.column),
-                "new_column": self.quote_name(new_field.column),
-                "type": new_type,
-            })
+            self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
         # Next, start accumulating actions to do
         actions = []
         null_actions = []
@@ -863,6 +858,14 @@ class BaseDatabaseSchemaEditor(object):
             fields = [model._meta.get_field(field) for field in field_names]
             output.append(self._create_index_sql(model, fields, suffix="_idx"))
         return output
+
+    def _rename_field_sql(self, table, old_field, new_field, new_type):
+        return self.sql_rename_column % {
+            "table": self.quote_name(table),
+            "old_column": self.quote_name(old_field.column),
+            "new_column": self.quote_name(new_field.column),
+            "type": new_type,
+        }
 
     def _create_fk_sql(self, model, field, suffix):
         from_table = model._meta.db_table

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -80,10 +80,21 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 )
         return super(DatabaseSchemaEditor, self)._delete_composed_index(model, fields, *args)
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
-        # Keep null property of old field, if it has changed, it will be handled separately
-        if old_field.null:
+    def _set_field_new_type_null_status(self, field, new_type):
+        """
+        Keep the null property of the old field. If it has changed, it will be
+        handled separately.
+        """
+        if field.null:
             new_type += " NULL"
         else:
             new_type += " NOT NULL"
+        return new_type
+
+    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+        new_type = self._set_field_new_type_null_status(old_field, new_type)
         return super(DatabaseSchemaEditor, self)._alter_column_type_sql(table, old_field, new_field, new_type)
+
+    def _rename_field_sql(self, table, old_field, new_field, new_type):
+        new_type = self._set_field_new_type_null_status(old_field, new_type)
+        return super(DatabaseSchemaEditor, self)._rename_field_sql(table, old_field, new_field, new_type)

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -25,3 +25,6 @@ Bugfixes
 
 * Fixed a regression which caused template context processors to overwrite
   variables set on a ``RequestContext`` after it's created (:ticket:`24847`).
+
+* Prevented the loss of ``null``/``not null`` column properties during field
+  renaming of MySQL databases (:ticket:`24817`).

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -87,6 +87,14 @@ class Note(models.Model):
         apps = new_apps
 
 
+class NoteRename(models.Model):
+    detail_info = models.TextField()
+
+    class Meta:
+        apps = new_apps
+        db_table = "schema_note"
+
+
 class Tag(models.Model):
     title = models.CharField(max_length=255)
     slug = models.SlugField(unique=True)


### PR DESCRIPTION
Previous PR - https://github.com/django/django/pull/4714
Opening against master.

https://code.djangoproject.com/ticket/24817