### PR TITLE
Fixed #24851 -- Fixed crash with reverse one-to-one relation in ModelAdmin.list_display

### DIFF
--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -200,7 +200,7 @@ def items_for_result(cl, result, form):
         except ObjectDoesNotExist:
             result_repr = EMPTY_CHANGELIST_VALUE
         else:
-            if f is None:
+            if f is None or f.auto_created:
                 if field_name == 'action_checkbox':
                     row_classes = ['action-checkbox']
                 allow_tags = getattr(attr, 'allow_tags', False)

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -383,7 +383,7 @@ class ChangeList(object):
             except FieldDoesNotExist:
                 pass
             else:
-                if isinstance(field.rel, models.ManyToOneRel):
+                if hasattr(field, 'rel') and isinstance(field.rel, models.ManyToOneRel):
                     return True
         return False
 

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -28,3 +28,6 @@ Bugfixes
 
 * Prevented the loss of ``null``/``not null`` column properties during field
   renaming of MySQL databases (:ticket:`24817`).
+
+* Fixed a crash when using a reverse one-to-one relation in
+  ``ModelAdmin.list_display`` (:ticket:`24851`).

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -102,7 +102,7 @@ site.register(Parent, NoListDisplayLinksParentAdmin)
 
 class SwallowAdmin(admin.ModelAdmin):
     actions = None  # prevent ['action_checkbox'] + list(list_display)
-    list_display = ('origin', 'load', 'speed')
+    list_display = ('origin', 'load', 'speed', 'swallowonetoone')
 
 site.register(Swallow, SwallowAdmin)
 

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -78,6 +78,10 @@ class Swallow(models.Model):
         ordering = ('speed', 'load')
 
 
+class SwallowOneToOne(models.Model):
+    swallow = models.OneToOneField(Swallow)
+
+
 class UnorderedObject(models.Model):
     """
     Model without any defined `Meta.ordering`.

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -25,7 +25,7 @@ from .admin import (
 from .models import (
     Band, Child, ChordsBand, ChordsMusician, CustomIdUser, Event, Genre, Group,
     Invitation, Membership, Musician, OrderedObject, Parent, Quartet, Swallow,
-    UnorderedObject,
+    SwallowOneToOne, UnorderedObject,
 )
 
 
@@ -478,8 +478,10 @@ class ChangeListTests(TestCase):
         Regression test for #17128
         (ChangeList failing under Python 2.5 after r16319)
         """
-        swallow = Swallow.objects.create(
-            origin='Africa', load='12.34', speed='22.2')
+        swallow = Swallow.objects.create(origin='Africa', load='12.34', speed='22.2')
+        swallow2 = Swallow.objects.create(origin='Africa', load='12.34', speed='22.2')
+        swallow_o2o = SwallowOneToOne.objects.create(swallow=swallow2)
+
         model_admin = SwallowAdmin(Swallow, admin.site)
         superuser = self._create_superuser('superuser')
         request = self._mocked_authenticated_request('/swallow/', superuser)
@@ -488,6 +490,9 @@ class ChangeListTests(TestCase):
         self.assertContains(response, six.text_type(swallow.origin))
         self.assertContains(response, six.text_type(swallow.load))
         self.assertContains(response, six.text_type(swallow.speed))
+        # Reverse one-to-one relations should work.
+        self.assertContains(response, '<td class="field-swallowonetoone">(None)</td>')
+        self.assertContains(response, '<td class="field-swallowonetoone">%s</td>' % swallow_o2o)
 
     def test_deterministic_order_for_unordered_model(self):
         """


### PR DESCRIPTION
In 1.8, `get_field()` returns reverse relations so we need to filter them out for backwards compatibility.