### PR TITLE
Fixed #24831 - Fixed pickling queryset with prefetch_related after objects deletion

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1471,6 +1471,11 @@ class ManyToOneRel(ForeignObjectRel):
 
         self.field_name = field_name
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('related_model', None)
+        return state
+
     def get_related_field(self):
         """
         Return the Field in the 'to' object to which this relationship is tied.

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -31,3 +31,6 @@ Bugfixes
 
 * Fixed a crash when using a reverse one-to-one relation in
   ``ModelAdmin.list_display`` (:ticket:`24851`).
+
+* Fixed pickling queryset cache issue when using ``prefetch_related`` after
+  objects deletion (:ticket:`24831`).

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -119,6 +119,22 @@ class PickleabilityTestCase(TestCase):
         groups = pickle.loads(pickle.dumps(groups))
         self.assertQuerysetEqual(groups, [g], lambda x: x)
 
+    def test_pickle_prefetch_related_with_m2m_and_objects_deletion(self):
+        g = Group.objects.create(name='foo')
+        m2m = M2MModel.objects.create()
+        m2m.groups.add(g)
+
+        Group.objects.all().delete()
+        M2MModel.objects.all().delete()
+
+        g = Group.objects.create(name='foo')
+        m2m = M2MModel.objects.create()
+        m2m.groups.add(g)
+
+        m2ms = M2MModel.objects.prefetch_related('groups')
+        m2ms = pickle.loads(pickle.dumps(m2ms))
+        self.assertQuerysetEqual(m2ms, [m2m], lambda x: x)
+
     def test_missing_django_version_unpickling(self):
         """
         #21430 -- Verifies a warning is raised for querysets that are


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24831

Not sure this approach is right - maybe we should cache `related_model` for all `ForeignObjectRel` inheritors except M2M one?