### PR TITLE
Fixed #24873 -- Prevented Prefetch objects from being overwritten.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1538,7 +1538,12 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     # contains some prefetch_related lookups. We don't want to trigger the
     # prefetch_related functionality by evaluating the query. Rather, we need
     # to merge in the prefetch_related lookups.
-    additional_lookups = getattr(rel_qs, '_prefetch_related_lookups', [])
+    # We need to copy the lookups in case it is a Prefetch object which could
+    # be reused later, which happens in nested prefetch_related.
+    additional_lookups = [
+        copy.copy(additional_lookup) for additional_lookup
+        in getattr(rel_qs, '_prefetch_related_lookups', [])
+    ]
     if additional_lookups:
         # Don't need to clone because the manager should have given us a fresh
         # instance, so we access an internal instead of using public interface


### PR DESCRIPTION
[Ticket 24873](https://code.djangoproject.com/ticket/24873)

Also I don't know if this could be considered a release blocker or not and where to discuss about it. `Prefetch` was introduced in Django 1.7 and this bug is there since the beginning. It keeps `Prefetch` from being used in applications with lots of relations.