### PR TITLE
Simpler sintaxis on documentation

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1021,8 +1021,8 @@ new value to be the new model instance you want to point to. For example::
 The ``update()`` method is applied instantly and returns the number of rows
 matched by the query (which may not be equal to the number of rows updated if
 some rows already have the new value). The only restriction on the
-:class:`~django.db.models.query.QuerySet` that is updated is that it can only
-access one database table, the model's main table. You can filter based on
+:class:`~django.db.models.query.QuerySet` being updated is that it can only
+access one database table: the model's main table. You can filter based on
 related fields, but you can only update columns in the model's main
 table. Example::
 


### PR DESCRIPTION
Avoiding the repetition of the same words makes it easier to read and comprehend the docs.

