### PR TITLE
Fixed #24883 -- Added MigrationGraph.__repr__()

### DIFF
--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -247,10 +247,14 @@ class MigrationGraph(object):
                     node = stack.pop()
 
     def __str__(self):
-        return "Graph: %s nodes, %s edges" % (
-            len(self.nodes),
-            sum(len(node.parents) for node in self.node_map.values()),
-        )
+        return "Graph: %s nodes, %s edges" % self._nodes_and_edges()
+
+    def __repr__(self):
+        nodes, edges = self._nodes_and_edges()
+        return '<%s: nodes=%s, edges=%s>' % (self.__class__.__name__, nodes, edges)
+
+    def _nodes_and_edges(self):
+        return len(self.nodes), sum(len(node.parents) for node in self.node_map.values())
 
     def make_state(self, nodes=None, at_end=True, real_apps=None):
         """

--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -283,3 +283,4 @@ class GraphTests(SimpleTestCase):
         graph.add_dependency("app_a.0003", ("app_a", "0003"), ("app_b", "0002"))
 
         self.assertEqual(force_text(graph), "Graph: 5 nodes, 3 edges")
+        self.assertEqual(repr(graph), "<MigrationGraph: nodes=5, edges=3>")


### PR DESCRIPTION
MigrationGraph now has a __repr__ method to
aid with debugging.

See: https://code.djangoproject.com/ticket/24883