### PR TITLE
Fixed #24481 -- New "sql" command based on migrations

### DIFF
--- a/django/core/management/commands/sql.py
+++ b/django/core/management/commands/sql.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+from django.core.management.base import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.apps import apps
+from django.db.migrations.state import ProjectState
+from django.db.migrations.graph import MigrationGraph
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
+from django.db.migrations.autodetector import MigrationAutodetector
+
+
+class Command(BaseCommand):
+    help = (
+        "Returns the CREATE TABLE, CREATE INDEX and other SQL statements"
+        "needed to set up a copy of the database, ignoring existing migrations"
+    )
+
+    output_transaction = True
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument('args', metavar='app_label', nargs='*',
+            help='Specify the app label(s) to create migrations for.')
+        parser.add_argument('--database', default=DEFAULT_DB_ALIAS,
+            help='Nominates a database to print the SQL for. Defaults to the '
+                 '"default" database.')
+
+    def handle(self, *app_labels, **options):
+        # Verify app labels
+        app_labels = set(app_labels)
+        bad_app_labels = set()
+        for app_label in app_labels:
+            try:
+                apps.get_app_config(app_label)
+            except LookupError:
+                bad_app_labels.add(app_label)
+        if bad_app_labels:
+            for app_label in bad_app_labels:
+                self.stderr.write("App '%s' could not be found. Is it in INSTALLED_APPS?" % app_label)
+            sys.exit(2)
+        app_labels = {config.label for config in apps.get_app_configs()}
+
+        # Set up the migration autodetector to make a from-scratch set of migrations to apply
+        initial_state = ProjectState()
+        questioner = NonInteractiveMigrationQuestioner(specified_apps=app_labels, dry_run=True)
+        autodetector = MigrationAutodetector(
+            initial_state,
+            ProjectState.from_apps(apps),
+            questioner,
+        )
+
+        # Run the autodetector
+        changes = autodetector.changes(
+            graph=MigrationGraph(),
+            trim_to_apps=app_labels or None,
+            convert_apps=app_labels or None,
+        )
+
+        # Loop the changes back into a graph we can apply from
+        loader = MigrationLoader.from_changes(changes)
+
+        # Fake-apply them to get SQL
+        executor = MigrationExecutor(connections[options['database']])
+        executor.loader = loader
+        executor.recorder = None
+        plan = executor.migration_plan(
+            [key for key in loader.graph.leaf_nodes() if key[0] in app_labels],
+            clean_start=True,
+        )
+        sql_statements = executor.collect_sql(plan)
+        return '\n'.join(sql_statements)

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,6 +6,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
+from django.db import migrations
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six
@@ -55,6 +56,40 @@ class MigrationLoader(object):
         else:
             app_package_name = apps.get_app_config(app_label).name
             return '%s.%s' % (app_package_name, MIGRATIONS_MODULE_NAME)
+
+    @classmethod
+    def from_changes(cls, changes):
+        """
+        Rather than loading migrations from disk, takes the output of the
+        autodetector's changes() function and loads those in as the disk
+        migrations, in order to operate on them straight away.
+
+        Implicitly sets the connection to None, as the names will not be
+        sensible and match up with the database (you should never try and
+        partially apply migrations with a from_changes loader - only
+        ever a full database create/teardown, or SQL output).
+        """
+        from django.db.migrations.writer import MigrationWriter
+        # Make loader
+        loader = cls(None, load=False)
+        # Make the fake disk migration entries from the changes
+        loader.disk_migrations = {}
+        loader.unmigrated_apps = set()
+        loader.migrated_apps = set()
+        for app_label, app_migrations in changes.items():
+            loader.migrated_apps.add(app_label)
+            for migration in app_migrations:
+                # Write it out to a string then re-exec it to ensure
+                # we behave exactly like writing to disk and reading back again
+                # (this prevents edge cases with e.g. model bindings left over)
+                contents = MigrationWriter(migration).as_string()
+                context = {}
+                exec(contents, context, context)
+                # Save it to the loader
+                loader.disk_migrations[app_label, migration.name] = context['Migration'](migration.name, app_label)
+        # Run the rest of the build
+        loader.build_graph(skip_load=True)
+        return loader
 
     def load_disk(self):
         """
@@ -168,14 +203,15 @@ class MigrationLoader(object):
                     raise ValueError("Dependency on app with no migrations: %s" % key[0])
         raise ValueError("Dependency on unknown app: %s" % key[0])
 
-    def build_graph(self):
+    def build_graph(self, skip_load=False):
         """
         Builds a migration dependency graph using both the disk and database.
         You'll need to rebuild the graph if you apply migrations. This isn't
         usually a problem as generally migration stuff runs in a one-shot process.
         """
         # Load disk data
-        self.load_disk()
+        if not skip_load:
+            self.load_disk()
         # Load database data
         if self.connection is None:
             self.applied_migrations = set()

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,7 +6,6 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
-from django.db import migrations
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -963,6 +963,21 @@ beyond those apps. Same as ``--list``, applied migrations are marked by an
 ``[X]``. For a verbosity of 2 and above, all dependencies of a migration will
 also be shown.
 
+sql
+---
+
+.. django-admin:: sql
+
+Prints the SQL statements to create a new database from scratch.
+
+The output of this tool *will not* match the SQL emitted by migrations, and
+*should not* be used for any sort of production or development database
+creation, as it will be incompatible with migrations. It is intended for
+testing and information use only.
+
+The :djadminopt:`--database` option can be used to specify the database for
+which to print the SQL.
+
 sqlflush
 --------
 


### PR DESCRIPTION
This implements part of https://code.djangoproject.com/ticket/24481 as it reimplements the `sql` command using the migration autodetector fed straight into the loader via a new `from_changes` method.

This same path can also be used to drive test database creation without running through existing migrations, in theory. This PR is not yet complete - a few more of the `sql*` commands can probably be emulated.