### PR TITLE
Fixed #24894 -- Added TransactionNow() database function to django.contrib.postgres

### DIFF
--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -1,0 +1,11 @@
+from django.db.models import DateTimeField
+from django.db.models.functions import Func
+
+
+class TransactionNow(Func):
+    template = 'CURRENT_TIMESTAMP'
+
+    def __init__(self, output_field=None, **extra):
+        if output_field is None:
+            output_field = DateTimeField()
+        super(TransactionNow, self).__init__(output_field=output_field, **extra)

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -1,0 +1,31 @@
+PostgreSQL specific database functions
+======================================
+
+All of these fields and widgets are available from the
+``django.contrib.postgres.functions`` module.
+
+.. currentmodule:: django.contrib.postgres.functions
+
+TransactionNow
+--------------
+
+.. class:: TransactionNow()
+
+.. versionadded:: 1.9
+
+Returns the date and time on the database server that the current transaction
+started. If you are not in a transaction it will return the date and time of
+the current statement. This is a complement to
+:class:`django.db.models.functions.Now`, which always returns the date and time
+of the current statement.
+
+Note that only the outermost call to :func:`~django.db.transaction.atomic()`
+sets up a transaction and thus sets the time that ``TransactionNow()`` will
+return; nested calls create savepoints which do not affect the transaction
+time.
+
+Usage example::
+
+    >>> from django.contrib.postgres.functions import TransactionNow
+    >>> Article.objects.filter(published__lte=TransactionNow())
+    [<Article: How to Django>]

--- a/docs/ref/contrib/postgres/index.txt
+++ b/docs/ref/contrib/postgres/index.txt
@@ -34,6 +34,7 @@ Psycopg2 2.5 or higher is required.
     aggregates
     fields
     forms
+    functions
     lookups
     operations
     validators

--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -132,6 +132,14 @@ Usage example::
     >>> Article.objects.filter(published__lte=Now())
     [<Article: How to Django>]
 
+.. note::
+
+    On PostgreSQL, ``CURRENT_TIMESTAMP`` returns the same date and time across
+    a transaction. For compatibility, ``Now()`` uses ``STATEMENT_TIMESTAMP``,
+    which returns the same date and time across the current statement only. If
+    you need the transaction timestamp, use
+    :class:`django.contrib.postgres.functions.TransactionNow`.
+
 Substr
 ------
 

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -130,6 +130,13 @@ class Migration(migrations.Migration):
                 ('related_field', models.ForeignKey('postgres_tests.AggregateTestModel', null=True)),
             ]
         ),
+        migrations.CreateModel(
+            name='NowTestModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('when', models.DateTimeField(null=True, default=None)),
+            ]
+        ),
     ]
 
     pg_92_operations = [

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -97,3 +97,7 @@ class StatTestModel(models.Model):
     int1 = models.IntegerField()
     int2 = models.IntegerField()
     related_field = models.ForeignKey(AggregateTestModel, null=True)
+
+
+class NowTestModel(models.Model):
+    when = models.DateTimeField(null=True, default=None)

--- a/tests/postgres_tests/test_functions.py
+++ b/tests/postgres_tests/test_functions.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from time import sleep
+
+from django.contrib.postgres.functions import TransactionNow
+
+from . import PostgreSQLTestCase
+from .models import NowTestModel
+
+
+class TestTransactionNow(PostgreSQLTestCase):
+
+    def test_transaction_now(self):
+        """
+        The test case puts everything under a transaction, so two models
+        updated with a short gap should have the same time.
+        """
+        m1 = NowTestModel.objects.create()
+        m2 = NowTestModel.objects.create()
+
+        NowTestModel.objects.filter(id=m1.id).update(when=TransactionNow())
+        sleep(0.1)
+        NowTestModel.objects.filter(id=m2.id).update(when=TransactionNow())
+
+        m1.refresh_from_db()
+        m2.refresh_from_db()
+
+        self.assertIsInstance(m1.when, datetime)
+        self.assertEqual(m1.when, m2.when)


### PR DESCRIPTION
[Ticket 24894](https://code.djangoproject.com/ticket/24894) , previously discussed on PR #4722 which implements `Now()`.