### PR TITLE
Fixed #24896 -- Doc'd clickjacking protection doesn't overwrite X-Frame-Options header.

### DIFF
--- a/docs/ref/clickjacking.txt
+++ b/docs/ref/clickjacking.txt
@@ -45,6 +45,11 @@ site:
 2. A set of view decorators that can be used to override the middleware or to
    only set the header for certain views.
 
+.. note::
+
+    The ``X-Frame-Options`` HTTP header will only be set by the middleware
+    or view decorators if it is not already present in the response.
+
 How to use it
 =============
 


### PR DESCRIPTION
Ticket https://code.djangoproject.com/ticket/24896
Current documentation doesn't specify the behaviour of clickjacking protection middleware or view decorators when the X-Frame-Options header is already set. This add a 'note' that the existing header will not be modified by the clickjacking protection.