### PR TITLE
Add git attribute merge=union for release notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *css text eol=lf
 tests/staticfiles_tests/apps/test/static/test/*txt text eol=lf
 tests/staticfiles_tests/project/documents/test/*txt text eol=lf
+docs/releases/*.txt merge=union


### PR DESCRIPTION
This will stop annoying merge conflicts for release notes by forcing git to take two both sets of additions on these files. See this article for more info: https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/