### PR TITLE
Fixed #24837 -- field__contained_by=Range

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -631,14 +631,18 @@ model::
     class Event(models.Model):
         name = models.CharField(max_length=200)
         ages = IntegerRangeField()
+        start = models.DateTimeField()
 
         def __str__(self):  # __unicode__ on Python 2
             return self.name
 
 We will also use the following example objects::
 
-    >>> Event.objects.create(name='Soft play', ages=(0, 10))
-    >>> Event.objects.create(name='Pub trip', ages=(21, None))
+    >>> import datetime
+    >>> from django.utils import timezone
+    >>> now = timezone.now()
+    >>> Event.objects.create(name='Soft play', ages=(0, 10), start=now)
+    >>> Event.objects.create(name='Pub trip', ages=(21, None), start=now - datetime.timedelta(days=1))
 
 and ``NumericRange``:
 
@@ -665,6 +669,22 @@ contained_by
 ''''''''''''
 
     >>> Event.objects.filter(ages__contained_by=NumericRange(0, 15))
+    [<Event: Soft play>]
+
+.. versionadded 1.9
+
+    The `contained_by` lookup is also available on the non-range field types:
+    :class:`~django.db.models.fields.IntegerField`,
+    :class:`~django.db.models.fields.BigIntegerField`,
+    :class:`~django.db.models.fields.FloatField`,
+    :class:`~django.db.models.fields.DateField`, and
+    :class:`~django.db.models.fields.DateTimeField`. For example::
+
+    >>> from psycopg2.extras import DateTimeTZRange
+    >>> Event.objects.filter(start__contained_by=DateTimeTZRange(
+    ...     timezone.now() - datetime.timedelta(hours=1),
+    ...     timezone.now() + datetime.timedelta(hours=1),
+    ... )
     [<Event: Soft play>]
 
 .. fieldlookup:: rangefield.overlap

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -91,6 +91,8 @@ Minor features
 :mod:`django.contrib.postgres`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Added support for the :lookup:`rangefield.contained_by` lookup for some built
+  in fields which correspond to the range fields.
 * Added :class:`~django.contrib.postgres.fields.JSONField`.
 * Added :doc:`/ref/contrib/postgres/aggregates`.
 

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -144,6 +144,21 @@ class Migration(migrations.Migration):
                 ('dates', DateRangeField(null=True, blank=True)),
             ],
             options={
+                'required_db_vendor': 'postgresql'
+            },
+            bases=(models.Model,)
+        ),
+        migrations.CreateModel(
+            name='RangeLookupsModel',
+            fields=[
+                ('parent', models.ForeignKey('postgres_tests.RangesModel', blank=True, null=True)),
+                ('integer', models.IntegerField(blank=True, null=True)),
+                ('big_integer', models.BigIntegerField(blank=True, null=True)),
+                ('float', models.FloatField(blank=True, null=True)),
+                ('timestamp', models.DateTimeField(blank=True, null=True)),
+                ('date', models.DateField(blank=True, null=True)),
+            ],
+            options={
                 'required_db_vendor': 'postgresql',
             },
             bases=(models.Model,),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -60,9 +60,21 @@ if connection.vendor == 'postgresql' and connection.pg_version >= 90200:
         floats = FloatRangeField(blank=True, null=True)
         timestamps = DateTimeRangeField(blank=True, null=True)
         dates = DateRangeField(blank=True, null=True)
+
+    class RangeLookupsModel(PostgreSQLModel):
+        parent = models.ForeignKey(RangesModel, blank=True, null=True)
+        integer = models.IntegerField(blank=True, null=True)
+        big_integer = models.BigIntegerField(blank=True, null=True)
+        float = models.FloatField(blank=True, null=True)
+        timestamp = models.DateTimeField(blank=True, null=True)
+        date = models.DateField(blank=True, null=True)
+
 else:
     # create an object with this name so we don't have failing imports
     class RangesModel(object):
+        pass
+
+    class RangeLookupsModel(object):
         pass
 
 


### PR DESCRIPTION
Provide `contained_by` lookups for the equivalent single valued fields related
to the range field types. This acts as the opposite direction to 
rangefield__contains.

With thanks to schinckel for the idea and initial tests.