### PR TITLE
Fix ImportError message in import_string

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -23,7 +23,7 @@ def import_string(dotted_path):
         return getattr(module, class_name)
     except AttributeError:
         msg = 'Module "%s" does not define a "%s" attribute/class' % (
-            dotted_path, class_name)
+            module_path, class_name)
         six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
 
 

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -115,7 +115,7 @@ class ModuleImportTestCase(unittest.TestCase):
 
         # Test exceptions raised
         self.assertRaises(ImportError, import_string, 'no_dots_in_path')
-        self.assertRaises(ImportError, import_string, 'utils_tests.unexistent')
+        self.assertRaisesRegexp(ImportError, 'Module "utils_tests"', import_string, 'utils_tests.unexistent')
 
 
 @modify_settings(INSTALLED_APPS={'append': 'utils_tests.test_module'})


### PR DESCRIPTION
It used the wrong variable for module path, which resulted in funny errors like „Module "path.to.module.SomeClass" does not define a "SomeClass" attribute/class”.