### PR TITLE
Fixed #24908: exclude wouldn't apply on inherited form fields.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -279,6 +279,13 @@ class ModelFormMetaclass(DeclarativeFieldsMetaclass):
                 # fields from the model"
                 opts.fields = None
 
+            if opts.exclude:
+                # A user-defined parent ModelForm might have declared fields
+                # which are excluded in this Modelform.
+                for excluded_field in opts.exclude:
+                    if excluded_field in new_class.base_fields:
+                        new_class.base_fields.pop(excluded_field)
+
             fields = fields_for_model(opts.model, opts.fields, opts.exclude,
                                       opts.widgets, formfield_callback,
                                       opts.localized_fields, opts.labels,

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -215,7 +215,7 @@ class FormsModelTestCase(TestCase):
 
         f = ExcludingForm({'name': 'Hello', 'value': 99, 'def_date': datetime.date(1999, 3, 2)})
         self.assertTrue(f.is_valid())
-        self.assertEqual(f.cleaned_data['name'], 'Hello')
+        self.assertNotIn('name', f.cleaned_data)
         obj = f.save()
         self.assertEqual(obj.name, 'class default value')
         self.assertEqual(obj.value, 99)
@@ -276,7 +276,7 @@ class ManyToManyExclusionTestCase(TestCase):
         instance.multi_choice = instance.multi_choice_int = [opt2, opt3]
         form = ChoiceFieldExclusionForm(data=data, instance=instance)
         self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data['multi_choice'], data['multi_choice'])
+        self.assertNotIn('multi_choice', form.cleaned_data)
         form.save()
         self.assertEqual(form.instance.choice.pk, data['choice'])
         self.assertEqual(form.instance.choice_int.pk, data['choice_int'])

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -357,6 +357,22 @@ class ModelFormBaseTest(TestCase):
         self.assertEqual(list(ExcludeFields.base_fields),
                          ['name', 'slug'])
 
+    def test_exclude_overridden_fields(self):
+        class NoExcludeFields(forms.ModelForm):
+            url = forms.URLField()
+
+            class Meta:
+                model = Category
+                exclude = []
+
+        class ExcludeFields(NoExcludeFields):
+            class Meta:
+                model = Category
+                exclude = ['url']
+
+        self.assertEqual(list(ExcludeFields.base_fields),
+                         ['name', 'slug'])
+
     def test_exclude_nonexistent_field(self):
         class ExcludeFields(forms.ModelForm):
             class Meta:

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -332,6 +332,22 @@ class ModelFormBaseTest(TestCase):
         wf = WriterForm({'name': 'Richard Lockridge'})
         self.assertTrue(wf.is_valid())
 
+    def tests_not_including_overridden_field(self):
+        class AllFields(forms.ModelForm):
+            url = forms.URLField()
+
+            class Meta:
+                model = Category
+                fields = '__all__'
+
+        class NameAndSlugOnly(AllFields):
+            class Meta:
+                model = Category
+                fields = ['name', 'slug']
+
+        self.assertEqual(list(NameAndSlugOnly.base_fields),
+                         ['name', 'slug'])
+
     def test_limit_nonexistent_field(self):
         expected_msg = 'Unknown field(s) (nonexistent) specified for Category'
         with self.assertRaisesMessage(FieldError, expected_msg):


### PR DESCRIPTION
If a ModelForm overrides a form field which would have been
automatically instanciated for a form field, then extending that model
form with this field in Meta.exclude should indeed exclude that field.

At this point, the test fails and the excluded field ends up in
base_fields.