### PR TITLE
Fixed #24629 -- Added Func.as_transform and use it in Unaccent.

### DIFF
--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -1,0 +1,5 @@
+from django.db.models.functions import Func
+
+
+class Unaccent(Func):
+    function = 'UNACCENT'

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,5 +1,7 @@
 from django.db.models import Lookup, Transform
 
+from . import functions
+
 
 class PostgresSimpleLookup(Lookup):
     def as_sql(self, qn, connection):
@@ -45,7 +47,4 @@ class HasAnyKeys(PostgresSimpleLookup):
     operator = '?|'
 
 
-class Unaccent(FunctionTransform):
-    bilateral = True
-    lookup_name = 'unaccent'
-    function = 'UNACCENT'
+Unaccent = functions.Unaccent.as_transform(lookup_name='unaccent', bilateral=True)

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -1,0 +1,26 @@
+======================================
+PostgreSQL specific database functions
+======================================
+
+.. versionadded:: 1.9
+
+The classes documented below are PostgreSQL specific
+:doc:`/ref/models/database-functions`.
+
+Unaccent
+========
+
+.. class:: django.contrib.postgres.functions.Unaccent
+
+The ``Unaccent`` function converts accented characters into their unaccented
+counterparts using a dedicated PostgreSQL extension.
+
+To use it, you need to add ``'django.contrib.postgres'`` in your
+:setting:`INSTALLED_APPS` and activate the `unaccent extension on PostgreSQL`_.
+The :class:`~django.contrib.postgres.operations.UnaccentExtension` migration
+operation is available if you want to perform this activation using
+migrations).
+
+.. _unaccent extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/unaccent.html
+
+``unaccent`` is also available :lookup:`as a lookup <unaccent>`.

--- a/docs/ref/contrib/postgres/index.txt
+++ b/docs/ref/contrib/postgres/index.txt
@@ -34,6 +34,7 @@ Psycopg2 2.5 or higher is required.
     aggregates
     fields
     forms
+    functions
     lookups
     operations
     validators

--- a/docs/ref/contrib/postgres/lookups.txt
+++ b/docs/ref/contrib/postgres/lookups.txt
@@ -17,6 +17,9 @@ the `unaccent extension on PostgreSQL`_. The
 :class:`~django.contrib.postgres.operations.UnaccentExtension` migration
 operation is available if you want to perform this activation using migrations).
 
+``unaccent`` is a bilateral transform, that is it is applied to both sides of
+the query.
+
 .. _unaccent extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/unaccent.html
 
 The ``unaccent`` lookup can be used on
@@ -28,9 +31,12 @@ The ``unaccent`` lookup can be used on
     >>> User.objects.filter(first_name__unaccent__startswith="Jerem")
     ['<User: Jeremy>', '<User: Jérémy>', '<User: Jérémie>', '<User: Jeremie>']
 
+``unaccent`` is also available :class:`as a database function
+<django.contrib.postgres.functions.Unaccent>`.
+
 .. warning::
 
     ``unaccent`` lookups should perform fine in most use cases. However, queries
     using this filter will generally perform full table scans, which can be slow
     on large tables. In those cases, using dedicated full text indexing tools
-    might be appropriate.
+    might be appropriate, or a functional index.

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -245,6 +245,24 @@ The ``Func`` API is as follows:
         A class attribute that denotes the character used to join the list of
         ``expressions`` together. Defaults to ``', '``.
 
+    .. classmethod:: as_transform(cls, lookup_name, bilateral=False, expressions=None)
+
+        .. versionadded:: 1.9
+
+        Converts a function into a :class:`~django.db.models.Transform`. ``lookup_name`` is the name which will be used in queries for this transform. ``bilateral`` refers to the :attr:`~django.db.models.Transform.bilateral` attribute on the Transform.
+
+        For single valued functions (such as :class:`~django.db.models.functions.Lower`) this will be sufficient, but other functions require more values. It may make sense in some applications to freeze some of these arguments for a commonly used use case. This can be done by passing ``expressions`` to ``as_transform()``. By default, the value being transformed will be the first argument of the function. If you need a different ordering, you can include the string ``'self'`` in your expressions list.
+
+        As an example, suppose your application is storing git commit hashes, and wants to query by a seven character short hash using a transform.::
+
+            class Commit(models.Model):
+                commit_hash = models.CharField(max_length=40)
+
+            ShortHash = Substr.as_transform(lookup_name='short', expressions=[1, 7])
+            models.CharField.register_lookup(ShortHash)
+
+            Commit.objects.filter(commit_hash__short='abcdef8')
+
 The ``*expressions`` argument is a list of positional expressions that the
 function will be applied to. The expressions will be converted to strings,
 joined together with ``arg_joiner``, and then interpolated into the ``template``

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -243,6 +243,9 @@ Models
 * Added the :class:`~django.db.models.functions.Now` database function, which
   returns the current date and time.
 
+* Added :func:`~django.db.models.Func.as_transform` to convert ``Func`` objects
+  into ``Transform`` objects.
+
 CSRF
 ^^^^
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -93,6 +93,7 @@ Minor features
 
 * Added :class:`~django.contrib.postgres.fields.JSONField`.
 * Added :doc:`/ref/contrib/postgres/aggregates`.
+* Added :doc:`/ref/contrib/postgres/functions`.
 
 :mod:`django.contrib.redirects`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Functions and Transforms have obvious potential for overlap, so provide an easy way to generate a Transform from a Lookup. Unaccent in contrib.postgres is a prime example, so dogfood it as well.