### PR TITLE
Fixed #24914 -- Added basic permission mixins to contrib.auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -581,6 +581,7 @@ answer newbie questions, and generally made Django that much better:
     Ram Rachum <ram@rachum.com>
     Randy Barlow <randy@electronsweatshop.com>
     Raphaël Barrois <raphael.barrois@m4x.org>
+    Raphael Michel <mail@raphaelmichel.de>
     Raúl Cumplido <raulcumplido@gmail.com>
     Remco Wendt <remco.wendt@gmail.com>
     Renaud Parent <renaud.parent@gmail.com>

--- a/django/contrib/auth/mixins.py
+++ b/django/contrib/auth/mixins.py
@@ -1,0 +1,85 @@
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.utils import six
+from django.utils.encoding import force_text
+
+
+class UserPassesTestMixin(object):
+    """
+    Mixin for class-based views that checks that the user passes the given by
+    the class method `test_func`.
+    """
+    login_url = None
+    raise_exception = False
+    redirect_field_name = REDIRECT_FIELD_NAME
+
+    def dispatch(self, request, *args, **kwargs):
+        user_test_result = self.get_test_func()(request.user)
+
+        if not user_test_result:
+            return self.handle_no_permission(request)
+
+        return super(UserPassesTestMixin, self).dispatch(request, *args, **kwargs)
+
+    def get_test_func(self):
+        return getattr(self, "test_func")
+
+    def test_func(self, user):
+        raise NotImplementedError(
+            '{0} is missing implementation of the '
+            'test_func method.'.format(self.__class__.__name__)
+        )
+
+    def handle_no_permission(self, request):
+        # In case the 403 handler should be called raise the exception
+        if self.raise_exception:
+            raise PermissionDenied
+        return redirect_to_login(request.get_full_path(), self.get_login_url(), self.get_redirect_field_name())
+
+    def get_login_url(self):
+        """
+        Override this method to customize the login_url.
+        """
+        login_url = self.login_url or settings.LOGIN_URL
+        if not login_url:
+            raise ImproperlyConfigured(
+                'Define {0}.login_url or settings.LOGIN_URL or override '
+                '{0}.get_login_url().'.format(self.__class__.__name__)
+            )
+
+        return force_text(login_url)
+
+    def get_redirect_field_name(self):
+        """
+        Override this method to customize the redirect_field_name.
+        """
+        return self.redirect_field_name
+
+
+class LoginRequiredMixin(UserPassesTestMixin):
+    """
+    Mixin for class-based views that checks that the user is logged in,
+    redirecting to the log-in page if necessary.
+    """
+
+    def test_func(self, user):
+        return user.is_authenticated()
+
+
+class PermissionRequiredMixin(UserPassesTestMixin):
+    """
+    Mixin for class-based views that checks whether a user has a particular
+    permission enabled, redirecting to the log-in page if necessary.
+    If the raise_exception parameter is given the PermissionDenied exception
+    is raised.
+    """
+    permission_required = None
+
+    def test_func(self, user):
+        if isinstance(self.permission_required, six.string_types):
+            perms = (self.permission_required, )
+        else:
+            perms = self.permission_required
+        return user.has_perms(perms)

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -117,6 +117,12 @@ Minor features
 * The permission argument of
   :func:`~django.contrib.auth.decorators.permission_required()` accepts all
   kinds of iterables, not only list and tuples.
+* The module ``django.contrib.auth.mixins`` was added with
+  :class:`~django.contrib.auth.mixins.LoginRequiredMixin`,
+  :class:`~django.contrib.auth.mixins.PermissionRequiredMixin` and
+  :class:`~django.contrib.auth.mixins.UserPassesTestMixin` mixins to provide the
+  functionality of the ``django.contrib.auth.decorators`` shortcuts to class-based
+  views.
 
 :mod:`django.contrib.gis`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -500,6 +500,41 @@ The login_required decorator
     :func:`django.contrib.admin.views.decorators.staff_member_required`
     decorator a useful alternative to ``login_required()``.
 
+.. currentmodule:: django.contrib.auth.mixins
+
+The LoginRequired mixin
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When using :doc:`class-based views </topics/class-based-views/index>`, you can
+achieve the same behavior as with ``login_required`` by using the
+``LoginRequiredMixin``.
+
+.. class:: LoginRequiredMixin
+
+    .. versionadded:: 1.9
+
+    If a view is using this mixin, all requests by non-authenticated users
+    will be redirected to the login page.
+
+    You can set any of the parameters of
+    :class:`~django.contrib.auth.mixins.UserPassesTestMixin` to customize
+    the URL the user is redirected to::
+
+        from django.contrib.auth.mixins import LoginRequiredMixin
+
+        class MyView(LoginRequiredMixin, View):
+            login_url = '/login/'
+            redirect_field_name = 'redirect_to'
+
+            ...
+
+.. note::
+
+    Just as the ``login_required`` decorator, this mixin does NOT check the
+    ``is_active`` flag on a user.
+
+.. currentmodule:: django.contrib.auth.decorators
+
 Limiting access to logged-in users that pass a test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -560,6 +595,47 @@ redirects to the login page::
         def my_view(request):
             ...
 
+
+.. currentmodule:: django.contrib.auth.mixins
+
+.. class:: UserPassesTestMixin
+
+    .. versionadded:: 1.9
+
+    When using :doc:`class-based views </topics/class-based-views/index>`, you
+    can use the ``UserPassesTestMixin`` to do this.
+
+    You have to override the ``test_func`` method of the class to provide
+    the actual test that is performed::
+
+        from django.contrib.auth.mixins import UserPassesTestMixin
+
+        class MyView(UserPassesTestMixin, View):
+
+            def test_func(self, user):
+                return user.email.endswith('@example.com')
+
+            ...
+
+    You can set the following optional attributes on your view to customize this mixin's
+    behavior:
+
+    ``login_url``
+        The URL that users who don't pass the test will be
+        redirected to. Defaults to :setting:`settings.LOGIN_URL <LOGIN_URL>`.
+
+    ``redirect_field_name``
+        The name of the query parameter that will contain the URL the user should
+        be redirected to after a successful login. If you set this to ``None``, no
+        query parameter will be added. Defaults to ``"next"``.
+
+    ``raise_exception``
+        If this attribute is set to ``True``, :class:`~django.core.exceptions.PermissionDenied`
+        exception will be raised instead of the redirect if the user does not pass the test.
+
+
+.. currentmodule:: django.contrib.auth.decorators
+
 The permission_required decorator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -583,7 +659,7 @@ The permission_required decorator
     The decorator may also take an iterable of permissions.
 
     Note that :func:`~django.contrib.auth.decorators.permission_required()`
-    also takes an optional ``login_url`` parameter. Example::
+    also takes an optional ``login_url`` parameter::
 
         from django.contrib.auth.decorators import permission_required
 
@@ -604,16 +680,37 @@ The permission_required decorator
         In older versions, the ``permission`` parameter only worked with
         strings, lists, and tuples instead of strings and any iterable.
 
+
+.. currentmodule:: django.contrib.auth.mixins
+
 .. _applying-permissions-to-generic-views:
 
 Applying permissions to generic views
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To apply a permission to a :doc:`class-based generic view
-</ref/class-based-views/index>`, decorate the :meth:`View.dispatch
-<django.views.generic.base.View.dispatch>` method on the class. See
-:ref:`decorating-class-based-views` for details. Another approach is to
-:ref:`write a mixin that wraps as_view() <mixins_that_wrap_as_view>`.
+</ref/class-based-views/index>`, you can use the following mixin:
+
+.. class:: PermissionRequiredMixin
+
+    .. versionadded:: 1.9
+
+    This mixin, just like the ``permisison_required``
+    decorator, checks whether the user accessing a view has a particular
+    permission. You should specify the permission (or a list or permissions)
+    using the ``permission_required`` parameter::
+
+        from django.contrib.auth.mixins import PermissionRequiredMixin
+
+        class MyView(PermissionRequiredMixin, View):
+            permission_required = 'polls.can_vote'
+
+            ...
+
+    You can set any of the parameters of
+    :class:`~django.contrib.auth.mixins.UserPassesTestMixin` to customize
+    the URL the user is redirected to.
+
 
 .. _session-invalidation-on-password-change:
 

--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -173,29 +173,6 @@ that inherits from ``View`` - for example, trying to use a form at the top of a
 list and combining :class:`~django.views.generic.edit.ProcessFormView` and
 :class:`~django.views.generic.list.ListView` - won't work as expected.
 
-.. _mixins_that_wrap_as_view:
-
-Mixins that wrap ``as_view()``
-------------------------------
-
-One way to apply common behavior to many classes is to write a mixin that wraps
-the :meth:`~django.views.generic.base.View.as_view()` method.
-
-For example, if you have many generic views that should be decorated with
-:func:`~django.contrib.auth.decorators.login_required` you could implement a
-mixin like this::
-
-    from django.contrib.auth.decorators import login_required
-
-    class LoginRequiredMixin(object):
-        @classmethod
-        def as_view(cls, **initkwargs):
-            view = super(LoginRequiredMixin, cls).as_view(**initkwargs)
-            return login_required(view)
-
-    class MyView(LoginRequiredMixin, ...):
-        # this is a generic view
-        ...
 
 Handling forms with class-based views
 =====================================

--- a/tests/auth_tests/test_mixins.py
+++ b/tests/auth_tests/test_mixins.py
@@ -1,0 +1,153 @@
+from django.contrib.auth import models
+from django.contrib.auth.mixins import (
+    LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin,
+)
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.views.generic import View
+
+from .test_views import AuthViewsTestCase
+
+
+class EmptyResponseView(View):
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse()
+
+
+class UserTestAlwaysTrueView(UserPassesTestMixin, EmptyResponseView):
+
+    def test_func(self, user):
+        return True
+
+
+class UserTestAlwaysFalseView(UserPassesTestMixin, EmptyResponseView):
+
+    def test_func(self, user):
+        return False
+
+
+class UserPassesTestTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+
+    def test_redirect(self, view=None, url='/accounts/login/?next=/rand'):
+        if not view:
+            view = UserTestAlwaysFalseView.as_view()
+        request = self.factory.get('/rand')
+        request.user = AnonymousUser()
+        response = view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, url)
+
+    def test_custom_redirect_url(self):
+        class AView(UserTestAlwaysFalseView):
+            login_url = '/login/'
+
+        self.test_redirect(AView.as_view(), '/login/?next=/rand')
+
+    def test_custom_redirect_parameter(self):
+        class AView(UserTestAlwaysFalseView):
+            redirect_field_name = 'goto'
+
+        self.test_redirect(AView.as_view(), '/accounts/login/?goto=/rand')
+
+    def test_no_redirect_parameter(self):
+        class AView(UserTestAlwaysFalseView):
+            redirect_field_name = None
+
+        self.test_redirect(AView.as_view(), '/accounts/login/')
+
+    def test_raise_exception(self):
+        class AView(UserTestAlwaysFalseView):
+            raise_exception = True
+
+        request = self.factory.get('/rand')
+        request.user = AnonymousUser()
+        self.assertRaises(PermissionDenied, AView.as_view(), request)
+
+    def test_user_passes(self):
+        view = UserTestAlwaysTrueView.as_view()
+        request = self.factory.get('/rand')
+        request.user = AnonymousUser()
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+
+
+class LoginRequiredMixinTestCase(AuthViewsTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = models.User.objects.create(username='joe', password='qwerty')
+        cls.factory = RequestFactory()
+
+    def test_login_required(self):
+        """
+        Check that login_required works on a simple view wrapped in a
+        login_required decorator.
+        """
+        class AView(LoginRequiredMixin, EmptyResponseView):
+            pass
+
+        view = AView.as_view()
+
+        request = self.factory.get('/rand')
+        request.user = AnonymousUser()
+        response = view(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual('/accounts/login/?next=/rand', response.url)
+        request = self.factory.get('/rand')
+        request.user = self.user
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+
+
+class PermissionsRequiredMixinTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = models.User.objects.create(username='joe', password='qwerty')
+        cls.factory = RequestFactory()
+        # Add permissions auth.add_customuser and auth.change_customuser
+        perms = models.Permission.objects.filter(codename__in=('add_customuser', 'change_customuser'))
+        cls.user.user_permissions.add(*perms)
+
+    def test_many_permissions_pass(self):
+        class AView(PermissionRequiredMixin, EmptyResponseView):
+            permission_required = ['auth.add_customuser', 'auth.change_customuser']
+
+        request = self.factory.get('/rand')
+        request.user = self.user
+        resp = AView.as_view()(request)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_single_permission_pass(self):
+        class AView(PermissionRequiredMixin, EmptyResponseView):
+            permission_required = 'auth.add_customuser'
+
+        request = self.factory.get('/rand')
+        request.user = self.user
+        resp = AView.as_view()(request)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_permissioned_denied_redirect(self):
+        class AView(PermissionRequiredMixin, EmptyResponseView):
+            permission_required = ['auth.add_customuser', 'auth.change_customuser', 'non-existent-permission']
+
+        request = self.factory.get('/rand')
+        request.user = self.user
+        resp = AView.as_view()(request)
+        self.assertEqual(resp.status_code, 302)
+
+    def test_permissioned_denied_exception_raised(self):
+        class AView(PermissionRequiredMixin, EmptyResponseView):
+            permission_required = ['auth.add_customuser', 'auth.change_customuser', 'non-existent-permission']
+            raise_exception = True
+
+        request = self.factory.get('/rand')
+        request.user = self.user
+        self.assertRaises(PermissionDenied, AView.as_view(), request)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24914

An initial version of implementation and tests is in the pull request, documentation is yet to be done. Comments on the code are very welcome.

This proposal provides all the and only the functionality of all three authentication decorators from contrib.auth.

While it is slightly differently implemented, it tries to stay compatible with the widely-used 3rd-party package django-braces in terms of parameter and method names. django-braces does have more functionality than the decorators have, but implementing this functionality in django itself is outside the scope of this ticket.