### PR TITLE
Refs #24125 -- Added a test to ensure that we can render the admindocs TemplateDetailView

### DIFF
--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -149,7 +149,13 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
 }])
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
 class AdminDocViewWithMultipleEngines(AdminDocViewTests):
-    pass
+    def test_templatefilter_index(self):
+        response = self.client.get(reverse('django-admindocs-filters'))
+        self.assertContains(response, '<title>Template filters</title>', html=True)
+
+    def test_templatetag_index(self):
+        response = self.client.get(reverse('django-admindocs-tags'))
+        self.assertContains(response, '<title>Template tags</title>', html=True)
 
 
 class XViewMiddlewareTest(TestDataMixin, AdminDocsTestCase):

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -117,6 +117,21 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
             html=True
         )
 
+    @override_settings(TEMPLATES=[{
+        'NAME': 'ONE',
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }, {
+        'NAME': 'TWO',
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }])
+    def test_template_detail__with_multiple_engines(self):
+        response = self.client.get(reverse('django-admindocs-templates',
+            args=['admin_doc/template_detail.html']))
+        self.assertContains(response,
+            '<h1>Template: "admin_doc/template_detail.html"</h1>', html=True)
+
     def test_template_detail(self):
         response = self.client.get(reverse('django-admindocs-templates',
             args=['admin_doc/template_detail.html']))

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -117,21 +117,6 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
             html=True
         )
 
-    @override_settings(TEMPLATES=[{
-        'NAME': 'ONE',
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-    }, {
-        'NAME': 'TWO',
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-    }])
-    def test_template_detail__with_multiple_engines(self):
-        response = self.client.get(reverse('django-admindocs-templates',
-            args=['admin_doc/template_detail.html']))
-        self.assertContains(response,
-            '<h1>Template: "admin_doc/template_detail.html"</h1>', html=True)
-
     def test_template_detail(self):
         response = self.client.get(reverse('django-admindocs-templates',
             args=['admin_doc/template_detail.html']))
@@ -151,6 +136,20 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
                                 'administration</a></h1>')
         finally:
             utils.docutils_is_available = True
+
+
+@override_settings(TEMPLATES=[{
+    'NAME': 'ONE',
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+}, {
+    'NAME': 'TWO',
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+}])
+@unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
+class AdminDocViewWithMultipleEngines(AdminDocViewTests):
+    pass
 
 
 class XViewMiddlewareTest(TestDataMixin, AdminDocsTestCase):


### PR DESCRIPTION
Without throwing an exception when using more than one Engine
This adds tests for 511a53b3142551a1bc3093ed1b6655f57634f510

Refs #24125.