### PR TITLE
Fixed #24677 -- made TextField to_python return a string

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2141,11 +2141,14 @@ class TextField(Field):
     def get_internal_type(self):
         return "TextField"
 
-    def get_prep_value(self, value):
-        value = super(TextField, self).get_prep_value(value)
+    def to_python(self, value):
         if isinstance(value, six.string_types) or value is None:
             return value
         return smart_text(value)
+
+    def get_prep_value(self, value):
+        value = super(TextField, self).get_prep_value(value)
+        return self.to_python(value)
 
     def formfield(self, **kwargs):
         # Passing max_length to forms.CharField means that the value's length

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -246,6 +246,13 @@ class ManyToManyFieldTests(test.SimpleTestCase):
         )
 
 
+class TextFieldTests(test.TestCase):
+    def test_to_python(self):
+        """TextField.to_python should return a string"""
+        f = models.CharField()
+        self.assertEqual(f.to_python(1), '1')
+
+
 class DateTimeFieldTests(test.TestCase):
     def test_datetimefield_to_python_usecs(self):
         """DateTimeField.to_python should support usecs"""

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -249,7 +249,7 @@ class ManyToManyFieldTests(test.SimpleTestCase):
 class TextFieldTests(test.TestCase):
     def test_to_python(self):
         """TextField.to_python should return a string"""
-        f = models.CharField()
+        f = models.TextField()
         self.assertEqual(f.to_python(1), '1')
 
 


### PR DESCRIPTION
Small fix for #24677. There was no TextField specific test class to went ahead and added one.