### PR TITLE
Changed 'content' to 'description'

### DIFF
--- a/docs/internals/contributing/writing-documentation.txt
+++ b/docs/internals/contributing/writing-documentation.txt
@@ -210,7 +210,7 @@ Our policy for new features is:
 
 Our preferred way for marking new features is by prefacing the features'
 documentation with: "``.. versionadded:: X.Y``", followed by a mandatory
-blank line and an optional content (indented).
+blank line and an optional description (indented).
 
 General improvements, or other changes to the APIs that should be emphasized
 should use the "``.. versionchanged:: X.Y``" directive (with the same format


### PR DESCRIPTION
In English, 'content' is not typically used as a singular noun (ie: the phrase "a piece of content" is preferable to "a content").

The phrase "add optional content" would also be acceptable, but this change is the least disruptive to the documentation.