### PR TITLE
Fixed #24859 -- Make UUID field raise TypeError on bad value

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2380,13 +2380,17 @@ class UUIDField(Field):
         return "UUIDField"
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if isinstance(value, six.string_types):
-            value = uuid.UUID(value)
-        if isinstance(value, uuid.UUID):
-            if connection.features.has_native_uuid_field:
-                return value
-            return value.hex
-        return value
+        if value is None:
+            return None
+        if not isinstance(value, uuid.UUID):
+            try:
+                value = uuid.UUID(value)
+            except AttributeError:
+                raise TypeError(self.error_messages['invalid'] % {'value': value})
+
+        if connection.features.has_native_uuid_field:
+            return value
+        return value.hex
 
     def to_python(self, value):
         if value and not isinstance(value, uuid.UUID):

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -37,6 +37,13 @@ class TestSaveLoad(TestCase):
         loaded = NullableUUIDModel.objects.get()
         self.assertEqual(loaded.field, None)
 
+    def test_pk_validated(self):
+        with self.assertRaisesMessage(TypeError, 'is not a valid UUID'):
+            PrimaryKeyUUIDModel.objects.get(pk={})
+
+        with self.assertRaisesMessage(TypeError, 'is not a valid UUID'):
+            PrimaryKeyUUIDModel.objects.get(pk=[])
+
     def test_wrong_value(self):
         self.assertRaisesMessage(
             ValueError, 'badly formed hexadecimal UUID string',


### PR DESCRIPTION
For consistency with AutoField. I'm not entirely sure `get_prep_value` is the best place to do this validation, please advise if not.