### PR TITLE
Fixed #24728 -- Rename mime_type to content_type for syndication feeds

### DIFF
--- a/django/contrib/syndication/views.py
+++ b/django/contrib/syndication/views.py
@@ -39,7 +39,7 @@ class Feed(object):
         except ObjectDoesNotExist:
             raise Http404('Feed object does not exist.')
         feedgen = self.get_feed(obj, request)
-        response = HttpResponse(content_type=feedgen.mime_type)
+        response = HttpResponse(content_type=feedgen.content_type)
         if hasattr(self, 'item_pubdate') or hasattr(self, 'item_updateddate'):
             # if item_pubdate or item_updateddate is defined for the feed, set
             # header so as ConditionalGetMiddleware is able to send 304 NOT MODIFIED

--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -24,8 +24,10 @@ http://web.archive.org/web/20110718035220/http://diveintomark.org/archives/2004/
 from __future__ import unicode_literals
 
 import datetime
+import warnings
 
 from django.utils import datetime_safe, six
+from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.six import StringIO
 from django.utils.six.moves.urllib.parse import urlparse
@@ -219,7 +221,7 @@ class Enclosure(object):
 
 
 class RssFeed(SyndicationFeed):
-    mime_type = 'application/rss+xml; charset=utf-8'
+    content_type = 'application/rss+xml; charset=utf-8'
 
     def write(self, outfile, encoding):
         handler = SimplerXMLGenerator(outfile, encoding)
@@ -260,6 +262,13 @@ class RssFeed(SyndicationFeed):
 
     def endChannelElement(self, handler):
         handler.endElement("channel")
+
+    @property
+    def mime_type(self):
+        warnings.warn("The mime_type attribute of RssFeed is deprecated. "
+                      "Use content_type instead.",
+                      RemovedInDjango21Warning, stacklevel=2)
+        return self.content_type
 
 
 class RssUserland091Feed(RssFeed):
@@ -318,7 +327,7 @@ class Rss201rev2Feed(RssFeed):
 
 class Atom1Feed(SyndicationFeed):
     # Spec: http://atompub.org/2005/07/11/draft-ietf-atompub-format-10.html
-    mime_type = 'application/atom+xml; charset=utf-8'
+    content_type = 'application/atom+xml; charset=utf-8'
     ns = "http://www.w3.org/2005/Atom"
 
     def write(self, outfile, encoding):
@@ -409,6 +418,13 @@ class Atom1Feed(SyndicationFeed):
         # Rights.
         if item['item_copyright'] is not None:
             handler.addQuickElement("rights", item['item_copyright'])
+
+    @property
+    def mime_type(self):
+        warnings.warn("The mime_type attribute of Atom1Feed is deprecated. "
+                      "Use content_type instead.",
+                      RemovedInDjango21Warning, stacklevel=2)
+        return self.content_type
 
 # This isolates the decision of what the system default is, so calling code can
 # do "feedgenerator.DefaultFeed" instead of "feedgenerator.Rss201rev2Feed".

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -66,6 +66,10 @@ details on these changes.
 * Support for custom error views with a single positional parameter will be
   dropped.
 
+* The ``mime_type`` attributes of ``django.utils.feedgenerator.Atom1Feed`` and
+  ``django.utils.feedgenerator.RssFeed`` will be removed in favor of
+  ``content_type``.
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -641,6 +641,10 @@ Miscellaneous
   signatures with only one request parameter are deprecated. The views should
   now also accept a second ``exception`` positional parameter.
 
+* ``django.utils.feedgenerator.Atom1Feed.mime_type`` and
+  ``django.utils.feedgenerator.RssFeed.mime_type`` are renamed to ``content_type``.
+  The old attributes are deprecated and will be removed in Django 2.1.
+
 .. removed-features-1.9:
 
 Features removed in 1.9

--- a/tests/utils_tests/test_feedgenerator.py
+++ b/tests/utils_tests/test_feedgenerator.py
@@ -89,7 +89,7 @@ class FeedgeneratorTest(unittest.TestCase):
         """
         atom_feed = feedgenerator.Atom1Feed("title", "link", "description")
         self.assertEqual(
-            atom_feed.mime_type, "application/atom+xml; charset=utf-8"
+            atom_feed.content_type, "application/atom+xml; charset=utf-8"
         )
 
     def test_rss_mime_type(self):
@@ -98,7 +98,7 @@ class FeedgeneratorTest(unittest.TestCase):
         """
         rss_feed = feedgenerator.Rss201rev2Feed("title", "link", "description")
         self.assertEqual(
-            rss_feed.mime_type, "application/rss+xml; charset=utf-8"
+            rss_feed.content_type, "application/rss+xml; charset=utf-8"
         )
 
     # Two regression tests for #14202


### PR DESCRIPTION
Renamed the mime_type properties of RssFeed and Atom1Feed to
content_type and start deprecation for the old names.