### PR TITLE
Fixed #24744 - Fixed relabeled_clone in Transform

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -70,8 +70,13 @@ class Transform(RegisterLookupMixin):
     def output_field(self):
         return self.lhs.output_field
 
+    def copy(self):
+        return copy(self)
+
     def relabeled_clone(self, relabels):
-        return self.__class__(self.lhs.relabeled_clone(relabels))
+        copy = self.copy()
+        copy.lhs = self.lhs.relabeled_clone(relabels)
+        return copy
 
     def get_group_by_cols(self):
         return self.lhs.get_group_by_cols()

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -57,3 +57,5 @@ Bugfixes
 * Corrected join promotion for multiple ``Case`` expressions. Annotating a
   query with multiple  ``Case`` expressions could unexpectedly filter out
   results (:ticket:`24924`).
+
+* Fixed usage of transforms in subqueries (:ticket:`24744`).

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -559,3 +559,18 @@ class CustomisedMethodsTests(TestCase):
     def test_overridden_get_transform_chain(self):
         q = CustomModel.objects.filter(field__transformfunc_banana__transformfunc_pear=3)
         self.assertIn('pear()', str(q.query))
+
+
+class SubqueryTransformTests(TestCase):
+    def test_subquery_usage(self):
+        models.IntegerField.register_lookup(Div3Transform)
+        try:
+            Author.objects.create(name='a1', age=1)
+            a2 = Author.objects.create(name='a2', age=2)
+            Author.objects.create(name='a3', age=3)
+            Author.objects.create(name='a4', age=4)
+            self.assertQuerysetEqual(
+                Author.objects.order_by('name').filter(id__in=Author.objects.filter(age__div3=2)),
+                [a2], lambda x: x)
+        finally:
+            models.IntegerField._unregister_lookup(Div3Transform)

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -228,6 +228,14 @@ class TestQuerying(PostgreSQLTestCase):
             [instance]
         )
 
+    def test_usage_in_subquery(self):
+        self.assertSequenceEqual(
+            NullableIntegerArrayModel.objects.filter(
+                id__in=NullableIntegerArrayModel.objects.filter(field__len=3)
+            ),
+            [self.objs[3]]
+        )
+
 
 class TestChecks(PostgreSQLTestCase):
 

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -132,6 +132,12 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[:2]
         )
 
+    def test_usage_in_subquery(self):
+        self.assertSequenceEqual(
+            HStoreModel.objects.filter(id__in=HStoreModel.objects.filter(field__a='b')),
+            self.objs[:2]
+        )
+
 
 class TestSerialization(PostgreSQLTestCase):
     test_data = '[{"fields": {"field": "{\\"a\\": \\"b\\"}"}, "model": "postgres_tests.hstoremodel", "pk": null}]'

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -204,6 +204,12 @@ class TestQuerying(TestCase):
             [self.objs[7], self.objs[8]]
         )
 
+    def test_usage_in_subquery(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(id__in=JSONModel.objects.filter(field__c=1)),
+            self.objs[7:9]
+        )
+
 
 @skipUnlessPG94
 class TestSerialization(TestCase):


### PR DESCRIPTION
That fixes problems with usage transforms in subqueries.
I also added missing tests for postgresql fields.