### PR TITLE
Fixed #19542: Made mirroring databases for tests work with Oracle

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -85,6 +85,13 @@ class BaseDatabaseCreation(object):
 
         return test_database_name
 
+    def set_as_test_mirror(self, primary_settings_dict):
+        """
+        Set this database up to be used in testing as a mirror of a primary database
+        whose settings are given
+        """
+        self.connection.settings_dict['NAME'] = primary_settings_dict['NAME']
+
     def serialize_db_to_string(self):
         """
         Serializes all data in the database into a JSON string.

--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -94,6 +94,14 @@ class DatabaseCreation(BaseDatabaseCreation):
 
         return self.connection.settings_dict['NAME']
 
+    def set_as_test_mirror(self, primary_settings_dict):
+        """
+        Set this database up to be used in testing as a mirror of a primary database
+        whose settings are given
+        """
+        self.connection.settings_dict['USER'] = primary_settings_dict['USER']
+        self.connection.settings_dict['PASSWORD'] = primary_settings_dict['PASSWORD']
+
     def _handle_objects_preventing_db_destruction(self, cursor, parameters, verbosity, autoclobber):
         # There are objects in the test tablespace which prevent dropping it
         # The easy fix is to drop the test user -- but are we allowed to do so?

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -377,8 +377,8 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwa
 
     for alias, mirror_alias in mirrored_aliases.items():
         mirrors.append((alias, connections[alias].settings_dict['NAME']))
-        connections[alias].settings_dict['NAME'] = (
-            connections[mirror_alias].settings_dict['NAME'])
+        connections[alias].creation.set_as_test_mirror(
+            connections[mirror_alias].settings_dict)
 
     if debug_sql:
         for alias in connections:


### PR DESCRIPTION
No tests are provided because there is no sane way to test database
settings within the Django test suite.

(but I did make sure that testing in general works after this, also when no mirrors are used)