### PR TITLE
Fixed #9061 -- Added 'can_delete_extra' option to BaseFormSet

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -172,6 +172,7 @@ answer newbie questions, and generally made Django that much better:
     Daniel Poelzleithner <http://poelzi.org/>
     Daniel Pyrathon <pirosb3@gmail.com>
     Daniel Roseman <http://roseman.org.uk/>
+    Daniel Ward <danieljward@gmail.com>
     Daniel Wiesmann <daniel.wiesmann@gmail.com>
     Danilo Bargen
     Dan Johnson <danj.py@gmail.com>

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -362,13 +362,14 @@ class BaseFormSet(object):
 
     def add_fields(self, form, index):
         """A hook for adding extra fields on to each form instance."""
+        initial_form_count = self.initial_form_count()
         if self.can_order:
             # Only pre-fill the ordering field for initial forms.
-            if index is not None and index < self.initial_form_count():
+            if index is not None and index < initial_form_count:
                 form.fields[ORDERING_FIELD_NAME] = IntegerField(label=_('Order'), initial=index + 1, required=False)
             else:
                 form.fields[ORDERING_FIELD_NAME] = IntegerField(label=_('Order'), required=False)
-        if self.can_delete:
+        if self.can_delete and (self.can_delete_extra or index < initial_form_count):
             form.fields[DELETION_FIELD_NAME] = BooleanField(label=_('Delete'), required=False)
 
     def add_prefix(self, index):
@@ -414,7 +415,7 @@ class BaseFormSet(object):
 
 def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
                     can_delete=False, max_num=None, validate_max=False,
-                    min_num=None, validate_min=False):
+                    min_num=None, validate_min=False, can_delete_extra=True):
     """Return a FormSet for the given form class."""
     if min_num is None:
         min_num = DEFAULT_MIN_NUM
@@ -426,6 +427,7 @@ def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
     absolute_max = max_num + DEFAULT_MAX_NUM
     attrs = {'form': form, 'extra': extra,
              'can_order': can_order, 'can_delete': can_delete,
+             'can_delete_extra': can_delete_extra,
              'min_num': min_num, 'max_num': max_num,
              'absolute_max': absolute_max, 'validate_min': validate_min,
              'validate_max': validate_max}

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -373,9 +373,9 @@ deletion, is greater than or equal to ``min_num``.
 Dealing with ordering and deletion of forms
 -------------------------------------------
 
-The :func:`~django.forms.formsets.formset_factory` provides two optional
-parameters ``can_order`` and ``can_delete`` to help with ordering of forms in
-formsets and deletion of forms from a formset.
+The :func:`~django.forms.formsets.formset_factory` provides three optional
+parameters ``can_order``, ``can_delete`` and ``can_delete_extra`` to help with
+ordering of forms in formsets and deletion of forms from a formset.
 
 ``can_order``
 ~~~~~~~~~~~~~
@@ -508,6 +508,16 @@ them::
 On the other hand, if you are using a plain ``FormSet``, it's up to you to
 handle ``formset.deleted_forms``, perhaps in your formset's ``save()`` method,
 as there's no general notion of what it means to delete a form.
+
+``can_delete_extra``
+~~~~~~~~~~~~~~~~~~~~
+
+.. attribute:: BaseFormSet.can_delete_extra
+
+Default: ``True``
+
+While setting ``can_delete=True``, specifying ``can_delete_extra=False`` will
+remove the option to delete extra forms.
 
 Adding additional fields to a formset
 -------------------------------------

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -461,6 +461,66 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertTrue(p.is_valid())
         self.assertEqual(len(p.deleted_forms), 1)
 
+    def test_delete_fields_are_not_added_for_extra_formset_forms(self):
+
+        """
+        When a formset is built with can_delete=True and extra>=1, the extra
+        forms should not be seen to hold DELETE fields.
+        """
+
+        class GenericForm(Form):
+            foo = CharField()
+
+        GenericFormFormset = formset_factory(
+            form=GenericForm,
+            can_delete=True,
+            can_delete_extra=False,
+            extra=2)
+
+        # Instantiate formset and check DELETE fields do not exist
+
+        formset = GenericFormFormset()
+
+        self.assertEqual(len(formset), 2)
+
+        self.assertNotIn('DELETE', formset.forms[0].fields)
+        self.assertNotIn('DELETE', formset.forms[1].fields)
+
+        # Instantiate formset with initial data, check DELETE's do not exist
+
+        formset = GenericFormFormset(initial=[{'foo': 'bar'}])
+
+        self.assertEqual(len(formset), 3)
+
+        self.assertIn('DELETE', formset.forms[0].fields)
+        self.assertNotIn('DELETE', formset.forms[1].fields)
+        self.assertNotIn('DELETE', formset.forms[2].fields)
+
+        # Ensure validation behaviour of formsets works correctly
+
+        formset = GenericFormFormset(data={
+            'form-0-foo': 'bar',
+            'form-0-DELETE': 'on',
+            'form-1-foo': 'baz',
+            'form-2-foo': '',
+            'form-TOTAL_FORMS': '3',
+            'form-INITIAL_FORMS': '1',
+        }, initial=[{'foo': 'bar'}])
+
+        # Check correct cleaned data from the formset
+
+        self.assertEqual(formset.cleaned_data, [
+            {'foo': u'bar', u'DELETE': True},
+            {'foo': u'baz'},
+            {},
+        ])
+
+        # Ensure deletion flag is correctly detected by formset method
+
+        self.assertTrue(formset._should_delete_form(formset.forms[0]))
+        self.assertFalse(formset._should_delete_form(formset.forms[1]))
+        self.assertFalse(formset._should_delete_form(formset.forms[2]))
+
     def test_formsets_with_ordering(self):
         # FormSets with ordering ######################################################
         # We can also add ordering ability to a FormSet with an argument to


### PR DESCRIPTION
Added in the `can_delete_extra` option along with supporting tests and documentation updates. This option, when set to `False` will prevent the deletion option from displaying for extra forms in formsets.

For further information - https://code.djangoproject.com/ticket/9061