### PR TITLE
Fixed #24922 -- Added system check for templates setting

### DIFF
--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -11,6 +11,7 @@ import django.core.checks.model_checks  # NOQA
 import django.core.checks.security.base  # NOQA
 import django.core.checks.security.csrf  # NOQA
 import django.core.checks.security.sessions  # NOQA
+import django.core.checks.templates  # NOQA
 
 __all__ = [
     'CheckMessage',

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -15,6 +15,7 @@ class Tags(object):
     models = 'models'
     security = 'security'
     signals = 'signals'
+    templates = 'templates'
 
 
 class CheckRegistry(object):

--- a/django/core/checks/templates.py
+++ b/django/core/checks/templates.py
@@ -6,8 +6,8 @@ from django.conf import settings
 from . import Error, Tags, register
 
 E001 = Error(
-    "You have APP_DIRS = True in your TEMPLATES, while explicitly specifying"
-    "the template loaders. Either set APP_DIRS to False or remove the "
+    "You have 'APP_DIRS': True in your TEMPLATES, while explicitly specifying"
+    "the template loaders. Either remove APP_DIRS or remove the "
     "'loaders' configuration.",
     id='templates.E001',
 )
@@ -17,7 +17,7 @@ E001 = Error(
 def check_setting_app_dirs_loaders(app_configs, **kwargs):
     passed_check = True
     for conf in settings.TEMPLATES:
-        if not conf.get('APP_DIRS', False):
+        if not conf.get('APP_DIRS'):
             continue
         if 'loaders' in conf.get('OPTIONS', {}):
             passed_check = False

--- a/django/core/checks/templates.py
+++ b/django/core/checks/templates.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+
+from . import Error, Tags, register
+
+E001 = Error(
+    "You have APP_DIRS = True in your TEMPLATES, while explicitly specifying"
+    "the template loaders. Either set APP_DIRS to False or remove the "
+    "'loaders' configuration.",
+    id='templates.E001',
+)
+
+
+@register(Tags.templates)
+def check_setting_app_dirs_loaders(app_configs, **kwargs):
+    passed_check = True
+    for conf in settings.TEMPLATES:
+        if not conf.get('APP_DIRS', False):
+            continue
+        if 'loaders' in conf.get('OPTIONS', {}):
+            passed_check = False
+    return [] if passed_check else [E001]

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -491,3 +491,14 @@ If you're using MySQL, the following checks will be performed:
 
 * **mysql.E001**: MySQL does not allow unique ``CharField``\s to have a
   ``max_length`` > 255.
+
+Templates
+---------
+
+The following checks verify that your :setting:`TEMPLATES` are correctly
+configured:
+
+* **templates.E001**: You have ``'APP_DIRS': True`` in your
+  :setting:`TEMPLATES` while explicitly specifying the template loaders.
+  Either set ``'APP_DIRS'`` to ``False`` or remove the ``'loaders'``
+  configuration.

--- a/tests/check_framework/test_templates.py
+++ b/tests/check_framework/test_templates.py
@@ -2,38 +2,38 @@ from django.core.checks.templates import E001
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
-            'loaders': [
-                ('django.template.loaders.cached.Loader', [
-                    'django.template.loaders.filesystem.Loader',
-                    'django.template.loaders.app_directories.Loader',
-                ]),
-            ],
+
+class CheckTemplateSettingsAppDirsTest(SimpleTestCase):
+    TEMPLATES_APPDIRS_AND_LOADERS = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'loaders': ['django.template.loaders.filesystem.Loader'],
+            },
         },
-    },
-]
+    ]
 
-
-class CheckTemplateSettingsTest(SimpleTestCase):
     @property
     def func(self):
         from django.core.checks.templates import check_setting_app_dirs_loaders
         return check_setting_app_dirs_loaders
 
-    @override_settings(TEMPLATES=TEMPLATES)
+    @override_settings(TEMPLATES=TEMPLATES_APPDIRS_AND_LOADERS)
     def test_app_dirs_and_loaders(self):
         """
         Error if template loaders are specified and APP_DIRS is `True`
         """
         self.assertEqual(self.func(None), [E001])
+
+    def test_app_dirs_removed(self):
+        TEMPLATES = self.TEMPLATES_APPDIRS_AND_LOADERS[:]
+        del TEMPLATES[0]['APP_DIRS']
+        with self.settings(TEMPLATES=TEMPLATES):
+            self.assertEqual(self.func(None), [])
+
+    def test_loaders_removed(self):
+        TEMPLATES = self.TEMPLATES_APPDIRS_AND_LOADERS[:]
+        del TEMPLATES[0]['OPTIONS']['loaders']
+        with self.settings(TEMPLATES=TEMPLATES):
+            self.assertEqual(self.func(None), [])

--- a/tests/check_framework/test_templates.py
+++ b/tests/check_framework/test_templates.py
@@ -1,0 +1,39 @@
+from django.core.checks.templates import E001
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'loaders': [
+                ('django.template.loaders.cached.Loader', [
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ]),
+            ],
+        },
+    },
+]
+
+
+class CheckTemplateSettingsTest(SimpleTestCase):
+    @property
+    def func(self):
+        from django.core.checks.templates import check_setting_app_dirs_loaders
+        return check_setting_app_dirs_loaders
+
+    @override_settings(TEMPLATES=TEMPLATES)
+    def test_app_dirs_and_loaders(self):
+        """
+        Error if template loaders are specified and APP_DIRS is `True`
+        """
+        self.assertEqual(self.func(None), [E001])


### PR DESCRIPTION
If `'loaders'` is present in the `TEMPLATES` options together with
`APP_DIRS` set to `True`, the template engine raises an exception. This
conflict is detected by the system check `templates.E001`