### PR TITLE
Fixed #4960 -- Added 'strip' option to CharField

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -210,8 +210,8 @@ class Field(six.with_metaclass(RenameFieldMethods, object)):
 
 
 class CharField(Field):
-    def __init__(self, max_length=None, min_length=None, *args, **kwargs):
-        self.max_length, self.min_length = max_length, min_length
+    def __init__(self, max_length=None, min_length=None, strip=False, *args, **kwargs):
+        self.max_length, self.min_length, self.strip = max_length, min_length, strip
         super(CharField, self).__init__(*args, **kwargs)
         if min_length is not None:
             self.validators.append(validators.MinLengthValidator(int(min_length)))
@@ -230,6 +230,12 @@ class CharField(Field):
             # The HTML attribute is maxlength, not max_length.
             attrs.update({'maxlength': str(self.max_length)})
         return attrs
+
+    def clean(self, value):
+        if self.strip and isinstance(value, six.text_type):
+            value = self.to_python(value)
+            value = value.strip()
+        return super(CharField, self).clean(value)
 
 
 class IntegerField(Field):

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -369,6 +369,13 @@ For each field, we describe the default widget used if you don't specify
     If provided, these arguments ensure that the string is at most or at least
     the given length.
 
+    Has one additional optional argument:
+
+    .. attribute:: strip
+
+    If set to ``True``, string values will have whitespace stripped prior to
+    any validation.
+
 ``ChoiceField``
 ~~~~~~~~~~~~~~~
 

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -164,6 +164,27 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(f.widget_attrs(PasswordInput()), {'maxlength': '10'})
         self.assertEqual(f.widget_attrs(Textarea()), {'maxlength': '10'})
 
+    def test_value_stripping(self):
+
+        """
+        Ensure that 'strip' argument works as intended (#4960).
+        """
+
+        # Test behaviour of strip method
+
+        f = CharField()  # strip=False
+        self.assertEqual(f.clean(' Foo bar '), ' Foo bar ')
+        self.assertEqual(f.clean(' Foo \nBar '), ' Foo \nBar ')
+        self.assertEqual(f.clean('Baz'), 'Baz')
+        self.assertEqual(f.clean(' '), ' ')
+
+        f = CharField(strip=True)
+        self.assertEqual(f.clean(' Foo bar '), 'Foo bar')
+        self.assertEqual(f.clean(' Foo \nBar '), 'Foo \nBar')
+        with self.assertRaises(forms.ValidationError) as err:
+            f.clean(' ')  # Whitespace, yet empty following strip
+        self.assertEqual(err.exception.messages[0], 'This field is required.')
+
     # IntegerField ################################################################
 
     def test_integerfield_1(self):


### PR DESCRIPTION
Added `strip` option to CharField, which when `True` will instruct clean to strip whitespace from the value. Any non-text values will be ignored.

For further information - https://code.djangoproject.com/ticket/4960