### PR TITLE
Removed datetime_cast_sql, which is never overridden or used anywhere in Django.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -90,15 +90,6 @@ class BaseDatabaseOperations(object):
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations may require a datetrunc_sql() method')
 
-    def datetime_cast_sql(self):
-        """
-        Returns the SQL necessary to cast a datetime value so that it will be
-        retrieved as a Python datetime object instead of a string.
-
-        This SQL should include a '%s' in place of the field's name.
-        """
-        return "%s"
-
     def datetime_cast_date_sql(self, field_name, tzname):
         """
         Returns the SQL necessary to cast a datetime value to date value.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -359,6 +359,11 @@ Database backend API
 * To use the new ``date`` lookup, third-party database backends may need to
   implement the ``DatabaseOperations.datetime_cast_date_sql()`` method.
 
+* The ``DatabaseOperations.datetime_cast_sql()`` (without "``_date_``") method
+  has been removed. This method served to format dates on Oracle long
+  before 1.0, but hasn't been overridden by any core backend in years,
+  and hasn't been called anywhere in Django's code or tests.
+
 Default settings that were tuples are now lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Done as a PR rather than a direct commit to give some chance to interested parties to stop it