### PR TITLE
Fixed #24829 -- Allowed usage of TemplateResponse in error handlers

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -377,6 +377,10 @@ Requests and Responses
 * The default 40x error views now accept a second positional parameter, the
   exception that triggered the view.
 
+* Error handlers now support rendering using
+  :class:`~django.template.response.TemplateResponse`, commonly used with
+  class based views.
+
 Tests
 ^^^^^
 

--- a/tests/handlers/templates/test_handler.html
+++ b/tests/handlers/templates/test_handler.html
@@ -1,0 +1,1 @@
+Error handler content

--- a/tests/handlers/tests_custom_error_handlers.py
+++ b/tests/handlers/tests_custom_error_handlers.py
@@ -1,0 +1,29 @@
+from django.conf.urls import url
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
+from django.test import SimpleTestCase, override_settings
+
+
+def template_response_error_handler(request, exception=None):
+    return TemplateResponse(request, 'test_handler.html', status=403)
+
+
+def permission_denied_view(request):
+    raise PermissionDenied
+
+
+urlpatterns = [
+    url(r'^$', permission_denied_view),
+]
+
+handler403 = template_response_error_handler
+
+
+@override_settings(ROOT_URLCONF='handlers.tests_custom_error_handlers')
+class CustomErrorHandlerTests(SimpleTestCase):
+
+    def test_custom_handler(self):
+        response = self.client.get('/')
+        # We need to force template rendering
+        response.content
+        self.assertContains(response, 'Error handler content', status_code=403)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24829

If a class based generic view is specified as an error handler, the template is
supposed to be rendered in advance, otherwise it raises
ContentNotRenderedError.