### PR TITLE
Fixed #24925 -- Add testcase for Coalesce bug on MySQL

### DIFF
--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -35,6 +35,16 @@ class FunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, 'Coalesce must take at least two expressions'):
             Author.objects.annotate(display_name=Coalesce('alias'))
 
+    def test_coalesce_datetime_output_field_null(self):
+        now = timezone.now()
+        Article.objects.create(title='Testing, testing.', written=now)
+
+        articles = Article.objects.annotate(
+            publised_default=Coalesce('published', now),
+        )
+        article = articles.get()
+        self.assertEqual(article.publised_default, now)
+
     def test_coalesce_mixed_values(self):
         a1 = Author.objects.create(name='John Smith', alias='smithj')
         a2 = Author.objects.create(name='Rhonda')

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -35,7 +35,7 @@ class FunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, 'Coalesce must take at least two expressions'):
             Author.objects.annotate(display_name=Coalesce('alias'))
 
-    def test_coalesce_datetime_output_field_null(self):
+    def test_coalesce_datetime_value(self):
         now = timezone.now()
         Article.objects.create(title='Testing, testing.', written=now)
 


### PR DESCRIPTION
A datetime passed to `Coalesce` is converted to a string in MySQL. This means an annotated value is a string, not a datetime.