### PR TITLE
Fixed #22728 - Prohibited lookups usage for get_or_create and update_or_create

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -511,6 +511,10 @@ class QuerySet(object):
             if f.attname in lookup:
                 lookup[f.name] = lookup.pop(f.attname)
         params = {k: v for k, v in kwargs.items() if LOOKUP_SEP not in k}
+        lookup_parameters = set(kwargs.keys()) - set(params.keys())
+        if lookup_parameters:
+            raise TypeError("Lookups are not allowed for get_or_create() and update_or_create(). "
+                            "Wrong parameters: %s" % sorted(lookup_parameters))
         params.update(defaults)
         return lookup, params
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1702,6 +1702,14 @@ whenever a request to a page has a side effect on your data. For more, see
   chapter because it isn't related to that book, but it can't create it either
   because ``title`` field should be unique.
 
+  .. versionchanged:: 1.9
+
+  Lookups usage is not allowed for ``get_or_create()``.
+  If you will try to use it, ``TypeError`` will be raised.
+
+      >>> Person.objects.get_or_create(name='Bob', birthday__gte=date(1800, 12, 12))
+      # Raises TypeError
+
 update_or_create
 ~~~~~~~~~~~~~~~~
 
@@ -1743,6 +1751,14 @@ For detailed description how names passed in ``kwargs`` are resolved see
 As described above in :meth:`get_or_create`, this method is prone to a
 race-condition which can result in multiple rows being inserted simultaneously
 if uniqueness is not enforced at the database level.
+
+  .. versionchanged:: 1.9
+
+  Lookups usage is not allowed for ``update_or_create()``.
+  If you will try to use it, ``TypeError`` will be raised.
+
+      >>> Person.objects.update_or_create(name='Bob', birthday__gte=date(1800, 12, 12))
+      # Raises TypeError
 
 bulk_create
 ~~~~~~~~~~~

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -559,6 +559,9 @@ Miscellaneous
   :attr:`~django.test.SimpleTestCase.allow_database_queries` class attribute
   to ``True`` on your test class.
 
+* Lookups usage in ``get_or_create()`` and ``update_or_create()`` was
+  prohibited.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -126,6 +126,16 @@ class GetOrCreateTests(TestCase):
         # The publisher should have three books.
         self.assertEqual(p.books.count(), 3)
 
+    def test_get_or_create_with_lookups_raises_exception(self):
+        Person.objects.create(first_name="Morihei", last_name="Ueshiba", birthday=date(1883, 12, 14))
+        self.assertRaisesMessage(
+            TypeError,
+            "Lookups are not allowed for get_or_create() and update_or_create(). "
+            "Wrong parameters: ['birthday__gte', 'first_name__iexact']",
+            Person.objects.get_or_create,
+            first_name__iexact='morihei', last_name="Ueshiba", birthday__gte=date(1800, 12, 12)
+        )
+
 
 class GetOrCreateTestsWithManualPKs(TestCase):
 
@@ -348,3 +358,13 @@ class UpdateOrCreateTests(TestCase):
         self.assertFalse(created)
         self.assertEqual(book.name, name)
         self.assertEqual(author.books.count(), 1)
+
+    def test_update_or_create_with_lookups_raises_exception(self):
+        Person.objects.create(first_name="Morihei", last_name="Ueshiba", birthday=date(1883, 12, 14))
+        self.assertRaisesMessage(
+            TypeError,
+            "Lookups are not allowed for get_or_create() and update_or_create(). "
+            "Wrong parameters: ['birthday__gte', 'first_name__iexact']",
+            Person.objects.update_or_create,
+            first_name__iexact='morihei', last_name="Ueshiba", birthday__gte=date(1800, 12, 12)
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/22728