### PR TITLE
Fixed #22276 -- Surfaced ValidationError to end-user if management form is invalid

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -92,10 +92,9 @@ class BaseFormSet(object):
         if self.is_bound:
             form = ManagementForm(self.data, auto_id=self.auto_id, prefix=self.prefix)
             if not form.is_valid():
-                raise ValidationError(
-                    _('ManagementForm data is missing or has been tampered with'),
-                    code='missing_management_form',
-                )
+                # Since the management formset is invalid, we don't know how
+                # many forms were submitted
+                form.cleaned_data[TOTAL_FORM_COUNT] = 0
         else:
             form = ManagementForm(auto_id=self.auto_id, prefix=self.prefix, initial={
                 TOTAL_FORM_COUNT: self.total_form_count(),
@@ -296,6 +295,10 @@ class BaseFormSet(object):
         Returns True if every form in self.forms is valid.
         """
         if not self.is_bound:
+            return False
+        if not self.management_form.is_valid():
+            error = _('Management form data is missing or has been tampered with.')
+            self._non_form_errors = self.error_class([error])
             return False
         # We loop over every form.errors here rather than short circuiting on the
         # first failure to make sure validation gets triggered for every form.

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1099,6 +1099,22 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertTrue(hasattr(formset, '__html__'))
         self.assertEqual(force_text(formset), formset.__html__())
 
+    def test_invalid_management_form_works(self):
+        class CheckForm(Form):
+            field = IntegerField()
+
+        data = {
+            'broken-TOTAL_FORMS': '',
+            'broken-INITIAL_FORMS': '',
+            'broken-MAX_NUM_FORMS': '',
+            'broken-0-field': '1'
+        }
+        CheckFormSet = formset_factory(CheckForm, max_num=1)
+        formset = CheckFormSet(data, prefix='broken')
+        self.assertFalse(formset.is_valid())
+        self.assertEqual(list(formset.non_form_errors()),
+            ['Management form data is missing or has been tampered with.'])
+
 
 data = {
     'choices-TOTAL_FORMS': '1',  # the number of forms rendered
@@ -1146,10 +1162,6 @@ ArticleFormSet = formset_factory(ArticleForm)
 
 
 class TestIsBoundBehavior(SimpleTestCase):
-    def test_no_data_raises_validation_error(self):
-        with self.assertRaises(ValidationError):
-            ArticleFormSet({}).is_valid()
-
     def test_with_management_data_attrs_work_fine(self):
         data = {
             'form-TOTAL_FORMS': '1',


### PR DESCRIPTION
This is a new implementation of #3634 