### PR TITLE
Fix #24769 - Cast optparse verbosity argument to an integer for better backwards compatibility

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -257,6 +257,9 @@ class BaseCommand(object):
 
         """
         if not self.use_argparse:
+            def store_as_int(option, opt_str, value, parser):
+                setattr(parser.values, option.dest, int(value))
+
             # Backwards compatibility: use deprecated optparse module
             warnings.warn("OptionParser usage for Django management commands "
                           "is deprecated, use ArgumentParser instead",
@@ -264,8 +267,8 @@ class BaseCommand(object):
             parser = OptionParser(prog=prog_name,
                                 usage=self.usage(subcommand),
                                 version=self.get_version())
-            parser.add_option('-v', '--verbosity', action='store', dest='verbosity', default='1',
-                type='choice', choices=['0', '1', '2', '3'],
+            parser.add_option('-v', '--verbosity', action='callback', dest='verbosity', default=1,
+                type='choice', choices=['0', '1', '2', '3'], callback=store_as_int,
                 help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output')
             parser.add_option('--settings',
                 help=(

--- a/tests/user_commands/management/commands/optparse_internal_cmd.py
+++ b/tests/user_commands/management/commands/optparse_internal_cmd.py
@@ -1,13 +1,12 @@
 from optparse import make_option
 
-from django.core.management.base import BaseCommand
+from django.core.management.commands.test import Command as TestCommand
 
 
-class Command(BaseCommand):
-    help = "Test optparse compatibility."
-    args = ''
+class Command(TestCommand):
+    help = "Test optparse compatibility when extending an internal command."
 
-    option_list = BaseCommand.option_list + (
+    option_list = TestCommand.option_list + (
         make_option("-s", "--style", default="Rock'n'Roll"),
         make_option("-x", "--example")
     )

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -118,6 +118,11 @@ class CommandTests(SimpleTestCase):
             management.execute_from_command_line(['django-admin', 'optparse_cmd'])
         self.assertEqual(stdout.getvalue(), "All right, let's dance Rock'n'Roll.\n")
 
+        # Test overridden internal command
+        out = StringIO()
+        management.call_command('optparse_internal_cmd', stdout=out)
+        self.assertEqual(out.getvalue(), "All right, let's dance Rock'n'Roll.\n")
+
     def test_calling_a_command_with_only_empty_parameter_should_ends_gracefully(self):
         out = StringIO()
         management.call_command('hal', "--empty", stdout=out)


### PR DESCRIPTION
Based on https://github.com/django/django/pull/4628

This PR adds tests and fixes the same problem (verbosity argument being string) when -v option was not specified.

A few questions:

- @freakboy3742 brought up the question of backwards compatibility when old management commands actually expect string, but reading https://code.djangoproject.com/ticket/24769 and https://code.djangoproject.com/ticket/24518 , it seems that it wasn't considered much of an issue.
- Is there a better way than assert in the test management command for ensuring that the verbosity option is actually int?