### PR TITLE
Use get_db_prep_value when getting instance attribute value in get_pr…

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1002,7 +1002,10 @@ def create_many_related_manager(superclass, rel, reverse):
                     getattr(result, '_prefetch_related_val_%s' % f.attname)
                     for f in fk.local_related_fields
                 ),
-                lambda inst: tuple(getattr(inst, f.attname) for f in fk.foreign_related_fields),
+                lambda inst: tuple(
+                    f.get_db_prep_value(getattr(inst, f.attname), connection)
+                    for f in fk.foreign_related_fields
+                ),
                 False,
                 self.prefetch_cache_name,
             )

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -50,3 +50,6 @@ Bugfixes
 
 * Fixed recording of applied status for squashed (replacement) migrations
   (:ticket:`24628`).
+
+* Fixed prefetch_related for models using UUID primary keys on non-PostgreSQL
+  databases (:ticket:`24912`).

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation,
 )
@@ -257,3 +258,11 @@ class Author2(models.Model):
 
     class Meta:
         ordering = ['id']
+
+
+# Model for many-to-many with UUID pk test:
+
+class Pet(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=20)
+    people = models.ManyToManyField(Person, related_name='pets')


### PR DESCRIPTION
…efetch_queryset

This resolves a problem for non-PostgreSQL databases when using
prefetch_related with a source model that uses a UUID primary key.