### PR TITLE
Fixed #13910 -- Added generator based rendering (streaming) of templates and supporting views

### DIFF
--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -9,6 +9,7 @@ from django.db.models.manager import Manager
 from django.db.models.query import QuerySet
 from django.http import (
     Http404, HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect,
+    StreamingHttpResponse,
 )
 from django.template import loader
 from django.utils import six
@@ -16,27 +17,31 @@ from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
 
-def render_to_response(template_name, context=None, content_type=None, status=None, using=None):
+def render_to_response(template_name, context=None, content_type=None, status=None, using=None, stream=False):
     """
-    Returns a HttpResponse whose content is filled with the result of calling
+    Return a response whose content is filled with the result of calling
     django.template.loader.render_to_string() with the passed arguments.
+    Can use HttpResponse or StreamingHttpResponse depending on stream parameter.
     """
-    content = loader.render_to_string(template_name, context, using=using)
-    return HttpResponse(content, content_type, status)
+    response_class = StreamingHttpResponse if stream else HttpResponse
+    content = loader.render_to_string(template_name, context, using=using, stream=stream)
+    return response_class(content, content_type, status)
 
 
-def render(request, template_name, context=None, content_type=None, status=None, using=None):
+def render(request, template_name, context=None, content_type=None, status=None, using=None, stream=False):
     """
-    Returns a HttpResponse whose content is filled with the result of calling
+    Returns a response whose content is filled with the result of calling
     django.template.loader.render_to_string() with the passed arguments.
+    Can use HttpResponse or StreamingHttpResponse depending on stream parameter.
     """
-    content = loader.render_to_string(template_name, context, request, using=using)
-    return HttpResponse(content, content_type, status)
+    response_class = StreamingHttpResponse if stream else HttpResponse
+    content = loader.render_to_string(template_name, context, request, using=using, stream=stream)
+    return response_class(content, content_type, status)
 
 
 def redirect(to, *args, **kwargs):
     """
-    Returns an HttpResponseRedirect to the appropriate URL for the arguments
+    Return an HttpResponseRedirect to the appropriate URL for the arguments
     passed.
 
     The arguments could be:
@@ -61,7 +66,7 @@ def redirect(to, *args, **kwargs):
 
 def _get_queryset(klass):
     """
-    Returns a QuerySet from a Model, Manager, or QuerySet. Created to make
+    Return a QuerySet from a Model, Manager, or QuerySet. Created to make
     get_object_or_404 and get_list_or_404 more DRY.
 
     Raises a ValueError if klass is not a Model, Manager, or QuerySet.
@@ -102,7 +107,7 @@ def get_object_or_404(klass, *args, **kwargs):
 
 def get_list_or_404(klass, *args, **kwargs):
     """
-    Uses filter() to return a list of objects, or raise a Http404 exception if
+    Use filter() to return a list of objects, or raise a Http404 exception if
     the list is empty.
 
     klass may be a Model, Manager, or QuerySet object. All other passed

--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -60,10 +60,10 @@ class Template(object):
     def origin(self):
         return self.template.origin
 
-    def render(self, context=None, request=None):
+    def render(self, context=None, request=None, stream=False):
         context = make_context(context, request, autoescape=self.backend.engine.autoescape)
         try:
-            return self.template.render(context)
+            return self.template.render(context, stream=stream)
         except TemplateDoesNotExist as exc:
             reraise(exc, self.backend)
 

--- a/django/template/backends/dummy.py
+++ b/django/template/backends/dummy.py
@@ -52,7 +52,10 @@ class TemplateStrings(BaseEngine):
 
 class Template(string.Template):
 
-    def render(self, context=None, request=None):
+    def render(self, context=None, request=None, stream=False):
+        if stream:
+            raise NotImplementedError()
+
         if context is None:
             context = {}
         else:

--- a/django/template/backends/jinja2.py
+++ b/django/template/backends/jinja2.py
@@ -60,13 +60,15 @@ class Template(object):
             name=template.filename, template_name=template.name,
         )
 
-    def render(self, context=None, request=None):
+    def render(self, context=None, request=None, stream=False):
         if context is None:
             context = {}
         if request is not None:
             context['request'] = request
             context['csrf_input'] = csrf_input_lazy(request)
             context['csrf_token'] = csrf_token_lazy(request)
+        if stream:
+            return self.template.stream(context)
         return self.template.render(context)
 
 

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -163,7 +163,7 @@ class Engine(object):
             template = Template(template, origin, template_name, engine=self)
         return template
 
-    def render_to_string(self, template_name, context=None):
+    def render_to_string(self, template_name, context=None, stream=False):
         """
         Render the template specified by template_name with the given context.
         For use in Django's test suite.
@@ -174,10 +174,9 @@ class Engine(object):
             t = self.get_template(template_name)
         # Django < 1.8 accepted a Context in `context` even though that's
         # unintended. Preserve this ability but don't rewrap `context`.
-        if isinstance(context, Context):
-            return t.render(context)
-        else:
-            return t.render(Context(context))
+        if not isinstance(context, Context):
+            context = Context(context)
+        return t.render(context, stream=stream)
 
     def select_template(self, template_name_list):
         """

--- a/django/template/loader.py
+++ b/django/template/loader.py
@@ -48,7 +48,7 @@ def select_template(template_name_list, using=None):
         raise TemplateDoesNotExist("No template names provided")
 
 
-def render_to_string(template_name, context=None, request=None, using=None):
+def render_to_string(template_name, context=None, request=None, using=None, stream=False):
     """
     Loads a template and renders it with a context. Returns a string.
 
@@ -58,7 +58,7 @@ def render_to_string(template_name, context=None, request=None, using=None):
         template = select_template(template_name, using=using)
     else:
         template = get_template(template_name, using=using)
-    return template.render(context, request)
+    return template.render(context, request, stream=stream)
 
 
 def _engine_list(using=None):

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -89,7 +89,16 @@ def instrumented_test_render(self, context):
     that can be intercepted by the test system Client
     """
     template_rendered.send(sender=self, template=self, context=context)
-    return self.nodelist.render(context)
+    return self.nodelist.render(context, stream=False)
+
+
+def instrumented_test_stream(self, context):
+    """
+    An instrumented Template stream method, providing a signal
+    that can be intercepted by the test system Client.
+    """
+    template_rendered.send(sender=self, template=self, context=context)
+    return self.nodelist.render(context, stream=True)
 
 
 def setup_test_environment():
@@ -101,6 +110,8 @@ def setup_test_environment():
     """
     Template._original_render = Template._render
     Template._render = instrumented_test_render
+    Template._original_stream = Template._stream
+    Template._stream = instrumented_test_stream
 
     # Storing previous values in the settings module itself is problematic.
     # Store them in arbitrary (but related) modules instead. See #20636.

--- a/django/views/generic/__init__.py
+++ b/django/views/generic/__init__.py
@@ -1,4 +1,6 @@
-from django.views.generic.base import RedirectView, TemplateView, View
+from django.views.generic.base import (
+    RedirectView, StreamingTemplateView, TemplateView, View,
+)
 from django.views.generic.dates import (
     ArchiveIndexView, DateDetailView, DayArchiveView, MonthArchiveView,
     TodayArchiveView, WeekArchiveView, YearArchiveView,
@@ -10,7 +12,7 @@ from django.views.generic.edit import (
 from django.views.generic.list import ListView
 
 __all__ = [
-    'View', 'TemplateView', 'RedirectView', 'ArchiveIndexView',
+    'View', 'TemplateView', 'StreamingTemplateView', 'RedirectView', 'ArchiveIndexView',
     'YearArchiveView', 'MonthArchiveView', 'WeekArchiveView', 'DayArchiveView',
     'TodayArchiveView', 'DateDetailView', 'DetailView', 'FormView',
     'CreateView', 'UpdateView', 'DeleteView', 'ListView', 'GenericViewError',

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -6,7 +6,9 @@ from functools import update_wrapper
 from django import http
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch, reverse
-from django.template.response import TemplateResponse
+from django.template.response import (
+    StreamingTemplateResponse, TemplateResponse,
+)
 from django.utils import six
 from django.utils.decorators import classonlymethod
 
@@ -151,11 +153,19 @@ class TemplateResponseMixin(object):
 class TemplateView(TemplateResponseMixin, ContextMixin, View):
     """
     A view that renders a template.  This view will also pass into the context
-    any keyword arguments passed by the URLconf.
+    any keyword arguments passed by the URLConf.
     """
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
+
+
+class StreamingTemplateView(TemplateView):
+    """
+    A view that streams a template. This view will also pass into the context
+    any keyword arguments passed by the URLConf.
+    """
+    response_class = StreamingTemplateResponse
 
 
 class RedirectView(View):

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -804,6 +804,24 @@ Notes:
   ``django.template.TemplateSyntaxError`` if they receive the wrong number or
   type of arguments.
 
+* You can implement a ``stream()`` method if your renderer can iterate.
+  This method allows to display the node as it is rendered if the template
+  is streamed.
+
+  The ``stream()`` method must be a generator::
+
+    class OneToNineNode(template.Node):
+        def render(self, context):
+            return ''.join(self.stream(context))
+
+        def stream(self, context):
+            for i in range(1, 10):
+                yield str(i)
+
+  .. versionadded:: 1.10
+
+      The ``stream()`` method was added.
+
 Ultimately, this decoupling of compilation and rendering results in an
 efficient template system, because a template can render multiple contexts
 without having to be parsed multiple times.

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -248,6 +248,7 @@ details on these changes.
   * ``django.template.Context()``
   * ``django.template.RequestContext()``
   * ``django.template.response.TemplateResponse()``
+  * ``django.template.response.StreamingTemplateResponse()``
 
 * The ``dictionary`` and ``context_instance`` parameters for the following
   functions will be removed:

--- a/docs/ref/template-response.txt
+++ b/docs/ref/template-response.txt
@@ -292,3 +292,43 @@ with a simple template and a context containing a queryset::
 
     def blog_index(request):
         return TemplateResponse(request, 'entry_list.html', {'entries': Entry.objects.all()})
+
+``StreamingTemplateResponse`` and ``SimpleStreamingTemplateResponse``
+=====================================================================
+
+.. versionadded:: 1.10
+
+:class:`~django.template.response.StreamingTemplateResponse` and
+:class:`~django.template.response.SimpleStreamingTemplateResponse` allow the
+same features as :class:`~django.template.response.TemplateResponse` and
+:class:`~django.template.response.SimpleTemplateResponse` but stream the
+template instead of rendering it.
+
+``SimpleStreamingTemplateResponse`` objects
+-------------------------------------------
+
+.. class:: SimpleStreamingTemplateResponse()
+
+    ``SimpleStreamingTemplateResponse`` shares most of
+    :class:`~django.template.response.SimpleTemplateResponse` attributes and
+    methods, however, ``SimpleStreamingTemplateResponse`` does not handle any
+    rendering attributes/methods (including callbacks).
+
+Attributes
+~~~~~~~~~~
+
+.. attribute:: SimpleStreamingTemplateResponse.streaming_content
+
+    The generator streaming the response content, using the current
+    template and context data.
+
+``StreamingTemplateResponse`` objects
+-------------------------------------
+
+.. class:: StreamingTemplateResponse()
+
+    ``StreamingTemplateResponse`` is a subclass of
+    :class:`~django.template.response.SimpleStreamingTemplateResponse` that
+    knows about the current :class:`~django.http.HttpRequest`. It is
+    initialized the same way as
+    :class:`~django.template.response.TemplateResponse`.

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -233,6 +233,17 @@ different contexts.
         >>> template.render(context)
         "My name is Dolores."
 
+    .. versionadded:: 1.10
+
+    You can pass `stream` as `True` to create a generator of the template
+    instead.
+
+        >>> template = Template("{% for value in values %}{{value}}{% endfor %}")
+        >>> context = Context(['one', 'two'])
+        >>> list(template.render(context, stream=True))
+        ['one', 'two']
+
+
 Variables and lookups
 ---------------------
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -257,6 +257,9 @@ Requests and Responses
 ^^^^^^^^^^^^^^^^^^^^^^
 
 * Added ``request.user`` to the debug view.
+* Added :class:`~django.template.response.StreamingTemplateResponse` and
+  :class:`~django.template.response.SimpleStreamingTemplateResponse` to
+  handle streaming of templates.
 
 * Added :class:`~django.http.HttpResponse` methods
   :meth:`~django.http.HttpResponse.readable()` and
@@ -280,6 +283,11 @@ Templates
 * Added the ``autoescape`` option to the
   :class:`~django.template.backends.django.DjangoTemplates` backend and the
   :class:`~django.template.Engine` class.
+* Support for iterating over templates was added. This add a
+  ``stream`` parameter to the ``Template.render()`` and
+  ``django.template.loader()`` methods, and to the
+  :func:`~django.shortcuts.render_to_response` and
+  :func:`~django.shortcuts.render` shortcuts.
 
 Tests
 ^^^^^

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -15,7 +15,7 @@ introduce controlled coupling for convenience's sake.
 ``render``
 ==========
 
-.. function:: render(request, template_name, context=None, content_type=None, status=None, using=None)
+.. function:: render(request, template_name, context=None, content_type=None, status=None, using=None, stream=False)
 
    Combines a given template with a given context dictionary and returns an
    :class:`~django.http.HttpResponse` object with that rendered text.
@@ -56,6 +56,14 @@ Optional arguments
     The :setting:`NAME <TEMPLATES-NAME>` of a template engine to use for
     loading the template.
 
+``stream``
+   If set to True, a :class:`~django.http.StreamingHttpResponse` will be
+   return instead.
+
+   .. versionchanged:: 1.10
+
+       The ``stream`` parameter was added.
+
 Example
 -------
 
@@ -84,7 +92,7 @@ This example is equivalent to::
 ``render_to_response``
 ======================
 
-.. function:: render_to_response(template_name, context=None, content_type=None, status=None, using=None)
+.. function:: render_to_response(template_name, context=None, content_type=None, status=None, using=None, stream=False)
 
    This function preceded the introduction of :func:`render` and works
    similarly except that it doesn't make the ``request`` available in the

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -155,7 +155,7 @@ must provide a ``render()`` method with the following signature:
 
 .. currentmodule:: django.template.backends.base
 
-.. method:: Template.render(context=None, request=None)
+.. method:: Template.render(context=None, request=None, stream=False)
 
     Renders this template with a given context.
 
@@ -165,6 +165,13 @@ must provide a ``render()`` method with the following signature:
     If ``request`` is provided, it must be an :class:`~django.http.HttpRequest`.
     Then the engine must make it, as well as the CSRF token, available in the
     template. How this is achieved is up to each backend.
+
+    If ``stream`` is set to True, it will return a generator for rendering
+    the template instead
+
+    .. versionadded:: 1.10
+
+        The stream argument was added.
 
 Here's an example of the search algorithm. For this example the
 :setting:`TEMPLATES` setting is::
@@ -238,7 +245,7 @@ the following templates:
 In addition, to cut down on the repetitive nature of loading and rendering
 templates, Django provides a shortcut function which automates the process.
 
-.. function:: render_to_string(template_name, context=None, request=None, using=None)
+.. function:: render_to_string(template_name, context=None, request=None, using=None, stream=False)
 
     ``render_to_string()`` loads a template like :func:`get_template` and
     calls its ``render()`` method immediately. It takes the following
@@ -255,6 +262,13 @@ templates, Django provides a shortcut function which automates the process.
     ``request``
         An optional :class:`~django.http.HttpRequest` that will be available
         during the template's rendering process.
+
+    ``stream``
+        If set to ``True``, it will return a generator of the template instead.
+
+        .. versionadded:: 1.10
+
+            The ``stream()`` argument was added.
 
 See also the :func:`~django.shortcuts.render()` shortcut which calls
 :func:`render_to_string()` and feeds the result into an

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -5,10 +5,12 @@ import unittest
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import resolve
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
-from django.views.generic import RedirectView, TemplateView, View
+from django.views.generic import (
+    RedirectView, StreamingTemplateView, TemplateView, View,
+)
 
 from . import views
 
@@ -47,6 +49,14 @@ class DecoratedDispatchView(SimpleView):
 
 
 class AboutTemplateView(TemplateView):
+    def get(self, request):
+        return self.render_to_response({})
+
+    def get_template_names(self):
+        return ['generic_views/about.html']
+
+
+class AboutStreamingTemplateView(StreamingTemplateView):
     def get(self, request):
         return self.render_to_response({})
 
@@ -348,6 +358,21 @@ class TemplateViewTest(SimpleTestCase):
     def test_resolve_login_required_view(self):
         match = resolve('/template/login_required/')
         self.assertIs(match.func.view_class, TemplateView)
+
+
+@override_settings(ROOT_URLCONF='generic_views.urls')
+class StreamingTemplateViewTest(SimpleTestCase):
+
+    rf = RequestFactory()
+
+    def test_get(self):
+        """
+        Test a view that simply streams a template on GET
+        """
+        response = AboutStreamingTemplateView.as_view()(self.rf.get('/about/'))
+        self.assertIsInstance(response, StreamingHttpResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<h1>About</h1>')
 
 
 @override_settings(ROOT_URLCONF='generic_views.urls')

--- a/tests/shortcuts/tests.py
+++ b/tests/shortcuts/tests.py
@@ -1,3 +1,4 @@
+from django.http import StreamingHttpResponse
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
 
@@ -69,3 +70,17 @@ class ShortcutTests(SimpleTestCase):
         self.assertEqual(response.content, b'DTL\n')
         response = self.client.get('/render/using/?using=jinja2')
         self.assertEqual(response.content, b'Jinja2\n')
+
+    def test_stream_to_response(self):
+        response = self.client.get('/stream_to_response/')
+        self.assertIsInstance(response, StreamingHttpResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, b'FOO.BAR..\n')
+        self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')
+
+    def test_stream(self):
+        response = self.client.get('/stream/')
+        self.assertIsInstance(response, StreamingHttpResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, b'FOO.BAR../stream/\n')
+        self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')

--- a/tests/shortcuts/urls.py
+++ b/tests/shortcuts/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     url(r'^render/content_type/$', views.render_view_with_content_type),
     url(r'^render/status/$', views.render_view_with_status),
     url(r'^render/using/$', views.render_view_with_using),
+    url(r'^stream_to_response/$', views.stream_to_response_view),
+    url(r'^stream/$', views.stream_view),
 ]

--- a/tests/shortcuts/views.py
+++ b/tests/shortcuts/views.py
@@ -82,3 +82,17 @@ def render_view_with_status(request):
 def render_view_with_using(request):
     using = request.GET.get('using')
     return render(request, 'shortcuts/using.html', using=using)
+
+
+def stream_to_response_view(request):
+    return render_to_response('shortcuts/render_test.html', {
+        'foo': 'FOO',
+        'bar': 'BAR',
+    }, stream=True)
+
+
+def stream_view(request):
+    return render(request, 'shortcuts/render_test.html', {
+        'foo': 'FOO',
+        'bar': 'BAR',
+    }, stream=True)

--- a/tests/template_loader/tests.py
+++ b/tests/template_loader/tests.py
@@ -154,3 +154,12 @@ class TemplateLoaderTests(SimpleTestCase):
         content = render_to_string(["template_loader/goodbye.html",
                                     "template_loader/hello.html"])
         self.assertEqual(content, "Goodbye! (Django templates)\n")
+
+    def test_stream_django_engine(self):
+        content = render_to_string("template_loader/goodbye.html", stream=True)
+        self.assertEqual(list(content), ["Goodbye! (Django templates)\n"])
+
+    def test_stream_django_engine_with_request(self):
+        request = RequestFactory().get('/foobar/')
+        content = render_to_string("template_loader/request.html", request=request, stream=True)
+        self.assertEqual(list(content), ["/foobar/", "\n"])

--- a/tests/template_tests/syntax_tests/test_autoescape.py
+++ b/tests/template_tests/syntax_tests/test_autoescape.py
@@ -119,3 +119,11 @@ class AutoescapeTagTests(SimpleTestCase):
         """
         output = self.engine.render_to_string('autoescape-lookup01', {'var': {'key': 'this & that'}})
         self.assertEqual(output, 'this &amp; that')
+
+    @setup({'autoescape-tag-stream': '{% autoescape off %}{{ first }}{{ second }}{% endautoescape %}'})
+    def test_autoescape_tag_stream(self):
+        output = self.engine.render_to_string(
+            'autoescape-tag-stream', {'first': '<b>first</b>', 'second': '<b>second</b>'}, stream=True
+        )
+        self.assertEqual(next(output), '<b>first</b>')
+        self.assertEqual(next(output), '<b>second</b>')

--- a/tests/template_tests/syntax_tests/test_filter_tag.py
+++ b/tests/template_tests/syntax_tests/test_filter_tag.py
@@ -45,3 +45,8 @@ class FilterTagTests(SimpleTestCase):
     def test_filter06bis(self):
         with self.assertRaises(TemplateSyntaxError):
             self.engine.get_template('filter06bis')
+
+    @setup({'filter-stream': '{% filter upper %}django{% endfilter %}'})
+    def test_filter_stream(self):
+        output = self.engine.render_to_string('filter-stream', stream=True)
+        self.assertEqual(next(output), 'DJANGO')

--- a/tests/template_tests/syntax_tests/test_for.py
+++ b/tests/template_tests/syntax_tests/test_for.py
@@ -154,3 +154,10 @@ class ForTagTests(SimpleTestCase):
     def test_for_tag_unpack14(self):
         with self.assertRaisesMessage(ValueError, 'Need 2 values to unpack in for loop; got 1.'):
             self.engine.render_to_string('for-tag-unpack14', {'items': (1, 2)})
+
+    @setup({'for-tag-stream': '{% for val in values %}{{ val }}{% endfor %}'})
+    def test_for_tag_stream(self):
+        output = self.engine.render_to_string('for-tag-stream', {'values': [1, 2, 3]}, stream=True)
+        self.assertEqual(next(output), '1')
+        self.assertEqual(next(output), '2')
+        self.assertEqual(next(output), '3')

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -527,3 +527,9 @@ class IfTagTests(SimpleTestCase):
         # A single equals sign is a syntax error.
         with self.assertRaises(TemplateSyntaxError):
             self.engine.render_to_string('if-tag-single-eq', {'foo': 1})
+
+    @setup({'if-tag-stream': '{% if foo %}{{ a }}42{% else %}no{% endif %}'})
+    def test_if_tag_stream(self):
+        output = self.engine.render_to_string('if-tag-stream', {'foo': True, 'a': 21}, stream=True)
+        self.assertEqual(next(output), '21')
+        self.assertEqual(next(output), '42')

--- a/tests/template_tests/syntax_tests/test_if_changed.py
+++ b/tests/template_tests/syntax_tests/test_if_changed.py
@@ -155,6 +155,13 @@ class IfChangedTagTests(SimpleTestCase):
         output = self.engine.render_to_string('ifchanged-filter-ws', {'num': (1, 2, 3)})
         self.assertEqual(output, '..1..2..3')
 
+    @setup({'ifchanged-stream': '{% for n in num %}{% ifchanged %}{{ n }}{% endifchanged %}{% endfor %}'})
+    def test_ifchanged_stream(self):
+        output = self.engine.render_to_string('ifchanged-stream', {'num': (1, 2, 3)}, stream=True)
+        self.assertEqual(next(output), '1')
+        self.assertEqual(next(output), '2')
+        self.assertEqual(next(output), '3')
+
 
 class IfChangedTests(SimpleTestCase):
 

--- a/tests/template_tests/syntax_tests/test_if_equal.py
+++ b/tests/template_tests/syntax_tests/test_if_equal.py
@@ -193,6 +193,12 @@ class IfEqualTagTests(SimpleTestCase):
         output = self.engine.render_to_string('ifequal-filter05', {'x': 'aaa'})
         self.assertEqual(output, 'x')
 
+    @setup({'ifequal-stream': '{% ifequal a b %}{{ a }}{{ b }}{% endifequal %}'})
+    def test_ifequal_stream(self):
+        output = self.engine.render_to_string('ifequal-stream', {'a': 1, 'b': 1}, stream=True)
+        self.assertEqual(next(output), '1')
+        self.assertEqual(next(output), '1')
+
 
 class IfNotEqualTagTests(SimpleTestCase):
 

--- a/tests/template_tests/syntax_tests/test_spaceless.py
+++ b/tests/template_tests/syntax_tests/test_spaceless.py
@@ -36,3 +36,10 @@ class SpacelessTagTests(SimpleTestCase):
     def test_spaceless06(self):
         output = self.engine.render_to_string('spaceless06', {'text': 'This & that'})
         self.assertEqual(output, "<b><i>This & that</i></b>")
+
+    @setup({'spaceless-stream': "{% spaceless %}<b>   <i>{{ text }}</i>  </b>{% endspaceless %}"})
+    def test_spaceless_stream(self):
+        output = self.engine.render_to_string('spaceless-stream', {'text': 'This & that'}, stream=True)
+        self.assertEqual(next(output), "<b><i>")
+        self.assertEqual(next(output), "This &amp; that")
+        self.assertEqual(next(output), "</i></b>")

--- a/tests/template_tests/syntax_tests/test_with.py
+++ b/tests/template_tests/syntax_tests/test_with.py
@@ -50,3 +50,9 @@ class WithTagTests(SimpleTestCase):
     def test_with_error02(self):
         with self.assertRaises(TemplateSyntaxError):
             self.engine.render_to_string('with-error02', {'dict': {'key': 50}})
+
+    @setup({'with-stream': '{% with key=dict.key %}{{ key }}42{% endwith %}'})
+    def test_with_stream(self):
+        output = self.engine.render_to_string('with-stream', {'dict': {'key': 50}}, stream=True)
+        self.assertEqual(next(output), '50')
+        self.assertEqual(next(output), '42')

--- a/tests/template_tests/test_nodelist.py
+++ b/tests/template_tests/test_nodelist.py
@@ -85,3 +85,8 @@ class ErrorIndexTest(TestCase):
             except (RuntimeError, TypeError) as e:
                 debug = e.template_debug
                 self.assertEqual((debug['start'], debug['end']), expected_error_source_index)
+            try:
+                ''.join(template.render(context, stream=True))
+            except (RuntimeError, TypeError) as e:
+                debug = e.template_debug
+                self.assertEqual((debug['start'], debug['end']), expected_error_source_index)


### PR DESCRIPTION
This is a port of https://github.com/django/django/pull/1037 (https://code.djangoproject.com/ticket/13910) to master.

What has been done:
- Added stream method to Template and Node classes
- Added stream function to template.loader
- Added stream_to_response shortcut, similar to render_to_response
- Added stream shortcut, similar to render
- Added stream functionality to defaulttags that would benefit from it
- Added StreamingTemplateResponse and SimpleStreamingTemplateResponse to complement the existing non-streaming template response classes
- Added generic StreamingTemplateView
- Tests
- Documentations
