### PR TITLE
Fixed #24927 -- Used python_2_unicode_compatible from six

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -25,6 +25,8 @@ class DjangoUnicodeDecodeError(UnicodeDecodeError):
                 type(self.obj))
 
 
+# Since version 1.9.0 six ships with this compatibility function. To maintain
+# backwards compatibility we keep the import / function accessible here.
 python_2_unicode_compatible = six.python_2_unicode_compatible
 
 

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -25,22 +25,7 @@ class DjangoUnicodeDecodeError(UnicodeDecodeError):
                 type(self.obj))
 
 
-def python_2_unicode_compatible(klass):
-    """
-    A decorator that defines __unicode__ and __str__ methods under Python 2.
-    Under Python 3 it does nothing.
-
-    To support Python 2 and 3 with a single code base, define a __str__ method
-    returning text and apply this decorator to the class.
-    """
-    if six.PY2:
-        if '__str__' not in klass.__dict__:
-            raise ValueError("@python_2_unicode_compatible cannot be applied "
-                             "to %s because it doesn't define __str__()." %
-                             klass.__name__)
-        klass.__unicode__ = klass.__str__
-        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
-    return klass
+python_2_unicode_compatible = six.python_2_unicode_compatible
 
 
 def smart_text(s, encoding='utf-8', strings_only=False, errors='strict'):

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -202,7 +202,7 @@ Model style
 
 * If you define a ``__str__`` method (previously ``__unicode__`` before Python 3
   was supported), decorate the model class with
-  :func:`~django.utils.encoding.python_2_unicode_compatible`.
+  :func:`~django.utils.six.python_2_unicode_compatible`.
 
 * The order of model inner classes and standard methods should be as
   follows (noting that these are not all required):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -528,7 +528,7 @@ details on these changes.
 
 * The ``django.utils.encoding.StrAndUnicode`` mix-in will be removed.
   Define a ``__str__`` method and apply the
-  :func:`~django.utils.encoding.python_2_unicode_compatible` decorator instead.
+  :func:`~django.utils.six.python_2_unicode_compatible` decorator instead.
 
 .. _deprecation-removed-in-1.6:
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -591,7 +591,7 @@ A few object methods have special purposes.
     On Python 3, as all strings are natively considered Unicode, only use the
     ``__str__()`` method (the ``__unicode__()`` method is obsolete).
     If you'd like compatibility with Python 2, you can decorate your model class
-    with :func:`~django.utils.encoding.python_2_unicode_compatible`.
+    with :func:`~django.utils.six.python_2_unicode_compatible`.
 
 ``__unicode__``
 ---------------

--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -260,7 +260,7 @@ Choosing between ``__str__()`` and ``__unicode__()``
     If you are on Python 3, you can skip this section because you'll always
     create ``__str__()`` rather than ``__unicode__()``. If you'd like
     compatibility with Python 2, you can decorate your model class with
-    :func:`~django.utils.encoding.python_2_unicode_compatible`.
+    :func:`~django.utils.six.python_2_unicode_compatible`.
 
 One consequence of using Unicode by default is that you have to take some care
 when printing data from the model.

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -189,6 +189,11 @@ The functions defined in this module share the following properties:
     To support Python 2 and 3 with a single code base, define a ``__str__``
     method returning text and apply this decorator to the class.
 
+    .. versionchanged:: 1.9
+
+        This function is now a shim to the equivalent function,
+        :func:`~django.utils.six.python_2_unicode_compatible`.
+
 .. function:: smart_text(s, encoding='utf-8', strings_only=False, errors='strict')
 
     Returns a text object representing ``s`` -- ``unicode`` on Python 2 and

--- a/docs/topics/python3.txt
+++ b/docs/topics/python3.txt
@@ -155,14 +155,14 @@ have little use for that method, because they hardly ever deal with ``bytes``.)
 Django provides a simple way to define :meth:`~object.__str__` and
 ` __unicode__()`_ methods that work on Python 2 and 3: you must
 define a :meth:`~object.__str__` method returning text and to apply the
-:func:`~django.utils.encoding.python_2_unicode_compatible` decorator.
+:func:`~django.utils.six.python_2_unicode_compatible` decorator.
 
 On Python 3, the decorator is a no-op. On Python 2, it defines appropriate
 ` __unicode__()`_ and :meth:`~object.__str__` methods (replacing the
 original :meth:`~object.__str__` method in the process). Here's an example::
 
     from __future__ import unicode_literals
-    from django.utils.encoding import python_2_unicode_compatible
+    from django.utils.six import python_2_unicode_compatible
 
     @python_2_unicode_compatible
     class MyClass(object):


### PR DESCRIPTION
python_2_unicode_compatible is now included in six, so include that function from inside django.utils.encoding instead. https://code.djangoproject.com/ticket/24927

I wondered if the encoding should be deprecated and the code should all be updated to refer to it in the new location, but I thought that perhaps six may change its behaviour at some point in future and you'd want to be able to switch back to a Django specific version. (See e.g. discussion of the six PR at https://bitbucket.org/gutworth/six/pull-request/48 for things six might do in future.)