### PR TITLE
Cleanup: Removed the try-except-fail antipattern from tests

### DIFF
--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -370,10 +370,7 @@ class LastExecutedQueryTest(TestCase):
         query has been run.
         """
         cursor = connection.cursor()
-        try:
-            connection.ops.last_executed_query(cursor, '', ())
-        except Exception:
-            self.fail("'last_executed_query' should not raise an exception.")
+        connection.ops.last_executed_query(cursor, '', ())
 
     def test_debug_sql(self):
         list(models.Reporter.objects.filter(first_name="test"))

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -6,7 +6,6 @@ import os
 import struct
 import tempfile
 import unittest
-import zlib
 from io import BytesIO, StringIO
 
 from django.core.files import File
@@ -233,10 +232,7 @@ class InconsistentGetImageDimensionsBug(unittest.TestCase):
         get_image_dimensions fails on some pngs, while Image.size is working good on them
         """
         img_path = os.path.join(os.path.dirname(upath(__file__)), "magic.png")
-        try:
-            size = images.get_image_dimensions(img_path)
-        except zlib.error:
-            self.fail("Exception raised from get_image_dimensions().")
+        size = images.get_image_dimensions(img_path)
         with open(img_path, 'rb') as fh:
             self.assertEqual(size, Image.open(fh).size)
 

--- a/tests/gis_tests/layermap/tests.py
+++ b/tests/gis_tests/layermap/tests.py
@@ -140,19 +140,19 @@ class LayerMapTest(TestCase):
     def test_layermap_unique_multigeometry_fk(self):
         "Testing the `unique`, and `transform`, geometry collection conversion, and ForeignKey mappings."
         # All the following should work.
-        try:
-            # Telling LayerMapping that we want no transformations performed on the data.
-            lm = LayerMapping(County, co_shp, co_mapping, transform=False)
 
-            # Specifying the source spatial reference system via the `source_srs` keyword.
-            lm = LayerMapping(County, co_shp, co_mapping, source_srs=4269)
-            lm = LayerMapping(County, co_shp, co_mapping, source_srs='NAD83')
+        # Telling LayerMapping that we want no transformations performed on the data.
+        lm = LayerMapping(County, co_shp, co_mapping, transform=False)
 
-            # Unique may take tuple or string parameters.
-            for arg in ('name', ('name', 'mpoly')):
-                lm = LayerMapping(County, co_shp, co_mapping, transform=False, unique=arg)
-        except Exception:
-            self.fail('No exception should be raised for proper use of keywords.')
+        # Specifying the source spatial reference system via the `source_srs` keyword.
+        lm = LayerMapping(County, co_shp, co_mapping, source_srs=4269)
+        lm = LayerMapping(County, co_shp, co_mapping, source_srs='NAD83')
+
+        # Unique may take tuple or string parameters.
+        for arg in ('name', ('name', 'mpoly')):
+            lm = LayerMapping(County, co_shp, co_mapping, transform=False, unique=arg)
+
+        # Now test for failures
 
         # Testing invalid params for the `unique` keyword.
         for e, arg in ((TypeError, 5.0), (ValueError, 'foobar'), (ValueError, ('name', 'mpolygon'))):

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -695,10 +695,7 @@ class BaseEmailBackendTests(HeadersCheckMixin, object):
         Test that connection can be closed (even when not explicitly opened)
         """
         conn = mail.get_connection(username='', password='')
-        try:
-            conn.close()
-        except Exception as e:
-            self.fail("close() unexpectedly raised an exception: %s" % e)
+        conn.close()
 
     def test_use_as_contextmanager(self):
         """
@@ -1146,7 +1143,4 @@ class SMTPBackendStoppedServerTest(SMTPBackendTestsBase):
         backend = smtp.EmailBackend(username='', password='')
         backend.open()
         self.server.stop()
-        try:
-            backend.close()
-        except Exception as e:
-            self.fail("close() unexpectedly raised an exception: %s" % e)
+        backend.close()


### PR DESCRIPTION
Found cases where testing code was doing

    try:
        whatever
    except (some excption type):
        self.fail("exception shouldn't be thrown")

replaced it with just

    whatever

as this makes the unexpected errors easier to debug, and the tests
would fail just as much and aren't rendered less readable.