### PR TITLE
Fixed #24929 -- permission_required decorator should take any iterable

### DIFF
--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import resolve_url
+from django.utils import six
 from django.utils.decorators import available_attrs
 from django.utils.six.moves.urllib.parse import urlparse
 
@@ -59,7 +60,7 @@ def permission_required(perm, login_url=None, raise_exception=False):
     is raised.
     """
     def check_perms(user):
-        if not isinstance(perm, (list, tuple)):
+        if isinstance(perm, six.string_types):
             perms = (perm, )
         else:
             perms = perm

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -580,7 +580,7 @@ The permission_required decorator
     (i.e. ``polls.can_vote`` for a permission on a model in the ``polls``
     application).
 
-    The decorator may also take a list of permissions.
+    The decorator may also take an iterable of permissions.
 
     Note that :func:`~django.contrib.auth.decorators.permission_required()`
     also takes an optional ``login_url`` parameter. Example::
@@ -598,6 +598,11 @@ The permission_required decorator
     :exc:`~django.core.exceptions.PermissionDenied`, prompting :ref:`the 403
     (HTTP Forbidden) view<http_forbidden_view>` instead of redirecting to the
     login page.
+
+    .. versionchanged:: 1.9
+
+        Before Django 1.9, the permission parameter only took strings, lists and
+        tuples instead of strings and any iterable.
 
 .. _applying-permissions-to-generic-views:
 

--- a/tests/auth_tests/test_decorators.py
+++ b/tests/auth_tests/test_decorators.py
@@ -76,6 +76,16 @@ class PermissionsRequiredDecoratorTest(TestCase):
         resp = a_view(request)
         self.assertEqual(resp.status_code, 200)
 
+    def test_many_permissions_in_set_pass(self):
+
+        @permission_required({'auth.add_customuser', 'auth.change_customuser'})
+        def a_view(request):
+            return HttpResponse()
+        request = self.factory.get('/rand')
+        request.user = self.user
+        resp = a_view(request)
+        self.assertEqual(resp.status_code, 200)
+
     def test_single_permission_pass(self):
 
         @permission_required('auth.add_customuser')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24929

There is no reason why permission_required only takes lists and tuples
of permissions, while has_perms itself can take any iterable. This
commit makes the behaviour consistend with the new mixins from #24914
and other parts of Django where both strings and iterables of strings
are accepted (see e.g. model._meta.ordering),