### PR TITLE
Fixed #24833 - Changed references check to look on expressions instead of aggregates

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -263,3 +263,17 @@ def refs_aggregate(lookup_parts, aggregates):
         if level_n_lookup in aggregates and aggregates[level_n_lookup].contains_aggregate:
             return aggregates[level_n_lookup], lookup_parts[n:]
     return False, ()
+
+
+def refs_expression(lookup_parts, annotations):
+    """
+    A helper method to check if the lookup_parts contains references
+    to the given annotations set. Because the LOOKUP_SEP is contained in the
+    default annotation names we must check each prefix of the lookup_parts
+    for a match.
+    """
+    for n in range(len(lookup_parts) + 1):
+        level_n_lookup = LOOKUP_SEP.join(lookup_parts[0:n])
+        if level_n_lookup in annotations and annotations[level_n_lookup]:
+            return annotations[level_n_lookup], lookup_parts[n:]
+    return False, ()

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -50,3 +50,7 @@ Bugfixes
 
 * Fixed recording of applied status for squashed (replacement) migrations
   (:ticket:`24628`).
+
+* Changed references check to look on expressions instead of aggregates
+  while solving lookup type to make ``Case`` expressions work with
+  ``.exclude()`` (:ticket:`22728`).

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -240,6 +240,18 @@ class CaseExpressionTests(TestCase):
             transform=itemgetter('integer', 'max', 'test')
         )
 
+    def test_annotate_exclude(self):
+        self.assertQuerysetEqual(
+            CaseTestModel.objects.annotate(test=Case(
+                When(integer=1, then=Value('one')),
+                When(integer=2, then=Value('two')),
+                default=Value('other'),
+                output_field=models.CharField(),
+            )).exclude(test='other').order_by('pk'),
+            [(1, 'one'), (2, 'two'), (2, 'two')],
+            transform=attrgetter('integer', 'test')
+        )
+
     def test_combined_expression(self):
         self.assertQuerysetEqual(
             CaseTestModel.objects.annotate(


### PR DESCRIPTION
This is to make to make `Case` expressions work with `.exclude()`.

https://code.djangoproject.com/ticket/24833