### PR TITLE
Fixed #24933: Make FormSet management forms optional

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -37,8 +37,8 @@ class ManagementForm(Form):
     increment the count field of this form as well.
     """
     def __init__(self, *args, **kwargs):
-        self.base_fields[TOTAL_FORM_COUNT] = IntegerField(widget=HiddenInput)
-        self.base_fields[INITIAL_FORM_COUNT] = IntegerField(widget=HiddenInput)
+        self.base_fields[TOTAL_FORM_COUNT] = IntegerField(required=False, widget=HiddenInput)
+        self.base_fields[INITIAL_FORM_COUNT] = IntegerField(required=False, widget=HiddenInput)
         # MIN_NUM_FORM_COUNT and MAX_NUM_FORM_COUNT are output with the rest of
         # the management form, but only for the convenience of client-side
         # code. The POST value of them returned from the client is not checked.
@@ -105,6 +105,33 @@ class BaseFormSet(object):
             })
         return form
 
+    def _extract_form_indices(self):
+        """Find indices of all submitted forms"""
+        prefix = self.prefix + '-'
+        prefix_len = len(prefix)
+        for key in self.data.keys():
+            if key.startswith(prefix):
+                identifier = key[prefix_len:].split('-', 1)[0]
+                if identifier.isdigit():
+                    yield int(identifier)
+
+    def _extract_total_form_count(self):
+        """Extract the number of submitted forms"""
+        if self.management_form.cleaned_data[TOTAL_FORM_COUNT]:
+            # prefer the management form if data is present
+            return self.management_form.cleaned_data[TOTAL_FORM_COUNT]
+        try:
+            return max(self._extract_form_indices()) + 1
+        except ValueError:  # no forms submitted
+            return 0
+
+    def _extract_initial_form_count(self):
+        """Extract the number of initial forms"""
+        if self.management_form.cleaned_data[INITIAL_FORM_COUNT]:
+            # prefer the management form if data is present
+            return self.management_form.cleaned_data[INITIAL_FORM_COUNT]
+        return 0
+
     def total_form_count(self):
         """Returns the total number of forms in this FormSet."""
         if self.is_bound:
@@ -112,7 +139,7 @@ class BaseFormSet(object):
             # count in the data; this is DoS protection to prevent clients
             # from forcing the server to instantiate arbitrary numbers of
             # forms
-            return min(self.management_form.cleaned_data[TOTAL_FORM_COUNT], self.absolute_max)
+            return min(self._extract_total_form_count(), self.absolute_max)
         else:
             initial_forms = self.initial_form_count()
             total_forms = max(initial_forms, self.min_num) + self.extra
@@ -127,11 +154,9 @@ class BaseFormSet(object):
     def initial_form_count(self):
         """Returns the number of forms that are required in this FormSet."""
         if self.is_bound:
-            return self.management_form.cleaned_data[INITIAL_FORM_COUNT]
-        else:
-            # Use the length of the initial data if it's there, 0 otherwise.
-            initial_forms = len(self.initial) if self.initial else 0
-        return initial_forms
+            return self._extract_initial_form_count()
+        # Use the length of the initial data if it's there, 0 otherwise.
+        return len(self.initial) if self.initial else 0
 
     @cached_property
     def forms(self):
@@ -328,7 +353,7 @@ class BaseFormSet(object):
         try:
             if (self.validate_max and
                     self.total_form_count() - len(self.deleted_forms) > self.max_num) or \
-                    self.management_form.cleaned_data[TOTAL_FORM_COUNT] > self.absolute_max:
+                    self._extract_total_form_count() > self.absolute_max:
                 raise ValidationError(ungettext(
                     "Please submit %d or fewer forms.",
                     "Please submit %d or fewer forms.", self.max_num) % self.max_num,

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1146,9 +1146,25 @@ ArticleFormSet = formset_factory(ArticleForm)
 
 
 class TestIsBoundBehavior(SimpleTestCase):
-    def test_no_data_raises_validation_error(self):
-        with self.assertRaises(ValidationError):
-            ArticleFormSet({}).is_valid()
+    def test_no_data_works_fine(self):
+        self.assertTrue(ArticleFormSet({}).is_valid(), True)
+
+    def test_missing_management_data_attrs_work_fine(self):
+        data = {
+            'form-0-title': 'Test',
+            'form-0-pub_date': '1904-06-16',
+            'form-1-title': 'Test',
+            'form-1-pub_date': '2015-06-05',
+        }
+        formset = ArticleFormSet(data)
+        self.assertEqual(0, formset.initial_form_count())
+        self.assertEqual(2, formset.total_form_count())
+        self.assertTrue(formset.is_bound)
+        self.assertTrue(formset.forms[0].is_bound)
+        self.assertTrue(formset.forms[1].is_bound)
+        self.assertTrue(formset.is_valid())
+        self.assertTrue(formset.forms[0].is_valid())
+        self.assertTrue(formset.forms[1].is_valid())
 
     def test_with_management_data_attrs_work_fine(self):
         data = {


### PR DESCRIPTION
The default behaviour is to trust the management form if provided and fall back to extracting the number from submitted data otherwise.

This is an example implementation of https://code.djangoproject.com/ticket/24933