### PR TITLE
Fixed #24925 -- cast dates and times in Value

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -549,6 +549,16 @@ class Value(Expression):
             return 'NULL', []
         return '%s', [val]
 
+    def as_mysql(self, compiler, connection):
+        sql, params = self.as_sql(compiler, connection)
+        if params and isinstance(params[0], datetime.datetime):
+            return 'cast(%s as datetime)', params
+        elif params and isinstance(params[0], datetime.date):
+            return 'cast(%s as date)', params
+        elif params and isinstance(params[0], datetime.time):
+            return 'cast(%s as time)', params
+        return sql, params
+
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
         c = super(Value, self).resolve_expression(query, allow_joins, reuse, summarize, for_save)
         c.for_save = for_save

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -843,6 +843,14 @@ class ValueTests(TestCase):
         UUID.objects.update(uuid=Value(uuid.UUID('12345678901234567890123456789012'), output_field=UUIDField()))
         self.assertEqual(UUID.objects.get().uuid, uuid.UUID('12345678901234567890123456789012'))
 
+    def test_datetime(self):
+        now = datetime.datetime.now()
+        Time.objects.create()
+        times = Time.objects.annotate(
+            datetime_value=Value(now, output_field=models.DateTimeField()),
+        )
+        self.assertEqual(times.get().datetime_value, now)
+
 
 class ReprTests(TestCase):
 


### PR DESCRIPTION
Add `Value.as_mysql` method to `cast` datetimes, dates and times to their
corresponding MySQL types.