### PR TITLE
Fixed #13751 -- Avoid open redirect issue with whitelist

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -33,6 +33,11 @@ INTERNAL_IPS = []
 # "*" matches anything, ".example.com" matches example.com and all subdomains
 ALLOWED_HOSTS = []
 
+# List of URLs outside the current host to which a redirection should be allowed.
+# Redirecting from HTTPS to a HTTP only address will display an alert
+# to the user.
+REDIRECT_WHITELIST_URLS = []
+
 # Local time zone for this installation. All choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name (although not all
 # systems may support all possibilities). When USE_TZ is True, this is

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2195,6 +2195,28 @@ will still be printed, but will not prevent management commands from running.
 
 See also the :doc:`/ref/checks` documentation.
 
+.. setting:: REDIRECT_WHITELIST_URLS
+
+REDIRECT_WHITELIST_URLS
+-----------------------
+
+.. versionadded:: 1.9
+
+Default: ``[]`` (Empty list)
+
+A list containing urls outside of the server host where redirections are
+allowed. For example an url where users will be redirected after their
+logout.
+
+The redirecting url must match or start with one in the list, meaning that
+if the list has ``https://www.foo.com/logout/``, a redirection to
+``https://www.foo.com/logout.html`` won't be allowed, but
+``https://www.foo.com/logout/bye.html`` will be allowed.
+
+.. warning::
+    A warning message will be displayed to the users if they are redirected
+    from a secure (HTTPS) address to a non-secure (HTTP) address.
+
 .. setting:: TEMPLATES
 
 TEMPLATES

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -129,6 +129,39 @@ class TestUtilsHttp(unittest.TestCase):
                      '/url%20with%20spaces/'):
             self.assertTrue(http.is_safe_url(good_url, host='testserver'), "%s should be allowed" % good_url)
 
+    def test_is_safe_url_whitelist(self):
+        whitelist_urls = ['https://www.daa.com/',
+                    'https://foo.com/bye/',
+                    'https://secure.bar.com/logout.html']
+        for bad_url in ('https://daa.com',
+                    'https://www.daa.com',
+                    'https://www.daa.com:443/',
+                    'http://www.daa.com/',
+                    'https://www.daa.co/',
+                    'http://www.example.com/',
+                    '//www.daa.com/',
+                    'https://foo.com/',
+                    'https://foo.com/bye',
+                    'https://foo.com/bye.html',
+                    'http://foo.com/bye/',
+                    'https://www.foo.com/bye/',
+                    'https://secure.bar.com/',
+                    'https://secure.bar.com/logout',
+                    'https://secure.bar.com/logout/',
+                    'https://secure.bar.com/logout.htm'):
+            self.assertFalse(http.is_safe_url(bad_url, host='testserver',
+                whitelist=whitelist_urls), "%s should be blocked" % bad_url)
+        for good_url in ('https://www.daa.com/',
+                    'https://www.daa.com/index.html',
+                    'https://www.daa.com/welcome/',
+                    'https://foo.com/bye/',
+                    'https://foo.com/bye/?param=bye',
+                    'https://foo.com/bye/index.html?param=bye',
+                    'https://secure.bar.com/logout.html',
+                    'HTTPS://secure.bar.com/logout.html'):
+            self.assertTrue(http.is_safe_url(good_url, host='testserver',
+                whitelist=whitelist_urls), "%s should be allowed" % good_url)
+
     def test_urlsafe_base64_roundtrip(self):
         bytestring = b'foo'
         encoded = http.urlsafe_base64_encode(bytestring)


### PR DESCRIPTION
Added a new settings REDIRECT_WHITELIST_URLS to allow a list of urls for redirection outside the application host. The match is done in utils.http.is_safe_url(). All tests passed, and the new setting has been documented.