### PR TITLE
Fixed #24915 - Added stricter session key validation

### DIFF
--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -161,10 +161,25 @@ class SessionBase(object):
             self._session_key = self._get_new_session_key()
         return self._session_key
 
+    def _validate_session_key(self, key):
+        """Key must be truthy and at least 8 characters long"""
+        return key and len(key) >= 8
+
     def _get_session_key(self):
-        return self._session_key
+        return self.__session_key
+
+    def _set_session_key(self, value):
+        """
+        Validate session key on assignment
+        Invalid values will set None instead
+        """
+        if self._validate_session_key(value):
+            self.__session_key = value
+        else:
+            self.__session_key = None
 
     session_key = property(_get_session_key)
+    _session_key = property(_get_session_key, _set_session_key)
 
     def _get_session(self, no_load=False):
         """

--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -162,7 +162,10 @@ class SessionBase(object):
         return self._session_key
 
     def _validate_session_key(self, key):
-        """Key must be truthy and at least 8 characters long"""
+        """
+        Key must be truthy and at least 8 characters long.
+        8 characters is an arbitrary lower bound for key security.
+        """
         return key and len(key) >= 8
 
     def _get_session_key(self):
@@ -170,8 +173,8 @@ class SessionBase(object):
 
     def _set_session_key(self, value):
         """
-        Validate session key on assignment
-        Invalid values will set None instead
+        Validate session key on assignment.
+        Invalid values will set None instead.
         """
         if self._validate_session_key(value):
             self.__session_key = value

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -198,6 +198,22 @@ class SessionTestsMixin(object):
             # session key; make sure that entry is manually deleted
             session.delete('1')
 
+    def test_session_key_empty_string_invalid(self):
+        """Falsey values (Such as an empty string) are rejected"""
+        self.session._session_key = ''
+        self.assertNotEqual(self.session.session_key, '')
+        self.assertEqual(self.session.session_key, None)
+
+    def test_session_key_too_short_invalid(self):
+        """Strings shorter than 8 characters are rejected"""
+        self.session._session_key = '1234567'
+        self.assertEqual(self.session.session_key, None)
+
+    def test_session_key_valid_string_saved(self):
+        """Strings of length 8 and up are accepted and stored"""
+        self.session._session_key = '12345678'
+        self.assertEqual(self.session.session_key, '12345678')
+
     def test_session_key_is_read_only(self):
         def set_session_key(session):
             session.session_key = session._get_new_session_key()

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -199,18 +199,17 @@ class SessionTestsMixin(object):
             session.delete('1')
 
     def test_session_key_empty_string_invalid(self):
-        """Falsey values (Such as an empty string) are rejected"""
+        """Falsey values (Such as an empty string) are rejected."""
         self.session._session_key = ''
-        self.assertNotEqual(self.session.session_key, '')
-        self.assertEqual(self.session.session_key, None)
+        self.assertIsNone(self.session.session_key)
 
     def test_session_key_too_short_invalid(self):
-        """Strings shorter than 8 characters are rejected"""
+        """Strings shorter than 8 characters are rejected."""
         self.session._session_key = '1234567'
-        self.assertEqual(self.session.session_key, None)
+        self.assertIsNone(self.session.session_key)
 
     def test_session_key_valid_string_saved(self):
-        """Strings of length 8 and up are accepted and stored"""
+        """Strings of length 8 and up are accepted and stored."""
         self.session._session_key = '12345678'
         self.assertEqual(self.session.session_key, '12345678')
 


### PR DESCRIPTION
Changed _session_key attribute to a property and implemented basic
validation in the setter. The session key must be 'truthy' and
at least 8 characters long. Otherwise, the value is set to None.

https://code.djangoproject.com/ticket/24915