### PR TITLE
Fixed #24924 -- Join promotion for multiple Case expressions

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -89,10 +89,8 @@ class Q(tree.Node):
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
         # We must promote any new joins to left outer joins so that when Q is
         # used as an expression, rows aren't filtered due to joins.
-        joins_before = query.tables[:]
         clause, joins = query._add_q(self, reuse, allow_joins=allow_joins, split_subq=False)
-        joins_to_promote = [j for j in joins if j not in joins_before]
-        query.promote_joins(joins_to_promote)
+        query.promote_joins(joins)
         return clause
 
     @classmethod

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -50,3 +50,7 @@ Bugfixes
 
 * Fixed recording of applied status for squashed (replacement) migrations
   (:ticket:`24628`).
+
+* Corrected join promotion for multiple ``Case`` expressions. Annotating a
+  query with multiple  ``Case`` expressions could unexpectedly filter out
+  results (:ticket:`24924`).


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/24924. Test case provided by @robline.

I would love some review on this. This is a follow up to the fix for https://code.djangoproject.com/ticket/24766 which was handled by @akaariai in be9d645346a20a6c394bf70d47b1b1d5c81ff530.

There are potentially related/overlapping PRs #4794 and #4801.