### PR TITLE
Fixed #24126 - deprecated current_app as a keyword

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -16,7 +16,9 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, QueryDict
 from django.shortcuts import resolve_url
 from django.template.response import TemplateResponse
-from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.deprecation import (
+    RemovedInDjango20Warning, deprecate_current_app,
+)
 from django.utils.encoding import force_text
 from django.utils.http import is_safe_url, urlsafe_base64_decode
 from django.utils.six.moves.urllib.parse import urlparse, urlunparse
@@ -26,13 +28,14 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 
 
+@deprecate_current_app
 @sensitive_post_parameters()
 @csrf_protect
 @never_cache
 def login(request, template_name='registration/login.html',
           redirect_field_name=REDIRECT_FIELD_NAME,
           authentication_form=AuthenticationForm,
-          current_app=None, extra_context=None):
+          extra_context=None):
     """
     Displays the login form and handles the login action.
     """
@@ -65,16 +68,14 @@ def login(request, template_name='registration/login.html',
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
+@deprecate_current_app
 def logout(request, next_page=None,
            template_name='registration/logged_out.html',
            redirect_field_name=REDIRECT_FIELD_NAME,
-           current_app=None, extra_context=None):
+           extra_context=None):
     """
     Logs out the user and displays 'You are logged out' message.
     """
@@ -104,22 +105,21 @@ def logout(request, next_page=None,
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
-def logout_then_login(request, login_url=None, current_app=None, extra_context=None):
+@deprecate_current_app
+def logout_then_login(request, login_url=None, extra_context=None):
     """
     Logs out the user if they are logged in. Then redirects to the log-in page.
     """
     if not login_url:
         login_url = settings.LOGIN_URL
     login_url = resolve_url(login_url)
-    return logout(request, login_url, current_app=current_app, extra_context=extra_context)
+    return logout(request, login_url, extra_context=extra_context)
 
 
+@deprecate_current_app
 def redirect_to_login(next, login_url=None,
                       redirect_field_name=REDIRECT_FIELD_NAME):
     """
@@ -143,6 +143,7 @@ def redirect_to_login(next, login_url=None,
 #   prompts for a new password
 # - password_reset_complete shows a success message for the above
 
+@deprecate_current_app
 @csrf_protect
 def password_reset(request, is_admin_site=False,
                    template_name='registration/password_reset_form.html',
@@ -152,7 +153,6 @@ def password_reset(request, is_admin_site=False,
                    token_generator=default_token_generator,
                    post_reset_redirect=None,
                    from_email=None,
-                   current_app=None,
                    extra_context=None,
                    html_email_template_name=None):
     if post_reset_redirect is None:
@@ -190,23 +190,18 @@ def password_reset(request, is_admin_site=False,
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
+@deprecate_current_app
 def password_reset_done(request,
                         template_name='registration/password_reset_done.html',
-                        current_app=None, extra_context=None):
+                        extra_context=None):
     context = {
         'title': _('Password reset sent'),
     }
     if extra_context is not None:
         context.update(extra_context)
-
-    if current_app is not None:
-        request.current_app = current_app
 
     return TemplateResponse(request, template_name, context)
 
@@ -214,12 +209,13 @@ def password_reset_done(request,
 # Doesn't need csrf_protect since no-one can guess the URL
 @sensitive_post_parameters()
 @never_cache
+@deprecate_current_app
 def password_reset_confirm(request, uidb64=None, token=None,
                            template_name='registration/password_reset_confirm.html',
                            token_generator=default_token_generator,
                            set_password_form=SetPasswordForm,
                            post_reset_redirect=None,
-                           current_app=None, extra_context=None):
+                           extra_context=None):
     """
     View that checks the hash in a password reset link and presents a
     form for entering a new password.
@@ -259,15 +255,13 @@ def password_reset_confirm(request, uidb64=None, token=None,
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
+@deprecate_current_app
 def password_reset_complete(request,
                             template_name='registration/password_reset_complete.html',
-                            current_app=None, extra_context=None):
+                            extra_context=None):
     context = {
         'login_url': resolve_url(settings.LOGIN_URL),
         'title': _('Password reset complete'),
@@ -275,20 +269,18 @@ def password_reset_complete(request,
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
 @sensitive_post_parameters()
 @csrf_protect
 @login_required
+@deprecate_current_app
 def password_change(request,
                     template_name='registration/password_change_form.html',
                     post_change_redirect=None,
                     password_change_form=PasswordChangeForm,
-                    current_app=None, extra_context=None):
+                    extra_context=None):
     if post_change_redirect is None:
         post_change_redirect = reverse('password_change_done')
     else:
@@ -312,23 +304,18 @@ def password_change(request,
     if extra_context is not None:
         context.update(extra_context)
 
-    if current_app is not None:
-        request.current_app = current_app
-
     return TemplateResponse(request, template_name, context)
 
 
 @login_required
+@deprecate_current_app
 def password_change_done(request,
                          template_name='registration/password_change_done.html',
-                         current_app=None, extra_context=None):
+                         extra_context=None):
     context = {
         'title': _('Password change successful'),
     }
     if extra_context is not None:
         context.update(extra_context)
-
-    if current_app is not None:
-        request.current_app = current_app
 
     return TemplateResponse(request, template_name, context)

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -8,8 +8,11 @@ from django.contrib.admindocs.views import get_return_data_type
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
-from django.test import TestCase, modify_settings, override_settings
+from django.test import (
+    TestCase, ignore_warnings, modify_settings, override_settings,
+)
 from django.test.utils import captured_stderr
+from django.utils.deprecation import RemovedInDjango20Warning
 
 from .models import Company, Person
 
@@ -54,6 +57,7 @@ class MiscTests(AdminDocsTestCase):
 
 
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
+@ignore_warnings(category=RemovedInDjango20Warning)
 class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Currently current_app is being passed in certain views inside
the django.contrib.admin.views module, but this behavior is deprecated
since Django 1.8.

A decorator is used to capture current_app as a keyword and raise a
deprecation warning while preserving the behavior for backwards
compatibility.