### PR TITLE
Fixed #24908: readonly for overridden form fields would cause double rendering.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -677,7 +677,8 @@ class ModelAdmin(BaseModelAdmin):
             exclude = []
         else:
             exclude = list(self.exclude)
-        exclude.extend(self.get_readonly_fields(request, obj))
+        readonly_fields = self.get_readonly_fields(request, obj)
+        exclude.extend(readonly_fields)
         if self.exclude is None and hasattr(self.form, '_meta') and self.form._meta.exclude:
             # Take the custom ModelForm's Meta.exclude into account only if the
             # ModelAdmin doesn't define its own.
@@ -685,8 +686,14 @@ class ModelAdmin(BaseModelAdmin):
         # if exclude is an empty list we pass None to be consistent with the
         # default on modelform_factory
         exclude = exclude or None
+
+        # Cancel out overridden form fields which are in readonly_fields.
+        new_attrs = OrderedDict([(f, None) for f in readonly_fields
+            if f in self.form.declared_fields])
+        form = type(self.form.__name__, (self.form,), new_attrs)
+
         defaults = {
-            "form": self.form,
+            "form": form,
             "fields": fields,
             "exclude": exclude,
             "formfield_callback": partial(self.formfield_for_dbfield, request=request),

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -224,6 +224,35 @@ class ModelAdminTests(TestCase):
             list(list(ma.get_formsets_with_inlines(request))[0][0]().forms[0].fields),
             ['main_band', 'opening_band', 'id', 'DELETE'])
 
+    def test_custom_formfield_override_readonly(self):
+        class AdminBandForm(forms.ModelForm):
+            name = forms.CharField()
+
+            class Meta:
+                exclude = tuple()
+                model = Band
+
+        class BandAdmin(ModelAdmin):
+            form = AdminBandForm
+            readonly_fields = ['name']
+
+        ma = BandAdmin(Band, self.site)
+
+        # Current : ['bio', 'sign_date', 'name']
+        # Is current correct or should it be like this ?
+        self.assertEqual(list(ma.get_form(request).base_fields),
+            ['bio', 'sign_date'])
+
+        # Current : ['bio', 'sign_date', 'name', u'name']
+        # Is current correct or should it be like this ?
+        self.assertEqual(list(ma.get_fields(request)),
+            ['bio', 'sign_date', 'name'])
+
+        # Current : [(None, {'fields': ['bio', 'sign_date', 'name', u'name']})]
+        self.assertEqual(list(ma.get_fieldsets(request)),
+            # No doubt that's how it should be ^^
+            [(None, {'fields': ['bio', 'sign_date', 'name']})])
+
     def test_custom_form_meta_exclude(self):
         """
         Ensure that the custom ModelForm's `Meta.exclude` is overridden if

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -238,19 +238,13 @@ class ModelAdminTests(TestCase):
 
         ma = BandAdmin(Band, self.site)
 
-        # Current : ['bio', 'sign_date', 'name']
-        # Is current correct or should it be like this ?
         self.assertEqual(list(ma.get_form(request).base_fields),
             ['bio', 'sign_date'])
 
-        # Current : ['bio', 'sign_date', 'name', u'name']
-        # Is current correct or should it be like this ?
         self.assertEqual(list(ma.get_fields(request)),
             ['bio', 'sign_date', 'name'])
 
-        # Current : [(None, {'fields': ['bio', 'sign_date', 'name', u'name']})]
         self.assertEqual(list(ma.get_fieldsets(request)),
-            # No doubt that's how it should be ^^
             [(None, {'fields': ['bio', 'sign_date', 'name']})])
 
     def test_custom_form_meta_exclude(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24908