### PR TITLE
Fixed #24908 -- Duplicate readonly field rendering.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -605,7 +605,8 @@ class ModelAdmin(BaseModelAdmin):
             exclude = []
         else:
             exclude = list(self.exclude)
-        exclude.extend(self.get_readonly_fields(request, obj))
+        readonly_fields = self.get_readonly_fields(request, obj)
+        exclude.extend(readonly_fields)
         if self.exclude is None and hasattr(self.form, '_meta') and self.form._meta.exclude:
             # Take the custom ModelForm's Meta.exclude into account only if the
             # ModelAdmin doesn't define its own.
@@ -613,8 +614,14 @@ class ModelAdmin(BaseModelAdmin):
         # if exclude is an empty list we pass None to be consistent with the
         # default on modelform_factory
         exclude = exclude or None
+
+        # Cancel out overridden form fields which are in readonly_fields.
+        new_attrs = OrderedDict([(f, None) for f in readonly_fields
+            if f in self.form.declared_fields])
+        form = type(self.form.__name__, (self.form,), new_attrs)
+
         defaults = {
-            "form": self.form,
+            "form": form,
             "fields": fields,
             "exclude": exclude,
             "formfield_callback": partial(self.formfield_for_dbfield, request=request),

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -616,8 +616,10 @@ class ModelAdmin(BaseModelAdmin):
         exclude = exclude or None
 
         # Cancel out overridden form fields which are in readonly_fields.
-        new_attrs = OrderedDict([(f, None) for f in readonly_fields
-            if f in self.form.declared_fields])
+        new_attrs = OrderedDict(
+            (f, None) for f in readonly_fields
+            if f in self.form.declared_fields
+        )
         form = type(self.form.__name__, (self.form,), new_attrs)
 
         defaults = {

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -221,6 +221,29 @@ class ModelAdminTests(TestCase):
             list(list(ma.get_formsets_with_inlines(request))[0][0]().forms[0].fields),
             ['main_band', 'opening_band', 'id', 'DELETE'])
 
+    def test_custom_formfield_override_readonly(self):
+        class AdminBandForm(forms.ModelForm):
+            name = forms.CharField()
+
+            class Meta:
+                exclude = tuple()
+                model = Band
+
+        class BandAdmin(ModelAdmin):
+            form = AdminBandForm
+            readonly_fields = ['name']
+
+        ma = BandAdmin(Band, self.site)
+
+        self.assertEqual(list(ma.get_form(request).base_fields),
+            ['bio', 'sign_date'])
+
+        self.assertEqual(list(ma.get_fields(request)),
+            ['bio', 'sign_date', 'name'])
+
+        self.assertEqual(list(ma.get_fieldsets(request)),
+            [(None, {'fields': ['bio', 'sign_date', 'name']})])
+
     def test_custom_form_meta_exclude(self):
         """
         Ensure that the custom ModelForm's `Meta.exclude` is overridden if

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -235,14 +235,20 @@ class ModelAdminTests(TestCase):
 
         ma = BandAdmin(Band, self.site)
 
-        self.assertEqual(list(ma.get_form(request).base_fields),
-            ['bio', 'sign_date'])
+        self.assertEqual(
+            list(ma.get_form(request).base_fields),
+            ['bio', 'sign_date']
+        )
 
-        self.assertEqual(list(ma.get_fields(request)),
-            ['bio', 'sign_date', 'name'])
+        self.assertEqual(
+            list(ma.get_fields(request)),
+            ['bio', 'sign_date', 'name']
+        )
 
-        self.assertEqual(list(ma.get_fieldsets(request)),
-            [(None, {'fields': ['bio', 'sign_date', 'name']})])
+        self.assertEqual(
+            list(ma.get_fieldsets(request)),
+            [(None, {'fields': ['bio', 'sign_date', 'name']})]
+        )
 
     def test_custom_form_meta_exclude(self):
         """


### PR DESCRIPTION
ModelAdmin added readonly_fields to exclude, but would not un-declare
them if they were overridden, causing the readonly field to be rendered
twice.

https://code.djangoproject.com/ticket/24908