### PR TITLE
Fixed #24945 -- PostgreSQL fuzzystrmatch support.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -3,7 +3,9 @@ from django.db.backends.signals import connection_created
 from django.db.models import CharField, TextField
 from django.utils.translation import ugettext_lazy as _
 
-from .lookups import SearchLookup, Unaccent
+from .lookups import (
+    DoubleMetaphone, Metaphone, SearchLookup, Soundex, Unaccent,
+)
 from .signals import register_hstore_handler
 
 
@@ -17,3 +19,9 @@ class PostgresConfig(AppConfig):
         TextField.register_lookup(Unaccent)
         CharField.register_lookup(SearchLookup)
         TextField.register_lookup(SearchLookup)
+        CharField.register_lookup(DoubleMetaphone)
+        TextField.register_lookup(DoubleMetaphone)
+        CharField.register_lookup(Metaphone)
+        TextField.register_lookup(Metaphone)
+        CharField.register_lookup(Soundex)
+        TextField.register_lookup(Soundex)

--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -1,5 +1,6 @@
 from django.db.models import DateTimeField
-from django.db.models.functions import Func
+from django.db.models.fields import PositiveIntegerField
+from django.db.models.functions import Func, Value
 
 
 class TransactionNow(Func):
@@ -9,3 +10,12 @@ class TransactionNow(Func):
         if output_field is None:
             output_field = DateTimeField()
         super(TransactionNow, self).__init__(output_field=output_field, **extra)
+
+
+class Levenshtein(Func):
+    function = 'LEVENSHTEIN'
+
+    def __init__(self, expression, string, **extra):
+        if not hasattr(string, 'resolve_expression'):
+            string = Value(string)
+        super(Levenshtein, self).__init__(expression, string, output_field=PositiveIntegerField(), **extra)

--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -19,3 +19,13 @@ class Levenshtein(Func):
         if not hasattr(string, 'resolve_expression'):
             string = Value(string)
         super(Levenshtein, self).__init__(expression, string, output_field=PositiveIntegerField(), **extra)
+
+
+class LevenshteinLessEqual(Func):
+    function = 'LEVENSHTEIN_LESS_EQUAL'
+
+    def __init__(self, expression, string, max_d, **extra):
+        if not hasattr(string, 'resolve_expression'):
+            string = Value(string)
+        super(LevenshteinLessEqual, self).__init__(
+            expression, string, max_d, output_field=PositiveIntegerField(), **extra)

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -60,3 +60,25 @@ class SearchLookup(SearchVectorExact):
             self.lhs = SearchVector(self.lhs)
         lhs, lhs_params = super(SearchLookup, self).process_lhs(qn, connection)
         return lhs, lhs_params
+
+
+class Soundex(Transform):
+    bilateral = True
+    lookup_name = 'soundex'
+    function = 'SOUNDEX'
+
+
+class Metaphone(Transform):
+    bilateral = True
+    lookup_name = 'metaphone'
+    function = 'METAPHONE'
+
+    def as_sql(self, qn, connection):
+        lhs, params = qn.compile(self.lhs)
+        return "%s(%s, 255)" % (self.function, lhs), params
+
+
+class DoubleMetaphone(Transform):
+    bilateral = True
+    lookup_name = 'double_metaphone'
+    function = 'DMETAPHONE'

--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -40,3 +40,9 @@ class UnaccentExtension(CreateExtension):
 
     def __init__(self):
         self.name = 'unaccent'
+
+
+class FuzzyStrMatchExtension(CreateExtension):
+
+    def __init__(self):
+        self.name = 'fuzzystrmatch'

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -30,3 +30,27 @@ Usage example::
     >>> from django.contrib.postgres.functions import TransactionNow
     >>> Article.objects.filter(published__lte=TransactionNow())
     <QuerySet [<Article: How to Django>]>
+
+``Levenshtein``
+===============
+
+.. class:: Levenshtein(expression, expression, **extra)
+
+.. versionadded:: 1.10
+
+Accepts a field name or expression, and a string or expression. Returns the
+Levenshtein distance between the two arguments.
+
+To use it, you need to activate the `fuzzystrmatch extension on PostgreSQL`_.
+The :class:`~django.contrib.postgres.operations.FuzzyStrMatchExtension`
+migration operation is available if you want to perform this activation using
+migrations).
+
+.. _fuzzystrmatch extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/fuzzystrmatch.html
+
+Usage example::
+
+    >>> from django.contrib.postgres.functions import Levenshtein
+    >>> Author.objects.create(name='William')
+    >>> print Author.objects.annotate(distance=Levenshtein('name', 'Will')).first().distance
+    3

--- a/docs/ref/contrib/postgres/functions.txt
+++ b/docs/ref/contrib/postgres/functions.txt
@@ -54,3 +54,30 @@ Usage example::
     >>> Author.objects.create(name='William')
     >>> print Author.objects.annotate(distance=Levenshtein('name', 'Will')).first().distance
     3
+
+``LevenshteinLessEqual``
+========================
+
+.. class:: LevenshteinLessEqual(expression, expression, max_distance, **extra)
+
+.. versionadded:: 1.10
+
+Accepts a field name or expression, a string or expression, and a maximum
+distance. This is faster than Levenshtein for low values of distance. If the
+actual distance is less or equal then max_distance, then LevenshteinLessEqual
+returns accurate value of it. Otherwise this function returns a value which is
+greater than max_distance.
+
+To use it, you need to activate the `fuzzystrmatch extension on PostgreSQL`_.
+The :class:`~django.contrib.postgres.operations.FuzzyStrMatchExtension`
+migration operation is available if you want to perform this activation using
+migrations).
+
+.. _fuzzystrmatch extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/fuzzystrmatch.html
+
+Usage example::
+
+    >>> from django.contrib.postgres.functions import LevenshteinLessEqual
+    >>> Author.objects.create(name='William')
+    >>> print Author.objects.annotate(distance=LevenshteinLessEqual('name', 'Will', 4)).first().distance
+    3

--- a/docs/ref/contrib/postgres/lookups.txt
+++ b/docs/ref/contrib/postgres/lookups.txt
@@ -34,3 +34,33 @@ The ``unaccent`` lookup can be used on
     using this filter will generally perform full table scans, which can be slow
     on large tables. In those cases, using dedicated full text indexing tools
     might be appropriate.
+
+Sound like lookups
+==================
+
+.. fieldlookup:: soundex
+.. fieldlookup:: metaphone
+.. fieldlookup:: double_metaphone
+
+.. versionadded:: 1.10
+
+The ``soundex``, ``metaphone`` and ``double_metaphone`` lookups allow you to
+perform "sounds like" comparisons with those algorithms, using a dedicated
+PostgreSQL extension.
+
+To use it, you need to add ``'django.contrib.postgres'`` in your
+:setting:`INSTALLED_APPS` and activate the `fuzzystrmatch extension on
+PostgreSQL`_. The
+:class:`~django.contrib.postgres.operations.FuzzyStrMatchExtension` migration
+operation is available if you want to perform this activation using
+migrations).
+
+.. _fuzzystrmatch extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/fuzzystrmatch.html
+
+The three lookups can can be used on
+:class:`~django.db.models.CharField` and :class:`~django.db.models.TextField`::
+
+    >>> City.objects.filter(name__soundex="Middlesborough")
+    ['<City: Middlesbrough>']
+    >>> City.objects.filter(name__double_metaphone="Katharine")
+    ['<City: Catherine>']

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -34,3 +34,13 @@ the ``django.contrib.postgres.operations`` module.
 
     A subclass of :class:`~django.contrib.postgres.operations.CreateExtension`
     which will install the ``unaccent`` extension.
+
+FuzzyStrMatchExtension
+----------------------
+
+.. class:: FuzzyStrMatchExtension()
+
+.. versionadded:: 1.10
+
+    A subclass of :class:`~django.contrib.postgres.operations.CreateExtension`
+    which will install the ``fuzzystrmatch`` extension.

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -34,8 +34,9 @@ database, combine the searches with other lookups, use different language
 configurations and weightings, and rank the results by relevance.
 
 It also adds :lookup:`soundex`, :lookup:`metaphone`, and
-:lookup:`double_metaphone` lookups, and a
-:class:`~django.contrib.postgres.functions.Levenshtein` function.
+:lookup:`double_metaphone` lookups, and
+:class:`~django.contrib.postgres.functions.Levenshtein` and
+:class:`~django.contrib.postgres.functions.LevenshteinLessEqual` functions.
 
 Minor features
 --------------

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -33,6 +33,10 @@ search engine. You can search across multiple fields in your relational
 database, combine the searches with other lookups, use different language
 configurations and weightings, and rank the results by relevance.
 
+It also adds :lookup:`soundex`, :lookup:`metaphone`, and
+:lookup:`double_metaphone` lookups, and a
+:class:`~django.contrib.postgres.functions.Levenshtein` function.
+
 Minor features
 --------------
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -412,6 +412,7 @@ latin
 lawrence
 Lawrence
 Leidel
+Levenshtein
 lexer
 lhs
 lifecycle

--- a/tests/postgres_tests/migrations/0001_setup_extensions.py
+++ b/tests/postgres_tests/migrations/0001_setup_extensions.py
@@ -5,11 +5,12 @@ from django.db import migrations
 
 try:
     from django.contrib.postgres.operations import (
-        CreateExtension, HStoreExtension, UnaccentExtension,
+        CreateExtension, FuzzyStrMatchExtension, HStoreExtension, UnaccentExtension,
     )
 except ImportError:
     from django.test import mock
     CreateExtension = mock.Mock()
+    FuzzyStrMatchExtension = mock.Mock()
     HStoreExtension = mock.Mock()
     UnaccentExtension = mock.Mock()
 
@@ -20,6 +21,7 @@ class Migration(migrations.Migration):
         # Ensure CreateExtension quotes extension names by creating one with a
         # dash in its name.
         CreateExtension('uuid-ossp'),
+        FuzzyStrMatchExtension(),
         HStoreExtension(),
         UnaccentExtension(),
     ]

--- a/tests/postgres_tests/test_fuzzystrmatch.py
+++ b/tests/postgres_tests/test_fuzzystrmatch.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.functions import Levenshtein
+from django.contrib.postgres.functions import Levenshtein, LevenshteinLessEqual
 from django.test import modify_settings
 
 from . import PostgreSQLTestCase
@@ -47,6 +47,15 @@ class FuzzyStrMatchTest(PostgreSQLTestCase):
             self.Model.objects.annotate(
                 distance=Levenshtein('field', 'Emelie')).order_by('distance'),
             [('Emelia', 1), ('Amelie', 1), ('Emily', 3), ('Fred', 5)],
+            transform=lambda instance: (instance.field, instance.distance),
+            ordered=True
+        )
+
+    def test_levenshteinlessequal(self):
+        self.assertQuerysetEqual(
+            self.Model.objects.annotate(
+                distance=LevenshteinLessEqual('field', 'Emelie', 3)).order_by('distance'),
+            [('Emelia', 1), ('Amelie', 1), ('Emily', 3), ('Fred', 4)],
             transform=lambda instance: (instance.field, instance.distance),
             ordered=True
         )

--- a/tests/postgres_tests/test_fuzzystrmatch.py
+++ b/tests/postgres_tests/test_fuzzystrmatch.py
@@ -1,0 +1,60 @@
+from django.contrib.postgres.functions import Levenshtein
+from django.test import modify_settings
+
+from . import PostgreSQLTestCase
+from .models import CharFieldModel, TextFieldModel
+
+
+@modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'})
+class FuzzyStrMatchTest(PostgreSQLTestCase):
+    Model = CharFieldModel
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.Model.objects.bulk_create([
+            cls.Model(field="Emily"),
+            cls.Model(field="Emelia"),
+            cls.Model(field="Amelie"),
+            cls.Model(field="Fred"),
+        ])
+
+    def test_soundex(self):
+        self.assertQuerysetEqual(
+            self.Model.objects.filter(field__soundex='Emelie'),
+            ['Emily', 'Emelia'],
+            transform=lambda instance: instance.field,
+            ordered=False,
+        )
+
+    def test_metaphone(self):
+        self.assertQuerysetEqual(
+            self.Model.objects.filter(field__metaphone='Emelie'),
+            ['Emily', 'Emelia'],
+            transform=lambda instance: instance.field,
+            ordered=False,
+        )
+
+    def test_double_metaphone(self):
+        self.assertQuerysetEqual(
+            self.Model.objects.filter(field__double_metaphone='Emelie'),
+            ['Emily', 'Emelia', 'Amelie'],
+            transform=lambda instance: instance.field,
+            ordered=False,
+        )
+
+    def test_levenshtein(self):
+        self.assertQuerysetEqual(
+            self.Model.objects.annotate(
+                distance=Levenshtein('field', 'Emelie')).order_by('distance'),
+            [('Emelia', 1), ('Amelie', 1), ('Emily', 3), ('Fred', 5)],
+            transform=lambda instance: (instance.field, instance.distance),
+            ordered=True
+        )
+
+
+class FuzzyStrMatchTextFieldTest(FuzzyStrMatchTest):
+    """
+    TextField should have the exact same behavior as CharField
+    regarding fuzzy string lookups.
+    """
+    Model = TextFieldModel


### PR DESCRIPTION
Just as I was in the area adding the trigram code, I thought I might as well take a look at this very similar functionality. I use Double Metaphone on my (Django powered) site http://theatricalia.com/ so that e.g. http://theatricalia.com/search?q=katie+stevens resolves to Katy Stephens.