### PR TITLE
Fixed #23190 -- Make Paginator.page_range an iterator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -593,6 +593,7 @@ answer newbie questions, and generally made Django that much better:
     Richard Davies <richard.davies@elastichosts.com>
     Richard House <Richard.House@i-logue.com>
     Rick Wagner <rwagner@physics.ucsd.edu>
+    Rigel Di Scala <rigel.discala@propylon.com>
     Robert Coup
     Robert Myers <myer0052@gmail.com>
     Roberto Aguilar <roberto@baremetal.io>

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -96,7 +96,7 @@ class Paginator(object):
         Returns a 1-based range of pages for iterating through within
         a template for loop.
         """
-        return list(six.moves.range(1, self.num_pages + 1))
+        return six.moves.range(1, self.num_pages + 1)
     page_range = property(_get_page_range)
 
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -356,6 +356,18 @@ Backwards incompatible changes in 1.9
     deprecation timeline for a given feature, its removal may appear as a
     backwards incompatible change.
 
+Paginator.page_range
+~~~~~~~~~~~~~~~~~~~~
+
+``Paginator.page_range`` is now an iterator, instead of a list.
+
+In versions of Django previous to 1.8, ``Paginator.page_range`` would return
+a ``list`` in Python 2.x, and a ``range`` object in 3.x. Django 1.8 consistently
+returned a list, but an iterator is preferable, as it is more efficient.
+
+Existing code that depends on ``list`` specific features, such as indexing,
+can be ported by converting the iterator into a ``list`` using ``list()``.
+
 Database backend API
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -24,8 +24,10 @@ page::
     4
     >>> p.num_pages
     2
+    >>> type(p.page_range)  # `<type 'rangeiterator'>` in Python 2.
+    <class 'range_iterator'>
     >>> p.page_range
-    [1, 2]
+    range(1, 3)
 
     >>> page1 = p.page(1)
     >>> page1
@@ -191,7 +193,12 @@ Attributes
 
 .. attribute:: Paginator.page_range
 
-    A 1-based range of page numbers, e.g., ``[1, 2, 3, 4]``.
+    A 1-based range iterator of page numbers, e.g. yielding ``[1, 2, 3, 4]``.
+
+    .. versionchanged:: 1.9
+
+        In older versions, ``page_range`` returned a list instead of an
+        iterator.
 
 
 ``InvalidPage`` exceptions

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -233,6 +233,15 @@ class PaginationTests(unittest.TestCase):
         self.assertEqual(page2.previous_page_number(), 1)
         self.assertIsNone(page2.next_page_number())
 
+    def test_page_range_iterator(self):
+        """
+        Paginator.page_range should be an iterator.
+        """
+        self.assertIsInstance(
+            Paginator([1, 2, 3], 2).page_range,
+            type(six.moves.range(0))
+        )
+
 
 class ModelPaginationTests(TestCase):
     """


### PR DESCRIPTION
This change fixes an inconsistency in the nature of
``Paginator.page_range``'s return value across major versions of
Python, ultimately caused by ``range``'s behaviour in 2.x and 3.x.

Fixes https://code.djangoproject.com/ticket/23190

This problem was first noted in https://code.djangoproject.com/ticket/23088