### PR TITLE
Fixed #18247 -- Added cast to NUMERIC for Decimals on sqlite

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -507,6 +507,15 @@ class Func(Expression):
         template = template or self.extra.get('template', self.template)
         return template % self.extra, params
 
+    def as_sqlite(self, *args, **kwargs):
+        sql, params = self.as_sql(*args, **kwargs)
+        try:
+            if self.output_field.get_internal_type() == 'DecimalField':
+                sql = 'CAST(%s AS NUMERIC)' % sql
+        except FieldError:
+            pass
+        return sql, params
+
     def copy(self):
         copy = super(Func, self).copy()
         copy.source_expressions = self.source_expressions[:]

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -349,6 +349,18 @@ class AggregationTests(TestCase):
             {'c__max': 3}
         )
 
+    def test_decimal_aggregate_annotation_filter(self):
+        # Test filters on an aggregate annotation, especially on decimal values
+        # which cause problems on SQLite (see #18247)
+        self.assertEqual(
+            len(Author.objects.annotate(sum=Sum('book_contact_set__price')).filter(sum__gt=Decimal(40))),
+            1
+        )
+        self.assertEqual(
+            len(Author.objects.annotate(sum=Sum('book_contact_set__price')).filter(sum__lte=Decimal(40))),
+            4
+        )
+
     def test_field_error(self):
         # Bad field requests in aggregates are caught and reported
         self.assertRaises(


### PR DESCRIPTION
On sqlite the SUM() of a decimal column doesn't have a NUMERIC type so when comparing it to a string literal (which a Decimal gets converted to in django) it is not compared as NUMERIC as may be expected.

Added CAST to NUMERIC type when using a SQL function that is expected to return a Decimal

Ran all tests in sqlite.