### PR TITLE
Make flatatt docstring match reality.

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -20,10 +20,12 @@ def flatatt(attrs):
     """
     Convert a dictionary of attributes to a single string.
     The returned string will contain a leading space followed by key="value",
-    XML-style pairs.  It is assumed that the keys do not need to be XML-escaped.
-    If the passed dictionary is empty, then return an empty string.
+    XML-style pairs. In the case of a boolean value, the key will appear
+    without a value. It is assumed that the keys do not need to be
+    XML-escaped. If the passed dictionary is empty, then return an empty
+    string.
 
-    The result is passed through 'mark_safe'.
+    The result is passed through 'mark_safe' (by way of 'format_html_join').
     """
     key_value_attrs = []
     boolean_attrs = []


### PR DESCRIPTION
The spirit of the docstring was correct, but referred to an outdated version of the function.