### PR TITLE
[1.8.x] Fixed #24903 -- Fixed assertRaisesMessage on Python 2.7.10.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -565,8 +565,7 @@ class SimpleTestCase(unittest.TestCase):
             msg_prefix + "Template '%s' was used unexpectedly in rendering"
             " the response" % template_name)
 
-    def assertRaisesMessage(self, expected_exception, expected_message,
-                           callable_obj=None, *args, **kwargs):
+    def assertRaisesMessage(self, expected_exception, expected_message, *args, **kwargs):
         """
         Asserts that the message in a raised exception matches the passed
         value.
@@ -574,12 +573,17 @@ class SimpleTestCase(unittest.TestCase):
         Args:
             expected_exception: Exception class expected to be raised.
             expected_message: expected error message string value.
-            callable_obj: Function to be called.
-            args: Extra args.
+            args: Function to be called and extra positional args.
             kwargs: Extra kwargs.
         """
+        # callable_obj was a documented kwarg in older version of Django, but
+        # had to be removed due to a bad fix for http://bugs.python.org/issue24134
+        # inadvertently making its way into Python 2.7.10.
+        callable_obj = kwargs.pop('callable_obj', None)
+        if callable_obj:
+            args = (callable_obj,) + args
         return six.assertRaisesRegex(self, expected_exception,
-                re.escape(expected_message), callable_obj, *args, **kwargs)
+                re.escape(expected_message), *args, **kwargs)
 
     def assertFieldOutput(self, fieldclass, valid, invalid, field_args=None,
             field_kwargs=None, empty_value=''):

--- a/docs/releases/1.7.9.txt
+++ b/docs/releases/1.7.9.txt
@@ -8,3 +8,6 @@ Django 1.7.9 fixes several bugs in 1.7.8.
 
 * Prevented the loss of ``null``/``not null`` column properties during field
   renaming of MySQL databases (:ticket:`24817`).
+
+* Fixed ``SimpleTestCase.assertRaisesMessage()`` on Python 2.7.10
+  (:ticket:`24903`).

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -59,3 +59,6 @@ Bugfixes
   results (:ticket:`24924`).
 
 * Fixed usage of transforms in subqueries (:ticket:`24744`).
+
+* Fixed ``SimpleTestCase.assertRaisesMessage()`` on Python 2.7.10
+  (:ticket:`24903`).

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -752,6 +752,12 @@ class AssertRaisesMsgTest(SimpleTestCase):
             raise ValueError("[.*x+]y?")
         self.assertRaisesMessage(ValueError, "[.*x+]y?", func1)
 
+    def test_callable_obj_param(self):
+        # callable_obj was a documented kwarg in older version of Django.
+        def func1():
+            raise ValueError("[.*x+]y?")
+        self.assertRaisesMessage(ValueError, "[.*x+]y?", callable_obj=func1)
+
 
 class AssertFieldOutputTests(SimpleTestCase):
 


### PR DESCRIPTION
A regression found in in Python 2.7.10 rc1 wasn't reverted for the final
release: https://bugs.python.org/issue24134

Backport of several commits from master:
* c2bc1cefdcbbf074408f4a4cace88b315cf9d652
* a0175724b086127a4e13612042961d3ba88d6bd9
* e89c3a46035e9fe17c373a6c9cd63b9fd631d596