### PR TITLE
Fixed #24971 -- Made startapp generate an apps.py

### DIFF
--- a/django/conf/app_template/__init__.py
+++ b/django/conf/app_template/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '{{ app_name }}.apps.{{ camel_case_app_name }}Config'

--- a/django/conf/app_template/apps.py
+++ b/django/conf/app_template/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class {{ camel_case_app_name }}Config(AppConfig):
+    name = '{{ app_name }}'

--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -98,10 +98,13 @@ class TemplateCommand(BaseCommand):
         base_name = '%s_name' % app_or_project
         base_subdir = '%s_template' % app_or_project
         base_directory = '%s_directory' % app_or_project
+        camel_case_name = 'camel_case_%s_name' % app_or_project
+        camel_case_value = ''.join(x for x in name.title() if x != '_')
 
         context = Context(dict(options, **{
             base_name: name,
             base_directory: top_dir,
+            camel_case_name: camel_case_value,
             'docs_version': get_docs_version(),
             'django_version': django.__version__,
             'unicode_literals': '' if six.PY3 else 'from __future__ import unicode_literals\n\n',

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1096,6 +1096,10 @@ with the ``--name`` option. The :class:`template context
 - ``app_directory`` -- the full path of the newly created app
 - ``docs_version`` -- the version of the documentation: ``'dev'`` or ``'1.x'``
 
+.. versionadded:: 1.9
+
+- ``camel_case_app_name`` -- the app name in camel case format
+
 .. _render_warning:
 
 .. warning::

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -270,6 +270,9 @@ Management Commands
 * The :djadmin:`createcachetable` command now has a ``--dry-run`` flag to
   print out the SQL rather than execute it.
 
+* The :djadmin:`startapp` command creates an ``apps.py`` file 
+  and add ``default_app_config`` path in ``__init__.py``.
+
 Models
 ^^^^^^
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -592,6 +592,14 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         self.addCleanup(shutil.rmtree, app_path)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
+        with open(os.path.join(app_path, 'apps.py'), 'r') as f:
+            content = f.read()
+            self.assertIn("class SettingsTestConfig(AppConfig)", content)
+            self.assertIn("name = 'settings_test'", content)
+        with open(os.path.join(app_path, '__init__.py'), 'r') as f:
+            content = f.read()
+            expected_content = "default_app_config = 'settings_test.apps.SettingsTestConfig'"
+            self.assertIn(expected_content, content)
         if not PY3:
             with open(os.path.join(app_path, 'models.py'), 'r') as fp:
                 content = fp.read()


### PR DESCRIPTION
Adding support for App config on the default app creation.