### PR TITLE
Fix #24972 -- index recreate check on MySQL composed index delete

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -80,7 +80,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         """
         first_field = model._meta.get_field(fields[0])
         if first_field.get_internal_type() == 'ForeignKey':
-            constraint_names = self._constraint_names(model, fields[0], index=True)
+            constraint_names = self._constraint_names(model, [model._meta.get_field(fields[0]).column], index=True)
             if not constraint_names:
                 self.execute(
                     self._create_index_sql(model, [model._meta.get_field(fields[0])], suffix="")

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -80,6 +80,15 @@ class BookWithSlug(models.Model):
         db_table = "schema_book"
 
 
+class BookWithoutAuthor(models.Model):
+    title = models.CharField(max_length=100, db_index=True)
+    pub_date = models.DateTimeField()
+
+    class Meta:
+        apps = new_apps
+        db_table = "schema_book"
+
+
 class IntegerPK(models.Model):
     i = models.IntegerField(primary_key=True)
     j = models.IntegerField(unique=True)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -22,8 +22,9 @@ from .fields import (
 )
 from .models import (
     Author, AuthorWithDefaultHeight, AuthorWithEvenLongerName, Book, BookWeak,
-    BookWithLongName, BookWithO2O, BookWithSlug, IntegerPK, Note, NoteRename,
-    Tag, TagIndexed, TagM2MTest, TagUniqueRename, Thing, UniqueTest, new_apps,
+    BookWithLongName, BookWithO2O, BookWithoutAuthor, BookWithSlug, IntegerPK,
+    Note, NoteRename, Tag, TagIndexed, TagM2MTest, TagUniqueRename, Thing,
+    UniqueTest, new_apps,
 )
 
 
@@ -1200,6 +1201,30 @@ class SchemaTests(TransactionTestCase):
         # Add the unique_together constraint
         with connection.schema_editor() as editor:
             editor.alter_unique_together(Book, [], [['author', 'title']])
+        # Alter it back
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(Book, [['author', 'title']], [])
+
+    def test_unique_together_with_fk_with_existing_index(self):
+        """
+        Regression test for #24972.
+        Tests removing and adding unique_together constraints that include
+        a foreign key, where the foreign key is added after the model is
+        created.
+        """
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(BookWithoutAuthor)
+            new_field = ForeignKey(Author)
+            new_field.set_attributes_from_name("author")
+            editor.add_field(BookWithoutAuthor, new_field)
+        # Ensure the fields are unique to begin with
+        self.assertEqual(Book._meta.unique_together, ())
+        # Add the unique_together constraint
+        with connection.schema_editor() as editor:
+            editor.alter_unique_together(Book, [], [['author', 'title']])
+
         # Alter it back
         with connection.schema_editor() as editor:
             editor.alter_unique_together(Book, [['author', 'title']], [])


### PR DESCRIPTION
Trac bug: https://code.djangoproject.com/ticket/24972

In the fix for #24757, the call to
DatabaseSchemaEditor._constraint_names passed a string as the
column_names argument, which is expected to be an iterable of column
names and is converted to a list inside the method.

_constraint_names then attempted to match each constraint against a list
containing each individual character of the foreign key's name as a
separate item, causing it to always return empty, so
_delete_composed_index tried to recreate the FK index even if it already
existed.

It also passed in the Django ORM field name (e.g. `myfk`), rather than
the database column name (e.g. `myfk_id`).