### PR TITLE
Corrected to not erroneously mention email as being required.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -290,7 +290,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
     An abstract base class implementing a fully featured User model with
     admin-compliant permissions.
 
-    Username, password and email are required. Other fields are optional.
+    Username and password are required. Other fields are optional.
     """
     username = models.CharField(
         _('username'),


### PR DESCRIPTION
Email field isn't required.