### PR TITLE
Removed django.utils.functional.total_ordering()

### DIFF
--- a/django/contrib/gis/geos/mutable_list.py
+++ b/django/contrib/gis/geos/mutable_list.py
@@ -8,8 +8,9 @@ See also http://www.aryehleib.com/MutableLists.html
 
 Author: Aryeh Leib Taurog.
 """
+from functools import total_ordering
+
 from django.utils import six
-from django.utils.functional import total_ordering
 from django.utils.six.moves import range
 
 

--- a/django/contrib/gis/maps/google/overlays.py
+++ b/django/contrib/gis/maps/google/overlays.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
+from functools import total_ordering
+
 from django.contrib.gis.geos import (
     LinearRing, LineString, Point, Polygon, fromstr,
 )
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.functional import total_ordering
 from django.utils.html import html_safe
 
 

--- a/django/contrib/gis/measure.py
+++ b/django/contrib/gis/measure.py
@@ -37,9 +37,9 @@ and Geoff Biggs' PhD work on dimensioned units for robotics.
 """
 __all__ = ['A', 'Area', 'D', 'Distance']
 from decimal import Decimal
+from functools import total_ordering
 
 from django.utils import six
-from django.utils.functional import total_ordering
 
 NUMERIC_TYPES = six.integer_types + (float, Decimal)
 AREA_PREFIX = "sq_"

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import sys
+from functools import total_ordering
 from itertools import dropwhile
 
 import django
@@ -17,7 +18,7 @@ from django.core.management.utils import (
 from django.utils import six
 from django.utils._os import upath
 from django.utils.encoding import DEFAULT_LOCALE_ENCODING, force_str
-from django.utils.functional import cached_property, total_ordering
+from django.utils.functional import cached_property
 from django.utils.jslex import prepare_js_for_gettext
 from django.utils.text import get_text_list
 

--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals
 
 import warnings
 from collections import deque
+from functools import total_ordering
 
 from django.db.migrations.state import ProjectState
 from django.utils.datastructures import OrderedSet
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.functional import total_ordering
 
 from .exceptions import CircularDependencyError, NodeNotFoundError
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -9,6 +9,7 @@ import math
 import uuid
 import warnings
 from base64 import b64decode, b64encode
+from functools import total_ordering
 
 from django.apps import apps
 from django.db import connection
@@ -20,7 +21,7 @@ from django.core import exceptions, validators, checks
 from django.utils.datastructures import DictWrapper
 from django.utils.dateparse import parse_date, parse_datetime, parse_time, parse_duration
 from django.utils.duration import duration_string
-from django.utils.functional import cached_property, curry, total_ordering, Promise
+from django.utils.functional import cached_property, curry, Promise
 from django.utils.text import capfirst
 from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango21Warning

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -1,7 +1,6 @@
 import copy
 import operator
-import sys
-from functools import wraps
+from functools import total_ordering, wraps
 
 from django.utils import six
 from django.utils.six.moves import copyreg
@@ -385,36 +384,3 @@ def partition(predicate, values):
     for item in values:
         results[predicate(item)].append(item)
     return results
-
-if sys.version_info >= (2, 7, 2):
-    from functools import total_ordering
-else:
-    # For Python < 2.7.2. total_ordering in versions prior to 2.7.2 is buggy.
-    # See http://bugs.python.org/issue10042 for details. For these versions use
-    # code borrowed from Python 2.7.3.
-    def total_ordering(cls):
-        """Class decorator that fills in missing ordering methods"""
-        convert = {
-            '__lt__': [('__gt__', lambda self, other: not (self < other or self == other)),
-                       ('__le__', lambda self, other: self < other or self == other),
-                       ('__ge__', lambda self, other: not self < other)],
-            '__le__': [('__ge__', lambda self, other: not self <= other or self == other),
-                       ('__lt__', lambda self, other: self <= other and not self == other),
-                       ('__gt__', lambda self, other: not self <= other)],
-            '__gt__': [('__lt__', lambda self, other: not (self > other or self == other)),
-                       ('__ge__', lambda self, other: self > other or self == other),
-                       ('__le__', lambda self, other: not self > other)],
-            '__ge__': [('__le__', lambda self, other: (not self >= other) or self == other),
-                       ('__gt__', lambda self, other: self >= other and not self == other),
-                       ('__lt__', lambda self, other: not self >= other)]
-        }
-        roots = set(dir(cls)) & set(convert)
-        if not roots:
-            raise ValueError('must define at least one ordering operation: < > <= >=')
-        root = max(roots)       # prefer __lt__ to __le__ to __gt__ to __ge__
-        for opname, opfunc in convert[root]:
-            if opname not in roots:
-                opfunc.__name__ = opname
-                opfunc.__doc__ = getattr(int, opname).__doc__
-                setattr(cls, opname, opfunc)
-        return cls

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -659,6 +659,10 @@ Miscellaneous
 
 * For security hardening, session keys must be at least 8 characters.
 
+* Private function ``django.utils.functional.total_ordering()`` has been
+  removed. It contained a workaround for a ``functools.total_ordering()`` bug
+  in Python versions older than 2.7.3.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9


### PR DESCRIPTION
Don't think Python < 2.7.3 support is needed anymore.