### PR TITLE
Refs #23763 -- Fixed Python 3.5 PendingDeprecationWarning in LazyStream.

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -327,12 +327,15 @@ class LazyStream(six.Iterator):
             while remaining != 0:
                 assert remaining > 0, 'remaining bytes to read should never go negative'
 
-                chunk = next(self)
-
-                emitting = chunk[:remaining]
-                self.unget(chunk[remaining:])
-                remaining -= len(emitting)
-                yield emitting
+                try:
+                    chunk = next(self)
+                except StopIteration:
+                    return
+                else:
+                    emitting = chunk[:remaining]
+                    self.unget(chunk[remaining:])
+                    remaining -= len(emitting)
+                    yield emitting
 
         out = b''.join(parts())
         return out


### PR DESCRIPTION
Fixed "PendingDeprecationWarning: generator 'LazyStream.read.<locals>.parts'
raised StopIteration" per PEP 0479.