### PR TITLE
Fixed #24992 merge subfieldbase-metaclass example code in docs

### DIFF
--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -337,30 +337,16 @@ appropriate Python object. The details of how this happens internally are a
 little complex, but the code you need to write in your ``Field`` class is
 simple: make sure your field subclass uses a special metaclass:
 
-For example, on Python 2::
-
-    class HandField(models.Field):
-
-        description = "A hand of cards (bridge style)"
-
-        __metaclass__ = models.SubfieldBase
-
-        def __init__(self, *args, **kwargs):
-            ...
-
-On Python 3, in lieu of setting the ``__metaclass__`` attribute, add
-``metaclass`` to the class definition::
-
-    class HandField(models.Field, metaclass=models.SubfieldBase):
-        ...
-
-If you want your code to work on Python 2 & 3, you can use
-:func:`six.with_metaclass`::
+For example::
 
     from django.utils.six import with_metaclass
 
     class HandField(with_metaclass(models.SubfieldBase, models.Field)):
-        ...
+
+        description = "A hand of cards (bridge style)"
+
+        def __init__(self, *args, **kwargs):
+            ...
 
 This ensures that the :meth:`.to_python` method will always be called when the
 attribute is initialized.


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.7/howto/custom-model-fields/#the-subfieldbase-metaclass contains three code examples:

* for Python 2 only
* for Python 3 only
* for Python 2+3 using six.with_metaclass()

What's about to remove the first two examples and leave only the six.with_metaclass() example?!?

Discussion: https://groups.google.com/forum/#!topic/django-developers/nYhZYyLcV1g
Ticket: https://code.djangoproject.com/ticket/24992
