### PR TITLE
Refs #9619 -- Added a test for Field.from_db_value() calls on QuerySet.values()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -325,6 +325,7 @@ answer newbie questions, and generally made Django that much better:
     Jeff Hui <jeffkhui@gmail.com>
     Jeffrey Gelens <jeffrey@gelens.org>
     Jeff Triplett <jeff.triplett@gmail.com>
+    Jens Diemer <django@htfx.de>
     Jens Page
     Jeong-Min Lee <falsetru@gmail.com>
     Jérémie Blaser <blaserje@gmail.com>

--- a/tests/from_db_value/tests.py
+++ b/tests/from_db_value/tests.py
@@ -13,9 +13,13 @@ class FromDBValueTest(TestCase):
         instance = CashModel.objects.get()
         self.assertIsInstance(instance.cash, Cash)
 
-    def test_values(self):
+    def test_values_list(self):
         values_list = CashModel.objects.values_list('cash', flat=True)
         self.assertIsInstance(values_list[0], Cash)
+
+    def test_values(self):
+        values_list = CashModel.objects.values('cash')
+        self.assertIsInstance(values_list[0]['cash'], Cash)
 
     def test_aggregation(self):
         maximum = CashModel.objects.aggregate(m=Max('cash'))['m']


### PR DESCRIPTION
ref.: https://code.djangoproject.com/ticket/9619

#9619 is fixed with Django v1.8 and the change from **to_python()** to **from_db_value()**
But there is no unittest for it.

Here i add a test. But i must also add **from_db_value()** to test existing test model field.