### PR TITLE
Fixed #24865 -- Added a feature to remove stale content types

### DIFF
--- a/django/contrib/contenttypes/management.py
+++ b/django/contrib/contenttypes/management.py
@@ -4,7 +4,8 @@ from django.utils import six
 from django.utils.six.moves import input
 
 
-def update_contenttypes(app_config, verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs):
+def update_contenttypes(app_config, verbosity=2, interactive=True,
+                        using=DEFAULT_DB_ALIAS, force_remove=False, **kwargs):
     """
     Creates content types for models in the given app, removing any model
     entries that no longer have a matching model class.
@@ -57,7 +58,9 @@ def update_contenttypes(app_config, verbosity=2, interactive=True, using=DEFAULT
 
     # Confirm that the content type is stale before deletion.
     if to_remove:
-        if interactive:
+        if force_remove:
+            ok_to_delete = 'yes'
+        elif interactive:
             content_type_display = '\n'.join(
                 '    %s | %s' % (ct.app_label, ct.model)
                 for ct in to_remove
@@ -82,3 +85,9 @@ If you're unsure, answer 'no'.
         else:
             if verbosity >= 2:
                 print("Stale content types remain.")
+
+
+def remove_contenttypes(app):
+    for app_config in apps.get_app_configs():
+        if app_config.name == app:
+            update_contenttypes(app_config, force_remove=True)

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -543,3 +543,29 @@ information.
 
     Subclasses of :class:`GenericInlineModelAdmin` with stacked and tabular
     layouts, respectively.
+
+
+.. module:: django.contrib.contenttypes.management
+
+Utilities
+=========
+.. versionadded:: 1.9
+
+The ``remove_contenttypes1`` method can be used to programmatically remove 
+stale content types. This is useful for automatic deployments where keyboard 
+input isn't available. 
+
+It accepts one argument, the application name, and is called within the 
+migration file. See the example below.
+
+.. code-block:: python
+
+    # 0002_my_migration.py
+    from django.contrib.contenttypes.management import remove_contenttypes
+
+    def remover(apps, schema_editor):
+        remove_contenttypes('my_app')
+
+    operations = [
+        migrations.RunPython(remover),
+    ]


### PR DESCRIPTION
Added an additional argument to `update_contenttypes` to automatically remove stale content types during migrations. Added tests and a new utility method to expose this functionality to users.