### PR TITLE
Fixed #20203 - Allowed custom default manager name for the abstract model

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -467,7 +467,10 @@ class ModelState(object):
                 (name, instance) for name, (cc, instance) in
                 sorted(managers_mapping.items(), key=lambda v: v[1])
             ]
-            if managers == [(default_manager_name, models.Manager())]:
+            # If the only manager on the model is the default
+            # manager defined by Django (`objects = models.Manager()`),
+            # this manager will not be added to the model state.
+            if managers == [('objects', models.Manager())]:
                 managers = []
         else:
             managers = []

--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -15,10 +15,7 @@ def ensure_default_manager(cls):
     points to a plain Manager instance (which could be the same as
     _default_manager if it's not a subclass of Manager).
     """
-    if cls._meta.abstract:
-        setattr(cls, 'objects', AbstractManagerDescriptor(cls))
-        return
-    elif cls._meta.swapped:
+    if cls._meta.swapped:
         setattr(cls, 'objects', SwappedManagerDescriptor(cls))
         return
     if not getattr(cls, '_default_manager', None):

--- a/tests/custom_managers/models.py
+++ b/tests/custom_managers/models.py
@@ -194,3 +194,15 @@ class OneToOneRestrictedModel(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class AbstractPerson(models.Model):
+    abstract_persons = models.Manager()
+    objects = models.CharField(max_length=30)
+
+    class Meta:
+        abstract = True
+
+
+class PersonFromAbstract(AbstractPerson):
+    pass

--- a/tests/custom_managers/tests.py
+++ b/tests/custom_managers/tests.py
@@ -6,8 +6,8 @@ from django.utils import six
 
 from .models import (
     Book, Car, CustomManager, CustomQuerySet, DeconstructibleCustomManager,
-    FunPerson, OneToOneRestrictedModel, Person, PersonManager,
-    PublishedBookManager, RelatedModel, RestrictedModel,
+    FunPerson, OneToOneRestrictedModel, Person, PersonFromAbstract,
+    PersonManager, PublishedBookManager, RelatedModel, RestrictedModel,
 )
 
 
@@ -511,6 +511,17 @@ class CustomManagerTests(TestCase):
                "dynamically generated with 'from_queryset()'.")
         with self.assertRaisesMessage(ValueError, msg):
             mgr.deconstruct()
+
+    def test_abstract_model_with_custom_manager_name(self):
+        """
+        A custom manager may be defined on an abstract model.
+        It will be inherited by the abstract model's children.
+        """
+        PersonFromAbstract.abstract_persons.create(objects='Test')
+        self.assertQuerysetEqual(
+            PersonFromAbstract.abstract_persons.all(), ["Test"],
+            lambda c: c.objects,
+        )
 
 
 class TestCars(TestCase):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -166,6 +166,26 @@ class StateTests(SimpleTestCase):
         self.assertEqual([mgr.args for name, mgr in food_order_manager_state.managers],
                          [('a', 'b', 1, 2), ('x', 'y', 3, 4)])
 
+    def test_custom_default_manager_added_to_the_model_state(self):
+        """
+        When the default manager of the model is a custom manager,
+        it needs to be added to the model state.
+        """
+        new_apps = Apps(["migrations"])
+        custom_manager = models.Manager()
+
+        class Author(models.Model):
+            objects = models.TextField()
+            authors = custom_manager
+
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+
+        project_state = ProjectState.from_apps(new_apps)
+        author_state = project_state.models['migrations', 'author']
+        self.assertEqual(author_state.managers, [('authors', custom_manager)])
+
     def test_apps_bulk_update(self):
         """
         StateApps.bulk_update() should update apps.ready to False and reset


### PR DESCRIPTION
https://code.djangoproject.com/ticket/20203

There are no direct commit message with `Fixed #20203`, because ticket issue resolved by fixing the indirect problem.
Also removed some old unused code.