### PR TITLE
Fixed #24997 -- Enabled bulk_create on a proxy model

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -724,6 +724,7 @@ answer newbie questions, and generally made Django that much better:
     Wiktor Kołodziej <wiktor@pykonik.org>
     Wiley Kestner <wiley.kestner@gmail.com>
     Wiliam Alves de Souza <wiliamsouza83@gmail.com>
+    William Schwartz <wkschwartz@gmail.com>
     Will Hardy <django@willhardy.com.au>
     Wilson Miner <wminer@gmail.com>
     wojtek

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1768,6 +1768,10 @@ This has a number of caveats though:
   does not retrieve and set the primary key attribute, as ``save()`` does.
 * It does not work with many-to-many relationships.
 
+.. versionchanged:: 1.9
+
+    Support for using ``bulk_create()`` with proxy models was added.
+
 The ``batch_size`` parameter controls how many objects are created in single
 query. The default is to create all objects in one batch, except for SQLite
 where the default is such that at most 999 variables per query are used.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -365,6 +365,9 @@ Management Commands
 Models
 ^^^^^^
 
+* :meth:`QuerySet.bulk_create() <django.db.models.query.QuerySet.bulk_create>`
+  now works on proxy models.
+
 * Database configuration gained a :setting:`TIME_ZONE <DATABASE-TIME_ZONE>`
   option for interacting with databases that store datetimes in local time and
   don't support time zones when :setting:`USE_TZ` is ``True``.

--- a/tests/bulk_create/models.py
+++ b/tests/bulk_create/models.py
@@ -6,6 +6,25 @@ class Country(models.Model):
     iso_two_letter = models.CharField(max_length=2)
 
 
+class ProxyCountry(Country):
+    class Meta:
+        proxy = True
+
+
+class ProxyProxyCountry(ProxyCountry):
+    class Meta:
+        proxy = True
+
+
+class ProxyMultiCountry(ProxyCountry):
+    pass
+
+
+class ProxyMultiProxyCountry(ProxyMultiCountry):
+    class Meta:
+        proxy = True
+
+
 class Place(models.Model):
     name = models.CharField(max_length=100)
 

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -7,7 +7,10 @@ from django.test import (
     TestCase, override_settings, skipIfDBFeature, skipUnlessDBFeature,
 )
 
-from .models import Country, Pizzeria, Restaurant, State, TwoFields
+from .models import (
+    Country, Pizzeria, ProxyCountry, ProxyMultiCountry, ProxyMultiProxyCountry,
+    ProxyProxyCountry, Restaurant, State, TwoFields,
+)
 
 
 class BulkCreateTests(TestCase):
@@ -35,21 +38,35 @@ class BulkCreateTests(TestCase):
         with self.assertNumQueries(1):
             Country.objects.bulk_create(self.data)
 
-    def test_inheritance(self):
-        Restaurant.objects.bulk_create([
-            Restaurant(name="Nicholas's")
-        ])
-        self.assertQuerysetEqual(Restaurant.objects.all(), [
-            "Nicholas's",
-        ], attrgetter("name"))
-        with self.assertRaises(ValueError):
+    def test_multi_table_inheritance_unsupported(self):
+        expected_message = "Can't bulk create a multi-table inherited model"
+        with self.assertRaisesMessage(ValueError, expected_message):
             Pizzeria.objects.bulk_create([
                 Pizzeria(name="The Art of Pizza")
             ])
-        self.assertQuerysetEqual(Pizzeria.objects.all(), [])
-        self.assertQuerysetEqual(Restaurant.objects.all(), [
-            "Nicholas's",
-        ], attrgetter("name"))
+        with self.assertRaisesMessage(ValueError, expected_message):
+            ProxyMultiCountry.objects.bulk_create([
+                ProxyMultiCountry(name="Fillory", iso_two_letter="FL")
+            ])
+        with self.assertRaisesMessage(ValueError, expected_message):
+            ProxyMultiProxyCountry.objects.bulk_create([
+                ProxyMultiProxyCountry(name="Fillory", iso_two_letter="FL")
+            ])
+
+    def test_proxy_inheritance_supported(self):
+        ProxyCountry.objects.bulk_create([
+            ProxyCountry(name="Qwghlm", iso_two_letter="QW"),
+            Country(name="Tortall", iso_two_letter="TA"),
+        ])
+        self.assertQuerysetEqual(ProxyCountry.objects.all(), {
+            "Qwghlm", "Tortall"
+        }, attrgetter("name"), ordered=False)
+        ProxyProxyCountry.objects.bulk_create([
+            ProxyProxyCountry(name="Neitherlands", iso_two_letter="NT")
+        ])
+        self.assertQuerysetEqual(ProxyProxyCountry.objects.all(), {
+            "Qwghlm", "Tortall", "Neitherlands",
+        }, attrgetter("name"), ordered=False)
 
     def test_non_auto_increment_pk(self):
         State.objects.bulk_create([


### PR DESCRIPTION
This patch enables `SomeProxyModel.objects.bulk_create(objs)`, which previously raised a `ValueError`. The real difficulty with bulk insertion is the multi-table case, and this patch correctly detects when a proxy model inherits from some other multi-table models.

The tests pass on Mac OS 10.10.2, Python 3.4.3 with both Sqlite 2.6.0 and PostgreSQL 9.4.4.

See https://code.djangoproject.com/ticket/24997.