### PR TITLE
Fixed #14200 -- Added a fallback if HttpRequest.urlconf is None.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -112,7 +112,7 @@ class BaseHandler(object):
         # resolver is set
         urlconf = settings.ROOT_URLCONF
         urlresolvers.set_urlconf(urlconf)
-        resolver = urlresolvers.RegexURLResolver(r'^/', urlconf)
+        resolver = urlresolvers.get_resolver(urlconf)
         # Use a flag to check if the response was rendered to prevent
         # multiple renderings or to force rendering if necessary.
         response_is_rendered = False
@@ -129,7 +129,7 @@ class BaseHandler(object):
                     # Reset url resolver with a custom urlconf.
                     urlconf = request.urlconf
                     urlresolvers.set_urlconf(urlconf)
-                    resolver = urlresolvers.RegexURLResolver(r'^/', urlconf)
+                    resolver = urlresolvers.get_resolver(urlconf)
 
                 resolver_match = resolver.resolve(request.path_info)
                 callback, callback_args, callback_kwargs = resolver_match

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -435,6 +435,11 @@ Requests and Responses
   :class:`~django.template.response.TemplateResponse`, commonly used with
   class-based views.
 
+* Request middleware can now set :attr:`HttpRequest.urlconf
+  <django.http.HttpRequest.urlconf>` to ``None`` to override any changes made
+  by previous middleware. It will use the value of :setting:`ROOT_URLCONF`
+  instead.
+
 Tests
 ^^^^^
 

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -42,7 +42,9 @@ algorithm the system follows to determine which Python code to execute:
    this is the value of the :setting:`ROOT_URLCONF` setting, but if the incoming
    ``HttpRequest`` object has an attribute called ``urlconf`` (set by
    middleware :ref:`request processing <request-middleware>`), its value
-   will be used in place of the :setting:`ROOT_URLCONF` setting.
+   will be used in place of the :setting:`ROOT_URLCONF` setting. ``urlconf``
+   can be set to ``None`` to override any changes made by previous middleware,
+   and use the value of :setting:`ROOT_URLCONF` instead.
 
 2. Django loads that Python module and looks for the variable
    ``urlpatterns``. This should be a Python list of :func:`django.conf.urls.url`
@@ -66,6 +68,12 @@ algorithm the system follows to determine which Python code to execute:
 5. If no regex matches, or if an exception is raised during any
    point in this process, Django invokes an appropriate
    error-handling view. See `Error handling`_ below.
+
+.. versionchanged:: 1.9
+
+    It is now possible to set :attr:`HttpRequest.urlconf
+    <django.http.HttpRequest.urlconf>` to ``None`` to override any changes
+    made by previous request middleware.
 
 Example
 =======

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -700,7 +700,17 @@ class RequestURLconfTests(SimpleTestCase):
         ]
     )
     def test_urlconf_overridden_with_null(self):
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/test/me/')
+        """
+        Overriding request.urlconf with None will fall back to the default
+        URLconf.
+        """
+        response = self.client.get('/test/me/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'outer:/test/me/,inner:/inner_urlconf/second_test/')
+        response = self.client.get('/inner_urlconf/second_test/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/second_test/')
+        self.assertEqual(response.status_code, 404)
 
     @override_settings(
         MIDDLEWARE_CLASSES=[


### PR DESCRIPTION
Made BaseHandler fall back to settings.ROOT_URLCONF if
HttpRequest.urlconf is set to None, rather than raising
ImproperlyConfigured.

https://code.djangoproject.com/ticket/14200