### PR TITLE
Fixed #25000 -- Fixed cast to string for lazy objects.

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -128,6 +128,11 @@ def lazy(func, *resultclasses):
             else:
                 return func(*self.__args, **self.__kw)
 
+        def __str__(self):
+            # object defines __str__, so __prepare_class__ won't overload any
+            # __str__ method from the proxied class.
+            return str(self.__cast())
+
         def __ne__(self, other):
             if isinstance(other, Promise):
                 other = other.__cast()

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -1,5 +1,9 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
 import unittest
 
+from django.utils import six
 from django.utils.functional import cached_property, lazy, lazy_property
 
 
@@ -53,6 +57,26 @@ class FunctionalTestCase(unittest.TestCase):
 
         self.assertRaises(NotImplementedError, lambda: A().do)
         self.assertEqual(B().do, 'DO IT')
+
+    def test_lazy_object_to_string(self):
+
+        class Klazz(object):
+            if six.PY3:
+                def __str__(self):
+                    return "Î am ā Ǩlâzz."
+
+                def __bytes__(self):
+                    return b"\xc3\x8e am \xc4\x81 binary \xc7\xa8l\xc3\xa2zz."
+            else:
+                def __unicode__(self):
+                    return "Î am ā Ǩlâzz."
+
+                def __str__(self):
+                    return b"\xc3\x8e am \xc4\x81 binary \xc7\xa8l\xc3\xa2zz."
+
+        t = lazy(lambda: Klazz(), Klazz)()
+        self.assertEqual(six.text_type(t), "Î am ā Ǩlâzz.")
+        self.assertEqual(six.binary_type(t), b"\xc3\x8e am \xc4\x81 binary \xc7\xa8l\xc3\xa2zz.")
 
     def test_cached_property(self):
         """


### PR DESCRIPTION
Implemented `__str__` and `__unicode__` in Python 2 and `__str__` and
`__bytes__` in Python 3 to return the string-representation of the
proxied object, not the proxy itself, if the lazy object didn't have
a string-like object in its resultclasses.

https://code.djangoproject.com/ticket/25000