### PR TITLE
Fixed #25005 - Made date and time fields with auto_now/auto_now_add use effective default

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -3,7 +3,7 @@ import logging
 
 from django.db.backends.utils import truncate_name
 from django.db.transaction import atomic
-from django.utils import six
+from django.utils import six, timezone
 from django.utils.encoding import force_bytes
 
 logger = logging.getLogger('django.db.backends.schema')
@@ -200,6 +200,13 @@ class BaseDatabaseSchemaEditor(object):
                 default = six.binary_type()
             else:
                 default = six.text_type()
+        elif getattr(field, 'auto_now', False) or getattr(field, 'auto_now_add', False):
+            default = timezone.now()  # default for DateTimeField
+            internal_type = field.get_internal_type()
+            if internal_type == 'DateField':
+                default = default.date()
+            elif internal_type == 'TimeField':
+                default = default.time()
         else:
             default = None
         # If it's a callable, call it

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -820,7 +820,11 @@ class MigrationAutodetector(object):
         preserve_default = True
         if (not field.null and not field.has_default() and
                 not isinstance(field, models.ManyToManyField) and
-                not (field.blank and field.empty_strings_allowed)):
+                not (field.blank and field.empty_strings_allowed) and
+                not (
+                    isinstance(field, (models.DateField, models.DateTimeField, models.TimeField)) and
+                    (field.auto_now or field.auto_now_add)
+                )):
             field = field.clone()
             field.default = self.questioner.ask_not_null_addition(field_name, model_name)
             preserve_default = False

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -55,6 +55,18 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default='Ada Lovelace')),
     ])
+    author_dates_of_birth_auto_now = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("date_of_birth", models.DateField(auto_now=True)),
+        ("date_time_of_birth", models.DateTimeField(auto_now=True)),
+        ("time_of_birth", models.TimeField(auto_now=True)),
+    ])
+    author_dates_of_birth_auto_now_add = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("date_of_birth", models.DateField(auto_now_add=True)),
+        ("date_time_of_birth", models.DateTimeField(auto_now_add=True)),
+        ("time_of_birth", models.TimeField(auto_now_add=True)),
+    ])
     author_name_deconstructable_1 = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructableObject())),
@@ -627,6 +639,36 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AddField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition',
+                side_effect=AssertionError("Should not have prompted for not null addition"))
+    def test_add_date_fields_with_auto_now_not_asking_for_default(self, mocked_ask_method):
+        # Make state
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_dates_of_birth_auto_now])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField", "AddField"])
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now=True)
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition',
+                side_effect=AssertionError("Should not have prompted for not null addition"))
+    def test_add_date_fields_with_auto_now_add_not_asking_for_default(self, mocked_ask_method):
+        # Make state
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_dates_of_birth_auto_now_add])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField", "AddField"])
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
 
     def test_remove_field(self):
         """Tests autodetection of removed fields."""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25005

Also fixed autodetector in migrations to skip promt for default for these fields.

Opened against master since we will not backport it to 1.8