### PR TITLE
Refs #23804 -- RasterField initialization only if HAS_GDAL

### DIFF
--- a/django/contrib/gis/gdal/__init__.py
+++ b/django/contrib/gis/gdal/__init__.py
@@ -53,7 +53,8 @@ try:
     HAS_GDAL = True
     __all__ += [
         'Driver', 'DataSource', 'gdal_version', 'gdal_full_version',
-        'GDAL_VERSION', 'SpatialReference', 'CoordTransform', 'OGRGeometry',
+        'GDALRaster', 'GDAL_VERSION', 'SpatialReference', 'CoordTransform',
+        'OGRGeometry',
     ]
 except GDALException:
     HAS_GDAL = False

--- a/tests/gis_tests/models.py
+++ b/tests/gis_tests/models.py
@@ -6,12 +6,12 @@ class DummyField(models.Field):
     def __init__(self, dim=None, srid=None, geography=None, spatial_index=True, *args, **kwargs):
         super(DummyField, self).__init__(*args, **kwargs)
 
+
 try:
     from django.contrib.gis.db import models
-    try:
-        models.RasterField()
-    except ImproperlyConfigured:
-        models.RasterField = DummyField
+    # Store a version of the original raster field for
+    # testing exception raised without GDAL
+    models.OriginalRasterField = models.RasterField
 except ImproperlyConfigured:
     models.GeoManager = models.Manager
     models.GeometryField = DummyField
@@ -20,4 +20,9 @@ except ImproperlyConfigured:
     models.MultiPolygonField = DummyField
     models.PointField = DummyField
     models.PolygonField = DummyField
+    models.RasterField = DummyField
+
+try:
+    models.RasterField()
+except ImproperlyConfigured:
     models.RasterField = DummyField

--- a/tests/gis_tests/rasterapp/models.py
+++ b/tests/gis_tests/rasterapp/models.py
@@ -2,7 +2,7 @@ from ..models import models
 
 
 class RasterModel(models.Model):
-    rast = models.RasterField(null=True, srid=4326, spatial_index=True, blank=True)
+    rast = models.RasterField('A Verbose Raster Name', null=True, srid=4326, spatial_index=True, blank=True)
 
     class Meta:
         required_db_features = ['supports_raster']

--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -1,9 +1,13 @@
 import json
+from unittest import skipIf
 
+from django.contrib.gis.gdal import HAS_GDAL
 from django.contrib.gis.shortcuts import numpy
-from django.test import TransactionTestCase, skipUnlessDBFeature
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 
 from ..data.rasters.textrasters import JSON_RASTER
+from ..models import models
 from .models import RasterModel
 
 
@@ -70,3 +74,21 @@ class RasterFieldTest(TransactionTestCase):
             [-87.9298551266551, 9.459646421449934e-06, 0.0,
              23.94249275457565, 0.0, -9.459646421449934e-06]
         )
+
+    def test_verbose_name_arg(self):
+        """
+        Test if the positional verbose name argument is accepted.
+        """
+        self.assertEqual(
+            RasterModel._meta.get_field('rast').verbose_name,
+            'A Verbose Raster Name'
+        )
+
+
+@skipIf(HAS_GDAL, 'Test raster field exception on systems without GDAL.')
+class RasterFieldWithoutGDALTest(TestCase):
+
+    def test_raster_field_without_gdal_exception(self):
+        msg = 'RasterField requires GDAL.'
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            models.OriginalRasterField()


### PR DESCRIPTION
The automatic instantiation of GDALRaster instances on field values fails if gdal is not installed.