### PR TITLE
Fixed #25016 -- Reallowed non-ASCII values for ForeignKey.related_name on Python 3.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -119,10 +119,18 @@ class RelatedField(Field):
         import re
         import keyword
         related_name = self.remote_field.related_name
-
-        is_valid_id = (related_name and re.match('^[a-zA-Z_][a-zA-Z0-9_]*$', related_name)
-                       and not keyword.iskeyword(related_name))
-        if related_name and not (is_valid_id or related_name.endswith('+')):
+        if not related_name:
+            return []
+        is_valid_id = True
+        if keyword.iskeyword(related_name):
+            is_valid_id = False
+        if six.PY3:
+            if not related_name.isidentifier():
+                is_valid_id = False
+        else:
+            if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*\Z', related_name):
+                is_valid_id = False
+        if not (is_valid_id or related_name.endswith('+')):
             return [
                 checks.Error(
                     "The name '%s' is invalid related_name for field %s.%s" %

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -5,6 +5,7 @@ from django.core.checks import Error, Warning as DjangoWarning
 from django.db import models
 from django.test.testcases import skipIfDBFeature
 from django.test.utils import override_settings
+from django.utils import six
 
 from .base import IsolatedModelsTestCase
 
@@ -559,9 +560,13 @@ class RelativeFieldTests(IsolatedModelsTestCase):
             'contains_%s_whitespace' % whitespace,
             'ends_with_with_illegal_non_alphanumeric_%s' % illegal_non_alphanumeric,
             'ends_with_whitespace_%s' % whitespace,
-            # Python's keyword
-            'with',
+            'with',  # Python's keyword
+            'related_name\n',
         ]
+        # The type fuction of Python 2 doesn't support the unicode strings.
+        # So only testing in Python 3.
+        if six.PY3:
+            invalid_related_names.append('，')
 
         class Parent(models.Model):
             pass
@@ -600,6 +605,10 @@ class RelativeFieldTests(IsolatedModelsTestCase):
             '_+',
             '+',
         ]
+        # The type fuction of Python 2 doesn't support the unicode strings.
+        # So only testing in Python 3.
+        if six.PY3:
+            related_names.extend(['試', '試驗+'])
 
         class Parent(models.Model):
             pass


### PR DESCRIPTION
add tests and implement for [25016](https://code.djangoproject.com/ticket/25016#comment:3)