### PR TITLE
Fixed a bug in unordered_list template filter.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -683,22 +683,28 @@ def unordered_list(value, autoescape=True):
 
     def walk_items(item_list):
         item_iterator = iter(item_list)
-        for item in item_iterator:
-            try:
-                next_item = next(item_iterator)
-            except StopIteration:
-                next_item = None
-            if not isinstance(next_item, six.string_types):
+        try:
+            item = next(item_iterator)
+            while True:
                 try:
-                    iter(next_item)
-                except TypeError:
-                    pass
-                else:
-                    yield item, next_item
-                    continue
-            yield item, None
-            if next_item:
-                yield next_item, None
+                    next_item = next(item_iterator)
+                except StopIteration:
+                    yield item, None
+                    break
+                if not isinstance(next_item, six.string_types):
+                    try:
+                        iter(next_item)
+                    except TypeError:
+                        pass
+                    else:
+                        yield item, next_item
+                        item = next(item_iterator)
+                        continue
+
+                yield item, None
+                item = next_item
+        except StopIteration:
+            pass
 
     def list_formatter(item_list, tabs=1):
         indent = '\t' * tabs

--- a/tests/template_tests/filter_tests/test_unordered_list.py
+++ b/tests/template_tests/filter_tests/test_unordered_list.py
@@ -83,6 +83,13 @@ class FunctionTests(SimpleTestCase):
             '</li>\n\t</ul>\n\t</li>\n\t<li>item 2</li>',
         )
 
+    def test_nested3(self):
+        self.assertEqual(
+            unordered_list(['item 1', 'item 2', ['item 2.1']]),
+            '\t<li>item 1</li>\n\t<li>item 2\n\t<ul>\n\t\t<li>item 2.1'
+            '</li>\n\t</ul>\n\t</li>',
+        )
+
     def test_nested_multiple(self):
         self.assertEqual(
             unordered_list(['item 1', ['item 1.1', ['item 1.1.1', ['item 1.1.1.1']]]]),


### PR DESCRIPTION
Fixed behavior of internal walk_items for cases such as ['a', 'a', ['b']].