### PR TITLE
[POC] #24721 -- Test extensions

### DIFF
--- a/django/contrib/messages/storage/locmem.py
+++ b/django/contrib/messages/storage/locmem.py
@@ -1,0 +1,15 @@
+from django.contrib import messages
+from django.contrib.messages.storage.base import BaseStorage
+
+
+class MemoryStorage(BaseStorage):
+
+    def _store(self, messages_to_store, response, *args, **kwargs):
+        if not hasattr(messages, 'outbox'):
+            messages.outbox = []
+        messages.outbox.extend(messages_to_store)
+
+    def _get(self, *args, **kwargs):
+        if not hasattr(messages, 'outbox'):
+            messages.outbox = []
+        return (messages.outbox, True)

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -11,7 +11,7 @@ class MessagesOutbox(TestExtension):
 
     def teardown_environment(self):
         settings.MESSAGE_STORAGE = self._original_message_storage
-        del self._original_message_storge
+        del self._original_message_storage
         del messages.outbox
 
     def setup_test(self):

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.contrib import messages
+from django.test.extensions import TestExtension
+
+
+class messagesOutbox(TestExtension):
+    def setup_test_environment(self):
+        self._original_message_storage = settings.MESSAGE_STORAGE
+        settings.MESSAGE_STORAGE = 'django.contrib.messages.storage.locmem.MemoryStorage'
+        messages.outbox = []
+
+    def teardown_test_environment(self):
+        settings.MESSAGE_STORAGE = self._original_message_storage
+        del self._original_message_storge
+        del messages.outbox
+
+    def pre_setup(self):
+        messages.outbox = []

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.test.extensions import TestExtension
 
 
-class messagesOutbox(TestExtension):
+class MessagesOutbox(TestExtension):
     def setup_test_environment(self):
         self._original_message_storage = settings.MESSAGE_STORAGE
         settings.MESSAGE_STORAGE = 'django.contrib.messages.storage.locmem.MemoryStorage'

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -4,15 +4,15 @@ from django.test.extensions import TestExtension
 
 
 class MessagesOutbox(TestExtension):
-    def setup_test_environment(self):
+    def setup_environment(self):
         self._original_message_storage = settings.MESSAGE_STORAGE
         settings.MESSAGE_STORAGE = 'django.contrib.messages.storage.locmem.MemoryStorage'
         messages.outbox = []
 
-    def teardown_test_environment(self):
+    def teardown_environment(self):
         settings.MESSAGE_STORAGE = self._original_message_storage
         del self._original_message_storge
         del messages.outbox
 
-    def pre_setup(self):
+    def setup_test(self):
         messages.outbox = []

--- a/django/contrib/messages/test.py
+++ b/django/contrib/messages/test.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
-from django.test.extensions import TestExtension
+from django.test import TestExtension
 
 
 class MessagesOutbox(TestExtension):

--- a/django/test/__init__.py
+++ b/django/test/__init__.py
@@ -3,6 +3,7 @@ Django Unit Test and Doctest framework.
 """
 
 from django.test.client import Client, RequestFactory
+from django.test.extensions import TestExtension
 from django.test.testcases import (
     TestCase, TransactionTestCase,
     SimpleTestCase, LiveServerTestCase, skipIfDBFeature,
@@ -15,7 +16,8 @@ __all__ = [
     'Client', 'RequestFactory', 'TestCase', 'TransactionTestCase',
     'SimpleTestCase', 'LiveServerTestCase', 'skipIfDBFeature',
     'skipUnlessAnyDBFeature', 'skipUnlessDBFeature', 'ignore_warnings',
-    'modify_settings', 'override_settings', 'override_system_checks'
+    'modify_settings', 'override_settings', 'override_system_checks',
+    'TestExtension'
 ]
 
 # To simplify Django's test suite; not meant as a public API

--- a/django/test/extensions.py
+++ b/django/test/extensions.py
@@ -3,29 +3,29 @@ from django.core import mail
 
 
 class TestExtension(object):
-    def setup_test_environment(self):
+    def setup_environment(self):
         pass
 
-    def teardown_test_environment(self):
+    def teardown_environment(self):
         pass
 
-    def pre_setup(self):
+    def setup_test(self):
         pass
 
-    def post_teardown(self):
+    def teardown_test(self):
         pass
 
 
 class MailOutbox(TestExtension):
-    def setup_test_environment(self):
+    def setup_environment(self):
         self._original_email_backend = settings.EMAIL_BACKEND
         settings.EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
         mail.outbox = []
 
-    def teardown_test_environment(self):
+    def teardown_environment(self):
         settings.EMAIL_BACKEND = self._original_email_backend
         del self._original_email_backend
         del mail.outbox
 
-    def pre_setup(self):
+    def setup_test(self):
         mail.outbox = []

--- a/django/test/extensions.py
+++ b/django/test/extensions.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.core import mail
+
+
+class TestExtension(object):
+    def setup_test_environment(self):
+        pass
+
+    def teardown_test_environment(self):
+        pass
+
+    def pre_setup(self):
+        pass
+
+    def post_teardown(self):
+        pass
+
+
+class MailOutbox(TestExtension):
+    def setup_test_environment(self):
+        self._original_email_backend = settings.EMAIL_BACKEND
+        settings.EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+        mail.outbox = []
+
+    def teardown_test_environment(self):
+        settings.EMAIL_BACKEND = self._original_email_backend
+        del self._original_email_backend
+        del mail.outbox
+
+    def pre_setup(self):
+        mail.outbox = []

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -108,7 +108,7 @@ class DiscoverRunner(object):
 
     def build_suite(self, test_labels=None, extra_tests=None, **kwargs):
         suite = self.test_suite()
-        test_labels = test_labels if test_labels is not None else ['.']
+        test_labels = test_labels or ['.']
         extra_tests = extra_tests or []
 
         discover_kwargs = {}

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -1,7 +1,7 @@
-from collections import OrderedDict
 import logging
 import os
 import unittest
+from collections import OrderedDict
 from importlib import import_module
 from unittest import TestSuite, defaultTestLoader
 

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -175,8 +175,8 @@ class DiscoverRunner(object):
             if isinstance(extension, string_types):
                 extension = import_string(extension)
             extensions[extension] = extension()
-        self.add_extensions_to_tests(suite, extensions, extensions.keys())
-        self._extensions = extensions.values()
+        self.add_extensions_to_tests(suite, extensions, list(extensions.keys()))
+        self._extensions = list(extensions.values())
 
     def add_extensions_to_tests(self, suite, extensions, global_extensions):
         for test in suite._tests:

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -108,7 +108,7 @@ class DiscoverRunner(object):
     def setup_test_environment(self, **kwargs):
         setup_test_environment()
         for extension in self._extensions:
-            extension.setup_test_environment()
+            extension.setup_environment()
         settings.DEBUG = False
         unittest.installHandler()
 
@@ -211,7 +211,7 @@ class DiscoverRunner(object):
     def teardown_test_environment(self, **kwargs):
         unittest.removeHandler()
         for extension in reversed(self._extensions):
-            extension.teardown_test_environment()
+            extension.teardown_environment()
         teardown_test_environment()
 
     def suite_result(self, suite, result, **kwargs):

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -183,13 +183,15 @@ class DiscoverRunner(object):
             if hasattr(test, '_tests'):
                 self.add_extensions_to_tests(test, extensions, global_extensions)
             else:
-                test_level_extensions = getattr(test, 'extensions', [])
-                test_level_extensions = [e for e in test_level_extensions if e not in global_extensions]
+                test_level_extensions = []
+                for extension in getattr(test, 'extensions', []):
+                    if isinstance(extension, string_types):
+                        extension = import_string(extension)
+                    if extension not in global_extensions:
+                        test_level_extensions.append(extension)
                 test._extensions = []
                 for extension in global_extensions + test_level_extensions:
                     if extension not in extensions:
-                        if isinstance(extension, string_types):
-                            extension = import_string(extension)
                         extensions[extension] = extension()
                     test._extensions.append(extensions[extension])
 

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -247,7 +247,7 @@ class SimpleTestCase(unittest.TestCase):
         """
         self._urlconf_teardown()
         for extension in reversed(self._extensions):
-            extension.pre_setup()
+            extension.post_teardown()
 
     def _urlconf_teardown(self):
         if hasattr(self, '_old_root_urlconf'):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -160,6 +160,7 @@ class SimpleTestCase(unittest.TestCase):
     client_class = Client
     _overridden_settings = None
     _modified_settings = None
+    extensions = []
     _extensions = []
 
     # Tests shouldn't be allowed to query the database since

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -227,7 +227,7 @@ class SimpleTestCase(unittest.TestCase):
         self.client = self.client_class()
         self._urlconf_setup()
         for extension in self._extensions:
-            extension.pre_setup()
+            extension.setup_test()
 
     def _urlconf_setup(self):
         if hasattr(self, 'urls'):
@@ -248,7 +248,7 @@ class SimpleTestCase(unittest.TestCase):
         """
         self._urlconf_teardown()
         for extension in reversed(self._extensions):
-            extension.post_teardown()
+            extension.teardown_test()
 
     def _urlconf_teardown(self):
         if hasattr(self, '_old_root_urlconf'):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -18,7 +18,6 @@ from unittest.util import safe_repr
 
 from django.apps import apps
 from django.conf import settings
-from django.core import mail
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.handlers.wsgi import WSGIHandler, get_path_info
 from django.core.management import call_command
@@ -223,11 +222,11 @@ class SimpleTestCase(unittest.TestCase):
 
         * Creating a test client.
         * If the class has a 'urls' attribute, replace ROOT_URLCONF with it.
-        * Clearing the mail test outbox.
         """
         self.client = self.client_class()
         self._urlconf_setup()
-        mail.outbox = []
+        for extension in self._extensions:
+            extension.pre_setup()
 
     def _urlconf_setup(self):
         if hasattr(self, 'urls'):
@@ -247,6 +246,8 @@ class SimpleTestCase(unittest.TestCase):
         * Putting back the original ROOT_URLCONF if it was changed.
         """
         self._urlconf_teardown()
+        for extension in reversed(self._extensions):
+            extension.pre_setup()
 
     def _urlconf_teardown(self):
         if hasattr(self, '_old_root_urlconf'):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -160,6 +160,7 @@ class SimpleTestCase(unittest.TestCase):
     client_class = Client
     _overridden_settings = None
     _modified_settings = None
+    _extensions = []
 
     # Tests shouldn't be allowed to query the database since
     # this base class doesn't enforce any isolation.

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -10,7 +10,6 @@ from xml.dom.minidom import Node, parseString
 
 from django.apps import apps
 from django.conf import UserSettingsHolder, settings
-from django.core import mail
 from django.core.signals import request_started
 from django.core.urlresolvers import get_script_prefix, set_script_prefix
 from django.db import reset_queries
@@ -96,7 +95,6 @@ def setup_test_environment():
     """Perform any global pre-test setup. This involves:
 
         - Installing the instrumented test renderer
-        - Set the email backend to the locmem email backend.
         - Setting the active locale to match the LANGUAGE_CODE setting.
     """
     Template._original_render = Template._render
@@ -105,13 +103,8 @@ def setup_test_environment():
     # Storing previous values in the settings module itself is problematic.
     # Store them in arbitrary (but related) modules instead. See #20636.
 
-    mail._original_email_backend = settings.EMAIL_BACKEND
-    settings.EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
-
     request._original_allowed_hosts = settings.ALLOWED_HOSTS
     settings.ALLOWED_HOSTS = ['*']
-
-    mail.outbox = []
 
     deactivate()
 
@@ -120,19 +113,13 @@ def teardown_test_environment():
     """Perform any global post-test teardown. This involves:
 
         - Restoring the original test renderer
-        - Restoring the email sending functions
 
     """
     Template._render = Template._original_render
     del Template._original_render
 
-    settings.EMAIL_BACKEND = mail._original_email_backend
-    del mail._original_email_backend
-
     settings.ALLOWED_HOSTS = request._original_allowed_hosts
     del request._original_allowed_hosts
-
-    del mail.outbox
 
 
 def get_runner(settings, test_runner_class=None):

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -4,7 +4,10 @@ from django.test import SimpleTestCase, override_settings
 from .urls import ContactFormViewWithMsg
 
 
-@override_settings(ROOT_URLCONF='messages_tests.urls')
+@override_settings(
+    ROOT_URLCONF='messages_tests.urls',
+    MESSAGE_STORAGE='django.contrib.messages.storage.cookie.CookieStorage',
+)
 class SuccessMessageMixinTests(SimpleTestCase):
 
     def test_set_messages_success(self):

--- a/tests/messages_tests/test_test_extension.py
+++ b/tests/messages_tests/test_test_extension.py
@@ -1,0 +1,18 @@
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
+
+from .urls import ContactFormViewWithMsg
+
+
+@override_settings(ROOT_URLCONF='messages_tests.urls')
+class TestMessagesOutbox(TestCase):
+    extensions = ['django.contrib.messages.test.MessagesOutbox']
+
+    def test_set_messages_success(self):
+        author = {'name': 'John Doe',
+                  'slug': 'success-msg'}
+        add_url = reverse('add_success_msg')
+        self.client.post(add_url, author)
+        self.assertEqual(ContactFormViewWithMsg.success_message % author,
+                      messages.outbox[0].message)

--- a/tests/test_runner/test_extensions.py
+++ b/tests/test_runner/test_extensions.py
@@ -2,7 +2,6 @@ from django.test import TestCase, TestExtension
 from django.test.runner import DiscoverRunner
 from django.utils import six
 
-
 state = {
     'count': 0,
 }

--- a/tests/test_runner/test_extensions.py
+++ b/tests/test_runner/test_extensions.py
@@ -1,0 +1,97 @@
+from django.test import TestCase, TestExtension
+from django.test.runner import DiscoverRunner
+from django.utils import six
+
+
+state = {
+    'count': 0,
+}
+
+
+class PlainRunner(DiscoverRunner):
+    """Strip default test runner behaviour."""
+    extensions = []
+
+    def setup_test_environment(self):
+        pass
+
+    def setup_databases(self):
+        pass
+
+    def teardown_test_environment(self):
+        pass
+
+    def teardown_databases(self, config):
+        pass
+
+
+class EnvironmentExtension(TestExtension):
+    def setup_environment(self):
+        state['count'] += 1
+
+    def teardown_environment(self):
+        state['count'] -= 1
+
+
+class EnvironmentRunner(PlainRunner):
+    extensions = ['test_runner.test_extensions.EnvironmentExtension']
+
+
+class TestCaseExtension(TestExtension):
+    def setup_test(self):
+        state['count'] += 1
+
+    def teardown_test(self):
+        state['count'] -= 1
+
+
+class TestCaseRunner(PlainRunner):
+    extensions = ['test_runner.test_extensions.TestCaseExtension']
+
+
+class TestExtensions(TestCase):
+    def _run_tests(self, runner_class, tests):
+        runner = runner_class()
+        stream = six.StringIO()
+        return runner.run_tests(test_labels=[], extra_tests=tests, stream=stream)
+
+    class CountOneTest(TestCase):
+        def runTest(self):
+            self.assertEqual(state['count'], 1)
+
+    class ExtendedCountOneTest(TestCase):
+        extensions = ['test_runner.test_extensions.EnvironmentExtension']
+
+        def runTest(self):
+            self.assertEqual(state['count'], 1)
+
+    class CountTwoTest(TestCase):
+        extensions = ['test_runner.test_extensions.TestCaseExtension']
+
+        def runTest(self):
+            self.assertEqual(state['count'], 2)
+
+    def test_setup_environment_runner(self):
+        result = self._run_tests(EnvironmentRunner, [self.CountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
+    def test_setup_environment_testcase(self):
+        result = self._run_tests(PlainRunner, [self.ExtendedCountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
+    def test_setup_test_runner(self):
+        result = self._run_tests(TestCaseRunner, [self.CountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
+    def test_multiple_extensions(self):
+        result = self._run_tests(EnvironmentRunner, [self.CountTwoTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
+    def test_deduplication(self):
+        result = self._run_tests(EnvironmentRunner, [self.ExtendedCountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)

--- a/tests/test_runner/test_extensions.py
+++ b/tests/test_runner/test_extensions.py
@@ -64,6 +64,12 @@ class TestExtensions(TestCase):
         def runTest(self):
             self.assertEqual(state['count'], 1)
 
+    class ClassExtendedCountOneTest(TestCase):
+        extensions = [EnvironmentExtension]
+
+        def runTest(self):
+            self.assertEqual(state['count'], 1)
+
     class CountTwoTest(TestCase):
         extensions = ['test_runner.test_extensions.TestCaseExtension']
 
@@ -80,6 +86,11 @@ class TestExtensions(TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(state['count'], 0)
 
+    def test_setup_environment_testcase_class(self):
+        result = self._run_tests(PlainRunner, [self.ClassExtendedCountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
     def test_setup_test_runner(self):
         result = self._run_tests(TestCaseRunner, [self.CountOneTest()])
         self.assertEqual(result, 0)
@@ -92,5 +103,10 @@ class TestExtensions(TestCase):
 
     def test_deduplication(self):
         result = self._run_tests(EnvironmentRunner, [self.ExtendedCountOneTest()])
+        self.assertEqual(result, 0)
+        self.assertEqual(state['count'], 0)
+
+    def test_deduplication_classes(self):
+        result = self._run_tests(EnvironmentRunner, [self.ClassExtendedCountOneTest()])
         self.assertEqual(result, 0)
         self.assertEqual(state['count'], 0)

--- a/tests/test_runner/test_extensions.py
+++ b/tests/test_runner/test_extensions.py
@@ -2,6 +2,8 @@ from django.test import TestCase, TestExtension
 from django.test.runner import DiscoverRunner
 from django.utils import six
 
+from .test_discover_runner import change_cwd
+
 state = {
     'count': 0,
 }
@@ -50,9 +52,10 @@ class TestCaseRunner(PlainRunner):
 
 class TestExtensions(TestCase):
     def _run_tests(self, runner_class, tests):
-        runner = runner_class()
-        stream = six.StringIO()
-        return runner.run_tests(test_labels=[], extra_tests=tests, stream=stream)
+        with change_cwd('no_tests'):
+            runner = runner_class()
+            stream = six.StringIO()
+            return runner.run_tests(test_labels=[], extra_tests=tests, stream=stream)
 
     class CountOneTest(TestCase):
         def runTest(self):


### PR DESCRIPTION
Proof of concept code to demonstrate test extensions, with the two main examples implemented.

Other possible use cases:
- Alternative data stores - a RedisExtension which selects an empty redis db and flushes it after each test
- Queue management - record celery tasks which have been queued and/or called by means of a custom Broker
- Setting up an external authentication system

Thoughts:

- Recursively iterating through the test suite classes to add `_extensions` is kinda ugly, but I deemed it preferable to the alternative code which would involve a global set of extensions. If nothing else, this will be easier to test.
- ~~As yet, I have not added a setting. There is some merit in `TEXT_EXTENSIONS` rather than subclassing the test runner, but given we already have `TEST_RUNNER`, and this functionality is dependent on the test runner being a subclass of our `DiscoverRunner`, I'm not sure it's worth worrying.~~
- ~~Current code in `TestCase` is not robust to the absence of `_extensions`.~~
- ~~Might be nice to allow the customisation of extensions on individual `TestCase` classes.~~
- Instead of attaching to `mail.outbox` and `messages.outbox`, how about attaching `TestCase._env` where such objects could live?
- Adding assertion helper methods could be nice too, but would be very magical