### PR TITLE
Fixed #24994 -- Documented, checked that settings.SECRET_KEY is valid unicode string.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -469,6 +469,8 @@ of the :djadmin:`check` command:
   ``'DENY'``. The default is ``'SAMEORIGIN'``, but unless there is a good reason
   for your site to serve other parts of itself in a frame, you should change
   it to ``'DENY'``.
+* **security.W020**: Your :setting:`SECRET_KEY` is invalid unicode.
+  Please generate a valid unicode string.
 
 Sites
 -----

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1901,7 +1901,7 @@ Default: ``''`` (Empty string)
 
 A secret key for a particular Django installation. This is used to provide
 :doc:`cryptographic signing </topics/signing>`, and should be set to a unique,
-unpredictable value.
+unpredictable, valid unicode string.
 
 :djadmin:`django-admin startproject <startproject>` automatically adds a
 randomly-generated ``SECRET_KEY`` to each new project.

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -92,3 +92,6 @@ Bugfixes
 
 * Fixed a regression in the ``unordered_list`` template filter on certain
   inputs (:ticket:`25031`).
+
+* Checked and documented that ``settings.SECRET_KEY`` is a valid unicode
+  string (:ticket:`24994`).

--- a/tests/check_framework/test_security.py
+++ b/tests/check_framework/test_security.py
@@ -429,11 +429,11 @@ class CheckSSLRedirectTest(SimpleTestCase):
         self.assertEqual(self.func(None), [])
 
 
-class CheckSecretKeyTest(SimpleTestCase):
+class CheckSecretKeyLengthTest(SimpleTestCase):
     @property
     def func(self):
-        from django.core.checks.security.base import check_secret_key
-        return check_secret_key
+        from django.core.checks.security.base import check_secret_key_length
+        return check_secret_key_length
 
     @override_settings(SECRET_KEY=('abcdefghijklmnopqrstuvwx' * 2) + 'ab')
     def test_okay_secret_key(self):
@@ -464,6 +464,18 @@ class CheckSecretKeyTest(SimpleTestCase):
         self.assertGreater(len(settings.SECRET_KEY), base.SECRET_KEY_MIN_LENGTH)
         self.assertLess(len(set(settings.SECRET_KEY)), base.SECRET_KEY_MIN_UNIQUE_CHARACTERS)
         self.assertEqual(self.func(None), [base.W009])
+
+
+class CheckSecretKeyValidUnicodeTest(SimpleTestCase):
+    @property
+    def func(self):
+        from django.core.checks.security.base import check_secret_key_valid_unicode
+        return check_secret_key_valid_unicode
+
+    @override_settings(SECRET_KEY=(b'\xffabcdefghijklmnopqrstuvwxyz' * 2))
+    def test_invalid_unicode_secret_key(self):
+        self.assertGreater(len(settings.SECRET_KEY), base.SECRET_KEY_MIN_LENGTH)
+        self.assertEqual(self.func(None), [base.W020])
 
 
 class CheckDebugTest(SimpleTestCase):


### PR DESCRIPTION
Documented that the settings.SECRET_KEY should be valid unicode, and checked
that it does indeed pass our expectations. In case of failure, it emits a
readable warning.