### PR TITLE
Fixed #25050 -- Allowed serialization of models with deferred fields.

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -37,7 +37,8 @@ class Serializer(base.Serializer):
         self._current = None
 
     def get_dump_object(self, obj):
-        data = OrderedDict([('model', force_text(obj._meta))])
+        model = obj._meta.proxy_for_model if obj._deferred else obj.__class__
+        data = OrderedDict([('model', force_text(model._meta))])
         if not self.use_natural_primary_keys or not hasattr(obj, 'natural_key'):
             data["pk"] = force_text(obj._get_pk_val(), strings_only=True)
         data['fields'] = self._current

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -52,7 +52,8 @@ class Serializer(base.Serializer):
             raise base.SerializationError("Non-model object (%s) encountered during serialization" % type(obj))
 
         self.indent(1)
-        attrs = OrderedDict([("model", smart_text(obj._meta))])
+        model = obj._meta.proxy_for_model if obj._deferred else obj.__class__
+        attrs = OrderedDict([("model", smart_text(model._meta))])
         if not self.use_natural_primary_keys or not hasattr(obj, 'natural_key'):
             obj_pk = obj._get_pk_val()
             if obj_pk is not None:

--- a/tests/serializers/tests.py
+++ b/tests/serializers/tests.py
@@ -224,6 +224,13 @@ class SerializersTestBase(object):
                                                 serial_str))
         self.assertEqual(deserial_objs[0].object.score, Approximate(3.4, places=1))
 
+    def test_deferred_field_serialization(self):
+        author = Author.objects.create(name='Victor Hugo')
+        author = Author.objects.defer('name').get(pk=author.pk)
+        serial_str = serializers.serialize(self.serializer_name, [author])
+        deserial_objs = list(serializers.deserialize(self.serializer_name, serial_str))
+        self.assertEqual(deserial_objs[0].object.__class__, Author)
+
     def test_custom_field_serialization(self):
         """Tests that custom fields serialize and deserialize intact"""
         team_str = "Spartak Moskva"


### PR DESCRIPTION
If the object's class is a model with deferred fields, retrieve the
original model and use it for the serialization.