### PR TITLE
Fixed #25054 -- Added app_label to swapped model AttributeError

### DIFF
--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -270,8 +270,8 @@ class SwappedManagerDescriptor(object):
         self.model = model
 
     def __get__(self, instance, type=None):
-        raise AttributeError("Manager isn't available; %s has been swapped for '%s'" % (
-            self.model._meta.object_name, self.model._meta.swapped
+        raise AttributeError("Manager isn't available; '%s.%s' has been swapped for '%s'" % (
+            self.model._meta.app_label, self.model._meta.object_name, self.model._meta.swapped
         ))
 
 

--- a/tests/managers_regress/tests.py
+++ b/tests/managers_regress/tests.py
@@ -113,7 +113,7 @@ class ManagersRegressionTests(TestCase):
                 SwappableModel.objects.all()
                 self.fail('Should raise an AttributeError')
             except AttributeError as e:
-                self.assertEqual(str(e), "Manager isn't available; SwappableModel has been swapped for 'managers_regress.Parent'")
+                self.assertEqual(str(e), "Manager isn't available; 'managers_regress.SwappableModel' has been swapped for 'managers_regress.Parent'")
 
         finally:
             apps.app_configs['managers_regress'].models = _old_models
@@ -141,7 +141,7 @@ class ManagersRegressionTests(TestCase):
                 SwappableModel.stuff.all()
                 self.fail('Should raise an AttributeError')
             except AttributeError as e:
-                self.assertEqual(str(e), "Manager isn't available; SwappableModel has been swapped for 'managers_regress.Parent'")
+                self.assertEqual(str(e), "Manager isn't available; 'managers_regress.SwappableModel' has been swapped for 'managers_regress.Parent'")
 
         finally:
             apps.app_configs['managers_regress'].models = _old_models
@@ -169,7 +169,7 @@ class ManagersRegressionTests(TestCase):
                 SwappableModel.objects.all()
                 self.fail('Should raise an AttributeError')
             except AttributeError as e:
-                self.assertEqual(str(e), "Manager isn't available; SwappableModel has been swapped for 'managers_regress.Parent'")
+                self.assertEqual(str(e), "Manager isn't available; 'managers_regress.SwappableModel' has been swapped for 'managers_regress.Parent'")
 
         finally:
             apps.app_configs['managers_regress'].models = _old_models


### PR DESCRIPTION
This is useful if you have swapped a model for one with the same name but
in another app - "User has been swapped with User", etc.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>