### PR TITLE
Added necessary dict() call to from_db example code

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -100,7 +100,7 @@ are loaded from the database::
         instance._state.adding = False
         instance._state.db = db
         # customization to store the original field values on the instance
-        instance._loaded_values = zip(field_names, values)
+        instance._loaded_values = dict(zip(field_names, values))
         return instance
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
This is a very small fix to the sample code documentation for from_db. The call to zip() alone just returns a list (or a zip object in Python 3).