### PR TITLE
migrations: loader: warn in case an explicit migration module is not found

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -12,6 +12,9 @@ from django.utils import six
 
 from .exceptions import AmbiguityError, BadMigrationError, NodeNotFoundError
 
+import logging
+logger = logging.getLogger(__name__)
+
 MIGRATIONS_MODULE_NAME = 'migrations'
 
 
@@ -74,6 +77,9 @@ class MigrationLoader(object):
                 # Might be better to try a directory check directly.
                 if "No module named" in str(e) and MIGRATIONS_MODULE_NAME in str(e):
                     self.unmigrated_apps.add(app_config.label)
+                    if app_config.label in settings.MIGRATION_MODULES:
+                        logger.warn('No migrations found for {}, which is configured explicitly in MIGRATION_MODULES ({}).'.format(
+                            app_config.label, module_name))
                     continue
                 raise
             else:


### PR DESCRIPTION
Logging a warning in this case helps with tracking down errors where you
have an invalid entry in MIGRATION_MODULES.

Does this make sense?
Is it OK to add `logging` here?