### PR TITLE
Fixed #25079 -- Added warning if both TEMPLATES and TEMPLATE_* settings are defined.

### DIFF
--- a/django/core/checks/__init__.py
+++ b/django/core/checks/__init__.py
@@ -8,6 +8,7 @@ from .messages import (
 from .registry import Tags, register, run_checks, tag_exists
 
 # Import these to force registration of checks
+import django.core.checks.compatibility.django_1_8_0  # NOQA isort:skip
 import django.core.checks.model_checks  # NOQA isort:skip
 import django.core.checks.security.base  # NOQA isort:skip
 import django.core.checks.security.csrf  # NOQA isort:skip

--- a/django/core/checks/compatibility/django_1_8_0.py
+++ b/django/core/checks/compatibility/django_1_8_0.py
@@ -1,0 +1,29 @@
+from __future__ import unicode_literals
+
+from django.conf import global_settings, settings
+
+from .. import Tags, Warning, register
+
+
+@register(Tags.compatibility)
+def check_duplicate_template_settings(app_configs, **kwargs):
+    if settings.TEMPLATES:
+        values = [
+            'TEMPLATE_DIRS',
+            'ALLOWED_INCLUDE_ROOTS',
+            'TEMPLATE_CONTEXT_PROCESSORS',
+            'TEMPLATE_DEBUG',
+            'TEMPLATE_LOADERS',
+            'TEMPLATE_STRING_IF_INVALID'
+        ]
+        duplicates = [value for value in values
+            if getattr(settings, value) != getattr(global_settings, value)]
+        if duplicates:
+            return [Warning(
+                "The standalone TEMPLATE_* settings were deprecated in Django "
+                "1.8 and the TEMPLATES dictionary takes precedence. You must "
+                "put the values of the following settings into your default "
+                "TEMPLATES dict: %s " % ", ".join(duplicates),
+                id='1_8.W001'
+            )]
+    return []

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -19,6 +19,7 @@ Django's system checks are organized using the following tags:
 * ``admin``: Checks of any admin site declarations.
 * ``compatibility``: Flagging potential problems with version upgrades.
 * ``security``: Checks security related configuration.
+* ``templates``: Checks template related configuration.
 
 Some checks may be registered with multiple tags.
 
@@ -185,6 +186,12 @@ that might occur as a result of a version upgrade.
   ``django.contrib.messages.middleware.MessageMiddleware`` were removed from
   the defaults. If your project needs these middleware then you should
   configure this setting. *This check was removed in Django 1.9*.
+* **1_8.W001**: The standalone ``TEMPLATE_*`` settings were deprecated in
+  Django 1.8 and the :setting:`TEMPLATES` dictionary takes precedence. You must
+  put the values of the following settings into your defaults ``TEMPLATES`` dict:
+  :setting:`TEMPLATE_DIRS`, :setting:`ALLOWED_INCLUDE_ROOTS`,
+  :setting:`TEMPLATE_CONTEXT_PROCESSORS`, :setting:`TEMPLATE_DEBUG`,
+  :setting:`TEMPLATE_LOADERS`, :setting:`TEMPLATE_STRING_IF_INVALID`
 
 Admin
 -----

--- a/tests/check_framework/test_compatibility.py
+++ b/tests/check_framework/test_compatibility.py
@@ -1,0 +1,26 @@
+from django.core.checks.compatibility.django_1_8_0 import \
+    check_duplicate_template_settings
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+
+class CheckDuplicateTemplateSettingsTest(SimpleTestCase):
+
+    def test_not_raised_if_no_templates_setting(self):
+        self.assertEqual(check_duplicate_template_settings(None), [])
+
+    @override_settings(TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    }], TEMPLATE_DIRS=['/path/to/dirs'])
+    def test_duplicate_setting(self):
+        result = check_duplicate_template_settings(None)
+        self.assertEqual(result[0].id, '1_8.W001')
+
+    @override_settings(TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    }], TEMPLATE_DIRS=['/path/to/dirs'], TEMPLATE_DEBUG=True)
+    def test_multiple_duplicate_settings(self):
+        result = check_duplicate_template_settings(None)
+        self.assertEqual(len(result), 1)
+        self.assertTrue('TEMPLATE_DIRS' in result[0].msg)
+        self.assertTrue('TEMPLATE_DEBUG' in result[0].msg)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -107,8 +107,6 @@ def setup(verbosity, test_labels):
     state = {
         'INSTALLED_APPS': settings.INSTALLED_APPS,
         'ROOT_URLCONF': getattr(settings, "ROOT_URLCONF", ""),
-        # Remove the following line in Django 1.10.
-        'TEMPLATE_DIRS': settings.TEMPLATE_DIRS,
         'TEMPLATES': settings.TEMPLATES,
         'LANGUAGE_CODE': settings.LANGUAGE_CODE,
         'STATIC_URL': settings.STATIC_URL,
@@ -121,8 +119,6 @@ def setup(verbosity, test_labels):
     settings.ROOT_URLCONF = 'urls'
     settings.STATIC_URL = '/static/'
     settings.STATIC_ROOT = os.path.join(TMPDIR, 'static')
-    # Remove the following line in Django 1.10.
-    settings.TEMPLATE_DIRS = [TEMPLATE_DIR]
     settings.TEMPLATES = [{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [TEMPLATE_DIR],


### PR DESCRIPTION
Django ignores the value of the TEMPLATE_* settings if TEMPLATES is also set,
which is confusing for users following older tutorials. Raise a system check
warning in this circumstance to explain what is going wrong.

Removes the TEMPLATE_DIRS from the test settings file; this was marked
for removal in 1.10 but no tests fail if it is removed now.

Refs https://code.djangoproject.com/ticket/25079