### PR TITLE
response.context_data -> response.context

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -405,7 +405,7 @@ based on :class:`~django.views.generic.list.ListView`:
             """Return the last five published questions."""
             return Question.objects.order_by('-pub_date')[:5]
 
-``response.context_data['latest_question_list']`` extracts the data this view
+``response.context['latest_question_list']`` extracts the data this view
 places into the context.
 
 We need to amend the ``get_queryset`` method and change it so that it also


### PR DESCRIPTION
As far as a I know `response.context_data` should be `response.context`