### PR TITLE
Fixed #25083 -- Added SessionAuthenticationMiddleware to auth installation docs

### DIFF
--- a/docs/topics/auth/index.txt
+++ b/docs/topics/auth/index.txt
@@ -60,12 +60,13 @@ startproject <startproject>`, these consist of two items listed in your
    </ref/contrib/contenttypes>`, which allows permissions to be associated with
    models you create.
 
-and two items in your :setting:`MIDDLEWARE_CLASSES` setting:
+and three items in your :setting:`MIDDLEWARE_CLASSES` setting:
 
 1. :class:`~django.contrib.sessions.middleware.SessionMiddleware` manages
    :doc:`sessions </topics/http/sessions>` across requests.
 2. :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` associates
    users with requests using sessions.
+3. :class:`~django.contrib.auth.middleware.SessionAuthenticationMiddleware` logs users out of their other sessions after a password change.
 
 With these settings in place, running the command ``manage.py migrate`` creates
 the necessary database tables for auth related models and permissions for any

--- a/docs/topics/auth/index.txt
+++ b/docs/topics/auth/index.txt
@@ -66,7 +66,8 @@ and three items in your :setting:`MIDDLEWARE_CLASSES` setting:
    :doc:`sessions </topics/http/sessions>` across requests.
 2. :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` associates
    users with requests using sessions.
-3. :class:`~django.contrib.auth.middleware.SessionAuthenticationMiddleware` logs users out of their other sessions after a password change.
+3. :class:`~django.contrib.auth.middleware.SessionAuthenticationMiddleware`
+   logs users out of their other sessions after a password change.
 
 With these settings in place, running the command ``manage.py migrate`` creates
 the necessary database tables for auth related models and permissions for any


### PR DESCRIPTION
Correction to my previous PR (https://github.com/django/django/pull/4963)

The (new in 1.7) django.contrib.auth.middleware.SessionAuthenticationMiddleware is an incredibly important security improvement that insures a user's other sessions are logged out after a password change.  We should add it to the >1.7 docs on auth installation as a default.