### PR TITLE
Fixes #25086 -- Allow mass updating of fields in unpersisted model objects

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1608,6 +1608,16 @@ class Model(six.with_metaclass(ModelBase)):
 
         return errors
 
+    def assign_attributes(self, values_dict):
+        """
+        Helper method to mass update fields in an unpersisted model object.
+        """
+        keys = values_dict.keys()
+        fields = [f.name for f in self._meta.get_fields()]
+        for k in keys:
+            if k in fields:
+                setattr(self, k, values_dict[k])
+
 
 ############################################
 # HELPER FUNCTIONS (CURRIED MODEL METHODS) #

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -995,3 +995,13 @@ class CustomFieldTests(unittest.TestCase):
             'exact', 'TEST', connection=connection, prepared=False
         )
         self.assertEqual(field.prep_value_count, 1)
+
+
+class AssignAttributesTest(unittest.TestCase):
+
+    def test_assign_attributes(self):
+        my_model = Foo()
+        my_model.a = 'Hi'
+        my_model.assign_attributes({'a': 'Updated!', 'd': 20.00})
+        self.assertEqual('Updated!', my_model.a)
+        self.assertEqual(20.00, my_model.d)


### PR DESCRIPTION
Fixes #25086.

Sometimes we have an unpersisted model instance generated from, say, a factory. Before saving this to the database, we might want to do some additional processing to update the fields.

I think it's a good idea to provide a helper method to mass update the fields, particularly if it's a model with many fields. 