### PR TITLE
Fixed #25072 -- Prevented GDALRaster memory to be uncollectable

### DIFF
--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -23,6 +23,11 @@ class RasterFieldTest(TransactionTestCase):
         r.refresh_from_db()
         self.assertIsNone(r.rast)
 
+    def test_access_band_data_directly_from_queryset(self):
+        RasterModel.objects.create(rast=JSON_RASTER)
+        qs = RasterModel.objects.all()
+        qs[0].rast.bands[0].data()
+
     def test_model_creation(self):
         """
         Test RasterField through a test model.


### PR DESCRIPTION
Setting GDALRaster.bands as a cached property is creating a circular
reference with objects having __del__ methods, which means the memory
can never be freed.