### PR TITLE
Add fix in case if site variable doesn't exists.

### DIFF
--- a/django/contrib/sitemaps/views.py
+++ b/django/contrib/sitemaps/views.py
@@ -59,6 +59,7 @@ def sitemap(request, sitemaps, section=None,
     page = request.GET.get("p", 1)
 
     urls = []
+    site = {}
     for site in maps:
         try:
             if callable(site):
@@ -71,7 +72,7 @@ def sitemap(request, sitemaps, section=None,
             raise Http404("No page '%s'" % page)
     response = TemplateResponse(request, template_name, {'urlset': urls},
                                 content_type=content_type)
-    if hasattr(site, 'latest_lastmod'):
+    if 'site' in locals() and hasattr(site, 'latest_lastmod'):
         # if latest_lastmod is defined for site, set header so as
         # ConditionalGetMiddleware is able to send 304 NOT MODIFIED
         lastmod = site.latest_lastmod


### PR DESCRIPTION
*site* variable is referenced outside for loop where it is discarded. Added check if site variable exists at all (it could be done via try/catch block too).

```
Environment:

Request Method: GET
Request URL: http://localhost:5000/sitemap.xml

Django Version: 1.8
Python Version: 2.7.6

Traceback:
File "/home/<??>/.virtualenvs/bunited/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/<??>/.virtualenvs/bunited/local/lib/python2.7/site-packages/django/contrib/sitemaps/views.py" in inner
  17.         response = func(request, *args, **kwargs)
File "/home/<??>/.virtualenvs/bunited/local/lib/python2.7/site-packages/django/contrib/sitemaps/views.py" in sitemap
  75.     if hasattr(site, 'latest_lastmod'):

Exception Type: UnboundLocalError at /sitemap.xml
Exception Value: local variable 'site' referenced before assignment
```