### PR TITLE
Fixed #25081 -- Prevented DISTINCT ON ordering from being cleared in get().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -376,7 +376,7 @@ class QuerySet(object):
         keyword arguments.
         """
         clone = self.filter(*args, **kwargs)
-        if self.query.can_filter():
+        if self.query.can_filter() and not self.query.distinct_fields:
             clone = clone.order_by()
         num = len(clone)
         if num == 1:

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -129,3 +129,11 @@ class DistinctOnTests(TestCase):
             qs, [self.p1_o2, self.p2_o1, self.p3_o1],
             lambda x: x
         )
+
+    def test_distinct_on_get_ordering_preserved(self):
+        """
+        Ordering shouldn't be cleared when distinct on fields are specified.
+        refs #25081
+        """
+        staff = Staff.objects.distinct('name').order_by('name', '-organisation').get(name='p1')
+        self.assertEqual(staff.organisation, 'o2')

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -280,6 +280,14 @@ class Queries1Tests(BaseQuerysetTest):
         qs = qs.order_by('id')
         self.assertNotIn('OUTER JOIN', str(qs.query))
 
+    def test_get_clears_ordering(self):
+        """
+        get() should clear ordering for optimization purposes.
+        """
+        with CaptureQueriesContext(connection) as captured_queries:
+            Author.objects.order_by('name').get(pk=self.a1.pk)
+        self.assertNotIn('order by', captured_queries[0]['sql'].lower())
+
     def test_tickets_4088_4306(self):
         self.assertQuerysetEqual(
             Report.objects.filter(creator=1001),

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1950,7 +1950,7 @@ class ExistsSql(TestCase):
             self.assertFalse(Tag.objects.exists())
         # Ok - so the exist query worked - but did it include too many columns?
         self.assertEqual(len(captured_queries), 1)
-        qstr = captured_queries[0]
+        qstr = captured_queries[0]['sql']
         id, name = connection.ops.quote_name('id'), connection.ops.quote_name('name')
         self.assertNotIn(id, qstr)
         self.assertNotIn(name, qstr)


### PR DESCRIPTION
Also added a regression test for the ordering clearing optimisation performed in `get()` since no tests were failing if we simply removed the `clone = clone.order_by()` below and adjusted a test to correctly test captured queries SQL.