### PR TITLE
Fixed #25019 -- Added UUID support in DjangoJSONEncoder

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 import decimal
 import json
+import uuid
 import sys
 
 from django.core.serializers.base import DeserializationError
@@ -86,7 +87,7 @@ def Deserializer(stream_or_string, **options):
 
 class DjangoJSONEncoder(json.JSONEncoder):
     """
-    JSONEncoder subclass that knows how to encode date/time and decimal types.
+    JSONEncoder subclass that knows how to encode date/time, decimal types and UUIDs.
     """
     def default(self, o):
         # See "Date Time String Format" in the ECMA-262 specification.
@@ -107,6 +108,8 @@ class DjangoJSONEncoder(json.JSONEncoder):
                 r = r[:12]
             return r
         elif isinstance(o, decimal.Decimal):
+            return str(o)
+        elif isinstance(o, uuid.UUID):
             return str(o)
         else:
             return super(DjangoJSONEncoder, self).default(o)

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -6,6 +6,7 @@ import json
 import os
 import pickle
 import unittest
+import uuid
 
 from django.core.exceptions import SuspiciousOperation
 from django.core.serializers.json import DjangoJSONEncoder
@@ -479,6 +480,11 @@ class JsonResponseTests(TestCase):
     def test_json_response_list(self):
         response = JsonResponse(['foo', 'bar'], safe=False)
         self.assertEqual(json.loads(response.content.decode()), ['foo', 'bar'])
+
+    def test_json_response_uuid(self):
+        u = uuid.uuid4()
+        response = JsonResponse(u, safe=False)
+        self.assertEqual(json.loads(response.content.decode()), str(u))
 
     def test_json_response_custom_encoder(self):
         class CustomDjangoJSONEncoder(DjangoJSONEncoder):


### PR DESCRIPTION
Backport of https://code.djangoproject.com/ticket/25019 to the 1.8.x branch as per discussion with @freakboy3742 in mailing list.