### PR TITLE
Fixed #24919: Add option to not migrate test databases

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -5,6 +5,13 @@ from django.apps import apps
 from django.conf import settings
 from django.core import serializers
 from django.db import router
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.graph import MigrationGraph
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
+from django.db.migrations.recorder import NullMigrationRecorder
+from django.db.migrations.state import ProjectState
 from django.utils.six import StringIO
 from django.utils.six.moves import input
 
@@ -63,13 +70,16 @@ class BaseDatabaseCreation(object):
         # We report migrate messages at one level lower than that requested.
         # This ensures we don't get flooded with messages during testing
         # (unless you really ask to be flooded).
-        call_command(
-            'migrate',
-            verbosity=max(verbosity - 1, 0),
-            interactive=False,
-            database=self.connection.alias,
-            run_syncdb=True,
-        )
+        if self.connection.settings_dict.get("TEST", {}).get("MIGRATE", True):
+            call_command(
+                'migrate',
+                verbosity=max(verbosity - 1, 0),
+                interactive=False,
+                database=self.connection.alias,
+                run_syncdb=True,
+            )
+        else:
+            self.populate_schema_directly()
 
         # We then serialize the current state of the database into a string
         # and store it on the connection. This slightly horrific process is so people
@@ -84,6 +94,42 @@ class BaseDatabaseCreation(object):
         self.connection.ensure_connection()
 
         return test_database_name
+
+    def populate_schema_directly(self):
+        """
+        Populates the schema of the database in question directly, without
+        using migrations at all.
+
+        This is done by running the migration autodetector over the current
+        loaded model set and directly executing the migrations it produces.
+        """
+
+        # Set up the migration autodetector to make a from-scratch set of migrations to apply
+        all_app_labels = {config.label for config in apps.get_app_configs()}
+        initial_state = ProjectState()
+        questioner = NonInteractiveMigrationQuestioner(specified_apps=all_app_labels, dry_run=True)
+        autodetector = MigrationAutodetector(
+            initial_state,
+            ProjectState.from_apps(apps),
+            questioner,
+        )
+
+        # Run the autodetector
+        changes = autodetector.changes(
+            graph=MigrationGraph(),
+            trim_to_apps=all_app_labels,
+            convert_apps=all_app_labels,
+        )
+
+        # Loop the changes back into a graph we can apply from
+        loader = MigrationLoader.from_changes(changes)
+
+        # Fake-apply them to get SQL
+        executor = MigrationExecutor(self.connection)
+        executor.loader = loader
+        executor.recorder = NullMigrationRecorder(self.connection)
+        targets = [key for key in loader.graph.leaf_nodes() if key[0] in all_app_labels]
+        sql_statements = executor.migrate(targets)
 
     def set_as_test_mirror(self, primary_settings_dict):
         """

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -56,6 +56,40 @@ class MigrationLoader(object):
             app_package_name = apps.get_app_config(app_label).name
             return '%s.%s' % (app_package_name, MIGRATIONS_MODULE_NAME)
 
+    @classmethod
+    def from_changes(cls, changes):
+        """
+        Rather than loading migrations from disk, takes the output of the
+        autodetector's changes() function and loads those in as the disk
+        migrations, in order to operate on them straight away.
+
+        Implicitly sets the connection to None, as the names will not be
+        sensible and match up with the database (you should never try and
+        partially apply migrations with a from_changes loader - only
+        ever a full database create/teardown, or SQL output).
+        """
+        from django.db.migrations.writer import MigrationWriter
+        # Make loader
+        loader = cls(None, load=False)
+        # Make the fake disk migration entries from the changes
+        loader.disk_migrations = {}
+        loader.unmigrated_apps = set()
+        loader.migrated_apps = set()
+        for app_label, app_migrations in changes.items():
+            loader.migrated_apps.add(app_label)
+            for migration in app_migrations:
+                # Write it out to a string then re-exec it to ensure
+                # we behave exactly like writing to disk and reading back again
+                # (this prevents edge cases with e.g. model bindings left over)
+                contents = MigrationWriter(migration).as_string()
+                context = {}
+                exec(contents, context, context)
+                # Save it to the loader
+                loader.disk_migrations[app_label, migration.name] = context['Migration'](migration.name, app_label)
+        # Run the rest of the build
+        loader.build_graph(skip_load=True)
+        return loader
+
     def load_disk(self):
         """
         Loads the migrations from all INSTALLED_APPS from disk.
@@ -168,14 +202,15 @@ class MigrationLoader(object):
                     raise ValueError("Dependency on app with no migrations: %s" % key[0])
         raise ValueError("Dependency on unknown app: %s" % key[0])
 
-    def build_graph(self):
+    def build_graph(self, skip_load=False):
         """
         Builds a migration dependency graph using both the disk and database.
         You'll need to rebuild the graph if you apply migrations. This isn't
         usually a problem as generally migration stuff runs in a one-shot process.
         """
         # Load disk data
-        self.load_disk()
+        if not skip_load:
+            self.load_disk()
         # Load database data
         if self.connection is None:
             self.applied_migrations = set()

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -84,3 +84,31 @@ class MigrationRecorder(object):
         Deletes all migration records. Useful if you're testing migrations.
         """
         self.migration_qs.all().delete()
+
+
+class NullMigrationRecorder(object):
+    """
+    Null version of MigrationRecorder which never records anything and always
+    says no migrations are applied.
+
+    Designed for use with migrations-direct-from-memory-models, during e.g.
+    test database creation.
+    """
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def ensure_schema(self):
+        pass
+
+    def applied_migrations(self):
+        return set()
+
+    def record_applied(self, app, name):
+        pass
+
+    def record_unapplied(self, app, name):
+        pass
+
+    def flush(self):
+        pass

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -688,6 +688,22 @@ The creation-order dependencies of the database. See the documentation
 on :ref:`controlling the creation order of test databases
 <topics-testing-creation-dependencies>` for details.
 
+.. setting:: TEST_MIGRATE
+
+MIGRATE
+^^^^^^^
+
+Default: ``True``
+
+If the test database should be created using apps' existing migrations (the
+default). If this is set to ``False``, Django will attempt to create the
+database schema directly from the apps' models.
+
+Creating directly from the models is likely faster for apps with larger numbers
+of migrations, but note that turning this on will ignore all existing migration
+code, including custom ``RunSQL`` and ``RunPython`` operations for things like
+populating data and creating custom indexes.
+
 .. setting:: TEST_MIRROR
 
 MIRROR

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -697,8 +697,8 @@ MIGRATE
 
 Default: ``True``
 
-If the test database should be created using apps' existing migrations (the
-default). If this is set to ``False``, Django will attempt to create the
+Whether or not the test database should be created using apps' existing migrations
+(the default). If this is set to ``False``, Django will attempt to create the
 database schema directly from the apps' models.
 
 Creating directly from the models is likely faster for apps with larger numbers

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -690,6 +690,8 @@ on :ref:`controlling the creation order of test databases
 
 .. setting:: TEST_MIGRATE
 
+.. versionadded:: 1.9
+
 MIGRATE
 ^^^^^^^
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -504,6 +504,9 @@ Tests
   site while skipping the authentication and verification steps of
   :meth:`~django.test.Client.login()`.
 
+* Added the :setting:`DATABASES['TEST']['MIGRATE'] <TEST_MIGRATE>` option to
+  allow disabling of migration running during test database creation.
+
 URLs
 ^^^^
 


### PR DESCRIPTION
This solves https://code.djangoproject.com/ticket/24919 by adding a new `MIGRATE` sub-setting of `DATABASES['TEST']` that can be set to `False` to make the database from scratch using a new autodetector-direct-into-migrations approach contained in Creation.