### PR TITLE
Fixed #25117 -- Added Romanian char map for Javascript slug generation

### DIFF
--- a/django/contrib/admin/static/admin/js/urlify.js
+++ b/django/contrib/admin/static/admin/js/urlify.js
@@ -28,6 +28,10 @@ var TURKISH_MAP = {
     'ş':'s', 'Ş':'S', 'ı':'i', 'İ':'I', 'ç':'c', 'Ç':'C', 'ü':'u', 'Ü':'U',
     'ö':'o', 'Ö':'O', 'ğ':'g', 'Ğ':'G'
 };
+var ROMANIAN_MAP = {
+    'ă':'a', 'î':'i', 'ș':'s', 'ț':'t', 'â':'a',
+    'Ă':'A', 'Î':'I', 'Ș':'S', 'Ț':'T', 'Â':'A'
+};
 var RUSSIAN_MAP = {
     'а':'a', 'б':'b', 'в':'v', 'г':'g', 'д':'d', 'е':'e', 'ё':'yo', 'ж':'zh',
     'з':'z', 'и':'i', 'й':'j', 'к':'k', 'л':'l', 'м':'m', 'н':'n', 'о':'o',
@@ -84,6 +88,7 @@ var ALL_DOWNCODE_MAPS = [
     LATIN_SYMBOLS_MAP,
     GREEK_MAP,
     TURKISH_MAP,
+    ROMANIAN_MAP,
     RUSSIAN_MAP,
     UKRAINIAN_MAP,
     CZECH_MAP,

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -151,6 +151,9 @@ Minor features
 * The time picker widget includes a '6 p.m' option for consistency of having
   predefined options every 6 hours.
 
+* Fixed #25117 -- Added Romanian char map for Javascript slug generation in 
+  django/contrib/admin/static/admin/js/urlify.js
+
 :mod:`django.contrib.auth`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fix for [Ticket 25117](https://code.djangoproject.com/ticket/25117)

Romanian characters missing in admin SlugField when using prepopulate_fields.