### PR TITLE
Refs #24121 - Added more meaningful repr to HttpResponse (& specific subclasses)

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -285,6 +285,13 @@ class HttpResponse(HttpResponseBase):
         # Content is a bytestring. See the `content` property methods.
         self.content = content
 
+    def __repr__(self):
+        return '<%(cls)s status_code=%(status_code)d, "%(content_type)s">' % {
+            'cls': self.__class__.__name__,
+            'status_code': self.status_code,
+            'content_type': self['Content-Type'],
+        }
+
     def serialize(self):
         """Full HTTP message, including headers, as a bytestring."""
         return self.serialize_headers() + b'\r\n\r\n' + self.content
@@ -403,6 +410,14 @@ class HttpResponseRedirectBase(HttpResponse):
 
     url = property(lambda self: self['Location'])
 
+    def __repr__(self):
+        return '<%(cls)s status_code=%(status_code)d, "%(content_type)s", url="%(url)s">' % {
+            'cls': self.__class__.__name__,
+            'status_code': self.status_code,
+            'content_type': self['Content-Type'],
+            'url': self.url,
+        }
+
 
 class HttpResponseRedirect(HttpResponseRedirectBase):
     status_code = 302
@@ -444,6 +459,14 @@ class HttpResponseNotAllowed(HttpResponse):
     def __init__(self, permitted_methods, *args, **kwargs):
         super(HttpResponseNotAllowed, self).__init__(*args, **kwargs)
         self['Allow'] = ', '.join(permitted_methods)
+
+    def __repr__(self):
+        return '<%(cls)s [%(methods)s] status_code=%(status_code)d, "%(content_type)s">' % {
+            'cls': self.__class__.__name__,
+            'status_code': self.status_code,
+            'content_type': self['Content-Type'],
+            'methods': self['Allow'],
+        }
 
 
 class HttpResponseGone(HttpResponse):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -443,6 +443,11 @@ class HttpResponseSubclassesTests(SimpleTestCase):
         r = HttpResponseRedirect(lazystr('/redirected/'))
         self.assertEqual(r.url, '/redirected/')
 
+    def test_redirect_repr(self):
+        response = HttpResponseRedirect('/redirected/')
+        expected = '<HttpResponseRedirect status_code=302, "text/html; charset=utf-8", url="/redirected/">'
+        self.assertEqual(repr(response), expected)
+
     def test_not_modified(self):
         response = HttpResponseNotModified()
         self.assertEqual(response.status_code, 304)
@@ -459,6 +464,11 @@ class HttpResponseSubclassesTests(SimpleTestCase):
             content='Only the GET method is allowed',
             content_type='text/html')
         self.assertContains(response, 'Only the GET method is allowed', status_code=405)
+
+    def test_not_allowed_repr(self):
+        response = HttpResponseNotAllowed(['GET', 'OPTIONS'], content_type='text/plain')
+        expected = '<HttpResponseNotAllowed [GET, OPTIONS] status_code=405, "text/plain">'
+        self.assertEqual(repr(response), expected)
 
 
 class JsonResponseTests(SimpleTestCase):

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -107,3 +107,8 @@ class HttpResponseTests(SimpleTestCase):
 
         response = HttpResponse(iso_content, content_type='text/plain')
         self.assertContains(response, iso_content)
+
+    def test_repr(self):
+        resp = HttpResponse(content="Café :)".encode(UTF8), status=201)
+        expected = '<HttpResponse status_code=201, "text/html; charset=utf-8">'
+        self.assertEqual(repr(resp), expected)


### PR DESCRIPTION
[Ticket is here](https://code.djangoproject.com/ticket/24121).
Trying to find the balance between providing useful information and brevity; suggestions welcome. 

- Some `repr()` components aren't addressable as an attribute (`content type` & `allowed methods`) but provide valuable info. I've opted for including the data even if it isn't directly addressable.