### PR TITLE
Fixed #25125 -- Added a check for SESSION_COOKIE_NAME and LANGUAGE_COOKIE_NAME collision

### DIFF
--- a/django/contrib/sessions/apps.py
+++ b/django/contrib/sessions/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import ugettext_lazy as _
 class SessionsConfig(AppConfig):
     name = 'django.contrib.sessions'
     verbose_name = _("Sessions")
+    checks_tag = 'contrib.sessions'

--- a/django/contrib/sessions/checks.py
+++ b/django/contrib/sessions/checks.py
@@ -1,0 +1,38 @@
+from collections import defaultdict
+from itertools import combinations
+
+from django.conf import settings
+from django.contrib.sessions.apps import SessionsConfig
+from django.core import checks
+
+
+@checks.register(SessionsConfig.checks_tag)
+def check_names_conflict(app_configs=None, **kwargs):
+    errors = []
+    duplicate_pairs = []
+    cookie_names = dict(
+        SESSION_COOKIE_NAME=settings.SESSION_COOKIE_NAME,
+        LANGUAGE_COOKIE_NAME=settings.LANGUAGE_COOKIE_NAME,
+        CSRF_COOKIE_NAME=settings.CSRF_COOKIE_NAME,
+    )
+
+    # search for duplicates, start by generating flipped, multiple values dict
+    flipped = defaultdict(set)
+    for k, v in cookie_names.items():
+        flipped[v].add(k)
+
+    # create duplicates pairs with itertools.combinations
+    for v in flipped.values():
+        if len(v) > 1:
+            duplicate_pairs.extend(combinations(v, 2))
+
+    for pair in duplicate_pairs:
+        pair = sorted(pair)
+        errors.append(
+            checks.Error(
+                "The '%s' and '%s' settings must be different." % (pair[0], pair[1]),
+                id='sessions.E001',
+            )
+        )
+
+    return errors

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -509,3 +509,11 @@ configured:
 * **templates.E001**: You have ``'APP_DIRS': True`` in your
   :setting:`TEMPLATES` but also specify ``'loaders'`` in ``OPTIONS``. Either
   remove ``APP_DIRS`` or remove the ``'loaders'`` option.
+
+Sessions
+--------
+
+The following checks verify sessions related configuration:
+
+* **sessions.E001**: The ``<cookie name>`` and ``<cookie name>`` settings must
+  be different.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -366,7 +366,8 @@ CSRF_COOKIE_NAME
 Default: ``'csrftoken'``
 
 The name of the cookie to use for the CSRF authentication token. This can be
-whatever you want. See :doc:`/ref/csrf`.
+whatever you want (as long as it's different from the other cookie names in
+your application). See :doc:`/ref/csrf`.
 
 .. setting:: CSRF_COOKIE_PATH
 
@@ -1614,8 +1615,8 @@ LANGUAGE_COOKIE_NAME
 Default: ``'django_language'``
 
 The name of the cookie to use for the language cookie. This can be whatever
-you want (but should be different from :setting:`SESSION_COOKIE_NAME`). See
-:doc:`/topics/i18n/index`.
+you want (as long as it's different from the other cookie names in your application).
+See :doc:`/topics/i18n/index`.
 
 .. setting:: LANGUAGE_COOKIE_PATH
 
@@ -2943,8 +2944,8 @@ SESSION_COOKIE_NAME
 
 Default: ``'sessionid'``
 
-The name of the cookie to use for sessions. This can be whatever you want (but
-should be different from :setting:`LANGUAGE_COOKIE_NAME`).
+The name of the cookie to use for sessions. This can be whatever you want
+(as long as it's different from the other cookie names in your application).
 
 .. setting:: SESSION_COOKIE_PATH
 

--- a/tests/sessions_tests/test_checks.py
+++ b/tests/sessions_tests/test_checks.py
@@ -1,0 +1,98 @@
+from django.conf import settings
+from django.core import checks
+from django.test import SimpleTestCase
+
+
+class SessionSettingsTests(SimpleTestCase):
+
+    @property
+    def func(self):
+        from django.contrib.sessions.checks import check_names_conflict
+        return check_names_conflict
+
+    def test_language_session_and_csrf_cookies_names_defaults(self):
+        cookie_values = (
+            settings.CSRF_COOKIE_NAME,
+            settings.LANGUAGE_COOKIE_NAME,
+            settings.SESSION_COOKIE_NAME,
+        )
+        self.assertEqual(len(cookie_values), len(set(cookie_values)))
+        self.assertEqual(self.func(), [])
+
+    def test_csrf_language_and_session_cookie_names_are_all_different(self):
+        cookies_settings = dict(
+            CSRF_COOKIE_NAME='foo',
+            LANGUAGE_COOKIE_NAME='bar',
+            SESSION_COOKIE_NAME='foobar',
+        )
+
+        with self.settings(**cookies_settings):
+            self.assertEqual(self.func(), [])
+
+    def test_csrf_language_and_session_cookie_names_are_all_equal(self):
+        cookie_settings = dict(
+            CSRF_COOKIE_NAME='foo',
+            LANGUAGE_COOKIE_NAME='foo',
+            SESSION_COOKIE_NAME='foo',
+        )
+        expected = [
+            checks.Error(
+                "The 'LANGUAGE_COOKIE_NAME' and 'SESSION_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+            checks.Error(
+                "The 'CSRF_COOKIE_NAME' and 'LANGUAGE_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+            checks.Error(
+                "The 'CSRF_COOKIE_NAME' and 'SESSION_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+        ]
+        with self.settings(**cookie_settings):
+            self.assertEqual(self.func(), expected)
+
+    def test_csrf_and_language_cookie_names_are_equal(self):
+        cookie_settings = dict(
+            CSRF_COOKIE_NAME='foo',
+            LANGUAGE_COOKIE_NAME='foo',
+            SESSION_COOKIE_NAME='bar',
+        )
+        expected = [
+            checks.Error(
+                "The 'CSRF_COOKIE_NAME' and 'LANGUAGE_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+        ]
+        with self.settings(**cookie_settings):
+            self.assertEqual(self.func(), expected)
+
+    def test_csrf_and_session_cookie_names_are_equal(self):
+        cookie_settings = dict(
+            CSRF_COOKIE_NAME='foo',
+            LANGUAGE_COOKIE_NAME='bar',
+            SESSION_COOKIE_NAME='foo',
+        )
+        expected = [
+            checks.Error(
+                "The 'CSRF_COOKIE_NAME' and 'SESSION_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+        ]
+        with self.settings(**cookie_settings):
+            self.assertEqual(self.func(), expected)
+
+    def test_language_and_session_cookie_names_are_equal(self):
+        cookie_settings = dict(
+            CSRF_COOKIE_NAME='bar',
+            LANGUAGE_COOKIE_NAME='foo',
+            SESSION_COOKIE_NAME='foo',
+        )
+        expected = [
+            checks.Error(
+                "The 'LANGUAGE_COOKIE_NAME' and 'SESSION_COOKIE_NAME' settings must be different.",
+                id='sessions.E001',
+            ),
+        ]
+        with self.settings(**cookie_settings):
+            self.assertEqual(self.func(), expected)


### PR DESCRIPTION
- check framework plugged into sessions app
- 'SESSION_COOKIE_NAME and LANGUAGE_COOKIE_NAME are different' check.