### PR TITLE
Fixed typo in docs on translation.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -843,8 +843,8 @@ language name (translated into the currently active locale).
 
 .. templatetag:: get_current_language
 
-``get_current_languages``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``get_current_language``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``{% get_current_language as LANGUAGE_CODE %}`` returns the current user's
 preferred language as a string. Example: ``en-us``. See


### PR DESCRIPTION
In docs/topic/i18n/translation.txt there was a typo in templatetag name.
Changed header from get_current_languages to get_current_language.