### PR TITLE
Fixed #25120 -- Deprecated egg template loader.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -208,7 +208,6 @@ TEMPLATE_DIRS = []
 TEMPLATE_LOADERS = [
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
 ]
 
 # List of processors used by RequestContext to populate the context.

--- a/django/template/loaders/eggs.py
+++ b/django/template/loaders/eggs.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     resource_string = None
 
+warnings.warn('The egg template loader is deprecated.', RemovedInDjango20Warning)
+
 
 class EggOrigin(Origin):
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -82,6 +82,8 @@ details on these changes.
 * ``Field._get_val_from_obj()`` will be removed in favor of
   ``Field.value_from_object()``.
 
+* ``django.template.loaders.eggs.Loader`` will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -893,6 +893,10 @@ loaders that come with Django:
 
 .. class:: eggs.Loader
 
+    .. deprecated:: 1.9
+
+        Distributing applications as eggs is not recommended.
+
     Just like ``app_directories`` above, but it loads templates from Python
     eggs rather than from the filesystem.
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1004,6 +1004,9 @@ Miscellaneous
 * ``django.db.models.Field._get_val_from_obj()`` is deprecated in favor of
   ``Field.value_from_object()``.
 
+* ``django.template.loaders.eggs.Loader`` is deprecated as distributing
+  applications as eggs is not recommended.
+
 .. removed-features-1.9:
 
 Features removed in 1.9

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -153,6 +153,7 @@ class EggLoaderTests(SimpleTestCase):
             del pkg_resources._provider_factories[MockLoader]
 
     @classmethod
+    @ignore_warnings(category=RemovedInDjango20Warning)
     def setUpClass(cls):
         cls.engine = Engine(loaders=[
             'django.template.loaders.eggs.Loader',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25120