### PR TITLE
Fixed #25138 -- Added view_decorator for CBVs.

### DIFF
--- a/django/views/generic/__init__.py
+++ b/django/views/generic/__init__.py
@@ -3,6 +3,7 @@ from django.views.generic.dates import (
     ArchiveIndexView, DateDetailView, DayArchiveView, MonthArchiveView,
     TodayArchiveView, WeekArchiveView, YearArchiveView,
 )
+from django.views.generic.decorators import view_decorator
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import (
     CreateView, DeleteView, FormView, UpdateView,
@@ -14,6 +15,7 @@ __all__ = [
     'YearArchiveView', 'MonthArchiveView', 'WeekArchiveView', 'DayArchiveView',
     'TodayArchiveView', 'DateDetailView', 'DetailView', 'FormView',
     'CreateView', 'UpdateView', 'DeleteView', 'ListView', 'GenericViewError',
+    'view_decorator',
 ]
 
 

--- a/django/views/generic/decorators.py
+++ b/django/views/generic/decorators.py
@@ -1,0 +1,14 @@
+"Decorators for generic class-based views"
+
+from django.utils.decorators import method_decorator
+
+
+def view_decorator(decorator):
+    """
+    Applies a function decorator to the dispatch method of a class, allowing
+    view decorators to be applied to class-based views.
+    """
+    def _dec(cls):
+        cls.dispatch = method_decorator(decorator)(cls.dispatch)
+        return cls
+    return _dec

--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -266,7 +266,7 @@ A method on a class isn't quite the same as a standalone function, so
 you can't just apply a function decorator to the method -- you need to
 transform it into a method decorator first. The ``view_decorator``
 decorator transforms a function decorator into a method decorator, and
-applies it to the ``dispatch`` method of the class. For example:
+applies it to the ``dispatch`` method of the class. For example::
 
     from django.contrib.auth.decorators import login_required
     from django.views.generic import TemplateView, view_decorator

--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -262,6 +262,8 @@ To decorate every instance of a class-based view, you need to decorate
 the class definition itself. To do this you apply the decorator to the
 :meth:`~django.views.generic.base.View.dispatch` method of the class.
 
+.. versionadded:: 1.9
+
 A method on a class isn't quite the same as a standalone function, so
 you can't just apply a function decorator to the method -- you need to
 transform it into a method decorator first. The ``view_decorator``

--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -264,20 +264,16 @@ the class definition itself. To do this you apply the decorator to the
 
 A method on a class isn't quite the same as a standalone function, so
 you can't just apply a function decorator to the method -- you need to
-transform it into a method decorator first. The ``method_decorator``
-decorator transforms a function decorator into a method decorator so
-that it can be used on an instance method. For example::
+transform it into a method decorator first. The ``view_decorator``
+decorator transforms a function decorator into a method decorator, and
+applies it to the ``dispatch`` method of the class. For example:
 
     from django.contrib.auth.decorators import login_required
-    from django.utils.decorators import method_decorator
-    from django.views.generic import TemplateView
+    from django.views.generic import TemplateView, view_decorator
 
+    @view_decorator(login_required)
     class ProtectedView(TemplateView):
         template_name = 'secret.html'
-
-        @method_decorator(login_required)
-        def dispatch(self, *args, **kwargs):
-            return super(ProtectedView, self).dispatch(*args, **kwargs)
 
 In this example, every instance of ``ProtectedView`` will have
 login protection.

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -8,7 +8,9 @@ from django.core.urlresolvers import resolve
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
-from django.views.generic import RedirectView, TemplateView, View, view_decorator
+from django.views.generic import (
+    RedirectView, TemplateView, View, view_decorator,
+)
 
 from . import views
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import resolve
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.test.utils import require_jinja2
-from django.views.generic import RedirectView, TemplateView, View
+from django.views.generic import RedirectView, TemplateView, View, view_decorator
 
 from . import views
 
@@ -44,6 +44,11 @@ class DecoratedDispatchView(SimpleView):
     @decorator
     def dispatch(self, request, *args, **kwargs):
         return super(DecoratedDispatchView, self).dispatch(request, *args, **kwargs)
+
+
+@view_decorator(decorator)
+class DecoratedClassView(SimpleView):
+    pass
 
 
 class AboutTemplateView(TemplateView):
@@ -175,6 +180,13 @@ class ViewTest(unittest.TestCase):
         are also present on the closure.
         """
         self.assertTrue(DecoratedDispatchView.as_view().is_decorated)
+
+    def test_class_decoration(self):
+        """
+        Tests that attributes set by decorator applied to the class with
+        view_decorator are also present on the closure returned by as_view.
+        """
+        self.assertTrue(DecoratedClassView.as_view().is_decorated)
 
     def test_options(self):
         """


### PR DESCRIPTION
`django.views.generic.view_decorator` takes a function decorator, converts it to a method decorator using `django.utils.decorators.method_decorator`, and applies it to `dispatch` method on the given class. For example:

```python
from django.views.generic import TemplateView, view_decorator
from django.contrib.auth.decorators import login_required

@view_decorator(login_required)
class ProtectedView(TemplateView):
    template_name = 'secret.html'
```

Trac: https://code.djangoproject.com/ticket/25138