### PR TITLE
Reword: same password as above to: "as before"

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -338,7 +338,7 @@ class AdminPasswordChangeForm(forms.Form):
     password2 = forms.CharField(
         label=_("Password (again)"),
         widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."),
+        help_text=_("Enter the same password as before, for verification."),
     )
 
     def __init__(self, user, *args, **kwargs):

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -72,7 +72,7 @@ class UserCreationForm(forms.ModelForm):
         widget=forms.PasswordInput)
     password2 = forms.CharField(label=_("Password confirmation"),
         widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."))
+        help_text=_("Enter the same password as before, for verification."))
 
     class Meta:
         model = User


### PR DESCRIPTION
"As above" refers to a spatial orientation, which might not be present, for example when the two password fields are shown next to each other. 

"As before" is free from a spatial orientation and might be better. Unless people are filling in a form backwards (do they do that?).