### PR TITLE
Fixed #25135 -- Deprecated the contrib.admin allow_tags attribute

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -14,7 +14,7 @@ from django.db.models.fields.related import ManyToManyRel
 from django.forms.utils import flatatt
 from django.template.defaultfilters import capfirst, linebreaksbr
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango110Warning
+from django.utils.deprecation import RemovedInDjango110Warning, RemovedInDjango20Warning
 from django.utils.encoding import force_text, smart_text
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, format_html
@@ -198,10 +198,16 @@ class AdminReadonlyField(object):
                 if boolean:
                     result_repr = _boolean_icon(value)
                 else:
-                    result_repr = smart_text(value)
-                    if getattr(attr, "allow_tags", False):
-                        result_repr = mark_safe(result_repr)
+                    if hasattr(value, "__html__"):
+                        result_repr = value
                     else:
+                        result_repr = smart_text(value)
+                        if getattr(attr, "allow_tags", False):
+                            warnings.warn(
+                                "The allow_tags attribute is deprecated. Return a SafeString instance by "
+                                "using format_html, format_html_join or mark_safe instead.",
+                                RemovedInDjango20Warning, stacklevel=2)
+                            result_repr = mark_safe(value)
                         result_repr = linebreaksbr(result_repr)
             else:
                 if isinstance(f.remote_field, ManyToManyRel) and value is not None:

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -753,7 +753,6 @@ class ModelAdmin(BaseModelAdmin):
         """
         return helpers.checkbox.render(helpers.ACTION_CHECKBOX_NAME, force_text(obj.pk))
     action_checkbox.short_description = mark_safe('<input type="checkbox" id="action-toggle" />')
-    action_checkbox.allow_tags = True
 
     def get_actions(self, request):
         """

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import warnings
 
 from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
@@ -16,6 +17,7 @@ from django.db import models
 from django.template import Library
 from django.template.loader import get_template
 from django.utils import formats
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 from django.utils.html import escapejs, format_html
 from django.utils.safestring import mark_safe
@@ -201,18 +203,18 @@ def items_for_result(cl, result, form):
         except ObjectDoesNotExist:
             result_repr = empty_value_display
         else:
-            empty_value_display = getattr(attr, 'empty_value_display', empty_value_display)
+            empty_value_display = mark_safe(getattr(attr, 'empty_value_display', empty_value_display))
             if f is None or f.auto_created:
                 if field_name == 'action_checkbox':
                     row_classes = ['action-checkbox']
                 allow_tags = getattr(attr, 'allow_tags', False)
                 boolean = getattr(attr, 'boolean', False)
-                if boolean or not value:
-                    allow_tags = True
                 result_repr = display_for_value(value, empty_value_display, boolean)
-                # Strip HTML tags in the resulting text, except if the
-                # function has an "allow_tags" attribute set to True.
                 if allow_tags:
+                    warnings.warn(
+                        "The allow_tags attribute is deprecated. Return a SafeString instance by "
+                        "using format_html, format_html_join or mark_safe instead.",
+                        RemovedInDjango20Warning, stacklevel=2)
                     result_repr = mark_safe(result_repr)
                 if isinstance(value, (datetime.date, datetime.time)):
                     row_classes.append('nowrap')

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -18,6 +18,7 @@ from django.core.mail import EmailMessage
 from django.db import models
 from django.forms.models import BaseModelFormSet
 from django.http import HttpResponse, StreamingHttpResponse
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.six import StringIO
 
@@ -446,7 +447,6 @@ class PostAdmin(admin.ModelAdmin):
 
     def multiline_html(self, instance):
         return mark_safe("Multiline<br>\nhtml<br>\ncontent")
-    multiline_html.allow_tags = True
 
     value.short_description = 'Value in $US'
 
@@ -570,8 +570,7 @@ class ComplexSortedPersonAdmin(admin.ModelAdmin):
     ordering = ('name',)
 
     def colored_name(self, obj):
-        return '<span style="color: #%s;">%s</span>' % ('ff00ff', obj.name)
-    colored_name.allow_tags = True
+        return format_html('<span style="color: #{};">{}</span>', 'ff00ff', obj.name)
     colored_name.admin_order_field = 'name'
 
 


### PR DESCRIPTION
Initial (naive) stab at deprecating the allow_tags for admin display methods.