### PR TITLE
Corrected HTML-escaping behaviour of url template tag.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.utils import six, timezone
 from django.utils.deprecation import RemovedInDjango110Warning
 from django.utils.encoding import force_text, smart_text
-from django.utils.html import format_html
+from django.utils.html import conditional_escape, format_html
 from django.utils.lorem_ipsum import paragraphs, words
 from django.utils.safestring import mark_safe
 
@@ -512,6 +512,8 @@ class URLNode(Node):
             context[self.asvar] = url
             return ''
         else:
+            if context.autoescape:
+                url = conditional_escape(url)
             return url
 
 

--- a/tests/template_tests/syntax_tests/test_url.py
+++ b/tests/template_tests/syntax_tests/test_url.py
@@ -95,7 +95,7 @@ class UrlTagTests(SimpleTestCase):
     @ignore_warnings(category=RemovedInDjango110Warning)
     def test_url12(self):
         output = self.engine.render_to_string('url12', {'client': {'id': 1}})
-        self.assertEqual(output, '/client/1/!$&\'()*+,;=~:@,/')
+        self.assertEqual(output, '/client/1/!$&amp;&#39;()*+,;=~:@,/')
 
     @ignore_warnings(category=RemovedInDjango110Warning)
     @setup({'url13': '{% url "template_tests.views.client_action" '
@@ -132,6 +132,15 @@ class UrlTagTests(SimpleTestCase):
     def test_url20(self):
         output = self.engine.render_to_string('url20', {'client': {'id': 1}, 'url_name_in_var': 'named.client'})
         self.assertEqual(output, '/named-client/1/')
+
+    @setup({'url21': '{% autoescape off %}'
+                     '{% url "template_tests.views.client_action" '
+                     'id=client.id action="!$&\'()*+,;=~:@," %}'
+                     '{% endautoescape %}'})
+    @ignore_warnings(category=RemovedInDjango110Warning)
+    def test_url21(self):
+        output = self.engine.render_to_string('url21', {'client': {'id': 1}})
+        self.assertEqual(output, '/client/1/!$&\'()*+,;=~:@,/')
 
     # Failures
     @setup({'url-fail01': '{% url %}'})


### PR DESCRIPTION
Due to the URL encoding applied by the tag for all parameters that might be
partly controllable by an end-user, there are no XSS/security problems
caused by this bug, only invalid HTML.