### PR TITLE
Simplified MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,26 +1,16 @@
-include README.rst
 include AUTHORS
+include Gruntfile.js
 include INSTALL
 include LICENSE
 include MANIFEST.in
-include django/contrib/gis/gdal/LICENSE
-include django/contrib/gis/geos/LICENSE
-include django/dispatch/license.txt
-include django/dispatch/license.python.txt
+include package.json
+include *.rst
+recursive-include django *
+prune django/contrib/admin/bin
 recursive-include docs *
-recursive-include scripts *
 recursive-include extras *
+recursive-include js_tests *
+recursive-include scripts *
 recursive-include tests *
-recursive-include django/conf/app_template *
-recursive-include django/conf/locale *
-recursive-include django/conf/project_template *
-recursive-include django/contrib/*/locale *
-recursive-include django/contrib/admin/templates *
-recursive-include django/contrib/admin/static *
-recursive-include django/contrib/admindocs/templates *
-recursive-include django/contrib/auth/templates *
-recursive-include django/contrib/gis/static *
-recursive-include django/contrib/gis/templates *
-recursive-include django/contrib/sitemaps/templates *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Also fixed missing django/contrib/auth/common-passwords.txt.gz file and added JavaScript tests.

mailing list discussion: https://groups.google.com/d/topic/django-developers/d6UWv53MwhE/discussion

Output of check-manifest:
```
lists of files in version control and sdist do not match!
missing from sdist:
  .editorconfig
  .eslintignore
  .eslintrc
  .gitattributes
  .tx
  .tx/config
you have django/conf/locale/af/LC_MESSAGES/django.mo in source control!
that's a bad idea: auto-generated files should not be versioned
this also applies to the following:
  django/conf/locale/ar/LC_MESSAGES/django.mo
  .... (all mo files)
```