### PR TITLE
Fixed #17464 -- Added save_form() and save_model() to ModelFormMixin

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -197,8 +197,17 @@ class ModelFormMixin(FormMixin, SingleObjectMixin):
         """
         If the form is valid, save the associated model.
         """
-        self.object = form.save()
+        self.object = self.save_form(form)
+        self.save_model(self.object)
         return super(ModelFormMixin, self).form_valid(form)
+
+    def save_form(self, form):
+        """Given a form, return an unsaved instance"""
+        return form.save(commit=False)
+
+    def save_model(self, obj):
+        """Save a given model instance to the database"""
+        obj.save()
 
 
 class ProcessFormView(View):

--- a/docs/ref/class-based-views/mixins-editing.txt
+++ b/docs/ref/class-based-views/mixins-editing.txt
@@ -195,6 +195,15 @@ ModelFormMixin
         redirects to
         :meth:`~django.views.generic.edit.FormMixin.get_success_url`.
 
+    .. method:: save_form(form)
+
+        Given a form, return an unsaved instance. Can be overridden to set
+        extra instance fields.
+
+    .. method:: save_model(obj)
+
+        Save a given model instance to the database.
+
     .. method:: form_invalid()
 
         Renders a response, providing the invalid form as context.

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -238,6 +238,15 @@ class CreateViewTests(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, message):
             MyCreateView().get_form_class()
 
+    def test_create_with_default_instance_fields(self):
+        res = self.client.post('/edit/authors/create/default-instance-fields/',
+            {'name': 'Randall Munroe'})
+        self.assertEqual(res.status_code, 302)
+        self.assertRedirects(res, '/list/authors/')
+        self.assertQuerysetEqual(Author.objects.all(), ['<Author: Randall Munroe>'])
+        author = Author.objects.get(name='Randall Munroe')
+        self.assertEqual(author.slug, 'awesome-slug')
+
 
 @override_settings(ROOT_URLCONF='generic_views.urls')
 class UpdateViewTests(TestCase):

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -82,6 +82,8 @@ urlpatterns = [
         views.NaiveAuthorCreate.as_view(success_url='/%C3%A9dit/author/{id}/update/')),
     url(r'^edit/authors/create/restricted/$',
         views.AuthorCreateRestricted.as_view()),
+    url(r'^edit/authors/create/default-instance-fields/$',
+        views.AuthorCreateDefaultInstanceFields.as_view()),
     url(r'^[eé]dit/authors/create/$',
         views.AuthorCreate.as_view()),
     url(r'^edit/authors/create/special/$',

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -125,6 +125,15 @@ class AuthorCreateRestricted(AuthorCreate):
     post = method_decorator(login_required)(AuthorCreate.post)
 
 
+class AuthorCreateDefaultInstanceFields(AuthorCreate):
+    fields = ['name']
+
+    def save_form(self, form):
+        obj = super(AuthorCreateDefaultInstanceFields, self).save_form(form)
+        obj.slug = 'awesome-slug'
+        return obj
+
+
 class ArtistUpdate(generic.UpdateView):
     model = Artist
     fields = '__all__'


### PR DESCRIPTION
This enable to do extra work before saving the object to the database,
like setting instance attributes based on other parts of the
request. This fixes https://code.djangoproject.com/ticket/17464.

This approach is inspired by BaseModelAdmin.