### PR TITLE
Fixed #25163 -- New hint for non-staff users in admin login page

### DIFF
--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -31,6 +31,15 @@
 {% endif %}
 
 <div id="content-main">
+
+{% if user.is_authenticated %}
+    <p class="errornote">
+        {% blocktrans with username=request.user.username %}
+            While you are authenticated as {{ username }}, you are unfortunately not authorized to access this page -- would you care to re-login?
+        {% endblocktrans %}
+    </p>
+{% endif %}
+
 <form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
   <div class="form-row">
     {{ form.username.errors }}

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1558,6 +1558,34 @@ class AdminViewPermissionsTest(TestCase):
         self.assertFalse(login.context)
         self.client.get(reverse('admin:logout'))
 
+    def test_logged_in_as_non_admin_behaviour(self):
+        """
+        A logged-in non-admin user trying to access the admin index
+        should be presented with login page and a hint indicating that the
+        current user doesn't have access to it. Refs #25163
+        """
+
+        hint_template = (
+            "While you are authenticated as {}, you are unfortunately not "
+            "authorized to access this page -- would you care to re-login?"
+        )
+
+        # Anonymous user should not be shown the hint
+        response = self.client.get(self.index_url, follow=True)
+        self.assertContains(response, 'login-form')
+        self.assertNotContains(
+            response, hint_template.format(''), status_code=200
+        )
+
+        # Non admin user should be shown the hint
+        self.client.login(**self.nostaff_login)
+        response = self.client.get(self.index_url, follow=True)
+        self.assertContains(response, 'login-form')
+
+        self.assertContains(
+            response, hint_template.format(self.u6.username), status_code=200
+        )
+
     def test_add_view(self):
         """Test add view restricts access and actually adds items."""
 


### PR DESCRIPTION
This code addresses the issue outlined in https://code.djangoproject.com/ticket/25163 and it's a candidate fix for it.

If the user is logged in as non-staff and attempts to access an admin page, he will get redirected to the login page, which can be a bit misleading, as the user is already authenticated

This PR adds a help text for such case.
