### PR TITLE
Fixed #18349 -- Added ipv6 support to django.contrib.gis.geoip.

### DIFF
--- a/django/contrib/gis/geoip/base.py
+++ b/django/contrib/gis/geoip/base.py
@@ -4,14 +4,16 @@ from ctypes import c_char_p
 
 from django.contrib.gis.geoip.libgeoip import GEOIP_SETTINGS
 from django.contrib.gis.geoip.prototypes import (
-    GeoIP_country_code_by_addr, GeoIP_country_code_by_name,
-    GeoIP_country_name_by_addr, GeoIP_country_name_by_name,
+    GeoIP_country_code_by_addr, GeoIP_country_code_by_addr_v6,
+    GeoIP_country_code_by_name, GeoIP_country_name_by_addr,
+    GeoIP_country_name_by_addr_v6, GeoIP_country_name_by_name,
     GeoIP_database_info, GeoIP_delete, GeoIP_lib_version, GeoIP_open,
-    GeoIP_record_by_addr, GeoIP_record_by_name,
+    GeoIP_record_by_addr, GeoIP_record_by_addr_v6, GeoIP_record_by_name,
 )
 from django.core.validators import ipv4_re
 from django.utils import six
 from django.utils.encoding import force_bytes
+from django.utils.ipv6 import is_valid_ipv6_address
 
 # Regular expressions for recognizing the GeoIP free database editions.
 free_regex = re.compile(r'^GEO-\d{3}FREE')
@@ -51,13 +53,17 @@ class GeoIP(object):
 
     # Paths to the city & country binary databases.
     _city_file = ''
+    _city6_file = ''
     _country_file = ''
+    _country6_file = ''
 
     # Initially, pointers to GeoIP file references are NULL.
     _city = None
+    _city6 = None
     _country = None
+    _country6 = None
 
-    def __init__(self, path=None, cache=0, country=None, city=None):
+    def __init__(self, path=None, cache=0, country=None, city=None, country6=None, city6=None):
         """
         Initializes the GeoIP object, no parameters are required to use default
         settings.  Keyword arguments may be passed in to customize the locations
@@ -104,10 +110,21 @@ class GeoIP(object):
                 self._country = GeoIP_open(force_bytes(country_db), cache)
                 self._country_file = country_db
 
+            country6_db = os.path.join(path, country6 or GEOIP_SETTINGS.get('GEOIP_COUNTRY6', 'GeoIPv6.dat'))
+            if os.path.isfile(country6_db):
+                self._country6 = GeoIP_open(force_bytes(country6_db), cache)
+                self._country6_file = country6_db
+
             city_db = os.path.join(path, city or GEOIP_SETTINGS.get('GEOIP_CITY', 'GeoLiteCity.dat'))
             if os.path.isfile(city_db):
                 self._city = GeoIP_open(force_bytes(city_db), cache)
                 self._city_file = city_db
+
+            city6_db = os.path.join(path, city6 or GEOIP_SETTINGS.get('GEOIP_CITY6', 'GeoLiteCityv6.dat'))
+            if os.path.isfile(city6_db):
+                self._city6 = GeoIP_open(force_bytes(city6_db), cache)
+                self._city6_file = city6_db
+
         elif os.path.isfile(path):
             # Otherwise, some detective work will be needed to figure
             # out whether the given database path is for the GeoIP country
@@ -133,8 +150,12 @@ class GeoIP(object):
             return
         if self._country:
             GeoIP_delete(self._country)
+        if self._country6:
+            GeoIP_delete(self._country6)
         if self._city:
             GeoIP_delete(self._city)
+        if self._city6:
+            GeoIP_delete(self._city6)
 
     def _check_query(self, query, country=False, city=False, city_or_country=False):
         "Helper routine for checking the query and database availability."
@@ -163,6 +184,9 @@ class GeoIP(object):
         if ipv4_re.match(query):
             # If an IP address was passed in
             return GeoIP_record_by_addr(self._city, c_char_p(enc_query))
+        elif is_valid_ipv6_address(query) and self._city6:
+            # If an IPv6 address was passed in
+            return GeoIP_record_by_addr_v6(self._city6, c_char_p(enc_query))
         else:
             # If a FQDN was passed in.
             return GeoIP_record_by_name(self._city, c_char_p(enc_query))
@@ -170,7 +194,9 @@ class GeoIP(object):
     def country_code(self, query):
         "Returns the country code for the given IP Address or FQDN."
         enc_query = self._check_query(query, city_or_country=True)
-        if self._country:
+        if self._country6 and is_valid_ipv6_address(query):
+            return GeoIP_country_code_by_addr_v6(self._country6, enc_query)
+        elif self._country:
             if ipv4_re.match(query):
                 return GeoIP_country_code_by_addr(self._country, enc_query)
             else:
@@ -181,7 +207,9 @@ class GeoIP(object):
     def country_name(self, query):
         "Returns the country name for the given IP Address or FQDN."
         enc_query = self._check_query(query, city_or_country=True)
-        if self._country:
+        if self._country6 and is_valid_ipv6_address(query):
+            return GeoIP_country_name_by_addr_v6(self._country6, enc_query)
+        elif self._country:
             if ipv4_re.match(query):
                 return GeoIP_country_name_by_addr(self._country, enc_query)
             else:

--- a/django/contrib/gis/geoip/prototypes.py
+++ b/django/contrib/gis/geoip/prototypes.py
@@ -81,7 +81,7 @@ def record_output(func):
     return func
 GeoIP_record_by_addr = record_output(lgeoip.GeoIP_record_by_addr)
 GeoIP_record_by_name = record_output(lgeoip.GeoIP_record_by_name)
-
+GeoIP_record_by_addr_v6 = record_output(lgeoip.GeoIP_record_by_addr_v6)
 
 # For opening & closing GeoIP database files.
 GeoIP_open = lgeoip.GeoIP_open
@@ -122,4 +122,6 @@ def string_output(func):
 GeoIP_country_code_by_addr = string_output(lgeoip.GeoIP_country_code_by_addr)
 GeoIP_country_code_by_name = string_output(lgeoip.GeoIP_country_code_by_name)
 GeoIP_country_name_by_addr = string_output(lgeoip.GeoIP_country_name_by_addr)
+GeoIP_country_code_by_addr_v6 = string_output(lgeoip.GeoIP_country_code_by_addr_v6)
+GeoIP_country_name_by_addr_v6 = string_output(lgeoip.GeoIP_country_name_by_addr_v6)
 GeoIP_country_name_by_name = string_output(lgeoip.GeoIP_country_name_by_name)

--- a/docs/ref/contrib/gis/geoip.txt
+++ b/docs/ref/contrib/gis/geoip.txt
@@ -86,6 +86,26 @@ GEOIP_CITY
 The basename to use for the GeoIP city data file.
 Defaults to ``'GeoLiteCity.dat'``.
 
+.. setting:: GEOIP_COUNTRY6
+
+GEOIP_COUNTRY6
+--------------
+
+.. versionadded:: 1.9
+
+The basename to use for the GeoIPv6 country data file.
+Defaults to ``'GeoIPv6.dat'``.
+
+.. setting:: GEOIP_CITY6
+
+GEOIP_CITY6
+-----------
+
+.. versionadded:: 1.9
+
+The basename to use for the GeoIPv6 city data file.
+Defaults to ``'GeoLiteCityv6.dat'``.
+
 ``GeoIP`` API
 =============
 
@@ -132,6 +152,10 @@ All the following querying routines may take either a string IP address
 or a fully qualified domain name (FQDN).  For example, both
 ``'205.186.163.125'`` and ``'djangoproject.com'`` would be valid query
 parameters.
+
+.. versionchanged:: 1.9
+
+    You can specify IPv6 addresses, like '2a03:2880:2110:3f01:face:b00c::'
 
 .. method:: GeoIP.city(query)
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -895,6 +895,9 @@ Miscellaneous
   whitespace by default. This can be disabled by setting the new
   :attr:`~django.forms.CharField.strip` argument to ``False``.
 
+* The ``django.contrib.gis.geoip`` connection to C database from GeoIP now
+  supports IPv6.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9

--- a/tests/gis_tests/test_geoip.py
+++ b/tests/gis_tests/test_geoip.py
@@ -16,12 +16,12 @@ if HAS_GEOIP:
 
 # Note: Requires use of both the GeoIP country and city datasets.
 # The GEOIP_DATA path should be the only setting set (the directory
-# should contain links or the actual database files 'GeoIP.dat' and
-# 'GeoLiteCity.dat'.
+# should contain links or the actual database files 'GeoIP.dat',
+# 'GeoIPv6.dat', 'GeoLiteCity.dat' and 'GeoLiteCityv6.dat'.
 
 
 @skipUnless(HAS_GEOIP and getattr(settings, "GEOIP_PATH", None),
-    "GeoIP is required along with the GEOIP_PATH setting.")
+            "GeoIP is required along with the GEOIP_PATH setting.")
 class GeoIPTest(unittest.TestCase):
 
     def test01_init(self):
@@ -118,3 +118,9 @@ class GeoIPTest(unittest.TestCase):
         d = g.country('200.26.205.1')
         # Some databases have only unaccented countries
         self.assertIn(d['country_name'], ('Curaçao', 'Curacao'))
+
+    def test06_ipv6_query(self):
+        "Testing that GeoIP can lookup ipv6 addresses."
+        g = GeoIP()
+        d = g.city('2a03:2880:2110:3f01:face:b00c::')
+        self.assertNotEqual(d, None)


### PR DESCRIPTION
Thanks to j and fcurella for original patches.

This is rebased and documented version of previous PR #1986