### PR TITLE
Fixed #25170 -- fixed the assertXMLEqual behavior.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -301,7 +301,7 @@ def compare_xml(want, got):
     _norm_whitespace_re = re.compile(r'[ \t\n][ \t\n]+')
 
     def norm_whitespace(v):
-        return _norm_whitespace_re.sub(' ', v)
+        return _norm_whitespace_re.sub(' ', v).strip()
 
     def child_text(element):
         return ''.join(c.data for c in element.childNodes

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -701,7 +701,7 @@ class XMLEqualTests(SimpleTestCase):
         xml2 = "<elem attr2='b' attr1='a' />"
         self.assertXMLEqual(xml1, xml2)
 
-    def test_simple_equal_with_witespaces(self):
+    def test_simple_equal_with_whitespaces(self):
         xml1 = "<elem attr1='a' attr2='b' />"
         xml2 = " <elem attr1='a' \n attr2='b' /> \n "
         self.assertXMLEqual(xml1, xml2)

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -701,6 +701,11 @@ class XMLEqualTests(SimpleTestCase):
         xml2 = "<elem attr2='b' attr1='a' />"
         self.assertXMLEqual(xml1, xml2)
 
+    def test_simple_equal_with_witespaces(self):
+        xml1 = "<elem attr1='a' attr2='b' />"
+        xml2 = " <elem attr1='a' \n attr2='b' /> \n "
+        self.assertXMLEqual(xml1, xml2)
+
     def test_simple_equal_raise(self):
         xml1 = "<elem attr1='a' />"
         xml2 = "<elem attr2='b' attr1='a' />"


### PR DESCRIPTION
Fixed the issue that caused two identical XMLs to be treated as
different if one of them had some extra whitespaces in the begining
or the end of the xml string. Now, it is ignoring all whitespaces as it
is expected to be. The corresponding test case was added.

Fix for ticket: https://code.djangoproject.com/ticket/25170