### PR TITLE
Fixed #25170 -- Made SimpleTestCase.assertXMLEqual() ignore whitespace outside of tags.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -384,6 +384,7 @@ answer newbie questions, and generally made Django that much better:
     Justin Myles Holmes <justin@slashrootcafe.com>
     Jyrki Pulliainen <jyrki.pulliainen@gmail.com>
     Kadesarin Sanjek
+    Kamil Warguła <kwargula@gmail.com>
     Karderio <karderio@gmail.com>
     Karen Tracey <kmtracey@gmail.com>
     Karol Sikora <elektrrrus@gmail.com>

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -338,7 +338,13 @@ def compare_xml(want, got):
             if node.nodeType != Node.COMMENT_NODE:
                 return node
 
+    def strip_witespaces(want, got):
+        want = want.strip()
+        got = got.strip()
+        return want, got
+
     want, got = strip_quotes(want, got)
+    want, got = strip_witespaces(want, got)
     want = want.replace('\\n', '\n')
     got = got.replace('\\n', '\n')
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -729,6 +729,16 @@ class XMLEqualTests(SimpleTestCase):
         xml2 = "<?xml version='1.0'?><!-- comment2 --><elem attr2='b' attr1='a' />"
         self.assertXMLEqual(xml1, xml2)
 
+    def test_simple_equal_with_whitespaces(self):
+        xml1 = "<elem>hello</elem>"
+        xml2 = " <elem>hello</elem> \t\n"
+        self.assertXMLEqual(xml1, xml2)
+
+    def test_simple_not_equal_with_whitespaces(self):
+        xml1 = "<elem>hello</elem>"
+        xml2 = " <elem>hello \n</elem> \t\n"
+        self.assertXMLNotEqual(xml1, xml2)
+
 
 class SkippingExtraTests(TestCase):
     fixtures = ['should_not_be_loaded.json']


### PR DESCRIPTION
In every argument passed to ``compare_xml`` will be applied ``split()`` function.
All withespaces in the beginning and or end of xml string in ``assertXMLEqual`` will be ignored.