### PR TITLE
Fixed #25181 -- Moved views.generic.dates.timezone_today() to utils.timezone.localdate()

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -6,7 +6,7 @@ This module uses pytz when it's available and fallbacks when it isn't.
 
 import sys
 import time as _time
-from datetime import datetime, timedelta, tzinfo
+from datetime import date, datetime, timedelta, tzinfo
 from threading import local
 
 from django.conf import settings
@@ -295,13 +295,15 @@ def template_localtime(value, use_tz=None):
 
 # Utilities
 
-def localtime(value, timezone=None):
+def localtime(value=None, timezone=None):
     """
     Converts an aware datetime.datetime to local time.
 
     Local time is defined by the current time zone, unless another time zone
     is specified.
     """
+    if value is None:
+        value = _now_utc()
     if timezone is None:
         timezone = get_current_timezone()
     # If `value` is naive, astimezone() will raise a ValueError,
@@ -319,9 +321,26 @@ def now():
     """
     if settings.USE_TZ:
         # timeit shows that datetime.now(tz=utc) is 24% slower
-        return datetime.utcnow().replace(tzinfo=utc)
+        return _now_utc()
     else:
         return datetime.now()
+
+
+def _now_utc():
+    """
+    Returns an aware datetime.datetime.
+    """
+    return datetime.utcnow().replace(tzinfo=utc)
+
+
+def localdate(value=None, timezone=None):
+    """
+    Return the datetime.date in the current time zone.
+    """
+    if settings.USE_TZ:
+        return localtime(value, timezone).date()
+    else:
+        return value.date() if value else date.today()
 
 
 # By design, these four functions don't perform any checks on their arguments.

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -367,7 +367,7 @@ class BaseDateListView(MultipleObjectMixin, DateMixin, View):
         paginate_by = self.get_paginate_by(qs)
 
         if not allow_future:
-            now = timezone.now() if self.uses_datetime_field else timezone_today()
+            now = timezone.now() if self.uses_datetime_field else timezone.localdate()
             qs = qs.filter(**{'%s__lte' % date_field: now})
 
         if not allow_empty:
@@ -741,7 +741,7 @@ def _get_next_prev(generic_view, date, is_previous, period):
         else:
             result = end
 
-        if allow_future or result <= timezone_today():
+        if allow_future or result <= timezone.localdate():
             return result
         else:
             return None
@@ -766,7 +766,7 @@ def _get_next_prev(generic_view, date, is_previous, period):
             if generic_view.uses_datetime_field:
                 now = timezone.now()
             else:
-                now = timezone_today()
+                now = timezone.localdate()
             lookup['%s__lte' % date_field] = now
 
         qs = generic_view.get_queryset().filter(**lookup).order_by(ordering)
@@ -786,13 +786,3 @@ def _get_next_prev(generic_view, date, is_previous, period):
 
         # Return the first day of the period.
         return get_current(result)
-
-
-def timezone_today():
-    """
-    Return the current date in the current time zone.
-    """
-    if settings.USE_TZ:
-        return timezone.localtime(timezone.now()).date()
-    else:
-        return datetime.date.today()

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -928,7 +928,7 @@ appropriate entities.
 
         ``override`` is now usable as a function decorator.
 
-.. function:: localtime(value, timezone=None)
+.. function:: localtime(value=None, timezone=None)
 
     Converts an aware :class:`~datetime.datetime` to a different time zone,
     by default the :ref:`current time zone <default-current-time-zone>`.
@@ -953,6 +953,17 @@ appropriate entities.
       times in UTC regardless of the value of :setting:`TIME_ZONE`;
       you can use :func:`localtime` to convert to a time in the current
       time zone.
+
+.. function:: localdate(value=None, timezone=None)
+
+    .. versionadded:: 1.9
+
+    Returns a :class:`~datetime.date`. This function assumes ``value``
+    is a :class:`~datetime.datetime`.  If USE_TZ is True, ``value`` and
+    ``timezone`` arguments will be passed to the ``localtime()`` and result of
+    this function will be converted to a date. Otherwise, if ``value`` is
+    specified, it will be converted to a date, or ``date.today()`` will
+    be returned.
 
 .. function:: is_aware(value)
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -915,6 +915,9 @@ Miscellaneous
   Set ``request.current_app`` to ``None`` if you don't want to use a namespace
   hint.
 
+* The ``views.generic.dates.timezone_today()`` function has been moved to
+  ``django.utils.timezone.localdate()``.
+
 .. _deprecated-features-1.9:
 
 Features deprecated in 1.9


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25181