### PR TITLE
[WIP] Refs #24121 - Added more reprs

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -42,6 +42,14 @@ class LazySettings(LazyObject):
 
         self._wrapped = Settings(settings_module)
 
+    def __repr__(self):
+        # Hardcode the class name as otherwise it yields `Settings`
+        if self._wrapped is empty:
+            return '<LazySettings [Unevaluated]>'
+        return '<LazySettings "%(settings_module)s">' % {
+            'settings_module': self._wrapped.SETTINGS_MODULE,
+        }
+
     def __getattr__(self, name):
         if self._wrapped is empty:
             self._setup(name)
@@ -136,6 +144,12 @@ class Settings(BaseSettings):
     def is_overridden(self, setting):
         return setting in self._explicit_settings
 
+    def __repr__(self):
+        return '<%(cls)s "%(settings_module)s">' % {
+            'cls': self.__class__.__name__,
+            'settings_module': self.SETTINGS_MODULE,
+        }
+
 
 class UserSettingsHolder(BaseSettings):
     """
@@ -175,5 +189,10 @@ class UserSettingsHolder(BaseSettings):
         set_locally = (setting in self.__dict__)
         set_on_default = getattr(self.default_settings, 'is_overridden', lambda s: False)(setting)
         return (deleted or set_locally or set_on_default)
+
+    def __repr__(self):
+        return '<%(cls)s>' % {
+            'cls': self.__class__.__name__,
+        }
 
 settings = LazySettings()

--- a/django/contrib/gis/geoip/base.py
+++ b/django/contrib/gis/geoip/base.py
@@ -13,7 +13,7 @@ from django.contrib.gis.geoip.prototypes import (
 from django.core.validators import ipv4_re
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, force_text
 
 # Regular expressions for recognizing the GeoIP free database editions.
 free_regex = re.compile(r'^GEO-\d{3}FREE')
@@ -144,6 +144,17 @@ class GeoIP(object):
             GeoIP_delete(self._country)
         if self._city:
             GeoIP_delete(self._city)
+
+    def __repr__(self):
+        version = ''
+        if GeoIP_lib_version is not None:
+            version += ' [v%s]' % force_text(GeoIP_lib_version())
+        return '<%(cls)s%(version)s _country_file="%(country)s", _city_file="%(city)s">' % {
+            'cls': self.__class__.__name__,
+            'version': version,
+            'country': self._country_file,
+            'city': self._city_file,
+        }
 
     def _check_query(self, query, country=False, city=False, city_or_country=False):
         "Helper routine for checking the query and database availability."

--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -133,6 +133,16 @@ class GeoIP2(object):
         if self._reader:
             self._reader.close()
 
+    def __repr__(self):
+        meta = self._reader.metadata()
+        version = '[v%s.%s]' % (meta.binary_format_major_version, meta.binary_format_minor_version)
+        return '<%(cls)s %(version)s _country_file="%(country)s", _city_file="%(city)s">' % {
+            'cls': self.__class__.__name__,
+            'version': version,
+            'country': self._country_file,
+            'city': self._city_file,
+        }
+
     def _check_query(self, query, country=False, city=False, city_or_country=False):
         "Helper routine for checking the query and database availability."
         # Making sure a string was passed in for the query.

--- a/django/contrib/messages/middleware.py
+++ b/django/contrib/messages/middleware.py
@@ -24,3 +24,9 @@ class MessageMiddleware(object):
             if unstored_messages and settings.DEBUG:
                 raise ValueError('Not all temporary messages could be stored.')
         return response
+
+    def __repr__(self):
+        return '<%(cls)s MESSAGE_STORAGE="%(storage)s">' % {
+            'cls': self.__class__.__name__,
+            'storage': settings.MESSAGE_STORAGE,
+        }

--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -38,6 +38,14 @@ class Message(object):
     def __str__(self):
         return force_text(self.message)
 
+    def __repr__(self):
+        return '<%(cls)s level=%(level)d, level_tag="%(tag)s", message="%(msg)s">' % {
+            'cls': self.__class__.__name__,
+            'level': self.level,
+            'msg': str(self),
+            'tag': self.level_tag,
+        }
+
     def _get_tags(self):
         extra_tags = force_text(self.extra_tags, strings_only=True)
         if extra_tags and self.level_tag:
@@ -183,3 +191,11 @@ class BaseStorage(object):
             self._level = int(value)
 
     level = property(_get_level, _set_level, _set_level)
+
+    def __repr__(self):
+        return '<%(cls)s [%(count)d] used=%(used)r, added_new=%(added)r>' % {
+            'cls': self.__class__.__name__,
+            'used': self.used,
+            'added': self.added_new,
+            'count': len(self),
+        }

--- a/django/contrib/messages/storage/cookie.py
+++ b/django/contrib/messages/storage/cookie.py
@@ -163,3 +163,12 @@ class CookieStorage(BaseStorage):
         # with the data.
         self.used = True
         return None
+
+    def __repr__(self):
+        return '<%(cls)s [%(count)d] used=%(used)r, added_new=%(added)r, cookie_name="%(name)s">' % {
+            'cls': self.__class__.__name__,
+            'used': self.used,
+            'added': self.added_new,
+            'count': len(self),
+            'name': self.cookie_name,
+        }

--- a/django/contrib/messages/storage/fallback.py
+++ b/django/contrib/messages/storage/fallback.py
@@ -16,6 +16,12 @@ class FallbackStorage(BaseStorage):
                          for storage_class in self.storage_classes]
         self._used_storages = set()
 
+    def __repr__(self):
+        return '<%(cls)s storages=%(storages)r>' % {
+            'cls': self.__class__.__name__,
+            'storages': self.storages,
+        }
+
     def _get(self, *args, **kwargs):
         """
         Gets a single list of messages from all storage backends.

--- a/tests/gis_tests/test_geoip.py
+++ b/tests/gis_tests/test_geoip.py
@@ -8,10 +8,12 @@ from unittest import skipUnless
 
 from django.conf import settings
 from django.contrib.gis.geoip import HAS_GEOIP
+from django.contrib.gis.geoip.prototypes import GeoIP_lib_version
 from django.contrib.gis.geos import HAS_GEOS, GEOSGeometry
 from django.test import ignore_warnings
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.encoding import force_text
 
 if HAS_GEOIP:
     from django.contrib.gis.geoip import GeoIP, GeoIPException
@@ -128,3 +130,21 @@ class GeoIPTest(unittest.TestCase):
         self.assertEqual(len(warns), 1)
         msg = str(warns[0].message)
         self.assertIn('django.contrib.gis.geoip is deprecated', msg)
+
+    def test_repr(self):
+        path = settings.GEOIP_PATH
+        g = GeoIP(path=path)
+        country_path = g._country_file
+        city_path = g._city_file
+        if GeoIP_lib_version:
+            expected = '<GeoIP [v%(version)s] _country_file="%(country)s", _city_file="%(city)s">' % {
+                'version': force_text(GeoIP_lib_version()),
+                'country': country_path,
+                'city': city_path,
+            }
+        else:
+            expected = '<GeoIP _country_file="%(country)s", _city_file="%(city)s">' % {
+                'country': country_path,
+                'city': city_path,
+            }
+        self.assertEqual(repr(g), expected)

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -137,3 +137,17 @@ class GeoIPTest(unittest.TestCase):
         self.assertEqual('US', d['country_code'])
         self.assertEqual('Lawrence', d['city'])
         self.assertEqual('KS', d['region'])
+
+    def test07_repr(self):
+        path = settings.GEOIP_PATH
+        g = GeoIP2(path=path)
+        meta = g._reader.metadata()
+        version = '%s.%s' % (meta.binary_format_major_version, meta.binary_format_minor_version)
+        country_path = g._country_file
+        city_path = g._city_file
+        expected = '<GeoIP2 [v%(version)s] _country_file="%(country)s", _city_file="%(city)s">' % {
+            'version': version,
+            'country': country_path,
+            'city': city_path,
+        }
+        self.assertEqual(repr(g), expected)

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -381,3 +381,8 @@ class BaseTests(object):
         tags = [msg.tags for msg in storage]
         self.assertEqual(tags,
                      ['info', 'custom', 'extra-tag', '', 'bad', 'success'])
+
+    def test_message_repr(self):
+        msg = Message(constants.INFO, 'Test message 1', extra_tags='tag')
+        expected = '<Message level=20, level_tag="info", message="Test message 1">'
+        self.assertEqual(repr(msg), expected)

--- a/tests/messages_tests/test_cookie.py
+++ b/tests/messages_tests/test_cookie.py
@@ -177,3 +177,8 @@ class CookieTest(BaseTests, SimpleTestCase):
         # Decode the messages in the old format (without is_safedata)
         decoded_messages = json.loads(encoded_messages, cls=MessageDecoder)
         self.assertEqual(messages, decoded_messages)
+
+    def test_repr(self):
+        storage = self.get_storage([Message(constants.INFO, 'Test message 1')])
+        expected = '<CookieStorage [1] used=False, added_new=False, cookie_name="messages">'
+        self.assertEqual(repr(storage), expected)

--- a/tests/messages_tests/test_fallback.py
+++ b/tests/messages_tests/test_fallback.py
@@ -1,4 +1,5 @@
 from django.contrib.messages import constants
+from django.contrib.messages.storage.base import Message
 from django.contrib.messages.storage.fallback import (
     CookieStorage, FallbackStorage,
 )
@@ -174,3 +175,11 @@ class FallbackTest(BaseTests, SimpleTestCase):
         self.assertEqual(cookie_storing, 0)
         session_storing = self.stored_session_messages_count(storage, response)
         self.assertEqual(session_storing, 1)
+
+    def test_repr(self):
+        storage = self.get_storage()
+        storage.storages[0]._loaded_data = [Message(constants.INFO, 'Test message 1'),
+                                            Message(constants.INFO, 'Test message 2', extra_tags='tag')]
+        expected = ('<FallbackStorage storages=[<CookieStorage [2] used=False, added_new=False, '
+                    'cookie_name="messages">, <SessionStorage [0] used=False, added_new=False>]>')
+        self.assertEqual(repr(storage), expected)

--- a/tests/messages_tests/test_middleware.py
+++ b/tests/messages_tests/test_middleware.py
@@ -17,3 +17,7 @@ class MiddlewareTest(unittest.TestCase):
         request = http.HttpRequest()
         response = http.HttpResponse()
         self.middleware.process_response(request, response)
+
+    def test_repr(self):
+        expected = '<MessageMiddleware MESSAGE_STORAGE="django.contrib.messages.storage.fallback.FallbackStorage">'
+        self.assertEqual(repr(self.middleware), expected)

--- a/tests/messages_tests/test_session.py
+++ b/tests/messages_tests/test_session.py
@@ -52,3 +52,8 @@ class SessionTest(BaseTests, TestCase):
         message = Message(constants.DEBUG, mark_safe("<b>Hello Django!</b>"))
         set_session_data(storage, [message])
         self.assertIsInstance(list(storage)[0].message, SafeData)
+
+    def test_repr(self):
+        storage = self.get_storage([Message(constants.INFO, 'Test message 1')])
+        expected = '<SessionStorage [1] used=False, added_new=False>'
+        self.assertEqual(repr(storage), expected)

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -4,7 +4,7 @@ import unittest
 import warnings
 from types import ModuleType
 
-from django.conf import LazySettings, Settings, settings
+from django.conf import ENVIRONMENT_VARIABLE, LazySettings, Settings, settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import (
@@ -441,6 +441,31 @@ class IsOverriddenTest(SimpleTestCase):
         self.assertFalse(settings.is_overridden('ALLOWED_HOSTS'))
         with override_settings(ALLOWED_HOSTS=[]):
             self.assertTrue(settings.is_overridden('ALLOWED_HOSTS'))
+
+    def test_unevaluated_lazysettings_repr(self):
+        lazy_settings = LazySettings()
+        expected = '<LazySettings [Unevaluated]>'
+        self.assertEqual(repr(lazy_settings), expected)
+
+    def test_evaluated_lazysettings_repr(self):
+        lazy_settings = LazySettings()
+        module = os.environ.get(ENVIRONMENT_VARIABLE)
+        expected = '<LazySettings "%s">' % module
+        # Force evaluation of the lazy object.
+        lazy_settings.APPEND_SLASH
+        self.assertEqual(repr(lazy_settings), expected)
+
+    def test_usersettingsholder_repr(self):
+        lazy_settings = LazySettings()
+        lazy_settings.configure(APPEND_SLASH=False)
+        expected = '<UserSettingsHolder>'
+        self.assertEqual(repr(lazy_settings._wrapped), expected)
+
+    def test_settings_repr(self):
+        module = os.environ.get(ENVIRONMENT_VARIABLE)
+        lazy_settings = Settings(module)
+        expected = '<Settings "%s">' % module
+        self.assertEqual(repr(lazy_settings), expected)
 
 
 class TestListSettings(unittest.TestCase):


### PR DESCRIPTION
Bunching slightly more work together, but I'd appreciate any thoughts on the following, before I commit more time to any others I'd care to tackle:

- the `contrib.messages` reprs include the count of messages (loaded and queued), but don't make it clear what the number represents. I'd prefer the message was `[3 messages]` vs `[3]` but I don't know how pluralization should be approached in the repr - ought it go through gettext, or is hardcoding english values ok? or leave as is? or drop the count?
- the `LazySettings` repr changes depending on if it was evaluated. I'm not sure whether that's appropriate, or whether it should call `_setup()` to ensure `_wrapped` is a real `Settings` object (prior to evaluation, trying to glean the settings module from `_wrapped` is an exception)

[Original ticket is here, for reference](https://code.djangoproject.com/ticket/24121)