### PR TITLE
Fixed #25185 -- Added support for functools.partial serialization in migrations

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import collections
 import datetime
 import decimal
+import functools
 import math
 import os
 import re
@@ -439,6 +440,23 @@ class MigrationWriter(object):
             string, imports = OperationWriter(value, indentation=0).serialize()
             # Nested operation, trailing comma is handled in upper OperationWriter._write()
             return string.rstrip(','), imports
+        elif isinstance(value, functools.partial):
+            imports = {'import functools'}
+
+            func_string, func_imports = cls.serialize(value.func)
+            args_string, args_imports = cls.serialize(value.args)
+            keywords_string, keywords_imports = cls.serialize(value.keywords)
+
+            imports.update(func_imports)
+            imports.update(args_imports)
+            imports.update(keywords_imports)
+
+            return (
+                "functools.partial(%s, *%s, **%s)" % (
+                    func_string, args_string, keywords_string,
+                ),
+                imports,
+            )
         # Anything that knows how to deconstruct itself.
         elif hasattr(value, 'deconstruct'):
             return cls.serialize_deconstructed(*value.deconstruct())

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -385,6 +385,8 @@ Migrations
   :djadminopt:`migrate --fake-initial <--fake-initial>` to more easily detect
   initial migrations.
 
+* Support for serialization of ``functools.partial`` objects.
+
 Models
 ^^^^^^
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -652,10 +652,16 @@ Django can serialize the following:
 - ``datetime.date``, ``datetime.time``, and ``datetime.datetime`` instances
   (include those that are timezone-aware)
 - ``decimal.Decimal`` instances
+- ``functools.partial`` instances which have serializable ``func``, ``args``,
+  and ``keywords`` values.
 - Any Django field
 - Any function or method reference (e.g. ``datetime.datetime.today``) (must be in module's top-level scope)
 - Any class reference (must be in module's top-level scope)
 - Anything with a custom ``deconstruct()`` method (:ref:`see below <custom-deconstruct-method>`)
+
+.. versionchanged:: 1.9
+
+    Serialization support for `functools.partial` was added.
 
 Django can serialize the following on Python 3 only:
 

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import functools
 import math
 import os
 import re
@@ -408,6 +409,14 @@ class WriterTests(SimpleTestCase):
     def test_serialize_timedelta(self):
         self.assertSerializedEqual(datetime.timedelta())
         self.assertSerializedEqual(datetime.timedelta(minutes=42))
+
+    def test_serialize_functools_partial(self):
+        value = functools.partial(datetime.timedelta, 1, seconds=2)
+        result = self.serialize_round_trip(value)
+
+        self.assertEqual(result.func, value.func)
+        self.assertEqual(result.args, value.args)
+        self.assertEqual(result.keywords, value.keywords)
 
     def test_simple_migration(self):
         """


### PR DESCRIPTION
Code for https://code.djangoproject.com/ticket/25185

### What was wrong?

The `MigrationWriter` class did not support serialization of `functools.partial` objects.  These can be quite useful for use as the value for the `default` keyword for model fields.

### How was it fixed.

Since the `functools.partial` object has the three properties `func`, `args`, and `keywords`, the `MigrationWriter` now serializes these individual values and then reconstructs the call to `functools.partial`.

In addition, a special case was required for handling the serialization of functions that are in the `__builtins__` module.

#### Cute animal picture

![the-world s-top-10-best-images-of-things-balanced-on-rabbits-heads-4](https://cloud.githubusercontent.com/assets/824194/8937756/c29b8bf6-3517-11e5-8c00-13f3a680e496.jpg)
