### PR TITLE
Fixed #25186 -- Improved migration's serialization of builtins on Python 2.

### DIFF
--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -472,6 +472,8 @@ class MigrationWriter(object):
                     "For more information, see "
                     "https://docs.djangoproject.com/en/%s/topics/migrations/#serializing-values"
                     % (value.__name__, module_name, get_docs_version()))
+            if module_name == '__builtin__':
+                return value.__name__, set()
             return "%s.%s" % (module_name, value.__name__), {"import %s" % module_name}
         # Other iterables
         elif isinstance(value, collections.Iterable):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -359,6 +359,11 @@ class WriterTests(SimpleTestCase):
         self.assertSerializedEqual(one_item_tuple)
         self.assertSerializedEqual(many_items_tuple)
 
+    def test_serialize_builtins(self):
+        string, imports = MigrationWriter.serialize(range)
+        self.assertEqual(string, 'range')
+        self.assertEqual(imports, set())
+
     @unittest.skipUnless(six.PY2, "Only applies on Python 2")
     def test_serialize_direct_function_reference(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25186

### What was wrong

When `MigrationWriter.serialize` is given something from the `__builtin__` module, the resulting string and imports also include the `__builtin__` module.

```python
>>> string, imports = MigrationWriter.serialize(range)
"__builtin__.range", {"import __builtin__"}
```

### How was it fixed.

Added a special case for when `value.__module__ == '__builtin__'` so that the result is more natural python.

```python
>>> string, imports = MigrationWriter.serialize(range)
"range", set()
```

#### Cute animal picture

![tumblr_marlasld1y1rxa4kho1_500](https://cloud.githubusercontent.com/assets/824194/8942560/480af572-3533-11e5-9925-f494f04bcc8f.jpg)
