### PR TITLE
Fixed #25190 -- Deprecated callable_obj parameter to assertRaisesMessage().

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -618,6 +618,10 @@ class SimpleTestCase(unittest.TestCase):
         # callable_obj was a documented kwarg in Django 1.8 and older.
         callable_obj = kwargs.pop('callable_obj', None)
         if callable_obj:
+            warnings.warn(
+                'The callable_obj kwarg is deprecated. Pass the callable '
+                'as a positional argument instead.', RemovedInDjango20Warning
+            )
             args = (callable_obj,) + args
         return six.assertRaisesRegex(self, expected_exception,
                 re.escape(expected_message), *args, **kwargs)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -89,6 +89,9 @@ details on these changes.
 
 * The ``current_app`` parameter to the ``contrib.auth`` views will be removed.
 
+* The ``callable_obj`` keyword argument to
+  ``SimpleTestCase.assertRaisesMessage()`` will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1077,6 +1077,10 @@ Miscellaneous
 * ``django.template.loaders.eggs.Loader`` is deprecated as distributing
   applications as eggs is not recommended.
 
+* The ``callable_obj`` keyword argument to
+  ``SimpleTestCase.assertRaisesMessage()`` is deprecated. Pass the callable as
+  a positional argument instead.
+
 .. removed-features-1.9:
 
 Features removed in 1.9

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1364,6 +1364,11 @@ your test suite.
         with self.assertRaisesMessage(ValueError, 'invalid literal for int()'):
             int('a')
 
+    .. deprecated:: 1.9
+
+        Passing ``callable`` as a keyword argument called ``callable_obj`` is
+        deprecated. Pass the callable as a positional argument instead.
+
 .. method:: SimpleTestCase.assertFieldOutput(fieldclass, valid, invalid, field_args=None, field_kwargs=None, empty_value='')
 
     Asserts that a form field behaves correctly with various inputs.

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import unittest
+import warnings
 
 from django.conf.urls import url
 from django.contrib.staticfiles.finders import get_finder, get_finders
@@ -13,12 +14,14 @@ from django.forms import EmailField, IntegerField
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.test import (
-    SimpleTestCase, TestCase, skipIfDBFeature, skipUnlessDBFeature,
+    SimpleTestCase, TestCase, ignore_warnings, skipIfDBFeature,
+    skipUnlessDBFeature,
 )
 from django.test.html import HTMLParseError, parse_html
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import six
 from django.utils._os import abspathu
+from django.utils.deprecation import RemovedInDjango20Warning
 
 from .models import Car, Person, PossessedCar
 from .views import empty_response
@@ -752,11 +755,22 @@ class AssertRaisesMsgTest(SimpleTestCase):
             raise ValueError("[.*x+]y?")
         self.assertRaisesMessage(ValueError, "[.*x+]y?", func1)
 
+    @ignore_warnings(category=RemovedInDjango20Warning)
     def test_callable_obj_param(self):
         # callable_obj was a documented kwarg in Django 1.8 and older.
         def func1():
             raise ValueError("[.*x+]y?")
-        self.assertRaisesMessage(ValueError, "[.*x+]y?", callable_obj=func1)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+            self.assertRaisesMessage(ValueError, "[.*x+]y?", callable_obj=func1)
+
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            'The callable_obj kwarg is deprecated. Pass the callable '
+            'as a positional argument instead.'
+        )
 
 
 class AssertFieldOutputTests(SimpleTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25190#ticket