### PR TITLE
Fixed #25189 - Allowed DateTimeField to validate datetime.isoformat() strings

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -390,7 +390,9 @@ TIME_INPUT_FORMATS = [
 # * Note that these format strings are different from the ones to display dates
 DATETIME_INPUT_FORMATS = [
     '%Y-%m-%d %H:%M:%S',     # '2006-10-25 14:30:59'
+    '%Y-%m-%dT%H:%M:%S',     # '2006-10-25T14:30:59'
     '%Y-%m-%d %H:%M:%S.%f',  # '2006-10-25 14:30:59.000200'
+    '%Y-%m-%dT%H:%M:%S.%f',  # '2006-10-25 14:30:59.000200'
     '%Y-%m-%d %H:%M',        # '2006-10-25 14:30'
     '%Y-%m-%d',              # '2006-10-25'
     '%m/%d/%Y %H:%M:%S',     # '10/25/2006 14:30:59'

--- a/tests/forms_tests/tests/test_input_formats.py
+++ b/tests/forms_tests/tests/test_input_formats.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, time
 
 from django import forms
 from django.test import SimpleTestCase, override_settings
+from django.utils.timezone import utc
 from django.utils.translation import activate, deactivate
 
 
@@ -865,3 +866,43 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         # Check that the parsed result does a round trip to default format
         text = f.widget._format_value(result)
         self.assertEqual(text, "2010-12-21 13:30:00")
+
+    def test_djangojsonencoder_input_format_with_microseconds(self):
+        """
+        The datetime format favoured by Django's internal JSON encoder
+        is to call `.isoformat()` and trim the microseconds to 3 digits,
+        which means some loss of resolution, so `input` != `output` but
+        is close.
+        """
+        input_data = datetime(2010, 12, 21, 13, 30, 5, 123456)
+        isoformatted = input_data.isoformat()
+        isoformatted = isoformatted[:23] + isoformatted[26:]
+        f = forms.DateTimeField()
+        result = f.clean(value=isoformatted)
+        expected = datetime(2010, 12, 21, 13, 30, 5, 123000)
+        self.assertEqual(expected, result)
+
+    def test_djangojsonencoder_input_format(self):
+        """
+        The datetime format favoured by Django's internal JSON encoder
+        is to call `.isoformat()`
+        """
+        input_data = datetime(2010, 12, 21, 13, 30, 5)
+        isoformatted = input_data.isoformat()
+        f = forms.DateTimeField()
+        result = f.clean(value=isoformatted)
+        self.assertEqual(input_data, result)
+
+    def test_djangojsonencoder_input_format_with_tzinfo(self):
+        """
+        Without special-casing "Z" as a trailing character indicating UTC,
+        it's not possible to restore the tzinfo for a datetime object, so
+        it cannot be added to DATETIME_INPUT_FORMATS and validation will
+        continue to fail.
+        """
+        input_data = datetime(2010, 12, 21, 13, 30, 5).replace(tzinfo=utc)
+        isoformatted = input_data.isoformat()
+        isoformatted = isoformatted[:-6] + 'Z'
+        f = forms.DateTimeField()
+        with self.assertRaises(forms.ValidationError):
+            f.clean(value=isoformatted)


### PR DESCRIPTION
using new DATETIME_INPUT_FORMATS values which match the naive-datetime case of JSON encoded values.

Tested for:
- a naive `datetime` with microseconds
- a naive `datetime` without microseconds
- a `datetime` with UTC tzinfo (which would end up as a special value "Z", which to my awareness isn't parsable by `strptime`)

[Ticket link for reference](https://code.djangoproject.com/ticket/25189)
