### PR TITLE
Removed unnecessary F() from Func expressions docs

### DIFF
--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -213,7 +213,7 @@ or they can be used to build a library of database functions::
     class Lower(Func):
         function = 'LOWER'
 
-    queryset.annotate(field_lower=Lower(F('field')))
+    queryset.annotate(field_lower=Lower('field'))
 
 But both cases will result in a queryset where each model is annotated with an
 extra attribute ``field_lower`` produced, roughly, from the following SQL::


### PR DESCRIPTION
This makes the example consistent with the [docs](https://docs.djangoproject.com/en/1.8/ref/models/database-functions/#lower) for the built in ``Lower()`` database function. 