### PR TITLE
Fixed #24690 -- Added a warning about mutable defaults for ArrayField/JSONField.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -17,6 +17,12 @@ ArrayField
     <ArrayField.size>`. ``ArrayField`` can be nested to store multi-dimensional
     arrays.
 
+    If you give the field a :attr:`~django.db.models.Field.default`, ensure
+    it's a callable such as ``list`` (for an empty default) or a callable that
+    returns a list (such as a function). Incorrectly using ``default=[]``
+    creates a mutable default that is shared between all instances of
+    ``ArrayField``.
+
     .. attribute:: base_field
 
         This is a required argument.
@@ -460,6 +466,12 @@ JSONField
     A field for storing JSON encoded data. In Python the data is represented in
     its Python native format: dictionaries, lists, strings, numbers, booleans
     and ``None``.
+
+    If you give the field a :attr:`~django.db.models.Field.default`, ensure
+    it's a callable such as ``dict`` (for an empty default) or a callable that
+    returns a dict (such as a function). Incorrectly using ``default={}``
+    creates a mutable default that is shared between all instances of
+    ``JSONField``.
 
 .. note::
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24690