### PR TITLE
docs: remove note about sentry/raven not handling wsgi properly in docs

### DIFF
--- a/docs/howto/deployment/wsgi/index.txt
+++ b/docs/howto/deployment/wsgi/index.txt
@@ -85,7 +85,6 @@ to combine a Django application with a WSGI application of another framework.
 .. note::
 
     Some third-party WSGI middleware do not call ``close`` on the response
-    object after handling a request — most notably Sentry's error reporting
-    middleware up to version 2.0.7. In those cases the
+    object after handling a request. In those cases the
     :data:`~django.core.signals.request_finished` signal isn't sent. This can
     result in idle connections to database and memcache servers.


### PR DESCRIPTION
2.0.7 was released in 2012, and if someone is running this version,
they are likely to have many other issues, including likely
incompatibilities with any modern Django.