### PR TITLE
allow to use the @register decorator with geoDjango admin

### DIFF
--- a/django/contrib/gis/admin/__init__.py
+++ b/django/contrib/gis/admin/__init__.py
@@ -1,6 +1,6 @@
 from django.contrib.admin import (
     HORIZONTAL, VERTICAL, AdminSite, ModelAdmin, StackedInline, TabularInline,
-    autodiscover, site,
+    autodiscover, site, register,
 )
 from django.contrib.gis.admin.options import GeoModelAdmin, OSMGeoAdmin
 from django.contrib.gis.admin.widgets import OpenLayersWidget
@@ -8,5 +8,5 @@ from django.contrib.gis.admin.widgets import OpenLayersWidget
 __all__ = [
     'autodiscover', 'site', 'AdminSite', 'ModelAdmin', 'StackedInline',
     'TabularInline', 'HORIZONTAL', 'VERTICAL', 'GeoModelAdmin', 'OSMGeoAdmin',
-    'OpenLayersWidget',
+    'OpenLayersWidget', 'register',
 ]


### PR DESCRIPTION
From Django 1.7, there is a [register] (https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#the-register-decorator) decorator for ModelAdmin classes. It  was not possible to use it in geoDjango.