### PR TITLE
Fixed #25211 -- Add USE_X_FORWARDED_PORT setting and HttpRequest.get_port()

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -428,6 +428,7 @@ DEFAULT_INDEX_TABLESPACE = ''
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 USE_X_FORWARDED_HOST = False
+USE_X_FORWARDED_PORT = False
 
 # The Python dotted path to the WSGI application that Django's internal server
 # (runserver) will use. If `None`, the return value of

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -79,7 +79,7 @@ class HttpRequest(object):
         else:
             # Reconstruct the host using the algorithm from PEP 333.
             host = self.META['SERVER_NAME']
-            server_port = str(self.META['SERVER_PORT'])
+            server_port = self.get_port()
             if server_port != ('443' if self.is_secure() else '80'):
                 host = '%s:%s' % (host, server_port)
 
@@ -97,6 +97,15 @@ class HttpRequest(object):
             else:
                 msg += " The domain name provided is not valid according to RFC 1034/1035."
             raise DisallowedHost(msg)
+
+    def get_port(self):
+        """Returns the port number for the request as a string"""
+        if settings.USE_X_FORWARDED_PORT and (
+                'HTTP_X_FORWARDED_PORT' in self.META):
+            port = self.META['HTTP_X_FORWARDED_PORT']
+        else:
+            port = self.META['SERVER_PORT']
+        return str(port)
 
     def get_full_path(self, force_append_slash=False):
         # RFC 3986 requires query string arguments to be in the ASCII range.

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -254,6 +254,14 @@ Methods
         :class:`~django.middleware.common.CommonMiddleware` or
         :class:`~django.middleware.csrf.CsrfViewMiddleware`.
 
+.. method:: HttpRequest.get_port()
+
+    .. versionadded:: 1.9
+
+    Returns the originating port of the request using information from the
+    ``HTTP_X_FORWARDED_PORT`` (if :setting:`USE_X_FORWARDED_PORT` is enabled)
+    and ``SERVER_PORT`` ``META`` variable, in that order.
+
 .. method:: HttpRequest.get_full_path()
 
     Returns the ``path``, plus an appended query string, if applicable.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2621,6 +2621,17 @@ A boolean that specifies whether to use the X-Forwarded-Host header in
 preference to the Host header. This should only be enabled if a proxy
 which sets this header is in use.
 
+.. setting:: USE_X_FORWARDED_PORT
+
+USE_X_FORWARDED_PORT
+--------------------
+
+Default: ``False``
+
+A boolean that specifies whether to use the X-Forwarded-Port header in
+preference to the ``SERVER_PORT`` ``META`` variable. This should only be
+enabled if a proxy which sets this header is in use.
+
 .. setting:: WSGI_APPLICATION
 
 WSGI_APPLICATION
@@ -3329,6 +3340,7 @@ HTTP
 * :setting:`SIGNING_BACKEND`
 * :setting:`USE_ETAGS`
 * :setting:`USE_X_FORWARDED_HOST`
+* :setting:`USE_X_FORWARDED_PORT`
 * :setting:`WSGI_APPLICATION`
 
 Logging

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -538,6 +538,15 @@ Requests and Responses
   returning an :class:`~django.http.HttpResponseForbidden` so that
   :data:`~django.conf.urls.handler403` is invoked.
 
+* Added :meth:`~django.http.HttpRequest.get_port()` to fetch the
+  originating port of the request potentially taking into account the
+  ``X-Forwarded-Port`` header if :setting:`USE_X_FORWARDED_PORT` is set
+  to ``True``, and falling back to ``request.META['SERVER_PORT']``.
+
+* Added :setting:`USE_X_FORWARDED_PORT`, defaulting to ``False`` which tells
+  :meth:`~django.http.HttpRequest.get_port()` to use the ``X-Forwarded-Port``
+  header instead of ``request.META['SERVER_PORT']`` if found.
+
 Tests
 ^^^^^
 

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -651,6 +651,38 @@ class HostValidationTests(SimpleTestCase):
                 }
                 request.get_host()
 
+    @override_settings(USE_X_FORWARDED_PORT=False)
+    def test_get_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_PORT': '80',
+        }
+        # Make sure it doesn't use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '8080')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
+    @override_settings(USE_X_FORWARDED_PORT=True)
+    def test_get_port_with_x_forwarded_port(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '8080',
+            'HTTP_X_FORWARDED_PORT': '80',
+        }
+        # Make sure we use use the X-Forwarded-Port header
+        self.assertEqual(request.get_port(), '80')
+
+        request = HttpRequest()
+        request.META = {
+            'SERVER_PORT': '8080',
+        }
+        self.assertEqual(request.get_port(), '8080')
+
     @override_settings(DEBUG=True, ALLOWED_HOSTS=[])
     def test_host_validation_disabled_in_debug_mode(self):
         """If ALLOWED_HOSTS is empty and DEBUG is True, all hosts pass."""


### PR DESCRIPTION
It's be nice to internally have a way to reference the "real" port number when behind a proxy.

Today, as an example:

If you were running a load balancer on port 80, which proxied back to an nginx which was running on 8080, it's possible that `get_host()` would resolve your request back to `example.com:8080` instead of the proper `example.com` since `SERVER_PORT` is coming from what nginx was listening on.

This just adds a proper method to `get_port()` and respect an optional `X-Forwarded-Port` header.

The benefits of this being internal to Django, is because anywhere that Django tries to resolve the port internally, we should be utilizing this method. This issue is easy to correct in user-land, but a bit harder when an internal Django method utilizes `SERVER_PORT` directly. The only option is to have a middleware which sets `request.META['SERVER_PORT'] = `request.META['HTTP_X_FORWARDED_PORT']` which is less than ideal IMO since it's overloading the meaning of the variable.

This is also relevant for #4337 since in the wild, we hit an issue with `SERVER_PORT` not reflecting what the upstream actually was, which caused issues. So this would unify and make #4337 leverage the new `get_port()`.