### PR TITLE
Fixed #25209 -- Removed parallel=True coverage option

### DIFF
--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -2,7 +2,6 @@
 branch = True
 omit =
     */django/utils/autoreload.py
-parallel = True
 source = django
 
 [report]


### PR DESCRIPTION
So one won't need to perform a `coverage combine` to have `coverage html` work after a `coverage run ./runtests.py`.