### PR TITLE
Actually test get_extra_descriptor_filter

### DIFF
--- a/tests/foreign_object/models.py
+++ b/tests/foreign_object/models.py
@@ -146,7 +146,7 @@ class ActiveTranslationField(models.ForeignObject):
     def get_extra_restriction(self, where_class, alias, related_alias):
         return ColConstraint(alias, 'lang', get_language())
 
-    def get_extra_descriptor_filter(self):
+    def get_extra_descriptor_filter(self, instance):
         return {'lang': get_language()}
 
     def contribute_to_class(self, cls, name):

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -319,6 +319,9 @@ class MultiColumnFKTests(TestCase):
         at1_fi.save()
         at2_en = ArticleTranslation(article=a1, lang='en', title='Title', body='Lalalalala')
         at2_en.save()
+
+        self.assertEqual(Article.objects.get(pk=a1.pk).active_translation, at1_fi)
+
         with self.assertNumQueries(1):
             fetched = Article.objects.select_related('active_translation').get(
                 active_translation__title='Otsikko')


### PR DESCRIPTION
CC @akaariai

``article.active_description`` was never actually called, so ``get_extra_descriptor_filter`` wasn't being tested.