### PR TITLE
Removed unused Field.get_flatchoices() method.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -826,14 +826,6 @@ class Field(RegisterLookupMixin):
     def get_choices_default(self):
         return self.get_choices()
 
-    def get_flatchoices(self, include_blank=True,
-                        blank_choice=BLANK_CHOICE_DASH):
-        """
-        Returns flattened choices with a default blank choice included.
-        """
-        first_choice = blank_choice if include_blank else []
-        return first_choice + list(self.flatchoices)
-
     @warn_about_renamed_method(
         'Field', '_get_val_from_obj', 'value_from_object',
         RemovedInDjango20Warning

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -480,8 +480,8 @@ class BooleanFieldTests(test.TestCase):
 class ChoicesTests(test.SimpleTestCase):
     def test_choices_and_field_display(self):
         """
-        Check that get_choices and get_flatchoices interact with
-        get_FIELD_display to return the expected values (#7913).
+        Check that get_choices() interacts with get_FIELD_display() to return
+        the expected values (#7913).
         """
         self.assertEqual(Whiz(c=1).get_c_display(), 'First')    # A nested value
         self.assertEqual(Whiz(c=0).get_c_display(), 'Other')    # A top level value


### PR DESCRIPTION
Unused since c2ba59fc1da5287d6286e2c2aca4083d5bafe056 (Django 1.0).

Thanks Andy Baker for the report.