### PR TITLE
Fixed #25215 -- Solved attribute error in HStore form field

### DIFF
--- a/django/contrib/postgres/forms/hstore.py
+++ b/django/contrib/postgres/forms/hstore.py
@@ -43,4 +43,4 @@ class HStoreField(forms.CharField):
         # the same as an empty dict, if the data or initial value we get
         # is None, replace it w/ {}.
         initial_value = self.to_python(initial)
-        return super(forms.HStoreField, self).has_changed(initial_value, data)
+        return super(HStoreField, self).has_changed(initial_value, data)

--- a/docs/releases/1.8.4.txt
+++ b/docs/releases/1.8.4.txt
@@ -21,3 +21,6 @@ Bugfixes
 
 * Prevented an exception in ``TestCase.setUpTestData()`` from leaking the
   transaction (:ticket:`25176`).
+
+* Fixed ``has_changed()`` method in
+  :class:`django.contrib.postgres.forms.HStoreField`.

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -191,11 +191,20 @@ class TestFormField(PostgreSQLTestCase):
         form_field = model_field.formfield()
         self.assertIsInstance(form_field, forms.HStoreField)
 
-    def test_empty_field_has_not_changed(self):
+    def test_field_has_changed(self):
         class HStoreFormTest(Form):
-            f1 = HStoreField()
+            f1 = forms.HStoreField()
         form_w_hstore = HStoreFormTest()
         self.assertFalse(form_w_hstore.has_changed())
+
+        form_w_hstore = HStoreFormTest({'f1': '{"a": 1}'})
+        self.assertTrue(form_w_hstore.has_changed())
+
+        form_w_hstore = HStoreFormTest({'f1': '{"a": 1}'}, initial={'f1': '{"a": 1}'})
+        self.assertFalse(form_w_hstore.has_changed())
+
+        form_w_hstore = HStoreFormTest({'f1': '{"a": 2}'}, initial={'f1': '{"a": 1}'})
+        self.assertTrue(form_w_hstore.has_changed())
 
 
 class TestValidator(PostgreSQLTestCase):


### PR DESCRIPTION
The super() call in HStoreField was passing forms.HStoreField instead of HStoreField.

The test was using the HStore _model_ field on the test form, so it didn't appear as a form field, and could never trigger.

Have corrected the error and added tests, verifying it failed before and works now.