### PR TITLE
Fixed #25217 -- Add a warning for ManyToManyField default option

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2299,6 +2299,7 @@ class ManyToManyField(RelatedField):
         )
         self.has_null_arg = 'null' in kwargs
         self.has_default_arg = 'default' in kwargs
+        self.has_validators_arg = 'validators' in kwargs
 
         super(ManyToManyField, self).__init__(**kwargs)
 
@@ -2339,7 +2340,7 @@ class ManyToManyField(RelatedField):
                 )
             )
 
-        if len(self._validators) > 0:
+        if self.has_validators_arg:
             warnings.append(
                 checks.Warning(
                     'ManyToManyField does not support validators.',

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -2298,6 +2298,7 @@ class ManyToManyField(RelatedField):
             db_constraint=db_constraint,
         )
         self.has_null_arg = 'null' in kwargs
+        self.has_default_arg = 'default' in kwargs
 
         super(ManyToManyField, self).__init__(**kwargs)
 
@@ -2345,6 +2346,16 @@ class ManyToManyField(RelatedField):
                     hint=None,
                     obj=self,
                     id='fields.W341',
+                )
+            )
+
+        if self.has_default_arg:
+            warnings.append(
+                checks.Warning(
+                    'default has no effect on ManyToManyField.',
+                    hint=None,
+                    obj=self,
+                    id='fields.W343',
                 )
             )
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -222,6 +222,7 @@ Related Fields
 * **fields.W341**: ``ManyToManyField`` does not support ``validators``.
 * **fields.W342**: Setting ``unique=True`` on a ``ForeignKey`` has the same
   effect as using a ``OneToOneField``.
+* **fields.W343**: Setting ``default`` on a ``ManyToManyField`` has no effect.
 
 Signals
 ~~~~~~~

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -153,7 +153,7 @@ class RelativeFieldTests(IsolatedModelsTestCase):
             name = models.CharField(max_length=20)
 
         class ModelM2M(models.Model):
-            m2m = models.ManyToManyField(Model, null=True, validators=[''])
+            m2m = models.ManyToManyField(Model, null=True, validators=[''], default=[])
 
         errors = ModelM2M.check()
         field = ModelM2M._meta.get_field('m2m')
@@ -174,6 +174,14 @@ class RelativeFieldTests(IsolatedModelsTestCase):
                 id='fields.W341',
             )
         )
+        expected.append(
+            DjangoWarning(
+                'default has no effect on ManyToManyField.',
+                hint=None,
+                obj=field,
+                id='fields.W343',
+            )
+         )
 
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Added warning when specifying a kwarg of 'default' to a ManyToMany related field. Also changed the warning check for 'validators' to match the same patter as the checks for 'null' and 'default'.