### PR TITLE
Fixed #24484 -- Add helpful message when running tests with models changes without migrations.

### DIFF
--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -87,7 +87,13 @@ class Command(BaseCommand):
             del options['liveserver']
 
         test_runner = TestRunner(**options)
-        failures = test_runner.run_tests(test_labels)
+        try:
+            failures = test_runner.run_tests(test_labels)
+        finally:
+            # We can't do I/O cleanly as the test runner
+            # is not an instance of BaseCommand, so do the reporting here
+            for notice in getattr(test_runner, 'migration_notices', []):
+                self.stdout.write(self.style.NOTICE(notice))
 
         if failures:
             sys.exit(bool(failures))

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -1,0 +1,28 @@
+from django.apps import apps
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.state import ProjectState
+
+
+def check_unmigrated_models(loader=None, connection=None):
+    """
+    :return: A (possibly empty) list of messages,
+    if the currently registered models have changes that are not
+    yet represented in a migration
+    """
+    messages = []
+    if loader is None:
+        loader = MigrationLoader(connection)
+
+    autodetector = MigrationAutodetector(
+        loader.project_state(),
+        ProjectState.from_apps(apps),
+    )
+    if autodetector.changes(graph=loader.graph):
+        messages.extend([
+            "  Your models have changes that are not yet reflected "
+            "in a migration, and so won't be applied.",
+            "  Run 'manage.py makemigrations' to make new "
+            "migrations, and then re-run 'manage.py migrate' to apply them.",
+        ])
+    return messages


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24484