### PR TITLE
Fixed #25226 -- Set the model attribute on the base_field in ArrayField

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -28,6 +28,10 @@ class ArrayField(Field):
             self.default_validators.append(ArrayMaxLengthValidator(self.size))
         super(ArrayField, self).__init__(**kwargs)
 
+    def contribute_to_class(self, cls, name, **kwargs):
+        super(ArrayField, self).contribute_to_class(cls, name, **kwargs)
+        self.base_field.model = cls
+
     def check(self, **kwargs):
         errors = super(ArrayField, self).check(**kwargs)
         if self.base_field.remote_field:

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -97,6 +97,13 @@ class TestSaveLoad(PostgreSQLTestCase):
         self.assertEqual(instance.uuids, loaded.uuids)
         self.assertEqual(instance.decimals, loaded.decimals)
 
+    def test_model_is_set_on_base_field_too(self):
+        instance = IntegerArrayModel()
+
+        field = instance._meta.get_field('field')
+        self.assertEqual(field.model, IntegerArrayModel)
+        self.assertEqual(field.base_field.model, IntegerArrayModel)
+
 
 class TestQuerying(PostgreSQLTestCase):
 


### PR DESCRIPTION
ArrayField doesn't set the model attribute on the base_field, causing check framework backend specific checks to fail for #5084