### PR TITLE
Fixed #25227 -- Added `ModelForm.get_updated_model()`

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -91,7 +91,7 @@ class UserCreationForm(forms.ModelForm):
         return password2
 
     def save(self, commit=True):
-        user = super(UserCreationForm, self).save(commit=False)
+        user = self.apply()
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -25,9 +25,9 @@ from django.utils.translation import ugettext, ugettext_lazy as _
 
 __all__ = (
     'ModelForm', 'BaseModelForm', 'model_to_dict', 'fields_for_model',
-    'save_instance', 'ModelChoiceField', 'ModelMultipleChoiceField',
-    'ALL_FIELDS', 'BaseModelFormSet', 'modelformset_factory',
-    'BaseInlineFormSet', 'inlineformset_factory', 'modelform_factory',
+    'ModelChoiceField', 'ModelMultipleChoiceField', 'ALL_FIELDS',
+    'BaseModelFormSet', 'modelformset_factory', 'BaseInlineFormSet',
+    'inlineformset_factory', 'modelform_factory',
 )
 
 ALL_FIELDS = '__all__'
@@ -62,50 +62,6 @@ def construct_instance(form, instance, fields=None, exclude=None):
     for f in file_field_list:
         f.save_form_data(instance, cleaned_data[f.name])
 
-    return instance
-
-
-def save_instance(form, instance, fields=None, fail_message='saved',
-                  commit=True, exclude=None, construct=True):
-    """
-    Saves bound Form ``form``'s cleaned_data into model instance ``instance``.
-
-    If commit=True, then the changes to ``instance`` will be saved to the
-    database. Returns ``instance``.
-
-    If construct=False, assume ``instance`` has already been constructed and
-    just needs to be saved.
-    """
-    if construct:
-        instance = construct_instance(form, instance, fields, exclude)
-    opts = instance._meta
-    if form.errors:
-        raise ValueError("The %s could not be %s because the data didn't"
-                         " validate." % (opts.object_name, fail_message))
-
-    # Wrap up the saving of m2m data as a function.
-    def save_m2m():
-        cleaned_data = form.cleaned_data
-        # Note that for historical reasons we want to include also
-        # virtual_fields here. (GenericRelation was previously a fake
-        # m2m field).
-        for f in chain(opts.many_to_many, opts.virtual_fields):
-            if not hasattr(f, 'save_form_data'):
-                continue
-            if fields and f.name not in fields:
-                continue
-            if exclude and f.name in exclude:
-                continue
-            if f.name in cleaned_data:
-                f.save_form_data(instance, cleaned_data[f.name])
-    if commit:
-        # If we are committing, save the instance and the m2m data immediately.
-        instance.save()
-        save_m2m()
-    else:
-        # We're not committing. Add a method to the form to allow deferred
-        # saving of m2m data.
-        form.save_m2m = save_m2m
     return instance
 
 
@@ -446,21 +402,63 @@ class BaseModelForm(BaseForm):
         except ValidationError as e:
             self._update_errors(e)
 
+    def _save_m2m(self):
+        """
+        Save the many-to-many fields and generic relations for this form.
+        """
+        cleaned_data = self.cleaned_data
+        exclude = self._meta.exclude
+        fields = self._meta.fields
+        opts = self.instance._meta
+        # Note that for historical reasons we want to include also
+        # virtual_fields here. (GenericRelation was previously a fake
+        # m2m field).
+        for f in chain(opts.many_to_many, opts.virtual_fields):
+            if not hasattr(f, 'save_form_data'):
+                continue
+            if fields and f.name not in fields:
+                continue
+            if exclude and f.name in exclude:
+                continue
+            if f.name in cleaned_data:
+                f.save_form_data(self.instance, cleaned_data[f.name])
+
+    def apply(self):
+        """
+        Add a save_m2m() method to the form which can be called after the
+        instance is saved manually at a later time.
+
+        Return the model instance.
+
+        This is a utility method for save(commit=False)
+        """
+        if self.errors:
+            raise ValueError(
+                "The %s could not be %s because the data didn't validate." % (
+                    self.instance._meta.object_name,
+                    'created' if self.instance._state.adding else 'changed',
+                )
+            )
+        # Not committing, so add a method to the form to allow deferred
+        # saving of m2m data.
+        self.save_m2m = self._save_m2m
+        return self.instance
+
     def save(self, commit=True):
         """
-        Saves this ``form``'s cleaned_data into model instance
-        ``self.instance``.
+        Save this form's self.instance object if commit=True.
 
-        If commit=True, then the changes to ``instance`` will be saved to the
-        database. Returns ``instance``.
+        Otherwise, add a save_m2m() method to the form which can be called i
+        after the instance is saved manually at a later time.
+
+        Return the model instance.
         """
-        if self.instance.pk is None:
-            fail_message = 'created'
-        else:
-            fail_message = 'changed'
-        return save_instance(self, self.instance, self._meta.fields,
-                             fail_message, commit, self._meta.exclude,
-                             construct=False)
+        self.apply()
+        if commit:
+            # If committing, save the instance and the m2m data immediately.
+            self.instance.save()
+            self.save_m2m()
+        return self.instance
 
     save.alters_data = True
 
@@ -637,17 +635,28 @@ class BaseModelFormSet(BaseFormSet):
         if commit:
             obj.delete()
 
+    def apply(self):
+        """Adds and changes instances for every form in the formset
+        as necessary, and returns the list of instances.
+
+        Does not commit any data to the database.
+
+        Utility method for FormSet.save(commit=False), parallel to ModelForm.apply().
+        """
+        self.saved_forms = []
+
+        def save_m2m():
+            for form in self.saved_forms:
+                form.save_m2m()
+        self.save_m2m = save_m2m
+        return self.save_existing_objects(commit=False) + self.save_new_objects(commit=False)
+
     def save(self, commit=True):
         """Saves model instances for every form, adding and changing instances
         as necessary, and returns the list of instances.
         """
         if not commit:
-            self.saved_forms = []
-
-            def save_m2m():
-                for form in self.saved_forms:
-                    form.save_m2m()
-            self.save_m2m = save_m2m
+            return self.apply()
         return self.save_existing_objects(commit) + self.save_new_objects(commit)
 
     save.alters_data = True

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1315,7 +1315,7 @@ templates used by the :class:`ModelAdmin` views:
 
         class ArticleAdmin(admin.ModelAdmin):
             def save_formset(self, request, form, formset, change):
-                instances = formset.save(commit=False)
+                instances = formset.apply()
                 for obj in formset.deleted_objects:
                     obj.delete()
                 for instance in instances:

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -1097,7 +1097,7 @@ code would be required in the app's ``admin.py`` file::
 
         def save(self, commit=True):
             # Save the provided password in hashed format
-            user = super(UserCreationForm, self).save(commit=False)
+            user = self.apply()
             user.set_password(self.cleaned_data["password1"])
             if commit:
                 user.save()

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -511,6 +511,12 @@ On the other hand, if you are using a plain ``FormSet``, it's up to you to
 handle ``formset.deleted_forms``, perhaps in your formset's ``save()`` method,
 as there's no general notion of what it means to delete a form.
 
+``formset.apply()`` will also return all of a ``FormSet`` instance's model instances without deleting them. In fact, it's a synonym for ``formset.save(commit=False)``, so the above code can be written as follows::
+
+    >>> instances = formset.apply() 
+    >>> for obj in formset.deleted_objects:
+    ...     obj.delete()
+
 Adding additional fields to a formset
 -------------------------------------
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -327,33 +327,77 @@ Note that if the form :ref:`hasn't been validated
 doesn't validate -- i.e., if ``form.errors`` evaluates to ``True``.
 
 This ``save()`` method accepts an optional ``commit`` keyword argument, which
-accepts either ``True`` or ``False``. If you call ``save()`` with
-``commit=False``, then it will return an object that hasn't yet been saved to
-the database. In this case, it's up to you to call ``save()`` on the resulting
-model instance. This is useful if you want to do custom processing on the
-object before saving it, or if you want to use one of the specialized
-:ref:`model saving options <ref-models-force-insert>`. ``commit`` is ``True``
-by default.
+accepts either ``True`` or ``False``. This is because calling ``save()`` on a
+``ModelForm`` is interpreted as "save to the model", where ``save(commit=False)``
+means "save to the model but not to the database", and ``save(commit=True)`` means
+"save to the model and also to the database". ``commit`` is ``True`` by default.
 
-Another side effect of using ``commit=False`` is seen when your model has
-a many-to-many relation with another model. If your model has a many-to-many
-relation and you specify ``commit=False`` when you save a form, Django cannot
-immediately save the form data for the many-to-many relation. This is because
-it isn't possible to save many-to-many data for an instance until the instance
-exists in the database.
+Because some people might have considered that confusing, :ref:`the new
+apply() method<get-updated-model-method>` was added to
+``ModelForm``. And because old code and tutorials exist that use
+``save(commit=False)``, the old way of doing things will still work. If you call
+``save()`` with ``commit=False``, then it will have the same behaviour as if you
+call ``apply()``.
 
-To work around this problem, every time you save a form using ``commit=False``,
-Django adds a ``save_m2m()`` method to your ``ModelForm`` subclass. After
-you've manually saved the instance produced by the form, you can invoke
-``save_m2m()`` to save the many-to-many form data. For example:
+There is a second ``save`` method called ``save_m2m()``, which is used for
+saving many-to-many data for a given model. This is only necessary when you've
+modified a ``ModelForm``'s data after acquiring a related model with either
+``get_updated_model`` or ``save(commit=False)``. :ref:`We'll explain `save_m2m()`
+<save-m2m-method> below`.
+
+.. _get-updated-model-method:
+
+The ``apply()`` method
+----------------------------------
+
+Sometimes you want to save a form's data straight to the database. Other times,
+you may instead want to do custom processing on the data before saving it, or
+perhaps you want to use one of the specialized :ref:`model saving options
+<ref-models-force-insert>`.
+
+As explained above, a ``ModelForm``'s ``apply()`` method has the
+same behaviour as ``save(commit=False)``, and will do all of the things that
+``save()`` does, except saving to the database.
+
+Most importantly, as its name suggests, ``apply()`` will return a
+database model instance updated with the data from the form. It can also accept
+an existing model instance as the keyword argument ``instance``. If this is
+supplied, ``apply(instance=instance)`` will update the passed-in
+instance. If it's not, ``apply()`` will just create a new one.
+
+``apply()`` is used primarily for adding to or modifying the data
+from a form. For example, we may want to add a timestamp whenever a newspaper
+article is first posted by a reporter:
+
+.. code-block:: python
+
+    class ArticleForm(forms.ModelForm):
+        def save(self, commit=True):
+            article = self.apply()
+            article.posted_date = timezone.now()
+            if commit:
+                article.save()
+            return
+
+.. _save-m2m-method:
+
+The ``save_m2m()`` method
+-----------------------
+
+Another side effect of using ``apply()`` -- or its synonym
+``save(commit=False)`` -- is seen when your model has a many-to-many relation
+with another model. If your model has a many-to-many relation,
+``apply()`` adds a ``save_m2m()`` method to your ``ModelForm``
+subclass. After you've manually saved the instance produced by the form, you can
+invoke ``save_m2m()`` to save the many-to-many form data. For example:
 
 .. code-block:: python
 
     # Create a form instance with POST data.
     >>> f = AuthorForm(request.POST)
 
-    # Create, but don't save the new author instance.
-    >>> new_author = f.save(commit=False)
+    # Create, but don't save the new author model instance.
+    >>> new_author = f.apply()
 
     # Modify the author in some way.
     >>> new_author.some_field = 'some_value'
@@ -364,10 +408,10 @@ you've manually saved the instance produced by the form, you can invoke
     # Now, save the many-to-many data for the form.
     >>> f.save_m2m()
 
-Calling ``save_m2m()`` is only required if you use ``save(commit=False)``.
-When you use a simple ``save()`` on a form, all data -- including
-many-to-many data -- is saved without the need for any additional method calls.
-For example:
+Calling ``save_m2m()`` is only required if you use ``save(commit=False)`` or
+``apply()``. When you use a simple ``save()`` on a form, all data --
+including many-to-many data -- is saved without the need for any additional
+method calls. For example:
 
 .. code-block:: python
 
@@ -378,12 +422,15 @@ For example:
     # Create and save the new author instance. There's no need to do anything else.
     >>> new_author = f.save()
 
-Other than the ``save()`` and ``save_m2m()`` methods, a ``ModelForm`` works
-exactly the same way as any other ``forms`` form. For example, the
-``is_valid()`` method is used to check for validity, the ``is_multipart()``
-method is used to determine whether a form requires multipart file upload (and
-hence whether ``request.FILES`` must be passed to the form), etc. See
-:ref:`binding-uploaded-files` for more information.
+Other ``ModelForm`` methods
+---------------------------
+
+Other than the ``save()``, ``get_updated_model`` and ``save_m2m()`` methods, a
+``ModelForm`` works exactly the same way as any other ``forms`` form. For
+example, the ``is_valid()`` method is used to check for validity, the
+``is_multipart()`` method is used to determine whether a form requires multipart
+file upload (and hence whether ``request.FILES`` must be passed to the form),
+etc. See :ref:`binding-uploaded-files` for more information.
 
 .. _modelforms-selecting-fields:
 

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -109,6 +109,33 @@ class DeletionTests(TestCase):
             obj.save()
         self.assertEqual(school.child_set.count(), 1)
 
+    def test_save_new_apply(self):
+        """
+        Make sure inlineformsets respect apply()
+        as an alias for save(commit=False)
+        regression for #10750
+        test for new utility method apply() #25227
+        """
+        # exclude some required field from the forms
+        ChildFormSet = inlineformset_factory(School, Child, exclude=['father', 'mother'])
+        school = School.objects.create(name='test')
+        mother = Parent.objects.create(name='mother')
+        father = Parent.objects.create(name='father')
+        data = {
+            'child_set-TOTAL_FORMS': '1',
+            'child_set-INITIAL_FORMS': '0',
+            'child_set-MAX_NUM_FORMS': '0',
+            'child_set-0-name': 'child',
+        }
+        formset = ChildFormSet(data, instance=school)
+        self.assertEqual(formset.is_valid(), True)
+        objects = formset.apply()
+        for obj in objects:
+            obj.mother = mother
+            obj.father = father
+            obj.save()
+        self.assertEqual(school.child_set.count(), 1)
+
 
 class InlineFormsetFactoryTest(TestCase):
     def test_inline_formset_factory(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1150,6 +1150,20 @@ class ModelFormBasicTests(TestCase):
         c1.save()
         self.assertEqual(Category.objects.count(), 1)
 
+    def test_apply(self):
+        # Test that #25227 didn't break anything when it added ModelForm.apply().
+        # If you call apply() it should have the effect and return value as
+        # if you call save() with commit=False, then it will return an object that
+        # hasn't yet been saved to the database. In this case, it's up to you to call
+        # save() on the resulting model instance.
+        f = BaseCategoryForm({'name': 'Third test', 'slug': 'third-test', 'url': 'third'})
+        self.assertTrue(f.is_valid())
+        c1 = f.apply()
+        self.assertEqual(c1.name, "Third test")
+        self.assertEqual(Category.objects.count(), 0)
+        c1.save()
+        self.assertEqual(Category.objects.count(), 1)
+
     def test_save_with_data_errors(self):
         # If you call save() with invalid data, you'll get a ValueError.
         f = BaseCategoryForm({'name': '', 'slug': 'not a slug!', 'url': 'foo'})
@@ -1309,6 +1323,63 @@ class ModelFormBasicTests(TestCase):
 
         # Save the m2m data on the form
         f.save_m2m()
+        self.assertQuerysetEqual(new_art.categories.order_by('name'),
+            ["Entertainment", "It's a test"])
+
+    def test_m2m_editing_apply(self):
+        # as above, but testing #25227 didn't break anything
+        # when adding ModelForm.get_updated_model
+        self.create_basic_data()
+        form_data = {
+            'headline': 'New headline',
+            'slug': 'new-headline',
+            'pub_date': '1988-01-04',
+            'writer': six.text_type(self.w_royko.pk),
+            'article': 'Hello.',
+            'categories': [six.text_type(self.c1.id), six.text_type(self.c2.id)]
+        }
+        # Create a new article, with categories, via the form.
+        f = ArticleForm(form_data)
+        new_art = f.save()
+        new_art = Article.objects.get(id=new_art.id)
+        art_id_1 = new_art.id
+        self.assertQuerysetEqual(new_art.categories.order_by('name'),
+                         ["Entertainment", "It's a test"])
+
+        # Now, submit form data with no categories. This deletes the existing categories.
+        form_data['categories'] = []
+        f = ArticleForm(form_data, instance=new_art)
+        new_art = f.save()
+        self.assertEqual(new_art.id, art_id_1)
+        new_art = Article.objects.get(id=art_id_1)
+        self.assertQuerysetEqual(new_art.categories.all(), [])
+
+        # Create a new article, with no categories, via the form.
+        f = ArticleForm(form_data)
+        new_art = f.save()
+        art_id_2 = new_art.id
+        self.assertNotIn(art_id_2, (None, art_id_1))
+        new_art = Article.objects.get(id=art_id_2)
+        self.assertQuerysetEqual(new_art.categories.all(), [])
+
+        # Create a new article, with categories, via the form, but use apply()
+        # The m2m data won't be saved until save_m2m() is invoked on the form.
+        form_data['categories'] = [six.text_type(self.c1.id), six.text_type(self.c2.id)]
+        f = ArticleForm(form_data)
+        new_art = f.apply()
+
+        # Manually save the instance
+        new_art.save()
+        art_id_3 = new_art.id
+        self.assertNotIn(art_id_3, (None, art_id_1, art_id_2))
+
+        # The instance doesn't have m2m data yet
+        new_art = Article.objects.get(id=art_id_3)
+        self.assertQuerysetEqual(new_art.categories.all(), [])
+
+        # Save the m2m data on the form calling ModelForm.save()
+        # no need to call ModelForm.save_m2m() independently.
+        f.save()
         self.assertQuerysetEqual(new_art.categories.order_by('name'),
             ["Entertainment", "It's a test"])
 

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -98,6 +98,20 @@ class ModelFormsTests(TestCase):
         article.author = self.author
         article.save()
 
+    def test_partial_validation_apply(self):
+        # Make sure model validation still works when "get_updated_model"
+        # replaces "save(commit=False)" in the idiom
+        # "commit=False and set field values later" idiom still
+        data = {
+            'title': 'The state of model validation',
+            'pub_date': '2010-1-10 14:49:00'
+        }
+        form = ArticleForm(data)
+        self.assertEqual(list(form.errors), [])
+        article = form.apply()
+        article.author = self.author
+        article.save()
+
     def test_validation_with_empty_blank_field(self):
         # Since a value for pub_date wasn't provided and the field is
         # blank=True, model-validation should pass.


### PR DESCRIPTION
Add utility method get_updated_model() to ModelForm

Additionally, add utility method get_updated_models() to FormSet

Rationale:

While doing the djangogirls tutorial, I noticed that ModelForm.save(commit=False) is given to newcomers as a reasonable way to acquire a form's populated model. This is an antipattern for several reasons:

  - It's counterintuitive. To a newcomer, it's the same as ``save(save=no)``. 
  - It's a leaky abstraction. Understanding it requires understanding that the save method does two things: a) prepare the model, and b) save it to the database.
  - It doesn't name its effect or return well.

All these problems are addressed in the current patch. Changes:

 - Implement ModelForm.get_updated_model()
 - Implement FormSet.get_updated_models()
 - Refactor ModelForm.save() and FormSet.save() to allow the above.
 - Both the tests and contrib.auth have been modified: any call to save(commit=False) for the purpose of obtaining a populated model has been replaced by get_updated_model(). Tests still pass, I'm confident it's a successful refactor.
- New tests have been added for the new methods in different contexts (from a ModelForm, from a FormSet, etc).
 - documentation has also been modified to showcase the new methods.

Notes:

Uses of ModelForm.save(commit=False) in the codebase have been left alone wherever it was used for its side effects and not for its return value.

The Djangogirls tutorial has a PR that depends on the changes in the present one:

https://github.com/DjangoGirls/tutorial/pull/450