### PR TITLE
Refs #14476 -- Added a test for default annotation name access in aggregate.

### DIFF
--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -1014,6 +1014,11 @@ class AggregationTests(TestCase):
             ['Peter Norvig'],
             lambda b: b.name
         )
+        # Referencing the auto-generated name in an aggregate() also works.
+        self.assertEqual(
+            Author.objects.annotate(Count('book')).aggregate(Max('book__count')),
+            {'book__count__max': 2}
+        )
 
     def test_annotate_joins(self):
         """


### PR DESCRIPTION
Fixed in f59fd15c4928caf3dfcbd50f6ab47be409a43b01