### PR TITLE
Refs #25236 -- Discouraged use of ifequal/ifnotequal template tags.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -396,7 +396,7 @@ clauses, as well as an ``{% else %}`` clause that will be displayed if all
 previous conditions fail. These clauses are optional.
 
 Boolean operators
-^^^^^^^^^^^^^^^^^
+"""""""""""""""""
 
 :ttag:`if` tags may use ``and``, ``or`` or ``not`` to test a number of
 variables or to negate a given variable::
@@ -438,9 +438,8 @@ them to indicate precedence, you should use nested :ttag:`if` tags.
 :ttag:`if` tags may also use the operators ``==``, ``!=``, ``<``, ``>``,
 ``<=``, ``>=`` and ``in`` which work as follows:
 
-
 ``==`` operator
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Equality. Example::
 
@@ -449,7 +448,7 @@ Equality. Example::
     {% endif %}
 
 ``!=`` operator
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Inequality. Example::
 
@@ -459,7 +458,7 @@ Inequality. Example::
     {% endif %}
 
 ``<`` operator
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 Less than. Example::
 
@@ -468,7 +467,7 @@ Less than. Example::
     {% endif %}
 
 ``>`` operator
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 Greater than. Example::
 
@@ -477,7 +476,7 @@ Greater than. Example::
     {% endif %}
 
 ``<=`` operator
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Less than or equal to. Example::
 
@@ -486,7 +485,7 @@ Less than or equal to. Example::
     {% endif %}
 
 ``>=`` operator
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Greater than or equal to. Example::
 
@@ -495,7 +494,7 @@ Greater than or equal to. Example::
     {% endif %}
 
 ``in`` operator
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Contained within. This operator is supported by many Python containers to test
 whether the given value is in the container. The following are some examples
@@ -516,10 +515,9 @@ of how ``x in y`` will be interpreted::
     {% endif %}
 
 ``not in`` operator
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 Not contained within. This is the negation of the ``in`` operator.
-
 
 The comparison operators cannot be 'chained' like in Python or in mathematical
 notation. For example, instead of using::
@@ -530,9 +528,8 @@ you should use::
 
     {% if a > b and b > c %}
 
-
 Filters
-^^^^^^^
+"""""""
 
 You can also use filters in the :ttag:`if` expression. For example::
 
@@ -541,7 +538,7 @@ You can also use filters in the :ttag:`if` expression. For example::
     {% endif %}
 
 Complex expressions
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
 All of the above can be combined to form complex expressions. For such
 expressions, it can be important to know how the operators are grouped when the
@@ -570,7 +567,6 @@ operators, from lowest to highest, is as follows:
 If you need different precedence, you will need to use nested :ttag:`if` tags.
 Sometimes that is better for clarity anyway, for the sake of those who do not
 know the precedence rules.
-
 
 .. templatetag:: ifchanged
 
@@ -812,7 +808,6 @@ This would display as "It is the 4th of September".
 
         It is {% now "SHORT_DATETIME_FORMAT" %}
 
-
 You can also use the syntax ``{% now "Y" as current_year %}`` to store the
 output (as a string) inside a variable. This is useful if you want to use
 ``{% now %}`` inside a template tag like :ttag:`blocktrans` for example::
@@ -831,7 +826,9 @@ regroup
 
 Regroups a list of alike objects by a common attribute.
 
-This complex tag is best illustrated by way of an example: say that "places" is a list of cities represented by dictionaries containing ``"name"``, ``"population"``, and ``"country"`` keys:
+This complex tag is best illustrated by way of an example: say that "places" is
+a list of cities represented by dictionaries containing ``"name"``,
+``"population"``, and ``"country"`` keys:
 
 .. code-block:: python
 
@@ -843,7 +840,8 @@ This complex tag is best illustrated by way of an example: say that "places" is 
         {'name': 'Tokyo', 'population': '33,000,000', 'country': 'Japan'},
     ]
 
-...and you'd like to display a hierarchical list that is ordered by country, like this:
+...and you'd like to display a hierarchical list that is ordered by country,
+like this:
 
 * India
 
@@ -858,7 +856,6 @@ This complex tag is best illustrated by way of an example: say that "places" is 
 * Japan
 
   * Tokyo: 33,000,000
-
 
 You can use the ``{% regroup %}`` tag to group the list of cities by country.
 The following snippet of template code would accomplish this::
@@ -939,7 +936,7 @@ Another solution is to sort the data in the template using the
     {% regroup cities|dictsort:"country" by country as country_list %}
 
 Grouping on other properties
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""
 
 Any valid template lookup is a legal grouping attribute for the regroup
 tag, including methods, attributes, dictionary keys and list items. For
@@ -2415,8 +2412,8 @@ Django's built-in :tfilter:`escape` filter. The default value for
 urlizetrunc
 ^^^^^^^^^^^
 
-Converts URLs and email addresses into clickable links just like urlize_, but truncates URLs
-longer than the given character limit.
+Converts URLs and email addresses into clickable links just like urlize_, but
+truncates URLs longer than the given character limit.
 
 **Argument:** Number of characters that link text should be truncated to,
 including the ellipsis that's added if truncation is necessary.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -568,6 +568,14 @@ If you need different precedence, you will need to use nested :ttag:`if` tags.
 Sometimes that is better for clarity anyway, for the sake of those who do not
 know the precedence rules.
 
+``ifequal`` and ``ifnotequal``
+""""""""""""""""""""""""""""""
+
+``{% ifequal a b %} ... {% endifequal %}`` is an obsolete way to write
+``{% if a == b %} ... {% endif %}``. Likewise, ``{% ifnotequal a b %} ...
+{% endifnotequal %}`` is superseded by ``{% if a != b %} ... {% endif %}``.
+The ``ifequal`` and ``ifnotequal`` tags will be deprecated in a future release.
+
 .. templatetag:: ifchanged
 
 ifchanged
@@ -612,41 +620,6 @@ will be displayed if the value has not changed::
                 {% endifchanged %}
             ">{{ match }}</div>
         {% endfor %}
-
-.. templatetag:: ifequal
-
-ifequal
-^^^^^^^
-
-Output the contents of the block if the two arguments equal each other.
-
-Example::
-
-    {% ifequal user.pk comment.user_id %}
-        ...
-    {% endifequal %}
-
-As in the :ttag:`if` tag, an ``{% else %}`` clause is optional.
-
-The arguments can be hard-coded strings, so the following is valid::
-
-    {% ifequal user.username "adrian" %}
-        ...
-    {% endifequal %}
-
-An alternative to the ``ifequal`` tag is to use the :ttag:`if` tag and the
-``==`` operator.
-
-.. templatetag:: ifnotequal
-
-ifnotequal
-^^^^^^^^^^
-
-Just like :ttag:`ifequal`, except it tests that the two arguments are not
-equal.
-
-An alternative to the ``ifnotequal`` tag is to use the :ttag:`if` tag and
-the ``!=`` operator.
 
 .. templatetag:: include
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -350,8 +350,6 @@ iendswith
 ies
 iexact
 ifchanged
-ifequal
-ifnotequal
 iframe
 inbox
 Incompliance


### PR DESCRIPTION
As there is resistant to deprecating these tags now, documented that these tags shouldn't be used in hopes of deprecating them in the future.