### PR TITLE
Fixed #25180 -- ArrayFields should not have varchar_patterns_ops or text_patterns_ops indexes

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -29,6 +29,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 # a second index that specifies their operator class, which is
                 # needed when performing correct LIKE queries outside the
                 # C locale. See #12234.
+                #
+                # The same does not apply to array fields such as varchar[size]
+                # and text[size], so we need to skip them
+                if '[' in db_type:
+                    continue
                 if db_type.startswith('varchar'):
                     output.append(self._create_index_sql(
                         model, [field], suffix='_like', sql=self.sql_create_varchar_index))

--- a/tests/postgres_tests/array_index_migrations/0001_initial.py
+++ b/tests/postgres_tests/array_index_migrations/0001_initial.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CharTextArrayIndexModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('char', django.contrib.postgres.fields.ArrayField(models.CharField(max_length=10), db_index=True, size=100)),
+                ('char2', models.CharField(max_length=11, db_index=True)),
+                ('text', django.contrib.postgres.fields.ArrayField(models.TextField(), db_index=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -307,6 +307,28 @@ class TestMigrations(TransactionTestCase):
         with connection.cursor() as cursor:
             self.assertNotIn(table_name, connection.introspection.table_names(cursor))
 
+    @override_settings(MIGRATION_MODULES={
+        "postgres_tests": "postgres_tests.array_index_migrations",
+    })
+    def test_adding_arrayfield_with_index(self):
+        table_name = 'postgres_tests_chartextarrayindexmodel'
+        call_command('migrate', 'postgres_tests', verbosity=0)
+        with connection.cursor() as cursor:
+            conslike = [
+                c.rsplit('_', 2)[0][len(table_name) + 1:]
+                for c in connection.introspection.get_constraints(cursor, table_name)
+                if c.endswith('_like')
+            ]
+            self.assertEqual(conslike, ['char2'])
+        with connection.cursor() as cursor:
+            indexes = connection.introspection.get_indexes(cursor, table_name)
+            self.assertIn('char', indexes)
+            self.assertIn('char2', indexes)
+            self.assertIn('text', indexes)
+        call_command('migrate', 'postgres_tests', 'zero', verbosity=0)
+        with connection.cursor() as cursor:
+            self.assertNotIn(table_name, connection.introspection.table_names(cursor))
+
 
 class TestSerialization(PostgreSQLTestCase):
     test_data = '[{"fields": {"field": "[\\"1\\", \\"2\\"]"}, "model": "postgres_tests.integerarraymodel", "pk": null}]'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25180