### PR TITLE
Minor fix in docs for contrib.messages: code formatting in an example

### DIFF
--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -388,8 +388,9 @@ method.
         success_message = "%(calculated_field)s was created successfully"
 
         def get_success_message(self, cleaned_data):
-            return self.success_message % dict(cleaned_data,
-                                               calculated_field=self.object.calculated_field)
+            return self.success_message % dict(
+                cleaned_data,
+                calculated_field=self.object.calculated_field)
 
 Expiration of messages
 ======================


### PR DESCRIPTION
The piece of example code in question was formatting weirdly on https://docs.djangoproject.com/.
Between first and second keyword arguments there was a visual blank line present.