### PR TITLE
Avoid errors in the edge case that the URLs is like ../fonts/foo.svg#…

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -166,6 +166,8 @@ class HashedFilesMixin(object):
             name_parts = name.split(os.sep)
             # Using posix normpath here to remove duplicates
             url = posixpath.normpath(url)
+            # Avoid errors in the edge case that the URLs is like ../fonts/foo.svg#../fonts/foo
+            url, fragment = urldefrag(url)
             url_parts = url.split('/')
             parent_level, sub_level = url.count('..'), url.count('/')
             if url.startswith('/'):


### PR DESCRIPTION
Avoid errors in the edge case that the URLs is like `../fonts/foo.svg#../fonts/foo`, which may be found in some fonts declaration. See http://www.smashingmagazine.com/2013/02/14/setting-weights-and-styles-at-font-face-declaration/

In this case the `url.count('..')` and `url.count('/')` could take into account the `#../` fragment, and collectstatic will not find the file, but it was in its correct place

I think is a trivial error, and I will not create a ticket for that. If you need it, I could create one. 