### PR TITLE
Fixed #25283 -- Allowed HashedFilesMixin to handle URLs with fragment paths

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -166,12 +166,15 @@ class HashedFilesMixin(object):
             name_parts = name.split(os.sep)
             # Using posix normpath here to remove duplicates
             url = posixpath.normpath(url)
-            url_parts = url.split('/')
-            parent_level, sub_level = url.count('..'), url.count('/')
-            if url.startswith('/'):
+            # Avoid errors in the edge case that the URLs
+            # is like ../fonts/foo.svg#../fonts/foo
+            url_path, fragment = urldefrag(url)
+            url_parts = url_path.split('/')
+            parent_level, sub_level = url_path.count('..'), url_path.count('/')
+            if url_path.startswith('/'):
                 sub_level -= 1
                 url_parts = url_parts[1:]
-            if parent_level or not url.startswith('/'):
+            if parent_level or not url_path.startswith('/'):
                 start, end = parent_level + 1, parent_level
             else:
                 if sub_level:
@@ -183,7 +186,12 @@ class HashedFilesMixin(object):
             joined_result = '/'.join(name_parts[:-start] + url_parts[end:])
             hashed_url = self.url(unquote(joined_result), force=True)
             file_name = hashed_url.split('/')[-1:]
-            relative_url = '/'.join(url.split('/')[:-1] + file_name)
+            relative_url = '/'.join(url_path.split('/')[:-1] + file_name)
+            if fragment:
+                if '?#' in url:
+                    relative_url += '?#%s' % fragment
+                else:
+                    relative_url += '#%s' % fragment
 
             # Return the hashed version to the file
             return template % unquote(relative_url)

--- a/tests/staticfiles_tests/project/documents/cached/css/fragments.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/fragments.css
@@ -1,6 +1,7 @@
 @font-face {
     src: url('fonts/font.eot?#iefix') format('embedded-opentype'),
          url('fonts/font.svg#webfontIyfZbseF') format('svg');
+         url('fonts/font.svg#../path/to/fonts/font.svg') format('svg');
          url('data:font/woff;charset=utf-8;base64,d09GRgABAAAAADJoAA0AAAAAR2QAAQAAAAAAAAAAAAA');
 }
 div {

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -83,7 +83,7 @@ class TestHashedFiles(object):
 
     def test_path_with_querystring_and_fragment(self):
         relpath = self.hashed_file_path("cached/css/fragments.css")
-        self.assertEqual(relpath, "cached/css/fragments.75433540b096.css")
+        self.assertEqual(relpath, "cached/css/fragments.ef92012a8c16.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b'fonts/font.a4b0478549d0.eot?#iefix', content)


### PR DESCRIPTION
See http://www.smashingmagazine.com/2013/02/14/setting-weights-and-styles-at-font-face-declaration/

In this case the url.count('..') and url.count('/') could take into
account the #../ fragment, and collectstatic will not find the file,
but it was in its correct place