### PR TITLE
bulk_create sets primary keys on created objects

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -835,6 +835,14 @@ class BaseDatabaseOperations(object):
         """
         return cursor.fetchone()[0]
 
+    def fetch_returned_insert_ids(self, cursor):
+        """
+        Given a cursor object that has just performed an INSERT...RETURNING
+        statement into a table that has an auto-incrementing ID, returns the
+        list of newly created IDs.
+        """
+        return [item[0] for item in cursor.fetchall()]
+
     def field_cast_sql(self, db_type, internal_type):
         """
         Given a column type (e.g. 'BLOB', 'VARCHAR'), and an internal type

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1624,7 +1624,9 @@ This has a number of caveats though:
   ``post_save`` signals will not be sent.
 * It does not work with child models in a multi-table inheritance scenario.
 * If the model's primary key is an :class:`~django.db.models.AutoField` it
-  does not retrieve and set the primary key attribute, as ``save()`` does.
+  does not retrieve and set the primary key attribute, as ``save()`` does,
+  unless the db backend also has the feature ``can_return_id_from_insert``
+  (currently ``postgresql_psycopg2`` and ``oracle``).
 
 The ``batch_size`` parameter controls how many objects are created in single
 query. The default is to create all objects in one batch, except for SQLite

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -165,3 +165,14 @@ class BulkCreateTests(TestCase):
         TwoFields.objects.all().delete()
         with self.assertNumQueries(1):
             TwoFields.objects.bulk_create(objs, len(objs))
+
+    @skipUnlessDBFeature('can_return_id_from_insert')
+    def test_set_pk_and_query_efficiency(self):
+        countries = []
+        with self.assertNumQueries(1):
+            countries = Country.objects.bulk_create(self.data)
+        self.assertEqual(len(countries), 4)
+        self.assertEqual(Country.objects.get(pk=countries[0].pk), countries[0])
+        self.assertEqual(Country.objects.get(pk=countries[1].pk), countries[1])
+        self.assertEqual(Country.objects.get(pk=countries[2].pk), countries[2])
+        self.assertEqual(Country.objects.get(pk=countries[3].pk), countries[3])


### PR DESCRIPTION
Postgres supports `RETURNING id` when doing a bulk create. With this,
we can set the primary keys on the newly saved objects from the keys
that the database supplied.

Addresses #19527