### PR TITLE
Fixed #25285 -- Prevented django-admin from raising "settings not configured" on an unknown command.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -483,6 +483,7 @@ answer newbie questions, and generally made Django that much better:
     mattycakes@gmail.com
     Max Burstein <http://maxburstein.com>
     Max Derkachev <mderk@yandex.ru>
+    Maxime Lorant <maxime.lorant@gmail.com>
     Maxime Turcotte <maxocub@riseup.net>
     Maximillian Dornseif <md@hudora.de>
     mccutchen@gmail.com

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -178,7 +178,9 @@ class ManagementUtility(object):
             app_name = commands[subcommand]
         except KeyError:
             # This might trigger ImproperlyConfigured (masked in get_commands)
-            settings.INSTALLED_APPS
+            # Ignore test in django-admin.py, where project might not exist yet
+            if self.prog_name != "django-admin.py":
+                settings.INSTALLED_APPS
             sys.stderr.write("Unknown command: %r\nType '%s help' for usage.\n" %
                 (subcommand, self.prog_name))
             sys.exit(1)

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -179,7 +179,7 @@ class ManagementUtility(object):
         except KeyError:
             # This might trigger ImproperlyConfigured (masked in get_commands)
             # Ignore test in django-admin.py, where project might not exist yet
-            if self.prog_name != "django-admin.py":
+            if "django-admin" in self.prog_name:
                 settings.INSTALLED_APPS
             sys.stderr.write("Unknown command: %r\nType '%s help' for usage.\n" %
                 (subcommand, self.prog_name))

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -283,7 +283,7 @@ class DjangoAdminDefaultSettings(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_custom_command_with_settings(self):
         "default: django-admin can execute user commands if settings are provided as argument"
@@ -351,7 +351,7 @@ class DjangoAdminFullPathDefaultSettings(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_custom_command_with_settings(self):
         "fulldefault: django-admin can execute user commands if settings are provided as argument"
@@ -418,7 +418,7 @@ class DjangoAdminMinimalSettings(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_custom_command_with_settings(self):
         "minimal: django-admin can't execute user commands, even if settings are provided as argument"
@@ -485,7 +485,7 @@ class DjangoAdminAlternateSettings(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_custom_command_with_settings(self):
         "alternate: django-admin can execute user commands if settings are provided as argument"
@@ -555,7 +555,7 @@ class DjangoAdminMultipleSettings(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_custom_command_with_settings(self):
         "alternate: django-admin can execute user commands if settings are provided as argument"
@@ -644,7 +644,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         args = ['noargs_command']
         out, err = self.run_django_admin(args)
         self.assertNoOutput(out)
-        self.assertOutput(err, "settings are not configured")
+        self.assertOutput(err, "Unknown command")
 
     def test_builtin_with_settings(self):
         "directory: django-admin builtin commands succeed if settings are provided as argument"


### PR DESCRIPTION
The project could not exist yet, so it can raise the wrong exception.

See https://code.djangoproject.com/ticket/25285