### PR TITLE
Consistent capitalization of the "class-based views" term across docs

### DIFF
--- a/docs/ref/class-based-views/index.txt
+++ b/docs/ref/class-based-views/index.txt
@@ -1,5 +1,5 @@
 ==============================
-Built-in Class-based views API
+Built-in class-based views API
 ==============================
 
 Class-based views API reference. For introductory material, see the

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -346,7 +346,7 @@ example::
    use one of the ``add_message`` family of methods. It does not hide failures
    that may occur for other reasons.
 
-Adding messages in Class Based Views
+Adding messages in class-based views
 ------------------------------------
 
 .. class:: views.SuccessMessageMixin

--- a/docs/topics/class-based-views/generic-display.txt
+++ b/docs/topics/class-based-views/generic-display.txt
@@ -1,7 +1,7 @@
 .. _Generic views:
 
 ==================================
-Built-in Class-based generic views
+Built-in class-based generic views
 ==================================
 
 Writing Web applications can be monotonous, because we repeat certain patterns

--- a/docs/topics/class-based-views/intro.txt
+++ b/docs/topics/class-based-views/intro.txt
@@ -1,5 +1,5 @@
 =================================
-Introduction to Class-based views
+Introduction to class-based views
 =================================
 
 Class-based views provide an alternative way to implement views as Python


### PR DESCRIPTION
Most often the term is written as “class-based views” in the docs. Documentation for ``contrib.messages`` is the worst offender with its “Class Based Views”.