### PR TITLE
Recommend use of JavaScript cookie instead of jQuery cookie

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -117,12 +117,12 @@ Acquiring the token is straightforward:
     }
     var csrftoken = getCookie('csrftoken');
 
-The above code could be simplified by using the `jQuery cookie plugin
-<http://plugins.jquery.com/cookie/>`_ to replace ``getCookie``:
+The above code could be simplified by using the `JavaScript Cookie library
+<https://github.com/js-cookie/js-cookie/>`_ to replace ``getCookie``:
 
 .. code-block:: javascript
 
-    var csrftoken = $.cookie('csrftoken');
+    var csrftoken = Cookies.get('csrftoken');
 
 .. note::
 


### PR DESCRIPTION
jQuery cookie is no longer maintained in favor to JavaScript cookie library. This works in the same way and it removes the jQuery dependency.

If you visit the [github](https://github.com/carhartl/jquery-cookie) of jquery-cookie you will be warned with this text:
># IMPORTANT!
>This project was moved to https://github.com/js-cookie/js-cookie, check [the discussion](https://github.com/carhartl/jquery-cookie/issues/349).