### PR TITLE
Refs #12400 -- Added supports_geometry_field_unique_index GIS database feature.

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -40,6 +40,9 @@ class BaseSpatialFeatures(object):
     # Does the database have raster support?
     supports_raster = False
 
+    # Does database support unique index on geometry fields?
+    supports_geometry_field_unique_index = True
+    
     @property
     def supports_bbcontains_lookup(self):
         return 'bbcontains' in self.connection.ops.gis_operators

--- a/django/contrib/gis/db/backends/oracle/features.py
+++ b/django/contrib/gis/db/backends/oracle/features.py
@@ -6,3 +6,4 @@ from django.db.backends.oracle.features import \
 class DatabaseFeatures(BaseSpatialFeatures, OracleDatabaseFeatures):
     supports_add_srs_entry = False
     supports_geometry_field_introspection = False
+    supports_geometry_field_unique_index = False

--- a/tests/gis_tests/geoapp/models.py
+++ b/tests/gis_tests/geoapp/models.py
@@ -63,7 +63,8 @@ class MultiFields(NamedModel):
 
     class Meta:
         unique_together = ('city', 'point')
-        required_db_features = ['gis_enabled']
+        required_db_features = ['gis_enabled',
+                                'supports_geometry_field_unique_index']
 
 
 class Truth(models.Model):


### PR DESCRIPTION
… geometry fields

https://code.djangoproject.com/ticket/12400

This change introduced new feature to GIS backends "supports_geometry_field_unique_index" which is True by default, and False for Oracle.

This PR allows GIS tests on Oracle to be runnable again.