### PR TITLE
Refs #19527 -- Allowed bulk_create() to set primary keys for PostgreSQL

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -24,6 +24,7 @@ class BaseDatabaseFeatures(object):
 
     can_use_chunked_reads = True
     can_return_id_from_insert = False
+    can_return_ids_from_bulk_insert = False
     has_bulk_insert = False
     uses_savepoints = False
     can_release_savepoints = False

--- a/django/db/backends/postgresql/compiler.py
+++ b/django/db/backends/postgresql/compiler.py
@@ -1,0 +1,61 @@
+from django.db.models.sql import compiler
+
+SQLCompiler = compiler.SQLCompiler
+SQLDeleteCompiler = compiler.SQLDeleteCompiler
+SQLUpdateCompiler = compiler.SQLUpdateCompiler
+SQLAggregateCompiler = compiler.SQLAggregateCompiler
+
+
+class SQLInsertCompiler(compiler.SQLInsertCompiler):
+    def as_sql(self):
+        """
+        Creates the SQL for this query. Returns the SQL string and list
+        of parameters.  This is overridden from the original Insert Query class
+        to handle the additional SQL Postgres requires to return
+        IDs from bulk insert statements.
+        """
+        if self.return_id and self.connection.features.can_return_ids_from_bulk_insert and \
+                (not any(hasattr(field, "get_placeholder") for field in self.query.fields)) and \
+                self.connection.features.has_bulk_insert:
+
+            # We don't need quote_name_unless_alias() here, since these are all
+            # going to be column names (so we can avoid the extra overhead).
+            qn = self.connection.ops.quote_name
+            opts = self.query.get_meta()
+            result = ['INSERT INTO %s' % qn(opts.db_table)]
+
+            has_fields = bool(self.query.fields)
+            fields = self.query.fields if has_fields else [opts.pk]
+            result.append('(%s)' % ', '.join(qn(f.column) for f in fields))
+
+            if has_fields:
+                params = values = [
+                    [
+                        f.get_db_prep_save(
+                            getattr(obj, f.attname) if self.query.raw else f.pre_save(obj, True),
+                            connection=self.connection
+                        ) for f in fields
+                    ]
+                    for obj in self.query.objs
+                ]
+            else:
+                values = [[self.connection.ops.pk_default_value()] for _ in self.query.objs]
+                params = [[]]
+                fields = [None]
+
+            placeholders = [
+                [self.placeholder(field, v) for field, v in zip(fields, val)]
+                for val in values
+            ]
+
+            result.append(self.connection.ops.bulk_insert_sql(fields, len(values), placeholders=placeholders))
+
+            r_fmt, r_params = self.connection.ops.return_insert_id()
+            if r_fmt:
+                col = "%s.%s" % (qn(opts.db_table), qn(opts.pk.column))
+                result.append(r_fmt % col)
+                params += r_params
+            return [(" ".join(result), tuple(v for val in values for v in val))]
+
+        else:
+            return super(SQLInsertCompiler, self).as_sql()

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -5,6 +5,7 @@ from django.db.utils import InterfaceError
 class DatabaseFeatures(BaseDatabaseFeatures):
     allows_group_by_selected_pks = True
     can_return_id_from_insert = True
+    can_return_ids_from_bulk_insert = True
     has_real_datatype = True
     has_native_uuid_field = True
     has_native_duration_field = True

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -7,6 +7,8 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 
 
 class DatabaseOperations(BaseDatabaseOperations):
+    compiler_module = "django.db.backends.postgresql.compiler"
+
     def unification_cast_sql(self, output_field):
         internal_type = output_field.get_internal_type()
         if internal_type in ("GenericIPAddressField", "IPAddressField", "TimeField", "UUIDField"):
@@ -58,6 +60,14 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def deferrable_sql(self):
         return " DEFERRABLE INITIALLY DEFERRED"
+
+    def fetch_returned_insert_ids(self, cursor):
+        """
+        Given a cursor object that has just performed an INSERT...RETURNING
+        statement into a table that has an auto-incrementing ID, returns the
+        list of newly created IDs.
+        """
+        return [item[0] for item in cursor.fetchall()]
 
     def lookup_cast(self, lookup_type, internal_type=None):
         lookup = '%s'
@@ -221,9 +231,16 @@ class DatabaseOperations(BaseDatabaseOperations):
     def return_insert_id(self):
         return "RETURNING %s", ()
 
-    def bulk_insert_sql(self, fields, num_values):
-        items_sql = "(%s)" % ", ".join(["%s"] * len(fields))
-        return "VALUES " + ", ".join([items_sql] * num_values)
+    def bulk_insert_sql(self, fields, num_values, placeholders=None):
+        # This allows non-`%s` placeholders; for example the placeholder DEFAULT
+        if placeholders:
+            items_sql = []
+            for placeholders_for_value in placeholders:
+                items_sql.append("(%s)" % ", ".join(placeholders_for_value))
+            return "VALUES " + ", ".join(items_sql)
+        else:
+            items_sql = "(%s)" % ", ".join(["%s"] * len(fields))
+            return "VALUES " + ", ".join([items_sql] * num_values)
 
     def adapt_datefield_value(self, value):
         return value

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -411,17 +411,20 @@ class QuerySet(object):
         Inserts each of the instances into the database. This does *not* call
         save() on each of the instances, does not send any pre/post save
         signals, and does not set the primary key attribute if it is an
-        autoincrement field. Multi-table models are not supported.
+        autoincrement field (except on Postgres). Multi-table models are
+        not supported.
         """
         # So this case is fun. When you bulk insert you don't get the primary
-        # keys back (if it's an autoincrement), so you can't insert into the
-        # child tables which references this. There are two workarounds, 1)
-        # this could be implemented if you didn't have an autoincrement pk,
-        # and 2) you could do it by doing O(n) normal inserts into the parent
-        # tables to get the primary keys back, and then doing a single bulk
-        # insert into the childmost table. Some databases might allow doing
-        # this by using RETURNING clause for the insert query. We're punting
-        # on these for now because they are relatively rare cases.
+        # keys back (if it's an autoincrement, except on Postgres), so you can't
+        # insert into the child tables which references this. There are two
+        # workarounds, 1) this could be implemented if you didn't have an
+        # autoincrement pk, and 2) you could do it by doing O(n) normal inserts
+        # into the parent tables to get the primary keys back, and then doing a
+        # single bulk insert into the childmost table. We currently set the
+        # primary keys on the objects when using Postgres via the RETURNING ID
+        # clause. It should be possible for Oracle as well, but the semantics
+        # for extracting the primary keys is trickier, so it is currently
+        # being punted.
         assert batch_size is None or batch_size > 0
         # Check that the parents share the same concrete model with the our
         # model to detect the inheritance pattern ConcreteGrandParent ->
@@ -447,7 +450,11 @@ class QuerySet(object):
                     self._batched_insert(objs_with_pk, fields, batch_size)
                 if objs_without_pk:
                     fields = [f for f in fields if not isinstance(f, AutoField)]
-                    self._batched_insert(objs_without_pk, fields, batch_size)
+                    ids = self._batched_insert(objs_without_pk, fields, batch_size)
+                    if connection.features.can_return_ids_from_bulk_insert:
+                        assert len(ids) == len(objs_without_pk)
+                    for i in range(len(ids)):
+                        objs_without_pk[i].pk = ids[i]
 
         return objs
 
@@ -1044,10 +1051,20 @@ class QuerySet(object):
             return
         ops = connections[self.db].ops
         batch_size = (batch_size or max(ops.bulk_batch_size(fields, objs), 1))
+        ret = []
         for batch in [objs[i:i + batch_size]
                       for i in range(0, len(objs), batch_size)]:
-            self.model._base_manager._insert(batch, fields=fields,
-                                             using=self.db)
+            if connections[self.db].features.can_return_ids_from_bulk_insert:
+                if len(objs) > 1:
+                    ret.extend(self.model._base_manager._insert(batch, fields=fields,
+                                                                using=self.db, return_id=True))
+                if len(objs) == 1:
+                    ret.append(self.model._base_manager._insert(batch, fields=fields,
+                                                                using=self.db, return_id=True))
+            else:
+                self.model._base_manager._insert(batch, fields=fields,
+                                                 using=self.db)
+        return ret
 
     def _clone(self, **kwargs):
         query = self.query.clone()

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -976,14 +976,18 @@ class SQLInsertCompiler(SQLCompiler):
             ]
 
     def execute_sql(self, return_id=False):
-        assert not (return_id and len(self.query.objs) != 1)
+        assert not (return_id and len(self.query.objs) != 1 and
+                    not self.connection.features.can_return_ids_from_bulk_insert)
         self.return_id = return_id
         with self.connection.cursor() as cursor:
             for sql, params in self.as_sql():
                 cursor.execute(sql, params)
             if not (return_id and cursor):
                 return
+            if self.connection.features.can_return_ids_from_bulk_insert and len(self.query.objs) > 1:
+                return self.connection.ops.fetch_returned_insert_ids(cursor)
             if self.connection.features.can_return_id_from_insert:
+                assert len(self.query.objs) == 1
                 return self.connection.ops.fetch_returned_insert_id(cursor)
             return self.connection.ops.last_insert_id(cursor,
                     self.query.get_meta().db_table, self.query.get_meta().pk.column)

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1802,12 +1802,16 @@ This has a number of caveats though:
   ``post_save`` signals will not be sent.
 * It does not work with child models in a multi-table inheritance scenario.
 * If the model's primary key is an :class:`~django.db.models.AutoField` it
-  does not retrieve and set the primary key attribute, as ``save()`` does.
+  does not retrieve and set the primary key attribute, as ``save()`` does,
+  unless the db backend also has the feature ``can_return_ids_from_bulk_insert``
+  (currently ``postgresql``).
 * It does not work with many-to-many relationships.
 
 .. versionchanged:: 1.9
 
     Support for using ``bulk_create()`` with proxy models was added.
+    Support for setting primary keys on objects on bulk_create, when using
+    Postgres, was added.
 
 The ``batch_size`` parameter controls how many objects are created in single
 query. The default is to create all objects in one batch, except for SQLite

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1248,3 +1248,5 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
 * Private API ``django.test.utils.TestTemplateLoader`` is removed.
 
 * The ``django.contrib.contenttypes.generic`` module is removed.
+
+* QuerySet.bulk_create sets pk on objects when using the Postgresql backend.

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -183,3 +183,14 @@ class BulkCreateTests(TestCase):
         TwoFields.objects.all().delete()
         with self.assertNumQueries(1):
             TwoFields.objects.bulk_create(objs, len(objs))
+
+    @skipUnlessDBFeature('can_return_ids_from_bulk_insert')
+    def test_set_pk_and_query_efficiency(self):
+        countries = []
+        with self.assertNumQueries(1):
+            countries = Country.objects.bulk_create(self.data)
+        self.assertEqual(len(countries), 4)
+        self.assertEqual(Country.objects.get(pk=countries[0].pk), countries[0])
+        self.assertEqual(Country.objects.get(pk=countries[1].pk), countries[1])
+        self.assertEqual(Country.objects.get(pk=countries[2].pk), countries[2])
+        self.assertEqual(Country.objects.get(pk=countries[3].pk), countries[3])


### PR DESCRIPTION
Postgres supports `RETURNING id` when doing a bulk create. With this,
we can set the primary keys on the newly saved objects from the keys
that the database supplied.

Addresses #19527