### PR TITLE
Fixed #23727 -- Inhibited the post_migrate signals when using serialized_rollback.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -698,6 +698,7 @@ answer newbie questions, and generally made Django that much better:
     Tome Cvitan <tome@cvitan.com>
     Tomek Paczkowski <tomek@hauru.eu>
     Tom Insam
+    Tommy Beadle <tbeadle@gmail.com>
     Tom Tobin
     torne-django@wolfpuppy.org.uk
     Travis Cline <travis.cline@gmail.com>

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -250,6 +250,13 @@ The initial serialization is usually very quick, but if you wish to exclude
 some apps from this process (and speed up test runs slightly), you may add
 those apps to :setting:`TEST_NON_SERIALIZED_APPS`.
 
+.. versionchanged:: 1.9
+
+To prevent serialized data from being loaded twice, setting
+``serialized_rollback=True`` disables the
+:data:`~django.db.models.signals.post_migrate` signal when flushing the test
+database.
+
 Other test conditions
 ---------------------
 

--- a/tests/test_utils/test_transactiontestcase.py
+++ b/tests/test_utils/test_transactiontestcase.py
@@ -1,0 +1,28 @@
+from django.test import TransactionTestCase, mock
+
+
+class TestSerializedRollbackInhibitsPostMigrate(TransactionTestCase):
+    """
+    TransactionTestCase._fixture_teardown() inhibits the post_migrate signal
+    for test classes with serialized_rollback=True.
+    """
+    available_apps = ['test_utils']
+    serialized_rollback = True
+
+    def setUp(self):
+        # self.available_apps must be None to test the serialized_rollback
+        # condition.
+        self.available_apps = None
+
+    def tearDown(self):
+        self.available_apps = ['test_utils']
+
+    @mock.patch('django.test.testcases.call_command')
+    def test(self, call_command):
+        # with a mocked call_command(), this doesn't have any effect.
+        self._fixture_teardown()
+        call_command.assert_called_with(
+            'flush', interactive=False, allow_cascade=False,
+            reset_sequences=False, inhibit_post_migrate=True,
+            database='default', verbosity=0,
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23727