### PR TITLE
Fixed #25300 - Add unit tests for BoundField.id_for_label

### DIFF
--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2289,6 +2289,25 @@ class FormsTestCase(SimpleTestCase):
 
         self.assertHTMLEqual(boundfield.label_tag(), '<label for="id_field"></label>')
 
+    def test_boundfield_id_for_label(self):
+        class SomeForm(Form):
+            field = CharField(label='')
+        boundfield = SomeForm()['field']
+
+        self.assertEqual(boundfield.id_for_label, 'id_field')
+
+    def test_boundfield_id_for_label_override_by_attrs(self):
+        """
+        If an id is provided in `Widget.attrs`, it overrides the generated ID,
+        unless it is `None`
+        """
+        class SomeForm(Form):
+            field = CharField(widget=forms.TextInput(attrs={'id': 'myCustomID'}))
+            field_none = CharField(widget=forms.TextInput(attrs={'id': None}))
+
+        self.assertEqual(SomeForm()['field'].id_for_label, 'myCustomID')
+        self.assertEqual(SomeForm()['field_none'].id_for_label, 'id_field_none')
+
     def test_label_tag_override(self):
         """
         BoundField label_suffix (if provided) overrides Form label_suffix


### PR DESCRIPTION
Not much to add, as asked by Tim on Trac.