### PR TITLE
Ticket #14217 fixed

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -210,16 +210,6 @@ class ModelBase(type):
                 # Things without _meta aren't functional models, so they're
                 # uninteresting parents.
                 continue
- 
-        # The super class has an attribute for each sub class with the same sub class but lower cased.
-        # Check for clashes between locally declared fields and sub class name in lower cased.
-            for field in field_names:
-                if field == name.lower():
-                   raise FieldError(
-                        'Local field %r in class %r clashes '
-                        'with subclass %r ' % (field, name, name)
-                    )
-
             parent_fields = base._meta.local_fields + base._meta.local_many_to_many
             # Check for clashes between locally declared fields and those
             # on the base classes (we cannot handle shadowed fields at the
@@ -1341,6 +1331,11 @@ class Model(six.with_metaclass(ModelBase)):
                     )
                 used_fields[f.name] = f
                 used_fields[f.attname] = f
+ 
+        # Also include shadow fields of parent class
+        for parent in cls._meta.get_parent_list():
+            field = parent._meta.get_field("%s"%cls.__name__.lower())
+            used_fields[field.name]=field
 
         # Check that fields defined in the model don't clash with fields from
         # parents.

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -210,6 +210,15 @@ class ModelBase(type):
                 # Things without _meta aren't functional models, so they're
                 # uninteresting parents.
                 continue
+ 
+        # The super class has an attribute for each sub class with the same sub class but lower cased.
+        # Check for clashes between locally declared fields and sub class name in lower cased.
+            for field in field_names:
+                if field == name.lower():
+                   raise FieldError(
+                        'Local field %r in class %r clashes '
+                        'with subclass %r ' % (field, name, name)
+                    )
 
             parent_fields = base._meta.local_fields + base._meta.local_many_to_many
             # Check for clashes between locally declared fields and those

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -822,7 +822,24 @@ class AccessorClashTests(IsolatedModelsTestCase):
         ]
         self.assertEqual(errors, expected)
 
-
+    def test_field_name_clash_with_sub_class_name(self):
+        """ Ref #14217 """       
+        class Parent(models.Model):
+            pass
+        class Child(Parent):
+            child = models.CharField(max_length=100)
+ 
+        errors = Child.check() 
+        expected = [
+             Error(
+                "The field 'child' clashes with the field 'child' from model 'invalid_models_tests.parent'.",
+                hint=None,
+                obj=Child._meta.get_field('child'),
+                id='models.E006',
+             )
+        ]
+        self.assertEqual(errors,expected)
+        
 class ReverseQueryNameClashTests(IsolatedModelsTestCase):
 
     def test_fk_to_integer(self):


### PR DESCRIPTION
The super class has an attribute for each sub class with the same sub class but lower cased. The child elements will inherit inherit this attributes causing errors when you try to initialise an instance of that model (it thinks the fields are all related fields rather than say a CharField).
So an exception is thrown when a field with the same lower case name as a subclass is defined.