### PR TITLE
Tweak some examples.

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -426,13 +426,13 @@ probably use:
 :lookup:`exact`
     An "exact" match. For example::
 
-        >>> Entry.objects.get(headline__exact="Man bites dog")
+        >>> Entry.objects.get(headline__exact="Cat bites dog")
 
     Would generate SQL along these lines:
 
     .. code-block:: sql
 
-        SELECT ... WHERE headline = 'Man bites dog';
+        SELECT ... WHERE headline = 'Cat bites dog';
 
     If you don't provide a lookup type -- that is, if your keyword argument
     doesn't contain a double underscore -- the lookup type is assumed to be

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -25,7 +25,7 @@ class ModelInstanceCreationTests(TestCase):
     def test_object_is_not_written_to_database_until_save_was_called(self):
         a = Article(
             id=None,
-            headline='Area man programs in Python',
+            headline='Parrot programs in Python',
             pub_date=datetime(2005, 7, 28),
         )
         self.assertIsNone(a.id)
@@ -130,7 +130,7 @@ class ModelInstanceCreationTests(TestCase):
 
     def test_querysets_checking_for_membership(self):
         headlines = [
-            'Area man programs in Python', 'Second article', 'Third article']
+            'Parrot programs in Python', 'Second article', 'Third article']
         some_pub_date = datetime(2014, 5, 16, 12, 1)
         for headline in headlines:
             Article(headline=headline, pub_date=some_pub_date).save()
@@ -437,7 +437,7 @@ class ModelLookupTest(TestCase):
         # Create an Article.
         self.a = Article(
             id=None,
-            headline='Area woman programs in Python',
+            headline='Swallow programs in Python',
             pub_date=datetime(2005, 7, 28),
         )
         # Save it into the database. You have to call save() explicitly.
@@ -445,17 +445,17 @@ class ModelLookupTest(TestCase):
 
     def test_all_lookup(self):
         # Change values by changing the attributes, then calling save().
-        self.a.headline = 'Area man programs in Python'
+        self.a.headline = 'Parrot programs in Python'
         self.a.save()
 
         # Article.objects.all() returns all the articles in the database.
         self.assertQuerysetEqual(Article.objects.all(),
-            ['<Article: Area man programs in Python>'])
+            ['<Article: Parrot programs in Python>'])
 
     def test_rich_lookup(self):
         # Django provides a rich database lookup API.
         self.assertEqual(Article.objects.get(id__exact=self.a.id), self.a)
-        self.assertEqual(Article.objects.get(headline__startswith='Area woman'), self.a)
+        self.assertEqual(Article.objects.get(headline__startswith='Swallow'), self.a)
         self.assertEqual(Article.objects.get(pub_date__year=2005), self.a)
         self.assertEqual(Article.objects.get(pub_date__year=2005, pub_date__month=7), self.a)
         self.assertEqual(Article.objects.get(pub_date__year=2005, pub_date__month=7, pub_date__day=28), self.a)
@@ -464,11 +464,11 @@ class ModelLookupTest(TestCase):
     def test_equal_lookup(self):
         # The "__exact" lookup type can be omitted, as a shortcut.
         self.assertEqual(Article.objects.get(id=self.a.id), self.a)
-        self.assertEqual(Article.objects.get(headline='Area woman programs in Python'), self.a)
+        self.assertEqual(Article.objects.get(headline='Swallow programs in Python'), self.a)
 
         self.assertQuerysetEqual(
             Article.objects.filter(pub_date__year=2005),
-            ['<Article: Area woman programs in Python>'],
+            ['<Article: Swallow programs in Python>'],
         )
         self.assertQuerysetEqual(
             Article.objects.filter(pub_date__year=2004),
@@ -476,12 +476,12 @@ class ModelLookupTest(TestCase):
         )
         self.assertQuerysetEqual(
             Article.objects.filter(pub_date__year=2005, pub_date__month=7),
-            ['<Article: Area woman programs in Python>'],
+            ['<Article: Swallow programs in Python>'],
         )
 
         self.assertQuerysetEqual(
             Article.objects.filter(pub_date__week_day=5),
-            ['<Article: Area woman programs in Python>'],
+            ['<Article: Swallow programs in Python>'],
         )
         self.assertQuerysetEqual(
             Article.objects.filter(pub_date__week_day=6),
@@ -522,7 +522,7 @@ class ModelLookupTest(TestCase):
 
         # pk can be used as a shortcut for the primary key name in any query.
         self.assertQuerysetEqual(Article.objects.filter(pk__in=[self.a.id]),
-            ["<Article: Area woman programs in Python>"])
+            ["<Article: Swallow programs in Python>"])
 
         # Model instances of the same type and same ID are considered equal.
         a = Article.objects.get(pk=self.a.id)
@@ -533,7 +533,7 @@ class ModelLookupTest(TestCase):
         # Create a very similar object
         a = Article(
             id=None,
-            headline='Area man programs in Python',
+            headline='Swallow bites Python',
             pub_date=datetime(2005, 7, 28),
         )
         a.save()
@@ -547,7 +547,7 @@ class ModelLookupTest(TestCase):
             MultipleObjectsReturned,
             "get\(\) returned more than one Article -- it returned 2!",
             Article.objects.get,
-            headline__startswith='Area',
+            headline__startswith='Swallow',
         )
         six.assertRaisesRegex(
             self,

--- a/tests/custom_methods/tests.py
+++ b/tests/custom_methods/tests.py
@@ -10,7 +10,7 @@ from .models import Article
 class MethodsTests(TestCase):
     def test_custom_methods(self):
         a = Article.objects.create(
-            headline="Area man programs in Python", pub_date=date(2005, 7, 27)
+            headline="Parrot programs in Python", pub_date=date(2005, 7, 27)
         )
         b = Article.objects.create(
             headline="Beatles reunite", pub_date=date(2005, 7, 27)
@@ -32,13 +32,13 @@ class MethodsTests(TestCase):
 
         self.assertQuerysetEqual(
             b.articles_from_same_day_1(), [
-                "Area man programs in Python",
+                "Parrot programs in Python",
             ],
             lambda a: a.headline,
         )
         self.assertQuerysetEqual(
             b.articles_from_same_day_2(), [
-                "Area man programs in Python",
+                "Parrot programs in Python",
             ],
             lambda a: a.headline
         )

--- a/tests/m2m_multiple/tests.py
+++ b/tests/m2m_multiple/tests.py
@@ -15,13 +15,13 @@ class M2MMultipleTests(TestCase):
         ]
 
         a1 = Article.objects.create(
-            headline="Area man steals", pub_date=datetime(2005, 11, 27)
+            headline="Parrot steals", pub_date=datetime(2005, 11, 27)
         )
         a1.primary_categories.add(c2, c3)
         a1.secondary_categories.add(c4)
 
         a2 = Article.objects.create(
-            headline="Area man runs", pub_date=datetime(2005, 11, 28)
+            headline="Parrot runs", pub_date=datetime(2005, 11, 28)
         )
         a2.primary_categories.add(c1, c2)
         a2.secondary_categories.add(c4)
@@ -48,7 +48,7 @@ class M2MMultipleTests(TestCase):
         )
         self.assertQuerysetEqual(
             c1.primary_article_set.all(), [
-                "Area man runs",
+                "Parrot runs",
             ],
             lambda a: a.headline
         )
@@ -57,8 +57,8 @@ class M2MMultipleTests(TestCase):
         )
         self.assertQuerysetEqual(
             c2.primary_article_set.all(), [
-                "Area man steals",
-                "Area man runs",
+                "Parrot steals",
+                "Parrot runs",
             ],
             lambda a: a.headline
         )
@@ -67,7 +67,7 @@ class M2MMultipleTests(TestCase):
         )
         self.assertQuerysetEqual(
             c3.primary_article_set.all(), [
-                "Area man steals",
+                "Parrot steals",
             ],
             lambda a: a.headline
         )
@@ -79,8 +79,8 @@ class M2MMultipleTests(TestCase):
         )
         self.assertQuerysetEqual(
             c4.secondary_article_set.all(), [
-                "Area man steals",
-                "Area man runs",
+                "Parrot steals",
+                "Parrot runs",
             ],
             lambda a: a.headline
         )

--- a/tests/str/tests.py
+++ b/tests/str/tests.py
@@ -15,11 +15,11 @@ class SimpleTests(TestCase):
     @skipIf(six.PY3, "tests a __str__ method returning unicode under Python 2")
     def test_basic(self):
         a = Article.objects.create(
-            headline=b'Area man programs in Python',
+            headline=b'Parrot programs in Python',
             pub_date=datetime.datetime(2005, 7, 28)
         )
-        self.assertEqual(str(a), str('Area man programs in Python'))
-        self.assertEqual(repr(a), str('<Article: Area man programs in Python>'))
+        self.assertEqual(str(a), str('Parrot programs in Python'))
+        self.assertEqual(repr(a), str('<Article: Parrot programs in Python>'))
 
     def test_international(self):
         a = InternationalArticle.objects.create(


### PR DESCRIPTION
"Area man/woman" is confusing to people not familiar with the
conventions of American journalism (like me).