### PR TITLE
Fixed #25302 -- Prevented BrokenLinkEmailsMiddleware from reporting 404s when Referer = URL.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -483,6 +483,7 @@ answer newbie questions, and generally made Django that much better:
     mattycakes@gmail.com
     Max Burstein <http://maxburstein.com>
     Max Derkachev <mderk@yandex.ru>
+    Maxime Lorant <maxime.lorant@gmail.com>
     Maxime Turcotte <maxocub@riseup.net>
     Maximillian Dornseif <md@hudora.de>
     mccutchen@gmail.com

--- a/docs/howto/error-reporting.txt
+++ b/docs/howto/error-reporting.txt
@@ -62,7 +62,14 @@ not found" errors). Django sends emails about 404 errors when:
 If those conditions are met, Django will email the users listed in the
 :setting:`MANAGERS` setting whenever your code raises a 404 and the request has
 a referer. (It doesn't bother to email for 404s that don't have a referer --
-those are usually just people typing in broken URLs or broken Web 'bots).
+those are usually just people typing in broken URLs or broken Web bots. It also
+ignores 404s when the referer is equal to the URL requested, since this behavior
+is from broken Web bots too).
+
+.. versionchanged:: 1.9
+
+    In older versions of Django, the error was not ignored when the referer was
+    equal to the URL requested.
 
 .. note::
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -551,6 +551,12 @@ Requests and Responses
   :class:`~django.http.JsonResponse` to allow passing keyword arguments to the
   ``json.dumps()`` call used to generate the response.
 
+* The :class:`~django.middleware.common.BrokenLinkEmailsMiddleware` now
+  ignores 404s where the referer is equal to the URL requested. To get around
+  the empty referer check (already implemented before), some web bots set the
+  referer to the URL requested. This could trigger a large amount of false
+  positive with malicious or broken bots that try a lot of URL.
+
 Tests
 ^^^^^
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/25302