### PR TITLE
Fixed #25068 -- Added metaclassmaker to resolve metaclass conflicts in migrations state.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -15,6 +15,7 @@ from django.db.models.utils import make_model_tuple
 from django.utils import six
 from django.utils.encoding import force_text, smart_text
 from django.utils.functional import cached_property
+from django.utils.metaclassmaker import metaclassmaker
 from django.utils.module_loading import import_string
 from django.utils.version import get_docs_version
 
@@ -548,7 +549,7 @@ class ModelState(object):
         body.update(self.construct_managers())
 
         # Then, make a Model object (apps.register_model is called in __new__)
-        return type(
+        return metaclassmaker()(
             str(self.name),
             bases,
             body,

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -549,11 +549,19 @@ class ModelState(object):
         body.update(self.construct_managers())
 
         # Then, make a Model object (apps.register_model is called in __new__)
-        return metaclassmaker()(
-            str(self.name),
-            bases,
-            body,
-        )
+        try:
+            return type(
+                str(self.name),
+                bases,
+                body,
+            )
+        except TypeError:
+            # Fallback to slower version of building classes with multiple metaclass inheritance.
+            return metaclassmaker()(
+                str(self.name),
+                bases,
+                body,
+            )
 
     def get_field_by_name(self, name):
         for fname, field in self.fields:

--- a/django/utils/metaclassmaker.py
+++ b/django/utils/metaclassmaker.py
@@ -56,9 +56,9 @@ def _get_noconflict_metaclass(bases, left_metas, right_metas):
 
 def metaclassmaker(left_metas=(), right_metas=()):
     """metaclass maker, has to be used as base metaclass if you inherit
-    from more then one class with custom metaclass.
-    It merges metaclasses from class bases and return new one.
-    If there is only one custom metaclass it just returns it.
+    from more than one class with custom metaclass.
+    It merges metaclasses from class bases and returns a new one.
+    If there is only one custom metaclass, it just returns it.
     If there is no custom metaclass then type is returned.
     """
     def make_class(name, bases, adict):

--- a/django/utils/metaclassmaker.py
+++ b/django/utils/metaclassmaker.py
@@ -1,0 +1,77 @@
+"""
+ Complex metaclass merger library for solving multiple metadatas inheritance.
+ Main code and idea is from:
+ http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
+"""
+from __future__ import absolute_import
+
+import inspect
+
+from django.utils import six
+
+memoized_metaclasses_map = {}
+
+
+def _skip_redundant(iterable, skip_set=None):
+    """Redundant items are repeated items or items in the original skip_set."""
+    if skip_set is None:
+        skip_set = set()
+    for item in iterable:
+        if item not in skip_set:
+            skip_set.add(item)
+            yield item
+
+
+def _remove_redundant(metaclasses):
+    skip_set = set(six.class_types)
+    for meta in metaclasses:  # determines the metaclasses to be skipped
+        skip_set.update(inspect.getmro(meta)[1:])
+    return tuple(_skip_redundant(metaclasses, skip_set))
+
+
+def _get_noconflict_metaclass(bases, left_metas, right_metas):
+    """Not intended to be used outside of this module, unless you know
+    what you are doing."""
+    # make tuple of needed metaclasses in specified priority order
+    metas = left_metas + tuple(map(type, bases)) + right_metas
+    needed_metas = _remove_redundant(metas)
+
+    # return existing confict-solving meta, if any
+    if needed_metas in memoized_metaclasses_map:
+        return memoized_metaclasses_map[needed_metas]
+    # nope: compute, memoize and return needed conflict-solving meta
+    elif not needed_metas:  # wee, a trivial case, happy us
+        meta = type
+    elif len(needed_metas) == 1:  # another trivial case
+        meta = needed_metas[0]
+    # check for recursion, can happen i.e. for Zope ExtensionClasses
+    elif needed_metas == bases:
+        raise TypeError("Incompatible root metatypes", needed_metas)
+    else:  # gotta work ...
+        metaname = '_' + ''.join([m.__name__ for m in needed_metas])
+        meta = metaclassmaker()(metaname, needed_metas, {})
+    memoized_metaclasses_map[needed_metas] = meta
+    return meta
+
+
+def metaclassmaker(left_metas=(), right_metas=()):
+    """metaclass maker, has to be used as base metaclass if you inherit
+    from more then one class with custom metaclass.
+    It merges metaclasses from class bases and return new one.
+    If there is only one custom metaclass it just returns it.
+    If there is no custom metaclass then type is returned.
+    """
+    def make_class(name, bases, adict):
+        metaclass = _get_noconflict_metaclass(bases, left_metas, right_metas)
+        return metaclass(name, bases, adict)
+    return make_class
+
+
+def six_with_metaclassmaker(*bases):
+    """Creates a base class type with a metaclassmaker.
+    It's like six.with_metaclass but adjusted to work properly
+    with metaclassmaker"""
+    class Metaclass(type):
+        def __new__(cls, name, this_bases, adict):
+            return metaclassmaker()(name, bases, adict)
+    return type.__new__(Metaclass, 'temporary_class', (), {})

--- a/django/utils/metaclassmaker.py
+++ b/django/utils/metaclassmaker.py
@@ -67,11 +67,21 @@ def metaclassmaker(left_metas=(), right_metas=()):
     return make_class
 
 
-def six_with_metaclassmaker(*bases):
+def six_with_metaclassmaker(*bases, **kwargs):
     """Creates a base class type with a metaclassmaker.
     It's like six.with_metaclass but adjusted to work properly
-    with metaclassmaker"""
+    with metaclassmaker
+    Usage:
+        class SomeClass(six_with_metaclassmaker(BaseClassA, BaseClassB, metaclass=MetaClass)):
+            ...
+    """
+    left_metas = kwargs.get('left_metas', tuple())
+    right_metas = kwargs.get('right_metas', tuple())
+    if 'metaclass' in kwargs:
+        right_metas += (kwargs['metaclass'],)
+
     class Metaclass(type):
         def __new__(cls, name, this_bases, adict):
-            return metaclassmaker()(name, bases, adict)
+            return metaclassmaker(left_metas, right_metas)(name, bases, adict)
+
     return type.__new__(Metaclass, 'temporary_class', (), {})

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -893,14 +893,15 @@ class ModelStateTests(SimpleTestCase):
                 apps = new_apps
                 swappable = 'TEST_SWAPPABLE_MODEL'
 
-        model_state = ModelState('migrations', 'migrations.test_state.MetaclassTestModel',
-                                 [], bases=[models.Model, Mixin])
+        # Reset apps to be able to render __fake__ modules
+        new_apps = Apps(['migrations'])
+        model_state = ModelState.from_model(MetaclassTestModel)
+
         try:
             class_obj = model_state.render(new_apps)
         except TypeError:
-            class_obj = None
+            raise AssertionError("Not resolved metaclass conflict")
 
-        self.assertIsNotNone(class_obj, "Not resolved metaclass conflict")
         self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)
 
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -897,10 +897,8 @@ class ModelStateTests(SimpleTestCase):
         new_apps = Apps(['migrations'])
         model_state = ModelState.from_model(MetaclassTestModel)
 
-        try:
-            class_obj = model_state.render(new_apps)
-        except TypeError:
-            raise AssertionError("Not resolved metaclass conflict")
+        # This rises metaclass conflict if it's not done properly
+        class_obj = model_state.render(new_apps)
 
         self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -886,18 +886,18 @@ class ModelStateTests(SimpleTestCase):
         class ItermidiateMetaClass(ModelBase, DummyMetaClass):
             pass
 
-        # create the same Model without metaclassmaker as you would normally do
+        # Create the same Model without metaclassmaker as you would normally do.
         class MetaclassTestModel(six.with_metaclass(ItermidiateMetaClass, models.Model, Mixin)):
             class Meta:
                 app_label = "migrations"
                 apps = new_apps
                 swappable = 'TEST_SWAPPABLE_MODEL'
 
-        # Reset apps to be able to render __fake__ modules
+        # Reset apps to be able to render __fake__ modules.
         new_apps = Apps(['migrations'])
         model_state = ModelState.from_model(MetaclassTestModel)
 
-        # This rises metaclass conflict if it's not done properly
+        # This raises metaclass conflict if it's not done properly.
         class_obj = model_state.render(new_apps)
 
         self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -878,20 +878,20 @@ class ModelStateTests(SimpleTestCase):
         new_apps = Apps(['migrations'])
 
         class DummyMetaClass(type):
+            dummy_attr = 'dummy'
             pass
 
         class Mixin(six.with_metaclass(DummyMetaClass, object)):
-            mixin_attr = True
+            mixin_attr = 'mixin'
 
-        class ItermidiateMetaClass(ModelBase, DummyMetaClass):
+        class IntermediateMetaClass(DummyMetaClass, ModelBase):
             pass
 
         # Create the same Model without metaclassmaker as you would normally do.
-        class MetaclassTestModel(six.with_metaclass(ItermidiateMetaClass, models.Model, Mixin)):
+        class MetaclassTestModel(six.with_metaclass(IntermediateMetaClass, Mixin, models.Model)):
             class Meta:
                 app_label = "migrations"
                 apps = new_apps
-                swappable = 'TEST_SWAPPABLE_MODEL'
 
         # Reset apps to be able to render __fake__ modules.
         new_apps = Apps(['migrations'])
@@ -900,8 +900,8 @@ class ModelStateTests(SimpleTestCase):
         # This raises metaclass conflict if it's not done properly.
         class_obj = model_state.render(new_apps)
 
-        self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)
-
+        self.assertEqual(getattr(class_obj, 'mixin_attr', False), 'mixin')
+        self.assertEqual(getattr(class_obj, 'dummy_attr', False), 'dummy')
 
 class RelatedModelsTests(SimpleTestCase):
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -879,7 +879,6 @@ class ModelStateTests(SimpleTestCase):
 
         class DummyMetaClass(type):
             dummy_attr = 'dummy'
-            pass
 
         class Mixin(six.with_metaclass(DummyMetaClass, object)):
             mixin_attr = 'mixin'

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -903,6 +903,7 @@ class ModelStateTests(SimpleTestCase):
         self.assertEqual(getattr(class_obj, 'mixin_attr', False), 'mixin')
         self.assertEqual(getattr(class_obj, 'dummy_attr', False), 'dummy')
 
+
 class RelatedModelsTests(SimpleTestCase):
 
     def setUp(self):

--- a/tests/utils_tests/test_metaclassmaker.py
+++ b/tests/utils_tests/test_metaclassmaker.py
@@ -29,12 +29,8 @@ class MetaClassTest(unittest.TestCase):
         class MixinClass(six.with_metaclass(Dummy2MetaClass, object)):
             mixin_attr = True
 
-        try:
-            class MetaclassTestModel(six_with_metaclassmaker(NormalClass, MixinClass)):
-                pass
-        except TypeError:
-            # TypeError: Error when calling the metaclass bases
-            raise AssertionError('Not resolved metaclass conflict"')
+        class MetaclassTestModel(six_with_metaclassmaker(NormalClass, MixinClass)):
+            pass
 
         obj = MetaclassTestModel()
         self.assertIsInstance(obj, MixinClass)

--- a/tests/utils_tests/test_metaclassmaker.py
+++ b/tests/utils_tests/test_metaclassmaker.py
@@ -34,8 +34,8 @@ class MetaClassTest(unittest.TestCase):
                 pass
         except TypeError:
             # TypeError: Error when calling the metaclass bases
-            MetaclassTestModel = None
-        self.assertIsNotNone(MetaclassTestModel)
+            raise AssertionError('Not resolved metaclass conflict"')
+
         obj = MetaclassTestModel()
         self.assertIsInstance(obj, MixinClass)
         self.assertIsInstance(obj, NormalClass)

--- a/tests/utils_tests/test_metaclassmaker.py
+++ b/tests/utils_tests/test_metaclassmaker.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import unittest
+
+from django.utils import six
+from django.utils.metaclassmaker import six_with_metaclassmaker
+
+
+class MetaClassTest(unittest.TestCase):
+
+    def test_six_with_metaclassmaker(self):
+        class Dummy1MetaClass(type):
+            def __init__(cls, name, bases, nmspc):
+                super(Dummy1MetaClass, cls).__init__(name, bases, nmspc)
+                if not hasattr(cls, 'meta_attr'):
+                    setattr(cls, 'meta_attr', True)
+
+        class Dummy2MetaClass(type):
+            def __init__(cls, name, bases, nmspc):
+                super(Dummy2MetaClass, cls).__init__(name, bases, nmspc)
+                if not hasattr(cls, 'meta_attr2'):
+                    setattr(cls, 'meta_attr2', True)
+
+        class NormalClass(six.with_metaclass(Dummy1MetaClass, object)):
+            normal_attr = True
+            pass
+
+        class MixinClass(six.with_metaclass(Dummy2MetaClass, object)):
+            mixin_attr = True
+
+        try:
+            class MetaclassTestModel(six_with_metaclassmaker(NormalClass, MixinClass)):
+                pass
+        except TypeError:
+            # TypeError: Error when calling the metaclass bases
+            MetaclassTestModel = None
+        self.assertIsNotNone(MetaclassTestModel)
+        obj = MetaclassTestModel()
+        self.assertIsInstance(obj, MixinClass)
+        self.assertIsInstance(obj, NormalClass)
+        self.assertEqual(getattr(obj, 'mixin_attr', False), True)
+        self.assertEqual(getattr(obj, 'normal_attr', False), True)
+        self.assertEqual(getattr(obj, 'meta_attr', False), True)
+        self.assertEqual(getattr(obj, 'meta_attr2', False), True)


### PR DESCRIPTION
https://github.com/django/django/pull/4968

Now it's faster, or more like it's not slowing down ;)