### PR TITLE
Fixed #25308 -- Make MigrationQuestioner respect MIGRATION_MODULES setting

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -9,7 +9,7 @@ from django.db.models.fields import NOT_PROVIDED
 from django.utils import datetime_safe, six, timezone
 from django.utils.six.moves import input
 
-from .loader import MIGRATIONS_MODULE_NAME
+from .loader import MigrationLoader
 
 
 class MigrationQuestioner(object):
@@ -37,7 +37,7 @@ class MigrationQuestioner(object):
             app_config = apps.get_app_config(app_label)
         except LookupError:         # It's a fake app.
             return self.defaults.get("ask_initial", False)
-        migrations_import_path = "%s.%s" % (app_config.name, MIGRATIONS_MODULE_NAME)
+        migrations_import_path = MigrationLoader.migrations_module(app_config.label)
         try:
             migrations_module = importlib.import_module(migrations_import_path)
         except ImportError:

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -610,6 +610,15 @@ class MakeMigrationsTests(MigrationTestBase):
             call_command("makemigrations", "migrations", stdout=out)
         self.assertIn("No changes detected in app 'migrations'", out.getvalue())
 
+    def test_makemigrations_no_apps_initial(self):
+        """
+        Makes sure that makemigrations detects initial is needed if no app provided.
+        """
+        out = six.StringIO()
+        with self.temporary_migration_module(module="migrations.test_migrations_empty"):
+            call_command("makemigrations", stdout=out)
+        self.assertIn("0001_initial.py", out.getvalue())
+
     def test_makemigrations_migrations_announce(self):
         """
         Makes sure that makemigrations announces the migration at the default verbosity level.


### PR DESCRIPTION
Updated MigrationQuestioner to use MigrationLoader.migrations_module to insure it is retrieving modules consistently with the rest of the migrations process.

See https://code.djangoproject.com/ticket/25308