### PR TITLE
Fixed #12405 -- Added settings.LOGOUT_REDIRECT_URL.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -489,6 +489,8 @@ LOGIN_URL = '/accounts/login/'
 
 LOGIN_REDIRECT_URL = '/accounts/profile/'
 
+LOGOUT_REDIRECT_URL = None
+
 # The number of days a password reset link is valid for
 PASSWORD_RESET_TIMEOUT_DAYS = 3
 

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -104,6 +104,8 @@ def logout(request, next_page=None,
 
     if next_page is not None:
         next_page = resolve_url(next_page)
+    elif settings.LOGOUT_REDIRECT_URL:
+        next_page = resolve_url(settings.LOGOUT_REDIRECT_URL)
 
     if (redirect_field_name in request.POST or
             redirect_field_name in request.GET):

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2642,6 +2642,25 @@ This setting also accepts view function names and :ref:`named URL patterns
 <naming-url-patterns>` which can be used to reduce configuration duplication
 since you don't have to define the URL in two places (``settings`` and URLconf).
 
+.. setting:: LOGOUT_REDIRECT_URL
+
+``LOGOUT_REDIRECT_URL``
+-----------------------
+
+.. versionadded:: 1.10
+
+Default: ``None``
+
+LOGIN_REDIRECT_URL counterpart.  The URL where requests are redirected after
+logout when the ``contrib.auth.logout`` view gets no ``next`` parameter.
+
+If ``None``, no redirection will be performed and the logout view will be
+rendered.
+
+This setting also accepts view function names and :ref:`named URL patterns
+<naming-url-patterns>` which can be used to reduce configuration duplication
+since you don't have to define the URL in two places (``settings`` and URLconf).
+
 .. setting:: PASSWORD_RESET_TIMEOUT_DAYS
 
 ``PASSWORD_RESET_TIMEOUT_DAYS``

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -488,6 +488,10 @@ Miscellaneous
   argument of the ``render_options()`` method is also removed, making
   ``selected_choices`` the first argument.
 
+* A new setting, :setting:`LOGOUT_REDIRECT_URL` where requests are redirected
+  after logout when the ``contrib.auth.logout`` view gets no ``next``
+  parameter.
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1105,7 +1105,9 @@ implementation details see :ref:`using-the-views`.
 
     **Optional arguments:**
 
-    * ``next_page``: The URL to redirect to after logout.
+    * ``next_page``: The URL to redirect to after logout.  Defaults to
+      :setting:`settings.LOGOUT_REDIRECT_URL <LOGOUT_REDIRECT_URL>` if not
+      supplied.
 
     * ``template_name``: The full name of a template to display after
       logging the user out. Defaults to

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -878,6 +878,18 @@ class LogoutTest(AuthViewsTestCase):
         self.client.get('/logout/')
         self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], 'pl')
 
+    @override_settings(LOGOUT_REDIRECT_URL='/custom/')
+    def test_logout_redirect_url_setting(self):
+        self.login()
+        response = self.client.get('/logout/')
+        self.assertRedirects(response, '/custom/', fetch_redirect_response=False)
+
+    @override_settings(LOGOUT_REDIRECT_URL='logout')
+    def test_logout_redirect_url_named_setting(self):
+        self.login()
+        response = self.client.get('/logout/')
+        self.assertRedirects(response, '/logout/', fetch_redirect_response=False)
+
 
 # Redirect in test_user_change_password will fail if session auth hash
 # isn't updated after password change (#21649)


### PR DESCRIPTION
After a user logs out via django.contrib.auth.views.logout, they should be
redirected to LOGOUT_REDIRECT_URL is no `next` parameter is provided.