### PR TITLE
Fixed #25058 -- Added GenericRelations with related_query_name to the admin's delete confirmation page.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -185,7 +185,7 @@ class NestedObjects(Collector):
                     'class': source._meta.model_name,
                     'app_label': source._meta.app_label,
                 }
-                self.add_edge(getattr(obj, related_name), obj)
+                self.add_edge(None, obj)
             else:
                 self.add_edge(None, obj)
             self.model_count[obj._meta.verbose_name_plural] += 1
@@ -220,8 +220,7 @@ class NestedObjects(Collector):
         """
         seen = set()
         roots = []
-        for key in self.edges.keys():
-            for root in self.edges.get(key, ()):
+        for root in self.edges.get(None, ()):
                 roots.extend(self._nested(root, seen, format_callback))
         return roots
 

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -220,8 +220,9 @@ class NestedObjects(Collector):
         """
         seen = set()
         roots = []
-        for root in self.edges.get(None, ()):
-            roots.extend(self._nested(root, seen, format_callback))
+        for key in self.edges.keys():
+            for root in self.edges.get(key, ()):
+                roots.extend(self._nested(root, seen, format_callback))
         return roots
 
     def can_fast_delete(self, *args, **kwargs):


### PR DESCRIPTION

![without related_query_name](https://cloud.githubusercontent.com/assets/3329991/9497214/95e47eb6-4c31-11e5-92ba-da798e57086a.png) This is without related_query_name field.
![with related_query_name](https://cloud.githubusercontent.com/assets/3329991/9497215/961778a2-4c31-11e5-8a7f-848bdd888eea.png)This is with related_query_name field


The bug has been fixed. But the related object is coming first as shown in the image. Should i fix this ?