### PR TITLE
Rename the context object from DetailView class.

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -281,7 +281,7 @@ views and use Django's generic views instead. To do so, open the
     class DetailView(generic.DetailView):
         model = Question
         template_name = 'polls/detail.html'
-
+        context_object_name = 'question'
 
     class ResultsView(generic.DetailView):
         model = Question


### PR DESCRIPTION
The detail.html received an object 'question' via context, so we needed to rename the default object from DetailView class to 'question'. Before it was getting an error. 

```python
    # file_name: polls/views.py
    context_object_name = 'question'