### PR TITLE
Remove unnecessary DBCacheTests.test_clear_commits_transaction

### DIFF
--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -971,13 +971,6 @@ class DBCacheTests(BaseCacheTests, TransactionTestCase):
         self.assertEqual(out.getvalue(),
             "Cache table 'test cache table' created.\n")
 
-    def test_clear_commits_transaction(self):
-        # Ensure the database transaction is committed (#19896)
-        cache.set("key1", "spam")
-        cache.clear()
-        transaction.rollback()
-        self.assertIsNone(cache.get("key1"))
-
 
 @override_settings(USE_TZ=True)
 class DBCacheWithTimeZoneTests(DBCacheTests):


### PR DESCRIPTION
Spotted whilst copying them to my own cache backend test and trying to run them under `TestCase` as opposed to `TransactionTestCase`.

Was added in 44164c5c308da32a804dfb03ce0bffde2a6b4c56 but the `transaction.commit_unless_managed(using=db)` line was removed in ba5138b1c0253fcf390b7509ad7b954117b3be88 ; thus as far as I can tell the test does nothing but check `clear()` runs.