### PR TITLE
Fixed #24994 -- Documented, checked that settings.SECRET_KEY is valid unicode string

### DIFF
--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -98,9 +98,13 @@ W019 = Warning(
 
 W020 = Warning(
     "ALLOWED_HOSTS must not be empty in deployment.",
+    id='security.W020',
+)
+
+W021 = Warning(
     "Your SECRET_KEY contains invalid Unicode. Please ensure you have a "
     "valid Unicode string.",
-    id='security.W020',
+    id='security.W021',
 )
 
 

--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.signing import force_bytes, force_text
 
 from .. import Tags, Warning, register
 
@@ -97,6 +98,8 @@ W019 = Warning(
 
 W020 = Warning(
     "ALLOWED_HOSTS must not be empty in deployment.",
+    "Your SECRET_KEY contains invalid Unicode. Please ensure you have a "
+    "valid Unicode string.",
     id='security.W020',
 )
 
@@ -165,13 +168,27 @@ def check_ssl_redirect(app_configs, **kwargs):
 
 
 @register(Tags.security, deploy=True)
-def check_secret_key(app_configs, **kwargs):
+def check_secret_key_length(app_configs, **kwargs):
     passed_check = (
         getattr(settings, 'SECRET_KEY', None) and
         len(set(settings.SECRET_KEY)) >= SECRET_KEY_MIN_UNIQUE_CHARACTERS and
         len(settings.SECRET_KEY) >= SECRET_KEY_MIN_LENGTH
     )
     return [] if passed_check else [W009]
+
+
+@register(Tags.security, deploy=True)
+def check_secret_key_valid_unicode(app_configs, **kwargs):
+    valid_unicode = True
+    try:
+        # To maintain backwards compatibility, instead of checking that
+        # SECRET_KEY is a valid unicode string, simply check if it goes through
+        # `force_bytes` and `force_text` without throwing an exception.
+        force_bytes(settings.SECRET_KEY)
+        force_text(settings.SECRET_KEY)
+    except UnicodeDecodeError:
+        valid_unicode = False
+    return [] if valid_unicode else [W020]
 
 
 @register(Tags.security, deploy=True)

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -537,6 +537,8 @@ of the :djadmin:`check` command:
   for your site to serve other parts of itself in a frame, you should change
   it to ``'DENY'``.
 * **security.W020**: :setting:`ALLOWED_HOSTS` must not be empty in deployment.
+* **security.W020**: Your :setting:`SECRET_KEY` is invalid Unicode.
+  Please generate a valid Unicode string.
 
 Sites
 -----

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1906,7 +1906,7 @@ Default: ``''`` (Empty string)
 
 A secret key for a particular Django installation. This is used to provide
 :doc:`cryptographic signing </topics/signing>`, and should be set to a unique,
-unpredictable value.
+unpredictable, valid unicode string.
 
 :djadmin:`django-admin startproject <startproject>` automatically adds a
 randomly-generated ``SECRET_KEY`` to each new project.

--- a/tests/check_framework/test_security.py
+++ b/tests/check_framework/test_security.py
@@ -429,11 +429,11 @@ class CheckSSLRedirectTest(SimpleTestCase):
         self.assertEqual(self.func(None), [])
 
 
-class CheckSecretKeyTest(SimpleTestCase):
+class CheckSecretKeyLengthTest(SimpleTestCase):
     @property
     def func(self):
-        from django.core.checks.security.base import check_secret_key
-        return check_secret_key
+        from django.core.checks.security.base import check_secret_key_length
+        return check_secret_key_length
 
     @override_settings(SECRET_KEY=('abcdefghijklmnopqrstuvwx' * 2) + 'ab')
     def test_okay_secret_key(self):
@@ -464,6 +464,18 @@ class CheckSecretKeyTest(SimpleTestCase):
         self.assertGreater(len(settings.SECRET_KEY), base.SECRET_KEY_MIN_LENGTH)
         self.assertLess(len(set(settings.SECRET_KEY)), base.SECRET_KEY_MIN_UNIQUE_CHARACTERS)
         self.assertEqual(self.func(None), [base.W009])
+
+
+class CheckSecretKeyValidUnicodeTest(SimpleTestCase):
+    @property
+    def func(self):
+        from django.core.checks.security.base import check_secret_key_valid_unicode
+        return check_secret_key_valid_unicode
+
+    @override_settings(SECRET_KEY=(b'\xffabcdefghijklmnopqrstuvwxyz' * 2))
+    def test_invalid_unicode_secret_key(self):
+        self.assertGreater(len(settings.SECRET_KEY), base.SECRET_KEY_MIN_LENGTH)
+        self.assertEqual(self.func(None), [base.W020])
 
 
 class CheckDebugTest(SimpleTestCase):


### PR DESCRIPTION
Documented that the settings.SECRET_KEY should be valid unicode, and checked
that it does indeed pass our expectations. In case of failure, it emits a
readable warning.