### PR TITLE
Fixed #25331 -- Remove trailing blank lines in docstrings

### DIFF
--- a/django/conf/urls/static.py
+++ b/django/conf/urls/static.py
@@ -16,7 +16,6 @@ def static(prefix, view=serve, **kwargs):
     urlpatterns = [
         # ... the rest of your URLconf goes here ...
     ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
     """
     # No-op if not in debug mode or an non-local prefix
     if not settings.DEBUG or (prefix and '://' in prefix):

--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -123,7 +123,6 @@ def get_deleted_objects(objs, opts, user, admin_site, using):
 
     Returns a nested list of strings suitable for display in the
     template with the ``unordered_list`` filter.
-
     """
     collector = NestedObjects(using=using)
     collector.collect(objs)
@@ -216,7 +215,6 @@ class NestedObjects(Collector):
     def nested(self, format_callback=None):
         """
         Return the graph as a nested list.
-
         """
         seen = set()
         roots = []
@@ -238,7 +236,6 @@ def model_format_dict(obj):
     typically for use with string formatting.
 
     `obj` may be a `Model` instance, `Model` subclass, or `QuerySet` instance.
-
     """
     if isinstance(obj, (models.Model, models.base.ModelBase)):
         opts = obj._meta
@@ -260,7 +257,6 @@ def model_ngettext(obj, n=None):
     `obj` may be a `Model` instance, `Model` subclass, or `QuerySet` instance.
     If `obj` is a `QuerySet` instance, `n` is optional and the length of the
     `QuerySet` is used.
-
     """
     if isinstance(obj, models.query.QuerySet):
         if n is None:
@@ -438,7 +434,6 @@ def reverse_field_path(model, path):
     return (Group, "user__order").
 
     Final field must be a related model, not a data field.
-
     """
     reversed_path = []
     parent = model

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -220,7 +220,6 @@ class PasswordResetForm(forms.Form):
         This allows subclasses to more easily customize the default policies
         that prevent inactive users and users with unusable passwords from
         resetting their password.
-
         """
         active_users = get_user_model()._default_manager.filter(
             email__iexact=email, is_active=True)

--- a/django/contrib/gis/maps/google/overlays.py
+++ b/django/contrib/gis/maps/google/overlays.py
@@ -239,7 +239,6 @@ class GIcon(object):
         infowindowanchor:
             The pixel coordinate relative to the top left corner of the icon
             image at which the info window is anchored to this icon.
-
     """
     def __init__(self, varname, image=None, iconsize=None,
                  shadow=None, shadowsize=None, iconanchor=None,

--- a/django/contrib/staticfiles/management/commands/runserver.py
+++ b/django/contrib/staticfiles/management/commands/runserver.py
@@ -19,7 +19,6 @@ class Command(RunserverCommand):
         Returns the static files serving handler wrapping the default handler,
         if static files should be served. Otherwise just returns the default
         handler.
-
         """
         handler = super(Command, self).get_handler(*args, **options)
         use_static_handler = options.get('use_static_handler', True)

--- a/django/contrib/staticfiles/templatetags/staticfiles.py
+++ b/django/contrib/staticfiles/templatetags/staticfiles.py
@@ -32,6 +32,5 @@ def do_static(parser, token):
         {% static variable_with_path %}
         {% static "myapp/css/base.css" as admin_base_css %}
         {% static variable_with_path as varname %}
-
     """
     return StaticFilesNode.handle_token(parser, token)

--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -44,7 +44,6 @@ def get_files(storage, ignore_patterns=None, location=''):
 def check_settings(base_url=None):
     """
     Checks if the staticfiles settings have sane values.
-
     """
     if base_url is None:
         base_url = settings.STATIC_URL

--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -232,7 +232,6 @@ class BaseCache(object):
         Warn about keys that would not be portable to the memcached
         backend. This encourages (but does not force) writing backend-portable
         cache code.
-
         """
         if len(key) > MEMCACHE_MAX_KEY_LENGTH:
             warnings.warn('Cache key will cause errors if used with memcached: '

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -39,7 +39,6 @@ class CheckRegistry(object):
                 return errors
             # or
             registry.register(my_check, 'mytag', 'anothertag')
-
         """
         kwargs.setdefault('deploy', False)
 
@@ -60,7 +59,8 @@ class CheckRegistry(object):
             return inner
 
     def run_checks(self, app_configs=None, tags=None, include_deployment_checks=False):
-        """ Run all registered checks and return list of Errors and Warnings.
+        """
+        Run all registered checks and return list of Errors and Warnings.
         """
         errors = []
         checks = self.get_checks(include_deployment_checks)

--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -214,6 +214,5 @@ def load_handler(path, *args, **kwargs):
         >>> request = HttpRequest()
         >>> load_handler('django.core.files.uploadhandler.TemporaryFileUploadHandler', request)
         <TemporaryFileUploadHandler object at 0x...>
-
     """
     return import_string(path)(*args, **kwargs)

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -30,7 +30,6 @@ class CommandError(Exception):
     result, raising this exception (with a sensible description of the
     error) is the preferred way to indicate that something has gone
     wrong in the execution of a command.
-
     """
     pass
 
@@ -71,7 +70,6 @@ def handle_default_options(options):
     Include any default options that all commands should accept here
     so that ManagementUtility can handle them before searching for
     user commands.
-
     """
     if options.settings:
         os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
@@ -237,7 +235,6 @@ class BaseCommand(object):
         Return the Django version, which should be correct for all
         built-in Django commands. User-supplied commands should
         override this method.
-
         """
         return django.get_version()
 
@@ -245,7 +242,6 @@ class BaseCommand(object):
         """
         Return a brief description of how to use this command, by
         default from the attribute ``self.help``.
-
         """
         usage = '%%prog %s [options] %s' % (subcommand, self.args)
         if self.help:
@@ -257,7 +253,6 @@ class BaseCommand(object):
         """
         Create and return the ``ArgumentParser`` which will be used to
         parse the arguments to this command.
-
         """
         if not self.use_argparse:
             def store_as_int(option, opt_str, value, parser):
@@ -324,7 +319,6 @@ class BaseCommand(object):
         """
         Print the help message for this command, derived from
         ``self.usage()``.
-
         """
         parser = self.create_parser(prog_name, subcommand)
         parser.print_help()
@@ -488,7 +482,6 @@ class BaseCommand(object):
         """
         The actual logic of the command. Subclasses must implement
         this method.
-
         """
         raise NotImplementedError('subclasses of BaseCommand must provide a handle() method')
 
@@ -541,7 +534,6 @@ class LabelCommand(BaseCommand):
 
     If the arguments should be names of installed applications, use
     ``AppCommand`` instead.
-
     """
     label = 'label'
     missing_args_message = "Enter at least one %s." % label
@@ -561,7 +553,6 @@ class LabelCommand(BaseCommand):
         """
         Perform the command's actions for ``label``, which will be the
         string as given on the command line.
-
         """
         raise NotImplementedError('subclasses of LabelCommand must provide a handle_label() method')
 
@@ -575,7 +566,6 @@ class NoArgsCommand(BaseCommand):
     no arguments are passed to the command.
 
     Attempting to pass arguments will raise ``CommandError``.
-
     """
     args = ''
 
@@ -595,6 +585,5 @@ class NoArgsCommand(BaseCommand):
     def handle_noargs(self, **options):
         """
         Perform this command's actions.
-
         """
         raise NotImplementedError('subclasses of NoArgsCommand must provide a handle_noargs() method')

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -317,7 +317,6 @@ class DefusedExpatParser(_ExpatParser):
     An expat parser hardened against XML bomb attacks.
 
     Forbids DTDs, external entity references
-
     """
     def __init__(self, *args, **kwargs):
         _ExpatParser.__init__(self, *args, **kwargs)

--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -176,7 +176,6 @@ class LocaleRegexProvider(object):
     """
     A mixin to provide a default regex property which can vary by active
     language.
-
     """
     def __init__(self, regex):
         # regex is either a string representing a regular expression, or a

--- a/django/core/wsgi.py
+++ b/django/core/wsgi.py
@@ -9,7 +9,6 @@ def get_wsgi_application():
 
     Allows us to avoid making django.core.handlers.WSGIHandler public API, in
     case the internal WSGI implementation changes or moves in the future.
-
     """
     django.setup()
     return WSGIHandler()

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -542,8 +542,9 @@ class FormatStylePlaceholderCursor(object):
 
 
 class CursorIterator(six.Iterator):
-
-    """Cursor iterator wrapper that invokes our custom row factory."""
+    """
+    Cursor iterator wrapper that invokes our custom row factory.
+    """
 
     def __init__(self, cursor):
         self.cursor = cursor

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -241,7 +241,6 @@ class Collector(object):
     def related_objects(self, related, objs):
         """
         Gets a QuerySet of objects related to ``objs`` via the relation ``related``.
-
         """
         return related.related_model._base_manager.using(self.using).filter(
             **{"%s__in" % related.field.name: objs}

--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -165,7 +165,6 @@ class FileDescriptor(object):
 
         >>> with open('/tmp/hello.world', 'r') as f:
         ...     instance.file = File(f)
-
     """
     def __init__(self, field):
         self.field = field

--- a/django/db/models/sql/aggregates.py
+++ b/django/db/models/sql/aggregates.py
@@ -49,7 +49,6 @@ class Aggregate(RegisterLookupMixin):
          * is_computed, a boolean indicating if this output of this aggregate
            is a computed float (e.g., an average), regardless of the input
            type.
-
         """
         self.col = col
         self.source = source

--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -41,7 +41,6 @@ class Join(object):
           to join_type)
         - as_sql()
         - relabeled_clone()
-
     """
     def __init__(self, table_name, parent_alias, table_alias, join_type,
                  join_field, nullable):

--- a/django/dispatch/dispatcher.py
+++ b/django/dispatch/dispatcher.py
@@ -306,7 +306,6 @@ def receiver(signal, **kwargs):
         @receiver([post_save, post_delete], sender=MyModel)
         def signals_receiver(sender, **kwargs):
             ...
-
     """
     def _decorator(func):
         if isinstance(signal, (list, tuple)):

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -457,7 +457,6 @@ class QueryDict(MultiValueDict):
                 'next=%2Fa%26b%2F'
                 >>> q.urlencode(safe='/')
                 'next=/a%26b/'
-
         """
         output = []
         if safe:
@@ -524,7 +523,6 @@ def validate_host(host, allowed_hosts):
     already had the port, if any, stripped off.
 
     Return ``True`` for a valid host, ``False`` otherwise.
-
     """
     host = host[:-1] if host.endswith('.') else host
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -173,7 +173,6 @@ class HttpResponseBase(six.Iterator):
         - a naive ``datetime.datetime`` object in UTC,
         - an aware ``datetime.datetime`` object in any time zone.
         If it is a ``datetime.datetime`` object then ``max_age`` will be calculated.
-
         """
         value = force_str(value)
         self.cookies[key] = value

--- a/django/shortcuts.py
+++ b/django/shortcuts.py
@@ -184,7 +184,6 @@ def resolve_url(to, *args, **kwargs):
           be used to reverse-resolve the name.
 
         * A URL, which will be returned as-is.
-
     """
     # If it's a model, use get_absolute_url()
     if hasattr(to, 'get_absolute_url'):

--- a/django/template/context_processors.py
+++ b/django/template/context_processors.py
@@ -67,7 +67,6 @@ def tz(request):
 def static(request):
     """
     Adds static-related context variables to the context.
-
     """
     return {'STATIC_URL': settings.STATIC_URL}
 
@@ -75,7 +74,6 @@ def static(request):
 def media(request):
     """
     Adds media-related context variables to the context.
-
     """
     return {'MEDIA_URL': settings.MEDIA_URL}
 

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -642,7 +642,6 @@ def cycle(parser, token):
             {% cycle 'row1' 'row2' as rowcolors silent %}
             <tr class="{{ rowcolors }}">{% include "subtemplate.html " %}</tr>
         {% endfor %}
-
     """
     # Note: This returns the exact same node on each {% cycle name %} call;
     # that is, the node object returned from {% cycle a b c as name %} and the
@@ -791,7 +790,6 @@ def firstof(parser, token):
     Or if only some variables should be escaped, you can use::
 
         {% firstof var1 var2|safe var3 "<strong>fallback value</strong>"|safe %}
-
     """
     bits = token.split_contents()[1:]
     asvar = None
@@ -866,7 +864,6 @@ def do_for(parser, token):
         ``forloop.parentloop``      For nested loops, this is the loop "above" the
                                     current one
         ==========================  ================================================
-
     """
     bits = token.split_contents()
     if len(bits) < 4:
@@ -1177,7 +1174,6 @@ def load(parser, token):
     a library::
 
         {% load byline from news %}
-
     """
     # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
     bits = token.contents.split()
@@ -1310,7 +1306,6 @@ def regroup(parser, token):
     before using it, i.e.::
 
         {% regroup people|dictsort:"gender" by gender as grouped %}
-
     """
     bits = token.split_contents()
     if len(bits) != 6:
@@ -1462,7 +1457,6 @@ def url(parser, token):
         {% with url_name="client-detail-view" %}
         {% url url_name client.id %}
         {% endwith %}
-
     """
     bits = token.split_contents()
     if len(bits) < 2:

--- a/django/templatetags/future.py
+++ b/django/templatetags/future.py
@@ -58,7 +58,6 @@ def firstof(parser, token):
     Or if only some variables should be escaped, you can use::
 
         {% firstof var1 var2|safe var3 "<strong>fallback value</strong>"|safe %}
-
     """
     warnings.warn(
         "Loading the `firstof` tag from the `future` library is deprecated and "

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -546,7 +546,6 @@ def language(parser, token):
         {% language "de" %}
             This is {{ bar }} and {{ boo }}.
         {% endlanguage %}
-
     """
     bits = token.split_contents()
     if len(bits) != 2:

--- a/django/templatetags/l10n.py
+++ b/django/templatetags/l10n.py
@@ -50,7 +50,6 @@ def localize_tag(parser, token):
         {% localize off %}
             var pi = {{ 3.1415 }};
         {% endlocalize %}
-
     """
     use_l10n = None
     bits = list(token.split_contents())

--- a/django/templatetags/static.py
+++ b/django/templatetags/static.py
@@ -65,7 +65,6 @@ def get_static_prefix(parser, token):
 
         {% get_static_prefix %}
         {% get_static_prefix as static_prefix %}
-
     """
     return PrefixNode.handle_token(parser, token, "STATIC_URL")
 
@@ -84,7 +83,6 @@ def get_media_prefix(parser, token):
 
         {% get_media_prefix %}
         {% get_media_prefix as media_prefix %}
-
     """
     return PrefixNode.handle_token(parser, token, "MEDIA_URL")
 
@@ -148,7 +146,6 @@ def do_static(parser, token):
         {% static variable_with_path %}
         {% static "myapp/css/base.css" as admin_base_css %}
         {% static variable_with_path as varname %}
-
     """
     return StaticNode.handle_token(parser, token)
 

--- a/django/templatetags/tz.py
+++ b/django/templatetags/tz.py
@@ -136,7 +136,6 @@ def localtime_tag(parser, token):
     Sample usage::
 
         {% localtime off %}{{ value_in_utc }}{% endlocaltime %}
-
     """
     bits = token.split_contents()
     if len(bits) == 1:
@@ -165,7 +164,6 @@ def timezone_tag(parser, token):
         {% timezone "Europe/Paris" %}
             It is {{ now }} in Paris.
         {% endtimezone %}
-
     """
     bits = token.split_contents()
     if len(bits) != 2:

--- a/django/test/html.py
+++ b/django/test/html.py
@@ -223,7 +223,6 @@ def parse_html(html):
     structure that can be easily compared against other HTML on semantic
     equivalence. Syntactical differences like which quotation is used on
     arguments will be ignored.
-
     """
     parser = Parser()
     parser.feed(html)

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -654,7 +654,6 @@ class SimpleTestCase(unittest.TestCase):
             field_args: the args passed to instantiate the field
             field_kwargs: the kwargs passed to instantiate the field
             empty_value: the expected clean output for inputs in empty_values
-
         """
         if field_args is None:
             field_args = []

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -121,7 +121,6 @@ def teardown_test_environment():
 
         - Restoring the original test renderer
         - Restoring the email sending functions
-
     """
     Template._render = Template._original_render
     del Template._original_render

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -114,7 +114,6 @@ def format_html_join(sep, format_string, args_generator):
 
       format_html_join('\n', "<li>{} {}</li>", ((u.first_name, u.last_name)
                                                   for u in users))
-
     """
     return mark_safe(conditional_escape(sep).join(
         format_html(format_string, *tuple(args))

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -25,7 +25,6 @@ def clean_ipv6_address(ip_str, unpack_ipv4=False,
 
     Returns:
         A compressed IPv6 address, or the same value
-
     """
     best_doublecolon_start = -1
     best_doublecolon_len = 0
@@ -153,7 +152,6 @@ def is_valid_ipv6_address(ip_str):
 
     Returns:
         A boolean, True if this is a valid IPv6 address.
-
     """
     from django.core.validators import validate_ipv4_address
 
@@ -218,7 +216,6 @@ def _explode_shorthand_ip_string(ip_str):
 
     Returns:
         A string, the expanded IPv6 address.
-
     """
     if not _is_shorthand_ip(ip_str):
         # We've already got a longhand ip_str.
@@ -262,7 +259,6 @@ def _is_shorthand_ip(ip_str):
 
     Returns:
         A boolean, True if the address is shortened.
-
     """
     if ip_str.count('::') == 1:
         return True

--- a/django/utils/jslex.py
+++ b/django/utils/jslex.py
@@ -25,7 +25,6 @@ def literals(choices, prefix="", suffix=""):
 
     If provided, `prefix` and `suffix` will be attached to each choice
     individually.
-
     """
     return "|".join(prefix + re.escape(c) + suffix for c in choices.split())
 

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -135,7 +135,6 @@ class CallbackFilter(logging.Filter):
     A logging filter that checks the return value of a given callable (which
     takes the record-to-be-logged as its only parameter) to decide whether to
     log a record.
-
     """
     def __init__(self, callback):
         self.callback = callback

--- a/django/utils/lru_cache.py
+++ b/django/utils/lru_cache.py
@@ -59,7 +59,6 @@ except ImportError:
         Access the underlying function with f.__wrapped__.
 
         See:  https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
-
         """
 
         # Users should only access the lru_cache through its public API:

--- a/django/utils/termcolors.py
+++ b/django/utils/termcolors.py
@@ -166,7 +166,6 @@ def parse_color_setting(config_string):
 
     Valid options:
         'bold', 'underscore', 'blink', 'reverse', 'conceal'
-
     """
     if not config_string:
         return PALETTES[DEFAULT_PALETTE]

--- a/django/views/decorators/clickjacking.py
+++ b/django/views/decorators/clickjacking.py
@@ -14,7 +14,6 @@ def xframe_options_deny(view_func):
     @xframe_options_deny
     def some_view(request):
         ...
-
     """
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)
@@ -35,7 +34,6 @@ def xframe_options_sameorigin(view_func):
     @xframe_options_sameorigin
     def some_view(request):
         ...
-
     """
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)
@@ -55,7 +53,6 @@ def xframe_options_exempt(view_func):
     @xframe_options_exempt
     def some_view(request):
         ...
-
     """
     def wrapped_view(*args, **kwargs):
         resp = view_func(*args, **kwargs)

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -722,7 +722,6 @@ def _get_next_prev(generic_view, date, is_previous, period):
         * If allow_empty is false and allow_future is false, return the next
           date that contains a valid object. If that date is in the future, or
           if there are no next objects, return None.
-
     """
     date_field = generic_view.get_date_field()
     allow_empty = generic_view.get_allow_empty()

--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -71,7 +71,6 @@ A model with useful documentation might look like this::
         """
         Stores a single blog entry, related to :model:`blog.Blog` and
         :model:`auth.User`.
-
         """
         slug = models.SlugField(help_text="A short label, generally used in URLs.")
         author = models.ForeignKey(
@@ -115,7 +114,6 @@ For example::
         **Template:**
 
         :template:`myapp/my_template.html`
-
         """
         context = {'mymodel': MyModel.objects.get(slug=slug)}
         return render(request, 'myapp/my_template.html', context)

--- a/tests/admin_docs/models.py
+++ b/tests/admin_docs/models.py
@@ -34,7 +34,6 @@ class Person(models.Model):
         :file: admin_docs/evilfile.txt
 
     .. include:: admin_docs/evilfile.txt
-
     """
     first_name = models.CharField(max_length=200, help_text="The person's first name")
     last_name = models.CharField(max_length=200, help_text="The person's last name")

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -389,7 +389,6 @@ class TestUtils(AdminDocsTestCase):
     :template:`myapp/my_template.html` (DESCRIPTION)
 
     some_metadata: some data
-
     """
 
     def setUp(self):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -477,7 +477,6 @@ class TestInlinePermissions(TestCase):
     """
     Make sure the admin respects permissions for objects that are edited
     inline. Refs #8060.
-
     """
 
     def setUp(self):

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1199,7 +1199,6 @@ class ManageCheck(AdminScriptTestCase):
         command should not raise `CommandError` exception.
 
         In this test we also test output format.
-
         """
 
         self.write_settings('settings.py',

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -2129,7 +2129,6 @@ class AdminViewDeletedObjectsTest(TestCase):
         """
         Cyclic relationships should still cause each object to only be
         listed once.
-
         """
         one = '<li>Cyclic one: <a href="%s">I am recursive</a>' % (
             reverse('admin:admin_views_cyclicone_change', args=(self.cy1.pk,)),
@@ -2181,7 +2180,6 @@ class AdminViewDeletedObjectsTest(TestCase):
         If a deleted object has two relationships from another model,
         both of those should be followed in looking for related
         objects to delete.
-
         """
         should_contain = '<li>Plot: <a href="%s">World Domination</a>' % reverse(
             'admin:admin_views_plot_change', args=(self.pl1.pk,)
@@ -2196,7 +2194,6 @@ class AdminViewDeletedObjectsTest(TestCase):
         If a deleted object has two relationships pointing to it from
         another object, the other object should still only be listed
         once.
-
         """
         should_contain = '<li>Plot: <a href="%s">World Peace</a></li>' % reverse(
             'admin:admin_views_plot_change', args=(self.pl2.pk,)
@@ -2209,7 +2206,6 @@ class AdminViewDeletedObjectsTest(TestCase):
         In the case of an inherited model, if either the child or
         parent-model instance is deleted, both instances are listed
         for deletion, as well as any relationships they have.
-
         """
         should_contain = [
             '<li>Villain: <a href="%s">Bob</a>' % reverse('admin:admin_views_villain_change', args=(self.sv1.pk,)),
@@ -2228,7 +2224,6 @@ class AdminViewDeletedObjectsTest(TestCase):
         """
         If a deleted object has GenericForeignKeys pointing to it,
         those objects should be listed for deletion.
-
         """
         plot = self.pl3
         tag = FunkyTag.objects.create(content_object=plot, name='hott')

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -391,7 +391,6 @@ class NamespacePackageAppTests(SimpleTestCase):
 
         (Because then we wouldn't know where to load its templates, static
         assets, etc from.)
-
         """
         # Temporarily add two directories to sys.path that both contain
         # components of the "nsapp" package.

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -340,7 +340,6 @@ class DateQuotingTest(TestCase):
         #12818__.
 
         __: http://code.djangoproject.com/ticket/12818
-
         """
         updated = datetime.datetime(2010, 2, 20)
         models.SchoolClass.objects.create(year=2009, last_updated=updated)
@@ -353,7 +352,6 @@ class DateQuotingTest(TestCase):
         which clash with strings passed to it (e.g. 'day') - see #12818__.
 
         __: http://code.djangoproject.com/ticket/12818
-
         """
         updated = datetime.datetime(2010, 2, 20)
         models.SchoolClass.objects.create(year=2009, last_updated=updated)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -548,7 +548,6 @@ class BaseCacheTests(object):
         keys that would be refused by memcached. This encourages portable
         caching code without making it too difficult to use production backends
         with more liberal key rules. Refs #6447.
-
         """
         # mimic custom ``make_key`` method being defined since the default will
         # never show the below warnings
@@ -1131,7 +1130,6 @@ class MemcachedCacheTests(BaseCacheTests, TestCase):
 
         In order to be memcached-API-library agnostic, we only assert
         that a generic exception of some kind is raised.
-
         """
         # memcached does not allow whitespace or control characters in keys
         self.assertRaises(Exception, cache.set, 'key with spaces', 'value')
@@ -1241,7 +1239,6 @@ class CustomCacheKeyValidationTests(SimpleTestCase):
     Tests for the ability to mixin a custom ``validate_key`` method to
     a custom cache backend that otherwise inherits from a builtin
     backend, and override the default key validation. Refs #6447.
-
     """
     def test_custom_key_validation(self):
         # this key is both longer than 250 characters, and has spaces

--- a/tests/delete_regress/tests.py
+++ b/tests/delete_regress/tests.py
@@ -63,7 +63,6 @@ class DeleteCascadeTests(TestCase):
         """
         Django cascades deletes through generic-related objects to their
         reverse relations.
-
         """
         person = Person.objects.create(name='Nelson Mandela')
         award = Award.objects.create(name='Nobel', content_object=person)
@@ -81,7 +80,6 @@ class DeleteCascadeTests(TestCase):
         some other model has an FK to that through model, deletion is cascaded
         from one of the participants in the M2M, to the through model, to its
         related model.
-
         """
         juan = Child.objects.create(name='Juan')
         paints = Toy.objects.create(name='Paints')
@@ -126,7 +124,6 @@ class DeleteCascadeTransactionTests(TransactionTestCase):
     def test_to_field(self):
         """
         Cascade deletion works with ForeignKey.to_field set to non-PK.
-
         """
         apple = Food.objects.create(name="apple")
         Eaten.objects.create(food=apple, meal="lunch")
@@ -156,7 +153,6 @@ class ProxyDeleteTest(TestCase):
     Tests on_delete behavior for proxy models.
 
     See #16128.
-
     """
     def create_image(self):
         """Return an Image referenced by both a FooImage and a FooFile."""
@@ -177,7 +173,6 @@ class ProxyDeleteTest(TestCase):
         """
         Deleting the *proxy* instance bubbles through to its non-proxy and
         *all* referring objects are deleted.
-
         """
         self.create_image()
 
@@ -195,7 +190,6 @@ class ProxyDeleteTest(TestCase):
         """
         Deleting a proxy-of-proxy instance should bubble through to its proxy
         and non-proxy parents, deleting *all* referring objects.
-
         """
         test_image = self.create_image()
 
@@ -221,7 +215,6 @@ class ProxyDeleteTest(TestCase):
         """
         Deleting an instance of a concrete model should also delete objects
         referencing its proxy subclass.
-
         """
         self.create_image()
 
@@ -244,7 +237,6 @@ class ProxyDeleteTest(TestCase):
         IntegrityError on databases unable to defer integrity checks).
 
         Refs #17918.
-
         """
         # Create an Image (proxy of File) and FooFileProxy (proxy of FooFile,
         # which has an FK to File)

--- a/tests/flatpages_tests/test_forms.py
+++ b/tests/flatpages_tests/test_forms.py
@@ -80,7 +80,6 @@ class FlatpageAdminFormTests(TestCase):
         """
         Existing flatpages can be edited in the admin form without triggering
         the url-uniqueness validation.
-
         """
         existing = FlatPage.objects.create(
             url="/myflatpage1/", title="Some page", content="The content")

--- a/tests/forms_tests/tests/test_regressions.py
+++ b/tests/forms_tests/tests/test_regressions.py
@@ -134,7 +134,6 @@ class FormsRegressionsTestCase(TestCase):
         """
         Re-cleaning an instance that was added via a ModelForm should not raise
         a pk uniqueness error.
-
         """
         class CheeseForm(ModelForm):
             class Meta:

--- a/tests/forms_tests/tests/test_widgets.py
+++ b/tests/forms_tests/tests/test_widgets.py
@@ -1295,7 +1295,6 @@ class FakeFieldFile(object):
     """
     Quacks like a FieldFile (has a .url and unicode representation), but
     doesn't require us to care about storages etc.
-
     """
     url = 'something'
 
@@ -1308,7 +1307,6 @@ class ClearableFileInputTests(SimpleTestCase):
         """
         A ClearableFileInput with is_required False and rendered with
         an initial value that is a file renders a clear checkbox.
-
         """
         widget = ClearableFileInput()
         widget.is_required = False
@@ -1368,7 +1366,6 @@ class ClearableFileInputTests(SimpleTestCase):
         """
         A ClearableFileInput with is_required=False does not render a clear
         checkbox.
-
         """
         widget = ClearableFileInput()
         widget.is_required = True
@@ -1384,7 +1381,6 @@ class ClearableFileInputTests(SimpleTestCase):
         """
         A ClearableFileInput instantiated with no initial value does not render
         a clear checkbox.
-
         """
         widget = ClearableFileInput()
         widget.is_required = False
@@ -1395,7 +1391,6 @@ class ClearableFileInputTests(SimpleTestCase):
         """
         ClearableFileInput.value_from_datadict returns False if the clear
         checkbox is checked, if not required.
-
         """
         widget = ClearableFileInput()
         widget.is_required = False
@@ -1408,7 +1403,6 @@ class ClearableFileInputTests(SimpleTestCase):
         """
         ClearableFileInput.value_from_datadict never returns False if the field
         is required.
-
         """
         widget = ClearableFileInput()
         widget.is_required = True

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -52,7 +52,6 @@ class BasicFieldTests(test.TestCase):
         """
         Regression test for #13071: NullBooleanField should not throw
         a validation error when given a value of None.
-
         """
         nullboolean = NullBooleanModel(nbfield=None)
         try:
@@ -691,7 +690,6 @@ class TypeCoercionTests(test.TestCase):
     Test that database lookups can accept the wrong types and convert
     them with no error: especially on Postgres 8.3+ which does not do
     automatic casting at the DB level. See #10015.
-
     """
     def test_lookup_integer_in_charfield(self):
         self.assertEqual(Post.objects.filter(title=9).count(), 0)
@@ -705,7 +703,6 @@ class FileFieldTests(unittest.TestCase):
         """
         Test that FileField.save_form_data will clear its instance attribute
         value if passed False.
-
         """
         d = Document(myfile='something.txt')
         self.assertEqual(d.myfile, 'something.txt')
@@ -717,7 +714,6 @@ class FileFieldTests(unittest.TestCase):
         """
         Test that FileField.save_form_data considers None to mean "no change"
         rather than "clear".
-
         """
         d = Document(myfile='something.txt')
         self.assertEqual(d.myfile, 'something.txt')
@@ -729,7 +725,6 @@ class FileFieldTests(unittest.TestCase):
         """
         Test that FileField.save_form_data, if passed a truthy value, updates
         its instance attribute.
-
         """
         d = Document(myfile='something.txt')
         self.assertEqual(d.myfile, 'something.txt')

--- a/tests/model_formsets_regress/tests.py
+++ b/tests/model_formsets_regress/tests.py
@@ -214,7 +214,6 @@ class InlineFormsetTests(TestCase):
         Existing and new inlines are saved with save_as_new.
 
         Regression for #14938.
-
         """
         efnet = Network.objects.create(name="EFNet")
         host1 = Host.objects.create(hostname="irc.he.net", network=efnet)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2692,7 +2692,6 @@ class ExcludeTest17600(TestCase):
     def test_exclude_plain(self):
         """
         This should exclude Orders which have some items with status 1
-
         """
         self.assertQuerysetEqual(
             Order.objects.exclude(items__status=1),
@@ -2701,7 +2700,6 @@ class ExcludeTest17600(TestCase):
     def test_exclude_plain_distinct(self):
         """
         This should exclude Orders which have some items with status 1
-
         """
         self.assertQuerysetEqual(
             Order.objects.exclude(items__status=1).distinct(),
@@ -2710,7 +2708,6 @@ class ExcludeTest17600(TestCase):
     def test_exclude_with_q_object_distinct(self):
         """
         This should exclude Orders which have some items with status 1
-
         """
         self.assertQuerysetEqual(
             Order.objects.exclude(Q(items__status=1)).distinct(),
@@ -2719,7 +2716,6 @@ class ExcludeTest17600(TestCase):
     def test_exclude_with_q_object_no_distinct(self):
         """
         This should exclude Orders which have some items with status 1
-
         """
         self.assertQuerysetEqual(
             Order.objects.exclude(Q(items__status=1)),
@@ -2729,7 +2725,6 @@ class ExcludeTest17600(TestCase):
         """
         Using exclude(condition) and exclude(Q(condition)) should
         yield the same QuerySet
-
         """
         self.assertEqual(
             list(Order.objects.exclude(items__status=1).distinct()),
@@ -2739,7 +2734,6 @@ class ExcludeTest17600(TestCase):
         """
         Using exclude(condition) and exclude(Q(condition)) should
         yield the same QuerySet
-
         """
         self.assertEqual(
             list(Order.objects.exclude(items__status=1)),

--- a/tests/serializers_regress/tests.py
+++ b/tests/serializers_regress/tests.py
@@ -592,7 +592,6 @@ class XmlDeserializerSecurityTests(SimpleTestCase):
 
         This is the most straightforward way to prevent all entity definitions
         and avoid both external entities and entity-expansion attacks.
-
         """
         xml = '<?xml version="1.0" standalone="no"?><!DOCTYPE example SYSTEM "http://example.com/example.dtd">'
         with self.assertRaises(DTDForbidden):

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -101,7 +101,6 @@ class ClassDecoratedTestCaseSuper(TestCase):
     """
     Dummy class for testing max recursion error in child class call to
     super().  Refs #17011.
-
     """
     def test_max_recursion_error(self):
         pass
@@ -130,7 +129,6 @@ class ClassDecoratedTestCase(ClassDecoratedTestCaseSuper):
         """
         Overriding a method on a super class and then calling that method on
         the super class should not trigger infinite recursion. See #17011.
-
         """
         try:
             super(ClassDecoratedTestCase, self).test_max_recursion_error()

--- a/tests/wsgi/tests.py
+++ b/tests/wsgi/tests.py
@@ -25,7 +25,6 @@ class WSGITest(TestCase):
         """
         Verify that ``get_wsgi_application`` returns a functioning WSGI
         callable.
-
         """
         application = get_wsgi_application()
 
@@ -80,7 +79,6 @@ class GetInternalWSGIApplicationTest(unittest.TestCase):
         """
         If ``WSGI_APPLICATION`` is a dotted path, the referenced object is
         returned.
-
         """
         app = get_internal_wsgi_application()
 
@@ -93,7 +91,6 @@ class GetInternalWSGIApplicationTest(unittest.TestCase):
         """
         If ``WSGI_APPLICATION`` is ``None``, the return value of
         ``get_wsgi_application`` is returned.
-
         """
         # Mock out get_wsgi_application so we know its return value is used
         fake_app = object()


### PR DESCRIPTION
The commit also includes 5 additions on two docstring that was on the same line than `"""` delimiters. Otherwise, it only contains deletion of blank line, using a regex search/replace from `\n\n(\s+)"""` to `\n\1"""`. It should have work regardless the indentation of the block (4, 8 or even 12 spaces)

It does not include those without spaces, since some of this strings are not documentation but actual strings displayed to the user, for example, the file [django/setup.py](https://github.com/django/django/blob/05239180c06819b4dc8e6a1d12cbd6d50a31d1ee/setup.py#L92-L94)... Those might need to be check manually, to avoid