### PR TITLE
Added support for lower case true/false values in NullBooleanSelect.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -589,12 +589,17 @@ class NullBooleanSelect(Select):
 
     def value_from_datadict(self, data, files, name):
         value = data.get(name)
-        return {'2': True,
-                True: True,
-                'True': True,
-                '3': False,
-                'False': False,
-                False: False}.get(value)
+
+        values = {'2': True,
+                  '3': False,
+                  'true': True,
+                  'false': False}.get(value)
+
+        if isinstance(value, six.string_types):
+            value = values.get(value.lower(), value)
+
+        return bool(value)
+
 
 
 class SelectMultiple(Select):


### PR DESCRIPTION
Before I spend time writing tests (there are none currently for these widgets) I wanted to get thoughts.

CheckBoxInput supports true, false in all case which can be seen here. https://github.com/django/django/blob/master/django/forms/widgets.py#L508

NullBooleanSelect only supports true false as 'True' or 'False'. I wanted to make them consistent because I ran into an issue when submitting GET requests through Javascript.  This can be seen here. https://github.com/django/django/blob/master/django/forms/widgets.py#L573