### PR TITLE
Fixed #25341 -- EmailMessage.message no longer ignores Bcc header

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -259,6 +259,8 @@ class EmailMessage(object):
         msg['To'] = self.extra_headers.get('To', ', '.join(map(force_text, self.to)))
         if self.cc:
             msg['Cc'] = ', '.join(map(force_text, self.cc))
+        if self.bcc:
+            msg['Bcc'] = ', '.join(map(force_text, self.bcc))
         if self.reply_to:
             msg['Reply-To'] = self.extra_headers.get('Reply-To', ', '.join(map(force_text, self.reply_to)))
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -86,11 +86,18 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         self.assertEqual(message['Cc'], 'cc@example.com, cc.other@example.com')
         self.assertEqual(email.recipients(), ['to@example.com', 'other@example.com', 'cc@example.com', 'cc.other@example.com'])
 
-        # Testing with Bcc
-        email = EmailMessage('Subject', 'Content', 'from@example.com', ['to@example.com', 'other@example.com'], cc=['cc@example.com', 'cc.other@example.com'], bcc=['bcc@example.com'])
+    def test_bcc(self):
+        """Regression test for #25341"""
+        email = EmailMessage('Subject', 'Content', 'from@example.com', ['to@example.com'], bcc=['bcc@example.com'])
         message = email.message()
-        self.assertEqual(message['Cc'], 'cc@example.com, cc.other@example.com')
-        self.assertEqual(email.recipients(), ['to@example.com', 'other@example.com', 'cc@example.com', 'cc.other@example.com', 'bcc@example.com'])
+        self.assertEqual(message['Bcc'], 'bcc@example.com')
+        self.assertEqual(email.recipients(), ['to@example.com', 'bcc@example.com'])
+
+        # Testing with multiple Bcc
+        email = EmailMessage('Subject', 'Content', 'from@example.com', ['to@example.com'], bcc=['bcc@example.com', 'bcc.other@example.com'])
+        message = email.message()
+        self.assertEqual(message['Bcc'], 'bcc@example.com, bcc.other@example.com')
+        self.assertEqual(email.recipients(), ['to@example.com', 'bcc@example.com', 'bcc.other@example.com'])
 
     def test_reply_to(self):
         email = EmailMessage(


### PR DESCRIPTION
As the subject says, with code and tests.
Ticket: https://code.djangoproject.com/ticket/25341