### PR TITLE
Fixed #25345 -- Updated links to code.google.com

### DIFF
--- a/django/contrib/admin/static/admin/fonts/README.txt
+++ b/django/contrib/admin/static/admin/fonts/README.txt
@@ -1,2 +1,2 @@
-Roboto webfont source: https://code.google.com/p/roboto-webfont/
+Roboto webfont source: https://www.google.com/fonts/specimen/Roboto
 Weights used in this project: Light (300), Regular (400), Bold (700)

--- a/django/contrib/gis/maps/google/overlays.py
+++ b/django/contrib/gis/maps/google/overlays.py
@@ -20,7 +20,7 @@ class GEvent(object):
     add_event() call.
 
     For more information please see the Google Maps API Reference:
-     http://code.google.com/apis/maps/documentation/reference.html#GEvent
+     https://developers.google.com/maps/documentation/javascript/reference#event
 
     Example:
 
@@ -84,7 +84,7 @@ class GPolygon(GOverlayBase):
     """
     A Python wrapper for the Google GPolygon object.  For more information
     please see the Google Maps API Reference:
-     http://code.google.com/apis/maps/documentation/reference.html#GPolygon
+     https://developers.google.com/maps/documentation/javascript/reference#Polygon
     """
     def __init__(self, poly,
                  stroke_color='#0000ff', stroke_weight=2, stroke_opacity=1,
@@ -144,7 +144,7 @@ class GPolyline(GOverlayBase):
     """
     A Python wrapper for the Google GPolyline object.  For more information
     please see the Google Maps API Reference:
-     http://code.google.com/apis/maps/documentation/reference.html#GPolyline
+     https://developers.google.com/maps/documentation/javascript/reference#Polyline
     """
     def __init__(self, geom, color='#0000ff', weight=2, opacity=1):
         """
@@ -195,7 +195,7 @@ class GIcon(object):
     in turn, correspond to a subset of the attributes of the official GIcon
     javascript object:
 
-    http://code.google.com/apis/maps/documentation/reference.html#GIcon
+    https://developers.google.com/maps/documentation/javascript/reference#Icon
 
     Because a Google map often uses several different icons, a name field has
     been added to the required arguments.
@@ -268,7 +268,7 @@ class GMarker(GOverlayBase):
     """
     A Python wrapper for the Google GMarker object.  For more information
     please see the Google Maps API Reference:
-     http://code.google.com/apis/maps/documentation/reference.html#GMarker
+     https://developers.google.com/maps/documentation/javascript/reference#Marker
 
     Example:
 

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -1,5 +1,5 @@
 # This code was mostly based on ipaddr-py
-# Copyright 2007 Google Inc. http://code.google.com/p/ipaddr-py/
+# Copyright 2007 Google Inc. https://github.com/google/ipaddr-py
 # Licensed under the Apache License, Version 2.0 (the "License").
 from django.core.exceptions import ValidationError
 from django.utils.six.moves import range

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -6,7 +6,7 @@ Deploying Django with Apache_ and `mod_wsgi`_ is a tried and tested way to get
 Django into production.
 
 .. _Apache: http://httpd.apache.org/
-.. _mod_wsgi: http://code.google.com/p/modwsgi/
+.. _mod_wsgi: http://www.modwsgi.org/
 
 mod_wsgi is an Apache module which can host any Python WSGI_ application,
 including Django. Django will work with any version of Apache which supports
@@ -18,8 +18,8 @@ The `official mod_wsgi documentation`_ is fantastic; it's your source for all
 the details about how to use mod_wsgi. You'll probably want to start with the
 `installation and configuration documentation`_.
 
-.. _official mod_wsgi documentation: http://code.google.com/p/modwsgi/
-.. _installation and configuration documentation: http://code.google.com/p/modwsgi/wiki/InstallationInstructions
+.. _official mod_wsgi documentation: http://modwsgi.readthedocs.org/
+.. _installation and configuration documentation: http://modwsgi.readthedocs.org/en/develop/installation.html
 
 Basic configuration
 ===================

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -915,7 +915,6 @@ by 3rd parties that allow you to use other databases with Django:
 * `Microsoft SQL Server`_
 * Firebird_
 * ODBC_
-* ADSDB_
 
 The Django versions and ORM features supported by these unofficial backends
 vary considerably. Queries regarding the specific capabilities of these
@@ -923,8 +922,7 @@ unofficial backends, along with any support queries, should be directed to
 the support channels provided by each 3rd party project.
 
 .. _SAP SQL Anywhere: https://github.com/sqlanywhere/sqlany-django
-.. _IBM DB2: http://code.google.com/p/ibm-db/
+.. _IBM DB2: https://pypi.python.org/pypi/ibm_db/
 .. _Microsoft SQL Server: http://django-mssql.readthedocs.org/en/latest/
 .. _Firebird: https://github.com/maxirobaina/django-firebird
 .. _ODBC: https://github.com/lionheart/django-pyodbc/
-.. _ADSDB: http://code.google.com/p/adsdb-django/

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -60,7 +60,7 @@ very well with `nginx`_. Additionally, Django follows the WSGI spec
 
 .. _Apache: http://httpd.apache.org/
 .. _nginx: http://nginx.org/
-.. _mod_wsgi: http://code.google.com/p/modwsgi/
+.. _mod_wsgi: http://www.modwsgi.org/
 
 .. _database-installation:
 

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -1,6 +1,5 @@
 """
 Testing of admin inline formsets.
-
 """
 from __future__ import unicode_literals
 

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -41,7 +41,7 @@ http://foo.com/blah_(wikipedia)_blah#cite-1
 http://foo.com/unicode_(✪)_in_parens
 http://foo.com/(something)?after=parens
 http://☺.damowmow.com/
-http://code.google.com/events/#&product=browser
+http://djangoproject.com/events/#&product=browser
 http://j.mp
 ftp://foo.bar/baz
 http://foo.bar/?q=Test%20URL-encoded%20stuff


### PR DESCRIPTION
There are still occurrences of "code.google.com" in the codebase for:

- selenium F.A.Q
- most of mod_wsgi help pages
- http://code.google.com/p/google-diff-match-patch/
- http://code.google.com/p/geodjango-basic-apps/
- http://code.google.com/p/memcached/wiki/NewProgramming#Expiration

As said in the Trac ticket, we should keep the ticket open, waiting for those libraries/third-parties to update their own documentations.