### PR TITLE
Updated static files howto title to include JavaScript

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -1,6 +1,6 @@
-===================================
-Managing static files (CSS, images)
-===================================
+====================================================
+Managing static files (e.g. images, JavaScript, CSS)
+====================================================
 
 Websites generally need to serve additional files such as images, JavaScript,
 or CSS. In Django, we refer to these files as "static files".  Django provides


### PR DESCRIPTION
This commit to documentation makes it clearer that static files in Django are not limited to CSS and images. It is now in sync with the paragraph text below that says that images, JavaScript and CSS are all examples of static files. The text concerned is the heading at this URL: https://docs.djangoproject.com/en/1.8/howto/static-files/