### PR TITLE
Updated references to the TEST_* database settings.

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -137,7 +137,7 @@ class BaseDatabaseCreation(object):
         Internal implementation - returns the name of the test DB that will be
         created. Only useful when called from create_test_db() and
         _create_test_db() and when no external munging is done with the 'NAME'
-        or 'TEST_NAME' settings.
+        settings.
         """
         if self.connection.settings_dict['TEST']['NAME']:
             return self.connection.settings_dict['TEST']['NAME']

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -62,7 +62,7 @@ The :setting:`DATABASES` setting in any test settings module needs to define
 two databases:
 
 * A ``default`` database. This database should use the backend that
-  you want to use for primary testing
+  you want to use for primary testing.
 
 * A database with the alias ``other``. The ``other`` database is used to
   establish that queries can be directed to different databases. As a result,
@@ -86,8 +86,8 @@ These test databases are deleted when the tests are finished.
 
 You will also need to ensure that your database uses UTF-8 as the default
 character set. If your database server doesn't use UTF-8 as a default charset,
-you will need to include a value for :setting:`TEST_CHARSET` in the settings
-dictionary for the applicable database.
+you will need to include a value for :setting:`CHARSET <TEST_CHARSET>` in the
+test settings dictionary for the applicable database.
 
 .. _runtests-specifying-labels:
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -97,7 +97,9 @@ configuration::
             'ENGINE': 'django.db.backends.mysql',
             'NAME': 'myproject',
             'HOST': 'dbreplica',
-            'TEST_MIRROR': 'default'
+            'TEST': {
+                'MIRROR': 'default',
+            },
             # ... plus some other settings
         }
     }
@@ -111,8 +113,8 @@ normal activity, any write to ``default`` will appear on ``replica``.
 If Django created two independent test databases, this would break any
 tests that expected replication to occur. However, the ``replica``
 database has been configured as a test mirror (using the
-:setting:`TEST_MIRROR` setting), indicating that under testing,
-``replica`` should be treated as a mirror of ``default``.
+:setting:`MIRROR <TEST_MIRROR>` test setting), indicating that under
+testing, ``replica`` should be treated as a mirror of ``default``.
 
 When the test environment is configured, a test version of ``replica``
 will *not* be created. Instead the connection to ``replica``
@@ -132,41 +134,51 @@ However, no guarantees are made on the creation order of any other
 databases in your test setup.
 
 If your database configuration requires a specific creation order, you
-can specify the dependencies that exist using the
-:setting:`TEST_DEPENDENCIES` setting. Consider the following
-(simplified) example database configuration::
+can specify the dependencies that exist using the :setting:`DEPENDENCIES
+<TEST_DEPENDENCIES>` test setting. Consider the following (simplified)
+example database configuration::
 
     DATABASES = {
         'default': {
-             # ... db settings
-             'TEST_DEPENDENCIES': ['diamonds']
+            # ... db settings
+            'TEST': {
+                'DEPENDENCIES': ['diamonds'],
+            },
         },
         'diamonds': {
-            # ... db settings
-             'TEST_DEPENDENCIES': []
+             ... db settings
+            'TEST': {
+                'DEPENDENCIES': [],
+            },
         },
         'clubs': {
             # ... db settings
-            'TEST_DEPENDENCIES': ['diamonds']
+            'TEST': {
+                'DEPENDENCIES': ['diamonds'],
+            },
         },
         'spades': {
             # ... db settings
-            'TEST_DEPENDENCIES': ['diamonds','hearts']
+            'TEST': {
+                'DEPENDENCIES': ['diamonds', 'hearts'],
+            },
         },
         'hearts': {
             # ... db settings
-            'TEST_DEPENDENCIES': ['diamonds','clubs']
+            'TEST': {
+                'DEPENDENCIES': ['diamonds', 'clubs'],
+            },
         }
     }
 
 Under this configuration, the ``diamonds`` database will be created first,
 as it is the only database alias without dependencies. The ``default`` and
 ``clubs`` alias will be created next (although the order of creation of this
-pair is not guaranteed); then ``hearts``; and finally ``spades``.
+pair is not guaranteed), then ``hearts``, and finally ``spades``.
 
-If there are any circular dependencies in the
-:setting:`TEST_DEPENDENCIES` definition, an ``ImproperlyConfigured``
-exception will be raised.
+If there are any circular dependencies in the :setting:`DEPENDENCIES
+<TEST_DEPENDENCIES>` definition, an
+:exc:`~django.core.exceptions.ImproperlyConfigured` exception will be raised.
 
 Advanced features of ``TransactionTestCase``
 ============================================


### PR DESCRIPTION
They were removed in Django 1.9.

I could leave the reference to TEST_DEPENDENCIES in the 1.2.4 release
notes because the link points to the right location and the name was
accurate at the time.