### PR TITLE
Fixed #25357 -- Database deduplication on Oracle.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -6,6 +6,7 @@ from unittest import TestSuite, defaultTestLoader
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db import DEFAULT_DB_ALIAS, connections
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import setup_test_environment, teardown_test_environment
 from django.utils.datastructures import OrderedSet
@@ -321,8 +322,6 @@ def partition_suite(suite, classes, bins, reverse=False):
 
 
 def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwargs):
-    from django.db import connections, DEFAULT_DB_ALIAS
-
     # First pass -- work out which databases actually need to be created,
     # and which ones are test mirrors or duplicate entries in DATABASES
     mirrored_aliases = {}

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -183,8 +183,7 @@ class DiscoverRunner(object):
         """
         Destroys all the non-mirror databases.
         """
-        old_names, mirrors = old_config
-        for connection, old_name, destroy in old_names:
+        for connection, old_name, destroy in old_config:
             if destroy:
                 connection.creation.destroy_test_db(old_name, self.verbosity, self.keepdb)
 
@@ -374,7 +373,6 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwa
     test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
 
     old_names = []
-    mirrors = []
 
     for signature, (db_name, aliases) in test_databases.items():
         first_alias = None
@@ -396,7 +394,6 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwa
                     connections[first_alias].settings_dict)
 
     for alias, mirror_alias in mirrored_aliases.items():
-        mirrors.append((alias, connections[alias].settings_dict['NAME']))
         connections[alias].creation.set_as_test_mirror(
             connections[mirror_alias].settings_dict)
 
@@ -404,4 +401,4 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwa
         for alias in connections:
             connections[alias].force_debug_cursor = True
 
-    return old_names, mirrors
+    return old_names

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -321,66 +321,63 @@ def partition_suite(suite, classes, bins, reverse=False):
                 bins[-1].add(test)
 
 
-def get_unique_databases_and_mirrors():
+def get_unique_databases():
     """
     Figure out which databases actually need to be created.
 
     Deduplicate entries in DATABASES that correspond the same database or are
     configured as test mirrors.
 
-    Returns two values:
-
-    - test_databases: ordered mapping of signatures to (name, list of aliases)
-                      where all aliases share the same unerlying database
-    - mirrored_aliases: mapping of mirror aliases to original aliases
+    Returns an ordered mapping of signatures to (name, list of aliases)
+    where all aliases share the same unerlying database.
     """
-    mirrored_aliases = {}
     test_databases = {}
     dependencies = {}
     default_sig = connections[DEFAULT_DB_ALIAS].creation.test_db_signature()
+
     for alias in connections:
         connection = connections[alias]
         test_settings = connection.settings_dict['TEST']
+
         if test_settings['MIRROR']:
-            # If the database is marked as a test mirror, save
-            # the alias.
-            mirrored_aliases[alias] = test_settings['MIRROR']
+            target = test_settings['MIRROR']
+            signature = connections[target].creation.test_db_signature()
+
         else:
-            # Store a tuple with DB parameters that uniquely identify it.
-            # If we have two aliases with the same values for that tuple,
-            # we only need to create the test database once.
-            item = test_databases.setdefault(
-                connection.creation.test_db_signature(),
-                (connection.settings_dict['NAME'], set())
-            )
-            item[1].add(alias)
+            signature = connection.creation.test_db_signature()
 
             if 'DEPENDENCIES' in test_settings:
                 dependencies[alias] = test_settings['DEPENDENCIES']
-            else:
-                if alias != DEFAULT_DB_ALIAS and connection.creation.test_db_signature() != default_sig:
-                    dependencies[alias] = test_settings.get('DEPENDENCIES', [DEFAULT_DB_ALIAS])
+            elif alias != DEFAULT_DB_ALIAS and signature != default_sig:
+                dependencies[alias] = test_settings.get('DEPENDENCIES', [DEFAULT_DB_ALIAS])
+
+        # Store a tuple with DB parameters that uniquely identify it.
+        # If we have two aliases with the same values for that tuple,
+        # we only need to create the test database once.
+        item = test_databases.setdefault(
+            signature, (connection.settings_dict['NAME'], set()))
+        item[1].add(alias)
 
     test_databases = dependency_ordered(test_databases.items(), dependencies)
     test_databases = collections.OrderedDict(test_databases)
-    return test_databases, mirrored_aliases
+    return test_databases
 
 
 def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwargs):
     """
     Creates the test databases.
     """
-    test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
+    test_databases = get_unique_databases()
 
     old_names = []
 
     for signature, (db_name, aliases) in test_databases.items():
         first_alias = None
-        # Actually create the database for the first connection
         for alias in aliases:
             connection = connections[alias]
             old_names.append((connection, db_name, first_alias is None))
 
+            # Actually create the database for the first connection
             if first_alias is None:
                 first_alias = alias
                 connection.creation.create_test_db(
@@ -389,13 +386,10 @@ def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, **kwa
                     keepdb=keepdb,
                     serialize=connection.settings_dict.get("TEST", {}).get("SERIALIZE", True),
                 )
+            # Configure all other connections as mirrors of the first one
             else:
                 connections[alias].creation.set_as_test_mirror(
                     connections[first_alias].settings_dict)
-
-    for alias, mirror_alias in mirrored_aliases.items():
-        connections[alias].creation.set_as_test_mirror(
-            connections[mirror_alias].settings_dict)
 
     if debug_sql:
         for alias in connections:

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -995,6 +995,7 @@ Miscellaneous
 * Private function ``django.utils.functional.total_ordering()`` has been
   removed. It contained a workaround for a ``functools.total_ordering()`` bug
   in Python versions older than 2.7.3.
+
 * XML serialization (either through :djadmin:`dumpdata` or the syndication
   framework) used to output any characters it received. Now if the content to
   be serialized contains any control characters not allowed in the XML 1.0
@@ -1022,6 +1023,12 @@ Miscellaneous
 * The ``FlatPage.enable_comments`` field is removed from the ``FlatPageAdmin``
   as it's unused by the application. If your project or a third-party app makes
   use of it, :ref:`create a custom ModelAdmin <flatpages-admin>` to add it back.
+
+* The return value of
+  :meth:`~django.test.runner.DiscoverRunner.setup_databases` and the first
+  argument of :meth:`~django.test.runner.DiscoverRunner.teardown_databases`
+  changed. They used to be ``(old_names, mirrors)`` tuples. Now they're just
+  the first item, ``old_names``.
 
 .. _deprecated-features-1.9:
 

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -240,7 +240,7 @@ class DummyBackendTest(unittest.TestCase):
         Test that setup_databases() doesn't fail with dummy database backend.
         """
         tested_connections = db.ConnectionHandler({})
-        with mock.patch('django.db.connections', new=tested_connections):
+        with mock.patch('django.test.runner.connections', new=tested_connections):
             runner_instance = DiscoverRunner(verbosity=0)
             try:
                 old_config = runner_instance.setup_databases()
@@ -263,7 +263,7 @@ class AliasedDefaultTestSetupTest(unittest.TestCase):
                 'NAME': 'dummy'
             }
         })
-        with mock.patch('django.db.connections', new=tested_connections):
+        with mock.patch('django.test.runner.connections', new=tested_connections):
             runner_instance = DiscoverRunner(verbosity=0)
             try:
                 old_config = runner_instance.setup_databases()
@@ -291,7 +291,7 @@ class SetupDatabasesTests(unittest.TestCase):
         })
 
         with mock.patch('django.db.backends.dummy.base.DatabaseCreation') as mocked_db_creation:
-            with mock.patch('django.db.connections', new=tested_connections):
+            with mock.patch('django.test.runner.connections', new=tested_connections):
                 old_config = self.runner_instance.setup_databases()
                 self.runner_instance.teardown_databases(old_config)
         mocked_db_creation.return_value.destroy_test_db.assert_called_once_with('dbname', 0, False)
@@ -316,7 +316,7 @@ class SetupDatabasesTests(unittest.TestCase):
             },
         })
         with mock.patch('django.db.backends.dummy.base.DatabaseCreation') as mocked_db_creation:
-            with mock.patch('django.db.connections', new=tested_connections):
+            with mock.patch('django.test.runner.connections', new=tested_connections):
                 self.runner_instance.setup_databases()
         mocked_db_creation.return_value.create_test_db.assert_called_once_with(
             0, autoclobber=False, serialize=True, keepdb=False
@@ -330,7 +330,7 @@ class SetupDatabasesTests(unittest.TestCase):
             },
         })
         with mock.patch('django.db.backends.dummy.base.DatabaseCreation') as mocked_db_creation:
-            with mock.patch('django.db.connections', new=tested_connections):
+            with mock.patch('django.test.runner.connections', new=tested_connections):
                 self.runner_instance.setup_databases()
         mocked_db_creation.return_value.create_test_db.assert_called_once_with(
             0, autoclobber=False, serialize=False, keepdb=False


### PR DESCRIPTION
This branch is incorrectly named. At first I thought the problem would affect mirrors, in fact it only affects duplicate database configurations.

I extracted this bugfix when I noticed the problem while working on a branch for another feature (#4761). The first commit is needed in that branch.

