### PR TITLE
Fixed #11544 -- Adjust admin css to not depend upon the !important declaration

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -91,14 +91,6 @@ ul li {
     padding: 1px 0;
 }
 
-ul.plainlist {
-    margin-left: 0 !important;
-}
-
-ul.plainlist li {
-    list-style-type: none;
-}
-
 li ul {
     margin-bottom: 0;
 }
@@ -187,8 +179,8 @@ p.mini {
     margin-top: -3px;
 }
 
-.help, p.help {
-    font-size: 10px !important;
+.help, p.help, form p.help {
+    font-size: 11px;
     color: #999;
 }
 
@@ -201,12 +193,8 @@ p img, h1 img, h2 img, h3 img, h4 img, td img {
 }
 
 .quiet, a.quiet:link, a.quiet:visited {
-    color: #999 !important;
-    font-weight: normal !important;
-}
-
-.quiet strong {
-    font-weight: bold !important;
+    color: #999;
+    font-weight: normal;
 }
 
 .float-right {
@@ -274,24 +262,6 @@ tfoot td {
 tfoot td {
     border-bottom: none;
     border-top: 1px solid #eee;
-}
-
-thead th:first-child,
-tfoot td:first-child {
-    border-left: none !important;
-}
-
-thead th.optional {
-    font-weight: normal !important;
-}
-
-tr.row-label td {
-    font-size: 9px;
-    padding-top: 2px;
-    padding-bottom: 0;
-    border-bottom: none;
-    color: #666;
-    margin-top: -1px;
 }
 
 tr.alt {
@@ -426,7 +396,7 @@ input, textarea, select, .form-row p, form .button {
 }
 
 textarea {
-    vertical-align: top !important;
+    vertical-align: top;
 }
 
 input[type=text], input[type=password], input[type=email], input[type=url],
@@ -571,7 +541,7 @@ ul.messagelist li.error {
 }
 
 .errornote {
-    font-size: 14px !important;
+    font-size: 14px;
     font-weight: 700;
     display: block;
     padding: 10px 12px;
@@ -584,14 +554,14 @@ ul.messagelist li.error {
 }
 
 ul.errorlist {
-    margin: 0 0 4px !important;
-    padding: 0 !important;
+    margin: 0 0 4px;
+    padding: 0;
     color: #ba2121;
     background: #fff;
 }
 
 ul.errorlist li {
-    font-size: 13px !important;
+    font-size: 13px;
     display: block;
     margin-bottom: 4px;
 }
@@ -606,12 +576,12 @@ ul.errorlist li a {
 }
 
 td ul.errorlist {
-    margin: 0 !important;
-    padding: 0 !important;
+    margin: 0;
+    padding: 0;
 }
 
 td ul.errorlist li {
-    margin: 0 !important;
+    margin: 0;
 }
 
 .form-row.errors {
@@ -769,7 +739,6 @@ table#change-history tbody th {
 
 #content {
     padding: 20px 40px;
-    margin: 0;
 }
 
 .dashboard #content {
@@ -796,17 +765,17 @@ table#change-history tbody th {
 /* COLUMN TYPES */
 
 .colMS {
-    margin-right: 20em !important;
+    margin-right: 300px;
 }
 
 .colSM {
-    margin-left: 20em !important;
+    margin-left: 300px;
 }
 
 .colSM #content-related {
     float: left;
     margin-right: 0;
-    margin-left: -19em;
+    margin-left: -300px;
 }
 
 .colSM #content-main {
@@ -816,13 +785,6 @@ table#change-history tbody th {
 .popup .colM {
     width: auto;
 }
-
-.subcol {
-    float: left;
-    width: 46%;
-    margin-right: 15px;
-}
-
 
 /* HEADER */
 

--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -19,14 +19,10 @@
     min-height: 400px;
 }
 
-.change-list .filtered {
-    background: #fff !important;
-}
-
 .change-list .filtered .results, .change-list .filtered .paginator,
 .filtered #toolbar, .filtered div.xfull {
-    margin-right: 280px !important;
-    width: auto !important;
+    margin-right: 280px;
+    width: auto;
 }
 
 .change-list .filtered table tbody th {
@@ -38,7 +34,7 @@
 }
 
 #changelist .toplinks {
-    border-bottom: 1px solid #ccc !important;
+    border-bottom: 1px solid #ddd;
 }
 
 #changelist .paginator {
@@ -191,8 +187,8 @@
 .change-list ul.toplinks {
     display: block;
     float: left;
-    padding: 0 !important;
-    margin: 0 !important;
+    padding: 0;
+    margin: 0;
     width: 100%;
 }
 
@@ -230,19 +226,18 @@
 }
 
 .paginator a.showall {
-    padding: 0 !important;
-    border: none !important;
-    background: none !important;
-    color: #5b80b2 !important;
+    padding: 0;
+    border: none;
+    background: none;
+    color: #5b80b2;
 }
 
 .paginator a.showall:hover {
-    color: #036 !important;
-    background: none !important;
+    background: none;
+    color: #036;
 }
 
 .paginator .end {
-    border-width: 2px !important;
     margin-right: 6px;
 }
 
@@ -261,7 +256,7 @@
 /* ACTIONS */
 
 .filtered .actions {
-    margin-right: 280px !important;
+    margin-right: 280px;
     border-right: none;
 }
 

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -20,7 +20,6 @@
 
 form .form-row p {
     padding-left: 0;
-    font-size: 11px !important;
 }
 
 .hidden {
@@ -29,21 +28,15 @@ form .form-row p {
 
 /* FORM LABELS */
 
-form h4 {
-    margin: 0 !important;
-    padding: 0 !important;
-    border: none !important;
-}
-
 label {
-    font-weight: normal !important;
+    font-weight: normal;
     color: #666;
     font-size: 13px;
 }
 
 .required label, label.required {
-    font-weight: bold !important;
-    color: #333 !important;
+    font-weight: bold;
+    color: #333;
 }
 
 /* RADIO BUTTONS */
@@ -91,8 +84,7 @@ form ul.inline li {
     height: 26px;
 }
 
-.aligned label + p:not(.help) {
-    font-size: 13px !important;
+.aligned label + p {
     padding: 6px 0;
     margin-top: 0;
     margin-bottom: 0;
@@ -158,7 +150,8 @@ form .aligned table p {
 }
 
 .aligned .vCheckboxLabel {
-    float: none !important;
+    float: none;
+    width: auto;
     display: inline-block;
     vertical-align: -3px;
     padding: 0 0 5px 5px;
@@ -174,7 +167,7 @@ form .aligned table p {
 
 .checkbox-row p.help {
     margin-left: 0;
-    padding-left: 0 !important;
+    padding-left: 0;
 }
 
 fieldset .field-box {
@@ -185,11 +178,11 @@ fieldset .field-box {
 /* WIDE FIELDSETS */
 
 .wide label {
-    width: 200px !important;
+    width: 200px;
 }
 
-form .wide p {
-    margin-left: 200px !important;
+form .wide p, form .wide input + p.help {
+    margin-left: 200px;
 }
 
 form .wide p.help {
@@ -207,7 +200,7 @@ fieldset.collapsed * {
 }
 
 fieldset.collapsed h2, fieldset.collapsed {
-    display: block !important;
+    display: block;
 }
 
 fieldset.collapsed {
@@ -227,7 +220,7 @@ fieldset .collapse-toggle {
 
 fieldset.collapsed .collapse-toggle {
     background: transparent;
-    display: inline !important;
+    display: inline;
     color: #447e9b;
 }
 
@@ -291,7 +284,7 @@ body.popup .submit-row {
 /* CUSTOM FORM FIELDS */
 
 .vSelectMultipleField {
-    vertical-align: top !important;
+    vertical-align: top;
 }
 
 .vCheckboxField {
@@ -300,6 +293,7 @@ body.popup .submit-row {
 
 .vDateField, .vTimeField {
     margin-right: 2px;
+    margin-bottom: 4px;
 }
 
 .vDateField {

--- a/django/contrib/admin/static/admin/css/rtl.css
+++ b/django/contrib/admin/static/admin/css/rtl.css
@@ -30,6 +30,11 @@ th {
     text-align: right;
 }
 
+.module ul, .module ol {
+    margin-left: 0;
+    margin-right: 1.5em;
+}
+
 .addlink, .changelink {
     padding-left: 0;
     padding-right: 16px;
@@ -74,8 +79,8 @@ div.breadcrumbs {
 }
 
 .colMS {
-    margin-left: 20em !important;
-    margin-right: 10px !important;
+    margin-left: 300px;
+    margin-right: 0;
 }
 
 /* SORTABLE TABLES */
@@ -98,10 +103,6 @@ thead th.sorted .text {
 
 /* changelists styles */
 
-.change-list .filtered {
-    background: #fff !important;
-}
-
 .change-list .filtered table {
     border-left: none;
     border-right: 0px none;
@@ -115,8 +116,8 @@ thead th.sorted .text {
 }
 
 .change-list .filtered .results, .change-list .filtered .paginator, .filtered #toolbar, .filtered div.xfull {
-    margin-right: 0px !important;
-    margin-left: 280px !important;
+    margin-right: 0;
+    margin-left: 280px;
 }
 
 #changelist-filter li.selected {
@@ -129,10 +130,8 @@ thead th.sorted .text {
 }
 
 .filtered .actions {
-    border-left:1px solid #DDDDDD;
-    margin-left:160px !important;
-    border-right: 0 none;
-    margin-right:0 !important;
+    margin-left: 280px;
+    margin-right: 0;
 }
 
 #changelist table tbody td:first-child, #changelist table tbody th:first-child {

--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -243,14 +243,12 @@ p.datetime {
     margin: 0;
     padding: 0;
     color: #666;
-    font-size: 13px !important;
     font-weight: bold;
 }
 
 form .form-row p.datetime {
-    font-size: 13px !important;
     margin-left: 160px;
-    padding-left: 10px !important;
+    padding-left: 10px;
 }
 
 .datetime span {
@@ -260,10 +258,10 @@ form .form-row p.datetime {
     color: #ccc;
 }
 
-.datetime input {
+.datetime input, .form-row .datetime input.vDateField, .form-row .datetime input.vTimeField {
     min-width: 0;
     margin-left: 5px;
-    margin-bottom: 4px !important;
+    margin-bottom: 4px;
 }
 
 table p.datetime {
@@ -490,8 +488,8 @@ span.clearable-file-input label {
 }
 
 .calendar-cancel {
-    margin: 0 !important;
-    padding: 4px 0 !important;
+    margin: 0;
+    padding: 4px 0;
     font-size: 12px;
     background: #eee;
     border-top: 1px solid #ddd;


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/11544

Notes:
- All `!important` rules were removed from `contrib.admin` CSS
- Few styles changed by adding parent element dependency to avoid `!important`
- Fixed two minor visual bugs when refactored RTL
- Couple of styles removed because there are no any mention in markup