### PR TITLE
Fixed #25356 -- Removed default_app_config from startapp template.

### DIFF
--- a/django/conf/app_template/__init__.py
+++ b/django/conf/app_template/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = '{{ app_name }}.apps.{{ camel_case_app_name }}Config'

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -199,14 +199,14 @@ But first we need to tell our project that the ``polls`` app is installed.
     Django installation.
 
 Edit the :file:`mysite/settings.py` file again, and change the
-:setting:`INSTALLED_APPS` setting to include the string ``'polls'``. So it'll
-look like this:
+:setting:`INSTALLED_APPS` setting to include the string
+``'polls.apps.PollsConfig'``. It'll look like this:
 
 .. snippet::
     :filename: mysite/settings.py
 
     INSTALLED_APPS = [
-        'polls',
+        'polls.apps.PollsConfig',
         'django.contrib.admin',
         'django.contrib.auth',
         'django.contrib.contenttypes',

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -81,7 +81,9 @@ subclass by default as follows::
 That will cause ``RockNRollConfig`` to be used when :setting:`INSTALLED_APPS`
 just contains ``'rock_n_roll'``. This allows you to make use of
 :class:`~django.apps.AppConfig` features without requiring your users to
-update their :setting:`INSTALLED_APPS` setting.
+update their :setting:`INSTALLED_APPS` setting. Besides this use case, it's
+best to avoid using ``default_app_config`` and instead specify the app config
+class in :setting:`INSTALLED_APPS` as described next.
 
 Of course, you can also tell your users to put
 ``'rock_n_roll.apps.RockNRollConfig'`` in their :setting:`INSTALLED_APPS`

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1523,7 +1523,7 @@ Default: ``[]`` (Empty list)
 A list of strings designating all applications that are enabled in this
 Django installation. Each string should be a dotted Python path to:
 
-* an application configuration class, or
+* an application configuration class (preferred), or
 * a package containing an application.
 
 :doc:`Learn more about application configurations </ref/applications>`.

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -409,8 +409,7 @@ Management Commands
 * The :djadmin:`createcachetable` command now has a ``--dry-run`` flag to
   print out the SQL rather than execute it.
 
-* The :djadmin:`startapp` command creates an ``apps.py`` file and adds
-  ``default_app_config`` in ``__init__.py``.
+* The :djadmin:`startapp` command creates an ``apps.py`` file.
 
 * When using the PostgreSQL backend, the :djadmin:`dbshell` command can connect
   to the database using the password from your settings file (instead of

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -599,10 +599,6 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
             content = f.read()
             self.assertIn("class SettingsTestConfig(AppConfig)", content)
             self.assertIn("name = 'settings_test'", content)
-        with open(os.path.join(app_path, '__init__.py'), 'r') as f:
-            content = f.read()
-            expected_content = "default_app_config = 'settings_test.apps.SettingsTestConfig'"
-            self.assertIn(expected_content, content)
         if not PY3:
             with open(os.path.join(app_path, 'models.py'), 'r') as fp:
                 content = fp.read()


### PR DESCRIPTION
Also discouraged its use outside the intended use case.

https://code.djangoproject.com/ticket/25356