### PR TITLE
Let template tag folding

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -109,7 +109,7 @@ UNKNOWN_SOURCE = '<unknown source>'
 
 # match a variable or block tag and capture the entire tag, including start/end
 # delimiters
-tag_re = (re.compile('(%s.*?%s|%s.*?%s|%s.*?%s)' %
+tag_re = (re.compile('(%s(.|\s)*?%s|%s.*?%s|%s(.|\s)*?%s)' %
           (re.escape(BLOCK_TAG_START), re.escape(BLOCK_TAG_END),
            re.escape(VARIABLE_TAG_START), re.escape(VARIABLE_TAG_END),
            re.escape(COMMENT_TAG_START), re.escape(COMMENT_TAG_END))))


### PR DESCRIPTION
The template tag must writing in one line, for example:
{% include "math2/paper_block.html" with bigs=question show_step=1 show_duihao=1 show_myanswer=1 hidden=0 only %}

Now we can write in multi lines, it is more clear:
{% include "math2/paper_block.html" with 
bigs=question
show_step=1
show_duihao=1
show_myanswer=1
hidden=0
only
%}

{#
title 
aaaaa
bbbbb
#}