### PR TITLE
Refs #25300 -- Fixed issue with importing TextInput

### DIFF
--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2301,8 +2301,8 @@ class FormsTestCase(SimpleTestCase):
         unless it is `None`.
         """
         class SomeForm(Form):
-            field = CharField(widget=forms.TextInput(attrs={'id': 'myCustomID'}))
-            field_none = CharField(widget=forms.TextInput(attrs={'id': None}))
+            field = CharField(widget=TextInput(attrs={'id': 'myCustomID'}))
+            field_none = CharField(widget=TextInput(attrs={'id': None}))
 
         form = SomeForm()
         self.assertEqual(form['field'].id_for_label, 'myCustomID')


### PR DESCRIPTION
PR #5172 accidentally uses `django.forms.forms.TextInput` instead of `django.forms.TextInput`.
This breaks the test as soon as the `TextInput` import gets removed from `django.forms.forms` (for examle in my pr #5249).