### PR TITLE
Fixed #25329 - Don't leave _nodb_connection open

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -569,10 +569,10 @@ class BaseDatabaseWrapper(object):
             if must_close:
                 self.close()
 
-    @cached_property
+    @property
     def _nodb_connection(self):
         """
-        Alternative connection to be used when there is no need to access
+        Return an alternative connection to be used when there is no need to access
         the main database, specifically for test db creation/deletion.
         This also prevents the production database from being exposed to
         potential child threads while (or after) the test database is destroyed.

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -232,7 +232,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         else:
             return True
 
-    @cached_property
+    @property
     def _nodb_connection(self):
         nodb_connection = super(DatabaseWrapper, self)._nodb_connection
         try:

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -173,12 +173,10 @@ class PostgreSQLTests(TestCase):
         self.assertIsNone(nodb_conn.settings_dict['NAME'])
 
         # Now assume the 'postgres' db isn't available
-        del connection._nodb_connection
         with warnings.catch_warnings(record=True) as w:
             with mock.patch('django.db.backends.base.base.BaseDatabaseWrapper.connect',
                             side_effect=mocked_connect, autospec=True):
                 nodb_conn = connection._nodb_connection
-        del connection._nodb_connection
         self.assertIsNotNone(nodb_conn.settings_dict['NAME'])
         self.assertEqual(nodb_conn.settings_dict['NAME'], connection.settings_dict['NAME'])
         # Check a RuntimeWarning has been emitted


### PR DESCRIPTION
[Ticket 25329](https://code.djangoproject.com/ticket/25329). Will mean an one extra connection open will occur on a test run.