### PR TITLE
Fixed #25379 -- Removed obsolete information from GeoDjango tutorial.

### DIFF
--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -46,37 +46,16 @@ Setting Up
 Create a Spatial Database
 -------------------------
 
-.. note::
-
-    MySQL and Oracle users can skip this section because spatial types
-    are already built into the database.
-
-First, create a spatial database for your project.
-
-If you are using PostGIS, create the database from the :ref:`spatial database
-template <spatialdb_template>`:
-
-.. code-block:: console
-
-    $ createdb -T template_postgis geodjango
+If you are using SQLite and SpatiaLite, consult the instructions on how to
+create a :ref:`SpatiaLite database <create_spatialite_db>`. Otherwise, no
+special setup is required and you can create a database as you would for any
+other project.
 
 .. note::
 
-    This command must be issued by a database user with enough privileges to
-    create a database.  To create a user with ``CREATE DATABASE`` privileges in
-    PostgreSQL, use the following commands:
+    If you are using PostGIS, the database user must be able to run ``CREATE
+    EXTENSION``
 
-    .. code-block:: console
-
-        $ sudo su - postgres
-        $ createuser --createdb geo
-        $ exit
-
-    Replace ``geo`` with your Postgres database user's username.
-    (In PostgreSQL, this user will also be an OS-level user.)
-
-If you are using SQLite and SpatiaLite, consult the instructions on how
-to create a :ref:`SpatiaLite database <create_spatialite_db>`.
 
 Create a New Project
 ------------------------


### PR DESCRIPTION
ref https://code.djangoproject.com/ticket/25379#ticket

### Update GeoDjango tutorial to Postgres 9.1+ and CreateExtension

The GeoDjango tutorial (https://docs.djangoproject.com/en/1.8/ref/contrib/gis/tutorial/) still instructs to create a db using the spatial template.

Since PostgresSQL 9.1, the preferred way is to use the `postgis` extension instead.

This brings up another issue: should `makemigrations` automatically add a `CreateExtension` operation? Is that even doable?

For now I've simply documented it, but it would be very handy to have it automatically.