### PR TITLE
Fixed #25203 -- Documented how to pass Apache environment variables to Django.

### DIFF
--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -125,6 +125,49 @@ mode`_.
 
 .. _details on setting up daemon mode: http://code.google.com/p/modwsgi/wiki/QuickConfigurationGuide#Delegation_To_Daemon_Process
 
+.. _apache-environment-variables:
+
+Apache environment variables
+============================
+
+If you want to specify a different Django settings file or additional variables
+for your Django application via the Apache configuration, you would do it like
+this:
+
+.. code-block:: apache
+
+    SetEnv DB_USER dbusername
+    SetEnv DJANGO_SETTINGS_MODULE mysite.alternate-settings
+
+The ``SetEnv`` directive creates Apache environment variables instead of OS
+environment variables, so you will need to replace the default ``wsgi.py`` file
+with::
+
+    import os
+
+    from django.core.wsgi import get_wsgi_application
+
+    # tuple of Apache environment variables to pass through to Django
+    env_variables_to_pass = ('DB_USER', )
+
+    def application(environ, start_response):
+        """
+        Wrapper for the WSGI application that passes environment variables
+        """
+        os.environ['DJANGO_SETTINGS_MODULE'] = environ.get('DJANGO_SETTINGS_MODULE', 'mysite.settings')
+        for var in env_variables_to_pass:
+            os.environ[var] = environ.get(var, '')
+        return get_wsgi_application()(environ, start_response)
+
+Now you can specify a new settings file in Apache using the
+``SetEnv DJANGO_SETTINGS_MODULE ...`` line and if that setting isn't specified,
+it uses the ``mysite.settings`` value as a default. Remember to change
+``mysite.settings`` to properly reference your ``settings.py`` file.
+
+Additionally you can use the ``env_variables_to_pass`` tuple to specify any
+other Apache environment variables that should be passed along to the Django
+application as OS environment variables such as database login values.
+
 .. _serving-files:
 
 Serving files


### PR DESCRIPTION
In an effort to address [Ticket 25203](https://code.djangoproject.com/ticket/25203), I added a section to the docs that explains how to pass Apache environment variables into the Django application by modifying the default wsgi.py file. The proposed wsgi.py file has been tested to work with Django 1.4 through 1.8 running on Ubuntu 14.04 with Apache 2.4.