### PR TITLE
25386 Explained that debug in class Engine defaults to settings.debug

### DIFF
--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -87,7 +87,9 @@ Configuring an engine
       which can be used to display a detailed report for any exception raised
       during template rendering.
 
-      It defaults to ``False``.
+       If you create your own instance of an Engine, ``debug`` defaults to
+       ``False``. If not, it defaults to :setting:`DEBUG` in settings, which
+       defaults to ``True``.
 
     * ``loaders`` is a list of template loader classes, specified as strings.
       Each ``Loader`` class knows how to import templates from a particular


### PR DESCRIPTION
[Ticket 25386][1] pointed out that options.debug defaults to settings.DEBUG, but the documentation for configuring a class engine and TEMPLATE_DEBUG both claim that they default to False without elaborating on that point. I added a line to the section of documentation configuring a class engine explaining this. 

I did not change the TEMPLATE_DEBUG documentation, because it is deprecated. I will explain how this affects options debug in another pull request. 

[1]: https://code.djangoproject.com/ticket/25386