### PR TITLE
Refs #6148 -- Meta table api

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -967,12 +967,22 @@ class MigrationAutodetector(object):
             new_model_state = self.to_state.models[app_label, model_name]
             old_db_table_name = old_model_state.options.get('db_table')
             new_db_table_name = new_model_state.options.get('db_table')
+            old_table_cls = old_model_state.options.get('table_cls')
+            new_table_cls = new_model_state.options.get('table_cls')
             if old_db_table_name != new_db_table_name:
                 self.add_operation(
                     app_label,
                     operations.AlterModelTable(
                         name=model_name,
                         table=new_db_table_name,
+                    )
+                )
+            if old_table_cls != new_table_cls:
+                self.add_operation(
+                    app_label,
+                    operations.AlterModelTable(
+                        name=model_name,
+                        table=new_table_cls
                     )
                 )
 

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -286,7 +286,10 @@ class AlterModelTable(Operation):
         )
 
     def state_forwards(self, app_label, state):
-        state.models[app_label, self.name_lower].options["db_table"] = self.table
+        if isinstance(self.table, models.ModelTable):
+            state.models[app_label, self.name_lower].options["table_cls"] = self.table
+        else:
+            state.models[app_label, self.name_lower].options["db_table"] = self.table
         state.reload_model(app_label, self.name_lower)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -22,6 +22,7 @@ from django.db.models.fields.related import (  # NOQA isort:skip
     ForeignKey, ForeignObject, OneToOneField, ManyToManyField,
     ManyToOneRel, ManyToManyRel, OneToOneRel,
 )
+from django.db.models.options import ModelTable  # NOQA isort:skip
 
 
 def permalink(func):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1226,6 +1226,34 @@ class Model(six.with_metaclass(ModelBase)):
                         id='models.E017',
                     )
                 )
+        if cls._meta.table_cls.schema and cls._meta.managed:
+            errors.append(
+                checks.Error(
+                    "Schema qualified model table for model '%s' requires setting managed to False." % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+        if not cls._meta.table_cls.plain_table_ref and cls._meta.managed:
+            errors.append(
+                checks.Error(
+                    "The table_cls attribute for model '%s' requires setting managed to False." % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+        if 'table_cls' in cls._meta.original_attrs and 'db_table' in cls._meta.original_attrs:
+            errors.append(
+                checks.Error(
+                    "Both table_cls and db_table set for model '%s'" % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+
         return errors
 
     @classmethod

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -114,11 +114,20 @@ class ModelTable(object):
             return self.schema == other.schema and self.table == other.table
         return False
 
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
         return hash((self.schema, self.table))
 
     def deconstruct(self):
-        return ("django.db.models.ModelTable", [self.table, self.schema], {})
+        return ("django.db.models.ModelTable", [self.schema, self.table], {})
+
+    def __str__(self):
+        if self.schema:
+            return "%s.%s" % (self.schema, self.table)
+        else:
+            return "%s" % self.table
 
 
 @python_2_unicode_compatible

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -65,9 +65,20 @@ def make_immutable_fields_list(name, data):
 
 
 class ModelTable(object):
+    """
+    The _meta.table_cls can hold either a regular table reference,
+    or anything else usable in a subquery. If table_cls is a
+    regular table reference, then plain_table_ref should be set
+    to True, and the table_cls must contain table and schema
+    attributes.
+
+    Note that currently there is no support for schema qualified
+    tables for migrations.
+    """
     plain_table_ref = True
 
-    def __init__(self, table):
+    def __init__(self, schema, table):
+        self.schema = schema
         self.table = table
         # Cache for the quoted table name per connection.
         self.cache = {}
@@ -77,27 +88,37 @@ class ModelTable(object):
             sql, params = self.cache[connection.vendor]
             return sql, params[:]
         except KeyError:
-            sql, params = connection.ops.quote_name(self.table), []
-            self.cache[connection.vendor] = (sql, params)
-            return sql, params[:]
+            if self.schema:
+                sql = '%s.%s' % (connection.ops.quote_name(self.schema),
+                                 connection.ops.quote_name(self.table))
+            else:
+                sql = connection.ops.quote_name(self.table)
+            self.cache[connection.vendor] = (sql, [])
+            return sql, []
 
     @cached_property
     def default_alias(self):
+        """
+        String to use as default alias for this table.
+        """
         return self.table
 
     def requires_alias(self, table_alias, compiler):
-        return table_alias != self.default_alias
+        """
+        Does this table require usage of aliases always?
+        """
+        return self.schema is not None or table_alias != self.default_alias
 
     def __eq__(self, other):
         if isinstance(other, ModelTable):
-            return self.table == other.table
+            return self.schema == other.schema and self.table == other.table
         return False
 
     def __hash__(self):
-        return hash(self.table)
+        return hash((self.schema, self.table))
 
     def deconstruct(self):
-        return ("django.db.models.ModelTable", [self.table], {})
+        return ("django.db.models.ModelTable", [self.table, self.schema], {})
 
 
 @python_2_unicode_compatible
@@ -271,7 +292,7 @@ class Options(object):
             raise TypeError("Can't assign a class to db_table property. "
                             "Use table_cls instead.")
         else:
-            self.table_cls = ModelTable(table)
+            self.table_cls = ModelTable(None, table)
 
     def _prepare(self, model):
         if self.order_with_respect_to:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -336,7 +336,7 @@ class SQLCompiler(object):
         """
         if name in self.quote_cache:
             return self.quote_cache[name]
-        tables = [getattr(t, 'table', None) for t in self.query.table_map]
+        tables = set(getattr(t, 'table', None) for t in self.query.table_map)
         if ((name in self.query.alias_map and name not in tables) or
                 name in self.query.extra_select or (
                     name in self.query.external_aliases and name not in tables)):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -135,7 +135,7 @@ class Query(object):
         # a result of split_exclude). Correct alias quoting needs to know these
         # aliases too.
         self.external_aliases = set()
-        self.table_map = {}     # Maps table names to list of aliases.
+        self.table_map = {}     # Maps table objects to list of aliases.
         self.default_cols = True
         self.default_ordering = True
         self.standard_ordering = True
@@ -677,7 +677,7 @@ class Query(object):
             for model, values in six.iteritems(seen):
                 callback(target, model, values)
 
-    def table_alias(self, table_name, create=False):
+    def table_alias(self, table, create=False):
         """
         Returns a table alias for the given table_name and whether this is a
         new alias or not.
@@ -685,7 +685,7 @@ class Query(object):
         If 'create' is true, a new alias is always created. Otherwise, the
         most recently created alias for the table (if one exists) is reused.
         """
-        alias_list = self.table_map.get(table_name)
+        alias_list = self.table_map.get(table)
         if not create and alias_list:
             alias = alias_list[0]
             self.alias_refcount[alias] += 1
@@ -697,8 +697,8 @@ class Query(object):
             alias_list.append(alias)
         else:
             # The first occurrence of a table uses the table name directly.
-            alias = table_name
-            self.table_map[alias] = [alias]
+            alias = table.default_alias
+            self.table_map[table] = [alias]
         self.alias_refcount[alias] = 1
         self.tables.append(alias)
         return alias, True
@@ -809,7 +809,7 @@ class Query(object):
             del self.alias_refcount[old_alias]
             del self.alias_map[old_alias]
 
-            table_aliases = self.table_map[alias_data.table_name]
+            table_aliases = self.table_map[alias_data.table]
             for pos, alias in enumerate(table_aliases):
                 if alias == old_alias:
                     table_aliases[pos] = new_alias
@@ -877,7 +877,7 @@ class Query(object):
             alias = self.tables[0]
             self.ref_alias(alias)
         else:
-            alias = self.join(BaseTable(self.get_meta().db_table, None))
+            alias = self.join(BaseTable(self.get_meta().table_cls, None))
         return alias
 
     def count_active_tables(self):
@@ -919,7 +919,7 @@ class Query(object):
             return reuse[0]
 
         # No reuse is possible, so we need a new alias.
-        alias, _ = self.table_alias(join.table_name, create=True)
+        alias, _ = self.table_alias(join.table, create=True)
         if join.join_type:
             if self.alias_map[join.parent_alias].join_type == LOUTER or join.nullable:
                 join_type = LOUTER
@@ -1398,7 +1398,7 @@ class Query(object):
                 nullable = self.is_nullable(join.join_field)
             else:
                 nullable = True
-            connection = Join(opts.db_table, alias, None, INNER, join.join_field, nullable)
+            connection = Join(opts.table_cls, alias, None, INNER, join.join_field, nullable)
             reuse = can_reuse if join.m2m else None
             alias = self.join(connection, reuse=reuse)
             joins.append(alias)
@@ -1730,7 +1730,9 @@ class Query(object):
         if where or params:
             self.where.add(ExtraWhere(where, params), AND)
         if tables:
-            self.extra_tables += tuple(tables)
+            # TODO - resolve circular import
+            from django.db.models import ModelTable
+            self.extra_tables += tuple(ModelTable(t) for t in tables)
         if order_by:
             self.extra_order_by = order_by
 
@@ -1930,7 +1932,7 @@ class Query(object):
         # But the first entry in the query's FROM clause must not be a JOIN.
         for table in self.tables:
             if self.alias_refcount[table] > 0:
-                self.alias_map[table] = BaseTable(self.alias_map[table].table_name, table)
+                self.alias_map[table] = BaseTable(self.alias_map[table].table, table)
                 break
         self.set_select([f.get_col(select_alias) for f in select_fields])
         return trimmed_prefix, contains_louter

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1732,7 +1732,7 @@ class Query(object):
         if tables:
             # TODO - resolve circular import
             from django.db.models import ModelTable
-            self.extra_tables += tuple(ModelTable(t) for t in tables)
+            self.extra_tables += tuple(ModelTable(None, t) for t in tables)
         if order_by:
             self.extra_order_by = order_by
 

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -23,7 +23,8 @@ class DeleteQuery(Query):
     compiler = 'SQLDeleteCompiler'
 
     def do_query(self, table, where, using):
-        self.tables = [table]
+        assert table.plain_table_ref, "Can only delete from plain tables"
+        self.tables = [table.table]
         self.where = where
         cursor = self.get_compiler(using).execute_sql(CURSOR)
         return cursor.rowcount if cursor else 0
@@ -43,7 +44,7 @@ class DeleteQuery(Query):
             self.where = self.where_class()
             self.add_q(Q(
                 **{field.attname + '__in': pk_list[offset:offset + GET_ITERATOR_CHUNK_SIZE]}))
-            num_deleted += self.do_query(self.get_meta().db_table, self.where, using=using)
+            num_deleted += self.do_query(self.get_meta().table_cls, self.where, using=using)
         return num_deleted
 
     def delete_qs(self, query, using):

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -739,22 +739,11 @@ class RelatedIndividual(models.Model):
         db_table = 'RelatedIndividual'
 
 
-class SchemaQualified(models.ModelTable):
-    def __init__(self, schema, table):
-        self.schema = schema
-        self.table = table
-
-    def as_sql(self, compiler, connection):
-        # Note that it would be easy to change the schema using thread locals
-        # if wanted.
-        return '%s.%s' % (connection.ops.quote_name(self.schema), connection.ops.quote_name(self.table)), []
-
-
 class SchemaQualified(models.Model):
     val = models.TextField()
 
     class Meta:
-        table_cls = SchemaQualified('other_schema', 'schema_qualified')
+        table_cls = models.ModelTable('other_schema', 'schema_qualified')
         managed = False
 
 
@@ -779,7 +768,7 @@ class Table(models.Model):
     val = models.TextField()
 
     class Meta:
-        table_cls = DynamicQuery('queries_table')
+        table_cls = DynamicQuery(None, 'queries_table')
 
 
 class ShadowTable(models.Model):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -28,9 +28,10 @@ from .models import (
     Order, OrderItem, Page, Paragraph, Person, Plaything, PointerA, Program,
     ProxyCategory, ProxyObjectA, ProxyObjectB, Ranking, Related,
     RelatedIndividual, RelatedObject, Report, ReservedName, Responsibility,
-    School, SharedConnection, SimpleCategory, SingleObject, SpecialCategory,
-    Staff, StaffUser, Student, Tag, Task, Ticket21203Child, Ticket21203Parent,
-    Ticket23605A, Ticket23605B, Ticket23605C, TvChef, Valid,
+    SchemaQualified, School, ShadowTable, SharedConnection, SimpleCategory,
+    SingleObject, SpecialCategory, Staff, StaffUser, Student, Table, Tag, Task,
+    Ticket21203Child, Ticket21203Parent, Ticket23605A, Ticket23605B,
+    Ticket23605C, TvChef, Valid,
 )
 
 
@@ -3858,3 +3859,36 @@ class Ticket23622Tests(TestCase):
             Ticket23605A.objects.filter(qx),
             [a2], lambda x: x
         )
+
+
+class TestMetaTableClass(TestCase):
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific DDL used')
+    def test_schema_qualified(self):
+        cursor = connection.cursor()
+        cursor.execute('create schema other_schema')
+        cursor.execute('create table other_schema.schema_qualified(id serial primary key, val text)')
+        SchemaQualified.objects.create(val='Foo')
+        list(SchemaQualified.objects.all())
+
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific DDL used')
+    def test_shadow_table(self):
+        # The idea is that we store current data in Table, and historical row
+        # versions in ShadowTable. We can query a point in time from the
+        # ShadowTable with a bit of meta table class magic.
+        # Lets create the shadow table situation manually, in reality
+        # the modifications to ShadowTable would be done manually.
+        t = Table.objects.create(val='foo')
+        valid1 = datetime.datetime.now()
+        st = ShadowTable.objects.create(id=t.id, val='foo', valid_from=valid1)
+        t.val = 'bar'
+        t.save()
+        valid2 = datetime.datetime.now()
+        st.valid_until = valid2
+        st.save()
+        ShadowTable.objects.create(id=t.id, val='bar', valid_from=valid2)
+        # Now, when we query Table normally, we get the latest value.
+        self.assertEqual(Table.objects.get(pk=t.pk).val, 'bar')
+        # But, if we alter the query time, then we get a different result.
+        qs = Table.objects.all()
+        qs.query.add_context('db_time', valid1)
+        self.assertEqual(qs.get(pk=t.pk).val, 'foo')


### PR DESCRIPTION
The idea is that one can do fancy things (multi-schema setups, shadow table querying, injecting complex subqueries into ORM queries) by changing the Meta.db_table to respect the as_sql() API.

This is work in progress, and I do not target for 1.9 inclusion.