### PR TITLE
Fixed #25393 -- Don't fail MySQL add of TextField with unhashable default

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -50,7 +50,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         super(DatabaseSchemaEditor, self).add_field(model, field)
 
         # Simulate the effect of a one-off default.
-        if self.skip_default(field) and field.default not in {None, NOT_PROVIDED}:
+        # Note: field.default can be unhashable, don't use a set here.
+        if self.skip_default(field) and field.default not in (None, NOT_PROVIDED):
             effective_default = self.effective_default(field)
             self.execute('UPDATE %(table)s SET %(column)s = %%s' % {
                 'table': self.quote_name(model._meta.db_table),

--- a/docs/releases/1.8.5.txt
+++ b/docs/releases/1.8.5.txt
@@ -29,3 +29,6 @@ Bugfixes
 
 * Alphabetized ordering of imports in ``from django.db import migrations,
   models`` statement in newly created migrations (:ticket:`25384`).
+
+* Fixed adding a text or a blob field with unhashable default to MySQL
+  (:ticket:`25393`).

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -869,6 +869,7 @@ unglamorous
 ungrouped
 unhandled
 unharmful
+unhashable
 unicode
 uninstall
 uninstalling

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1673,3 +1673,19 @@ class SchemaTests(TransactionTestCase):
             )
             if connection.features.can_introspect_default:
                 self.assertIsNone(field.default)
+
+    def test_add_textfield_unhashable_default(self):
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        # Create a row
+        Author.objects.create(name='Anonymous1')
+        # Create a field that has an unhashable default
+        new_field = TextField(default={})
+        new_field.set_attributes_from_name("info")
+        # Fail if an exception is raised
+        try:
+            with connection.schema_editor() as editor:
+                editor.add_field(Author, new_field)
+        except:
+            self.fail("An exception should not be raised")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25393