### PR TITLE
Fixed #25400 - __getattr__ did not raise AttributeError (gis)

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -98,9 +98,8 @@ class BaseSpatialFeatures(object):
         m = re.match(r'has_(\w*)_function$', name)
         if m:
             func_name = m.group(1)
-            if func_name not in self.connection.ops.unsupported_functions:
-                return True
-        return False
+            return func_name not in self.connection.ops.unsupported_functions
+        raise AttributeError
 
     def has_ops_method(self, method):
         return getattr(self.connection.ops, method, False)


### PR DESCRIPTION
With commit d9ff5ef36d3f714736d633435d45f03eac9c17b5 the behaviour of
`hasattr` on `connection.features` has changed, e.g. the following will
be True now always, and was previously so only for Django < 1.5.

    hasattr(connection.features, 'confirm')

This fixes it by raising AttributeError in this case.

I am not sure if this fix is proper - let's see what the tests say about it first.

Ref: https://code.djangoproject.com/ticket/25400.