### PR TITLE
Fixed #25373 -- Added warning logging for exceptions during {% include %} tag rendering.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -902,8 +902,13 @@ class Variable(object):
                             else:
                                 raise
         except Exception as e:
-            template_name = getattr(context, 'template_name', 'unknown')
-            logger.debug('%s - %s', template_name, e)
+            template_name = getattr(context, 'template_name', None) or 'unknown'
+            logger.debug(
+                'Exception raised while resolving variable %s in template %s.',
+                bit,
+                template_name,
+                exc_info=True
+            )
 
             if getattr(e, 'silent_variable_failure', False):
                 current = context.template.engine.string_if_invalid

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -903,7 +903,7 @@ class Variable(object):
                                 raise
         except Exception as e:
             template_name = getattr(context, 'template_name', 'unknown')
-            logger.debug('{} - {}'.format(template_name, e))
+            logger.debug('%s - %s', template_name, e)
 
             if getattr(e, 'silent_variable_failure', False):
                 current = context.template.engine.string_if_invalid

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -211,7 +211,7 @@ class IncludeNode(Node):
             if context.template.engine.debug:
                 raise
             else:
-                template_name = getattr(context, 'template_name', 'unknown')
+                template_name = getattr(context, 'template_name', None) or 'unknown'
                 logger.warn(
                     'Exception raised while rendering {%% include %%} for '
                     'template %s. Empty string rendered instead.',

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 
 from django.utils import six
@@ -11,6 +12,8 @@ from .library import Library
 register = Library()
 
 BLOCK_CONTEXT_KEY = 'block_context'
+
+logger = logging.getLogger('django.template')
 
 
 class ExtendsError(Exception):
@@ -207,6 +210,14 @@ class IncludeNode(Node):
         except Exception:
             if context.template.engine.debug:
                 raise
+            else:
+                template_name = getattr(context, 'template_name', 'unknown')
+                logger.warn(
+                    'Exception raised while rendering {%% include %%} for '
+                    'template %s. Empty string rendered instead.',
+                    template_name,
+                    exc_info=True,
+                )
             return ''
 
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -673,9 +673,14 @@ if it's missing or has syntax errors), the behavior varies depending on the
 :class:`template engine's <django.template.Engine>` ``debug`` option (if not
 set, this option defaults to the value of :setting:`DEBUG`). When debug mode is
 turned on, an exception like :exc:`~django.template.TemplateDoesNotExist` or
-:exc:`~django.template.TemplateSyntaxError` will be raised; otherwise
-``{% include %}`` silences any exception that happens while rendering the
-included template and returns an empty string.
+:exc:`~django.template.TemplateSyntaxError` will be raised. When debug mode
+is turned off, ``{% include %}`` logs a warning to the ``django.template``
+logger with the exception that happens while rendering the included template
+and returns an empty string.
+
+.. versionchanged:: 1.9
+
+    Template logging now includes the warning logging mentioned above.
 
 .. note::
     The :ttag:`include` tag should be considered as an implementation of

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -593,8 +593,14 @@ Templates
 * Added a :meth:`Context.setdefault() <django.template.Context.setdefault>`
   method.
 
-* A warning will now be logged for missing context variables. These messages
-  will be logged to the :ref:`django.template <django-template-logger>` logger.
+* The :ref:`django.template <django-template-logger>` logger was added and
+  includes the following messages:
+
+  * A ``DEBUG`` level message for missing context variables.
+
+  * A ``WARNING`` level message for uncaught exceptions raised
+    during the rendering of an ``{% include %}`` when debug mode is off (since
+    ``{% include %}`` silences the exception and returns an empty string).
 
 * The :ttag:`firstof` template tag supports storing the output in a variable
   using 'as'.

--- a/tests/template_tests/test_logging.py
+++ b/tests/template_tests/test_logging.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from django.template import Engine, Variable, VariableDoesNotExist
+from django.template import Context, Engine, Variable, VariableDoesNotExist
 from django.test import SimpleTestCase
 
 
@@ -15,17 +15,21 @@ class TestHandler(logging.Handler):
         self.log_record = record
 
 
-class VariableResolveLoggingTests(SimpleTestCase):
+class BaseTemplateLoggingTestCase(SimpleTestCase):
     def setUp(self):
         self.test_handler = TestHandler()
         self.logger = logging.getLogger('django.template')
         self.original_level = self.logger.level
         self.logger.addHandler(self.test_handler)
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(self.loglevel)
 
     def tearDown(self):
         self.logger.removeHandler(self.test_handler)
         self.logger.level = self.original_level
+
+
+class VariableResolveLoggingTests(BaseTemplateLoggingTestCase):
+    loglevel = logging.DEBUG
 
     def test_log_on_variable_does_not_exist_silent(self):
         class TestObject(object):
@@ -52,7 +56,7 @@ class VariableResolveLoggingTests(SimpleTestCase):
 
         Variable('article').resolve(TestObject())
         self.assertEqual(
-            self.test_handler.log_record.msg,
+            self.test_handler.log_record.getMessage(),
             'template - Attribute does not exist.'
         )
 
@@ -61,7 +65,7 @@ class VariableResolveLoggingTests(SimpleTestCase):
             Variable('article.author').resolve({'article': {'section': 'News'}})
 
         self.assertEqual(
-            self.test_handler.log_record.msg,
+            self.test_handler.log_record.getMessage(),
             'unknown - Failed lookup for key [author] in %r' %
             ("{%r: %r}" % ('section', 'News'), )
         )
@@ -69,3 +73,30 @@ class VariableResolveLoggingTests(SimpleTestCase):
     def test_no_log_when_variable_exists(self):
         Variable('article.section').resolve({'article': {'section': 'News'}})
         self.assertIsNone(self.test_handler.log_record)
+
+
+class IncludeNodeLoggingTests(BaseTemplateLoggingTestCase):
+    loglevel = logging.WARN
+
+    def test_logs_exceptions_during_rendering_with_debug_disabled(self):
+        engine = Engine(loaders=[
+            ('django.template.loaders.locmem.Loader', {
+                'child': '{{ raises_exception }}',
+            }),
+        ], debug=False)
+
+        def error_method():
+            raise IndexError("some generic exception")
+
+        ctx = Context({'raises_exception': error_method})
+        named_template = engine.from_string('{% include "child" %}')
+        named_template.name = "template_name"
+
+        self.assertEqual(named_template.render(ctx), '')
+        self.assertEqual(
+            self.test_handler.log_record.getMessage(),
+            'Exception raised while rendering {% include %} for template '
+            'template_name. Empty string rendered instead.'
+        )
+        self.assertIsNotNone(self.test_handler.log_record.exc_info)
+        self.assertEqual(self.test_handler.log_record.levelno, logging.WARN)


### PR DESCRIPTION
PR for patch referenced in [ticket 25373](https://code.djangoproject.com/ticket/25373)