### PR TITLE
Refs #25149 -- Fixed regression in admin date-time widget for timezones on the negative side of UTC.

### DIFF
--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -12,7 +12,7 @@
 {% load i18n %}
 
 <body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
-  data-admin-utc-offset="{% filter escapejs %}{% now "Z" %}{% endfilter %}">
+  data-admin-utc-offset="{% now "Z" %}">
 
 <!-- Container -->
 <div id="container">

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -884,6 +884,21 @@ class DateTimePickerShortcutsSeleniumIETests(DateTimePickerShortcutsSeleniumFire
     webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
 
 
+# The above tests run with Asia/Singapore which are on the positive side of
+# UTC. Here we test with a timezone on the negative side.
+@override_settings(TIME_ZONE='US/Eastern')
+class DateTimePickerShortcutsAltTimezoneSeleniumFirefoxTests(DateTimePickerShortcutsSeleniumFirefoxTests):
+    pass
+
+
+class DateTimePickerShortcutsAltTimezoneSeleniumChromeTests(DateTimePickerShortcutsAltTimezoneSeleniumFirefoxTests):
+    webdriver_class = 'selenium.webdriver.chrome.webdriver.WebDriver'
+
+
+class DateTimePickerShortcutsAltTimezoneSeleniumIETests(DateTimePickerShortcutsAltTimezoneSeleniumFirefoxTests):
+    webdriver_class = 'selenium.webdriver.ie.webdriver.WebDriver'
+
+
 @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'],
     ROOT_URLCONF='admin_widgets.urls')
 class HorizontalVerticalFilterSeleniumFirefoxTests(SeleniumDataMixin, AdminSeleniumWebDriverTestCase):


### PR DESCRIPTION
Clicking 'Today' or 'Now' for a datetime input would result in 'NaN-NaN-Nan' or 'NaN:NaN:NaN'. This is a regression introduced by https://code.djangoproject.com/ticket/25149.