### PR TITLE
Refs #24526 -- Made the django logger handle INFO messages.

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -42,6 +42,7 @@ DEFAULT_LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console', 'mail_admins'],
+            'level': 'INFO',
         },
         'py.warnings': {
             'handlers': ['console'],

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -827,7 +827,8 @@ Changes to the default logging configuration
 
 To make it easier to write custom logging configurations, Django's default
 logging configuration no longer defines 'django.request' and 'django.security'
-loggers. Instead, it defines a single 'django' logger with two handlers:
+loggers. Instead, it defines a single 'django' logger, filtered at the ``INFO``
+level, with two handlers:
 
 * 'console': filtered at the ``INFO`` level and only active if ``DEBUG=True``.
 * 'mail_admins': filtered at the ``ERROR`` level and only active if

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -6,6 +6,7 @@ import warnings
 
 from admin_scripts.tests import AdminScriptTestCase
 
+from django.conf import settings
 from django.core import mail
 from django.core.files.temp import NamedTemporaryFile
 from django.test import RequestFactory, SimpleTestCase, override_settings
@@ -13,7 +14,8 @@ from django.test.utils import LoggingCaptureMixin, patch_logger
 from django.utils.deprecation import RemovedInNextVersionWarning
 from django.utils.encoding import force_text
 from django.utils.log import (
-    AdminEmailHandler, CallbackFilter, RequireDebugFalse, RequireDebugTrue,
+    DEFAULT_LOGGING, AdminEmailHandler, CallbackFilter, RequireDebugFalse,
+    RequireDebugTrue,
 )
 from django.utils.six import StringIO
 
@@ -67,6 +69,17 @@ class LoggingFiltersTest(SimpleTestCase):
 
 class DefaultLoggingTest(LoggingCaptureMixin, SimpleTestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super(DefaultLoggingTest, cls).setUpClass()
+        cls._logging = settings.LOGGING
+        logging.config.dictConfig(DEFAULT_LOGGING)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(DefaultLoggingTest, cls).tearDownClass()
+        logging.config.dictConfig(cls._logging)
+
     def test_django_logger(self):
         """
         The 'django' base logger only output anything when DEBUG=True.
@@ -77,6 +90,21 @@ class DefaultLoggingTest(LoggingCaptureMixin, SimpleTestCase):
         with self.settings(DEBUG=True):
             self.logger.error("Hey, this is an error.")
             self.assertEqual(self.logger_output.getvalue(), 'Hey, this is an error.\n')
+
+    def test_django_logger_warning(self):
+        with self.settings(DEBUG=True):
+            self.logger.warning('warning')
+            self.assertEqual(self.logger_output.getvalue(), 'warning\n')
+
+    def test_django_logger_info(self):
+        with self.settings(DEBUG=True):
+            self.logger.info('info')
+            self.assertEqual(self.logger_output.getvalue(), 'info\n')
+
+    def test_django_logger_debug(self):
+        with self.settings(DEBUG=True):
+            self.logger.debug('debug')
+            self.assertEqual(self.logger_output.getvalue(), '')
 
 
 class WarningLoggerTests(SimpleTestCase):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import atexit
+import copy
 import logging
 import os
 import shutil
@@ -154,7 +155,7 @@ def setup(verbosity, test_labels, parallel):
         'contenttypes': 'contenttypes_tests.migrations',
         'sessions': 'sessions_tests.migrations',
     }
-    log_config = DEFAULT_LOGGING
+    log_config = copy.deepcopy(DEFAULT_LOGGING)
     # Filter out non-error logging so we don't have to capture it in lots of
     # tests.
     log_config['loggers']['django']['level'] = 'ERROR'


### PR DESCRIPTION
Without an explicit 'level', only messages at WARNING or higher
are handled. This makes the config consistent with the docs
which say, "The django catch-all logger sends all messages at
the INFO level or higher to the console."