### PR TITLE
Updated docs coverage example to run in a single process

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -192,9 +192,10 @@ Contributors are encouraged to run coverage on the test suite to identify areas
 that need additional tests. The coverage tool installation and use is described
 in :ref:`testing code coverage<topics-testing-code-coverage>`.
 
-To run coverage on the Django test suite using the standard test settings::
+Coverage should be run in a single process to obtain accurate statistics. To
+run coverage on the Django test suite using the standard test settings::
 
-   $ coverage run ./runtests.py --settings=test_sqlite
+   $ coverage run ./runtests.py --settings=test_sqlite --parallel=1
 
 After running coverage, generate the html report by running::
 


### PR DESCRIPTION
This commit adds a note and updates an example in the contributing section of the docs: https://docs.djangoproject.com/en/1.8/internals/contributing/writing-code/unit-tests/#code-coverage. It recommends running the tests in a single process when trying to obtain coverage statistics. Running with the default 4 processes led to underestimating the actual code coverage: http://dpaste.com/1AB9KP9