### PR TITLE
Refs #24622 -- Documented the change of behavior when using alternative template engines with the test client

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -458,6 +458,12 @@ Specifically, a ``Response`` object has the following attributes:
             >>> response.context['name']
             'Arthur'
 
+        .. note::
+          This attribute is only populated when using the Django Template
+          Language. If you use another template engine,
+          :attr:`~django.template.response.SimpleTemplateResponse.context_data`
+          is a suitable alternative.
+
     .. method:: json(**kwargs)
 
         .. versionadded:: 1.9
@@ -493,6 +499,13 @@ Specifically, a ``Response`` object has the following attributes:
         ``template.name`` to get the template's file name, if the template was
         loaded from a file. (The name is a string such as
         ``'admin/index.html'``.)
+
+        .. note::
+          This attribute is only populated when using the Django Template
+          Language. If you use another template engine,
+          :attr:`~django.template.response.SimpleTemplateResponse.template_name`
+          may be suitable alternative if you only need the name of the template
+          used for rendering.
 
     .. attribute:: resolver_match
 


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/24622. This just documents the change in behavior and recommends alternative attributes that could be used instead.