### PR TITLE
Refs #24215 -- Fixed Python 3.5 compatiblity for unhandled lazy ops error.

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -381,6 +381,10 @@ class Apps(object):
 
             def function(model):
                 next_function = partial(supplied_fn, model)
+                # Annotate the function with its field for retrieval in
+                # migrations.state.StateApps.
+                if getattr(supplied_fn, 'keywords', None):
+                    next_function.field = supplied_fn.keywords.get('field')
                 self.lazy_model_operation(next_function, *more_models)
 
         # If the model is already loaded, pass it to the function immediately.

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -244,11 +244,9 @@ class StateApps(Apps):
         has a keyword argument called 'field'.
         """
         def extract_field(operation):
-            # Expect a functools.partial() with a kwarg called 'field' applied.
-            try:
-                return operation.func.keywords['field']
-            except (AttributeError, KeyError):
-                return None
+            # operation is annotated with the field in
+            # apps.register.Apps.lazy_model_operation().
+            return getattr(operation, 'field', None)
 
         def extract_field_names(operations):
             return (str(field) for field in map(extract_field, operations) if field)


### PR DESCRIPTION
As described in http://bugs.python.org/issue25137 it seems we shouldn't rely on the behavior of < Python 3.4.