### PR TITLE
Fixed #8936 -- Added view permissions and a read-only admin

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -224,7 +224,8 @@ class InlineAdminFormSet(object):
     A wrapper around an inline formset for use in the admin system.
     """
     def __init__(self, inline, formset, fieldsets, prepopulated_fields=None,
-            readonly_fields=None, model_admin=None):
+            readonly_fields=None, uneditable_fields=None, has_add_permission=True,
+            model_admin=None):
         self.opts = inline
         self.formset = formset
         self.fieldsets = fieldsets
@@ -232,30 +233,35 @@ class InlineAdminFormSet(object):
         if readonly_fields is None:
             readonly_fields = ()
         self.readonly_fields = readonly_fields
+        if uneditable_fields is None:
+            uneditable_fields = ()
+        self.uneditable_fields = uneditable_fields
         if prepopulated_fields is None:
             prepopulated_fields = {}
         self.prepopulated_fields = prepopulated_fields
+        self.has_add_permission = has_add_permission
 
     def __iter__(self):
         for form, original in zip(self.formset.initial_forms, self.formset.get_queryset()):
             view_on_site_url = self.opts.get_view_on_site_url(original)
             yield InlineAdminForm(self.formset, form, self.fieldsets,
-                self.prepopulated_fields, original, self.readonly_fields,
+                self.prepopulated_fields, original, self.uneditable_fields,
                 model_admin=self.opts, view_on_site_url=view_on_site_url)
         for form in self.formset.extra_forms:
             yield InlineAdminForm(self.formset, form, self.fieldsets,
                 self.prepopulated_fields, None, self.readonly_fields,
                 model_admin=self.opts)
-        yield InlineAdminForm(self.formset, self.formset.empty_form,
-            self.fieldsets, self.prepopulated_fields, None,
-            self.readonly_fields, model_admin=self.opts)
+        if self.has_add_permission:
+            yield InlineAdminForm(self.formset, self.formset.empty_form,
+                self.fieldsets, self.prepopulated_fields, None,
+                self.readonly_fields, model_admin=self.opts)
 
     def fields(self):
         fk = getattr(self.formset, "fk", None)
         for i, field_name in enumerate(flatten_fieldsets(self.fieldsets)):
             if fk and fk.name == field_name:
                 continue
-            if field_name in self.readonly_fields:
+            if field_name in self.uneditable_fields:
                 yield {
                     'label': label_for_field(field_name, self.opts.model, self.opts),
                     'widget': {

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -448,7 +448,7 @@ class AdminSite(object):
                 'object_name': model._meta.object_name,
                 'perms': perms,
             }
-            if perms.get('change'):
+            if perms.get('change') or perms.get('view'):
                 try:
                     model_dict['admin_url'] = reverse('admin:%s_%s_changelist' % info, current_app=self.name)
                 except NoReverseMatch:

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -17,7 +17,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
-&rsaquo; {% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+&rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
 &rsaquo; {% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
 </div>
 {% endblock %}

--- a/django/contrib/admin/templatetags/admin_modify.py
+++ b/django/contrib/admin/templatetags/admin_modify.py
@@ -27,25 +27,30 @@ def submit_row(context):
     Displays the row of buttons for delete and save.
     """
     opts = context['opts']
+    add = context['add']
     change = context['change']
     is_popup = context['is_popup']
     save_as = context['save_as']
     show_save = context.get('show_save', True)
     show_save_and_continue = context.get('show_save_and_continue', True)
+    has_change_permission = context['has_change_permission']
+    has_add_permission = context['has_add_permission']
+    has_inline_admin_formsets = context['has_inline_admin_formsets']
+    can_save = (has_change_permission and change) or (has_add_permission and add) or has_inline_admin_formsets
     ctx = {
         'opts': opts,
         'show_delete_link': (
             not is_popup and context['has_delete_permission'] and
             change and context.get('show_delete', True)
         ),
-        'show_save_as_new': not is_popup and change and save_as,
+        'show_save_as_new': not is_popup and has_change_permission and change and save_as,
         'show_save_and_add_another': (
-            context['has_add_permission'] and not is_popup and
-            (not save_as or context['add'])
+            has_add_permission and not is_popup and
+            (not save_as or add) and can_save
         ),
-        'show_save_and_continue': not is_popup and context['has_change_permission'] and show_save_and_continue,
+        'show_save_and_continue': not is_popup and can_save and show_save_and_continue,
         'is_popup': is_popup,
-        'show_save': show_save,
+        'show_save': show_save and can_save,
         'preserved_filters': context.get('preserved_filters'),
     }
     if context.get('original') is not None:

--- a/django/contrib/contenttypes/admin.py
+++ b/django/contrib/contenttypes/admin.py
@@ -102,7 +102,7 @@ class GenericInlineModelAdmin(InlineModelAdmin):
             exclude = []
         else:
             exclude = list(self.exclude)
-        exclude.extend(self.get_readonly_fields(request, obj))
+        exclude.extend(self.get_uneditable_fields(request, obj))
         if self.exclude is None and hasattr(self.form, '_meta') and self.form._meta.exclude:
             # Take the custom ModelForm's Meta.exclude into account only if the
             # GenericInlineModelAdmin doesn't define its own.

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -83,7 +83,7 @@ class Options(object):
         self.unique_together = []
         self.index_together = []
         self.select_on_save = False
-        self.default_permissions = ('add', 'change', 'delete')
+        self.default_permissions = ('view', 'add', 'change', 'delete')
         self.permissions = []
         self.object_name = None
         self.app_label = app_label

--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -34,6 +34,16 @@ models. For example, here's the user module from Django's built-in
     For more background on bulk deletion, see the documentation on :ref:`object
     deletion <topics-db-queries-delete>`.
 
+.. note::
+
+    .. versionadded:: 1.10
+
+    ``Change`` permission is needed for actions to accessible.
+
+    The ``change`` permission is newly needed to trigger actions by user
+    (previously they couldn't be even accessed in admin without ``change``
+    permission).
+
 Read on to find out how to add your own actions to this list.
 
 Writing actions

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1469,7 +1469,7 @@ templates used by the :class:`ModelAdmin` views:
     a ``list`` or ``tuple`` of :class:`~django.contrib.admin.InlineModelAdmin`
     objects, as described below in the :class:`~django.contrib.admin.InlineModelAdmin`
     section. For example, the following would return inlines without the default
-    filtering based on add, change, and delete permissions::
+    filtering based on view, add, change, and delete permissions::
 
         class MyModelAdmin(admin.ModelAdmin):
             inlines = (MyInline,)
@@ -1712,6 +1712,18 @@ templates used by the :class:`ModelAdmin` views:
     Should return ``True`` if adding an object is permitted, ``False``
     otherwise.
 
+.. method:: ModelAdmin.has_view_permission(request, obj=None)
+
+    .. versionadded:: 1.10
+
+    Should return ``True`` if viewing obj is permitted, ``False`` otherwise.
+    If obj is ``None``, should return ``True`` or ``False`` to indicate whether
+    viewing of objects of this type is permitted in general (e.g., ``False``
+    will be interpreted as meaning that the current user is not permitted to
+    view any object of this type).
+    The ``view`` permission has been made with backward compatibility in mind, so
+    ``change`` permission imply that user can also view objects.
+
 .. method:: ModelAdmin.has_change_permission(request, obj=None)
 
     Should return ``True`` if editing obj is permitted, ``False`` otherwise.
@@ -1734,7 +1746,8 @@ templates used by the :class:`ModelAdmin` views:
     accessing the module's index page is permitted, ``False`` otherwise.
     Uses :meth:`User.has_module_perms()
     <django.contrib.auth.models.User.has_module_perms>` by default. Overriding
-    it does not restrict access to the add, change or delete views,
+    it does not restrict access to the view, add, change, or delete views,
+    :meth:`~ModelAdmin.has_view_permission`,
     :meth:`~ModelAdmin.has_add_permission`,
     :meth:`~ModelAdmin.has_change_permission`, and
     :meth:`~ModelAdmin.has_delete_permission` should be used for that.
@@ -2023,6 +2036,7 @@ adds some of its own (the shared features are actually defined in the
 - :meth:`~ModelAdmin.formfield_for_choice_field`
 - :meth:`~ModelAdmin.formfield_for_foreignkey`
 - :meth:`~ModelAdmin.formfield_for_manytomany`
+- :meth:`~ModelAdmin.has_view_permission`
 - :meth:`~ModelAdmin.has_add_permission`
 - :meth:`~ModelAdmin.has_change_permission`
 - :meth:`~ModelAdmin.has_delete_permission`

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -268,7 +268,7 @@ Django quotes column and table names behind the scenes.
 .. attribute:: Options.permissions
 
     Extra permissions to enter into the permissions table when creating this object.
-    Add, delete and change permissions are automatically created for each
+    View, add, delete and change permissions are automatically created for each
     model. This example specifies an extra permission, ``can_deliver_pizzas``::
 
         permissions = (("can_deliver_pizzas", "Can deliver pizzas"),)
@@ -281,11 +281,15 @@ Django quotes column and table names behind the scenes.
 
 .. attribute:: Options.default_permissions
 
-    Defaults to ``('add', 'change', 'delete')``. You may customize this list,
+    Defaults to ``('view', 'add', 'change', 'delete')``. You may customize this list,
     for example, by setting this to an empty list if your app doesn't require
     any of the default permissions. It must be specified on the model before
     the model is created by :djadmin:`migrate` in order to prevent any omitted
     permissions from being created.
+
+    .. versionchanged:: 1.10
+
+        The ``view`` permission was added.
 
 ``proxy``
 ---------

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -36,6 +36,22 @@ Minor features
   link <django.contrib.admin.AdminSite.site_url>` at the top of each admin page
   will now point to ``request.META['SCRIPT_NAME']`` if set, instead of ``/``.
 
+* Added ``view`` permission to the
+  :attr:`~django.db.models.Options.default_permissions`.
+  This allows to define read only access to the models and admin pages.
+  The :meth:`ModelAdmin.has_view_permission()
+  <django.contrib.admin.ModelAdmin.has_view_permission>` function was introduced.
+  The ``view`` permission has been made with backward compatibility in mind, so
+  ``change`` permission imply that user can also view objects.
+
+  The ``change`` permission is newly needed to trigger :doc:`/ref/contrib/admin/actions`
+  by user.
+
+  To use list_editable option, the ``change`` permission is also needed.
+
+  This works also for inlines. To display the change view of the base object,
+  at least ``view`` permission is needed.
+
 * The success message that appears after adding or editing an object now
   contains a link to the object's change form.
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -169,6 +169,7 @@ The Django admin site uses permissions as follows:
 
 Permissions can be set not only per type of object, but also per specific
 object instance. By using the
+:meth:`~django.contrib.admin.ModelAdmin.has_view_permission`,
 :meth:`~django.contrib.admin.ModelAdmin.has_add_permission`,
 :meth:`~django.contrib.admin.ModelAdmin.has_change_permission` and
 :meth:`~django.contrib.admin.ModelAdmin.has_delete_permission` methods provided

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -145,6 +145,10 @@ class RowLevelChangePermissionModelAdmin(admin.ModelAdmin):
         """ Only allow changing objects with even id number """
         return request.user.is_staff and (obj is not None) and (obj.id % 2 == 0)
 
+    def has_view_permission(self, request, obj=None):
+        """ Only allow viewing objects with even id number """
+        return request.user.is_staff and (obj is not None) and (obj.id % 2 == 0)
+
 
 class CustomArticleAdmin(admin.ModelAdmin):
     """

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1290,6 +1290,12 @@ class AdminViewPermissionsTest(TestCase):
             first_name='No', last_name='Staff', email='nostaff@example.com',
             is_staff=False, is_active=True, date_joined=datetime.datetime(2007, 5, 30, 13, 20, 10)
         )
+        cls.viewuser = User.objects.create(
+            password='sha1$995a3$6011485ea3834267d719b4c801409b8b1ddd0158',
+            last_login=datetime.datetime(2007, 5, 30, 13, 20, 10), is_superuser=False, username='viewuser',
+            first_name='View', last_name='User', email='vuser@example.com',
+            is_staff=True, is_active=True, date_joined=datetime.datetime(2007, 5, 30, 13, 20, 10)
+        )
         cls.s1 = Section.objects.create(name='Test section')
         cls.a1 = Article.objects.create(
             content='<p>Middle content</p>', date=datetime.datetime(2008, 3, 18, 11, 54, 58), section=cls.s1
@@ -1314,6 +1320,10 @@ class AdminViewPermissionsTest(TestCase):
         # User who can delete Articles
         cls.deleteuser.user_permissions.add(get_perm(Article, get_permission_codename('delete', opts)))
         cls.deleteuser.user_permissions.add(get_perm(Section, get_permission_codename('delete', Section._meta)))
+
+        # User who can view Articles
+        cls.viewuser.user_permissions.add(get_perm(Article, get_permission_codename('view', opts)))
+        cls.viewuser.user_permissions.add(get_perm(Section, get_permission_codename('view', Section._meta)))
 
         # login POST dicts
         cls.index_url = reverse('admin:index')
@@ -1355,6 +1365,11 @@ class AdminViewPermissionsTest(TestCase):
         cls.joepublic_login = {
             REDIRECT_FIELD_NAME: cls.index_url,
             'username': 'joepublic',
+            'password': 'secret',
+        }
+        cls.viewuser_login = {
+            REDIRECT_FIELD_NAME: cls.index_url,
+            'username': 'viewuser',
             'password': 'secret',
         }
         cls.no_username_login = {
@@ -1431,6 +1446,24 @@ class AdminViewPermissionsTest(TestCase):
         self.assertEqual(login.status_code, 200)
         form = login.context[0].get('form')
         self.assertEqual(form.errors['username'][0], 'This field is required.')
+
+    def test_login_view_user(self):
+        """
+        Make sure that staff members with only view permission can log in.
+
+        Successful posts to the login page will redirect to the original url.
+        Unsuccessful attempts will continue to render the login page with
+        a 200 status code.
+        """
+        login_url = '%s?next=%s' % (reverse('admin:login'), reverse('admin:index'))
+
+        # View User
+        response = self.client.get(self.index_url)
+        self.assertEqual(response.status_code, 302)
+        login = self.client.post(login_url, self.viewuser_login)
+        self.assertRedirects(login, self.index_url)
+        self.assertFalse(login.context)
+        self.client.get(reverse('admin:logout'))
 
     def test_login_redirect_for_direct_get(self):
         """
@@ -1609,6 +1642,18 @@ class AdminViewPermissionsTest(TestCase):
         self.assertEqual(post.status_code, 403)
         self.client.get(reverse('admin:logout'))
 
+        # view user should be able to view the article but not change any of them
+        # (the POST can be sent, but no modification occures)
+        self.client.force_login(self.viewuser)
+        response = self.client.get(article_changelist_url)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(article_change_url)
+        self.assertEqual(response.status_code, 200)
+        post = self.client.post(article_change_url, change_dict)
+        self.assertEqual(post.status_code, 302)
+        self.assertEqual(Article.objects.get(pk=self.a1.pk).content, '<p>Middle content</p>')
+        self.client.get(reverse('admin:logout'))
+
         # change user can view all items and edit them
         self.client.force_login(self.changeuser)
         response = self.client.get(article_changelist_url)
@@ -1636,7 +1681,14 @@ class AdminViewPermissionsTest(TestCase):
         r2 = RowLevelChangePermissionModel.objects.create(id=2, name="even id")
         change_url_1 = reverse('admin:admin_views_rowlevelchangepermissionmodel_change', args=(r1.pk,))
         change_url_2 = reverse('admin:admin_views_rowlevelchangepermissionmodel_change', args=(r2.pk,))
-        for login_user in [self.superuser, self.adduser, self.changeuser, self.deleteuser]:
+        logins = [
+            self.superuser,
+            self.viewuser,
+            self.changeuser,
+            self.adduser,
+            self.deleteuser
+            ]
+        for login_user in logins:
             self.client.force_login(login_user)
             response = self.client.get(change_url_1)
             self.assertEqual(response.status_code, 403)
@@ -1716,7 +1768,12 @@ class AdminViewPermissionsTest(TestCase):
         # Test redirection when using row-level change permissions. Refs #11513.
         rl1 = RowLevelChangePermissionModel.objects.create(name="odd id")
         rl2 = RowLevelChangePermissionModel.objects.create(name="even id")
-        for login_user in [self.superuser, self.adduser, self.changeuser, self.deleteuser]:
+        logins = [self.superuser,
+                  self.viewuser,
+                  self.changeuser,
+                  self.adduser,
+                  self.deleteuser]
+        for login_user in logins:
             self.client.force_login(login_user)
             url = reverse('admin:admin_views_rowlevelchangepermissionmodel_history', args=(rl1.pk,))
             response = self.client.get(url)
@@ -1738,6 +1795,20 @@ class AdminViewPermissionsTest(TestCase):
             self.assertContains(response, 'login-form')
 
             self.client.get(reverse('admin:logout'))
+
+    def test_history_view_with_view_permission(self):
+        """
+        History view should restrict access for user with view permissions.
+
+        The user should be able to view the list of article but not change any of them.
+        """
+        login_url = '%s?next=%s' % (reverse('admin:login'), reverse('admin:index'))
+
+        self.client.get(self.index_url)
+        self.client.post(login_url, self.viewuser_login)
+        response = self.client.get(reverse('admin:admin_views_article_history', args=(self.a1.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.client.get(reverse('admin:logout'))
 
     def test_history_view_bad_url(self):
         self.client.force_login(self.changeuser)
@@ -1904,6 +1975,17 @@ class AdminViewPermissionsTest(TestCase):
         self.assertContains(response, 'admin_views')
         self.assertContains(response, 'Articles')
 
+    def test_has_module_view_permission(self):
+        """
+        Ensure that has_module_permission() returns True for all users who
+        have view permission for that module, so that
+        the module is displayed on the admin index page.
+        """
+        self.client.login(**self.viewuser_login)
+        response = self.client.get(self.index_url)
+        self.assertContains(response, 'admin_views')
+        self.assertContains(response, 'Articles')
+
     def test_overriding_has_module_permission(self):
         """
         Ensure that overriding has_module_permission() has the desired effect.
@@ -1934,6 +2016,20 @@ class AdminViewPermissionsTest(TestCase):
         response = self.client.get(index_url)
         self.assertNotContains(response, 'admin_views')
         self.assertNotContains(response, 'Articles')
+
+    def test_overriding_has_module_view_permission(self):
+        """
+        Ensure that overriding has_module_permission() has the desired effect.
+        In this case, it always returns False, so the module should not be
+        displayed on the admin index page for any users.
+        """
+        index_url = reverse('admin7:index')
+
+        self.client.login(**self.viewuser_login)
+        response = self.client.get(index_url)
+        self.assertNotContains(response, 'admin_views')
+        self.assertNotContains(response, 'Articles')
+        self.client.logout()
 
     def test_post_save_message_no_forbidden_links_visible(self):
         """
@@ -3860,6 +3956,16 @@ class AdminInlineTests(TestCase):
             first_name='Super', last_name='User', email='super@example.com',
             is_staff=True, is_active=True, date_joined=datetime.datetime(2007, 5, 30, 13, 20, 10)
         )
+        cls.permissionuser = User.objects.create(
+            password='sha1$995a3$6011485ea3834267d719b4c801409b8b1ddd0158',
+            last_login=datetime.datetime(2007, 5, 30, 13, 20, 10), is_superuser=False, username='permissionuser',
+            first_name='View', last_name='User', email='vuser@example.com',
+            is_staff=True, is_active=True, date_joined=datetime.datetime(2007, 5, 30, 13, 20, 10)
+        )
+
+        # User who can view Articles
+        cls.permissionuser.user_permissions.add(get_perm(Collector, get_permission_codename('view', Collector._meta)))
+        cls.permissionuser.user_permissions.add(get_perm(Widget, get_permission_codename('view', Widget._meta)))
 
     def setUp(self):
         self.post_data = {
@@ -3977,6 +4083,63 @@ class AdminInlineTests(TestCase):
         self.assertEqual(Widget.objects.all()[0].name, "Widget 1")
 
         # Now modify that inline
+        self.post_data['widget_set-INITIAL_FORMS'] = "1"
+        self.post_data['widget_set-0-id'] = str(widget_id)
+        self.post_data['widget_set-0-name'] = "Widget 1 Updated"
+        response = self.client.post(collector_url, self.post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Widget.objects.count(), 1)
+        self.assertEqual(Widget.objects.all()[0].name, "Widget 1 Updated")
+
+    def test_simple_inline_permissions(self):
+        "A simple model doesn't perform changes without change permissions for related object"
+        result = self.client.login(username='permissionuser', password='secret')
+        self.assertEqual(result, True)
+
+        # Without add permission, we can't add a new inline
+        self.post_data['widget_set-0-name'] = "Widget 1"
+        collector_url = reverse('admin:admin_views_collector_change', args=(self.collector.pk,))
+        response = self.client.post(collector_url, self.post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Widget.objects.count(), 0)
+
+        # But after getting the permisson, we can
+        self.permissionuser.user_permissions.add(get_perm(Widget, get_permission_codename('add', Widget._meta)))
+
+        self.post_data['widget_set-0-name'] = "Widget 1"
+        collector_url = reverse('admin:admin_views_collector_change', args=(self.collector.pk,))
+        response = self.client.post(collector_url, self.post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Widget.objects.count(), 1)
+        self.assertEqual(Widget.objects.all()[0].name, "Widget 1")
+        widget_id = Widget.objects.all()[0].id
+
+        # Check that the PK link exists on the rendered form
+        response = self.client.get(collector_url)
+        self.assertContains(response, 'name="widget_set-0-id"')
+
+        # Now resave that inline
+        self.post_data['widget_set-INITIAL_FORMS'] = "1"
+        self.post_data['widget_set-0-id'] = str(widget_id)
+        self.post_data['widget_set-0-name'] = "Widget 1"
+        response = self.client.post(collector_url, self.post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Widget.objects.count(), 1)
+        self.assertEqual(Widget.objects.all()[0].name, "Widget 1")
+
+        # Without change permissions we can send POST data, but nothing changes
+        self.post_data['widget_set-INITIAL_FORMS'] = "1"
+        self.post_data['widget_set-0-id'] = str(widget_id)
+        self.post_data['widget_set-0-name'] = "Widget 1 Updated"
+        response = self.client.post(collector_url, self.post_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Widget.objects.count(), 1)
+        self.assertEqual(Widget.objects.all()[0].name, "Widget 1")
+
+        # If we get the permissions, everything goes OK
+        self.permissionuser.user_permissions.remove(get_perm(Widget, get_permission_codename('add', Widget._meta)))
+        self.permissionuser.user_permissions.add(get_perm(Widget, get_permission_codename('change', Widget._meta)))
+
         self.post_data['widget_set-INITIAL_FORMS'] = "1"
         self.post_data['widget_set-0-id'] = str(widget_id)
         self.post_data['widget_set-0-name'] = "Widget 1 Updated"

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -691,10 +691,10 @@ class PermissionTestCase(TestCase):
         ]
         create_permissions(auth_app_config, verbosity=0)
 
-        # add/change/delete permission by default + custom permission
+        # view/add/change/delete permission by default + custom permission
         self.assertEqual(models.Permission.objects.filter(
             content_type=permission_content_type,
-        ).count(), 4)
+        ).count(), 5)
 
         models.Permission.objects.filter(content_type=permission_content_type).delete()
         models.Permission._meta.default_permissions = []

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1577,6 +1577,12 @@ class ModelAdminPermissionTests(SimpleTestCase):
                 return True
             return False
 
+    class MockViewUser(MockUser):
+        def has_perm(self, perm):
+            if perm == "modeladmin.view_band":
+                return True
+            return False
+
     class MockChangeUser(MockUser):
         def has_perm(self, perm):
             if perm == "modeladmin.change_band":
@@ -1589,6 +1595,22 @@ class ModelAdminPermissionTests(SimpleTestCase):
                 return True
             return False
 
+    def test_has_view_permission(self):
+        """
+        Ensure that has_view_permission returns True for users who can add
+        objects and False for users who can't.
+        """
+        ma = ModelAdmin(Band, AdminSite())
+        request = MockRequest()
+        request.user = self.MockViewUser()
+        self.assertTrue(ma.has_view_permission(request))
+        request.user = self.MockAddUser()
+        self.assertFalse(ma.has_view_permission(request))
+        request.user = self.MockChangeUser()
+        self.assertFalse(ma.has_view_permission(request))
+        request.user = self.MockDeleteUser()
+        self.assertFalse(ma.has_view_permission(request))
+
     def test_has_add_permission(self):
         """
         Ensure that has_add_permission returns True for users who can add
@@ -1596,6 +1618,8 @@ class ModelAdminPermissionTests(SimpleTestCase):
         """
         ma = ModelAdmin(Band, AdminSite())
         request = MockRequest()
+        request.user = self.MockViewUser()
+        self.assertFalse(ma.has_add_permission(request))
         request.user = self.MockAddUser()
         self.assertTrue(ma.has_add_permission(request))
         request.user = self.MockChangeUser()
@@ -1610,6 +1634,8 @@ class ModelAdminPermissionTests(SimpleTestCase):
         """
         ma = ModelAdmin(Band, AdminSite())
         request = MockRequest()
+        request.user = self.MockViewUser()
+        self.assertFalse(ma.has_change_permission(request))
         request.user = self.MockAddUser()
         self.assertFalse(ma.has_change_permission(request))
         request.user = self.MockChangeUser()
@@ -1624,6 +1650,8 @@ class ModelAdminPermissionTests(SimpleTestCase):
         """
         ma = ModelAdmin(Band, AdminSite())
         request = MockRequest()
+        request.user = self.MockViewUser()
+        self.assertFalse(ma.has_delete_permission(request))
         request.user = self.MockAddUser()
         self.assertFalse(ma.has_delete_permission(request))
         request.user = self.MockChangeUser()
@@ -1638,6 +1666,8 @@ class ModelAdminPermissionTests(SimpleTestCase):
         """
         ma = ModelAdmin(Band, AdminSite())
         request = MockRequest()
+        request.user = self.MockViewUser()
+        self.assertTrue(ma.has_module_permission(request))
         request.user = self.MockAddUser()
         self.assertTrue(ma.has_module_permission(request))
         request.user = self.MockChangeUser()
@@ -1648,6 +1678,8 @@ class ModelAdminPermissionTests(SimpleTestCase):
         original_app_label = ma.opts.app_label
         ma.opts.app_label = 'anotherapp'
         try:
+            request.user = self.MockViewUser()
+            self.assertFalse(ma.has_module_permission(request))
             request.user = self.MockAddUser()
             self.assertFalse(ma.has_module_permission(request))
             request.user = self.MockChangeUser()


### PR DESCRIPTION
This is implementation of ticket [8936](https://code.djangoproject.com/ticket/8936).
It adds 'view' permission to Django models options besides existing 'add', 'delete' and 'edit' permissions. It also changes the behaviour of admin if that permission is set. It completes the CRUD pattern for Django permissions.

The implementation is quite straightforward. Still, there few weak spots, that I am feeling that should be discussed with someone more experienced:
* Model situation: User has defined `ModelAdmin` with custom `has_change_permission()` such that it disallows to change (consequently also view) anything.
 * Then adding view permissions allows superuser to view that `ModelAdmin`.
 * I had to change `RowLevelChangePermissionModelAdmin` in tests for this.
* How should change `RelatedFieldWidgetWrapper`