### PR TITLE
Fixed #25296 -- Prevented related object cache pollution when create() fails due to an unsaved object.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -643,6 +643,8 @@ class Model(six.with_metaclass(ModelBase)):
                 # constraints aren't supported by the database, there's the
                 # unavoidable risk of data corruption.
                 if obj and obj.pk is None:
+                    if not field.remote_field.multiple:
+                        delattr(obj, field.remote_field.get_cache_name())
                     raise ValueError(
                         "save() prohibited to prevent data loss due to "
                         "unsaved related object '%s'." % field.name

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -135,9 +135,14 @@ class OneToOneTests(TestCase):
         should raise an exception.
         """
         place = Place(name='User', address='London')
+        with self.assertRaises(Restaurant.DoesNotExist):
+            place.restaurant
         msg = "save() prohibited to prevent data loss due to unsaved related object 'place'."
         with self.assertRaisesMessage(ValueError, msg):
             Restaurant.objects.create(place=place, serves_hot_dogs=True, serves_pizza=False)
+        # place should not cache restaurant
+        with self.assertRaises(Restaurant.DoesNotExist):
+            place.restaurant
 
     def test_reverse_relationship_cache_cascade(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25296

See behavior in `one_to_one.tests.OneToOneTests.test_unsaved_object`: because `Restaurant.objects.create` failed, `place._restaurant_cache` should not exist.

Any feedback is much appreciated!