### PR TITLE
Restricted a couple of test dependencies.

### DIFF
--- a/tests/requirements/mysql.txt
+++ b/tests/requirements/mysql.txt
@@ -1,1 +1,2 @@
-mysqlclient
+# Due to a bug that will be fixed in mysqlclient 1.3.7.
+mysqlclient <= 1.3.5

--- a/tests/requirements/py2.txt
+++ b/tests/requirements/py2.txt
@@ -1,3 +1,4 @@
 -r base.txt
-python-memcached
+# Due to https://github.com/linsomniac/python-memcached/issues/79 in newer versions.
+python-memcached <= 1.53
 mock


### PR DESCRIPTION
Since pip 7 now caches wheel files by default, I'm going to remove our own "wheelhouse" on Jenkins. This means we need to add more specific versions for packages where the latest version has a compatibility problem with the Django test suite.