### PR TITLE
Refs #17785 -- Made docstring for sqlite3's get_relations() consistent with other backends.

### DIFF
--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -100,8 +100,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
     def get_relations(self, cursor, table_name):
         """
-        Returns a dictionary of {field_index: (field_index_other_table, other_table)}
-        representing all relationships to the given table. Indexes are 0-based.
+        Returns a dictionary of {field_name: (field_name_other_table, other_table)}
+        representing all relationships to the given table.
         """
 
         # Dictionary of relations to return


### PR DESCRIPTION
This was an obsoleted comment from Django 1.7 before the `DatabaseIntrospection.get_relations` method has been changed in all backends in 1.8 (4c413e23).

The fixed comment is consistent with all other backends. I don't see any similar mistake. (I am updating a custom backend to 1.8 and these comments are useful for me.)