### PR TITLE
Fixed #25424 -- Use force_str for test client URLs.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -355,7 +355,7 @@ class RequestFactory(object):
                 content_type='application/octet-stream', secure=False,
                 **extra):
         """Constructs an arbitrary HTTP request."""
-        parsed = urlparse(path)
+        parsed = urlparse(force_str(path))
         data = force_bytes(data, settings.DEFAULT_CHARSET)
         r = {
             'PATH_INFO': self._get_path(parsed),

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -26,6 +26,7 @@ import datetime
 
 from django.contrib.auth.models import User
 from django.core import mail
+from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse
 from django.test import (
     Client, RequestFactory, SimpleTestCase, TestCase, override_settings,
@@ -622,6 +623,14 @@ class ClientTest(TestCase):
         self.assertEqual(mail.outbox[0].from_email, 'from@example.com')
         self.assertEqual(mail.outbox[0].to[0], 'first@example.com')
         self.assertEqual(mail.outbox[0].to[1], 'second@example.com')
+
+    def test_reverse_lazy_decodes(self):
+        "Use reverse_lazy works in the test client; see ticket 25424"
+        data = {'var': 'data'}
+        response = self.client.get(reverse_lazy('get_view'), data)
+
+        # Check some response details
+        self.assertContains(response, 'This is a test')
 
     def test_mass_mail_sending(self):
         "Test that mass mail is redirected to a dummy outbox during test setup"


### PR DESCRIPTION
urlparse() fails with an AttributeError ("'__proxy__' object has no
attribute 'decode'") if reverse_lazy is used to look up the URL
(this is exactly the same problem that caused ticket #18776). The
solution is to use force_str() on the path before handing it to
urlparse().