### PR TITLE
Fixed #25430 -- Fixed incorrect RunSQL examples.

### DIFF
--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -218,8 +218,8 @@ queries and parameters in the same way as :ref:`cursor.execute()
 <executing-custom-sql>`. These three operations are equivalent::
 
     migrations.RunSQL("INSERT INTO musician (name) VALUES ('Reinhardt');")
-    migrations.RunSQL(["INSERT INTO musician (name) VALUES ('Reinhardt');", None])
-    migrations.RunSQL(["INSERT INTO musician (name) VALUES (%s);", ['Reinhardt']])
+    migrations.RunSQL([("INSERT INTO musician (name) VALUES ('Reinhardt');", None)])
+    migrations.RunSQL([("INSERT INTO musician (name) VALUES (%s);", ['Reinhardt'])])
 
 If you want to include literal percent signs in the query, you have to double
 them if you are passing parameters.
@@ -228,8 +228,8 @@ The ``reverse_sql`` queries are executed when the migration is unapplied, so
 you can reverse the changes done in the forwards queries::
 
     migrations.RunSQL(
-        ["INSERT INTO musician (name) VALUES (%s);", ['Reinhardt']],
-        ["DELETE FROM musician where name=%s;", ['Reinhardt']],
+        [("INSERT INTO musician (name) VALUES (%s);", ['Reinhardt'])],
+        [("DELETE FROM musician where name=%s;", ['Reinhardt'])],
     )
 
 The ``state_operations`` argument is so you can supply operations that are


### PR DESCRIPTION
ref: https://code.djangoproject.com/ticket/25430#comment:1

The current documentation for the `RunSQL` operation (https://docs.djangoproject.com/en/dev/ref/migration-operations/#runsql) includes the following example:

```
migrations.RunSQL(["INSERT INTO musician (name) VALUES (%s);", ['Reinhardt']])
```

That doesn't actually work. The code that actually executes the replacement, in `django.db.migrations.operations.special.RunSQL._run_sql` is:

```
    def _run_sql(self, schema_editor, sqls):
        if isinstance(sqls, (list, tuple)):
            for sql in sqls:
                params = None
                if isinstance(sql, (list, tuple)):
                    elements = len(sql)
                    if elements == 2:
                        sql, params = sql
                    else:
                        raise ValueError("Expected a 2-tuple but got %d" % elements)
                schema_editor.execute(sql, params=params)
```

The provided example should instead be:

```
migrations.RunSQL([["INSERT INTO musician (name) VALUES (%s);", ['Reinhardt']]])
```