### PR TITLE
Fixed #25431 -- Removed foreign key exclusion in ModelForm._post_clean() self.instance construction.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -376,6 +376,11 @@ class BaseModelForm(BaseForm):
 
         exclude = self._get_validation_exclusions()
 
+        try:
+            self.instance = construct_instance(self, self.instance, opts.fields, exclude)
+        except ValidationError as e:
+            self._update_errors(e)
+
         # Foreign Keys being used to represent inline relationships
         # are excluded from basic field value validation. This is for two
         # reasons: firstly, the value may not be supplied (#12507; the
@@ -386,11 +391,6 @@ class BaseModelForm(BaseForm):
         for name, field in self.fields.items():
             if isinstance(field, InlineForeignKeyField):
                 exclude.append(name)
-
-        try:
-            self.instance = construct_instance(self, self.instance, opts.fields, exclude)
-        except ValidationError as e:
-            self._update_errors(e)
 
         try:
             self.instance.full_clean(exclude=exclude, validate_unique=False)

--- a/docs/releases/1.8.5.txt
+++ b/docs/releases/1.8.5.txt
@@ -43,3 +43,6 @@ Bugfixes
 * Moved the :ref:`unsaved model instance assignment data loss check
   <unsaved-model-instance-check-18>` on reverse relations to ``Model.save()``
   (:ticket:`25160`).
+
+* Readded inline foreign keys to form instances when validating model formsets
+  (:ticket:`25431`).

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -37,6 +37,10 @@ class Book(models.Model):
     def __str__(self):
         return self.title
 
+    def clean(self):
+        # Ensure author is always accessible in clean method
+        assert self.author.name is not None
+
 
 @python_2_unicode_compatible
 class BookWithCustomPK(models.Model):


### PR DESCRIPTION
Too much field exclusions in form's construct_instance() could lead to some
unexpected missing ForeignKey values. Fixes a regression from 45e049937.
Refs #13776.