### PR TITLE
Fixed #25434 -- Added missing docs for request.site

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -183,6 +183,17 @@ All attributes should be considered read-only, unless stated otherwise below.
     support activated. See the :doc:`session documentation
     </topics/http/sessions>` for full details.
 
+.. attribute:: HttpRequest.site
+
+    An object of type :class:`~django.contrib.sites.models.Site` or
+    :class:`~django.contrib.sites.requests.RequestSite` as returned by
+    :func:`~django.contrib.sites.shortcuts.get_current_site()`
+    representing the current site.
+
+    ``site`` is only available if your Django installation has the
+    :class:`~django.contrib.sites.middleware.CurrentSiteMiddleware`
+    activated. For more, see :doc:`/ref/contrib/sites`.
+
 .. attribute:: HttpRequest.urlconf
 
     Not defined by Django itself, but will be read if other code (e.g., a custom


### PR DESCRIPTION
This should also be backported to 1.7 and 1.8 with `.. versionadded:: 1.7`