### PR TITLE
Updated docstring in `urlresolvers` module

### DIFF
--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -1,10 +1,9 @@
 """
 This module converts requested URLs to callback view functions.
 
-RegexURLResolver is the main class here. Its resolve() method takes a URL (as
-a string) and returns a tuple in this format:
-
-    (view_function, function_args, function_kwargs)
+RegexURLResolver is the main class here. Its resolve() method takes
+a URL (as a string) and returns a ResolverMatch object which
+provides access to all attributes of the resolved URL match.
 """
 from __future__ import unicode_literals
 


### PR DESCRIPTION
The `resolve` method in `RegexURLResolver` no longer returns a tuple.
It has returned a `ResolverMatch` object since commit e0fb90b2.