### PR TITLE
Recommended against default_app_config.

### DIFF
--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -57,6 +57,14 @@ subclass for that application.
 If there is no ``default_app_config``, Django uses the base
 :class:`~django.apps.AppConfig` class.
 
+``default_app_config`` allows applications that predate Django 1.7 such as
+``django.contrib.admin`` to opt-in to :class:`~django.apps.AppConfig` features
+without requiring users to update their :setting:`INSTALLED_APPS`.
+
+New applications should avoid ``default_app_config``. Instead they should
+require the dotted path to the appropriate :class:`~django.apps.AppConfig`
+subclass to be configured explicitly in :setting:`INSTALLED_APPS`.
+
 For application authors
 -----------------------
 


### PR DESCRIPTION
Most likely this is a losing fight -- people seem to love this small
convention -- but at least the reasons for avoiding it will be
documented.

Refs #25356.