### PR TITLE
Fixed #25426 -- RuntimeError pickling SimpleLazyObject

### DIFF
--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 
 from django.core.files.temp import NamedTemporaryFile
-from django.db import DJANGO_VERSION_PICKLE_KEY, models
+from django.db import models
 from django.test import TestCase, mock
 from django.utils._os import npath, upath
 from django.utils.encoding import force_text
@@ -25,10 +25,8 @@ class ModelPickleTestCase(TestCase):
             title = models.CharField(max_length=10)
 
             def __reduce__(self):
-                reduce_list = super(MissingDjangoVersion, self).__reduce__()
-                data = reduce_list[-1]
-                del data[DJANGO_VERSION_PICKLE_KEY]
-                return reduce_list
+                unpickler, args, data = super(MissingDjangoVersion, self).__reduce__()
+                return unpickler, args[:-1], data
 
         p = MissingDjangoVersion(title="FooBar")
         with warnings.catch_warnings(record=True) as recorded:
@@ -46,10 +44,9 @@ class ModelPickleTestCase(TestCase):
             title = models.CharField(max_length=10)
 
             def __reduce__(self):
-                reduce_list = super(DifferentDjangoVersion, self).__reduce__()
-                data = reduce_list[-1]
-                data[DJANGO_VERSION_PICKLE_KEY] = '1.0'
-                return reduce_list
+                unpickler, args, data = super(DifferentDjangoVersion, self).__reduce__()
+                args = args[:-1] + ('1.0',)
+                return unpickler, args, data
 
         p = DifferentDjangoVersion(title="FooBar")
         with warnings.catch_warnings(record=True) as recorded:

--- a/tests/utils_tests/test_simplelazyobject.py
+++ b/tests/utils_tests/test_simplelazyobject.py
@@ -3,9 +3,15 @@ from __future__ import unicode_literals
 import pickle
 
 from django.contrib.auth.models import User
+from django.db import models
 from django.test import TestCase
 from django.utils import six
 from django.utils.functional import SimpleLazyObject
+
+
+class UserProfile(models.Model):
+    user = models.OneToOneField(User, models.CASCADE, related_name='profile')
+    dummy = models.BooleanField(default=True)
 
 
 class TestUtilsSimpleLazyObjectDjangoTestCase(TestCase):
@@ -29,3 +35,16 @@ class TestUtilsSimpleLazyObjectDjangoTestCase(TestCase):
 
             # This would fail with "TypeError: expected string or Unicode object, NoneType found".
             cPickle.dumps(x)
+
+    def test_pickle_model_instance_with_one_to_one_field(self):
+
+        # See ticket #25426
+        user = User.objects.create_user('johndoe', 'john@example.com', 'pass')
+        UserProfile.objects.create(user=user)
+
+        x = SimpleLazyObject(lambda: user)
+        x.profile  # accsss related object
+
+        # This would fail with "RuntimeError: dictionary changed size during iteration",
+        # on django 1.8 both on python3.x and 2.x
+        pickle.dumps(x)  # Fails


### PR DESCRIPTION
I worked on this patch because nobody seems interested in this issue. The patch is for saving django version info as unpickler's argument instead of setting it as model instance's attribute which results in RuntimeError. This happens on django 1.8.x with both python3.x/2.x.
please see https://code.djangoproject.com/ticket/25426 for details