### PR TITLE
Fixed #25447 -- Emphasized the need to restart dev server when adding template tags.

### DIFF
--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -25,8 +25,8 @@ don't forget the ``__init__.py`` file to ensure the directory is treated as a
 Python package. 
 
 .. note:: 
-    After adding this module, you will need to restart your server
-    before you can use the tags or filters in templates.
+    After adding the ``templatetags``  module, you will need to restart your 
+    server before you can use the tags or filters in templates.
 
 Your custom tags and filters will live in a module inside the ``templatetags``
 directory. The name of the module file is the name you'll use to load the tags

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -22,8 +22,8 @@ described below are automatically made available to load within templates.
 The app should contain a ``templatetags`` directory, at the same level as
 ``models.py``, ``views.py``, etc. If this doesn't already exist, create it -
 don't forget the ``__init__.py`` file to ensure the directory is treated as a
-Python package. After adding this module, you will need to restart your server
-before you can use the tags or filters in templates.
+Python package. **After adding this module, you will need to restart your server
+before you can use the tags or filters in templates.**
 
 Your custom tags and filters will live in a module inside the ``templatetags``
 directory. The name of the module file is the name you'll use to load the tags

--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -22,8 +22,11 @@ described below are automatically made available to load within templates.
 The app should contain a ``templatetags`` directory, at the same level as
 ``models.py``, ``views.py``, etc. If this doesn't already exist, create it -
 don't forget the ``__init__.py`` file to ensure the directory is treated as a
-Python package. **After adding this module, you will need to restart your server
-before you can use the tags or filters in templates.**
+Python package. 
+
+.. note:: 
+    After adding this module, you will need to restart your server
+    before you can use the tags or filters in templates.
 
 Your custom tags and filters will live in a module inside the ``templatetags``
 directory. The name of the module file is the name you'll use to load the tags


### PR DESCRIPTION
Right now, it is rather easy to miss the fact that adding a new template tag or filter to an app requires a restart. I made that text a note to make it harder to miss (which caused me about 15 minutes of pain earlier today).