### PR TITLE
Refs #25438 Oracle GIS test failures for Django 1.9

### DIFF
--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -182,7 +182,7 @@ class GISFunctionsTests(TestCase):
     @skipUnlessDBFeature("has_Difference_function")
     def test_difference_mixed_srid(self):
         """Testing with mixed SRID (Country has default 4326)."""
-        geom = Point(556597.4, 2632018.6, srid=3857)  # Spherical mercator
+        geom = Point(556597.4, 2632018.6, srid=3785)  # Spherical mercator
         qs = Country.objects.annotate(difference=functions.Difference('mpoly', geom))
         # For some reason SpatiaLite does something screwy with the Texas geometry here.
         if spatialite:


### PR DESCRIPTION
Changed EPSG:3857 (which is not available in Oracle ver. < 11.2.0.3) to EPSG:3785 (which should be available in all backends), tests in progress...