### PR TITLE
Fixed #25407 -- Removed network dependency in GeoIP tests.

### DIFF
--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -8,6 +8,7 @@ from unittest import skipUnless
 from django.conf import settings
 from django.contrib.gis.geoip2 import HAS_GEOIP2
 from django.contrib.gis.geos import HAS_GEOS, GEOSGeometry
+from django.test import mock
 from django.utils import six
 
 if HAS_GEOIP2:
@@ -64,8 +65,10 @@ class GeoIPTest(unittest.TestCase):
         self.assertRaises(TypeError, cntry_g.country_code, 17)
         self.assertRaises(TypeError, cntry_g.country_name, GeoIP2)
 
-    def test03_country(self):
+    @mock.patch('socket.gethostbyname')
+    def test03_country(self, gethostbyname):
         "GeoIP country querying methods."
+        gethostbyname.return_value = '128.249.1.1'
         g = GeoIP2(city='<foo>')
 
         for query in (self.fqdn, self.addr):
@@ -85,8 +88,10 @@ class GeoIPTest(unittest.TestCase):
             )
 
     @skipUnless(HAS_GEOS, "Geos is required")
-    def test04_city(self):
+    @mock.patch('socket.gethostbyname')
+    def test04_city(self, gethostbyname):
         "GeoIP city querying methods."
+        gethostbyname.return_value = '128.249.1.1'
         g = GeoIP2(country='<foo>')
 
         for query in (self.fqdn, self.addr):
@@ -121,8 +126,10 @@ class GeoIPTest(unittest.TestCase):
                 self.assertAlmostEqual(lon, tup[0], 4)
                 self.assertAlmostEqual(lat, tup[1], 4)
 
-    def test05_unicode_response(self):
+    @mock.patch('socket.gethostbyname')
+    def test05_unicode_response(self, gethostbyname):
         "GeoIP strings should be properly encoded (#16553)."
+        gethostbyname.return_value = '194.27.42.76'
         g = GeoIP2()
         d = g.city("nigde.edu.tr")
         self.assertEqual('Niğde', d['city'])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25407

This PR includes 2 commits. 

The first one is for mocking DNS resolution for `geoip2` tests. 
The second one is optional and contains same issue workaround for `geoip` tests. See trac ticket for more details. The second commit can be either thrown away upon check in or squashed. 