### PR TITLE
Fixed #25410 -- Fixed empty ClearableFileInput crash on Python 2.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -378,14 +378,6 @@ class ClearableFileInput(FileInput):
         """
         Return whether value is considered to be initial value.
         """
-        # hasattr() masks exceptions on Python 2.
-        if six.PY2:
-            try:
-                getattr(value, 'url')
-            except AttributeError:
-                return False
-            else:
-                return bool(value)
         return bool(value and hasattr(value, 'url'))
 
     def get_template_substitution_values(self, value):

--- a/tests/forms_tests/widget_tests/test_clearablefileinput.py
+++ b/tests/forms_tests/widget_tests/test_clearablefileinput.py
@@ -57,25 +57,6 @@ class ClearableFileInputTest(WidgetTest):
         self.assertIn('my&lt;div&gt;file', output)
         self.assertNotIn('my<div>file', output)
 
-    def test_html_does_not_mask_exceptions(self):
-        """
-        A ClearableFileInput should not mask exceptions produced while
-        checking that it has a value.
-        """
-        @python_2_unicode_compatible
-        class FailingURLFieldFile(object):
-            @property
-            def url(self):
-                raise RuntimeError('Canary')
-
-            def __str__(self):
-                return 'value'
-
-        widget = ClearableFileInput()
-        field = FailingURLFieldFile()
-        with self.assertRaisesMessage(RuntimeError, 'Canary'):
-            widget.render('myfile', field)
-
     def test_clear_input_renders_only_if_not_required(self):
         """
         A ClearableFileInput with is_required=False does not render a clear

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1885,6 +1885,19 @@ class FileAndImageFieldTests(TestCase):
         self.assertIn('something.txt', rendered)
         self.assertIn('myfile-clear', rendered)
 
+    def test_render_empty_file_field(self):
+        class DocumentForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = '__all__'
+
+        doc = Document.objects.create()
+        form = DocumentForm(instance=doc)
+        self.assertEqual(
+            str(form['myfile']),
+            '<input id="id_myfile" name="myfile" type="file" />'
+        )
+
     def test_file_field_data(self):
         # Test conditions when files is either not given or empty.
         f = TextFileForm(data={'description': 'Assistance'})


### PR DESCRIPTION
Reverted "Fixes #24727 -- Prevented ClearableFileInput from masking
exceptions on Python 2" and added a regression test.

This reverts commit 5c412dd8a724b263489c1bd7a2fea381460665d7.