### PR TITLE
Fixed #25457 -- Join createsuperuser validation errors with newline instead of comma

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -153,7 +153,7 @@ class Command(BaseCommand):
                     try:
                         validate_password(password2, self.UserModel(**fake_user_data))
                     except exceptions.ValidationError as err:
-                        self.stderr.write(', '.join(err.messages))
+                        self.stderr.write('\n'.join(err.messages))
                         password = None
 
             except KeyboardInterrupt:


### PR DESCRIPTION
Solution suggested by timgraham.

Sample error message after applying this patch:

~~~bash
$ ./manage.py createsuperuser
Username (leave blank to use 'uranusjr'): 
Email address: 
Password: admin
Password (again): admin
This password is too short. It must contain at least 8 characters.
This password is too common.
Password: ^C
Operation cancelled.
~~~