### PR TITLE
Fixed #25464 -- Allowed skipping IN clause on prefetch queries.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -790,8 +790,8 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
 
             queryset._add_hints(instance=instances[0])
             queryset = queryset.using(queryset._db or self._db)
-            
-            filter_on_instances:
+    
+            if filter_on_instances:
                 query = {'%s__in' % self.query_field_name: instances}
                 queryset = queryset._next_is_sticky().filter(**query)
 

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -293,7 +293,7 @@ class ReverseOneToOneDescriptor(object):
             manager = self.related.related_model._base_manager
         return manager.db_manager(hints=hints).all()
 
-    def get_prefetch_queryset(self, instances, queryset=None):
+    def get_prefetch_queryset(self, instances, queryset=None, filter_on_instances=True):
         if queryset is None:
             queryset = self.get_queryset()
         queryset._add_hints(instance=instances[0])
@@ -790,7 +790,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
 
             queryset._add_hints(instance=instances[0])
             queryset = queryset.using(queryset._db or self._db)
-    
+
             if filter_on_instances:
                 query = {'%s__in' % self.query_field_name: instances}
                 queryset = queryset._next_is_sticky().filter(**query)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1318,7 +1318,7 @@ class Prefetch(object):
         self.to_attr = to_attr
         self.filter_on_instances = filter_on_instances
         if not self.filter_on_instances and not self.queryset:
-            raise AttributeError("Must specify 'queryset' when 'filter_on_instances' is False")
+            raise ValueError("Must specify 'queryset' when 'filter_on_instances' is False")
 
     def add_prefix(self, prefix):
         self.prefetch_through = LOOKUP_SEP.join([prefix, self.prefetch_through])

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1306,7 +1306,7 @@ class RawQuerySet(object):
 
 
 class Prefetch(object):
-    def __init__(self, lookup, queryset=None, to_attr=None):
+    def __init__(self, lookup, queryset=None, to_attr=None, filter_on_instances=False):
         # `prefetch_through` is the path we traverse to perform the prefetch.
         self.prefetch_through = lookup
         # `prefetch_to` is the path to the attribute that stores the result.
@@ -1316,6 +1316,9 @@ class Prefetch(object):
 
         self.queryset = queryset
         self.to_attr = to_attr
+        self.filter_on_instances = filter_on_instances
+        if self.filter_on_instances and not self.queryset:
+            raise AttributeError("Must specify 'queryset' when 'filter_on_instances' is True")
 
     def add_prefix(self, prefix):
         self.prefetch_through = LOOKUP_SEP.join([prefix, self.prefetch_through])
@@ -1547,7 +1550,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     # in a dictionary.
 
     rel_qs, rel_obj_attr, instance_attr, single, cache_name = (
-        prefetcher.get_prefetch_queryset(instances, lookup.get_current_queryset(level)))
+        prefetcher.get_prefetch_queryset(instances, lookup.get_current_queryset(level)), lookup.filter_on_instances)
     # We have to handle the possibility that the QuerySet we just got back
     # contains some prefetch_related lookups. We don't want to trigger the
     # prefetch_related functionality by evaluating the query. Rather, we need

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1306,7 +1306,7 @@ class RawQuerySet(object):
 
 
 class Prefetch(object):
-    def __init__(self, lookup, queryset=None, to_attr=None, filter_on_instances=False):
+    def __init__(self, lookup, queryset=None, to_attr=None, filter_on_instances=True):
         # `prefetch_through` is the path we traverse to perform the prefetch.
         self.prefetch_through = lookup
         # `prefetch_to` is the path to the attribute that stores the result.
@@ -1317,8 +1317,8 @@ class Prefetch(object):
         self.queryset = queryset
         self.to_attr = to_attr
         self.filter_on_instances = filter_on_instances
-        if self.filter_on_instances and not self.queryset:
-            raise AttributeError("Must specify 'queryset' when 'filter_on_instances' is True")
+        if not self.filter_on_instances and not self.queryset:
+            raise AttributeError("Must specify 'queryset' when 'filter_on_instances' is False")
 
     def add_prefix(self, prefix):
         self.prefetch_through = LOOKUP_SEP.join([prefix, self.prefetch_through])


### PR DESCRIPTION
When using prefetch_related() on a large queryset, the prefetch query SQL can be inefficient. Consider this:

    Category.objects.filter(type=5).prefetch_related('items')

If 100.000 categories have type=5, then an IN clause with 100.000 Category IDs is generated to get the Item objects. Even with a custom queryset using a Prefetch() object, the IN clause is generated, even though it is A) redundant, B) sends a potentially multi-megabyte SQL statement over the wire for the database to process, C) may confuse the query planner to generate an inefficient execution plan, and D) doesn't scale:

    Category.objects.filter(type=5).prefetch_related(Prefetch('items', queryset=Item.objects.filter(category__item=5)))

This pull request adds the possibility to skip the IN clause in cases where we are sure that a better queryset will get (at least) the same items as the IN clause would:

    Category.objects.filter(type=5).prefetch_related(Prefetch('items', queryset=Item.objects.filter(category__item=5), filter_on_instances=False))

In my tests, this speeds up prefetch_related() by 20x-50x on large querysets.