### PR TITLE
Fixed IndexError with empty related names

### DIFF
--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -154,7 +154,7 @@ class ForeignObjectRel(object):
 
     def is_hidden(self):
         "Should the related object be hidden?"
-        return self.related_name is not None and self.related_name[-1] == '+'
+        return self.related_name is not None and len(self.related_name) > 0 self.related_name[-1] == '+'
 
     def get_joining_columns(self):
         return self.field.get_reverse_joining_columns()


### PR DESCRIPTION
Hi.
When trying to make migrations for models containing fields with empty "related_name", this line raises an IndexError. This tiny patch should fix it.