### PR TITLE
Fix help text when there are no password validators

### DIFF
--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -84,6 +84,8 @@ def password_validators_help_text_html(password_validators=None):
     """
     help_texts = password_validators_help_texts(password_validators)
     help_items = [format_html('<li>{}</li>', help_text) for help_text in help_texts]
+    if not help_items:
+        return ''
     return '<ul>%s</ul>' % ''.join(help_items)
 
 

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -68,6 +68,11 @@ class PasswordValidationTest(TestCase):
         self.assertEqual(help_text.count('<li>'), 2)
         self.assertIn('12 characters', help_text)
 
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[])
+    def test_empty_password_validator_help_text_html(self):
+        help_text = password_validators_help_text_html()
+        self.assertEqual(help_text, '')
+
 
 class MinimumLengthValidatorTest(TestCase):
     def test_validate(self):


### PR DESCRIPTION
This avoids having an empty list which is invalid HTML 4.
<http://www.w3.org/TR/html4/struct/lists.html#h-10.2>