### PR TITLE
Clarified that Model.delete() is not called as a result of a cascading delete.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -835,9 +835,11 @@ code will automatically support those arguments when they are added.
 
     Note that the :meth:`~Model.delete()` method for an object is not
     necessarily called when :ref:`deleting objects in bulk using a
-    QuerySet<topics-db-queries-delete>`. To ensure customized delete logic
-    gets executed, you can use :data:`~django.db.models.signals.pre_delete`
-    and/or :data:`~django.db.models.signals.post_delete` signals.
+    QuerySet<topics-db-queries-delete>` or as a result of a
+    :attr:`cascading delete<django.db.models.ForeignKey.on_delete>`. To ensure
+    customized delete logic gets executed, you can use
+    :data:`~django.db.models.signals.pre_delete` and/or
+    :data:`~django.db.models.signals.post_delete` signals.
 
     Unfortunately, there isn't a workaround when
     :meth:`creating<django.db.models.query.QuerySet.bulk_create>` or


### PR DESCRIPTION
Couldn't see any clarification in the docs that delete() on dependent models is not called during a cascading delete, so thought it might be good to explicitly state so.