### PR TITLE
Fixed #22938 -- Modified session expiry date to allow cleanup of file based sessions

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -71,6 +71,16 @@ class SessionStore(SessionBase):
             modification = datetime.datetime.fromtimestamp(modification)
         return modification
 
+    def _expiry_date(self, session_data):
+        """
+        Return the expiry time of the file storing the session's content.
+        """
+        expiry = session_data.get('_session_expiry')
+        if not expiry:
+            expiry = self._last_modification() + \
+                datetime.timedelta(seconds=settings.SESSION_COOKIE_AGE)
+        return expiry
+
     def load(self):
         session_data = {}
         try:
@@ -90,8 +100,7 @@ class SessionStore(SessionBase):
 
                 # Remove expired sessions.
                 expiry_age = self.get_expiry_age(
-                    modification=self._last_modification(),
-                    expiry=session_data.get('_session_expiry'))
+                    expiry=self._expiry_date(session_data))
                 if expiry_age < 0:
                     session_data = {}
                     self.delete()

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -149,7 +149,7 @@ Internationalization
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 
-* ...
+* :djadmin:`clearsessions` was fixed to remove file-based sessions.
 
 Migrations
 ^^^^^^^^^^

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -521,8 +521,10 @@ class FileSessionTests(SessionTestsMixin, unittest.TestCase):
         self.assertRaises(InvalidSessionKey,
                           self.backend()._key_to_file, "a/b/c")
 
-    @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.file",
-    SESSION_COOKIE_AGE=0)
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.file",
+        SESSION_COOKIE_AGE=0,
+    )
     def test_clearsessions_command(self):
         """
         Test clearsessions command for clearing expired sessions.
@@ -557,7 +559,7 @@ class FileSessionTests(SessionTestsMixin, unittest.TestCase):
         # Three sessions are in the filesystem before clearsessions...
         self.assertEqual(3, count_sessions())
         management.call_command('clearsessions')
-        # ... and one is deleted.
+        # ... and two are deleted.
         self.assertEqual(1, count_sessions())
 
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -274,15 +274,6 @@ class SessionTestsMixin(object):
         age = self.session.get_expiry_age(modification=modification)
         self.assertEqual(age, 10)
 
-        self.session.set_expiry(None)
-
-        date = self.session.get_expiry_date(modification=modification)
-        self.assertEqual(date, modification +
-                         timedelta(seconds=settings.SESSION_COOKIE_AGE))
-
-        age = self.session.get_expiry_age(modification=modification)
-        self.assertEqual(age, settings.SESSION_COOKIE_AGE)
-
     def test_custom_expiry_reset(self):
         self.session.set_expiry(None)
         self.session.set_expiry(10)


### PR DESCRIPTION
This PR fix https://code.djangoproject.com/ticket/22938

new test indicated:
```
======================================================================
FAIL: test_clearsessions_command (sessions_tests.tests.FileSessionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ola/DJANGO/src/django/test/utils.py", line 182, in inner
    return test_func(*args, **kwargs)
  File "/Users/ola/DJANGO/src/tests/sessions_tests/tests.py", line 503, in test_clearsessions_command
    self.assertEqual(1, count_sessions())
AssertionError: 1 != 2

----------------------------------------------------------------------
Ran 223 tests in 0.258s
```

set SESSION_ENGINE to use django.contrib.sessions.backends.file
- create few sessions, wait untill they expire (you may use set_expiry, to reduce the waiting time)
- try ```django-admin.py clearsessions``` directly to clean out expired sessions.

Files should be deleted from your temp dir.

