### PR TITLE
Fixed #25490 -- Made the logout() view send "no-cache" headers.

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -92,6 +92,7 @@ def login(request, template_name='registration/login.html',
 
 
 @deprecate_current_app
+@never_cache
 def logout(request, next_page=None,
            template_name='registration/logged_out.html',
            redirect_field_name=REDIRECT_FIELD_NAME,

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -770,6 +770,15 @@ class LogoutTest(AuthViewsTestCase):
         response = self.client.get('/logout/')
         self.assertIn('site', response.context)
 
+    def test_logout_doesnt_cache(self):
+        """
+        The logout() view should send "no-cache" headers for reasons
+        described in #25490.
+        """
+        self.login()
+        response = self.client.get('/logout/')
+        self.assertIn('no-store', response['Cache-Control'])
+
     def test_logout_with_overridden_redirect_url(self):
         # Bug 11223
         self.login()


### PR DESCRIPTION
We've recently run into a few issues with certain browsers caching the logout view when it's a redirect and thus not logging out. It appears that Safari will sometimes cache redirects, even when cookies are set, so when logout is visited a second time, it is never hit and the user is never logged out.

https://discussions.apple.com/thread/5531657

I haven't contributed before so I'll sign the CLA if it's needed, but I'm pretty sure this counts as a trivial change.