### PR TITLE
Fixed #24865 -- Added remove_stale_contenttypes management command.

### DIFF
--- a/django/contrib/contenttypes/apps.py
+++ b/django/contrib/contenttypes/apps.py
@@ -5,7 +5,7 @@ from django.db.models.signals import post_migrate, pre_migrate
 from django.utils.translation import ugettext_lazy as _
 
 from .management import (
-    inject_rename_contenttypes_operations, update_contenttypes,
+    create_contenttypes, inject_rename_contenttypes_operations,
 )
 
 
@@ -15,5 +15,5 @@ class ContentTypesConfig(AppConfig):
 
     def ready(self):
         pre_migrate.connect(inject_rename_contenttypes_operations, sender=self)
-        post_migrate.connect(update_contenttypes)
+        post_migrate.connect(create_contenttypes)
         checks.register(check_generic_foreign_keys, checks.Tags.models)

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -1,0 +1,86 @@
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+from django.db import DEFAULT_DB_ALIAS, router
+from django.db.models.deletion import Collector
+from django.utils import six
+from django.utils.six.moves import input
+
+from ...management import get_contenttypes_and_models
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput', '--no-input',
+            action='store_false', dest='interactive', default=True,
+            help='Tells Django to NOT prompt the user for input of any kind.',
+        )
+        parser.add_argument(
+            '--database', action='store', dest='database', default=DEFAULT_DB_ALIAS,
+            help='Nominates the database to use. Defaults to the "default" database.',
+        )
+
+    def handle(self, **options):
+        db = options['database']
+        interactive = options['interactive']
+        verbosity = options['verbosity']
+
+        for app_config in apps.get_app_configs():
+            content_types, app_models = get_contenttypes_and_models(app_config, db, ContentType)
+            if not app_models:
+                continue
+            to_remove = [
+                ct for (model_name, ct) in six.iteritems(content_types)
+                if model_name not in app_models
+            ]
+            # Confirm that the content type is stale before deletion.
+            using = router.db_for_write(ContentType)
+            if to_remove:
+                if interactive:
+                    ct_info = []
+                    for ct in to_remove:
+                        ct_info.append('    - Content type for %s.%s' % (ct.app_label, ct.model))
+                        collector = NoFastDeleteCollector(using=using)
+                        collector.collect([ct])
+
+                        for obj_type, objs in collector.data.items():
+                            if objs == {ct}:
+                                continue
+                            ct_info.append('    - %s %s object(s)' % (
+                                len(objs),
+                                obj_type._meta.label,
+                            ))
+                        content_type_display = '\n'.join(ct_info)
+                    self.stdout.write("""Some content types in your database are stale and can be deleted.
+Any objects that depend on these content types will also be deleted.
+The content types and dependent objects that would be deleted are:
+
+%s
+
+This list doesn't include any cascade deletions to data outside of Django's
+models (uncommon).
+
+Are you sure you want to delete these content types?
+If you're unsure, answer 'no'.\n""" % content_type_display)
+                    ok_to_delete = input("Type 'yes' to continue, or 'no' to cancel: ")
+                else:
+                    ok_to_delete = False
+
+                if ok_to_delete == 'yes':
+                    for ct in to_remove:
+                        if verbosity >= 2:
+                            self.stdout.write("Deleting stale content type '%s | %s'" % (ct.app_label, ct.model))
+                        ct.delete()
+                else:
+                    if verbosity >= 2:
+                        self.stdout.write("Stale content types remain.")
+
+
+class NoFastDeleteCollector(Collector):
+    def can_fast_delete(self, *args, **kwargs):
+        """
+        Always load related objects to display them when showing confirmation.
+        """
+        return False

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -118,10 +118,7 @@ class ContentTypeManager(models.Manager):
 
     def clear_cache(self):
         """
-        Clear out the content-type cache. This needs to happen during database
-        flushes to prevent caching of "stale" content type IDs (see
-        django.contrib.contenttypes.management.update_contenttypes for where
-        this gets called).
+        Clear out the content-type cache.
         """
         self._cache.clear()
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1456,6 +1456,28 @@ it could be useful if you have a ``ForeignKey`` in
 allow creating an instance instead of entering the primary key of an existing
 instance.
 
+``django.contrib.contenttypes``
+-------------------------------
+
+``remove_stale_contenttypes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. django-admin:: remove_stale_contenttypes
+
+.. versionadded:: 1.11
+
+This command is only available if Django's :doc:`contenttypes app
+</ref/contrib/contenttypes>` (:mod:`django.contrib.contenttypes`) is installed.
+
+Deletes stale content types (from deleted models) in your database. Any objects
+that depend on the deleted content types will also be deleted. A list of
+deleted objects will be displayed before you confirm it's okay to proceed with
+the deletion.
+
+.. django-admin-option:: --database DATABASE
+
+Specifies the database to use. Defaults to ``default``.
+
 ``django.contrib.gis``
 ----------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -104,9 +104,11 @@ Minor features
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* When stale content types are detected after the ``migrate`` command, there's
-  now a list of related objects such as ``auth.Permission``\s that will also be
-  deleted. Previously, only the content types were listed.
+* When stale content types are detected in the
+  :djadmin:`remove_stale_contenttypes` command, there's now a list of related
+  objects such as ``auth.Permission``\s that will also be deleted. Previously,
+  only the content types were listed (and this prompt was after ``migrate``
+  rather than in a separate command).
 
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -476,6 +478,10 @@ Miscellaneous
   :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified. This could
   be backwards-incompatible if you have some :ref:`template tags that aren't
   thread safe <template_tag_thread_safety>`.
+
+* The prompt for stale content type deletion no longer occurs after running the
+  ``migrate`` command. Use the new :djadmin:`remove_stale_contenttypes` command
+  instead.
 
 .. _deprecated-features-1.11:
 


### PR DESCRIPTION
The idea is that removing stale contenttypes is not so critical that it needs to happen in a post_migrate handler. Also, it allows a way to run the functionality outside the migration process which is often automated with `--noinput` causing these deletions to be skipped.

https://code.djangoproject.com/ticket/24865