### PR TITLE
Fixed the external link to the MySQL Connector/Python Django Backend documentation

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -266,7 +266,7 @@ In addition to a DB API driver, Django needs an adapter to access the database
 drivers from its ORM. Django provides an adapter for MySQLdb/mysqlclient while
 MySQL Connector/Python includes `its own`_.
 
-.. _its own: http://dev.mysql.com/doc/refman/5.6/en/connector-python-info.html
+.. _its own: http://dev.mysql.com/doc/connector-python/en/connector-python-django-backend.html
 
 MySQLdb
 ~~~~~~~


### PR DESCRIPTION
Currently, the link in the documentation is broken. This change just fixes the link. I'd like the change to be cherry-picked back as far as possible, if possible.