### PR TITLE
Fixed #25500 -- Added option --fail-level to check command.

### DIFF
--- a/django/core/checks/messages.py
+++ b/django/core/checks/messages.py
@@ -48,8 +48,8 @@ class CheckMessage(object):
         return "<%s: level=%r, msg=%r, hint=%r, obj=%r, id=%r>" % \
             (self.__class__.__name__, self.level, self.msg, self.hint, self.obj, self.id)
 
-    def is_serious(self):
-        return self.level >= ERROR
+    def is_serious(self, level=ERROR):
+        return self.level >= level
 
     def is_silenced(self):
         from django.conf import settings

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -355,7 +355,7 @@ class BaseCommand(object):
                 translation.activate(saved_locale)
 
     def check(self, app_configs=None, tags=None, display_num_errors=False,
-              include_deployment_checks=False):
+              include_deployment_checks=False, fail_level=checks.ERROR):
         """
         Uses the system check framework to validate entire Django project.
         Raises CommandError for any serious message (error or critical errors).
@@ -409,7 +409,7 @@ class BaseCommand(object):
                 len(all_issues) - visible_issue_count,
             )
 
-        if any(e.is_serious() and not e.is_silenced() for e in all_issues):
+        if any(e.is_serious(fail_level) and not e.is_silenced() for e in all_issues):
             msg = self.style.ERROR("SystemCheckError: %s" % header) + body + footer
             raise SystemCheckError(msg)
         else:

--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -20,6 +20,13 @@ class Command(BaseCommand):
             help='List available tags.')
         parser.add_argument('--deploy', action='store_true', dest='deploy',
             help='Check deployment settings.')
+        parser.add_argument(
+            '--fail-level',
+            default='ERROR',
+            choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'],
+            dest='fail_level',
+            help='Level that command exits with a non-zero status. Default is ERROR.'
+        )
 
     def handle(self, *app_labels, **options):
         include_deployment_checks = options['deploy']
@@ -49,4 +56,5 @@ class Command(BaseCommand):
             tags=tags,
             display_num_errors=True,
             include_deployment_checks=include_deployment_checks,
+            fail_level=getattr(checks, options['fail_level']),
         )

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -147,6 +147,15 @@ Or you could run it directly on a production or staging deployment to verify
 that the correct settings are in use (omitting ``--settings``). You could even
 make it part of your integration test suite.
 
+.. django-admin-option:: --fail-level
+
+.. versionadded:: 1.10
+
+Level that check command exits with a non-zero status. Default is ``ERROR``.
+
+Available levels are: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, and
+``DEBUG``.
+
 compilemessages
 ---------------
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -150,7 +150,9 @@ Internationalization
 Management Commands
 ^^^^^^^^^^^^^^^^^^^
 
-* ...
+* Added option :djadminopt:`--fail-level` to the :djadmin:`check` command. This
+  option specifies the level that check command exits with a non-zero
+  status. Default is ``ERROR``.
 
 Migrations
 ^^^^^^^^^^

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -116,7 +116,7 @@ def simple_system_check(**kwargs):
 
 def tagged_system_check(**kwargs):
     tagged_system_check.kwargs = kwargs
-    return []
+    return [checks.Warning('System Check')]
 tagged_system_check.tags = ['simpletag']
 
 
@@ -191,6 +191,11 @@ class CheckCommandTests(SimpleTestCase):
     def test_tags_deployment_check_included(self):
         call_command('check', deploy=True, tags=['deploymenttag'])
         self.assertIn('Deployment Check', sys.stderr.getvalue())
+
+    @override_system_checks([tagged_system_check])
+    def test_fail_level(self):
+        with self.assertRaises(CommandError):
+            call_command('check', fail_level='WARNING')
 
 
 def custom_error_system_check(app_configs, **kwargs):


### PR DESCRIPTION
This option specifies the level that check command exits with a
non-zero status. Default is ``ERROR``.