### PR TITLE
Fixed #25423 -- Changed error message for unknown template tag to be more helpful

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -553,13 +553,13 @@ class Parser(object):
         if parse_until:
             raise self.error(
                 token,
-                "Invalid block tag on line %d: '%s', expected %s" % (
+                "Invalid block tag on line %d: '%s', expected %s. Did you forget to register or load this tag?" % (
                     token.lineno,
                     command,
                     get_text_list(["'%s'" % p for p in parse_until]),
                 ),
             )
-        raise self.error(token, "Invalid block tag on line %d: '%s'" % (token.lineno, command))
+        raise self.error(token, "Invalid block tag on line %d: '%s'. Did you forget to register or load this tag?" % (token.lineno, command))
 
     def unclosed_block_tag(self, parse_until):
         command, token = self.command_stack.pop()

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -553,13 +553,15 @@ class Parser(object):
         if parse_until:
             raise self.error(
                 token,
-                "Invalid block tag on line %d: '%s', expected %s. Did you forget to register or load this tag?" % (
+                "Invalid block tag on line %d: '%s', expected %s. "
+                "Did you forget to register or load this tag?" % (
                     token.lineno,
                     command,
                     get_text_list(["'%s'" % p for p in parse_until]),
                 ),
             )
-        raise self.error(token, "Invalid block tag on line %d: '%s'. Did you forget to register or load this tag?" % (token.lineno, command))
+        raise self.error(token, "Invalid block tag on line %d: '%s'. "
+            "Did you forget to register or load this tag?" % (token.lineno, command))
 
     def unclosed_block_tag(self, parse_until):
         command, token = self.command_stack.pop()

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -74,7 +74,8 @@ class TemplateTests(SimpleTestCase):
 
         self.assertEqual(
             e.exception.args[0],
-            "Invalid block tag on line 1: 'endblock', expected 'elif', 'else' or 'endif'. Did you forget to register or load this tag?",
+            "Invalid block tag on line 1: 'endblock', expected 'elif', 'else'"
+            " or 'endif'. Did you forget to register or load this tag?",
         )
 
     def test_unknown_block_tag(self):
@@ -88,7 +89,8 @@ class TemplateTests(SimpleTestCase):
 
         self.assertEqual(
             e.exception.args[0],
-            "Invalid block tag on line 1: 'foobar'. Did you forget to register or load this tag?",
+            "Invalid block tag on line 1: 'foobar'. Did you forget to register"
+            " or load this tag?",
         )
 
     def test_compile_filter_expression_error(self):

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -74,7 +74,21 @@ class TemplateTests(SimpleTestCase):
 
         self.assertEqual(
             e.exception.args[0],
-            "Invalid block tag on line 1: 'endblock', expected 'elif', 'else' or 'endif'",
+            "Invalid block tag on line 1: 'endblock', expected 'elif', 'else' or 'endif'. Did you forget to register or load this tag?",
+        )
+
+    def test_unknown_block_tag(self):
+        """
+        #25423 -- Using custom tag without {% load %} result in confusing traceback.
+        """
+        engine = Engine()
+
+        with self.assertRaises(TemplateSyntaxError) as e:
+            engine.from_string("lala{% foobar %}")
+
+        self.assertEqual(
+            e.exception.args[0],
+            "Invalid block tag on line 1: 'foobar'. Did you forget to register or load this tag?",
         )
 
     def test_compile_filter_expression_error(self):


### PR DESCRIPTION
Adds "Did you forget to register or load this tag" to the template parser's invalid block tag error message as suggested in https://code.djangoproject.com/ticket/25423