### PR TITLE
Refs #12118 -- Allowed "mode=memory" in test database names for sqlite

### DIFF
--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -11,14 +11,16 @@ class DatabaseCreation(BaseDatabaseCreation):
 
     def _get_test_db_name(self):
         test_database_name = self.connection.settings_dict['TEST']['NAME']
+        can_share_in_memory_db = self.connection.features.can_share_in_memory_db
         if test_database_name and test_database_name != ':memory:':
-            if 'mode=memory' in test_database_name:
+            if 'mode=memory' in test_database_name and not can_share_in_memory_db:
                 raise ImproperlyConfigured(
-                    "Using `mode=memory` parameter in the database name is not allowed, "
+                    "Using shared memory db with `mode=memory` parameter in the "
+                    "database name is not supported in your environment, "
                     "use `:memory:` instead."
                 )
             return test_database_name
-        if self.connection.features.can_share_in_memory_db:
+        if can_share_in_memory_db:
             return 'file:memorydb_%s?mode=memory&cache=shared' % self.connection.alias
         return ':memory:'
 

--- a/docs/releases/1.8.6.txt
+++ b/docs/releases/1.8.6.txt
@@ -9,4 +9,4 @@ Django 1.8.6 fixes several bugs in 1.8.5.
 Bugfixes
 ========
 
-* ...
+* Allowed "mode=memory" in test database names for sqlite (:ticket:`12118`).

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -728,6 +728,7 @@ spatialite
 Springmeyer
 SQL
 sqlflush
+sqlite
 sqlmigrate
 sqlsequencereset
 squashmigrations


### PR DESCRIPTION
Let user specify in memory database names.

Removed restriction added in 8c99b7920e8187f98cf4d7dbd9918bd6c6da1238.