### PR TITLE
Fixed #25506 -- Allowed filtering over a RawSQL annotation

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -151,7 +151,7 @@ class BuiltinLookup(Lookup):
         lhs_sql = connection.ops.field_cast_sql(
             db_type, field_internal_type) % lhs_sql
         lhs_sql = connection.ops.lookup_cast(self.lookup_name, field_internal_type) % lhs_sql
-        return lhs_sql, params
+        return lhs_sql, list(params)
 
     def as_sql(self, compiler, connection):
         lhs_sql, params = self.process_lhs(compiler, connection)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -57,6 +57,13 @@ class BasicExpressionsTests(TestCase):
         )
         self.assertEqual(companies['result'], 2395)
 
+    def test_annotate_values_filter(self):
+        companies = Company.objects.annotate(
+            foo=RawSQL('%s', ['value']),
+        ).filter(foo='value')
+
+        assert set(companies) == set(Company.objects.all())
+
     def test_filter_inter_attribute(self):
         # We can filter on attribute relationships on same model obj, e.g.
         # find companies where the number of employees is greater


### PR DESCRIPTION
This generates an error when you want to `annotate(x=RawSQL()).filter(x=...)`.

It looks like a release blocker as well.

Thanks,