### PR TITLE
Fixed #25510 -- Allowed runserver to start with incorrect INSTALLED_APPS.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
-import collections
 import os
 import pkgutil
 import sys
+from collections import OrderedDict, defaultdict
 from importlib import import_module
 
 import django
@@ -142,7 +142,7 @@ class ManagementUtility(object):
                 "",
                 "Available subcommands:",
             ]
-            commands_dict = collections.defaultdict(lambda: [])
+            commands_dict = defaultdict(lambda: [])
             for name, app in six.iteritems(get_commands()):
                 if app == 'django.core':
                     app = 'django'
@@ -312,8 +312,11 @@ class ManagementUtility(object):
                     autoreload.check_errors(django.setup)()
                 except Exception:
                     # The exception will be raised later in the child process
-                    # started by the autoreloader.
-                    pass
+                    # started by the autoreloader. Pretend it didn't happen by
+                    # loading an empty list of applications.
+                    apps.all_models = defaultdict(OrderedDict)
+                    apps.app_configs = OrderedDict()
+                    apps.apps_ready = apps.models_ready = apps.ready = True
 
             # In all other cases, django.setup() is required to succeed.
             else:

--- a/docs/releases/1.8.6.txt
+++ b/docs/releases/1.8.6.txt
@@ -25,3 +25,7 @@ Bugfixes
 * Allowed filtering over a ``RawSQL`` annotation (:ticket:`25506`).
 
 * Made the ``Concat`` database function idempotent on SQLite (:ticket:`25517`).
+
+* Avoided a confusing stack trace when starting :djadmin:`runserver` with an
+  invalid :setting:`INSTALLED_APPS` setting (:ticket:`25510`). This regression
+  appeared in 1.8.5 as a side effect of fixing :ticket:`24704`.


### PR DESCRIPTION
In that case, the content of INSTALLED_APPS will be ignored until it's
fixed and the autoreloader kicks in. I confirmed this behavior manually.
As explained on the ticket it's hard to write a test for this case.