### PR TITLE
Fixed #24976 - Issue with missing label for inline admin formset.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -265,7 +265,15 @@ class InlineAdminFormSet(object):
                     'help_text': help_text_for_field(field_name, self.opts.model),
                 }
             else:
-                yield self.formset.form.base_fields[field_name]
+                form_field = self.formset.form.base_fields[field_name]
+                label = form_field.label
+                if label is None:
+                    label = label_for_field(field_name, self.opts.model, self.opts)
+                yield {
+                    'label': label,
+                    'widget': form_field.widget,
+                    'required': form_field.required,
+                    'help_text': form_field.help_text}
 
     def _media(self):
         media = self.opts.media + self.formset.media

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -72,6 +72,7 @@ class InnerInline3(admin.StackedInline):
 
 
 class TitleForm(forms.ModelForm):
+    title1 = forms.CharField(max_length=100)
 
     def clean(self):
         cleaned_data = self.cleaned_data

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -97,6 +97,13 @@ class TestInline(TestDataMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(Fashionista.objects.filter(person__firstname='Imelda')), 1)
 
+    def test_custom_form_tabular_inline_label(self):
+        """Bug #24976."""
+        response = self.client.get(
+            reverse('admin:admin_inlines_titlecollection_add'))
+        self.assertContains(
+            response, '<th colspan="2" class="required">Title1</th>', html=True)
+
     def test_tabular_non_field_errors(self):
         """
         Ensure that non_field_errors are displayed correctly, including the


### PR DESCRIPTION
Updated InlineAdminFormSet to use the value of label_for_field as label
for fields when the field itself does not define a label.

https://code.djangoproject.com/ticket/24976