### PR TITLE
Refs #25520 -- Tests for IntegrityErrors deleting M2M to proxy models

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -57,6 +57,7 @@ def get_candidate_relations_to_delete(opts):
     # relations coming from proxy models.
     candidate_models = {opts}
     candidate_models = candidate_models.union(opts.concrete_model._meta.proxied_children)
+    candidate_models = candidate_models.union([model._meta for model in opts.get_proxy_parent_list()])
     # For each model, get all candidate fields.
     candidate_model_fields = chain.from_iterable(
         opts.get_fields(include_hidden=True) for opts in candidate_models

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -524,6 +524,21 @@ class Options(object):
                 result.add(ancestor)
         return list(result)
 
+    def get_proxy_parent_list(self):
+        """
+        Returns all the proxy model ancestors of this model as a list.
+        Useful to combine with `get_parent_list` to get all ancestors, concrete
+        and proxy, that could define behaviour or be involved in relationships.
+        """
+        result = OrderedSet()
+        for parent in self.get_parent_list():
+            for proxy_model_opts in parent._meta.proxied_children:
+                # Ignore proxy that is myself, or proxy that isn't an ancestor
+                if self != proxy_model_opts \
+                        and issubclass(self.model, proxy_model_opts.model):
+                    result.add(proxy_model_opts.model)
+        return list(result)
+
     def get_ancestor_link(self, ancestor):
         """
         Returns the field on the current model which points to the given

--- a/tests/delete_regress/models.py
+++ b/tests/delete_regress/models.py
@@ -139,3 +139,30 @@ class OrderedPerson(models.Model):
 
     class Meta:
         ordering = ['name']
+
+
+# Models for #23076
+
+
+class ConcretePhoto(Photo):
+    pass
+
+
+class M2MtoFile(models.Model):
+    # M2M to concrete proxy base
+    my_files = models.ManyToManyField(File)
+
+
+class M2MtoImage(M2MtoFile):
+    # M2M to proxy
+    my_images = models.ManyToManyField(Image)
+
+
+class M2MtoPhoto(M2MtoImage):
+    # M2M to proxy of proxy
+    my_photos = models.ManyToManyField(Photo)
+
+
+class M2MtoConcretePhoto(M2MtoPhoto):
+    # M2M to concrete proxy child
+    my_concrete_photos = models.ManyToManyField(ConcretePhoto)

--- a/tests/delete_regress/models.py
+++ b/tests/delete_regress/models.py
@@ -141,7 +141,7 @@ class OrderedPerson(models.Model):
         ordering = ['name']
 
 
-# Models for #23076
+# Models for #25520
 
 
 class ConcretePhoto(Photo):

--- a/tests/delete_regress/tests.py
+++ b/tests/delete_regress/tests.py
@@ -265,7 +265,7 @@ class ProxyDeleteM2MRelationshipsTest(TransactionTestCase):
         foreign key constraint "FKConstraint" on table "M2MThroughTable"
         DETAIL:  Key (id)=(6) is still referenced from table "M2MThroughTable".
 
-    See Django issue #23076.
+    See Django issues #23076 and #25520.
     """
 
     available_apps = ['delete_regress']
@@ -273,12 +273,6 @@ class ProxyDeleteM2MRelationshipsTest(TransactionTestCase):
     def setUp(self):
         self.concrete_photo = ConcretePhoto.objects.create()
         self.m2m_source = M2MtoConcretePhoto.objects.create()
-
-    def test_delete_with_m2m_to_concrete_base(self):
-        self.m2m_source.my_files.add(self.concrete_photo)
-
-        self.concrete_photo.delete()
-        self.assertEqual(len(self.m2m_source.my_files.all()), 0)
 
     def test_delete_with_m2m_to_proxy(self):
         self.m2m_source.my_images.add(self.concrete_photo)
@@ -291,12 +285,6 @@ class ProxyDeleteM2MRelationshipsTest(TransactionTestCase):
 
         self.concrete_photo.delete()
         self.assertEqual(len(self.m2m_source.my_photos.all()), 0)
-
-    def test_delete_with_m2m_to_concrete_proxy_child(self):
-        self.m2m_source.my_concrete_photos.add(self.concrete_photo)
-
-        self.concrete_photo.delete()
-        self.assertEqual(len(self.m2m_source.my_concrete_photos.all()), 0)
 
 
 class Ticket19102Tests(TestCase):

--- a/tests/model_meta/models.py
+++ b/tests/model_meta/models.py
@@ -139,3 +139,39 @@ class SecondParent(CommonAncestor):
 
 class Child(FirstParent, SecondParent):
     pass
+
+
+# ProxyParentListTests
+
+
+class CommonProxyAncestor(models.Model):
+    pass
+
+
+class FirstProxy(CommonProxyAncestor):
+    class Meta:
+        proxy = True
+
+
+class SecondProxy(FirstProxy):
+    class Meta:
+        proxy = True
+
+
+# This proxy model is not ancestor of any models below
+class SiblingProxy(FirstProxy):
+    class Meta:
+        proxy = True
+
+
+class FirstConcreteProxyChild(SecondProxy):
+    pass
+
+
+class ThirdProxy(FirstConcreteProxyChild):
+    class Meta:
+        proxy = True
+
+
+class SecondConcreteProxyChild(ThirdProxy):
+    pass

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -9,7 +9,9 @@ from django.test import SimpleTestCase
 
 from .models import (
     AbstractPerson, BasePerson, Child, CommonAncestor, FirstParent, Person,
-    ProxyPerson, Relating, Relation, SecondParent,
+    ProxyPerson, Relating, Relation, SecondParent, CommonProxyAncestor,
+    FirstProxy, SecondProxy, SiblingProxy, FirstConcreteProxyChild, ThirdProxy,
+    SecondConcreteProxyChild,
 )
 from .results import TEST_RESULTS
 
@@ -265,3 +267,14 @@ class ParentListTests(SimpleTestCase):
         self.assertEqual(FirstParent._meta.get_parent_list(), [CommonAncestor])
         self.assertEqual(SecondParent._meta.get_parent_list(), [CommonAncestor])
         self.assertEqual(Child._meta.get_parent_list(), [FirstParent, SecondParent, CommonAncestor])
+
+
+class ProxyParentListTests(SimpleTestCase):
+    def test_get_proxy_parent_list(self):
+        self.assertEqual(CommonProxyAncestor._meta.get_proxy_parent_list(), [])
+        self.assertEqual(FirstProxy._meta.get_proxy_parent_list(), [])
+        self.assertEqual(SecondProxy._meta.get_proxy_parent_list(), [FirstProxy])
+        self.assertEqual(SiblingProxy._meta.get_proxy_parent_list(), [FirstProxy])
+        self.assertEqual(FirstConcreteProxyChild._meta.get_proxy_parent_list(), [FirstProxy, SecondProxy])
+        self.assertEqual(ThirdProxy._meta.get_proxy_parent_list(), [FirstProxy, SecondProxy])
+        self.assertEqual(SecondConcreteProxyChild._meta.get_proxy_parent_list(), [ThirdProxy, FirstProxy, SecondProxy])


### PR DESCRIPTION
Add unit tests that demonstrate the error condition where deleting a
proxy-based object fails if that object has reverse M2M relationships
to a proxy ancestor, using a database that enforces foreign key
integrity constraints (e.g. PostgreSQL, not SQLite)

The root cause is Django does not find/include reverse M2M relationships
to proxy models when collecting objects for deletion via
`get_deleted_objects` etc, these relationships are only included if they
target concrete parent models.

In the new tests:
- two of the four tests pass, because the M2M relationship targets a
  concrete model
- the other two tests fail with integrity errors, because the M2M rel
  targets a proxy model.