### PR TITLE
Fixed #22705 -- Fixed QuerySet.bulk_create() on models without any fieds for Oracle.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -267,6 +267,9 @@ WHEN (new.%(col_name)s IS NULL)
     def max_name_length(self):
         return 30
 
+    def pk_default_value(self):
+        return "NULL"
+
     def prep_for_iexact_query(self, x):
         return x
 

--- a/tests/bulk_create/models.py
+++ b/tests/bulk_create/models.py
@@ -47,3 +47,7 @@ class State(models.Model):
 class TwoFields(models.Model):
     f1 = models.IntegerField(unique=True)
     f2 = models.IntegerField(unique=True)
+
+
+class NoFields(models.Model):
+    pass

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -10,8 +10,8 @@ from django.test import (
 )
 
 from .models import (
-    Country, Pizzeria, ProxyCountry, ProxyMultiCountry, ProxyMultiProxyCountry,
-    ProxyProxyCountry, Restaurant, State, TwoFields,
+    Country, NoFields, Pizzeria, ProxyCountry, ProxyMultiCountry,
+    ProxyMultiProxyCountry, ProxyProxyCountry, Restaurant, State, TwoFields,
 )
 
 
@@ -176,6 +176,10 @@ class BulkCreateTests(TestCase):
         TwoFields.objects.all().delete()
         TwoFields.objects.bulk_create(objs, len(objs))
         self.assertEqual(TwoFields.objects.count(), len(objs))
+
+    def test_empty_model(self):
+        NoFields.objects.bulk_create([NoFields() for i in range(2)])
+        self.assertEqual(NoFields.objects.count(), 2)
 
     @skipUnlessDBFeature('has_bulk_insert')
     def test_explicit_batch_size_efficiency(self):


### PR DESCRIPTION
Fixed on other backends by 134ca4d.

https://code.djangoproject.com/ticket/22705