### PR TITLE
Fixed #25533 -- Changed dataypes mappings for GDALRasters

### DIFF
--- a/django/contrib/gis/gdal/raster/const.py
+++ b/django/contrib/gis/gdal/raster/const.py
@@ -2,7 +2,7 @@
 GDAL - Constant definitions
 """
 from ctypes import (
-    c_byte, c_double, c_float, c_int16, c_int32, c_uint16, c_uint32,
+    c_double, c_float, c_int16, c_int32, c_ubyte, c_uint16, c_uint32,
 )
 
 # See http://www.gdal.org/gdal_8h.html#a22e22ce0a55036a96f652765793fb7a4
@@ -29,7 +29,7 @@ GDAL_INTEGER_TYPES = [1, 2, 3, 4, 5]
 # or to hold the space for data to be read into. The lookup below helps
 # selecting the right ctypes object for a given gdal pixel type.
 GDAL_TO_CTYPES = [
-    None, c_byte, c_uint16, c_int16, c_uint32, c_int32,
+    None, c_ubyte, c_uint16, c_int16, c_uint32, c_int32,
     c_float, c_double, None, None, None, None
 ]
 

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -121,6 +121,27 @@ class GDALRasterTests(unittest.TestCase):
         self.assertEqual(len(self.rs.bands), 1)
         self.assertIsInstance(self.rs.bands[0], GDALBand)
 
+    def test_memory_based_raster_creation(self):
+        # Create uint8 raster with full pixel data range (0-255)
+        rast = GDALRaster({
+            'datatype': 1,
+            'width': 16,
+            'height': 16,
+            'srid': 4326,
+            'bands': [{
+                'data': range(256),
+                'nodata_value': 255,
+            }],
+        })
+
+        # Get array from raster
+        result = rast.bands[0].data()
+        if numpy:
+            result = result.flatten().tolist()
+
+        # Assert data is same as original input
+        self.assertEqual(result, list(range(256)))
+
     def test_file_based_raster_creation(self):
         # Prepare tempfile
         rstfile = tempfile.NamedTemporaryFile(suffix='.tif')


### PR DESCRIPTION
Changed datatype mapping in ``contrib.gis.gdal.raster.const.GDAL_TO_CTYPES`` and added corresponding regression test.