### PR TITLE
Fixed #25346 -- Allowed collectstatic to delete broken symlinks.

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -218,7 +218,12 @@ class Command(BaseCommand):
                          smart_text(fpath), level=1)
             else:
                 self.log("Deleting '%s'" % smart_text(fpath), level=1)
-                self.storage.delete(fpath)
+                full_path = self.storage.path(fpath)
+                if not os.path.exists(full_path) and os.path.lexists(full_path):
+                    # Delete if the file is a broken symlink
+                    os.unlink(full_path)
+                else:
+                    self.storage.delete(fpath)
         for d in dirs:
             self.clear_dir(os.path.join(path, d))
 

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -323,8 +323,8 @@ class TestCollectionLinks(CollectionTestCase, TestDefaults):
     the standard file resolving tests here, to make sure using
     ``--link`` does not change the file-selection semantics.
     """
-    def run_collectstatic(self):
-        super(TestCollectionLinks, self).run_collectstatic(link=True)
+    def run_collectstatic(self, clear=False):
+        super(TestCollectionLinks, self).run_collectstatic(link=True, clear=clear)
 
     def test_links_created(self):
         """
@@ -340,3 +340,13 @@ class TestCollectionLinks(CollectionTestCase, TestDefaults):
         os.unlink(path)
         self.run_collectstatic()
         self.assertTrue(os.path.islink(path))
+
+    def test_clear_broken_symlink(self):
+        """
+        With ``--clear``, broken symbolic links are deleted.
+        """
+        not_exists_file_path = os.path.join(settings.STATIC_ROOT, 'not_exists.txt')
+        broken_symlink_path = os.path.join(settings.STATIC_ROOT, 'symlink.txt')
+        os.symlink(not_exists_file_path, broken_symlink_path)
+        self.run_collectstatic(clear=True)
+        self.assertFalse(os.path.lexists(broken_symlink_path))


### PR DESCRIPTION
Fixed the bug that `manage.py collectstatic --clear` does not delete broken symlinks.

https://code.djangoproject.com/ticket/25346

`FileSystemStorage.delete` [checks if file exists](https://github.com/django/django/blob/1bbca7961cee20c4ddd453a7d74d316e84f4bbb5/django/core/files/storage.py#L286-L291) before removing file the file.
However, [`os.path.exists`](https://docs.python.org/3/library/os.path.html#os.path.exists) used in `FileSystemStorage.delete` returns `False` for broken symlinks.
[`os.path.lexists`](https://docs.python.org/3/library/os.path.html#os.path.lexists) returns `True` for broken symlinks, so we should use this.

Perhaps I should have changed `FileSystemStorage.delete` to use `os.path.lexists`. I avoided to change `FileSystemStorage.delete`, because changing `FileSystemStorage` has a wide influence.