### PR TITLE
Fixed #25519 -- Added support for SCRIPT_NAME for admin view site

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -306,11 +306,14 @@ class AdminSite(object):
         """
         Returns a dictionary of variables to put in the template context for
         *every* page in the admin site.
+        If request has SCRIPT_NAME set, then use SCRIPT_NAME as site_url for view site
         """
+        script_name = request.META['SCRIPT_NAME']
+        site_url = script_name if self.site_url == '/' and script_name else self.site_url
         return {
             'site_title': self.site_title,
             'site_header': self.site_header,
-            'site_url': self.site_url,
+            'site_url': site_url,
             'has_permission': self.has_permission(request),
             'available_apps': self.get_app_list(request),
         }

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2511,7 +2511,8 @@ Templates can override or extend base admin templates as described in
 .. attribute:: AdminSite.site_url
 
     The URL for the "View site" link at the top of each admin page. By default,
-    ``site_url`` is ``/``. Set it to ``None`` to remove the link.
+    ``site_url`` is ``SCRIPT_NAME`` if ``SCRIPT_NAME`` is set otherwise it is
+    ``/``. Set it to ``None`` to remove the link.
 
 .. attribute:: AdminSite.index_title
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -32,7 +32,8 @@ Minor features
 :mod:`django.contrib.admin`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ...
+* The URL for the ``View site`` link on the top of each admin page will now point
+  to ``SCRIPT_NAME`` if ``SCRIPT_NAME`` is set instead of default ``/``.
 
 :mod:`django.contrib.admindocs`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/admin_views/test_adminsite.py
+++ b/tests/admin_views/test_adminsite.py
@@ -51,6 +51,13 @@ class SiteEachContextTest(TestCase):
         self.assertEqual(ctx['site_url'], '/')
         self.assertEqual(ctx['has_permission'], True)
 
+    def test_each_context_site_url_with_script_name(self):
+        factory = RequestFactory()
+        request = factory.get(reverse('test_adminsite:index'), SCRIPT_NAME='/my-script-name/')
+        request.user = self.u1
+        ctx = site.each_context(request)
+        self.assertEqual(ctx['site_url'], '/my-script-name/')
+
     def test_available_apps(self):
         ctx = self.ctx
         apps = ctx['available_apps']


### PR DESCRIPTION
Used request.META['SCRIPT_NAME'] to determine if SCRIPT_NAME is set.
If it is indeed there and site_url is '/' then used this as site_url