### PR TITLE
Fixed #25556 - added DatePart and DateTimePart expressions

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -892,6 +892,22 @@ class Date(Expression):
         return value
 
 
+class DatePart(Date):
+    """
+    Add a partial date selection column.
+
+    Enables construction of complex date queries
+    involving date fields with lookup types of:
+    'year', 'month', 'day'. E.g.:
+
+    `MyModel.objects.filter(date1__month=DatePart('date2', 'month')`
+    """
+    def as_sql(self, compiler, connection):
+        sql, params = self.col.as_sql(compiler, connection)
+        assert not(params)
+        return connection.ops.date_extract_sql(self.lookup_type, sql), []
+
+
 class DateTime(Expression):
     """
     Add a datetime selection column.
@@ -948,6 +964,22 @@ class DateTime(Expression):
             value = value.replace(tzinfo=None)
             value = timezone.make_aware(value, self.tzinfo)
         return value
+
+
+class DateTimePart(DateTime):
+    """
+    Add a partial datetime selection column.
+
+    Enables construction of complex date queries
+    involving datetime fields with lookup types of:
+    'year', 'month', 'day'. E.g.:
+
+    `MyModel.objects.filter(date1__month=DatePart('date2', 'month')`
+    """
+    def as_sql(self, compiler, connection):
+        sql, params = self.col.as_sql(compiler, connection)
+        assert not(params)
+        return connection.ops.datetime_extract_sql(self.lookup_type, sql, self.tzname)
 
 
 class OrderBy(BaseExpression):


### PR DESCRIPTION
This PR addresses the lacking functionality of: QuerySet filtering by matching the year/month/day part of two separate date fields.

The PR adds DatePart and DateTimePart db lookup expressions (to `django.db.models.expressions`),
enabling complex lookups on certain lookup elements of Date(Time) fields. Namely: year, month, day.

Makes the following query possible:

`MyModel.objects.filter(date1__month=DatePart('date2', 'month'))`

which returns only objects where date1 and date2 fields have the same month.