### PR TITLE
Fix #25558-  Non-deterministic test failure on Windows

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -99,7 +99,7 @@ class SessionStore(SessionBase):
 
                 # Remove expired sessions.
                 expiry_age = self.get_expiry_age(expiry=self._expiry_date(session_data))
-                if expiry_age < 0:
+                if expiry_age <= 0:
                     session_data = {}
                     self.delete()
                     self.create()


### PR DESCRIPTION
test_clearsessions_command

This test creates three sessions in the file backend.
One with expiration in the past, one with expiration in the future, and one
that has no expiration. However the session cookie age is set to zero, so the
session with no age should already be expired when the sessions are cleared.

On windows we were consistently getting into the situation where the time
to expire was coming back as zero due to timing issues. The check was making
sure that the expiration was less than zero. Thus keeping the session stored
in the backend, and failing the test.

Fix seems to be to check if the expiration age of the session is less than or
equal to zero instead, since it would seem that a session with a time of zero
until it expires is theoretically already expired.