### PR TITLE
[1.8.x] Fixed #23372 -- Improved test suite execution time on MSSQL.

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -253,8 +253,14 @@ class Command(BaseCommand):
                     "and cannot be listed in settings.FIXTURE_DIRS." % (app_dir, app_label)
                 )
 
-            if self.app_label and app_label != self.app_label:
-                continue
+            if self.app_label:
+                # Passing app_label as a set is a temporary hack for Django 1.8
+                # to speedup Django's test suite on django-mssql.
+                if isinstance(self.app_label, set):
+                    if app_label not in self.app_label:
+                        continue
+                elif app_label != self.app_label:
+                    continue
             if os.path.isdir(app_dir):
                 dirs.append(app_dir)
         dirs.extend(list(fixture_dirs))

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import itertools
+import os
 import time
 import traceback
 import warnings
@@ -358,6 +359,11 @@ class Command(BaseCommand):
 
         # Load initial_data fixtures (unless that has been disabled)
         if self.load_initial_data:
+            # Passing app_label as a set is a temporary hack for Django 1.8
+            # to speedup Django's test suite on django-mssql.
+            if os.environ.get('BULK_LOAD_INITIAL_DATA'):
+                app_labels = [app_labels]
+
             for app_label in app_labels:
                 call_command(
                     'loaddata', 'initial_data', verbosity=self.verbosity,


### PR DESCRIPTION
Executing loaddata for each app in Django's test suite is very
expensive on MSSQL due to the re-enabling of constraint checks
that happen each time, even if no fixtures need to be loaded.

django-mssql should set os.environ['BULK_LOAD_INITIAL_DATA'] = 1
for its test suite. This improves the speed by ~20% (2.5 hours).

https://code.djangoproject.com/ticket/23372