### PR TITLE
#25367 passing lookup instances to filter method

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -11,20 +11,20 @@ from django.conf import settings
 from django.core import exceptions
 from django.db import (
     DJANGO_VERSION_PICKLE_KEY, IntegrityError, connections, router,
-    transaction,
-)
+    transaction)
 from django.db.models import sql
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.deletion import Collector
 from django.db.models.expressions import F, Date, DateTime
 from django.db.models.fields import AutoField
 from django.db.models.query_utils import (
-    Q, InvalidQuery, check_rel_lookup_compatibility, deferred_class_factory,
-)
+    Q, InvalidQuery, check_rel_lookup_compatibility, deferred_class_factory)
 from django.db.models.sql.constants import CURSOR
 from django.utils import six, timezone
 from django.utils.functional import partition
 from django.utils.version import get_version
+
+
 
 # The maximum number of items to display in a QuerySet.__repr__
 REPR_OUTPUT_SIZE = 20
@@ -1708,3 +1708,5 @@ def get_related_populators(klass_info, select, db):
         rel_cls = RelatedPopulator(rel_klass_info, select, db)
         iterators.append(rel_cls)
     return iterators
+
+

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -16,9 +16,12 @@ from django.db.backends import utils
 from django.db.models.constants import LOOKUP_SEP
 from django.utils import tree
 
+
+
 # PathInfo is used when converting lookups (fk__somecol). The contents
 # describe the relation in Model terms (model Options and Fields for both
 # sides of the relation. The join_field is the field backing the relation.
+
 PathInfo = namedtuple('PathInfo', 'from_opts to_opts target_fields join_field m2m direct')
 
 

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -18,7 +18,7 @@ from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Col, Ref
 from django.db.models.fields.related_lookups import MultiColSource
-from django.db.models.lookups import IsNull
+from django.db.models.lookups import IsNull, Lookup
 from django.db.models.query_utils import Q, PathInfo, check_rel_lookup_compatibility, \
     refs_expression
 from django.db.models.sql.constants import (
@@ -1066,7 +1066,10 @@ class Query(object):
                                        allow_joins, split_subq)
 
     def add_filter(self, filter_clause):
-        self.add_q(Q(**{filter_clause[0]: filter_clause[1]}))
+        if isinstance(filter_clause, Lookup):
+            self.add_q(Q(filter_clause))
+        else:
+            self.add_q(Q(**{filter_clause[0]: filter_clause[1]}))
 
     def add_q(self, q_object):
         """
@@ -1988,7 +1991,6 @@ class QueryKeywordLookupHelper(object):
         used_joins = set(used_joins).union(set(join_list))
         targets, alias, join_list = self.query.trim_joins(sources, join_list,
                                                           path)
-
         if field.is_relation:
             # No support for transforms for relational fields
             assert len(lookup_parts) == 1

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -778,8 +778,23 @@ class ObjectLookupTests(LookupTests):
 
     def test_lookup_exclude(self):
         lookup = lookups.LessThanOrEqual(F('id'), Value(5))
-        queryset = Article.objects.all().exclude(lookup)
+        queryset = Article.objects.exclude(lookup)
         self.assertQuerysetEqual(queryset, ['<Article: Article 6>',  '<Article: Article 7>'])
+
+    def test_lookup_exclude2(self):
+        season_2009 = Season.objects.create(year=2009, gt=111)
+        season_2009.games.create(home="Houston Astros", away="St. Louis Cardinals")
+
+        season_2010 = Season.objects.create(year=2010, gt=222)
+        season_2010.games.create(home="Houston Astros", away="Chicago Cubs")
+
+        # keyword-based lookup
+        games = Game.objects.exclude(season__year__gte=2010)
+        self.assertQuerysetEqual(games, ['<Game: St. Louis Cardinals at Houston Astros>'])
+
+        # object-based lookup
+        games = Game.objects.exclude(lookups.GreaterThanOrEqual(F('season__year'), Value(2010)))
+        self.assertQuerysetEqual(games, ['<Game: St. Louis Cardinals at Houston Astros>'])
 
 
 class LookupTransactionTests(TransactionTestCase):

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -7,6 +7,8 @@ from unittest import skipUnless
 
 from django.core.exceptions import FieldError
 from django.db import connection
+from django.db.models import lookups, F, Value, Count
+from django.db.models.functions import Upper, Lower
 from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 
 from .models import Article, Author, Game, MyISAMArticle, Player, Season, Tag
@@ -665,7 +667,6 @@ class LookupTests(TestCase):
         types ('year', 'gt', 'range', 'in' etc.).
         Refs #11670.
         """
-
         # Here we're using 'gt' as a code number for the year, e.g. 111=>2009.
         season_2009 = Season.objects.create(year=2009, gt=111)
         season_2009.games.create(home="Houston Astros", away="St. Louis Cardinals")
@@ -751,6 +752,29 @@ class LookupTests(TestCase):
              '<Article: Article 7>'],
             ordered=False
         )
+
+
+class ObjectLookupTests(LookupTests):
+    def test_direct_lookup_init(self):
+        lookup = lookups.GreaterThan(F('id'), Value(5))
+        queryset = Article.objects.filter(lookup)
+        self.assertQuerysetEqual(queryset, ['<Article: Article 6>',  '<Article: Article 7>'])
+
+    def test_lookup_with_no_name(self):
+        class CustomGreaterThanLookup(lookups.GreaterThan):
+            lookup_name = None
+
+            def get_rhs_op(self, connect, rhs):
+                return '> {}'.format(rhs)
+
+        lookup = CustomGreaterThanLookup(F('id'), Value(5))
+        queryset = Article.objects.filter(lookup)
+        self.assertQuerysetEqual(queryset, ['<Article: Article 6>',  '<Article: Article 7>'])
+
+    def test_direct_lookup_with_transform(self):
+        lookup = lookups.Contains(Upper(Lower(Upper(F('headline')))), 'ARTICLE 5')
+        queryset = Article.objects.filter(lookup)
+        self.assertQuerysetEqual(queryset, ['<Article: Article 5>'])
 
 
 class LookupTransactionTests(TransactionTestCase):

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -776,6 +776,11 @@ class ObjectLookupTests(LookupTests):
         queryset = Article.objects.filter(lookup)
         self.assertQuerysetEqual(queryset, ['<Article: Article 5>'])
 
+    def test_lookup_exclude(self):
+        lookup = lookups.LessThanOrEqual(F('id'), Value(5))
+        queryset = Article.objects.all().exclude(lookup)
+        self.assertQuerysetEqual(queryset, ['<Article: Article 6>',  '<Article: Article 7>'])
+
 
 class LookupTransactionTests(TransactionTestCase):
     available_apps = ['lookup']

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -805,11 +805,25 @@ class ObjectLookupTests(LookupTests):
         season_2010.games.create(home="Houston Astros", away="Chicago Cubs")
 
         print('\n --------------------- start test -------------------------- ')
-        qs1 = Season.objects.exclude(games__home__icontains='Houston')
-        self.assertQuerysetEqual(qs1, [])
+        list(Season.objects.filter(games__home__contains='Cardinals'))
+        qs1 = Season.objects.exclude(games__home__contains='Cardinals')
+        self.assertQuerysetEqual(qs1, ['<Season: 2010>'])
 
-        qs2 = Season.objects.exclude(lookups.Contains(F('games__home'), Value('Houston')))
-        self.assertQuerysetEqual(qs2, [])
+        print('\n second test ')
+        qs2 = Season.objects.exclude(lookups.Contains(F('games__home'), 'Cardinals'))
+        self.assertQuerysetEqual(qs2, ['<Season: 2010>'])
+
+    def test_lookup_join(self):
+        season_2009 = Season.objects.create(year=2009, gt=111)
+        season_2009.games.create(home="Houston Astros", away="St. Louis Cardinals")
+        season_2009.games.create(home="Houston Astros", away="Chicago Cubs")
+        season_2009.games.create(home="St. Louis Cardinals", away="Houston Atros")
+
+        season_2010 = Season.objects.create(year=2010, gt=222)
+        season_2010.games.create(home="Houston Astros", away="Chicago Cubs")
+
+        lst = list(Season.objects.filter(lookups.Contains(F('games__home'), 'Houston')))
+        self.assertQuerysetEqual(lst, ['<Season: 2009>', '<Season: 2009>', '<Season: 2010>'])
 
 
 class LookupTransactionTests(TransactionTestCase):

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -796,6 +796,21 @@ class ObjectLookupTests(LookupTests):
         games = Game.objects.exclude(lookups.GreaterThanOrEqual(F('season__year'), Value(2010)))
         self.assertQuerysetEqual(games, ['<Game: St. Louis Cardinals at Houston Astros>'])
 
+    def test_lookup_exclude3(self):
+        season_2009 = Season.objects.create(year=2009, gt=111)
+        season_2009.games.create(home="Houston Astros", away="St. Louis Cardinals")
+        season_2009.games.create(home="Houston Astros", away="Chicago Cubs")
+        season_2009.games.create(home="St. Louis Cardinals", away="Houston Atros")
+        season_2010 = Season.objects.create(year=2010, gt=222)
+        season_2010.games.create(home="Houston Astros", away="Chicago Cubs")
+
+        print('\n --------------------- start test -------------------------- ')
+        qs1 = Season.objects.exclude(games__home__icontains='Houston')
+        self.assertQuerysetEqual(qs1, [])
+
+        qs2 = Season.objects.exclude(lookups.Contains(F('games__home'), Value('Houston')))
+        self.assertQuerysetEqual(qs2, [])
+
 
 class LookupTransactionTests(TransactionTestCase):
     available_apps = ['lookup']


### PR DESCRIPTION
This fix allows passing lookup instances to filter method.

Several comments:
- F expressions became real expressions (Expression subclass).
- Expression got a new method - get_source_f_object, which walks through children classes and find if it has F object passed. In that case output_field-related code should be postponed, until compiler resolves it (which cannot be done during lookup init time).
- some code related to query.build_filter method (responsible to lookups/transform parsing, and calculating joins), extracted into separate helper classes - QueryKeywordLookupHelper and QueryObjectLookupHelper. They have common code base, but some of methods work in a different way.

Ticket: https://code.djangoproject.com/ticket/25367
Discussion: https://groups.google.com/forum/#!topic/django-developers/W0OYXhavY68