### PR TITLE
Fixed #25586 -- Fixed possible table cell misalignment in admin's tabular inline.

### DIFF
--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -7,9 +7,10 @@
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
      <thead><tr>
+       <th class="original"></th>
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
-         <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
+         <th{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
          {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
          </th>
        {% endif %}


### PR DESCRIPTION
This fixes the table body (tbody) to be shifted by one column to the
left.  While the width of td.original and th.original is set to 0 in the
CSS, th.original was not defined.

I cannot really believe that this was broken for so long, and therefore some non-default settings / behaviour might trigger it?!  And/or browser behaviour changed in that regard?  Or some JS got missing?

Anyway, the problem can be seen in both Firefox and Chromium for me.