### PR TITLE
Fixed #25578 -- Correct the spelling of GitHub

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -751,6 +751,7 @@ answer newbie questions, and generally made Django that much better:
     Yasushi Masuda <whosaysni@gmail.com>
     ye7cakf02@sneakemail.com
     ymasuda@ethercube.com
+    Yusuke Miyazaki <miyazaki.dev@gmail.com>
     Zachary Voase <zacharyvoase@gmail.com>
     Zach Thompson <zthompson47@gmail.com>
     Zain Memon

--- a/docs/internals/contributing/writing-code/working-with-git.txt
+++ b/docs/internals/contributing/writing-code/working-with-git.txt
@@ -40,10 +40,10 @@ used to associate your commits with your GitHub account.
 Setting up local repository
 ---------------------------
 
-When you have created your GitHub account, with the nick "github_nick", and
+When you have created your GitHub account, with the nick "GitHub_nick", and
 forked Django's repository, create a local copy of your fork::
 
-    git clone git@github.com:github_nick/django.git
+    git clone git@github.com:GitHub_nick/django.git
 
 This will create a new directory "django", containing a clone of your GitHub
 repository. The rest of the git commands on this page need to be run within the
@@ -103,7 +103,7 @@ You can publish your work on GitHub just by doing::
 When you go to your GitHub page you will notice a new branch has been created.
 
 If you are working on a Trac ticket, you should mention in the ticket that
-your work is available from branch ticket_xxxxx of your github repo. Include a
+your work is available from branch ticket_xxxxx of your GitHub repo. Include a
 link to your branch.
 
 Note that the above branch is called a "topic branch" in Git parlance. You are

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -1494,7 +1494,7 @@ Django will also accept URLs (\fBhttp\fP, \fBhttps\fP, \fBftp\fP) to compressed
 archives with the app template files, downloading and extracting them on the
 fly.
 .sp
-For example, taking advantage of Github\(aqs feature to expose repositories as
+For example, taking advantage of GitHub\(aqs feature to expose repositories as
 zip files, you can use a URL like:
 .INDENT 0.0
 .INDENT 3.5
@@ -1596,7 +1596,7 @@ Django will also accept URLs (\fBhttp\fP, \fBhttps\fP, \fBftp\fP) to compressed
 archives with the project template files, downloading and extracting them on the
 fly.
 .sp
-For example, taking advantage of Github\(aqs feature to expose repositories as
+For example, taking advantage of GitHub\(aqs feature to expose repositories as
 zip files, you can use a URL like:
 .INDENT 0.0
 .INDENT 3.5

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1097,7 +1097,7 @@ Django will also accept URLs (``http``, ``https``, ``ftp``) to compressed
 archives with the app template files, downloading and extracting them on the
 fly.
 
-For example, taking advantage of Github's feature to expose repositories as
+For example, taking advantage of GitHub's feature to expose repositories as
 zip files, you can use a URL like::
 
     django-admin startapp --template=https://github.com/githubuser/django-app-template/archive/master.zip myapp
@@ -1172,7 +1172,7 @@ Django will also accept URLs (``http``, ``https``, ``ftp``) to compressed
 archives with the project template files, downloading and extracting them on the
 fly.
 
-For example, taking advantage of Github's feature to expose repositories as
+For example, taking advantage of GitHub's feature to expose repositories as
 zip files, you can use a URL like::
 
     django-admin startproject --template=https://github.com/githubuser/django-project-template/archive/master.zip myproject

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -726,7 +726,7 @@ The localflavor contrib app has been split into separate packages.
 ``django.contrib.localflavor`` itself will be removed in Django 1.6,
 after an accelerated deprecation.
 
-The new packages are available on Github. The core team cannot
+The new packages are available on GitHub. The core team cannot
 efficiently maintain these packages in the long term — it spans just a
 dozen countries at this time; similar to translations, maintenance
 will be handed over to interested members of the community.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -929,7 +929,7 @@ Removal of ``django.contrib.formtools``
 The formtools contrib app has been moved to a separate package and the
 relevant documentation pages have been updated or removed.
 
-The new package is available `on Github`_ and on PyPI.
+The new package is available `on GitHub`_ and on PyPI.
 
 .. _on GitHub: https://github.com/django/django-formtools/
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -305,7 +305,7 @@ Gettext
 GiB
 gid
 gis
-github
+GitHub
 globalization
 Godwin
 google


### PR DESCRIPTION
"GitHub" was spelled as "Github" in some documents, so I fixed them.
