### PR TITLE
Fixed #25397 -- Documented class-based view context variable clash with context processors.

### DIFF
--- a/docs/ref/class-based-views/generic-display.txt
+++ b/docs/ref/class-based-views/generic-display.txt
@@ -52,6 +52,14 @@ DetailView
                 context['now'] = timezone.now()
                 return context
 
+
+    .. admonition:: Contents of context in this example
+
+        In this example context will contain current date under ``now`` key,
+        selected article under two keys (``object`` and ``article``),
+        for full explanation see: :meth:`SingleObjectMixin.get_context_data
+        <django.views.generic.detail.SingleObjectMixin.get_context_data>`.
+
     **Example myapp/urls.py**::
 
         from django.conf.urls import url

--- a/docs/ref/class-based-views/mixins-single-object.txt
+++ b/docs/ref/class-based-views/mixins-single-object.txt
@@ -102,20 +102,33 @@ SingleObjectMixin
 
         Returns context data for displaying the list of objects.
 
-        The base implementation of this method requires that the ``object``
+        The base implementation of this method requires that the ``self.object``
         attribute be set by the view (even if ``None``). Be sure to do this if
         you are using this mixin without one of the built-in views that does so.
+
+        The base implementation of this method returns context with following
+        contents:
+
+        1. ``object``: The object that this view is displaying (``self.object``)
+        2. ``context_object_name``: ``self.object`` will also be stored under
+           name returned by :meth:`get_context_object_name`, which defaults to
+           name of the model.
+
+        .. admonition:: Possible name shadowing in the context
+
+            Please note that any variables set by the :meth:`get_context_data`,
+            will shadow context variables injected by :ref:`context processors
+            <subclassing-context-requestcontext>`. This means that if your
+            view sets :attr:`model` attribute to :class:`~django.contrib.auth.models.User`,
+            context object will **override** currently logged in user stored
+            in context variable named ``user`` by the :ref:`the auth context
+            processor <context-processors-auth>`
 
     .. method:: get_slug_field()
 
         Returns the name of a slug field to be used to look up by slug. By
         default this simply returns the value of :attr:`slug_field`.
 
-    **Context**
-
-    * ``object``: The object that this view is displaying. If
-      ``context_object_name`` is specified, that variable will also be
-      set in the context, with the same value as ``object``.
 
 SingleObjectTemplateResponseMixin
 ---------------------------------

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -656,6 +656,8 @@ Context processors
 
 Here's what each of the built-in processors does:
 
+.. _context-processors-auth:
+
 django.contrib.auth.context_processors.auth
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/class-based-views/generic-display.txt
+++ b/docs/topics/class-based-views/generic-display.txt
@@ -230,12 +230,20 @@ template, but you can override it to send more::
     Generally, ``get_context_data`` will merge the context data of all parent
     classes with those of the current class. To preserve this behavior in your
     own classes where you want to alter the context, you should be sure to call
-    ``get_context_data`` on the super class. When no two classes try to define the
-    same key, this will give the expected results. However if any class
+    ``get_context_data`` on the super class. When no two classes try to define
+    the same key, this will give the expected results. However if any class
     attempts to override a key after parent classes have set it (after the call
     to super), any children of that class will also need to explicitly set it
     after super if they want to be sure to override all parents. If you're
     having trouble, review the method resolution order of your view.
+
+.. warning::
+
+    Context created by default, by
+    :meth:`~django.views.generic.detail.SingleObjectMixin.get_context_data`, can
+    shadow variables provided by the context processors, please see
+    documentation of :meth:`that method
+    <django.views.generic.detail.SingleObjectMixin.get_context_data>`.
 
 .. _generic-views-list-subsets:
 


### PR DESCRIPTION
Documented context possible shadowing of context
processor variables by default implementation of get_context_data.

PS. Previous PR https://github.com/django/django/pull/5451 auto-closed because I made some error in
in my fork. 