### PR TITLE
Fixed #25583 -- Allowed calling `transform` with `CoordTransform` even if SRID is invalid.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -494,14 +494,17 @@ class GEOSGeometry(GEOSBase, ListMixin):
             else:
                 return
 
-        if (srid is None) or (srid < 0):
+        if isinstance(ct, gdal.CoordTransform):
+            # We don't care about SRID because CoordTransform presuppose source SRS.
+            srid = None
+        elif srid is None or srid < 0:
             raise GEOSException("Calling transform() with no SRID set is not supported")
 
         if not gdal.HAS_GDAL:
             raise GEOSException("GDAL library is not available to transform() geometry.")
 
         # Creating an OGR Geometry, which is then transformed.
-        g = self.ogr
+        g = gdal.OGRGeometry(self.wkb, srid)
         g.transform(ct)
         # Getting a new GEOS pointer
         ptr = wkb_r().read(g.wkb)

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -553,6 +553,14 @@ is returned instead.
 
     Requires GDAL. Raises :class:`~django.contrib.gis.geos.GEOSException` if
     GDAL is not available or if the geometry's SRID is ``None`` or less than 0.
+    Imposes no constraints on the geometry's SRID if called with a
+    :class:`~django.contrib.gis.gdal.CoordTransform` object.
+
+    .. versionchanged:: 1.10
+
+        In previous versions of Django, required the geometry's SRID to be positive integer
+        even if called with a :class:`~django.contrib.gis.gdal.CoordTransform` object.
+
 
 ``Point``
 ---------

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -656,23 +656,24 @@ class GEOSTest(unittest.TestCase, TestDataMixin):
 
     @skipUnless(HAS_GDAL, "GDAL is required.")
     def test_custom_srid(self):
-        """ Test with a srid unknown from GDAL """
-        pnt = Point(111200, 220900, srid=999999)
-        self.assertTrue(pnt.ewkt.startswith("SRID=999999;POINT (111200.0"))
-        self.assertIsInstance(pnt.ogr, gdal.OGRGeometry)
-        self.assertIsNone(pnt.srs)
+        """ Test with a null srid and a srid unknown from GDAL """
+        for srid in [None, 999999]:
+            pnt = Point(111200, 220900, srid=srid)
+            self.assertTrue(pnt.ewkt.startswith(("SRID=%s;" % srid if srid else '') + "POINT (111200.0"))
+            self.assertIsInstance(pnt.ogr, gdal.OGRGeometry)
+            self.assertIsNone(pnt.srs)
 
-        # Test conversion from custom to a known srid
-        c2w = gdal.CoordTransform(
-            gdal.SpatialReference(
-                '+proj=mill +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +R_A +ellps=WGS84 '
-                '+datum=WGS84 +units=m +no_defs'
-            ),
-            gdal.SpatialReference(4326))
-        new_pnt = pnt.transform(c2w, clone=True)
-        self.assertEqual(new_pnt.srid, 4326)
-        self.assertAlmostEqual(new_pnt.x, 1, 3)
-        self.assertAlmostEqual(new_pnt.y, 2, 3)
+            # Test conversion from custom to a known srid
+            c2w = gdal.CoordTransform(
+                gdal.SpatialReference(
+                    '+proj=mill +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +R_A +ellps=WGS84 '
+                    '+datum=WGS84 +units=m +no_defs'
+                ),
+                gdal.SpatialReference(4326))
+            new_pnt = pnt.transform(c2w, clone=True)
+            self.assertEqual(new_pnt.srid, 4326)
+            self.assertAlmostEqual(new_pnt.x, 1, 3)
+            self.assertAlmostEqual(new_pnt.y, 2, 3)
 
     def test_mutable_geometries(self):
         "Testing the mutability of Polygons and Geometry Collections."


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25583