### PR TITLE
Fixed #25585 -- Allowed `None` to be set as SRID and SRS value for `OGRGeometry`.

### DIFF
--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -270,6 +270,8 @@ class OGRGeometry(GDALBase):
         elif isinstance(srs, six.integer_types + six.string_types):
             sr = SpatialReference(srs)
             srs_ptr = sr.ptr
+        elif srs is None:
+            srs_ptr = None
         else:
             raise TypeError('Cannot assign spatial reference with object of type: %s' % type(srs))
         capi.assign_srs(self.ptr, srs_ptr)
@@ -284,7 +286,7 @@ class OGRGeometry(GDALBase):
         return None
 
     def _set_srid(self, srid):
-        if isinstance(srid, six.integer_types):
+        if isinstance(srid, six.integer_types) or srid is None:
             self.srs = srid
         else:
             raise TypeError('SRID must be set with an integer.')

--- a/tests/gis_tests/gdal_tests/test_geom.py
+++ b/tests/gis_tests/gdal_tests/test_geom.py
@@ -320,6 +320,11 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
                     self.assertEqual('WGS 72', ring.srs.name)
                     self.assertEqual(4322, ring.srid)
 
+            # test assigning of SRS and SRID to their own values
+            mpoly = OGRGeometry(mp.wkt, srs=None)
+            mpoly.srs = mpoly.srs
+            mpoly.srid = mpoly.srid
+
     def test_srs_transform(self):
         "Testing transform()."
         orig = OGRGeometry('POINT (-104.609 38.255)', 4326)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25585