### PR TITLE
Fixed #25592 -- Typo in PostGISOperators

### DIFF
--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -73,7 +73,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         'left': PostGISOperator(op='<<'),
         'right': PostGISOperator(op='>>'),
         'strictly_below': PostGISOperator(op='<<|'),
-        'stricly_above': PostGISOperator(op='|>>'),
+        'strictly_above': PostGISOperator(op='|>>'),
         'same_as': PostGISOperator(op='~='),
         'exact': PostGISOperator(op='~='),  # alias of same_as
         'contains_properly': PostGISOperator(func='ST_ContainsProperly'),


### PR DESCRIPTION
Fixes `'strictly_above'` dictionary key typo in `PostGISOperators`.

https://code.djangoproject.com/ticket/25592