### PR TITLE
Refs #25589 -- Fixed admin_scripts test failure on Windows.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -642,7 +642,7 @@ class DjangoAdminSettingsDirectory(AdminScriptTestCase):
         self.addCleanup(shutil.rmtree, app_path)
         self.assertNoOutput(err)
         self.assertTrue(os.path.exists(app_path))
-        with open(os.path.join(app_path, 'apps.py'), 'r') as f:
+        with open(os.path.join(app_path, 'apps.py'), 'r', encoding='utf8') as f:
             content = f.read()
             self.assertIn("class こんにちはConfig(AppConfig)", content)
             self.assertIn("name = 'こんにちは'", content)


### PR DESCRIPTION
Traceback (most recent call last):
  File "tests\admin_scripts\tests.py", line 646, in test_startapp_unicode_name
    content = f.read()
  File "lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 46: character maps to <undefined>