### PR TITLE
ReverseSingleRelatedObjectDescriptor was renamed

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1490,3 +1490,5 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
 * Private API ``django.test.utils.TestTemplateLoader`` is removed.
 
 * The ``django.contrib.contenttypes.generic`` module is removed.
+
+* ``ReverseSingleRelatedObjectDescriptor`` was renamed to ``ForwardManyToOneDescriptor``.


### PR DESCRIPTION
This class appears in a few public repos and was difficult to track down the name change. Document the change.