### PR TITLE
Removed hardcoded utf-8 BOM, used value from codecs instead.

### DIFF
--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -12,8 +12,7 @@ from django.utils._os import npath, upath
 def has_bom(fn):
     with open(fn, 'rb') as f:
         sample = f.read(4)
-    return (sample[:3] == b'\xef\xbb\xbf' or
-        sample.startswith((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)))
+    return sample.startswith((codecs.BOM_UTF8, codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE))
 
 
 def is_writable(path):


### PR DESCRIPTION
Small cleanup. Avoids hardcoding the utf-8 BOM in a magic string as it exists in the stdlib's codecs.