### PR TITLE
Fixed #25597 -- Fixed crash with SplitArrayField and IntegerField on invalid value.

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -166,7 +166,7 @@ class SplitArrayField(forms.Field):
                 errors.append(None)
             except ValidationError as error:
                 errors.append(ValidationError(
-                    string_concat(self.error_messages['item_invalid'], error.message),
+                    string_concat(self.error_messages['item_invalid'], ' '.join(error.messages)),
                     code='item_invalid',
                     params={'nth': i},
                 ))

--- a/docs/releases/1.8.6.txt
+++ b/docs/releases/1.8.6.txt
@@ -38,3 +38,6 @@ Bugfixes
 
 * Fixed a typo in the name of the `strictly_above` PostGIS lookup
   (:ticket:`25592`).
+
+* Fixed crash with ``contrib.postgres.forms.SplitArrayField`` and
+  ``IntegerField`` on invalid value (:ticket:`25597`).

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -509,6 +509,11 @@ class TestSplitFormField(PostgreSQLTestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors, {'array': ['Item 2 in the array did not validate: This field is required.']})
 
+    def test_invalid_integer(self):
+        msg = 'Item 1 in the array did not validate: Ensure this value is less than or equal to 100.'
+        with self.assertRaisesMessage(exceptions.ValidationError, msg):
+            SplitArrayField(forms.IntegerField(max_value=100), size=2).clean([0, 101])
+
     def test_rendering(self):
         class SplitForm(forms.Form):
             array = SplitArrayField(forms.CharField(), size=3)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25597