### PR TITLE
[1.8.x] Fixed #25618 -- Added a helpful message when both Django & south migrations exist in the same directory.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -116,6 +116,12 @@ class MigrationLoader(object):
                     break
                 self.disk_migrations[app_config.label, migration_name] = migration_module.Migration(migration_name, app_config.label)
             if south_style_migrations:
+                if app_config.label in self.migrated_apps:
+                    raise BadMigrationError(
+                        "Migrated app %r contains South migrations. Make sure "
+                        "all numbered South migrations are deleted prior to "
+                        "creating Django migrations." % app_config.label
+                    )
                 self.unmigrated_apps.add(app_config.label)
 
     def get_migration(self, app_label, name_prefix):

--- a/docs/releases/1.8.6.txt
+++ b/docs/releases/1.8.6.txt
@@ -41,3 +41,6 @@ Bugfixes
 
 * Fixed crash with ``contrib.postgres.forms.SplitArrayField`` and
   ``IntegerField`` on invalid value (:ticket:`25597`).
+
+* Added a helpful error message when Django and South migrations exist in the
+  same directory (:ticket:`25618`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25618

No tests (except manual) because "south_style_migrations" is already untested and this logic will be removed in Django 1.10: https://github.com/django/django/pull/5488