### PR TITLE
Fixed #21516 -- Updated imports paths for some formset functions/classes.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1681,7 +1681,7 @@ templates used by the :class:`ModelAdmin` views:
     changelist page if :attr:`~ModelAdmin.list_editable` is used. To use a
     custom formset, for example::
 
-        from django.forms.models import BaseModelFormSet
+        from django.forms import BaseModelFormSet
 
         class MyAdminFormSet(BaseModelFormSet):
             pass

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -20,7 +20,7 @@ form::
 You might want to allow the user to create several articles at once. To create
 a formset out of an ``ArticleForm`` you would do::
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> ArticleFormSet = formset_factory(ArticleForm)
 
 You now have created a formset named ``ArticleFormSet``. The formset gives you
@@ -60,7 +60,7 @@ number of forms it generates from the initial data. Let's take a look at an
 example::
 
     >>> import datetime
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, extra=2)
     >>> formset = ArticleFormSet(initial=[
@@ -93,7 +93,7 @@ Limiting the maximum number of forms
 The ``max_num`` parameter to :func:`~django.forms.formsets.formset_factory`
 gives you the ability to limit the number of forms the formset will display::
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, extra=2, max_num=1)
     >>> formset = ArticleFormSet()
@@ -130,7 +130,7 @@ Validation with a formset is almost identical to a regular ``Form``. There is
 an ``is_valid`` method on the formset to provide a convenient way to validate
 all forms in the formset::
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm)
     >>> data = {
@@ -253,8 +253,8 @@ Custom formset validation
 A formset has a ``clean`` method similar to the one on a ``Form`` class. This
 is where you define your own validation that works at the formset level::
 
-    >>> from django.forms.formsets import BaseFormSet
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import BaseFormSet
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
 
     >>> class BaseArticleFormSet(BaseFormSet):
@@ -309,7 +309,7 @@ If ``validate_max=True`` is passed to
 that the number of forms in the data set, minus those marked for
 deletion, is less than or equal to ``max_num``.
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, max_num=1, validate_max=True)
     >>> data = {
@@ -351,7 +351,7 @@ If ``validate_min=True`` is passed to
 that the number of forms in the data set, minus those marked for
 deletion, is greater than or equal to ``min_num``.
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, min_num=3, validate_min=True)
     >>> data = {
@@ -388,7 +388,7 @@ Default: ``False``
 
 Lets you create a formset with the ability to order::
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, can_order=True)
     >>> formset = ArticleFormSet(initial=[
@@ -448,7 +448,7 @@ Default: ``False``
 
 Lets you create a formset with the ability to select forms for deletion::
 
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> ArticleFormSet = formset_factory(ArticleForm, can_delete=True)
     >>> formset = ArticleFormSet(initial=[
@@ -519,8 +519,8 @@ accomplished. The formset base class provides an ``add_fields`` method. You
 can simply override this method to add your own fields or even redefine the
 default fields/attributes of the order and deletion fields::
 
-    >>> from django.forms.formsets import BaseFormSet
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import BaseFormSet
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
     >>> class BaseArticleFormSet(BaseFormSet):
     ...     def add_fields(self, form, index):
@@ -543,8 +543,8 @@ Passing custom parameters to formset forms
 Sometimes your form class takes custom parameters, like ``MyArticleForm``.
 You can pass this parameter when instantiating the formset::
 
-    >>> from django.forms.formsets import BaseFormSet
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import BaseFormSet
+    >>> from django.forms import formset_factory
     >>> from myapp.forms import ArticleForm
 
     >>> class MyArticleForm(ArticleForm):
@@ -560,8 +560,8 @@ base class provides a ``get_form_kwargs`` method. The method takes a single
 argument - the index of the form in the formset. The index is ``None`` for the
 :ref:`empty_form`::
 
-    >>> from django.forms.formsets import BaseFormSet
-    >>> from django.forms.formsets import formset_factory
+    >>> from django.forms import BaseFormSet
+    >>> from django.forms import formset_factory
 
     >>> class BaseArticleFormSet(BaseFormSet):
     ...     def get_form_kwargs(self, index):
@@ -581,7 +581,7 @@ Using a formset inside a view is as easy as using a regular ``Form`` class.
 The only thing you will want to be aware of is making sure to use the
 management form inside the template. Let's look at a sample view::
 
-    from django.forms.formsets import formset_factory
+    from django.forms import formset_factory
     from django.shortcuts import render_to_response
     from myapp.forms import ArticleForm
 
@@ -658,7 +658,7 @@ borrow much of its behavior from forms. With that said you are able to use
 more than one formset to be sent to a view without name clashing. Lets take
 a look at how this might be accomplished::
 
-    from django.forms.formsets import formset_factory
+    from django.forms import formset_factory
     from django.shortcuts import render_to_response
     from myapp.forms import ArticleForm, BookForm
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -729,7 +729,7 @@ Like :doc:`regular formsets </topics/forms/formsets>`, Django provides a couple
 of enhanced formset classes that make it easy to work with Django models. Let's
 reuse the ``Author`` model from above::
 
-    >>> from django.forms.models import modelformset_factory
+    >>> from django.forms import modelformset_factory
     >>> from myapp.models import Author
     >>> AuthorFormSet = modelformset_factory(Author, fields=('name', 'title'))
 
@@ -773,7 +773,7 @@ queryset that includes all objects in the model (e.g.,
 Alternatively, you can create a subclass that sets ``self.queryset`` in
 ``__init__``::
 
-    from django.forms.models import BaseModelFormSet
+    from django.forms import BaseModelFormSet
     from myapp.models import Author
 
     class BaseAuthorFormSet(BaseModelFormSet):
@@ -941,7 +941,7 @@ Using a model formset in a view
 Model formsets are very similar to formsets. Let's say we want to present a
 formset to edit ``Author`` model instances::
 
-    from django.forms.models import modelformset_factory
+    from django.forms import modelformset_factory
     from django.shortcuts import render_to_response
     from myapp.models import Author
 
@@ -975,7 +975,7 @@ the unique constraints on your model (either ``unique``, ``unique_together`` or
 on a ``ModelFormSet`` and maintain this validation, you must call the parent
 class's ``clean`` method::
 
-    from django.forms.models import BaseModelFormSet
+    from django.forms import BaseModelFormSet
 
     class MyModelFormSet(BaseModelFormSet):
         def clean(self):
@@ -991,7 +991,7 @@ have already been created for each ``Form``. Modifying a value in
 to modify a value in ``ModelFormSet.clean()`` you must modify
 ``form.instance``::
 
-    from django.forms.models import BaseModelFormSet
+    from django.forms import BaseModelFormSet
 
     class MyModelFormSet(BaseModelFormSet):
         def clean(self):
@@ -1009,7 +1009,7 @@ Using a custom queryset
 As stated earlier, you can override the default queryset used by the model
 formset::
 
-    from django.forms.models import modelformset_factory
+    from django.forms import modelformset_factory
     from django.shortcuts import render_to_response
     from myapp.models import Author
 
@@ -1113,7 +1113,7 @@ you have these two models::
 If you want to create a formset that allows you to edit books belonging to
 a particular author, you could do this::
 
-    >>> from django.forms.models import inlineformset_factory
+    >>> from django.forms import inlineformset_factory
     >>> BookFormSet = inlineformset_factory(Author, Book, fields=('title',))
     >>> author = Author.objects.get(name='Mike Royko')
     >>> formset = BookFormSet(instance=author)
@@ -1137,7 +1137,7 @@ When overriding methods on ``InlineFormSet``, you should subclass
 
 For example, if you want to override ``clean()``::
 
-    from django.forms.models import BaseInlineFormSet
+    from django.forms import BaseInlineFormSet
 
     class CustomInlineFormSet(BaseInlineFormSet):
         def clean(self):
@@ -1152,7 +1152,7 @@ See also :ref:`model-formsets-overriding-clean`.
 Then when you create your inline formset, pass in the optional argument
 ``formset``::
 
-    >>> from django.forms.models import inlineformset_factory
+    >>> from django.forms import inlineformset_factory
     >>> BookFormSet = inlineformset_factory(Author, Book, fields=('title',),
     ...     formset=CustomInlineFormSet)
     >>> author = Author.objects.get(name='Mike Royko')


### PR DESCRIPTION
Updated the import path for FormSet classes and factories in the
documentation. Since #21489, FormSet classes and factories are exposed on
the django.forms package.
Refs #21489