### PR TITLE
Added the srid property to GDALRaster.

### DIFF
--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -215,6 +215,20 @@ class GDALRaster(GDALBase):
         self._flush()
 
     @property
+    def srid(self):
+        """
+        Shortcut to access the srid of this GDALRaster.
+        """
+        return self.srs.srid
+
+    @srid.setter
+    def srid(self, value):
+        """
+        Shortcut to set this GDALRaster's srs from an srid.
+        """
+        self.srs = value
+
+    @property
     def geotransform(self):
         """
         Returns the geotransform of the data source.

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1204,6 +1204,21 @@ blue.
             >>> rst.srs.srid
             3086
 
+    .. attribute:: srid
+
+        The Spatial Reference System Identifier (SRID) of the raster. This
+        property is a shortcut to getting or setting the SRID through the
+        :attr:`srs` attribute.
+
+            >>> rst = GDALRaster({'width': 10, 'height': 20, 'srid': 4326})
+            >>> rst.srid
+            4326
+            >>> rst.srid = 3086
+            >>> rst.srid
+            3086
+            >>> rst.srs.srid  # This is equivalent
+            3086
+
     .. attribute:: geotransform
 
         The affine transformation matrix used to georeference the source, as a

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -83,6 +83,16 @@ class GDALRasterTests(unittest.TestCase):
         self.assertEqual(self.rs.srs.srid, 3086)
         self.assertEqual(self.rs.srs.units, (1.0, 'metre'))
 
+    def test_rs_srid(self):
+        rast = GDALRaster({
+            'width': 16,
+            'height': 16,
+            'srid': 4326,
+        })
+        self.assertEqual(rast.srid, 4326)
+        rast.srid = 3086
+        self.assertEqual(rast.srid, 3086)
+
     def test_geotransform_and_friends(self):
         # Assert correct values for file based raster
         self.assertEqual(self.rs.geotransform,


### PR DESCRIPTION
Geometry objects have an srid property, so this addition makes the raster api more similar to the geometries api.