### PR TITLE
Fixed #25620 -- Made URLValidator prohibit URLs with consecutive dots in the domain section.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -84,7 +84,7 @@ class URLValidator(RegexValidator):
 
     # Host patterns
     hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]*[a-z' + ul + r'0-9])?'
-    domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]*(?<!-))*'
+    domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]+(?<!-))*'
     tld_re = r'\.(?:[a-z' + ul + r']{2,}|xn--[a-z0-9]+)\.?'
     host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
 

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -49,3 +49,4 @@ http://.www.foo.bar./
 http://[::1:2::3]:8080/
 http://[]
 http://[]:8080
+http://example..com/


### PR DESCRIPTION
Initially domain name regex had '*' which was allowing '.' to pass
the regex and making invalid URLs as valid (http://example...com).
Now atleast one unicode character will be required after '.' in
domain name regex