### PR TITLE
Fixed #25635 -- Made URLValidator allow '+' in scheme.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -89,7 +89,7 @@ class URLValidator(RegexValidator):
     host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
 
     regex = _lazy_re_compile(
-        r'^(?:[a-z0-9\.\-]*)://'  # scheme is validated separately
+        r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
         r'(?:\S+(?::\S*)?@)?'  # user:pass authentication
         r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
         r'(?::\d{2,5})?'  # port

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -22,7 +22,7 @@ from django.test.utils import str_prefix
 from django.utils._os import upath
 
 NOW = datetime.now()
-EXTENDED_SCHEMES = ['http', 'https', 'ftp', 'ftps', 'git', 'file']
+EXTENDED_SCHEMES = ['http', 'https', 'ftp', 'ftps', 'git', 'file', 'git+ssh']
 
 TEST_DATA = [
     # (validator, value, expected),
@@ -205,6 +205,7 @@ TEST_DATA = [
 
     (URLValidator(EXTENDED_SCHEMES), 'file://localhost/path', None),
     (URLValidator(EXTENDED_SCHEMES), 'git://example.com/', None),
+    (URLValidator(EXTENDED_SCHEMES), 'git+ssh://git@github.com/example/hg-git.git', None),
 
     (URLValidator(EXTENDED_SCHEMES), 'git://-invalid.com', ValidationError),
     # Trailing newlines not accepted


### PR DESCRIPTION
Modified scheme regex to allow schemes with '+' in them like (ssh+git://). Also made scheme part compulsory. 