### PR TITLE
Fixed #25489 -- Documented that SESSION_SAVE_EVERY_REQUEST doesn't create empty sessions.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2915,7 +2915,8 @@ Default: ``False``
 
 Whether to save the session data on every request. If this is ``False``
 (default), then the session data will only be saved if it has been modified --
-that is, if any of its dictionary values have been assigned or deleted.
+that is, if any of its dictionary values have been assigned or deleted. Empty
+sessions won't be created, even if this setting is active.
 
 .. setting:: SESSION_SERIALIZER
 

--- a/docs/releases/1.4.22.txt
+++ b/docs/releases/1.4.22.txt
@@ -21,7 +21,8 @@ by sending repeated requests, potentially filling up the session store or
 causing other users' session records to be evicted.
 
 The :class:`~django.contrib.sessions.middleware.SessionMiddleware` has been
-modified to no longer create empty session records.
+modified to no longer create empty session records, including when
+:setting:`SESSION_SAVE_EVERY_REQUEST` is active.
 
 Additionally, the ``contrib.sessions.backends.base.SessionBase.flush()`` and
 ``cache_db.SessionStore.flush()`` methods have been modified to avoid creating

--- a/docs/releases/1.7.10.txt
+++ b/docs/releases/1.7.10.txt
@@ -17,7 +17,8 @@ by sending repeated requests, potentially filling up the session store or
 causing other users' session records to be evicted.
 
 The :class:`~django.contrib.sessions.middleware.SessionMiddleware` has been
-modified to no longer create empty session records.
+modified to no longer create empty session records, including when
+:setting:`SESSION_SAVE_EVERY_REQUEST` is active.
 
 Additionally, the ``contrib.sessions.backends.base.SessionBase.flush()`` and
 ``cache_db.SessionStore.flush()`` methods have been modified to avoid creating

--- a/docs/releases/1.8.4.txt
+++ b/docs/releases/1.8.4.txt
@@ -17,7 +17,8 @@ by sending repeated requests, potentially filling up the session store or
 causing other users' session records to be evicted.
 
 The :class:`~django.contrib.sessions.middleware.SessionMiddleware` has been
-modified to no longer create empty session records.
+modified to no longer create empty session records, including when
+:setting:`SESSION_SAVE_EVERY_REQUEST` is active.
 
 Bugfixes
 ========


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25489