### PR TITLE
Fixed #25639  -- Cascade deleting cause deadlock

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -241,20 +241,21 @@ class Collector(object):
 
     def sort(self):
         sorted_models = []
-        concrete_models = set()
         models = list(self.data)
         while len(sorted_models) < len(models):
-            found = False
+            to_add_models = []
             for model in models:
-                if model in sorted_models:
-                    continue
-                dependencies = self.dependencies.get(model._meta.concrete_model)
-                if not (dependencies and dependencies.difference(concrete_models)):
-                    sorted_models.append(model)
-                    concrete_models.add(model._meta.concrete_model)
-                    found = True
-            if not found:
+                if not (model in sorted_models or self.dependencies.get(model._meta.concrete_model)):
+                    to_add_models.append(model)
+            if not to_add_models:
                 return
+            to_add_models.sort(key=lambda x: x._meta.db_table)
+            sorted_models.extend(to_add_models)
+            for m in to_add_models:
+                concrete_model = m._meta.concrete_model
+                for value in self.dependencies.values():
+                    if concrete_model in value:
+                        value.remove(concrete_model)
         self.data = OrderedDict((model, self.data[model])
                                 for model in sorted_models)
 

--- a/tests/cascade_deletion/models.py
+++ b/tests/cascade_deletion/models.py
@@ -1,0 +1,41 @@
+"""
+Use the same order when cascade deletion
+"""
+
+from django.db import models
+
+
+class Author(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class Article(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+    headline = models.CharField(max_length=100)
+    pub_date = models.DateTimeField(auto_now_add=True)
+
+
+class Comment(models.Model):
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    content = models.CharField(max_length=1024)
+
+
+class CommentReply(models.Model):
+    comment = models.ForeignKey(Comment, on_delete=models.CASCADE)
+    content = models.CharField(max_length=1024)
+
+
+class Profile(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+    mobile = models.CharField(max_length=100)
+
+
+class Book(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+
+
+class BookArticle(models.Model):
+    book = models.ForeignKey(Book, on_delete=models.CASCADE)
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    sequence = models.IntegerField(default=0)

--- a/tests/cascade_deletion/tests.py
+++ b/tests/cascade_deletion/tests.py
@@ -1,0 +1,22 @@
+from django.db.models.deletion import Collector
+from django.test import TestCase
+
+from .models import (
+    Article, Author, Book, BookArticle, Comment, CommentReply, Profile,
+)
+
+
+class CascadeDeletionTest(TestCase):
+    def test_cascade_sort(self):
+        author = Author.objects.create(name="John")
+        Profile.objects.create(author=author, mobile="13333333333")
+        article = Article.objects.create(author=author)
+        comment = Comment.objects.create(article=article, content="content")
+        CommentReply.objects.create(comment=comment, content="content")
+        book = Book.objects.create(author=author, name="name")
+        BookArticle.objects.create(book=book, article=article)
+        for i in range(10):
+            collector = Collector(using='default')
+            collector.collect(Author.objects.filter(pk=author.pk))
+            collector.sort()
+            self.assertEqual(collector.data.keys(), [Book, Comment, Article, Author])


### PR DESCRIPTION
Refactored the sort method in django.db.models.deletion to
return same order every time.