### PR TITLE
Fixed #8065 -- Allowed QuerySet.in_bulk() to accept no arguments.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -559,16 +559,19 @@ class QuerySet(object):
             return objects[0]
         return None
 
-    def in_bulk(self, id_list):
+    def in_bulk(self, id_list=None):
         """
         Returns a dictionary mapping each of the given IDs to the object with
-        that ID.
+        that ID. If called without any arguments, the entire queryset is evaluated.
         """
         assert self.query.can_filter(), \
             "Cannot use 'limit' or 'offset' with in_bulk"
-        if not id_list:
-            return {}
-        qs = self.filter(pk__in=id_list).order_by()
+        if id_list is not None:
+            if not id_list:
+                return {}
+            qs = self.filter(pk__in=id_list).order_by()
+        else:
+            qs = self._clone()
         return {obj._get_pk_val(): obj for obj in qs}
 
     def delete(self):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1836,7 +1836,7 @@ database query like ``count()`` would.
 in_bulk
 ~~~~~~~
 
-.. method:: in_bulk(id_list)
+.. method:: in_bulk(id_list=None)
 
 Takes a list of primary-key values and returns a dictionary mapping each
 primary-key value to an instance of the object with the given ID.
@@ -1849,8 +1849,15 @@ Example::
     {1: <Blog: Beatles Blog>, 2: <Blog: Cheddar Talk>}
     >>> Blog.objects.in_bulk([])
     {}
+    >>> Blog.objects.in_bulk()
+    {1: <Blog: Beatles Blog>, 2: <Blog: Cheddar Talk>}
 
 If you pass ``in_bulk()`` an empty list, you'll get an empty dictionary.
+
+.. versionchanged:: 1.10
+
+``in_bulk()`` may be called without any arguments to return all objects
+in the queryset.
 
 iterator
 ~~~~~~~~

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -241,6 +241,8 @@ Models
 * The :attr:`~django.db.models.Func.arity` class attribute is added to
   :class:`~django.db.models.Func`. This attribute can be used to set the number
   of arguments the function accepts.
+* :meth:`QuerySet.in_bulk() <django.db.models.query.QuerySet.in_bulk>`
+  may be called without any arguments to return all objects in the queryset.
 
 Requests and Responses
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -116,6 +116,18 @@ class LookupTests(TestCase):
         arts = Article.objects.in_bulk([self.a1.id, self.a2.id])
         self.assertEqual(arts[self.a1.id], self.a1)
         self.assertEqual(arts[self.a2.id], self.a2)
+        self.assertEqual(
+            Article.objects.in_bulk(),
+            {
+                self.a1.id: self.a1,
+                self.a2.id: self.a2,
+                self.a3.id: self.a3,
+                self.a4.id: self.a4,
+                self.a5.id: self.a5,
+                self.a6.id: self.a6,
+                self.a7.id: self.a7,
+            }
+        )
         self.assertEqual(Article.objects.in_bulk([self.a3.id]), {self.a3.id: self.a3})
         self.assertEqual(Article.objects.in_bulk({self.a3.id}), {self.a3.id: self.a3})
         self.assertEqual(Article.objects.in_bulk(frozenset([self.a3.id])), {self.a3.id: self.a3})
@@ -124,7 +136,6 @@ class LookupTests(TestCase):
         self.assertEqual(Article.objects.in_bulk([]), {})
         self.assertEqual(Article.objects.in_bulk(iter([self.a1.id])), {self.a1.id: self.a1})
         self.assertEqual(Article.objects.in_bulk(iter([])), {})
-        self.assertRaises(TypeError, Article.objects.in_bulk)
         self.assertRaises(TypeError, Article.objects.in_bulk, headline__startswith='Blah')
 
     def test_values(self):


### PR DESCRIPTION
Modified in_bulk() to return all objects in the queryset when called
with no arguments.