### PR TITLE
Fixed #24212 -- Updated the cache documentation for the pylibmc binding

### DIFF
--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -114,6 +114,15 @@ In this example, Memcached is available through a local Unix socket file
         }
     }
 
+When using the ``pylibmc`` binding, do not include the ``unix:/`` prefix::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+            'LOCATION': '/tmp/memcached.sock',
+        }
+    }
+
 One excellent feature of Memcached is its ability to share a cache over
 multiple servers. This means you can run Memcached daemons on multiple
 machines, and the program will treat the group of machines as a *single*


### PR DESCRIPTION
Updated the cache documentation to clarify the pylibmc binding should
not include the 'unix:/' prefix when specifying Unix socket files.