### PR TITLE
Restricted blank validation

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -586,7 +586,7 @@ class Field(RegisterLookupMixin):
         if value is None and not self.null:
             raise exceptions.ValidationError(self.error_messages['null'], code='null')
 
-        if not self.blank and value in self.empty_values:
+        if not self.blank and str(value).strip() in self.empty_values:
             raise exceptions.ValidationError(self.error_messages['blank'], code='blank')
 
     def clean(self, value, model_instance):


### PR DESCRIPTION
An exception will be raised for non-empty strings that contain just whitespace.