### PR TITLE
Fixed #25169 -- Clarify stacking of permission_required and login_required

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -685,7 +685,7 @@ The ``permission_required`` decorator
     If the ``raise_exception`` parameter is given, the decorator will raise
     :exc:`~django.core.exceptions.PermissionDenied`, prompting :ref:`the 403
     (HTTP Forbidden) view<http_forbidden_view>` instead of redirecting to the
-    login page. If want to give your users a chance to login first, you can 
+    login page. If you want to give your users a chance to login first, you can
     stack the :func:`~django.contrib.auth.decorators.login_required` decorator::
 
         from django.contrib.auth.decorators import login_required

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -685,7 +685,16 @@ The ``permission_required`` decorator
     If the ``raise_exception`` parameter is given, the decorator will raise
     :exc:`~django.core.exceptions.PermissionDenied`, prompting :ref:`the 403
     (HTTP Forbidden) view<http_forbidden_view>` instead of redirecting to the
-    login page.
+    login page. If want to give your users a chance to login first, you can 
+    stack the :func:`~django.contrib.auth.decorators.login_required` decorator::
+
+        from django.contrib.auth.decorators import login_required
+        from django.contrib.auth.decorators import permission_required
+
+        @permission_required('polls.can_vote', raise_exception=True)
+        @login_required
+        def my_view(request):
+            ...
 
     .. versionchanged:: 1.9
 


### PR DESCRIPTION
Stacking @login_required before @permission_required gives users a
chance to login before potentially being redirected to a 403 page.