### PR TITLE
Fixed #25644 -- Fixed reset cookie expiry date bug

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -190,6 +190,8 @@ class HttpResponseBase(six.Iterator):
                 max_age = max(0, delta.days * 86400 + delta.seconds)
             else:
                 self.cookies[key]['expires'] = expires
+        else:
+            self.cookies[key]['expires'] = ''
         if max_age is not None:
             self.cookies[key]['max-age'] = max_age
             # IE requires expires, so set it if hasn't been already.

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -208,6 +208,14 @@ class RequestsTests(SimpleTestCase):
         datetime_cookie = response.cookies['datetime']
         self.assertEqual(datetime_cookie['max-age'], 10)
 
+    def test_create_cookie_after_deleting_cookie(self):
+        """ Setting a cookie after deletion should not keep 1970 as expiry date. """
+        response = HttpResponse()
+        response.set_cookie('c', 'old-value')
+        response.delete_cookie('c')
+        response.set_cookie('c', 'new-value')
+        self.assertNotEqual(response.cookies['c']['expires'], 'Thu, 01-Jan-1970 00:00:00 GMT')
+
     def test_far_expiration(self):
         "Cookie will expire when an distant expiration time is provided"
         response = HttpResponse()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25644

Setting a cookie with the same key as a previously deleted cookie would set its expiry date to `'Thu, 01-Jan-1970 00:00:00 GMT'`.

