### PR TITLE
Fixed #25658 -- Allowed inspectdb to inspect a specific set of tables.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -366,6 +366,7 @@ answer newbie questions, and generally made Django that much better:
     Jordan Dimov <s3x3y1@gmail.com>
     Jorge Bastida <me@jorgebastida.com>
     Jorge Gajon <gajon@gajon.org>
+    José Tomás Tocino García <josetomas.tocino@gmail.com>
     Joseph Kocherhans <joseph@jkocherhans.com>
     Josh Smeaton <josh.smeaton@gmail.com>
     Joshua Ginsberg <jag@flowtheory.net>

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -19,6 +19,8 @@ class Command(BaseCommand):
         parser.add_argument('--database', action='store', dest='database',
             default=DEFAULT_DB_ALIAS, help='Nominates a database to '
             'introspect. Defaults to using the "default" database.')
+        parser.add_argument('table', action='store', nargs='*', type=str,
+            help='Selects what tables or views should be introspected')
 
     def handle(self, **options):
         try:
@@ -50,7 +52,13 @@ class Command(BaseCommand):
             yield ''
             yield 'from %s import models' % self.db_module
             known_models = []
-            for table_name in connection.introspection.table_names(cursor):
+
+            if options['table']:
+                tables_to_introspect = options['table']
+            else:
+                tables_to_introspect = connection.introspection.table_names(cursor)
+
+            for table_name in tables_to_introspect:
                 if table_name_filter is not None and callable(table_name_filter):
                     if not table_name_filter(table_name):
                         continue

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -353,7 +353,8 @@ file) to standard output.
 
 Use this if you have a legacy database with which you'd like to use Django.
 The script will inspect the database and create a model for each table within
-it.
+it. It is possible to choose what tables should be inspected by appending their
+names to the command.
 
 As you might expect, the created models will have an attribute for every field
 in the table. Note that ``inspectdb`` has a few special cases in its field-name

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -161,6 +161,9 @@ Management Commands
   command exit with a non-zero status when model changes without migrations are
   detected.
 
+* The :djadmin:`inspectdb` command now lets you choose what table/views should
+  be inspected by specifying their names with the command.
+
 Migrations
 ^^^^^^^^^^
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -443,6 +443,10 @@ Management Commands
 * Management commands that have the ``--noinput`` option now also take
   ``--no-input`` as an alias for that option.
 
+* The :djadmin:`inspectdb` command now lets you choose what table/views should
+  be inspected by specifying their names with the command.
+
+
 Migrations
 ^^^^^^^^^^
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -443,10 +443,6 @@ Management Commands
 * Management commands that have the ``--noinput`` option now also take
   ``--no-input`` as an alias for that option.
 
-* The :djadmin:`inspectdb` command now lets you choose what table/views should
-  be inspected by specifying their names with the command.
-
-
 Migrations
 ^^^^^^^^^^
 

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -27,6 +27,20 @@ class InspectDBTestCase(TestCase):
         # inspected
         self.assertNotIn("class DjangoContentType(models.Model):", out.getvalue(), msg=error_message)
 
+    def test_table_and_view_name_filter_option(self):
+        out = StringIO()
+
+        # Tell inspectdb to just inspect the inspectdb_people table
+        call_command('inspectdb', 'inspectdb_people', stdout=out)
+
+        # Check that the chosen table has been inspected
+        self.assertIn('class InspectdbPeople(models.Model):', out.getvalue(),
+            msg="inspectdb hasn't examined a table that's been chosen to be inspected")
+
+        # Check that no other tables have been inspected
+        self.assertNotIn("class InspectdbPeopledata(models.Model):", out.getvalue(),
+            msg="inspectdb has examined a table that hasn't been chosen to be inspected")
+
     def make_field_type_asserter(self):
         """Call inspectdb and return a function to validate a field type in its output"""
         out = StringIO()


### PR DESCRIPTION
This adds a new option to the `inspectdb` command so that, instead of automatically detecting and inspecting all existing views and tables in a database, the user can input what tables and views should be inspected.

Usage is simple:

    ./manage.py inspectdb tablename1 viewname2

Trac ticket: https://code.djangoproject.com/ticket/25658#ticket