### PR TITLE
Cache SingleObjectMixin's queryset

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -65,7 +65,8 @@ class SingleObjectMixin(ContextMixin):
         """
         if self.queryset is None:
             if self.model:
-                return self.model._default_manager.all()
+                self.queryset = self.model._default_manager
+                return self.queryset.all()
             else:
                 raise ImproperlyConfigured(
                     "%(cls)s is missing a QuerySet. Define "


### PR DESCRIPTION
Cache django.views.generic.detail.SingleObjectMixin's self.queryset when self.get_queryset is called, to be able to call self.get_object multiple times cost-free.