### PR TITLE
Don't try to initialize object with parameters

### DIFF
--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -22,6 +22,9 @@ class BaseFinder(object):
     A base file finder to be used for custom staticfiles finder classes.
     """
 
+    def __init__(self, *args, **kwargs):
+        super(BaseFinder, self).__init__()
+
     def find(self, path, all=False):
         """
         Given a relative file path this ought to find an


### PR DESCRIPTION
Solves:

    File ".../lib/python3.4/site-packages/django/contrib/staticfiles/finders.py", line 140, in __init__
        super(AppDirectoriesFinder, self).__init__(*args, **kwargs)
    TypeError: object.__init__() takes no parameters