### PR TITLE
unmached ] removed in auth.login function call doc

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -935,7 +935,7 @@ All authentication views
 This is a list with all the views ``django.contrib.auth`` provides. For
 implementation details see :ref:`using-the-views`.
 
-.. function:: login(request, template_name=`registration/login.html`, redirect_field_name=, authentication_form, current_app, extra_context])
+.. function:: login(request, template_name=`registration/login.html`, redirect_field_name=, authentication_form, current_app, extra_context)
 
     **URL name:** ``login``
 


### PR DESCRIPTION
small change, an umached ] in the function call docs for auth.login.
probably left over from when it was used to wrap optional parameters.