### PR TITLE
Fixed #25671 -- arrange model in django admin index page.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -108,6 +108,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
     view_on_site = True
     show_full_result_count = True
     checks_class = BaseModelAdminChecks
+    order = None
 
     def check(self, **kwargs):
         return self.checks_class().check(self, **kwargs)

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -448,7 +448,7 @@ class AdminSite(object):
             try:
                 model_order = int(model_admin.order)
             except (TypeError, ValueError):
-                model_order = None
+                model_order = model_name
 
             model_dict = {
                 'name': model_name,

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -443,10 +443,18 @@ class AdminSite(object):
                 continue
 
             info = (app_label, model._meta.model_name)
+            model_name = capfirst(model._meta.verbose_name_plural)
+            # Generate model order
+            try:
+                model_order = int(model_admin.order)
+            except (TypeError, ValueError):
+                model_order = None
+
             model_dict = {
-                'name': capfirst(model._meta.verbose_name_plural),
+                'name': model_name,
                 'object_name': model._meta.object_name,
                 'perms': perms,
+                'order': model_order,
             }
             if perms.get('change'):
                 try:
@@ -490,7 +498,7 @@ class AdminSite(object):
 
         # Sort the models alphabetically within each app.
         for app in app_list:
-            app['models'].sort(key=lambda x: x['name'])
+            app['models'].sort(key=lambda x: x['order'])
 
         return app_list
 


### PR DESCRIPTION
add an option to `ModelAdmin` that get integer value like this:
`order = 1`
if order exists and has a valid integer value, it apply as model order, else previous behaviour(arrange model by name in alphabetical order) applied.
