### PR TITLE
fix #25675 -- divisibleby template filter optimization

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -797,8 +797,11 @@ def default_if_none(value, arg):
 
 @register.filter(is_safe=False)
 def divisibleby(value, arg):
-    """Returns True if the value is devisible by the argument."""
-    return int(value) % int(arg) == 0
+    """Returns True if the value is devisible by the argument. Otherwise return False"""
+    try:
+        return int(value) % int(arg) == 0
+    except (TypeError, ValueError):
+        return False
 
 
 @register.filter(is_safe=False)


### PR DESCRIPTION
django template system return `ValueError` if in `divisibleby` template filter, ‍‍‍value or argument can not convert to Int.
it is better to return `False` in this case 