### PR TITLE
[1.8.x] fixed #25618 -- Added migration support for non-upgraded apps

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -97,6 +97,7 @@ class MigrationLoader(object):
                         migration_names.add(import_name)
             # Load them
             south_style_migrations = False
+            django_style_migrations = False
             for migration_name in migration_names:
                 try:
                     migration_module = import_module("%s.%s" % (module_name, migration_name))
@@ -115,8 +116,10 @@ class MigrationLoader(object):
                     south_style_migrations = True
                     break
                 self.disk_migrations[app_config.label, migration_name] = migration_module.Migration(migration_name, app_config.label)
+                django_style_migrations = True
+
             if south_style_migrations:
-                if app_config.label in self.migrated_apps:
+                if django_style_migrations:
                     raise BadMigrationError(
                         "Migrated app %r contains South migrations. Make sure "
                         "all numbered South migrations are deleted prior to "


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25618

This PR fixes ticket  #25618, specifically, the problem related in [this comment](https://code.djangoproject.com/ticket/25618#comment:7).

In this sense, a non-upgraded app is one that retains south migrations
in the `migrations` module and does not introduce Django migrations at all.

Such an app would, under the previous solution, break the migration system.