### PR TITLE
Fixed #25670 -- Implemented ordering by numeric `arg` for `dictsort` and `dictsortreversed` filters

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -813,7 +813,7 @@ TECHNICAL_500_TEMPLATE = ("""
                 </tr>
               </thead>
               <tbody>
-                {% for var in frame.vars|dictsort:"0" %}
+                {% for var in frame.vars|dictsort:0 %}
                   <tr>
                     <td>{{ var.0|force_escape }}</td>
                     <td class="code"><pre>{{ var.1 }}</pre></td>
@@ -995,7 +995,7 @@ Exception Value: {{ exception_value|force_escape }}
       </tr>
     </thead>
     <tbody>
-      {% for var in request.META.items|dictsort:"0" %}
+      {% for var in request.META.items|dictsort:0 %}
         <tr>
           <td>{{ var.0 }}</td>
           <td class="code"><pre>{{ var.1|pprint }}</pre></td>
@@ -1017,7 +1017,7 @@ Exception Value: {{ exception_value|force_escape }}
       </tr>
     </thead>
     <tbody>
-      {% for var in settings.items|dictsort:"0" %}
+      {% for var in settings.items|dictsort:0 %}
         <tr>
           <td>{{ var.0 }}</td>
           <td class="code"><pre>{{ var.1|pprint }}</pre></td>
@@ -1107,12 +1107,12 @@ FILES:{% for k, v in request.FILES.items %}
 COOKIES:{% for k, v in request.COOKIES.items %}
 {{ k }} = {{ v|stringformat:"r" }}{% empty %} No cookie data{% endfor %}
 
-META:{% for k, v in request.META.items|dictsort:"0" %}
+META:{% for k, v in request.META.items|dictsort:0 %}
 {{ k }} = {{ v|stringformat:"r" }}{% endfor %}
 {% else %}Request data not supplied
 {% endif %}
 Settings:
-Using settings module {{ settings.SETTINGS_MODULE }}{% for k, v in settings.items|dictsort:"0" %}
+Using settings module {{ settings.SETTINGS_MODULE }}{% for k, v in settings.items|dictsort:0 %}
 {{ k }} = {{ v|stringformat:"r" }}{% endfor %}
 
 {% if not is_email %}

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1443,6 +1443,40 @@ then the output would be::
     * 1984 (George)
     * Timequake (Kurt)
 
+.. versionchanged:: 1.10
+
+``dictsort`` can also order a list of lists (or any other object, implementing
+``__getitem__``) by elements at specified index.
+For example, the following call to ``dictsort``::
+
+    {% vars|dictsort:0 %}
+
+Where ``vars`` is defined as:
+
+.. code-block:: python
+
+    [
+        ('a', '42'),
+        ('c', 'string'),
+        ('b', 'foo')
+    ]
+
+produces the following output:
+
+.. code-block:: python
+
+    [
+        ('a', '42'),
+        ('b', 'foo'),
+        ('c', 'string')
+    ]
+
+Note, that you should pass index as an integer, rather than a string. The following block::
+
+    {% vars|dictsort:"0" %}
+
+produces empty output.
+
 .. templatefilter:: dictsortreversed
 
 ``dictsortreversed``

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -330,6 +330,9 @@ Templates
 
 * Added the ``is`` comparison operator to the :ttag:`if` tag.
 
+* Added support for a list of lists ordering by an element at specified index
+  to :tfilter:`dictsort`
+
 Tests
 ~~~~~
 

--- a/tests/template_tests/filter_tests/test_dictsort.py
+++ b/tests/template_tests/filter_tests/test_dictsort.py
@@ -33,6 +33,32 @@ class FunctionTests(SimpleTestCase):
 
         self.assertEqual([d['foo']['bar'] for d in sorted_data], [3, 2, 1])
 
+    def test_sort_list_of_tuples(self):
+        data = [
+            ('a', '42'), ('c', 'string'), ('b', 'foo')
+        ]
+        expected = [
+            ('a', '42'), ('b', 'foo'), ('c', 'string')
+        ]
+        sorted_data = dictsort(data, 0)
+
+        self.assertEqual(expected, sorted_data)
+
+    def test_sort_list_of_tuple_like_dicts(self):
+        data = [
+            {'0': 'a', '1': '42'},
+            {'0': 'c', '1': 'string'},
+            {'0': 'b', '1': 'foo'}
+        ]
+        expected = [
+            {'0': 'a', '1': '42'},
+            {'0': 'b', '1': 'foo'},
+            {'0': 'c', '1': 'string'}
+        ]
+        sorted_data = dictsort(data, '0')
+
+        self.assertEqual(expected, sorted_data)
+
     def test_invalid_values(self):
         """
         If dictsort is passed something other than a list of dictionaries,

--- a/tests/template_tests/filter_tests/test_dictsortreversed.py
+++ b/tests/template_tests/filter_tests/test_dictsortreversed.py
@@ -19,6 +19,32 @@ class FunctionTests(SimpleTestCase):
              [('age', 18), ('name', 'Jonny B Goode')]],
         )
 
+    def test_sort_list_of_tuples(self):
+        data = [
+            ('a', '42'), ('c', 'string'), ('b', 'foo')
+        ]
+        expected = [
+            ('c', 'string'), ('b', 'foo'), ('a', '42')
+        ]
+        sorted_data = dictsortreversed(data, 0)
+
+        self.assertEqual(expected, sorted_data)
+
+    def test_sort_list_of_tuple_like_dicts(self):
+        data = [
+            {'0': 'a', '1': '42'},
+            {'0': 'c', '1': 'string'},
+            {'0': 'b', '1': 'foo'}
+        ]
+        expected = [
+            {'0': 'c', '1': 'string'},
+            {'0': 'b', '1': 'foo'},
+            {'0': 'a', '1': '42'}
+        ]
+        sorted_data = dictsortreversed(data, '0')
+
+        self.assertEqual(expected, sorted_data)
+
     def test_invalid_values(self):
         """
         If dictsortreversed is passed something other than a list of


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25670