### PR TITLE
Make sure to never catch SystemExit.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -97,10 +97,7 @@ class BaseHandler(object):
                     RemovedInDjango20Warning, stacklevel=2
                 )
                 response = callback(request, **param_dict)
-        except SystemExit:
-            # Allow sys.exit() to actually exit.
-            raise
-        except:
+        except Exception:
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
 
@@ -243,9 +240,7 @@ class BaseHandler(object):
                         "HttpResponse object. It returned None instead."
                         % (middleware_method.__self__.__class__.__name__))
             response = self.apply_response_fixes(request, response)
-        except SystemExit:
-            raise
-        except:  # Any exception should be gathered and handled
+        except Exception:  # Any exception should be gathered and handled
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -97,6 +97,9 @@ class BaseHandler(object):
                     RemovedInDjango20Warning, stacklevel=2
                 )
                 response = callback(request, **param_dict)
+        except SystemExit:
+            # Allow sys.exit() to actually exit.
+            raise
         except:
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
@@ -240,6 +243,8 @@ class BaseHandler(object):
                         "HttpResponse object. It returned None instead."
                         % (middleware_method.__self__.__class__.__name__))
             response = self.apply_response_fixes(request, response)
+        except SystemExit:
+            raise
         except:  # Any exception should be gathered and handled
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -159,6 +159,8 @@ class WSGIHandler(base.BaseHandler):
                     # Check that middleware is still uninitialized.
                     if self._request_middleware is None:
                         self.load_middleware()
+                except SystemExit:
+                    raise
                 except:
                     # Unload whatever middleware we got
                     self._request_middleware = None

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -159,9 +159,7 @@ class WSGIHandler(base.BaseHandler):
                     # Check that middleware is still uninitialized.
                     if self._request_middleware is None:
                         self.load_middleware()
-                except SystemExit:
-                    raise
-                except:
+                except Exception:
                     # Unload whatever middleware we got
                     self._request_middleware = None
                     raise

--- a/django/template/loaders/eggs.py
+++ b/django/template/loaders/eggs.py
@@ -36,6 +36,11 @@ class Loader(BaseLoader):
     def get_contents(self, origin):
         try:
             source = resource_string(origin.app_name, origin.pkg_name)
+        except SystemExit:
+            # Make sure to re-raise a SystemExit, we don't want it to be
+            # transformed into another exception which will get caught later
+            # on.
+            raise
         except:
             raise TemplateDoesNotExist(origin)
 

--- a/django/template/loaders/eggs.py
+++ b/django/template/loaders/eggs.py
@@ -36,12 +36,7 @@ class Loader(BaseLoader):
     def get_contents(self, origin):
         try:
             source = resource_string(origin.app_name, origin.pkg_name)
-        except SystemExit:
-            # Make sure to re-raise a SystemExit, we don't want it to be
-            # transformed into another exception which will get caught later
-            # on.
-            raise
-        except:
+        except Exception:
             raise TemplateDoesNotExist(origin)
 
         if six.PY2:

--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -48,6 +48,8 @@ def autodiscover_modules(*args, **kwargs):
                     before_import_registry = copy.copy(register_to._registry)
 
                 import_module('%s.%s' % (app_config.name, module_to_search))
+            except SystemExit:
+                raise
             except:
                 # Reset the registry to the state before the last import
                 # as this import will have to reoccur on the next request and

--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -48,9 +48,7 @@ def autodiscover_modules(*args, **kwargs):
                     before_import_registry = copy.copy(register_to._registry)
 
                 import_module('%s.%s' % (app_config.name, module_to_search))
-            except SystemExit:
-                raise
-            except:
+            except Exception:
                 # Reset the registry to the state before the last import
                 # as this import will have to reoccur on the next request and
                 # this could raise NotRegistered and AlreadyRegistered


### PR DESCRIPTION
If a `SystemExit` is raised one way or another, it should not be caught.

In some places, there are already some guards against catching `SystemExit`, but it's good to add some more.