### PR TITLE
Fixed #25683 -- Made ModelChoiceField queryset accept Manager objects.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1102,9 +1102,11 @@ class ModelChoiceIterator(object):
     def __iter__(self):
         if self.field.empty_label is not None:
             yield ("", self.field.empty_label)
+        queryset = self.queryset.all()
         # Can't use iterator() when queryset uses prefetch_related()
-        method = 'all' if self.queryset._prefetch_related_lookups else 'iterator'
-        for obj in getattr(self.queryset, method)():
+        if not queryset._prefetch_related_lookups:
+            queryset = queryset.iterator()
+        for obj in queryset:
             yield self.choice(obj)
 
     def __len__(self):

--- a/docs/releases/1.8.7.txt
+++ b/docs/releases/1.8.7.txt
@@ -12,4 +12,7 @@ Bugfixes
 * Fixed a crash of the debug view during the autumn DST change when
   :setting:`USE_TZ` is ``False`` and ``pytz`` is installed.
 
+* Fixed a regression in 1.8.6, ``ModelChoiceField`` can now again take
+  ``Manager`` objects for the queryset argument (:ticket:`25683`).
+
 * ...

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -167,6 +167,12 @@ class ModelFormCallableModelDefault(TestCase):
 
 
 class FormsModelTestCase(TestCase):
+    def test_modelchoicefield_manager(self):
+        f = ModelChoiceField(ChoiceOptionModel.objects)
+        choice = ChoiceOptionModel.objects.create(name="choice 1")
+        self.assertEqual(list(f.choices), [('', '---------'),
+                                           (choice.pk, six.text_type(choice))])
+
     def test_unicode_filename(self):
         # FileModel with unicode filename and data #########################
         file1 = SimpleUploadedFile('我隻氣墊船裝滿晒鱔.txt', 'मेरी मँडराने वाली नाव सर्पमीनों से भरी ह'.encode('utf-8'))


### PR DESCRIPTION
This was a regression from the fix of #25496. Additionally, I refactored
some iffy code from that fix.

This fix was sponsored by [voicecom.ee](https://voicecom.ee).