### PR TITLE
[1.8.x] Fixed #25683 -- ModelChoiceField accepts Manager objects for queryset.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1092,17 +1092,19 @@ class ModelChoiceIterator(object):
     def __iter__(self):
         if self.field.empty_label is not None:
             yield ("", self.field.empty_label)
-        method = 'all' if self.queryset._prefetch_related_lookups else 'iterator'
-        queryset = getattr(self.queryset, method)
+        queryset = self.queryset.all()
+        if not queryset._prefetch_related_lookups:
+            queryset = queryset.iterator()
+
         if self.field.cache_choices:
             if self.field.choice_cache is None:
                 self.field.choice_cache = [
-                    self.choice(obj) for obj in queryset()
+                    self.choice(obj) for obj in queryset
                 ]
             for choice in self.field.choice_cache:
                 yield choice
         else:
-            for obj in queryset():
+            for obj in queryset:
                 yield self.choice(obj)
 
     def __len__(self):

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -87,6 +87,12 @@ class TestTicket14567(TestCase):
         self.assertIsInstance(form.cleaned_data['multi_choice'], models.query.QuerySet)
 
 
+class TestTicket25683(TestCase):
+    def test_modelchoicefield_manager(self):
+        f = ModelChoiceField(ChoiceOptionModel.objects)
+        self.assertTrue(list(f.choices))
+
+
 class ModelFormCallableModelDefault(TestCase):
     def test_no_empty_option(self):
         "If a model's ForeignKey has blank=False and a default, no empty option is created (Refs #10792)."


### PR DESCRIPTION
This was a regression from the fix of #25496. Additionally, I refactored
some iffy code from that fix.

This fix was sponsored by [voicecom.ee](https://voicecom.ee).