### PR TITLE
Fixed #25686 -- Allow routers without "allow_migrate" method

### DIFF
--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -299,12 +299,12 @@ class ConnectionRouter(object):
                 continue
 
             if six.PY3:
-                sig = inspect.signature(router.allow_migrate)
+                sig = inspect.signature(method)
                 has_deprecated_signature = not any(
                     p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
                 )
             else:
-                argspec = inspect.getargspec(router.allow_migrate)
+                argspec = inspect.getargspec(method)
                 has_deprecated_signature = len(argspec.args) == 3 and not argspec.keywords
 
             if has_deprecated_signature:

--- a/docs/releases/1.8.7.txt
+++ b/docs/releases/1.8.7.txt
@@ -9,4 +9,4 @@ Django 1.8.7 fixes several bugs in 1.8.6.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression where database routers without a ``allow_migrate`` method raised an exception (:ticket:`25686`).


### PR DESCRIPTION
Fixes regression introduced in e2ea30c
Ticket: https://code.djangoproject.com/ticket/25686
Old PR: https://github.com/django/django/pull/5556