### PR TITLE
Fixed #25170 --- assertXMLEquals ignores whitespace around tags.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -338,6 +338,8 @@ def compare_xml(want, got):
                 return node
 
     want, got = strip_quotes(want, got)
+    want = want.strip()
+    got = got.strip()
     want = want.replace('\\n', '\n')
     got = got.replace('\\n', '\n')
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -707,6 +707,22 @@ class XMLEqualTests(SimpleTestCase):
         xml2 = "<elem attr1='a' attr2='b' />"
         self.assertXMLEqual(xml1, xml2)
 
+    def test_newline_after_tag(self):
+        xml1 = "<elem attr1='a' attr2='b' />"
+        xml2 = "<elem attr1='a' attr2='b' />\n"
+        self.assertXMLEqual(xml1, xml2)
+
+    def test_whitespace_around_tag(self):
+        xml1 = "<elem attr1='a' attr2='b' /> "
+        xml2 = " <elem attr1='a' attr2='b' />"
+        self.assertXMLEqual(xml1, xml2)
+
+    def test_whitespace_inside_tag(self):
+        xml1 = "<elem><a/></elem> "
+        xml2 = "<elem> <a/>\n</elem> "
+        with self.assertRaises(AssertionError):
+            self.assertXMLEqual(xml1, xml2)
+
     def test_simple_equal_unordered(self):
         xml1 = "<elem attr1='a' attr2='b' />"
         xml2 = "<elem attr2='b' attr1='a' />"


### PR DESCRIPTION
Test function assertXMLEquals will now ignore whitespace around
outermost tags in the string given to it, whitespace inside
tags, or between them is not ignored.