### PR TITLE
Fixed #25274 --- Made inspectdb handle renamed fields in unique_together.

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
                 except NotImplementedError:
                     constraints = {}
                 used_column_names = []  # Holds column names used in the table so far
-                column_to_field_name = {}  # Maps original column names to names of django fields
+                column_to_field_name = {}  # Maps original column names to names of model fields
                 for row in connection.introspection.get_table_description(cursor, table_name):
                     comment_notes = []  # Holds Field notes, to be displayed in a Python comment.
                     extra_params = OrderedDict()  # Holds Field parameters such as 'db_column'.
@@ -257,8 +257,7 @@ class Command(BaseCommand):
                 if len(columns) > 1:
                     # we do not want to include the u"" or u'' prefix
                     # so we build the string rather than interpolate the tuple
-                    tup = '(' + ', '.join(
-                        "'%s'" % column_to_field_name[c] for c in columns) + ')'
+                    tup = '(' + ', '.join("'%s'" % column_to_field_name[c] for c in columns) + ')'
                     unique_together.append(tup)
         meta = ["",
                 "    class Meta:",

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -71,6 +71,7 @@ class Command(BaseCommand):
                 except NotImplementedError:
                     constraints = {}
                 used_column_names = []  # Holds column names used in the table so far
+                column_to_field_name = {}  # Maps original column names to names of django fields
                 for row in connection.introspection.get_table_description(cursor, table_name):
                     comment_notes = []  # Holds Field notes, to be displayed in a Python comment.
                     extra_params = OrderedDict()  # Holds Field parameters such as 'db_column'.
@@ -83,6 +84,7 @@ class Command(BaseCommand):
                     comment_notes.extend(notes)
 
                     used_column_names.append(att_name)
+                    column_to_field_name[column_name] = att_name
 
                     # Add primary_key and unique, if necessary.
                     if column_name in indexes:
@@ -145,7 +147,7 @@ class Command(BaseCommand):
                     if comment_notes:
                         field_desc += '  # ' + ' '.join(comment_notes)
                     yield '    %s' % field_desc
-                for meta_line in self.get_meta(table_name, constraints):
+                for meta_line in self.get_meta(table_name, constraints, column_to_field_name):
                     yield meta_line
 
     def normalize_col_name(self, col_name, used_column_names, is_relation):
@@ -242,7 +244,7 @@ class Command(BaseCommand):
 
         return field_type, field_params, field_notes
 
-    def get_meta(self, table_name, constraints):
+    def get_meta(self, table_name, constraints, column_to_field_name):
         """
         Return a sequence comprising the lines of code necessary
         to construct the inner Meta class for the model corresponding
@@ -255,7 +257,8 @@ class Command(BaseCommand):
                 if len(columns) > 1:
                     # we do not want to include the u"" or u'' prefix
                     # so we build the string rather than interpolate the tuple
-                    tup = '(' + ', '.join("'%s'" % c for c in columns) + ')'
+                    tup = '(' + ', '.join(
+                        "'%s'" % column_to_field_name[c] for c in columns) + ')'
                     unique_together.append(tup)
         meta = ["",
                 "    class Meta:",

--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -73,5 +73,14 @@ class UniqueTogether(models.Model):
     field1 = models.IntegerField()
     field2 = models.CharField(max_length=10)
 
+    from_field = models.IntegerField(db_column="from")
+
+    non_unique = models.IntegerField(db_column="non__unique_column")
+    non_unique_0 = models.IntegerField(db_column="non_unique__column")
+
     class Meta:
-        unique_together = ('field1', 'field2')
+        unique_together = [
+            ('field1', 'field2'),
+            ('from_field', 'field1'),
+            ('non_unique', 'non_unique_0')
+        ]

--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -72,9 +72,7 @@ class ColumnTypes(models.Model):
 class UniqueTogether(models.Model):
     field1 = models.IntegerField()
     field2 = models.CharField(max_length=10)
-
     from_field = models.IntegerField(db_column="from")
-
     non_unique = models.IntegerField(db_column="non__unique_column")
     non_unique_0 = models.IntegerField(db_column="non_unique__column")
 
@@ -82,5 +80,5 @@ class UniqueTogether(models.Model):
         unique_together = [
             ('field1', 'field2'),
             ('from_field', 'field1'),
-            ('non_unique', 'non_unique_0')
+            ('non_unique', 'non_unique_0'),
         ]

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -252,54 +252,56 @@ class InspectDBTestCase(TestCase):
 
 
 class TestUniqueTogether(TestCase):
-
     """
     We test whether ``unique_together`` is generated properly, specifically we
     test whether ``unique_together`` contains field names properly generated
     from columns whose names were cleaned.
     """
-
     def setUp(self):
         out = StringIO()
         call_command('inspectdb',
                      table_name_filter=lambda tn: tn.startswith('inspectdb_uniquetogether'),
                      stdout=out)
         self.inspect_output = out.getvalue()
-        # self.unique_re = re.compile(r".*unique_together = \(([\'\w\s,\d_\(\)]+),\).*")
         self.unique_re = re.compile(r".*unique_together = \((.+),\).*")
 
     def test_unique_together_meta(self):
-
+        """Tests whether unique_together is generated at all by inspectdb"""
         self.assertIn("unique_together", self.inspect_output,
             msg='inspectdb should generate unique_together.')
 
     def test_simple_fields(self):
-
+        """Tests whether inspect generates unique_together with "normal" fields"""
         match_list = re.findall(self.unique_re, self.inspect_output)
-
-        self.assertEqual(len(match_list), 1, "There should be exactly one unique block")
+        # There should be exactly one unique block
+        self.assertEqual(len(match_list), 1)
         fields = match_list[0]
-
-        self.assertIn("('field1', 'field2')", fields,
-            msg="Tuple ('field1', 'field2') should be in unique_together Meta entry")
+        # Fields named ('field1', 'field2') should be in unique_together Meta entry
+        self.assertIn("('field1', 'field2')", fields)
 
     def test_simple_keyword(self):
-
+        """
+        Tests whether inspect generates unique_together with fields generated
+        from columns whose names are Python keywords
+        """
         match_list = re.findall(self.unique_re, self.inspect_output)
-
-        self.assertEqual(len(match_list), 1, "There should be exactly one unique block")
+        # There should be exactly one unique block
+        self.assertEqual(len(match_list), 1)
         fields = match_list[0]
 
-        self.assertIn("('non_unique_column', 'non_unique_column_0')", fields,
-            msg="Tuple ('from_field', 'field1') should be in unique_together Meta entry")
+        # Fields named ('from_field', 'field1') should be in unique_together Meta entry
+        self.assertIn("('non_unique_column', 'non_unique_column_0')", fields)
 
     def test_renamed_columns(self):
-
+        """
+        Tests whether inspect generates unique_together for columns whose names
+        normalize to the same python field name (and hence are
+        given integer postfix)
+        """
         match_list = re.findall(self.unique_re, self.inspect_output)
-
-        self.assertEqual(len(match_list), 1, "There should be exactly one unique block")
+        # There should be exactly one unique block
+        self.assertEqual(len(match_list), 1)
         fields = match_list[0]
-
-        self.assertIn("('non_unique_column', 'non_unique_column_0')", fields,
-            msg="Tuple ('non_unique_column', 'non_unique_column_0') "
-                "should be in unique_together Meta entry")
+        # Fields named ('non_unique_column', 'non_unique_column_0')
+        # should be in unique_together Meta entry
+        self.assertIn("('non_unique_column', 'non_unique_column_0')", fields)


### PR DESCRIPTION
Inspectdb now handles renamed fields in unique_together. 

It was tested on sqlite and postgresql (I don't know whether I'm supposed to check it on other all databases). 