### PR TITLE
Fixed #25688 -- Made admin.register() disallow an empty list of models.

### DIFF
--- a/django/contrib/admin/decorators.py
+++ b/django/contrib/admin/decorators.py
@@ -3,7 +3,7 @@ def register(*models, **kwargs):
     Registers the given model(s) classes and wrapped ModelAdmin class with
     admin site:
 
-    Atleast one model must be passed for register.
+    At least one model must be passed to register.
 
     @register(Author)
     class AuthorAdmin(admin.ModelAdmin):
@@ -17,7 +17,7 @@ def register(*models, **kwargs):
 
     def _model_admin_wrapper(admin_class):
         if not models:
-            raise ValueError('Atleast one model must be passed for register')
+            raise ValueError('At least one model must be passed to register')
 
         admin_site = kwargs.pop('site', site)
 

--- a/django/contrib/admin/decorators.py
+++ b/django/contrib/admin/decorators.py
@@ -3,6 +3,8 @@ def register(*models, **kwargs):
     Registers the given model(s) classes and wrapped ModelAdmin class with
     admin site:
 
+    Atleast one model must be passed for register.
+
     @register(Author)
     class AuthorAdmin(admin.ModelAdmin):
         pass
@@ -14,6 +16,9 @@ def register(*models, **kwargs):
     from django.contrib.admin.sites import site, AdminSite
 
     def _model_admin_wrapper(admin_class):
+        if not models:
+            raise ValueError('Atleast one model must be passed for register')
+
         admin_site = kwargs.pop('site', site)
 
         if not isinstance(admin_site, AdminSite):

--- a/django/contrib/admin/decorators.py
+++ b/django/contrib/admin/decorators.py
@@ -17,7 +17,7 @@ def register(*models, **kwargs):
 
     def _model_admin_wrapper(admin_class):
         if not models:
-            raise ValueError('At least one model must be passed to register')
+            raise ValueError('At least one model must be passed to register.')
 
         admin_site = kwargs.pop('site', site)
 

--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -135,5 +135,5 @@ class TestRegistrationDecorator(SimpleTestCase):
             register(Person, site=Traveler), NameAdmin)
 
     def test_empty_models_list_registration_fails(self):
-        self.assertRaisesMessage(ValueError, 'At least one model must be passed to register.',
-            register(), NameAdmin)
+        with self.assertRaisesMessage(ValueError, 'At least one model must be passed to register.'):
+            register()(NameAdmin)

--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -133,3 +133,7 @@ class TestRegistrationDecorator(SimpleTestCase):
     def test_custom_site_not_an_admin_site(self):
         self.assertRaisesMessage(ValueError, 'site must subclass AdminSite',
             register(Person, site=Traveler), NameAdmin)
+
+    def test_empty_models_list_registration_fails(self):
+        self.assertRaisesMessage(ValueError, 'At least one model must be passed to register.',
+            register(), NameAdmin)


### PR DESCRIPTION
admin.register shouldn't allow an empty list of models to be registered