### PR TITLE
Fixed #25680 -- Added django-admin shell --command option

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -15,6 +15,8 @@ class Command(BaseCommand):
             help='When using plain Python, ignore the PYTHONSTARTUP environment variable and ~/.pythonrc.py script.')
         parser.add_argument('-i', '--interface', choices=self.shells, dest='interface',
             help='Specify an interactive interpreter interface. Available options: "ipython" and "bpython"')
+        parser.add_argument('-c', '--command', dest='command',
+            help='Instead of opening an interactive shell, run one command as Django and exit.')
 
     def _ipython_pre_011(self):
         """Start IPython pre-0.11"""
@@ -62,6 +64,11 @@ class Command(BaseCommand):
 
     def handle(self, **options):
         try:
+            # Just execute this command and get out.
+            if options['command']:
+                exec(options['command'])
+                return
+
             if options['plain']:
                 # Don't bother loading IPython, because the user wants plain Python.
                 raise ImportError

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -966,6 +966,15 @@ behavior you can use the ``--no-startup`` option. e.g.::
 
     django-admin shell --plain --no-startup
 
+.. versionadded:: 1.10
+
+.. django-admin-option:: --command, -c <command>
+
+The ``--command`` option lets you pass a command as a string to execute it
+as Django, like so::
+
+    django-admin shell --command="import django; print(django.__version__)"
+
 showmigrations [<app_label> [<app_label>]]
 ------------------------------------------
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -161,6 +161,9 @@ Management Commands
   command exit with a non-zero status when model changes without migrations are
   detected.
 
+* The new :djadminopt:`shell --command <command>` option lets you run a command
+  as Django and exit (instead of opening the interactive shell).
+
 Migrations
 ^^^^^^^^^^
 

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -1,0 +1,15 @@
+from django import __version__
+from django.core.management import call_command
+from django.test import SimpleTestCase
+from django.test.utils import patch_logger
+
+
+class ShellCommandTestCase(SimpleTestCase):
+
+    def test_command_option(self):
+        with patch_logger('test', 'info') as logger:
+            call_command('shell',
+                         command='import django; from logging import getLogger;'
+                                 'getLogger("test").info(django.__version__)')
+            self.assertEqual(len(logger), 1)
+            self.assertEqual(logger[0], __version__)


### PR DESCRIPTION
Add a -c option to the shell command to execute a command passed as a
string as Django.