### PR TITLE
Fixed #25695 -- Added template_name parameter to csrf_failure view

### DIFF
--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.http import HttpResponseForbidden
-from django.template import Context, Engine
+from django.template import Context, Engine, TemplateDoesNotExist, loader
 from django.utils.translation import ugettext as _
 from django.utils.version import get_docs_version
-
 
 # We include the template inline since we need to be able to reliably display
 # this error message, especially for the sake of developers, and there isn't any
@@ -95,14 +94,14 @@ CSRF_FAILURE_TEMPLATE = """
 </body>
 </html>
 """
+CSRF_FAILURE_TEMPLATE_NAME = "403_csrf.html"
 
 
-def csrf_failure(request, reason=""):
+def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
     """
     Default view used when request fails CSRF protection
     """
     from django.middleware.csrf import REASON_NO_REFERER, REASON_NO_CSRF_COOKIE
-    t = Engine().from_string(CSRF_FAILURE_TEMPLATE)
     c = Context({
         'title': _("Forbidden"),
         'main': _("CSRF verification failed. Request aborted."),
@@ -131,4 +130,13 @@ def csrf_failure(request, reason=""):
         'docs_version': get_docs_version(),
         'more': _("More information is available with DEBUG=True."),
     })
+    try:
+        t = loader.get_template(template_name)
+    except TemplateDoesNotExist:
+        if template_name == CSRF_FAILURE_TEMPLATE_NAME:
+            # If the default-named template does not exist, fall back to the default template shipping with Django
+            t = Engine().from_string(CSRF_FAILURE_TEMPLATE)
+        else:
+            # If a template does not exist, that a user intentionally configured, we should present an error message
+            raise
     return HttpResponseForbidden(t.render(c), content_type='text/html')

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -385,6 +385,15 @@ where ``reason`` is a short message (intended for developers or logging, not for
 end users) indicating the reason the request was rejected.  See
 :doc:`/ref/csrf`.
 
+The default implementation ``django.views.csrf.csrf_failure`` takes an additional
+keyword parameter ``template_name`` that defaults to ``'403_csrf.html'``. If a
+template can be found under this name, it will be used to render the error
+message.
+
+.. versionchanged:: 1.10
+
+   The ``template_name`` parameter of ``csrf_failure`` has been added.
+
 .. setting:: CSRF_HEADER_NAME
 
 CSRF_HEADER_NAME

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -113,7 +113,10 @@ Cache
 CSRF
 ^^^^
 
-* ...
+* The default implementation of :setting:`CSRF_FAILURE_VIEW` now takes
+  an optional ``template_name`` parameter defaulting to
+  ``'403_csrf.html'`` and looks for a template of this name to render
+  its error message.
 
 Database backends
 ^^^^^^^^^^^^^^^^^

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -1,5 +1,9 @@
-from django.test import Client, SimpleTestCase, override_settings
+from django.template import TemplateDoesNotExist
+from django.test import (
+    Client, RequestFactory, SimpleTestCase, override_settings,
+)
 from django.utils.translation import override
+from django.views.csrf import CSRF_FAILURE_TEMPLATE_NAME, csrf_failure
 
 
 @override_settings(ROOT_URLCONF="view_tests.urls")
@@ -74,3 +78,29 @@ class CsrfViewTests(SimpleTestCase):
         """
         response = self.client.post('/')
         self.assertContains(response, "Forbidden", status_code=403)
+
+    @override_settings(TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'OPTIONS': {
+            'loaders': [
+                ('django.template.loaders.locmem.Loader', {
+                    CSRF_FAILURE_TEMPLATE_NAME: 'Test template for CSRF failure'
+                }),
+            ],
+        },
+    }])
+    def test_custom_template(self):
+        """
+        Test that csrf_failed.html is used correctly, if it exists.
+        """
+        response = self.client.post('/')
+        self.assertContains(response, "Test template for CSRF failure", status_code=403)
+
+    def test_custom_template_does_not_exist(self):
+        """
+        Test that an exception is raised if we supply a custom template name
+        """
+        factory = RequestFactory()
+        request = factory.post('/')
+        with self.assertRaises(TemplateDoesNotExist):
+            csrf_failure(request, template_name="non_existant.html")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25695