### PR TITLE
Fixed #8851: Added default filter option to the admin.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -307,6 +307,7 @@ answer newbie questions, and generally made Django that much better:
     Gustavo Picon
     hambaloney
     Hannes Struß <x@hannesstruss.de>
+    Harro van der Klauw <hvdklauw@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
     Henrique Romano <onaiort@gmail.com>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -493,6 +493,8 @@ class ModelAdmin(BaseModelAdmin):
     list_display = ('__str__',)
     list_display_links = ()
     list_filter = ()
+    list_filter_defaults = {}
+    list_filter_sentinel = '_off_'
     list_select_related = False
     list_per_page = 100
     list_max_show_all = 200
@@ -895,6 +897,14 @@ class ModelAdmin(BaseModelAdmin):
         the right sidebar of the changelist page.
         """
         return self.list_filter
+
+    def get_list_filter_defaults(self, request):
+        """Return a dictionary containing the list filter defaults."""
+        return self.list_filter_defaults
+
+    def get_list_filter_sentinel(self, request):
+        """Returns the sentinel value for disabling filters."""
+        return self.list_filter_sentinel
 
     def get_list_select_related(self, request):
         """

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -28,7 +28,7 @@ SEARCH_VAR = 'q'
 ERROR_FLAG = 'e'
 
 IGNORED_PARAMS = (
-    ALL_VAR, ORDER_VAR, ORDER_TYPE_VAR, SEARCH_VAR, IS_POPUP_VAR, TO_FIELD_VAR)
+    ALL_VAR, ORDER_VAR, ORDER_TYPE_VAR, SEARCH_VAR, IS_POPUP_VAR, TO_FIELD_VAR,)
 
 
 class ChangeList:
@@ -49,6 +49,8 @@ class ChangeList:
         self.list_max_show_all = list_max_show_all
         self.model_admin = model_admin
         self.preserved_filters = model_admin.get_preserved_filters(request)
+        self.filter_params_defaults = model_admin.get_list_filter_defaults(request) or {}
+        self.filter_params_sentinel = model_admin.get_list_filter_sentinel(request)
 
         # Get search parameters from the query string.
         try:
@@ -93,6 +95,15 @@ class ChangeList:
         for ignored in IGNORED_PARAMS:
             if ignored in lookup_params:
                 del lookup_params[ignored]
+
+        # Add defaults to the the lookup params.
+        for param, default in self.filter_params_defaults.items():
+            if param not in lookup_params:
+                lookup_params[param] = default
+
+        lookup_params = dict(
+            (param, value) for param, value in lookup_params.items() if value != self.filter_params_sentinel
+        )
         return lookup_params
 
     def get_filters(self, request):

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -972,6 +972,32 @@ subclass::
     See the default template provided by Django (``admin/filter.html``) for
     a concrete example.
 
+.. attribute:: ModelAdmin.list_filter_defaults
+
+    .. versionadded:: 2.0
+
+    Set ``list_filter_defaults`` to specify defaults for the filters, when the
+    user has not specified a filter the default will automatically be used.
+
+    The value should be a dictionary with as key the list filter field and as
+    value the default.
+
+    If you want to specify a more dynamic value that depends on the request or
+    database query results you can use the
+    :meth:`~ModelAdmin.get_list_filter_defaults` method.
+
+.. attribute:: ModelAdmin.list_filter_sentinel
+
+    .. versionadded:: 2.0
+
+    Set the ``list_filter_sentinel`` to change the sentinel value used for
+    distinguishing between having no filter selected or the user wanting to
+    disable the filter. It should be a string value and defaults to ``_off_``.
+
+    If you want to specify a more dynamic value that depends on the request or
+    database query results you can use the
+    :meth:`~ModelAdmin.get_list_filter_sentinel` method.
+
 .. attribute:: ModelAdmin.list_max_show_all
 
     Set ``list_max_show_all`` to control how many items can appear on a "Show
@@ -1486,6 +1512,22 @@ templates used by the :class:`ModelAdmin` views:
     The ``get_list_filter`` method is given the ``HttpRequest`` and is expected
     to return the same kind of sequence type as for the
     :attr:`~ModelAdmin.list_filter` attribute.
+
+.. method:: ModelAdmin.get_list_filter_defaults(request)
+
+    .. versionadded:: 1.11
+
+    The ``get_list_filter_defaults`` method is given the ``HttpRequest`` and
+    should return a dictionary as :attr:`ModelAdmin.list_filter_defaults`
+    does.
+
+.. method:: ModelAdmin.get_list_filter_sentinel(request)
+
+    .. versionadded:: 1.11
+
+    The ``get_list_filter_sentinel`` method is given the ``HttpRequest`` and
+    should return a string as :attr:`ModelAdmin.list_filter_sentinel`
+    does.
 
 .. method:: ModelAdmin.get_list_select_related(request)
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -52,7 +52,10 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+ * Default filters in the admin, you can now specify filters to be enabled by
+   default while still allowing the user to disable the filter and see all
+   results.
+
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_filters/models.py
+++ b/tests/admin_filters/models.py
@@ -76,3 +76,17 @@ class Bookmark(models.Model):
 
     def __str__(self):
         return self.url
+
+
+ORDER_STATE_CHOICES = (
+    ('started', 'Started'),
+    ('completed', 'Completed'),
+    ('canceled', 'Canceled'),
+)
+
+
+class Order(models.Model):
+    state = models.CharField(max_length=50, choices=ORDER_STATE_CHOICES)
+
+    def __str__(self):
+        return self.state


### PR DESCRIPTION
Added an option to add default values for filters in the admin, to be able to
distinguish between having no filter select and disabling the filter I added
a per ModelAdmin configurable sentinel value.
