### PR TITLE
Fixed #25170 -- Made assertXMLEqual ignore leading and trailing whitespace

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -232,6 +232,7 @@ answer newbie questions, and generally made Django that much better:
     Espen Grindhaug <http://grindhaug.org/>
     Eugene Lazutkin <http://lazutkin.com/blog/>
     Fabrice Aneche <akh@nobugware.com>
+    Federico Capoano <nemesis@ninux.org>
     favo@exoweb.net
     fdr <drfarina@gmail.com>
     Filip Noetzel <http://filip.noetzel.co.uk/>
@@ -483,6 +484,7 @@ answer newbie questions, and generally made Django that much better:
     Matt McClanahan <http://mmcc.cx/>
     Matt Riggott
     Matt Robenolt <m@robenolt.com>
+    Mattia Larentis <mattia@laretis.eu>
     mattycakes@gmail.com
     Max Burstein <http://maxburstein.com>
     Max Derkachev <mderk@yandex.ru>

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -293,7 +293,7 @@ def compare_xml(want, got):
     """Tries to do a 'xml-comparison' of want and got.  Plain string
     comparison doesn't always work because, for example, attribute
     ordering should not be important. Comment nodes are not considered in the
-    comparison.
+    comparison. Leading and trailing whitespace is ignored.
 
     Based on http://codespeak.net/svn/lxml/trunk/src/lxml/doctestcompare.py
     """
@@ -337,7 +337,11 @@ def compare_xml(want, got):
             if node.nodeType != Node.COMMENT_NODE:
                 return node
 
+    def strip_whitespaces(want, got):
+        return want.strip(), got.strip()
+
     want, got = strip_quotes(want, got)
+    want, got = strip_whitespaces(want, got)
     want = want.replace('\\n', '\n')
     got = got.replace('\\n', '\n')
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -753,6 +753,21 @@ class XMLEqualTests(SimpleTestCase):
         xml2 = "<?xml version='1.0'?><!-- comment2 --><elem attr2='b' attr1='a' />"
         self.assertXMLEqual(xml1, xml2)
 
+    def test_simple_equal_with_whitespaces_at_the_begin(self):
+        xml1 = "<elem>foo</elem>"
+        xml2 = " \t\n<elem>foo</elem>"
+        self.assertXMLEqual(xml1, xml2)
+
+    def test_simple_equal_with_whitespaces_at_the_end(self):
+        xml1 = "<elem>foo</elem>"
+        xml2 = "<elem>foo</elem>\t \n"
+        self.assertXMLEqual(xml1, xml2)
+
+    def test_simple_not_equal_with_whitespaces_in_the_middle(self):
+        xml1 = "<elem>foo</elem><elem>bar</elem>"
+        xml2 = "<elem>foo</elem> <elem>bar</elem>"
+        self.assertXMLNotEqual(xml1, xml2)
+
 
 class SkippingExtraTests(TestCase):
     fixtures = ['should_not_be_loaded.json']


### PR DESCRIPTION
Made assertXMLEqual() and assertXMLNotEqual() ignore whitespaces outside of tags.