### PR TITLE
Fixed #25063 -- Added path to makemigration's output of migration name.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -172,7 +172,11 @@ class Command(BaseCommand):
                 # Describe the migration
                 writer = MigrationWriter(migration)
                 if self.verbosity >= 1:
-                    self.stdout.write("  %s:\n" % (self.style.MIGRATE_LABEL(writer.filename),))
+                    # Write out the relative path if it's a sensible one, absolute otherwise
+                    migration_string = os.path.relpath(writer.path)
+                    if migration_string.startswith('..'):
+                        migration_string = writer.path
+                    self.stdout.write("  %s:\n" % (self.style.MIGRATE_LABEL(migration_string),))
                     for operation in migration.operations:
                         self.stdout.write("    - %s\n" % operation.describe())
                 if not self.dry_run:

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1009,6 +1009,16 @@ class MakeMigrationsTests(MigrationTestBase):
         with self.temporary_migration_module(module="migrations.test_migrations_no_changes"):
             call_command("makemigrations", "--check", "migrations", verbosity=0)
 
+    def test_makemigrations_output(self):
+        """
+        makemigrations should print the relative paths to the migrations unless they are
+        outside of the current tree, in which case the absolute path should be shown.
+        """
+        out = six.StringIO()
+        apps.register_model('migrations', UnicodeModel)
+        with self.temporary_migration_module() as migration_dir:
+            call_command("makemigrations", "migrations", stdout=out)
+            self.assertIn('%s/%s' % (migration_dir, '0001_initial.py'), out.getvalue())
 
 class SquashMigrationsTests(MigrationTestBase):
     """


### PR DESCRIPTION
Instead of just printing the name of the generated migrations, let
makemigrations print the path to the migration. If it's inside the
current directory print the relative path, otherwise the absolute one.