### PR TITLE
Removed ability to pass a geometry string to GIS functions

### DIFF
--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 from django.contrib.gis.db.models.fields import GeometryField
 from django.contrib.gis.db.models.sql import AreaField
-from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.contrib.gis.measure import (
     Area as AreaMeasure, Distance as DistanceMeasure,
 )
@@ -91,16 +90,9 @@ class GeomValue(Value):
 
 class GeoFuncWithGeoParam(GeoFunc):
     def __init__(self, expression, geom, *expressions, **extra):
-        if not hasattr(geom, 'srid'):
-            # Try to interpret it as a geometry input
-            try:
-                geom = GEOSGeometry(geom)
-            except Exception:
-                raise ValueError("This function requires a geometric parameter.")
-        if not geom.srid:
+        if not hasattr(geom, 'srid') or not geom.srid:
             raise ValueError("Please provide a geometry attribute with a defined SRID.")
-        geom = GeomValue(geom)
-        super(GeoFuncWithGeoParam, self).__init__(expression, geom, *expressions, **extra)
+        super(GeoFuncWithGeoParam, self).__init__(expression, GeomValue(geom), *expressions, **extra)
 
 
 class SQLiteDecimalToFloatMixin(object):

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -516,9 +516,7 @@ class DistanceFunctionsTests(TestCase):
             dist_qs = [dist1]
         else:
             dist2 = SouthTexasCityFt.objects.annotate(distance=Distance('point', lagrange)).order_by('id')
-            # Using EWKT string parameter.
-            dist3 = SouthTexasCityFt.objects.annotate(distance=Distance('point', lagrange.ewkt)).order_by('id')
-            dist_qs = [dist1, dist2, dist3]
+            dist_qs = [dist1, dist2]
 
         # Original query done on PostGIS, have to adjust AlmostEqual tolerance
         # for Oracle.


### PR DESCRIPTION
This was a possible confusion source with column name arguments.
Thanks Sergey Fedoseev for the suggestion.