### PR TITLE
Fixed #25616 -- Added a note regarding missing dependencies on LookupError

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -151,6 +151,7 @@ class Apps(object):
             for app_config in self.get_app_configs():
                 if app_config.name == app_label:
                     message += " Did you mean '%s'?" % app_config.label
+                    message += " Perhaps a missing dependency on a migration?"
                     break
             raise LookupError(message)
 


### PR DESCRIPTION
This  fixes #25616 by including additional information in the traceback regarding missing dependencies during an attempted migration.