### PR TITLE
Fixed 25473 -- Changed underscores in URL names to dashes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -686,6 +686,7 @@ answer newbie questions, and generally made Django that much better:
     Terry Huang <terryh.tp@gmail.com>
     thebjorn <bp@datakortet.no>
     Thejaswi Puthraya <thejaswi.puthraya@gmail.com>
+    Thijs van Dien <thijs@vandien.net>
     Thomas Chaumeny <t.chaumeny@gmail.com>
     Thomas Güttler <hv@tbz-pariv.de>
     Thomas Kerpe <thomas@kerpe.net>

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -17,12 +17,12 @@ callable view object. For example, given the following ``url``::
 
     from news import views
 
-    url(r'^archive/$', views.archive, name='news_archive')
+    url(r'^archive/$', views.archive, name='news-archive')
 
 you can use any of the following to reverse the URL::
 
     # using the named URL
-    reverse('news_archive')
+    reverse('news-archive')
 
     # passing a callable object
     # (This is discouraged because you can't reverse namespaced views this way.)

--- a/docs/topics/class-based-views/generic-editing.txt
+++ b/docs/topics/class-based-views/generic-editing.txt
@@ -153,9 +153,9 @@ Finally, we hook these new views into the URLconf:
 
     urlpatterns = [
         # ...
-        url(r'author/add/$', AuthorCreate.as_view(), name='author_add'),
-        url(r'author/(?P<pk>[0-9]+)/$', AuthorUpdate.as_view(), name='author_update'),
-        url(r'author/(?P<pk>[0-9]+)/delete/$', AuthorDelete.as_view(), name='author_delete'),
+        url(r'author/add/$', AuthorCreate.as_view(), name='author-add'),
+        url(r'author/(?P<pk>[0-9]+)/$', AuthorUpdate.as_view(), name='author-update'),
+        url(r'author/(?P<pk>[0-9]+)/delete/$', AuthorDelete.as_view(), name='author-delete'),
     ]
 
 .. note::

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1342,7 +1342,7 @@ prepend the current active language code to all url patterns defined within
     from sitemap.views import sitemap
 
     urlpatterns = [
-        url(r'^sitemap\.xml$', sitemap, name='sitemap_xml'),
+        url(r'^sitemap\.xml$', sitemap, name='sitemap-xml'),
     ]
 
     news_patterns = ([
@@ -1364,7 +1364,7 @@ function. Example::
     from django.utils.translation import activate
 
     >>> activate('en')
-    >>> reverse('sitemap_xml')
+    >>> reverse('sitemap-xml')
     '/sitemap.xml'
     >>> reverse('news:index')
     '/en/news/'
@@ -1400,7 +1400,7 @@ URL patterns can also be marked translatable using the
     from sitemaps.views import sitemap
 
     urlpatterns = [
-        url(r'^sitemap\.xml$', sitemap, name='sitemap_xml'),
+        url(r'^sitemap\.xml$', sitemap, name='sitemap-xml'),
     ]
 
     news_patterns = ([


### PR DESCRIPTION
To improve consistency, sample URL names that had underscores in them now use dashes instead. That excludes URL names that have some relation to the code, such as those generated by DjangoAdmin. Thanks guettli, for reporting this.