### PR TITLE
Fixed #25412 -- Fixed missing index on Char/TextField when using AlterField.

### DIFF
--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -129,6 +129,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # Find the index for this field.
             # This is needed because the BaseDatabaseSchemaEditor._alter_field
             # method doesn't drop the '_like' indexes.
+            index_to_remove = self._create_index_name(model, [old_field.column], suffix='_like')
             index_names = self._constraint_names(model, [old_field.column], index=True)
             for index_name in index_names:
-                self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
+                if index_name == index_to_remove:
+                    self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -30,8 +30,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def _create_like_index_sql(self, model, field):
         """
-        Returns the statement to create an index with varchar operator pattern
-        when the column type is 'varchar' or 'text', otherwise returns None.
+        Return the statement to create an index with varchar operator pattern
+        when the column type is 'varchar' or 'text', otherwise return None.
         """
         db_type = field.db_type(connection=self.connection)
         if db_type is not None and (field.db_index or field.unique):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -23,10 +23,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return output
 
         for field in model._meta.local_fields:
-            # Fields with database column types of `varchar` and `text` need
-            # a second index that specifies their operator class, which is
-            # needed when performing correct LIKE queries outside the
-            # C locale. See #12234.
             like_index_statement = self._create_like_index_sql(model, field)
             if like_index_statement is not None:
                 output.append(like_index_statement)
@@ -117,10 +113,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         )
         # Added an index?
         if ((not old_field.db_index and new_field.db_index) or (not old_field.unique and new_field.unique)):
-            # Fields with database column types of `varchar` and `text` need
-            # a second index that specifies their operator class, which is
-            # needed when performing correct LIKE queries outside the
-            # C locale. See #12234.
             like_index_statement = self._create_like_index_sql(model, new_field)
             if like_index_statement is not None:
                 self.execute(like_index_statement)

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -27,12 +27,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # a second index that specifies their operator class, which is
             # needed when performing correct LIKE queries outside the
             # C locale. See #12234.
-            like_index_statement = self._varchar_operator_index_sql(model, field)
+            like_index_statement = self._create_like_index_sql(model, field)
             if like_index_statement is not None:
                 output.append(like_index_statement)
         return output
 
-    def _varchar_operator_index_sql(self, model, field):
+    def _create_like_index_sql(self, model, field):
         """
         Returns the statement to create an index with varchar operator pattern
         when the column type is 'varchar' or 'text', otherwise returns None.
@@ -121,7 +121,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # a second index that specifies their operator class, which is
             # needed when performing correct LIKE queries outside the
             # C locale. See #12234.
-            like_index_statement = self._varchar_operator_index_sql(model, new_field)
+            like_index_statement = self._create_like_index_sql(model, new_field)
             if like_index_statement is not None:
                 self.execute(like_index_statement)
 

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -45,11 +45,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             if '[' in db_type:
                 return None
             if db_type.startswith('varchar'):
-                return self._create_index_sql(
-                    model, [field], suffix='_like', sql=self.sql_create_varchar_index)
+                return self._create_index_sql(model, [field], suffix='_like', sql=self.sql_create_varchar_index)
             elif db_type.startswith('text'):
-                return self._create_index_sql(
-                    model, [field], suffix='_like', sql=self.sql_create_text_index)
+                return self._create_index_sql(model, [field], suffix='_like', sql=self.sql_create_text_index)
         return None
 
     def _alter_column_type_sql(self, table, old_field, new_field, new_type):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -94,3 +94,41 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return super(DatabaseSchemaEditor, self)._alter_column_type_sql(
                 table, old_field, new_field, new_type
             )
+
+    def _alter_field(self, model, old_field, new_field, old_type, new_type,
+                     old_db_params, new_db_params, strict=False):
+        super(DatabaseSchemaEditor, self)._alter_field(
+            model, old_field, new_field, old_type, new_type, old_db_params,
+            new_db_params, strict
+        )
+        # Added an index?
+        if ((not old_field.db_index and new_field.db_index) or (not old_field.unique and new_field.unique)):
+            db_type = new_field.db_type(connection=self.connection)
+            if db_type is not None and (new_field.db_index or new_field.unique):
+                # Fields with database column types of `varchar` and `text` need
+                # a second index that specifies their operator class, which is
+                # needed when performing correct LIKE queries outside the
+                # C locale. See #12234.
+                #
+                # This code resambles the one found in `self._model_indexes_sql`.
+                # The only difference is that here the statements are
+                # executed immediately.
+                #
+                # The same doesn't apply to array fields such as varchar[size]
+                # and text[size], so skip them.
+                if '[' in db_type:
+                    return
+                if db_type.startswith('varchar'):
+                    self.execute(self._create_index_sql(
+                        model, [new_field], suffix='_like', sql=self.sql_create_varchar_index))
+                elif db_type.startswith('text'):
+                    self.execute(self._create_index_sql(
+                        model, [new_field], suffix='_like', sql=self.sql_create_text_index))
+        # Removed an index?
+        if ((not new_field.db_index and old_field.db_index) or (not new_field.unique and old_field.unique)):
+            # Find the index for this field.
+            # This is needed because the BaseDatabaseSchemaEditor._alter_field
+            # method doesn't drop the '_like' indexes.
+            index_names = self._constraint_names(model, [old_field.column], index=True)
+            for index_name in index_names:
+                self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1731,7 +1731,7 @@ class SchemaTests(TransactionTestCase):
                 name_indexes.append(name)
         self.assertEqual(2, len(name_indexes), 'Indexes are missing for name column')
         # Check that one of the indexes ends with `_like`
-        like_index = list(filter(lambda x: x.endswith('_like'), name_indexes))
+        like_index = [x for x in name_indexes if x.endswith('_like')]
         self.assertEqual(1, len(like_index), 'Index with the operator class is missing for the name column')
         # Remove the index
         with connection.schema_editor() as editor:
@@ -1765,7 +1765,7 @@ class SchemaTests(TransactionTestCase):
                 info_indexes.append(name)
         self.assertEqual(2, len(info_indexes), 'Indexes are missing for info column')
         # Check that one of the indexes ends with `_like`
-        like_index = list(filter(lambda x: x.endswith('_like'), info_indexes))
+        like_index = [x for x in info_indexes if x.endswith('_like')]
         self.assertEqual(1, len(like_index), 'Index with the operator class is missing for the info column')
         # Remove the index
         with connection.schema_editor() as editor:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1728,15 +1728,19 @@ class SchemaTests(TransactionTestCase):
         name_indexes = []
         for name, details in constraints.items():
             if details['columns'] == ['name']:
-                name_indexes.append(details)
+                name_indexes.append(name)
         self.assertEqual(2, len(name_indexes), 'Indexes are missing for name column')
+        # Check that one of the indexes ends with `_like`
+        like_index = list(filter(lambda x: x.endswith('_like'), name_indexes))
+        self.assertEqual(1, len(like_index),
+                         'Index with the operator class is missing for the name column')
         # Remove the index
         with connection.schema_editor() as editor:
             editor.alter_field(Author, new_field, old_field, strict=True)
         # Ensure the name constraints where dropped
         constraints = self.get_constraints(Author._meta.db_table)
         name_indexes = []
-        for name, details in constraints.items():
+        for details in constraints.values():
             if details['columns'] == ['name']:
                 name_indexes.append(details)
         self.assertEqual(0, len(name_indexes), 'Indexes were not dropped for the name column')

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1716,10 +1716,7 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.create_model(Author)
         # Ensure the table is there and has no index
-        self.assertNotIn(
-            "name",
-            self.get_indexes(Author._meta.db_table),
-        )
+        self.assertNotIn("name", self.get_indexes(Author._meta.db_table))
         # Alter to add the index
         old_field = Author._meta.get_field('name')
         new_field = CharField(max_length=255, db_index=True)
@@ -1732,8 +1729,7 @@ class SchemaTests(TransactionTestCase):
         for name, details in constraints.items():
             if details['columns'] == ['name']:
                 name_indexes.append(details)
-        self.assertEqual(2, len(name_indexes),
-                         'Indexes are missing for name column')
+        self.assertEqual(2, len(name_indexes), 'Indexes are missing for name column')
         # Remove the index
         with connection.schema_editor() as editor:
             editor.alter_field(Author, new_field, old_field, strict=True)
@@ -1743,5 +1739,4 @@ class SchemaTests(TransactionTestCase):
         for name, details in constraints.items():
             if details['columns'] == ['name']:
                 name_indexes.append(details)
-        self.assertEqual(0, len(name_indexes),
-                         'Indexes were not dropped for the name column')
+        self.assertEqual(0, len(name_indexes), 'Indexes were not dropped for the name column')

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1744,3 +1744,38 @@ class SchemaTests(TransactionTestCase):
             if details['columns'] == ['name']:
                 name_indexes.append(details)
         self.assertEqual(0, len(name_indexes), 'Indexes were not dropped for the name column')
+
+    @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific")
+    def test_alter_field_add_index_to_textfield(self):
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(Note)
+        # Ensure the table is there and has no index
+        self.assertNotIn("info", self.get_indexes(Note._meta.db_table))
+        # Alter to add the index
+        old_field = Note._meta.get_field('info')
+        new_field = TextField(db_index=True)
+        new_field.set_attributes_from_name('info')
+        with connection.schema_editor() as editor:
+            editor.alter_field(Note, old_field, new_field, strict=True)
+        # Check that all the constraints are there
+        constraints = self.get_constraints(Note._meta.db_table)
+        info_indexes = []
+        for name, details in constraints.items():
+            if details['columns'] == ['info']:
+                info_indexes.append(name)
+        self.assertEqual(2, len(info_indexes), 'Indexes are missing for info column')
+        # Check that one of the indexes ends with `_like`
+        like_index = list(filter(lambda x: x.endswith('_like'), info_indexes))
+        self.assertEqual(1, len(like_index),
+                         'Index with the operator class is missing for the info column')
+        # Remove the index
+        with connection.schema_editor() as editor:
+            editor.alter_field(Note, new_field, old_field, strict=True)
+        # Ensure the info constraints where dropped
+        constraints = self.get_constraints(Note._meta.db_table)
+        info_indexes = []
+        for details in constraints.values():
+            if details['columns'] == ['info']:
+                info_indexes.append(details)
+        self.assertEqual(0, len(info_indexes), 'Indexes were not dropped for the info column')

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1732,8 +1732,7 @@ class SchemaTests(TransactionTestCase):
         self.assertEqual(2, len(name_indexes), 'Indexes are missing for name column')
         # Check that one of the indexes ends with `_like`
         like_index = list(filter(lambda x: x.endswith('_like'), name_indexes))
-        self.assertEqual(1, len(like_index),
-                         'Index with the operator class is missing for the name column')
+        self.assertEqual(1, len(like_index), 'Index with the operator class is missing for the name column')
         # Remove the index
         with connection.schema_editor() as editor:
             editor.alter_field(Author, new_field, old_field, strict=True)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1766,8 +1766,7 @@ class SchemaTests(TransactionTestCase):
         self.assertEqual(2, len(info_indexes), 'Indexes are missing for info column')
         # Check that one of the indexes ends with `_like`
         like_index = list(filter(lambda x: x.endswith('_like'), info_indexes))
-        self.assertEqual(1, len(like_index),
-                         'Index with the operator class is missing for the info column')
+        self.assertEqual(1, len(like_index), 'Index with the operator class is missing for the info column')
         # Remove the index
         with connection.schema_editor() as editor:
             editor.alter_field(Note, new_field, old_field, strict=True)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -241,7 +241,7 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.alter_field(Author, new_field2, new_field, strict=True)
         # Make sure no FK constraint is present
-            constraints = self.get_constraints(Author._meta.db_table)
+        constraints = self.get_constraints(Author._meta.db_table)
         for name, details in constraints.items():
             if details['columns'] == ["tag_id"] and details['foreign_key']:
                 self.fail("FK constraint for tag_id found")


### PR DESCRIPTION
Fixed the PostgreSQL schema editor to create/remove the index with the
operator class when altering a CharField or a TextField.
Thanks also to Emanuele Palazzetti for the help.