### PR TITLE
Fixed #25526 -- Documented how to output colored text in custom management commands.

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -67,7 +67,7 @@ look like this::
                 poll.opened = False
                 poll.save()
 
-                self.stdout.write('Successfully closed poll "%s"' % poll_id)
+                self.stdout.write(self.style.SUCCESS('Successfully closed poll "%s"' % poll_id))
 
 .. _management-commands-output:
 
@@ -255,6 +255,15 @@ All attributes can be set in your derived class and can be used in
     :data:`~BaseCommand.can_import_settings` option is set to ``False`` too
     because attempting to set the locale needs access to settings. This
     condition will generate a :class:`CommandError`.
+
+.. attribute:: BaseCommand.style
+
+    An instance attribute that defines the style of the output when writing to
+    stdout or stderr.
+
+    Used for emphasizing messages by adding a color to them. To avoid text
+    highlighting, pass the :djadminopt:`--no-color` option when running your
+    command. To modify the color palette, see the :ref:`syntax-coloring`.
 
 Methods
 -------


### PR DESCRIPTION
Added short description for CommandBase.style attribute. Also added 2 examples of how the style can be used when outputting to stdout.