### PR TITLE
Fixed #25720 -- Made Py2 gettext() return bytestring if input is bytestring.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -103,6 +103,8 @@ class DjangoTranslation(gettext_module.GNUTranslations):
     def __init__(self, language):
         """Create a GNUTranslations() using many locale directories"""
         gettext_module.GNUTranslations.__init__(self)
+        # For Python 2 gettext (refs #25720)
+        self.set_output_charset('utf-8')
 
         self.__language = language
         self.__to_language = to_language(language)

--- a/docs/releases/1.8.7.txt
+++ b/docs/releases/1.8.7.txt
@@ -24,3 +24,6 @@ Bugfixes
 
 * Fixed a data loss possibility with :class:`~django.db.models.Prefetch` if
   ``to_attr`` is set to a ``ManyToManyField`` (:ticket:`25693`).
+
+* Fixed a regression in 1.8.0, ``gettext`` in Python 2 now returns UTF-8
+  bytestrings if the input is a bytestring (:ticket:`25720`).

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -144,6 +144,18 @@ class TranslationTests(SimpleTestCase):
         self.assertNotEqual(s, s4)
 
     @skipUnless(six.PY2, "No more bytestring translations on PY3")
+    def test_bytestrings(self):
+        """gettext() returns a bytestring if input is bytestring."""
+
+        # Using repr() to check translated text and type
+        self.assertEqual(repr(gettext(b"Time")), repr(b"Time"))
+        self.assertEqual(repr(gettext("Time")), repr("Time"))
+
+        with translation.override('de', deactivate=True):
+            self.assertEqual(repr(gettext(b"Time")), repr(b"Zeit"))
+            self.assertEqual(repr(gettext("Time")), repr(b"Zeit"))
+
+    @skipUnless(six.PY2, "No more bytestring translations on PY3")
     def test_lazy_and_bytestrings(self):
         # On Python 2, (n)gettext_lazy should not transform a bytestring to unicode
         self.assertEqual(gettext_lazy(b"test").upper(), b"TEST")


### PR DESCRIPTION
This is consistent with the behavior of Django 1.7.x and earlier.