### PR TITLE
Fixed #25718 -- Fixed JSONField isnull lookups

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -65,6 +65,7 @@ JSONField.register_lookup(lookups.HasKey)
 JSONField.register_lookup(lookups.HasKeys)
 JSONField.register_lookup(lookups.HasAnyKeys)
 JSONField.register_lookup(lookups.JSONIsNull)
+JSONField.register_lookup(lookups.JSONExact)
 
 
 class KeyTransform(Transform):

--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -64,6 +64,7 @@ JSONField.register_lookup(lookups.ContainedBy)
 JSONField.register_lookup(lookups.HasKey)
 JSONField.register_lookup(lookups.HasKeys)
 JSONField.register_lookup(lookups.HasAnyKeys)
+JSONField.register_lookup(lookups.JSONIsNull)
 
 
 class KeyTransform(Transform):

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,4 +1,5 @@
 from django.db.models import Lookup, Transform
+from django.db.models.lookups import IsNull
 
 
 class PostgresSimpleLookup(Lookup):
@@ -43,3 +44,17 @@ class Unaccent(Transform):
     bilateral = True
     lookup_name = 'unaccent'
     function = 'UNACCENT'
+
+
+class JSONIsNull(IsNull):
+    lookup_name = 'isnull'
+
+    def as_sql(self, compiler, connection):
+        if isinstance(self.lhs, Transform):
+            sql, params = compiler.compile(self.lhs)
+            if self.rhs:
+                return "%s = 'null'" % sql, params
+            else:
+                return "%s != 'null'" % sql, params
+        else:
+            return super(JSONIsNull, self).as_sql(compiler, connection)

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,5 +1,5 @@
 from django.db.models import Lookup, Transform
-from django.db.models.lookups import IsNull
+from django.db.models.lookups import Exact, IsNull
 
 
 class PostgresSimpleLookup(Lookup):
@@ -47,7 +47,6 @@ class Unaccent(Transform):
 
 
 class JSONIsNull(IsNull):
-    lookup_name = 'isnull'
 
     def as_sql(self, compiler, connection):
         if isinstance(self.lhs, Transform):
@@ -58,3 +57,12 @@ class JSONIsNull(IsNull):
                 return "%s != 'null'" % sql, params
         else:
             return super(JSONIsNull, self).as_sql(compiler, connection)
+
+
+class JSONExact(Exact):
+
+    def process_rhs(self, compiler, connection):
+        result = super(JSONExact, self).process_rhs(compiler, connection)
+        if result == ('%s', [None]):
+            return "'null'", []
+        return result

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -122,6 +122,26 @@ class TestQuerying(TestCase):
             [self.objs[8]]
         )
 
+    def test_deep_lookup_isnull_exclude(self):
+        obj = JSONModel.objects.create(field={'j': 1})
+        self.assertSequenceEqual(
+            JSONModel.objects.exclude(field__j__isnull=True),
+            [obj]
+        )
+
+    def test_deep_lookup_none_value(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__j=None),
+            [self.objs[8]]
+        )
+
+    def test_deep_lookup_none_value_exclude(self):
+        obj = JSONModel.objects.create(field={'j': 1})
+        self.assertSequenceEqual(
+            JSONModel.objects.exclude(field__j=None),
+            [obj]
+        )
+
     def test_deep_lookup_not_isnull(self):
         self.assertSequenceEqual(
             JSONModel.objects.filter(field__l__isnull=False),

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -116,6 +116,18 @@ class TestQuerying(TestCase):
             [self.objs[6]]
         )
 
+    def test_deep_lookup_isnull(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__j__isnull=True),
+            [self.objs[8]]
+        )
+
+    def test_deep_lookup_not_isnull(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__l__isnull=False),
+            [self.objs[10]]
+        )
+
     def test_exact_complex(self):
         self.assertSequenceEqual(
             JSONModel.objects.filter(field__exact={'a': 'b', 'c': 1}),


### PR DESCRIPTION
Initially it was only about JSONField from `django.contrib.postgres`, but in fact, an ability to query `None` values might be helpful.
In current trunk there is only one case for `None` - convert it to SQL's `NULL` , but with some complex types it is also possible to have another options of `None` conversion. In this case - JSON's `null`.
At that moment I'm not completely sure about `isnull` lookup usage, because it corresponds to `IS NULL` in SQL, which is an other concept rather then `null` in JSON. Please give an advise.
Thanks.