### PR TITLE
[1.7.x] Fixed #25693 -- Prevented data loss with Prefetch and ManyToM…

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1910,6 +1910,14 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
         instance_attr_val = instance_attr(obj)
         vals = rel_obj_cache.get(instance_attr_val, [])
         to_attr, as_attr = lookup.get_current_to_attr(level)
+
+        # Check we are not shadowing a field on obj.
+        if as_attr:
+            for related_m2m in obj._meta.get_all_related_many_to_many_objects():
+                if related_m2m.get_accessor_name() == to_attr:
+                    msg = 'to_attr={} conflicts with a field on the {} model.'
+                    raise ValueError(msg.format(to_attr, obj.__class__.__name__))
+
         if single:
             val = vals[0] if vals else None
             to_attr = to_attr if as_attr else cache_name

--- a/docs/releases/1.7.11.txt
+++ b/docs/releases/1.7.11.txt
@@ -1,0 +1,13 @@
+===========================
+Django 1.7.11 release notes
+===========================
+
+*Under development*
+
+Django 1.7.11 fixes a data loss bug in 1.7.10.
+
+Bugfixes
+========
+
+* Fixed a data loss possibility with :class:`~django.db.models.Prefetch` if
+  ``to_attr`` is set to a ``ManyToManyField`` (:ticket:`25693`).

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -25,6 +25,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   1.7.11
    1.7.10
    1.7.9
    1.7.8

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -221,6 +221,17 @@ class PrefetchRelatedTests(TestCase):
         self.assertTrue('prefetch_related' in str(cm.exception))
         self.assertTrue("name" in str(cm.exception))
 
+    def test_m2m_shadow(self):
+        msg = 'to_attr=books conflicts with a field on the Author model.'
+        poems = Book.objects.filter(title='Poems')
+        with self.assertRaisesMessage(ValueError, msg):
+            list(Author.objects.prefetch_related(
+                Prefetch('books', queryset=poems, to_attr='books'),
+            ))
+        # Without the ValueError, a book was deleted due to the implicit
+        # save of reverse relation assignment.
+        self.assertEqual(self.author1.books.count(), 2)
+
 
 class CustomPrefetchTests(TestCase):
     @classmethod


### PR DESCRIPTION
…anyField.

Thanks to Jamie Matthews for finding and explaining the bug.

Backport of 4608573788c04fc047da42b4b7b48fdee8136ad3 from master