### PR TITLE
Fixed #25734 -- Made GDALBand min and max properties use GDALComputeRasterStatistics.

### DIFF
--- a/django/contrib/gis/gdal/prototypes/raster.py
+++ b/django/contrib/gis/gdal/prototypes/raster.py
@@ -62,8 +62,17 @@ get_band_ds = voidptr_output(std_call('GDALGetBandDataset'), [c_void_p])
 get_band_datatype = int_output(std_call('GDALGetRasterDataType'), [c_void_p])
 get_band_nodata_value = double_output(std_call('GDALGetRasterNoDataValue'), [c_void_p, POINTER(c_int)])
 set_band_nodata_value = void_output(std_call('GDALSetRasterNoDataValue'), [c_void_p, c_double])
-get_band_minimum = double_output(std_call('GDALGetRasterMinimum'), [c_void_p, POINTER(c_int)])
-get_band_maximum = double_output(std_call('GDALGetRasterMaximum'), [c_void_p, POINTER(c_int)])
+get_band_statistics = void_output(std_call('GDALGetRasterStatistics'),
+    [
+        c_void_p, c_int, c_int, POINTER(c_double), POINTER(c_double),
+        POINTER(c_double), POINTER(c_double), c_void_p, c_void_p,
+    ],
+    errcheck=False
+)
+compute_band_statistics = void_output(std_call('GDALComputeRasterStatistics'),
+    [c_void_p, c_int, POINTER(c_double), POINTER(c_double), POINTER(c_double), POINTER(c_double), c_void_p, c_void_p],
+    errcheck=False
+)
 
 # Reprojection routine
 reproject_image = void_output(std_call('GDALReprojectImage'),

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1413,6 +1413,35 @@ blue.
 
         The total number of pixels in this band. Is equal to ``width * height``.
 
+    .. method:: statistics(refresh=False, approximate=False)
+
+        .. versionadded:: 1.10
+
+        Compute statistics on the pixel values of this band. The return value
+        is a tuple with the following structure:
+        ``(minimum, maximum, mean, standard deviation)``.
+
+        If the ``approximate`` argument is set to ``True``, the statistics may
+        be computed based on overviews or a subset of image tiles.
+
+        If the ``refresh`` argument is set to ``True``, the statistics will be
+        computed from the data directly, and the cache will be updated with the
+        result.
+
+        If a persistent cache value is found, that value is returned. For
+        raster formats using Persistent Auxiliary Metadata (PAM) services, the
+        statistics might be cached in an auxiliary file. In some cases this
+        metadata might be out of sync with the pixel values or cause values
+        from a previous call to be returned which don't reflect the value of
+        the approximate argument. In such cases, use the ``refresh`` argument
+        to get updated values and store them in the cache.
+
+        For empty bands (where all pixel values are "no data"), all statistics
+        are returned as ``None``.
+
+        The statistics can also be retrieved directly by accessing the
+        :attr:`min`, :attr:`max`, :attr:`mean`, and :attr:`std` properties.
+
     .. attribute:: min
 
         The minimum pixel value of the band (excluding the "no data" value).
@@ -1420,6 +1449,20 @@ blue.
     .. attribute:: max
 
         The maximum pixel value of the band (excluding the "no data" value).
+
+    .. attribute:: mean
+
+        .. versionadded:: 1.10
+
+        The mean of all pixel values of the band (excluding the "no data"
+        value).
+
+    .. attribute:: std
+
+        .. versionadded:: 1.10
+
+        The standard deviation of all pixel values of the band (excluding the
+        "no data" value).
 
     .. attribute:: nodata_value
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -73,6 +73,10 @@ Minor features
 
 * Added the :meth:`GEOSGeometry.covers()
   <django.contrib.gis.geos.GEOSGeometry.covers>` binary predicate.
+* Added the :meth:`GDALBand.statistics()
+  <django.contrib.gis.gdal.GDALBand.statistics>` method and
+  :attr:`~django.contrib.gis.gdal.GDALBand.mean`
+  and :attr:`~django.contrib.gis.gdal.GDALBand.std` attributes.
 
 :mod:`django.contrib.messages`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Properties now use the GDALComputeRasterStatistics function to retrieve values.