### PR TITLE
Fixed #25725 -- Made HttpReponse immediately consume iterators

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -314,13 +314,16 @@ class HttpResponse(HttpResponseBase):
     def content(self, value):
         # Consume iterators upon assignment to allow repeated iteration.
         if hasattr(value, '__iter__') and not isinstance(value, (bytes, six.string_types)):
+            content = b''.join(self.make_bytes(chunk) for chunk in value)
             if hasattr(value, 'close'):
-                self._closable_objects.append(value)
-            value = b''.join(self.make_bytes(chunk) for chunk in value)
+                try:
+                    value.close()
+                except Exception:
+                    pass
         else:
-            value = self.make_bytes(value)
+            content = self.make_bytes(value)
         # Create a list of properly encoded bytestrings to support write().
-        self._container = [value]
+        self._container = [content]
 
     def __iter__(self):
         return iter(self._container)

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -610,6 +610,14 @@ Finally, you can pass ``HttpResponse`` an iterator rather than strings.
 ``HttpResponse`` will consume the iterator immediately, store its content as a
 string, and discard it.
 
+Closeable objects passed to a ``HttpResponse``,
+such as file objects and generators, are immediately being closed.
+
+.. versionchanged:: 1.10
+
+    Closeable objects used be closed once the WSGI server called close on
+    the response. They are now being closed immediately.
+
 If you need the response to be streamed from the iterator to the client, you
 must use the :class:`StreamingHttpResponse` class instead.
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -295,6 +295,16 @@ to use this form::
     admin.site.unregister(User)
     admin.site.register(User, MyUserAdmin)
 
+Requests and Responses
+~~~~~~~~~~~~~~~~~~~~~~
+
+Iterators you pass to :class:`~django.http.HttpResponse`
+are now being properly consumed, closed and discarded.
+Closeable objects used be closed once the WSGI server called close on
+the response. They are now being closed immediately.
+Be aware that file resources passed to a :class:`~django.http.HttpResponse`
+are now immediately closed.
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -120,6 +120,7 @@ clearable
 clearsessions
 clickable
 clickjacking
+closeable
 cms
 codebase
 codec

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -590,18 +590,8 @@ class FileCloseTests(SimpleTestCase):
         # file isn't closed until we close the response.
         file1 = open(filename)
         r = HttpResponse(file1)
-        self.assertFalse(file1.closed)
-        r.close()
         self.assertTrue(file1.closed)
-
-        # don't automatically close file when we finish iterating the response.
-        file1 = open(filename)
-        r = HttpResponse(file1)
-        self.assertFalse(file1.closed)
-        list(r)
-        self.assertFalse(file1.closed)
         r.close()
-        self.assertTrue(file1.closed)
 
         # when multiple file are assigned as content, make sure they are all
         # closed with the response.
@@ -609,9 +599,6 @@ class FileCloseTests(SimpleTestCase):
         file2 = open(filename)
         r = HttpResponse(file1)
         r.content = file2
-        self.assertFalse(file1.closed)
-        self.assertFalse(file2.closed)
-        r.close()
         self.assertTrue(file1.closed)
         self.assertTrue(file2.closed)
 

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import io
 
 from django.conf import settings
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.http.response import HttpResponseBase
 from django.test import SimpleTestCase
@@ -121,3 +122,13 @@ class HttpResponseTests(SimpleTestCase):
         with io.TextIOWrapper(r, UTF8) as buf:
             buf.write(content)
         self.assertEqual(r.content, content.encode(UTF8))
+
+    def test_generator_cache(self):
+        generator = ("{}".format(i) for i in range(10))
+        response = HttpResponse(content=generator)
+        self.assertEqual(response.content, b'0123456789')
+        self.assertRaises(StopIteration, next, generator)
+
+        cache.set('my-response-key', response)
+        response = cache.get('my-response-key')
+        self.assertEqual(response.content, b'0123456789')


### PR DESCRIPTION
Previously iterators passed to a HttpResponse where stored in
_closable_objects to be closed when the WSGI server called `close`
instead of being disgarded as defined in the documenation.

Now the iterator is closed and discarded after it was consumed.
The closeables are being closed, in case people passed File objects
to a response without closing it.