### PR TITLE
Fixed #25304 -- Added option to allow management commands to check if migrations are applied.

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -14,6 +14,7 @@ class Command(BaseCommand):
     help = "Change a user's password for django.contrib.auth."
 
     requires_system_checks = False
+    requires_migrations_checks = True
 
     def _get_pass(self, prompt="Password: "):
         p = getpass.getpass(prompt=force_str(prompt))

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -23,6 +23,7 @@ class NotRunningInTTYException(Exception):
 
 class Command(BaseCommand):
     help = 'Used to create a superuser.'
+    requires_migrations_checks = True
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -11,8 +11,10 @@ from argparse import ArgumentParser
 
 import django
 from django.core import checks
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style, no_style
-from django.db import connections
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.exceptions import MigrationSchemaMissing
 from django.utils.encoding import force_str
 
 
@@ -174,6 +176,10 @@ class BaseCommand(object):
         is the list of application's configuration provided by the
         app registry.
 
+    ``requires_migrations_checks``
+        A boolean; if ``True``, checks to see if the set of migrations on disk matches the
+        migrations in the database. Prints a warning if they don't match.
+
     ``leave_locale_alone``
         A boolean indicating whether the locale set in settings should be
         preserved during the execution of the command instead of translations
@@ -200,6 +206,7 @@ class BaseCommand(object):
     output_transaction = False  # Whether to wrap the output in a "BEGIN; COMMIT;"
     leave_locale_alone = False
     requires_system_checks = True
+    requires_migrations_checks = False
 
     def __init__(self, stdout=None, stderr=None, no_color=False):
         self.stdout = OutputWrapper(stdout or sys.stdout)
@@ -336,6 +343,8 @@ class BaseCommand(object):
         try:
             if self.requires_system_checks and not options.get('skip_checks'):
                 self.check()
+            if self.requires_migrations_checks:
+                self.check_migrations()
             output = self.handle(*args, **options)
             if output:
                 if self.output_transaction:
@@ -418,6 +427,38 @@ class BaseCommand(object):
                 self.stderr.write(msg, lambda x: x)
             else:
                 self.stdout.write(msg)
+
+    def check_migrations(self):
+        """
+        Checks to see if the set of migrations on disk matches the
+        migrations in the database. Prints a warning if they don't match.
+        """
+        from django.db.migrations.executor import MigrationExecutor
+        try:
+            executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+        except ImproperlyConfigured:
+            # No databases are configured (or the dummy one)
+            return
+        except MigrationSchemaMissing:
+            self.stdout.write(self.style.NOTICE(
+                "\nNot checking migrations as it is not possible to access/create the django_migrations table."
+            ))
+            return
+
+        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+        if plan:
+            apps_waiting_migration = sorted(set(migration.app_label for migration, backwards in plan))
+            self.stdout.write(
+                self.style.NOTICE(
+                    "\nYou have %(unpplied_migration_count)s unapplied migration(s). "
+                    "Your project may not work properly until you apply the "
+                    "migrations for app(s): %(apps_waiting_migration)s." % {
+                        "unpplied_migration_count": len(plan),
+                        "apps_waiting_migration": ", ".join(apps_waiting_migration),
+                    }
+                )
+            )
+            self.stdout.write(self.style.NOTICE("Run 'python manage.py migrate' to apply them.\n"))
 
     def handle(self, *args, **options):
         """

--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -8,12 +8,8 @@ import sys
 from datetime import datetime
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
 from django.core.servers.basehttp import get_internal_wsgi_application, run
-from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.migrations.exceptions import MigrationSchemaMissing
-from django.db.migrations.executor import MigrationExecutor
 from django.utils import autoreload, six
 from django.utils.encoding import force_text, get_system_encoding
 
@@ -114,6 +110,8 @@ class Command(BaseCommand):
 
         self.stdout.write("Performing system checks...\n\n")
         self.check(display_num_errors=True)
+        # checking migrations without the attribute requires_migrations_check
+        # to be able to run it at this level
         self.check_migrations()
         now = datetime.now().strftime('%B %d, %Y - %X')
         if six.PY2:
@@ -153,37 +151,6 @@ class Command(BaseCommand):
             if shutdown_message:
                 self.stdout.write(shutdown_message)
             sys.exit(0)
-
-    def check_migrations(self):
-        """
-        Checks to see if the set of migrations on disk matches the
-        migrations in the database. Prints a warning if they don't match.
-        """
-        try:
-            executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
-        except ImproperlyConfigured:
-            # No databases are configured (or the dummy one)
-            return
-        except MigrationSchemaMissing:
-            self.stdout.write(self.style.NOTICE(
-                "\nNot checking migrations as it is not possible to access/create the django_migrations table."
-            ))
-            return
-
-        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-        if plan:
-            apps_waiting_migration = sorted(set(migration.app_label for migration, backwards in plan))
-            self.stdout.write(
-                self.style.NOTICE(
-                    "\nYou have %(unpplied_migration_count)s unapplied migration(s). "
-                    "Your project may not work properly until you apply the "
-                    "migrations for app(s): %(apps_waiting_migration)s." % {
-                        "unpplied_migration_count": len(plan),
-                        "apps_waiting_migration": ", ".join(apps_waiting_migration),
-                    }
-                )
-            )
-            self.stdout.write(self.style.NOTICE("Run 'python manage.py migrate' to apply them.\n"))
 
 # Kept for backward compatibility
 BaseRunserverCommand = Command

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -236,6 +236,14 @@ All attributes can be set in your derived class and can be used in
     A boolean; if ``True``, the entire Django project will be checked for
     potential problems prior to executing the command. Default value is ``True``.
 
+.. versionadded:: 1.10
+
+.. attribute:: BaseCommand.requires_migrations_checks
+
+    A boolean; if ``True``, checks to see if the set of migrations on disk matches the
+    migrations in the database. Prints a warning if they don't match. Default value is
+    ``False``.
+
 .. attribute:: BaseCommand.leave_locale_alone
 
     A boolean indicating whether the locale set in settings should be preserved

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -248,6 +248,10 @@ Management Commands
 * Added a warning to :djadmin:`dumpdata` if a proxy model is specified (which
   results in no output) without its concrete parent.
 
+* BaseCommand has a new attribute requires_migrations_checks if ``True`` checks
+  to see if the set of migrations on disk matches the migrations in the database.
+  Prints a warning if they don't match.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1367,7 +1367,7 @@ class ManageRunserver(AdminScriptTestCase):
         Ensure runserver.check_migrations doesn't choke on empty DATABASES.
         """
         tested_connections = ConnectionHandler({})
-        with mock.patch('django.core.management.commands.runserver.connections', new=tested_connections):
+        with mock.patch('django.core.management.base.connections', new=tested_connections):
             self.cmd.check_migrations()
 
     def test_readonly_database(self):


### PR DESCRIPTION
adding required_migrations_checks to BaseCommand to support unapplied migrationgs on other managements command, runserver, createsuperuser and changepassword activate this check