### PR TITLE
Bumped mysqlclient test requirement to >= 1.3.7.

### DIFF
--- a/tests/requirements/mysql.txt
+++ b/tests/requirements/mysql.txt
@@ -1,2 +1,2 @@
 # Due to a bug that will be fixed in mysqlclient 1.3.7.
-mysqlclient <= 1.3.5
+mysqlclient >= 1.3.7


### PR DESCRIPTION
mysqlclient 1.3.7 fixes the test failures caused by 1.3.6.