### PR TITLE
Minor language tweak.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1779,8 +1779,8 @@ For example::
 
     {{ value|lower }}
 
-If ``value`` is ``Still MAD At Yoko``, the output will be
-``still mad at yoko``.
+If ``value`` is ``Totally LOVING this Album!``, the output will be
+``totally loving this album!``.
 
 .. templatefilter:: make_list
 


### PR DESCRIPTION
"Still MAD at Yoko" is a bit of an odd and overloaded phrase for us to use here.
We oughta go with something neutral instead.