### PR TITLE
Fixed docstring to be consistent with documentation

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -213,8 +213,8 @@ class BaseCommand(object):
     def get_version(self):
         """
         Return the Django version, which should be correct for all
-        built-in Django commands. User-supplied commands should
-        override this method.
+        built-in Django commands. User-supplied commands can
+        override this method to return their own version.
         """
         return django.get_version()
 


### PR DESCRIPTION
This puts the docstring in line with the documentation at https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#django.core.management.BaseCommand.get_version (which I think is the one that makes more sense).