### PR TITLE
Fixed #25349 - ModelForm bug that occurs when saving None value to a ForeignKey with null=True, blank=False and required=False.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -193,14 +193,7 @@ class ForwardManyToOneDescriptor(object):
         - ``instance`` is the ``child`` instance
         - ``value`` in the ``parent`` instance on the right of the equal sign
         """
-        # If null=True, we can assign null here, but otherwise the value needs
-        # to be an instance of the related class.
-        if value is None and self.field.null is False:
-            raise ValueError(
-                'Cannot assign None: "%s.%s" does not allow null values.' %
-                (instance._meta.object_name, self.field.name)
-            )
-        elif value is not None and not isinstance(value, self.field.remote_field.model._meta.concrete_model):
+        if value is not None and not isinstance(value, self.field.remote_field.model._meta.concrete_model):
             raise ValueError(
                 'Cannot assign "%r": "%s.%s" must be a "%s" instance.' % (
                     value,

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -376,11 +376,6 @@ class BaseModelForm(BaseForm):
 
         exclude = self._get_validation_exclusions()
 
-        try:
-            self.instance = construct_instance(self, self.instance, opts.fields, exclude)
-        except ValidationError as e:
-            self._update_errors(e)
-
         # Foreign Keys being used to represent inline relationships
         # are excluded from basic field value validation. This is for two
         # reasons: firstly, the value may not be supplied (#12507; the
@@ -391,6 +386,11 @@ class BaseModelForm(BaseForm):
         for name, field in self.fields.items():
             if isinstance(field, InlineForeignKeyField):
                 exclude.append(name)
+
+        try:
+            self.instance = construct_instance(self, self.instance, opts.fields, opts.exclude)
+        except ValidationError as e:
+            self._update_errors(e)
 
         try:
             self.instance.full_clean(exclude=exclude, validate_unique=False)

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -7,7 +7,6 @@ from django.core.exceptions import FieldError
 from django.db import IntegrityError
 from django.db.models import Q
 from django.test import SimpleTestCase, TestCase
-from django.utils import six
 
 from .models import (
     AllowsNullGFK, Animal, Carrot, Comparison, ConcreteRelatedModel,
@@ -711,14 +710,10 @@ class ProxyRelatedModelTest(TestCase):
 
 
 class TestInitWithNoneArgument(SimpleTestCase):
-    def test_none_not_allowed(self):
-        # TaggedItem requires a content_type, initializing with None should
-        # raise a ValueError.
-        with six.assertRaisesRegex(self, ValueError,
-          'Cannot assign None: "TaggedItem.content_type" does not allow null values'):
-            TaggedItem(content_object=None)
 
     def test_none_allowed(self):
         # AllowsNullGFK doesn't require a content_type, so None argument should
         # also be allowed.
         AllowsNullGFK(content_object=None)
+        # Model instantiation with generic foreign key set to None should be allowed (#25349)
+        TaggedItem(content_object=None)

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -247,6 +247,37 @@ class ForeignKeyTests(test.TestCase):
             "Pending lookup added for a foreign key on an abstract model"
         )
 
+    def test_save_with_null_false(self):
+        """
+        #25349 -- Assigning None to foreign key field with null=False should be possible.
+        However saving should not be possible.
+        """
+        b = Bar(b='abc', a=None)
+
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                b.save()
+
+    def test_create_with_null_false(self):
+        """
+        #25349 -- Saving model with None value of foreign key field with null=True
+        should not be possible.
+        """
+        with transaction.atomic():
+            with self.assertRaises(IntegrityError):
+                Bar.objects.create(b='abc', a=None)
+
+    def test_full_clean_with_blank_false_null_false(self):
+        """
+        #25349 -- Model validation for None value of foreign key field with null=False
+        should raise ValidationError
+        """
+        b = Bar(b='abc', a=None)
+
+        with transaction.atomic():
+            with self.assertRaises(ValidationError):
+                b.full_clean()
+
 
 class ManyToManyFieldTests(test.SimpleTestCase):
     def test_abstract_model_pending_operations(self):

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -474,3 +474,9 @@ class StrictAssignmentAll(models.Model):
         if self._should_error is True:
             raise ValidationError(message="Cannot set attribute", code='invalid')
         super(StrictAssignmentAll, self).__setattr__(key, value)
+
+
+# Model for #25349
+class Award(models.Model):
+    character = models.ForeignKey(Character, models.SET_NULL, blank=False, null=True)
+    name = models.CharField(max_length=30)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25349