### PR TITLE
Changed section title from Model syntax to Introduction to models

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -60,7 +60,7 @@ Django provides an abstraction layer (the "models") for structuring and
 manipulating the data of your Web application. Learn more about it below:
 
 * **Models:**
-  :doc:`Model syntax <topics/db/models>` |
+  :doc:`Introduction to models <topics/db/models>` |
   :doc:`Field types <ref/models/fields>` |
   :doc:`Meta options <ref/models/options>` |
   :doc:`Model class <ref/models/class>`


### PR DESCRIPTION
The original title "Model syntax" wasn't reflective of the purpose of the document, which led to confusion as to where to start when learning about the subject (as I found out just now when attempting to do so myself).