### PR TITLE
Fixed #25758 -- Date filter doesn't use internationalization when USE_L10N is True

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -726,8 +726,6 @@ def date(value, arg=None):
     """Formats a date according to the given format."""
     if value in (None, ''):
         return ''
-    if arg is None:
-        arg = settings.DATE_FORMAT
     try:
         return formats.date_format(value, arg)
     except AttributeError:


### PR DESCRIPTION
Deleted default value of args that used settings.DATE_FORMAT when should use internationalization if USE_l10n is true.

This, doesn't break the code, because formats.date_format(value, arg) sets a default date format from settings.DATE_FORMAT or internationalization when args is None.