### PR TITLE
Fixed #27062 -- Eased implementing select_for_update() on MSSQL.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -232,6 +232,9 @@ class BaseDatabaseFeatures(object):
     # be equal?
     ignores_quoted_identifier_case = False
 
+    # Used to place FOR UPDATE part right after FROM clause, this is used on MSSQL
+    for_update_after_from = False
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -402,6 +402,27 @@ class SQLCompiler(object):
             result.extend(from_)
             params.extend(f_params)
 
+            for_update_part = None
+            if self.query.select_for_update and self.connection.features.has_select_for_update:
+                if self.connection.get_autocommit():
+                    raise TransactionManagementError(
+                        "select_for_update cannot be used outside of a transaction."
+                    )
+
+                nowait = self.query.select_for_update_nowait
+                skip_locked = self.query.select_for_update_skip_locked
+                # If we've been asked for a NOWAIT/SKIP LOCKED query but the
+                # backend does not support it, raise a DatabaseError otherwise
+                # we could get an unexpected deadlock.
+                if nowait and not self.connection.features.has_select_for_update_nowait:
+                    raise DatabaseError('NOWAIT is not supported on this database backend.')
+                elif skip_locked and not self.connection.features.has_select_for_update_skip_locked:
+                    raise DatabaseError('SKIP LOCKED is not supported on this database backend.')
+                for_update_part = self.connection.ops.for_update_sql(nowait=nowait, skip_locked=skip_locked)
+
+            if for_update_part and self.connection.features.for_update_after_from:
+                result.append(for_update_part)
+
             if where:
                 result.append('WHERE %s' % where)
                 params.extend(w_params)
@@ -439,22 +460,8 @@ class SQLCompiler(object):
                             result.append('LIMIT %d' % val)
                     result.append('OFFSET %d' % self.query.low_mark)
 
-            if self.query.select_for_update and self.connection.features.has_select_for_update:
-                if self.connection.get_autocommit():
-                    raise TransactionManagementError(
-                        "select_for_update cannot be used outside of a transaction."
-                    )
-
-                nowait = self.query.select_for_update_nowait
-                skip_locked = self.query.select_for_update_skip_locked
-                # If we've been asked for a NOWAIT/SKIP LOCKED query but the
-                # backend does not support it, raise a DatabaseError otherwise
-                # we could get an unexpected deadlock.
-                if nowait and not self.connection.features.has_select_for_update_nowait:
-                    raise DatabaseError('NOWAIT is not supported on this database backend.')
-                elif skip_locked and not self.connection.features.has_select_for_update_skip_locked:
-                    raise DatabaseError('SKIP LOCKED is not supported on this database backend.')
-                result.append(self.connection.ops.for_update_sql(nowait=nowait, skip_locked=skip_locked))
+            if for_update_part and not self.connection.features.for_update_after_from:
+                result.append(for_update_part)
 
             return ' '.join(result), tuple(params)
         finally:


### PR DESCRIPTION
In MSSQL the FOR UPDATE modificator (WITH (ROWLOCK, UPDLOCK [, NOWAIT])) is a part of the FROM clause https://msdn.microsoft.com/en-us/library/ms177634.aspx
and as such it must be placed right after FROM and not at the end of statement.
https://code.djangoproject.com/ticket/27062