### PR TITLE
Fixed typo in 1.9 release docs

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1411,7 +1411,7 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
 * The model and form ``IPAddressField`` is removed. A stub field remains for
   compatibility with historical migrations.
 
-* ``AppCommand.handle_app()`` is no longer be supported.
+* ``AppCommand.handle_app()`` is removed.
 
 * ``RequestSite`` and ``get_current_site()`` are no longer importable from
   ``django.contrib.sites.models``.


### PR DESCRIPTION
Similar lines say `is removed`, and I verified that `AppCommand.handle_app()` was indeed removed.