### PR TITLE
Fixed #25769 -- Updated get_version() release candidate naming for PEP 0440.

### DIFF
--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -14,7 +14,7 @@ def get_version(version=None):
     # Now build the two parts of the version number:
     # main = X.Y[.Z]
     # sub = .devN - for pre-alpha releases
-    #     | {a|b|c}N - for alpha, beta and rc releases
+    #     | {a|b|rc}N - for alpha, beta, and rc releases
 
     main = get_main_version(version)
 
@@ -25,7 +25,7 @@ def get_version(version=None):
             sub = '.dev%s' % git_changeset
 
     elif version[3] != 'final':
-        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
         sub = mapping[version[3]] + str(version[4])
 
     return str(main + sub)

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -312,6 +312,9 @@ Miscellaneous
 
 * Support for SpatiaLite < 3.0 and GEOS < 3.3 is dropped.
 
+* ``utils.version.get_version()`` returns :pep:`440` compliant release
+  candidate versions (e.g. '1.10rc1' instead of '1.10c1').
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10

--- a/tests/version/tests.py
+++ b/tests/version/tests.py
@@ -17,9 +17,9 @@ class VersionTests(TestCase):
         tuples_to_strings = (
             ((1, 4, 0, 'alpha', 1), '1.4a1'),
             ((1, 4, 0, 'beta', 1), '1.4b1'),
-            ((1, 4, 0, 'rc', 1), '1.4c1'),
+            ((1, 4, 0, 'rc', 1), '1.4rc1'),
             ((1, 4, 0, 'final', 0), '1.4'),
-            ((1, 4, 1, 'rc', 2), '1.4.1c2'),
+            ((1, 4, 1, 'rc', 2), '1.4.1rc2'),
             ((1, 4, 1, 'final', 0), '1.4.1'),
         )
         for ver_tuple, ver_string in tuples_to_strings:


### PR DESCRIPTION
https://groups.google.com/d/topic/django-developers/pAnfNrTvrrM/discussion