### PR TITLE
Allow chaining of the result of ``refresh_from_db``

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -557,7 +557,7 @@ class Model(six.with_metaclass(ModelBase)):
         """
         if fields is not None:
             if len(fields) == 0:
-                return
+                return self
             if any(LOOKUP_SEP in f for f in fields):
                 raise ValueError(
                     'Found "%s" in fields argument. Relations and transforms '
@@ -595,6 +595,7 @@ class Model(six.with_metaclass(ModelBase)):
                 if local_val != related_val:
                     del self.__dict__[field.get_cache_name()]
         self._state.db = db_instance._state.db
+        return self
 
     def serializable_value(self, field_name):
         """

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -154,6 +154,14 @@ update, you could write a test similar to this::
         obj.refresh_from_db()
         self.assertEqual(obj.val, 2)
 
+The ``refresh_from_db()`` method returns the model instance itself, allowing
+for chaining of the result::
+
+    def test_update_result(self):
+        obj = MyModel.objects.create(val=1)
+        MyModel.objects.filter(pk=obj.pk).update(val=F('val') + 1)
+        self.assertEqual(obj.refresh_from_db().val, 2)
+
 Note that when deferred fields are accessed, the loading of the deferred
 field's value happens through this method. Thus it is possible to customize
 the way deferred loading happens. The example below shows how one can reload

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -720,6 +720,11 @@ class ModelRefreshTests(TestCase):
         with self.assertNumQueries(1):
             a.refresh_from_db()
             self.assertEqual(a.headline, 'new headline')
+        # Check that it returns itself
+        with self.assertNumQueries(1):
+            self.assertEqual(a.refresh_from_db().headline, 'new headline')
+        with self.assertNumQueries(1):
+            self.assert_(a.refresh_from_db() is a)
 
         orig_pub_date = a.pub_date
         new_pub_date = a.pub_date + timedelta(10)


### PR DESCRIPTION
This will make some common test patterns shorter, ie. not requiring an
extra line, etc.