### PR TITLE
[1.9.x] Correct stacklevel in Engine.render_to_string warnings

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -208,7 +208,7 @@ class Engine(object):
         else:
             warnings.warn(
                 "The context_instance argument of render_to_string is "
-                "deprecated.", RemovedInDjango110Warning, stacklevel=2)
+                "deprecated.", RemovedInDjango110Warning, stacklevel=3)
         if dirs is _dirs_undefined:
             # Do not set dirs to None here to avoid triggering the deprecation
             # warning in select_template or get_template.
@@ -216,13 +216,13 @@ class Engine(object):
         else:
             warnings.warn(
                 "The dirs argument of render_to_string is deprecated.",
-                RemovedInDjango110Warning, stacklevel=2)
+                RemovedInDjango110Warning, stacklevel=3)
         if dictionary is _dictionary_undefined:
             dictionary = None
         else:
             warnings.warn(
                 "The dictionary argument of render_to_string was renamed to "
-                "context.", RemovedInDjango110Warning, stacklevel=2)
+                "context.", RemovedInDjango110Warning, stacklevel=3)
             context = dictionary
 
         if isinstance(template_name, (list, tuple)):


### PR DESCRIPTION
.. otherwise we just see django.template.loader and not the "original"
(ie. useful!) callsites.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>