### PR TITLE
Add @csrf_header_only decorator support

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -196,7 +196,7 @@ class CsrfViewMiddleware(object):
 
             # Check non-cookie token for match.
             request_csrf_token = ""
-            if request.method == "POST":
+            if request.method == "POST" and not getattr(callback, 'csrf_header_only', False):
                 try:
                     request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
                 except IOError:

--- a/django/views/decorators/csrf.py
+++ b/django/views/decorators/csrf.py
@@ -58,3 +58,14 @@ def csrf_exempt(view_func):
         return view_func(*args, **kwargs)
     wrapped_view.csrf_exempt = True
     return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
+
+
+def csrf_header_only(view_func):
+    """
+    Marks a view function to be exempt from looking for CSRF token in POST
+    data. Prevents clashes with updating HttpRequest.upload_handlers.
+    """
+    def wrapped_view(*args, **kwargs):
+        return view_func(*args, **kwargs)
+    wrapped_view.csrf_header_only = True
+    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)


### PR DESCRIPTION
Allows decorating a view so the CSRF middleware will _only_ look for the token in the header.

This helps avoid problems when trying to use a custom upload handler for a single view.  Whilst it's possible to do this without, this can make it easier.