### PR TITLE
consider empty-space as NoneType in IntegerField

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1865,7 +1865,7 @@ class IntegerField(Field):
 
     def get_prep_value(self, value):
         value = super(IntegerField, self).get_prep_value(value)
-        if value is None:
+        if value in [None, '']:
             return None
         return int(value)
 


### PR DESCRIPTION
consider the code below:
```python
# models.py
class IntegerModel(models.Model):
   some_int_field = models.IntegerField(null=True, blank=True)

# views.py
def some_handler(request):
    some_int = request.POST['some_int_data']
    IntegerModel.objects.create(some_int_field=some_int)
    ...
```
This would raise an exception (`ValueError: invalid literal for int() with base 10: ''`) when the data **some_int_data** in the POST request is **an empty string**. We could consider empty strings as "`None`", since, it is really a NoneType in python.

The workaround for the Exception above (without the suggested bugfix/improvement in this PR) would be to add the following code 
```python
some_int = request.POST['some_int_data']
# we want to catch empty string, and replace it with None
if not some_int:
    some_int = None
...
```

You might also think that the code below will do the trick, but somehow, django returns empty string and not `None`. I assume this is similar to running `"" or None` in python, which would return `""` instead of `None`

```python
  some_int = request.POST.get('some_int_data', None)
```

The suggested improvement is to check if the value is `None` or `''` and return None on any case


