### PR TITLE
Fixed #25773 -- Deprecated the geos.MultiPolygon.cascaded_union property.

### DIFF
--- a/django/contrib/gis/geos/collections.py
+++ b/django/contrib/gis/geos/collections.py
@@ -3,6 +3,7 @@
  GeometryCollection, MultiPoint, MultiLineString, and MultiPolygon
 """
 import json
+import warnings
 from ctypes import byref, c_int, c_uint
 
 from django.contrib.gis.geos import prototypes as capi
@@ -13,6 +14,7 @@ from django.contrib.gis.geos.libgeos import get_pointer_arr
 from django.contrib.gis.geos.linestring import LinearRing, LineString
 from django.contrib.gis.geos.point import Point
 from django.contrib.gis.geos.polygon import Polygon
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.six.moves import range
 
 
@@ -135,6 +137,10 @@ class MultiPolygon(GeometryCollection):
     @property
     def cascaded_union(self):
         "Returns a cascaded union of this MultiPolygon."
+        warnings.warn(
+            "`cascaded_union` is deprecated, use the `unary_union` property instead.",
+            RemovedInDjango20Warning, 2
+        )
         return GEOSGeometry(capi.geos_cascaded_union(self.ptr), self.srid)
 
 # Setting the allowed types here since GeometryCollection is defined before

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -121,6 +121,9 @@ details on these changes.
 * The ``get_coords()`` and ``set_coords()`` methods of
   ``django.contrib.gis.geos.Point`` will be removed.
 
+* The ``cascaded_union`` property of
+  :class:`~django.contrib.gis.geos.MultiPolygon` will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -715,6 +715,10 @@ Geometry Collections
 
    .. attribute:: cascaded_union
 
+   .. deprecated:: 1.10
+
+      Use the :attr:`GEOSGeometry.unary_union` property instead.
+
    Returns a :class:`Polygon` that is the union of all of the component
    polygons in this collection.  The algorithm employed is significantly
    more efficient (faster) than trying to union the geometries together

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -350,6 +350,10 @@ This prevents confusion about an assignment resulting in an implicit save.
   :class:`~django.contrib.gis.geos.Point` are deprecated in favor of the
   ``tuple`` property.
 
+* The ``cascaded_union`` property of
+  :class:`~django.contrib.gis.geos.MultiPolygon` is deprecated in favor of the
+  :attr:`django.contrib.gis.geos.GEOSGeometry.unary_union` property.
+
 Miscellaneous
 ~~~~~~~~~~~~~
 

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1188,3 +1188,9 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
 
         p.set_coords((3, 2, 1))
         self.assertEqual(p.get_coords(), (3, 2, 1))
+
+    @ignore_warnings(category=RemovedInDjango20Warning)
+    def test_deprecated_cascaded_union(self):
+        for geom in self.geometries.multipolygons:
+            mpoly = GEOSGeometry(geom.wkt)
+            self.assertEqual(mpoly.cascaded_union, mpoly.unary_union)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25773