### PR TITLE
[1.8.x] Fixed #25685 -- Fixed a duplicate query regression on deletion of proxied models.

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -58,9 +58,9 @@ def get_candidate_relations_to_delete(opts):
     candidate_models = {opts}
     candidate_models = candidate_models.union(opts.concrete_model._meta.proxied_children)
     # For each model, get all candidate fields.
-    candidate_model_fields = chain.from_iterable(
+    candidate_model_fields = set(chain.from_iterable(
         opts.get_fields(include_hidden=True) for opts in candidate_models
-    )
+    ))
     # The candidate relations are the ones that come from N-1 and 1-1 relations.
     # N-N  (i.e., many-to-many) relations aren't candidates for deletion.
     return (

--- a/docs/releases/1.8.7.txt
+++ b/docs/releases/1.8.7.txt
@@ -39,3 +39,6 @@ Bugfixes
 
 * Fixed ``Model.refresh_from_db()`` updating of ``ForeignKey`` fields with
   ``on_delete=models.SET_NULL`` (:ticket:`25715`).
+
+* Fixed a duplicate query regression in 1.8 on proxied model deletion
+  (:ticket:`25685`).

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -98,6 +98,12 @@ class Avatar(models.Model):
     desc = models.TextField(null=True)
 
 
+# This model is used to test a duplicate query regression (#25685)
+class AvatarProxy(Avatar):
+    class Meta:
+        proxy = True
+
+
 class User(models.Model):
     avatar = models.ForeignKey(Avatar, null=True)
 

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -349,6 +349,17 @@ class DeletionTests(TestCase):
         self.assertFalse(S.objects.exists())
         self.assertFalse(T.objects.exists())
 
+    def test_proxied_model_duplicate_queries(self):
+        """
+        #25685 - Deleting instances of a model with existing proxy
+        classes should not issue multiple queries during cascade
+        deletion of referring models.
+        """
+        avatar = Avatar.objects.create()
+        # One query for the Avatar table and a second for the User one.
+        with self.assertNumQueries(2):
+            avatar.delete()
+
 
 class FastDeleteTests(TestCase):
 


### PR DESCRIPTION
Thanks to Trac alias ppetrid for the report.