### PR TITLE
Fixed #25784 -- Fixed 'collectstatic help' crash if STATIC_ROOT unset.

### DIFF
--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -9,6 +9,7 @@ from django.core.files.storage import FileSystemStorage
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.color import no_style
 from django.utils.encoding import smart_text
+from django.utils.functional import cached_property
 from django.utils.six.moves import input
 
 
@@ -28,12 +29,14 @@ class Command(BaseCommand):
         self.post_processed_files = []
         self.storage = staticfiles_storage
         self.style = no_style()
+
+    @cached_property
+    def local(self):
         try:
             self.storage.path('')
         except NotImplementedError:
-            self.local = False
-        else:
-            self.local = True
+            return False
+        return True
 
     def add_arguments(self, parser):
         parser.add_argument('--noinput', '--no-input',

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import unittest
 
+from admin_scripts.tests import AdminScriptTestCase
+
 from django.conf import settings
 from django.contrib.staticfiles import storage
 from django.contrib.staticfiles.management.commands import collectstatic
@@ -128,6 +130,18 @@ class TestConfiguration(StaticFilesTestCase):
             staticfiles_storage._wrapped = empty
             collectstatic.staticfiles_storage = staticfiles_storage
             storage.staticfiles_storage = staticfiles_storage
+
+
+class TestCollectionsHelpSubcommand(AdminScriptTestCase):
+    @override_settings(STATIC_ROOT=None)
+    def test_missing_settings_dont_prevent_help(self):
+        """
+        Even if the :setting:`STATIC_ROOT` is not set, one can still call the
+        `manage.py help collectstatic` command.
+        """
+        self.write_settings('settings.py', apps=['django.contrib.staticfiles'])
+        out, err = self.run_manage(['help', 'collectstatic'])
+        self.assertNoOutput(err)
 
 
 class TestCollection(CollectionTestCase, TestDefaults):


### PR DESCRIPTION
Made the `manage.py help collectstatic` don't fail if the `STATIC_ROOT`
setting is empty.