### PR TITLE
Remove note about django.setup in django-admin doc

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -6,15 +6,13 @@ django-admin and manage.py
 This document outlines all it can do.
 
 In addition, ``manage.py`` is automatically created in each Django project.
-``manage.py`` is a thin wrapper around ``django-admin`` that takes care of
-several things for you before delegating to ``django-admin``:
+``manage.py`` does the same things than ``django-admin`` but takes care of
+a few things for you:
 
-* It puts your project's package on ``sys.path``.
+* It automatically puts your project's package on ``sys.path``.
 
 * It sets the :envvar:`DJANGO_SETTINGS_MODULE` environment variable so that
   it points to your project's ``settings.py`` file.
-
-* It calls :func:`django.setup()` to initialize various internals of Django.
 
 The ``django-admin`` script should be on your system path if you installed
 Django via its ``setup.py`` utility. If it's not on your path, you can find it


### PR DESCRIPTION
The doc about `django-admin` states that `manage.py` is a wrapper around `django-admin`, which is not true.

Also, `manage.py` doesn't call `django.setup()`.

This PR fixes that.