### PR TITLE
Clarified default value for DateField to emulate auto_now_add.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -492,7 +492,8 @@ optional arguments:
     it's not just a default value that you can override. So even if you
     set a value for this field when creating the object, it will be ignored.
     If you want to be able to modify this field, set ``default=timezone.now``
-    (from :func:`django.utils.timezone.now`) instead of ``auto_now_add=True``.
+    (from :func:`django.utils.timezone.now`) or ``default=date.today``
+    (from `datetime.date.today`) instead of ``auto_now_add=True``.
 
 
 The default form widget for this field is a


### PR DESCRIPTION
If you add `default=timezone.now` to `DateField` it will give you wrong format error.