### PR TITLE
Fixed #25812 -- Restored the ability to use custom formats with the date template filter.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -749,6 +749,7 @@ answer newbie questions, and generally made Django that much better:
     Wilson Miner <wminer@gmail.com>
     wojtek
     Xia Kai <http://blog.xiaket.org/>
+    Yann Fouillat <gagaro42@gmail.com>
     Yann Malet
     Yasushi Masuda <whosaysni@gmail.com>
     ye7cakf02@sneakemail.com

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -110,8 +110,6 @@ def get_format(format_type, lang=None, use_l10n=None):
     be localized (or not), overriding the value of settings.USE_L10N.
     """
     format_type = force_str(format_type)
-    if format_type not in FORMAT_SETTINGS:
-        return format_type
     if use_l10n or (use_l10n is None and settings.USE_L10N):
         if lang is None:
             lang = get_language()
@@ -120,9 +118,6 @@ def get_format(format_type, lang=None, use_l10n=None):
             cached = _format_cache[cache_key]
             if cached is not None:
                 return cached
-            else:
-                # Return the general setting by default
-                return getattr(settings, format_type)
         except KeyError:
             for module in get_format_modules(lang):
                 try:
@@ -137,6 +132,9 @@ def get_format(format_type, lang=None, use_l10n=None):
                 except AttributeError:
                     pass
             _format_cache[cache_key] = None
+    if format_type not in FORMAT_SETTINGS:
+        return format_type
+    # Return the general setting by default
     return getattr(settings, format_type)
 
 get_format_lazy = lazy(get_format, six.text_type, list, tuple)

--- a/docs/topics/i18n/formatting.txt
+++ b/docs/topics/i18n/formatting.txt
@@ -164,7 +164,8 @@ the package where format files will exist, for instance::
     ]
 
 Files are not placed directly in this directory, but in a directory named as
-the locale, and must be named ``formats.py``.
+the locale, and must be named ``formats.py``. Be careful not to put sensitive
+information in these files, as values inside can be exposed.
 
 To customize the English formats, a structure like this would be needed::
 

--- a/tests/i18n/other/locale/fr/formats.py
+++ b/tests/i18n/other/locale/fr/formats.py
@@ -1,0 +1,2 @@
+# A user-defined format
+CUSTOM_DAY_FORMAT = 'd/m/Y CUSTOM'

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1252,6 +1252,11 @@ class FormattingTests(SimpleTestCase):
     def test_format_arbitrary_settings(self):
         self.assertEqual(get_format('DEBUG'), 'DEBUG')
 
+    def test_get_custom_format(self):
+        with self.settings(FORMAT_MODULE_PATH='i18n.other.locale'):
+            with translation.override('fr', deactivate=True):
+                self.assertEqual('d/m/Y CUSTOM', get_format('CUSTOM_DAY_FORMAT'))
+
 
 class MiscTests(SimpleTestCase):
 


### PR DESCRIPTION
Before the security fix in 1.8.7, we could have custom formats in formats.py files and used them. For example, if I have the following formats.py:

```python
CUSTOM_DAY_FORMAT = 'd/m/Y CUSTOM'
```

I could used it:

```python
>>> get_format('CUSTOM_DAY_FORMAT')
'd/m/Y CUSTOM'
```

But now it returns `CUSTOM_DAY_FORMAT` instead.