### PR TITLE
Fixed manual page by escaping ".pot" at the start of a line

### DIFF
--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -860,7 +860,7 @@ for technically skilled translators to understand each message\(aqs context.
 .UNINDENT
 .sp
 Use the \fB\-\-keep\-pot\fP option to prevent Django from deleting the temporary
-.pot files it generates before creating the .po file. This is useful for
+\&.pot files it generates before creating the .po file. This is useful for
 debugging errors which may prevent the final language files from being created.
 .sp
 \fBSEE ALSO:\fP


### PR DESCRIPTION
Words starting with a dot at the start of a line are treated as formatting
commands. Since .pot is an unknown command the whole line is dropped
from the output.

This has been spotted by Debian package checker tool (lintian):
W: python-django-common: manpage-has-errors-from-man usr/share/man/man1/django-admin.1.gz 880: warning: macro `pot' not defined (possibly missing space after `po')