### PR TITLE
Keep security fix on date template filter formats, but still allow to add some custom formats

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -387,6 +387,24 @@ NUMBER_GROUPING = 0
 # Thousand separator symbol
 THOUSAND_SEPARATOR = ','
 
+# Allowed formats to prevent leak possibility in the date template filter.
+FORMAT_SETTINGS = (
+    'DECIMAL_SEPARATOR',
+    'THOUSAND_SEPARATOR',
+    'NUMBER_GROUPING',
+    'FIRST_DAY_OF_WEEK',
+    'MONTH_DAY_FORMAT',
+    'TIME_FORMAT',
+    'DATE_FORMAT',
+    'DATETIME_FORMAT',
+    'SHORT_DATE_FORMAT',
+    'SHORT_DATETIME_FORMAT',
+    'YEAR_MONTH_FORMAT',
+    'DATE_INPUT_FORMATS',
+    'TIME_INPUT_FORMATS',
+    'DATETIME_INPUT_FORMATS',
+)
+
 # The tablespaces to use for each model when not specified otherwise.
 DEFAULT_TABLESPACE = ''
 DEFAULT_INDEX_TABLESPACE = ''

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -30,24 +30,6 @@ ISO_INPUT_FORMATS = {
 }
 
 
-FORMAT_SETTINGS = frozenset([
-    'DECIMAL_SEPARATOR',
-    'THOUSAND_SEPARATOR',
-    'NUMBER_GROUPING',
-    'FIRST_DAY_OF_WEEK',
-    'MONTH_DAY_FORMAT',
-    'TIME_FORMAT',
-    'DATE_FORMAT',
-    'DATETIME_FORMAT',
-    'SHORT_DATE_FORMAT',
-    'SHORT_DATETIME_FORMAT',
-    'YEAR_MONTH_FORMAT',
-    'DATE_INPUT_FORMATS',
-    'TIME_INPUT_FORMATS',
-    'DATETIME_INPUT_FORMATS',
-])
-
-
 def reset_format_cache():
     """Clear any cached formats.
 
@@ -110,7 +92,7 @@ def get_format(format_type, lang=None, use_l10n=None):
     be localized (or not), overriding the value of settings.USE_L10N.
     """
     format_type = force_str(format_type)
-    if format_type not in FORMAT_SETTINGS:
+    if format_type not in settings.FORMAT_SETTINGS:
         return format_type
     if use_l10n or (use_l10n is None and settings.USE_L10N):
         if lang is None:


### PR DESCRIPTION
One should be able to define some new custom date formats for example.
Fix security commit 316bc3f did not allow that.