### PR TITLE
Fixed #25302 (again) -- Ignored scheme when checking for bad referers.

### DIFF
--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -383,9 +383,18 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         self.req.META['HTTP_REFERER'] = self.req.path
         BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
         self.assertEqual(len(mail.outbox), 0)
+
         # URL with scheme and domain should also be ignored
         self.req.META['HTTP_REFERER'] = 'http://testserver%s' % self.req.path
         BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
+        self.assertEqual(len(mail.outbox), 0)
+
+        # URL with a different scheme should be ignored as well because bots
+        # tend to use http:// in referers even when browsing HTTPS websites.
+        self.req.META['HTTP_X_PROTO'] = 'https'
+        self.req.META['SERVER_PORT'] = 443
+        with self.settings(SECURE_PROXY_SSL_HEADER=('HTTP_X_PROTO', 'https')):
+            BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_referer_equal_to_requested_url_on_another_domain(self):


### PR DESCRIPTION
The check introduced in 4ce433e was too strict in real life. The poorly
implemented bots this patch attempted to ignore are sloppy when it comes
to http vs. https.