### PR TITLE
Fixed #25811 -- Added a helpful error when making _in queries across different databases.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -203,6 +203,13 @@ class In(BuiltinLookup):
     lookup_name = 'in'
 
     def process_rhs(self, compiler, connection):
+        db_rhs = getattr(self.rhs, '_db', None)
+        if db_rhs is not None and db_rhs != connection.alias:
+            raise ValueError(
+                "Subqueries aren't allowed across different databases. Instead, "
+                "force the inner query to be evaluated using `list(inner_query)`."
+            )
+
         if self.rhs_is_direct_value():
             # rhs should be an iterable, we use batch_process_rhs
             # to prepare/transform those values

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -476,6 +476,14 @@ class LookupTests(TestCase):
                 '<Article: Article 1>',
             ])
 
+    def test_in_different_database(self):
+        with self.assertRaisesMessage(
+            ValueError,
+            "Subqueries aren't allowed across different databases. Instead, "
+            "force the inner query to be evaluated using `list(inner_query)`."
+        ):
+            list(Article.objects.filter(id__in=Article.objects.using('other').all()))
+
     def test_error_messages(self):
         # Programming errors are pointed out with nice error messages
         try:


### PR DESCRIPTION
Normally it vlookup IN is used with a list, but we go through another query argument, generating a single SQL query like adding a second subquery, but we must check if there is db attribute and validate the 2 consultations belong to the same base data, otherwise evaluation must force the second query.