### PR TITLE
Fixed #25827 -- DateTimeField spacing and alignment

### DIFF
--- a/django/contrib/admin/static/admin/css/widgets.css
+++ b/django/contrib/admin/static/admin/css/widgets.css
@@ -255,11 +255,6 @@ p.datetime {
     font-weight: bold;
 }
 
-form .form-row p.datetime {
-    margin-left: 160px;
-    padding-left: 10px;
-}
-
 .datetime span {
     white-space: nowrap;
     font-weight: normal;
@@ -274,7 +269,7 @@ form .form-row p.datetime {
 }
 
 table p.datetime {
-    font-size: 10px;
+    font-size: 11px;
     margin-left: 0;
     padding-left: 0;
 }


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/25827

- Fixed extra space in TabularAdmin caused by useless left margin
- Put date and time fields side by side to avoid vertical extra space and improve UX

Screenshot of how it looks now:
<img width="616" alt="screenshot 2015-11-29 at 03 13 16" src="https://cloud.githubusercontent.com/assets/209663/11454243/3a74091a-9647-11e5-9d49-860361559f92.png">
 