### PR TITLE
Fixed #25840 -- Added get_or_set method to dummy cache backend

### DIFF
--- a/django/core/cache/backends/dummy.py
+++ b/django/core/cache/backends/dummy.py
@@ -28,6 +28,15 @@ class DummyCache(BaseCache):
     def get_many(self, keys, version=None):
         return {}
 
+    def get_or_set(self, key, default=None, timeout=DEFAULT_TIMEOUT, version=None):
+        if default is None:
+            raise ValueError('You need to specify a value.')
+        key = self.make_key(key, version=version)
+        self.validate_key(key)
+        if callable(default):
+            default = default()
+        return default
+
     def has_key(self, key, version=None):
         key = self.make_key(key, version=version)
         self.validate_key(key)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -114,6 +114,19 @@ class DummyCacheTests(SimpleTestCase):
         self.assertIsNone(cache.get("key1"))
         self.assertIsNone(cache.get("key2"))
 
+    def test_get_or_set(self):
+        "Get or set allways will return default value on the dummy cahce backend"
+        cache.set("key1", "spam")
+        self.assertRaises(ValueError, cache.get_or_set, "key1")
+        self.assertEqual(
+            cache.get_or_set("key1", "eggs"),
+            "eggs"
+        )
+        self.assertEqual(
+            cache.get_or_set("key1", lambda: "fish"),
+            "fish"
+        )
+
     def test_has_key(self):
         "The has_key method doesn't ever return True for the dummy cache backend"
         cache.set("hello1", "goodbye1")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25840