### PR TITLE
update link to 1000 common passwords

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -349,7 +349,7 @@ Django includes four validators:
 
     Validates whether the password is not a common password. By default, this
     checks against a list of 1000 common password created by
-    `Mark Burnett <https://xato.net/passwords/more-top-worst-passwords/>`_.
+    `Mark Burnett <https://web.archive.org/web/20150315154609/https://xato.net/passwords/more-top-worst-passwords/>`_.
 
     The ``password_list_path`` can be set to the path of a custom file of
     common passwords. This file should contain one password per line and


### PR DESCRIPTION
xato.net is dead; replace with link to archive.org, as the xato.net site suggests.