### PR TITLE
Fixed #25840 -- Added a 'default' argument to self.get signature on BaseCache.get_or_set()

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -165,7 +165,7 @@ class BaseCache(object):
                 default = default()
             val = self.add(key, default, timeout=timeout, version=version)
             if val:
-                return self.get(key, version=version)
+                return self.get(key, default, version)
         return val
 
     def has_key(self, key, version=None):

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -9,4 +9,5 @@ Django 1.9.1 fixes several bugs in 1.9.
 Bugfixes
 ========
 
-* ...
+* Fixed the faulty behaviour of ``BaseCache.get_or_set()`` when DummyCache
+  selected as a cache backend (:ticket:`25840`).

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -202,6 +202,15 @@ class DummyCacheTests(SimpleTestCase):
         self.assertRaises(ValueError, cache.decr_version, 'answer')
         self.assertRaises(ValueError, cache.decr_version, 'does_not_exist')
 
+    def test_get_or_set(self):
+        self.assertEqual(cache.get_or_set('mykey', 'default'), 'default')
+
+    def test_get_or_set_callable(self):
+        def my_callable():
+            return 'default'
+
+        self.assertEqual(cache.get_or_set('mykey', my_callable), 'default')
+
 
 def custom_key_func(key, key_prefix, version):
     "A customized cache key function"


### PR DESCRIPTION
Refactored Django's built-in BaseCache.get_or_set() to
work well with DummyCache.

get_or_set implementation tries to fetch the key first.
If it doesn't exists, it adds the default value
(passed as 'default' parameter) to the cache and gets it.

Since DummyCache backend doesn't actually add something
but returns True on add operation, get_or_cache() thinks
that it's successfully added to the cache and do a GET
operation to the related key which returns None. This way
instead of returning default, returns None.

This also fixes possible data eviction problems
between setting and getting a key. Another thread possibly
remove the key before get_and_set access it again.

Also added the get_or_set related unit tests for DummyCache backend.
