### PR TITLE
Refs #22955 -- Added a test for browser refresh clearing ModelAdmin.filter_horizontal items.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -47,6 +47,7 @@ class FilteredSelectMultiple(forms.SelectMultiple):
 
         attrs['data-field-name'] = self.verbose_name
         attrs['data-is-stacked'] = int(self.is_stacked)
+        attrs['autocomplete'] = 'off'
         output = super(FilteredSelectMultiple, self).render(name, value, attrs, choices)
         return mark_safe(output)
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -1166,6 +1166,28 @@ class HorizontalVerticalFilterSeleniumFirefoxTests(SeleniumDataMixin, AdminSelen
         self.assertSelectOptions('#id_alumni_from', expected_unselected_values)
         self.assertSelectOptions('#id_alumni_to', expected_selected_values)
 
+    def test_refresh_page(self):
+        """
+        Horizontal and vertical filters keep selected options on page reload. (#22955)
+        """
+        self.school.students.add(self.arthur, self.jason)
+        self.school.alumni.add(self.arthur, self.jason)
+
+        self.admin_login(username='super', password='secret', login_url='/')
+        change_url = reverse('admin:admin_widgets_school_change', args=(self.school.id,))
+        self.selenium.get(self.live_server_url + change_url)
+
+        options_len = len(self.selenium.find_elements_by_css_selector('#id_students_to > option'))
+        self.assertEqual(options_len, 2)
+
+        # self.selenium.refresh() or send_keys(Keys.F5) does hard reload and it doesn't
+        # demostrate what really happens when user clicks on 'Refresh' button in browser.
+        self.selenium.execute_script("location.reload()")
+        self.wait_page_loaded()
+
+        options_len = len(self.selenium.find_elements_by_css_selector('#id_students_to > option'))
+        self.assertEqual(options_len, 2)
+
 
 class HorizontalVerticalFilterSeleniumChromeTests(HorizontalVerticalFilterSeleniumFirefoxTests):
     webdriver_class = 'selenium.webdriver.chrome.webdriver.WebDriver'

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -272,7 +272,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render('test', 'test'),
             '<select multiple="multiple" name="test" class="selectfilter" '
-            'data-field-name="test\\" data-is-stacked="0">\n</select>'
+            'data-field-name="test\\" data-is-stacked="0" autocomplete="off">\n</select>'
         )
 
     def test_stacked_render(self):
@@ -281,7 +281,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render('test', 'test'),
             '<select multiple="multiple" name="test" class="selectfilterstacked" '
-            'data-field-name="test\\" data-is-stacked="1">\n</select>'
+            'data-field-name="test\\" data-is-stacked="1" autocomplete="off">\n</select>'
         )
 
 


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/22955

One only thing -- W3C says that `autocomplete` attribute isn't valid for `select` element. So I think it's Firefox fault. Anyway this one-line trick fixes problem in Firefox.