### PR TITLE
Document removed functions from django.db.models

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1398,6 +1398,11 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
 * ``django.db.models.signals.pre_syncdb`` and
   ``django.db.models.signals.post_syncdb`` is removed.
 
+* A number of functions from ``django.db.models`` have been removed. These
+  are: ``load_app``, ``app_cache_ready``, ``get_app``, ``get_apps``,
+  ``get_app_package``, ``get_app_path``, ``get_app_paths``, and
+  ``register_models``.
+
 * Support for ``allow_syncdb`` on database routers is removed.
 
 * Automatic syncing of apps without migrations is removed. Migrations are


### PR DESCRIPTION
These were functions removed here:
  cf5b67d3a053831ce5a3ef24acb7059fc1f29469

But I couldn't find a notice in the 1.9 release notes that these
have been removed.