### PR TITLE
Fixed #25845 -- Fixed body.getAttribute check in django admin.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -21,7 +21,7 @@
         init: function() {
             var body = document.getElementsByTagName('body')[0];
             var serverOffset = body.getAttribute('data-admin-utc-offset');
-            if (serverOffset !== undefined) {
+            if (serverOffset !== null || serverOffset !== "") {
                 var localOffset = new Date().getTimezoneOffset() * -60;
                 DateTimeShortcuts.timezoneOffset = localOffset - serverOffset;
             }


### PR DESCRIPTION
body.getAttribute('data-admin-utc-offset') call returns empty
string ("") or null if it isn't set. However, current call
checks the value for undefined which is a wrong check. Fixed
that faulty behaviour.

https://code.djangoproject.com/ticket/25845