### PR TITLE
made fieldset stylable.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -58,14 +58,14 @@ class AdminForm(object):
 
 class Fieldset(object):
     def __init__(self, form, name=None, readonly_fields=(), fields=(), classes=(),
-      description=None, model_admin=None):
+      description=None, model_admin=None, style=None):
         self.form = form
         self.name, self.fields = name, fields
         self.classes = ' '.join(classes)
         self.description = description
         self.model_admin = model_admin
         self.readonly_fields = readonly_fields
-
+        self.style=style
     def _media(self):
         if 'collapse' in self.classes:
             extra = '' if settings.DEBUG else '.min'

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -1,4 +1,4 @@
-<fieldset class="module aligned {{ fieldset.classes }}">
+<fieldset class="module aligned {{ fieldset.classes }}" {% if fieldset.style %} style="{{fieldset.style}}" {% endif %} >
     {% if fieldset.name %}<h2>{{ fieldset.name }}</h2>{% endif %}
     {% if fieldset.description %}
         <div class="description">{{ fieldset.description|safe }}</div>


### PR DESCRIPTION
With this path, we could inject style attribute to fieldsets, and make the fieldsets horizentally placed.
class XXXXAdmin(admin.ModelAdmin):
  fieldsets = [
        ('field1', {'fields': ['id', ],
                    'style': 'width: 24%; float: left; '
                    }),
        ('field2', {'fields': ['client_tag'],
                    'style': 'width: 24%; float: left; margin-left: 3px'
                    }),
        ('field3', {'fields': ['confirm_username',],
                    'style': 'width: 24%; float: left; margin-left: 3px'
                    }),
        ('field4', {'fields': ['amount',],
                    'style': 'width: 24%; float: left; margin-left: 3px'
                    }),
        (None, {'fields': [], 'style': 'clear: both; display: invisible; border-width:0px', }),
    ]

