### PR TITLE
Fixed #25657 -- Ignored TypeErrors when destroying geometry objects

### DIFF
--- a/django/contrib/gis/gdal/datasource.py
+++ b/django/contrib/gis/gdal/datasource.py
@@ -87,8 +87,10 @@ class DataSource(GDALBase):
 
     def __del__(self):
         "Destroys this DataStructure object."
-        if self._ptr and capi:
+        try:
             capi.destroy_ds(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def __iter__(self):
         "Allows for iteration over the layers in a data source."

--- a/django/contrib/gis/gdal/feature.py
+++ b/django/contrib/gis/gdal/feature.py
@@ -29,8 +29,10 @@ class Feature(GDALBase):
 
     def __del__(self):
         "Releases a reference to this object."
-        if self._ptr and capi:
+        try:
             capi.destroy_feature(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def __getitem__(self, index):
         """

--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -121,8 +121,10 @@ class OGRGeometry(GDALBase):
 
     def __del__(self):
         "Deletes this Geometry."
-        if self._ptr and capi:
+        try:
             capi.destroy_geom(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     # Pickle routines
     def __getstate__(self):

--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -131,8 +131,10 @@ class GDALRaster(GDALBase):
             raise GDALException('Invalid data source input type: "{}".'.format(type(ds_input)))
 
     def __del__(self):
-        if self._ptr and capi:
+        try:
             capi.close_ds(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def __str__(self):
         return self.name

--- a/django/contrib/gis/gdal/srs.py
+++ b/django/contrib/gis/gdal/srs.py
@@ -96,8 +96,10 @@ class SpatialReference(GDALBase):
 
     def __del__(self):
         "Destroys this spatial reference."
-        if self._ptr and capi:
+        try:
             capi.release_srs(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def __getitem__(self, target):
         """
@@ -341,8 +343,10 @@ class CoordTransform(GDALBase):
 
     def __del__(self):
         "Deletes this Coordinate Transformation object."
-        if self._ptr and capi:
+        try:
             capi.destroy_ct(self._ptr)
+        except (AttributeError, TypeError):
+            pass
 
     def __str__(self):
         return 'Transform from "%s" to "%s"' % (self._srs1_name, self._srs2_name)

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -123,8 +123,10 @@ class GEOSGeometry(GEOSBase, ListMixin):
         Destroys this Geometry; in other words, frees the memory used by the
         GEOS C++ object.
         """
-        if self._ptr and capi:
+        try:
             capi.destroy_geom(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def __copy__(self):
         """

--- a/django/contrib/gis/geos/prepared.py
+++ b/django/contrib/gis/geos/prepared.py
@@ -21,8 +21,10 @@ class PreparedGeometry(GEOSBase):
         self.ptr = capi.geos_prepare(geom.ptr)
 
     def __del__(self):
-        if self._ptr and capi:
+        try:
             capi.prepared_destroy(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
     def contains(self, other):
         return capi.prepared_contains(self.ptr, other.ptr)

--- a/django/contrib/gis/geos/prototypes/io.py
+++ b/django/contrib/gis/geos/prototypes/io.py
@@ -120,8 +120,10 @@ class IOBase(GEOSBase):
 
     def __del__(self):
         # Cleaning up with the appropriate destructor.
-        if self._ptr:
+        try:
             self._destructor(self._ptr)
+        except (AttributeError, TypeError):
+            pass  # Some part might already have been garbage collected
 
 # ### Base WKB/WKT Reading and Writing objects ###
 


### PR DESCRIPTION
Due to randomness of garbage collection with geometry objects, it's
easier to simply ignore TypeErrors generally raised when parts of
objects are already garbage-collected.