### PR TITLE
Fixed #25845 -- Fixed incorrect timezone warnings in custom admin templates.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -21,7 +21,7 @@
         init: function() {
             var body = document.getElementsByTagName('body')[0];
             var serverOffset = body.getAttribute('data-admin-utc-offset');
-            if (serverOffset !== undefined) {
+            if (serverOffset) {
                 var localOffset = new Date().getTimezoneOffset() * -60;
                 DateTimeShortcuts.timezoneOffset = localOffset - serverOffset;
             }
@@ -43,7 +43,7 @@
         now: function() {
             var body = document.getElementsByTagName('body')[0];
             var serverOffset = body.getAttribute('data-admin-utc-offset');
-            if (serverOffset !== undefined) {
+            if (serverOffset) {
                 var localNow = new Date();
                 var localOffset = localNow.getTimezoneOffset() * -60;
                 localNow.setTime(localNow.getTime() + 1000 * (serverOffset - localOffset));

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -43,3 +43,7 @@ Bugfixes
 
 * Fixed a state bug when using an ``AlterModelManagers`` operation
   (:ticket:`25852`).
+
+* Fixed incorrect timezone warnings in custom admin templates that don't have
+  a data-admin-utc-offset attribute in the body tag.
+  (:ticket:`25845`).

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -16,4 +16,8 @@ test('init', function(assert) {
     assert.equal(shortcuts.length, 1);
     assert.equal(shortcuts.find('a:first').text(), 'Today');
     assert.equal(shortcuts.find('a:last .date-icon').length, 1);
+
+    // timezoneOffset should be 0 when no timezone offset is set in the body attribute, otherwise incorrect timezone
+    // warnings may appear on date and time widgets (#25845).
+    assert.equal(DateTimeShortcuts.timezoneOffset, 0);
 });


### PR DESCRIPTION
Fixed false timezone warnings if a custom admin base.html template doesn't specify the "data-admin-utc-offset" body attribute.

Added Selenium tests for Firefox, Chrome and IE based on `DateTimePickerShortcutsSeleniumFirefoxTests`, as suggested by @timgraham in #5769.

https://code.djangoproject.com/ticket/25845