### PR TITLE
Added note about model inheritence incompatibility

### DIFF
--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1060,6 +1060,8 @@ You should make sure that:
   Specifically, you shouldn't import models in the root module of an
   application nor in the module that define its configuration class.
 
+* No app contains a model that inherits from a concrete (abstract = False) model that is defined in another app's models.py file.
+
 Django will enforce these requirements as of version 1.9, after a deprecation
 period.
 


### PR DESCRIPTION
This updates the 1.7 release notes for a breaking change that was introduced with the app loading re-factor but missed in the release (and subsequent ones). The effect of the change is that inheriting a model that is not abstract and defined outside of the same app is no longer possible. 

See also: https://code.djangoproject.com/ticket/22872#comment:12