### PR TITLE
Document npm compatibility in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "pretest": "eslint django/ js_tests/admin/ js_tests/gis/",
     "test": "grunt test --verbose"
   },
+  "engines": {
+    "npm": ">=1.3.0 <3.0.0"
+  },
   "devDependencies": {
     "eslint": "^0.22.1",
     "grunt": "^0.4.5",


### PR DESCRIPTION
See ticket #25803.

Django's `npm install` / `npm test` procedure (documented here: https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/javascript/#testing-from-the-command-line) only works with npm versions 1.3.x - 2.x,
from what I've tested, while 3.5.1 is the latest npm version.

I think it's a good idea to document this somewhere to reduce confusion.

One place we could do this is the "engines" filed in package.json.
https://docs.npmjs.com/files/package.json#engines