### PR TITLE
Fixed #24675 -- `SET SQL_AUTO_IS_NULL = 0` on versions of MySQL that don't need it

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -267,12 +267,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return conn
 
     def init_connection_state(self):
-        with self.cursor() as cursor:
-            # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
-            # on a recently-inserted row will return when the field is tested for
-            # NULL.  Disabling this value brings this aspect of MySQL in line with
-            # SQL standards.
-            cursor.execute('SET SQL_AUTO_IS_NULL = 0')
+        if self.features.can_return_last_inserted_id_with_auto_is_null:
+            with self.cursor() as cursor:
+                # SQL_AUTO_IS_NULL in MySQL controls whether an AUTO_INCREMENT column
+                # on a recently-inserted row will return when the field is tested for
+                # NULL.  Disabling this value brings this aspect of MySQL in line with
+                # SQL standards.
+                cursor.execute('SET SQL_AUTO_IS_NULL = 0')
 
     def create_cursor(self):
         cursor = self.connection.cursor()

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -47,6 +47,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return self._mysql_storage_engine != 'MyISAM'
 
     @cached_property
+    def can_return_last_inserted_id_with_auto_is_null(self):
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT @@SQL_AUTO_IS_NULL")
+            return cursor.fetchone()[0] == 1
+
+    @cached_property
     def supports_microsecond_precision(self):
         # See https://github.com/farcepest/MySQLdb1/issues/24 for the reason
         # about requiring MySQLdb 1.2.5

--- a/tests/backends/test_mysql.py
+++ b/tests/backends/test_mysql.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Unit and doctests for the MySQL backend.
+from __future__ import unicode_literals
+
+import unittest
+
+from django.db import connection
+from django.test import TestCase, override_settings
+
+
+@override_settings(DEBUG=True)
+@unittest.skipUnless(connection.vendor == 'mysql', 'MySQL specific test.')
+class MySQLTests(TestCase):
+
+    def test_auto_is_null_auto_config(self):
+        query = "set sql_auto_is_null = 0"
+        connection.init_connection_state()
+        last_query = connection.queries[-1]['sql'].lower()
+        if connection.features.can_return_last_inserted_id_with_auto_is_null:
+            self.assertIn(query, last_query)
+        else:
+            self.assertNotIn(query, last_query)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24675

`SET SQL_AUTO_IS_NULL = 0` isn't needed when it's disabled globally, or the MySQL/MariaDB server version is >=5.5.3. (See more: https://mariadb.com/kb/en/mariadb/server-system-variables/#sql_auto_is_null)

There seems to be prior work on this that didn't get merged due to the original author becoming inactive, so I decided to revise the code since one of the core developers gave a go on the previous source code. and I also added a test case under `tests/backends/tests.py`, which was the original reason why the prior work didn't get merged.

