### PR TITLE
Fixed #25883 -- Fixed admin deletion page summary counts for related objects.

### DIFF
--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -19,3 +19,5 @@ Bugfixes
 
 * Fixed a state bug when migrating a ``SeparateDatabaseAndState`` operation
   backwards (:ticket:`25896`).
+
+* Fixed admin deletion page summary counts for related objects (:ticket:`25883`).

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -40,6 +40,7 @@ class Article(models.Model):
     content = models.TextField()
     date = models.DateTimeField()
     section = models.ForeignKey(Section, models.CASCADE, null=True, blank=True)
+    another_section = models.ForeignKey(Section, models.CASCADE, null=True, blank=True, related_name='+')
     sub_section = models.ForeignKey(Section, models.SET_NULL, null=True, blank=True, related_name='+')
 
     def __str__(self):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1292,7 +1292,8 @@ class AdminViewPermissionsTest(TestCase):
         )
         cls.s1 = Section.objects.create(name='Test section')
         cls.a1 = Article.objects.create(
-            content='<p>Middle content</p>', date=datetime.datetime(2008, 3, 18, 11, 54, 58), section=cls.s1
+            content='<p>Middle content</p>', date=datetime.datetime(2008, 3, 18, 11, 54, 58), section=cls.s1,
+            another_section=cls.s1,
         )
         cls.a2 = Article.objects.create(
             content='<p>Oldest content</p>', date=datetime.datetime(2000, 3, 18, 11, 54, 58), section=cls.s1
@@ -3203,7 +3204,7 @@ class AdminActionsTest(TestCase):
         self.assertIsInstance(confirmation, TemplateResponse)
         self.assertContains(confirmation, "Are you sure you want to delete the selected subscribers?")
         self.assertContains(confirmation, "<h2>Summary</h2>")
-        self.assertContains(confirmation, "<li>Subscribers: 3</li>")
+        self.assertContains(confirmation, "<li>Subscribers: 2</li>")
         self.assertContains(confirmation, "<li>External subscribers: 1</li>")
         self.assertContains(confirmation, ACTION_CHECKBOX_NAME, count=2)
         self.client.post(reverse('admin:admin_views_subscriber_changelist'), delete_confirmation_data)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25883