### PR TITLE
[WIP] Disable/enable constraints for required tables only

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -84,14 +84,14 @@ class Command(BaseCommand):
         }
         if has_bz2:
             self.compression_formats['bz2'] = (bz2.BZ2File, 'r')
-
-        with connection.constraint_checks_disabled():
+        models = self.find_models_from_labels(fixture_labels)
+        table_names = [model._meta.db_table for model in models]
+        with connection.constraint_checks_disabled(table_names):
             for fixture_label in fixture_labels:
                 self.load_label(fixture_label)
 
         # Since we disabled constraint checks, we must manually check for
         # any invalid keys that might have been added
-        table_names = [model._meta.db_table for model in self.models]
         try:
             connection.check_constraints(table_names=table_names)
         except Exception as e:
@@ -118,6 +118,31 @@ class Command(BaseCommand):
             else:
                 self.stdout.write("Installed %d object(s) (of %d) from %d fixture(s)" %
                     (self.loaded_object_count, self.fixture_object_count, self.fixture_count))
+
+    def find_models_from_labels(self, fixture_labels):
+        """
+        Find models in the fixture_labels.
+        """
+        models = set()
+        for fixture_label in fixture_labels:
+            for fixture_file, fixture_dir, fixture_name in self.find_fixtures(fixture_label):
+                _, ser_fmt, cmp_fmt = self.parse_name(os.path.basename(fixture_file))
+                open_method, mode = self.compression_formats[cmp_fmt]
+                fixture = open_method(fixture_file, mode)
+                try:
+                    objects = serializers.deserialize(ser_fmt, fixture,
+                        using=self.using, ignorenonexistent=self.ignore)
+                    for obj in objects:
+                        if router.allow_migrate_model(self.using, obj.object.__class__):
+                            models.add(obj.object._meta.concrete_model)
+                            for m2m_set in obj.m2m_data.keys():
+                                m2m_field = obj.object._meta.get_field(m2m_set)
+                                models.add(m2m_field.remote_field.through)
+                except Exception:
+                    pass
+                finally:
+                    fixture.close()
+        return models
 
     def load_label(self, fixture_label):
         """

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -22,6 +22,10 @@ except ImportError:
 
 NO_DB_ALIAS = '__no_db__'
 
+tables_seen = 0
+max_seen = 0
+times = 0
+
 
 class BaseDatabaseWrapper(object):
     """
@@ -432,26 +436,34 @@ class BaseDatabaseWrapper(object):
     # ##### Foreign key constraints checks handling #####
 
     @contextmanager
-    def constraint_checks_disabled(self):
+    def constraint_checks_disabled(self, table_names):
         """
         Context manager that disables foreign key constraint checking.
         """
-        disabled = self.disable_constraint_checking()
+        disabled = self.disable_constraint_checking(table_names)
         try:
             yield
         finally:
             if disabled:
-                self.enable_constraint_checking()
+                self.enable_constraint_checking(table_names)
 
-    def disable_constraint_checking(self):
+    def disable_constraint_checking(self, table_names):
         """
         Backends can implement as needed to temporarily disable foreign key
         constraint checking. Should return True if the constraints were
         disabled and will need to be reenabled.
         """
+        global tables_seen
+        global max_seen
+        global times
+        tables_seen += len(table_names)
+        max_seen = max(max_seen, len(table_names))
+        times += 1
+        print("Tables seen: %s, called %s times, max seen %s, this time seen %s" %
+              (tables_seen, times, max_seen, len(table_names)))
         return False
 
-    def enable_constraint_checking(self):
+    def enable_constraint_checking(self, table_names):
         """
         Backends can implement as needed to re-enable foreign key constraint
         checking.

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -288,7 +288,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         with self.wrap_database_errors:
             self.connection.autocommit(autocommit)
 
-    def disable_constraint_checking(self):
+    def disable_constraint_checking(self, table_names):
         """
         Disables foreign key checks, primarily for use in adding rows with forward references. Always returns True,
         to indicate constraint checks need to be re-enabled.
@@ -296,7 +296,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.cursor().execute('SET foreign_key_checks=0')
         return True
 
-    def enable_constraint_checking(self):
+    def enable_constraint_checking(self, table_names):
         """
         Re-enable foreign key checks after they have been disabled.
         """

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1009,7 +1009,7 @@ class UUIDUserTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # A LogEntry is created with pk=1 which breaks a FK constraint on MySQL
-        with connection.constraint_checks_disabled():
+        with connection.constraint_checks_disabled([LogEntry._meta.db_table]):
             response = self.client.post(password_change_url, {
                 'password1': 'password1',
                 'password2': 'password1',

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -893,9 +893,9 @@ class FkConstraintsTests(TransactionTestCase):
             a = models.Article.objects.get(headline="Test article")
             a.reporter_id = 30
             try:
-                connection.disable_constraint_checking()
+                connection.disable_constraint_checking([models.Article._meta.db_table])
                 a.save()
-                connection.enable_constraint_checking()
+                connection.enable_constraint_checking([models.Article._meta.db_table])
             except IntegrityError:
                 self.fail("IntegrityError should not have occurred.")
             transaction.set_rollback(True)
@@ -916,7 +916,7 @@ class FkConstraintsTests(TransactionTestCase):
             a = models.Article.objects.get(headline="Test article")
             a.reporter_id = 30
             try:
-                with connection.constraint_checks_disabled():
+                with connection.constraint_checks_disabled([models.Article._meta.db_table]):
                     a.save()
             except IntegrityError:
                 self.fail("IntegrityError should not have occurred.")
@@ -936,7 +936,7 @@ class FkConstraintsTests(TransactionTestCase):
             # Retrieve it from the DB
             a = models.Article.objects.get(headline="Test article")
             a.reporter_id = 30
-            with connection.constraint_checks_disabled():
+            with connection.constraint_checks_disabled([models.Article._meta.db_table]):
                 a.save()
                 with self.assertRaises(IntegrityError):
                     connection.check_constraints()

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -69,6 +69,18 @@ class BasicExpressionsTests(TestCase):
             ],
         )
 
+    def test_annotate_values_filter2(self):
+        companies = Company.objects.annotate(
+            foo=RawSQL('(select max(id) from expressions_company)', [])
+        ).filter(foo__gte=1).order_by('name')
+        self.assertQuerysetEqual(
+            companies, [
+                '<Company: Example Inc.>',
+                '<Company: Foobar Ltd.>',
+                '<Company: Test GmbH>',
+            ],
+        )
+
     def test_filter_inter_attribute(self):
         # We can filter on attribute relationships on same model obj, e.g.
         # find companies where the number of employees is greater

--- a/tests/serializers/test_data.py
+++ b/tests/serializers/test_data.py
@@ -392,9 +392,13 @@ def serializerTest(format, self):
 
     # Create all the objects defined in the test data
     objects = []
+    classes = set()
     instance_count = {}
-    for (func, pk, klass, datum) in test_data:
-        with connection.constraint_checks_disabled():
+    for (_, _, klass, _) in test_data:
+        classes.add(klass._meta.db_table)
+
+    with connection.constraint_checks_disabled(classes):
+        for (func, pk, klass, datum) in test_data:
             objects.extend(func[0](pk, klass, datum))
 
     # Get a count of the number of objects created for each class

--- a/tests/serializers/test_data.py
+++ b/tests/serializers/test_data.py
@@ -392,12 +392,12 @@ def serializerTest(format, self):
 
     # Create all the objects defined in the test data
     objects = []
-    classes = set()
+    tables = set()
     instance_count = {}
     for (_, _, klass, _) in test_data:
-        classes.add(klass._meta.db_table)
+        tables.add(klass._meta.db_table)
 
-    with connection.constraint_checks_disabled(classes):
+    with connection.constraint_checks_disabled(tables):
         for (func, pk, klass, datum) in test_data:
             objects.extend(func[0](pk, klass, datum))
 

--- a/tests/serializers/test_natural.py
+++ b/tests/serializers/test_natural.py
@@ -14,7 +14,7 @@ class NaturalKeySerializerTests(TestCase):
 
 def natural_key_serializer_test(format, self):
     # Create all the objects defined in the test data
-    with connection.constraint_checks_disabled():
+    with connection.constraint_checks_disabled([NaturalKeyAnchor._meta.db_table, FKDataNaturalKey._meta.db_table]):
         objects = [
             NaturalKeyAnchor.objects.create(id=1100, data="Natural Key Anghor"),
             FKDataNaturalKey.objects.create(id=1101, data_id=1100),

--- a/tests/serializers/tests.py
+++ b/tests/serializers/tests.py
@@ -379,8 +379,9 @@ class SerializersTransactionTestBase(object):
         # The deserialization process needs to run in a transaction in order
         # to test forward reference handling.
         with transaction.atomic():
-            objs = serializers.deserialize(self.serializer_name, self.fwd_ref_str)
-            with connection.constraint_checks_disabled():
+            objs = list(serializers.deserialize(self.serializer_name, self.fwd_ref_str))
+            tables = set([obj.object._meta.db_table for obj in objs])
+            with connection.constraint_checks_disabled(tables):
                 for obj in objs:
                     obj.save()
 


### PR DESCRIPTION
The idea is to speed up tests on mssql by disabling/enabling constraints only for those tables that have actually changed.

I believe this could give roughly two orders of magnitude better performance for constraint checking. The reason is that currently mssql checks every table for every disable/enable constraint checks call. This is around 1500 tables * 225 calls, that is roughly 330 000 disable/enable cycles. With the patch, the amount of disable/enable cycles is 473. (EDIT: Actually, currently there are roughly 750 calls to disable constraints, of which around 500 are from a loop in tests.serializers.test_data).

With this approach, it is possible that a constraint in some *other* table might fail if we delete a row from a referenced table, but I don't believe this is a problem for Django's test suite, and it can be a problem in fixture loading only in extreme cases (where one updates an already existing row's column pointed by a row in some other table). Of course, this could be fixed simply by adding the other table to the list of tables to disable/enable constraints for.

To get the speed benefit for mssql, the mssql backend should only disable/enable constraints for the tables required. That is, to see the full speed benefit of this change, the mssql backend needs to be updated.

This is an alternate to https://github.com/django/django/pull/5438.

I am not intending to continue work on this pull request in the immediate future - others are welcome to take over my work.