### PR TITLE
Fixed #25900 -- Fixed regression in CommonMiddleware ETag support.

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -118,9 +118,12 @@ class CommonMiddleware(object):
                 set_response_etag(response)
 
             if response.has_header('ETag'):
+                # NOTE: get_conditional_response requires an unquoted
+                # version of the response's ETag to work properly.
+                unquoted_etag = response['ETag'].strip('"')
                 return get_conditional_response(
                     request,
-                    etag=response['ETag'],
+                    etag=unquoted_etag,
                     response=response,
                 )
 

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -16,3 +16,5 @@ Bugfixes
   (:ticket:`25548`).
 
 * Fixed a system check crash with nested ``ArrayField``\s (:ticket:`25867`).
+
+* Fixed a regression in ``CommonMixin`` causing If-None-Match checks to always return HTTP 200.

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -270,6 +270,42 @@ class CommonMiddlewareTest(SimpleTestCase):
         self.assertEqual(r.url,
             'http://www.testserver/customurlconf/slash/')
 
+    # ETag + If-Not-Modified support tests
+
+    @override_settings(USE_ETAGS=True)
+    def test_etag(self):
+        req = HttpRequest()
+        res = HttpResponse('content')
+        self.assertTrue(
+            CommonMiddleware().process_response(req, res).has_header('ETag'))
+
+    @override_settings(USE_ETAGS=True)
+    def test_etag_streaming_response(self):
+        req = HttpRequest()
+        res = StreamingHttpResponse(['content'])
+        res['ETag'] = 'tomatoes'
+        self.assertEqual(
+            CommonMiddleware().process_response(req, res).get('ETag'),
+            'tomatoes')
+
+    @override_settings(USE_ETAGS=True)
+    def test_no_etag_streaming_response(self):
+        req = HttpRequest()
+        res = StreamingHttpResponse(['content'])
+        self.assertFalse(
+            CommonMiddleware().process_response(req, res).has_header('ETag'))
+
+    @override_settings(USE_ETAGS=True)
+    def test_if_none_match(self):
+        first_req = HttpRequest()
+        first_res = CommonMiddleware().process_response(first_req, HttpResponse('content'))
+
+        second_req = HttpRequest()
+        second_req.method = 'GET'
+        second_req.META['HTTP_IF_NONE_MATCH'] = first_res['ETag']
+        second_res = CommonMiddleware().process_response(second_req, HttpResponse('content'))
+        self.assertEqual(second_res.status_code, 304)
+
     # Other tests
 
     @override_settings(DISALLOWED_USER_AGENTS=[re.compile(r'foo')])
@@ -473,29 +509,6 @@ class ConditionalGetMiddlewareTest(SimpleTestCase):
         self.resp.status_code = 400
         self.resp = ConditionalGetMiddleware().process_response(self.req, self.resp)
         self.assertEqual(self.resp.status_code, 400)
-
-    @override_settings(USE_ETAGS=True)
-    def test_etag(self):
-        req = HttpRequest()
-        res = HttpResponse('content')
-        self.assertTrue(
-            CommonMiddleware().process_response(req, res).has_header('ETag'))
-
-    @override_settings(USE_ETAGS=True)
-    def test_etag_streaming_response(self):
-        req = HttpRequest()
-        res = StreamingHttpResponse(['content'])
-        res['ETag'] = 'tomatoes'
-        self.assertEqual(
-            CommonMiddleware().process_response(req, res).get('ETag'),
-            'tomatoes')
-
-    @override_settings(USE_ETAGS=True)
-    def test_no_etag_streaming_response(self):
-        req = HttpRequest()
-        res = StreamingHttpResponse(['content'])
-        self.assertFalse(
-            CommonMiddleware().process_response(req, res).has_header('ETag'))
 
     # Tests for the Last-Modified header
 


### PR DESCRIPTION
- Fixed ETag support broken in 1.9 (comparison of If-None-Match on the request vs ETag on the response is incorrect.  Response's ETag is quoted, while the Etag(s) from If-None-Match are not).
- Added test case to demonstrate regression (tests/
- Moved 3 CommonMiddleware-related tests to the proper tests case
