### PR TITLE
Fixed #25939 -- Removed transaction from QuerySet.update_or_create's save().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -485,8 +485,7 @@ class QuerySet(object):
         for k, v in six.iteritems(defaults):
             setattr(obj, k, v)
 
-        with transaction.atomic(using=self.db, savepoint=False):
-            obj.save(using=self.db)
+        obj.save(using=self.db)
         return obj, False
 
     def _create_object_from_params(self, lookup, params):

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -361,6 +361,10 @@ Miscellaneous
   :class:`~django.http.HttpResponse` are now closed immediately instead of when
   the WSGI server calls ``close()`` on the response.
 
+* ``obj.save()`` call in ``dlango.db.models.query.update_or_create`` is not
+  wrapped in transaction.atomic context anymore. This may affect query
+  counts tested by ``assertNumQueries`` in ``TransactionTestCase``.
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10


### PR DESCRIPTION
There is no need to wrap calls of create and save methods in
transaction.atomic as it's already done down the call stack in
Model.save_base method.