### PR TITLE
Add removal of build_request_repr to 1.9 release notes

### DIFF
--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -853,8 +853,9 @@ It was redundant to display the full details of the
 :class:`~django.http.HttpRequest` each time it appeared as a stack frame
 variable in the HTML version of the debug page and error email. Thus, the HTTP
 request will now display the same standard representation as other variables
-(``repr(request)``). As a result, the method
-``ExceptionReporterFilter.get_request_repr()`` was removed.
+(``repr(request)``). As a result, the methods
+``ExceptionReporterFilter.get_request_repr()`` and ``django.http.build_request_repr``
+has been removed.
 
 The contents of the text version of the email were modified to provide a
 traceback of the same structure as in the case of AJAX requests. The traceback


### PR DESCRIPTION
`django.http.build_request_repr` was removed by https://github.com/django/django/commit/8f8c54f70bfa3aa8e311514297f1eeded2c32593

Not sure if it's fitting for the release notes but it makes them more complete I think.

Note to myself: other things that have maybe been removed: `django.utils.log.NullHandler`, `TagHelperNode`