### PR TITLE
Fixed #25894 -- Fixed evaluation of zero-length slices of queryset.values().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -363,8 +363,6 @@ class SQLCompiler(object):
         If 'with_limits' is False, any limit/offset information is not included
         in the query.
         """
-        if with_limits and self.query.low_mark == self.query.high_mark:
-            return '', ()
         self.subquery = subquery
         refcounts_before = self.query.alias_refcount.copy()
         try:

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -19,3 +19,5 @@ Bugfixes
 
 * Fixed a state bug when migrating a ``SeparateDatabaseAndState`` operation
   backwards (:ticket:`25896`).
+
+* Fixed evaluation of zero-length slices of ``QuerySet.values()`` (:ticket:`25894`).

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2429,6 +2429,12 @@ class WeirdQuerysetSlicingTests(BaseQuerysetTest):
     def test_empty_sliced_subquery_exclude(self):
         self.assertEqual(Eaten.objects.exclude(food__in=Food.objects.all()[0:0]).count(), 1)
 
+    def test_zero_length_values_slicing(self):
+        N = 42
+        with self.assertNumQueries(0):
+            self.assertQuerysetEqual(Article.objects.values()[N:N], [])
+            self.assertQuerysetEqual(Article.objects.values_list()[N:N], [])
+
 
 class EscapingTests(TestCase):
     def test_ticket_7302(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25894