### PR TITLE
Simplify MANIFEST.in commands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,12 +6,12 @@ include LICENSE.python
 include MANIFEST.in
 include package.json
 include *.rst
-recursive-include django *
+graft django
 prune django/contrib/admin/bin
-recursive-include docs *
-recursive-include extras *
-recursive-include js_tests *
-recursive-include scripts *
-recursive-include tests *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
+graft docs
+graft extras
+graft js_tests
+graft scripts
+graft tests
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
The full MANIFEST.in syntax is here: https://docs.python.org/3/distutils/commandref.html

Dunno if we should include it as a comment inside the file for others to easily reference.