### PR TITLE
Fixed #25926 - Removed gis.utils.ogrinfo.sample backwards compatibility alias.

### DIFF
--- a/django/contrib/gis/utils/__init__.py
+++ b/django/contrib/gis/utils/__init__.py
@@ -5,7 +5,7 @@ from django.contrib.gis.gdal import HAS_GDAL
 from django.contrib.gis.utils.wkt import precision_wkt  # NOQA
 
 if HAS_GDAL:
-    from django.contrib.gis.utils.ogrinfo import ogrinfo, sample  # NOQA
+    from django.contrib.gis.utils.ogrinfo import ogrinfo  # NOQA
     from django.contrib.gis.utils.ogrinspect import mapping, ogrinspect  # NOQA
     from django.contrib.gis.utils.srs import add_srs_entry  # NOQA
     from django.core.exceptions import ImproperlyConfigured

--- a/django/contrib/gis/utils/ogrinfo.py
+++ b/django/contrib/gis/utils/ogrinfo.py
@@ -49,6 +49,3 @@ def ogrinfo(data_source, num_features=10):
                 else:
                     output += ' (None)'
                 print(output)
-
-# For backwards compatibility.
-sample = ogrinfo


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25926