### PR TITLE
Fixed #25933 -- Allowed an unprefixed default language in i18n_patterns.

### DIFF
--- a/django/conf/urls/i18n.py
+++ b/django/conf/urls/i18n.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import LocaleRegexURLResolver
 from django.views.i18n import set_language
 
 
-def i18n_patterns(*urls):
+def i18n_patterns(*urls, prefix_default_language=True):
     """
     Adds the language code prefix to every URL pattern within this
     function. This may only be used in the root URLconf, not in an included
@@ -12,7 +12,10 @@ def i18n_patterns(*urls):
     """
     if not settings.USE_I18N:
         return urls
-    return [LocaleRegexURLResolver(list(urls))]
+    return [LocaleRegexURLResolver(
+        list(urls),
+        prefix_default_language=prefix_default_language,
+    )]
 
 
 urlpatterns = [

--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -12,6 +12,7 @@ import re
 from importlib import import_module
 from threading import local
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.http import Http404
 from django.utils import lru_cache, six
@@ -469,7 +470,11 @@ class LocaleRegexURLResolver(RegexURLResolver):
     def regex(self):
         language_code = get_language()
         if language_code not in self._regex_dict:
-            regex_compiled = re.compile('^%s/' % language_code, re.UNICODE)
+            regex_compiled = (
+                re.compile('', re.UNICODE) if language_code == settings.LANGUAGE_CODE and
+                not getattr(settings, 'I18N_PREFIX_DEFAULT_LANGUAGE', True) else
+                re.compile('^%s/' % language_code, re.UNICODE)
+            )
             self._regex_dict[language_code] = regex_compiled
         return self._regex_dict[language_code]
 

--- a/django/core/urlresolvers.py
+++ b/django/core/urlresolvers.py
@@ -462,9 +462,13 @@ class LocaleRegexURLResolver(RegexURLResolver):
     Rather than taking a regex argument, we just override the ``regex``
     function to always return the active language-code as regex.
     """
-    def __init__(self, urlconf_name, default_kwargs=None, app_name=None, namespace=None):
+    def __init__(
+        self, urlconf_name, default_kwargs=None, app_name=None, namespace=None,
+        prefix_default_language=True
+    ):
         super(LocaleRegexURLResolver, self).__init__(
             None, urlconf_name, default_kwargs, app_name, namespace)
+        self.prefix_default_language = prefix_default_language
 
     @property
     def regex(self):
@@ -472,7 +476,7 @@ class LocaleRegexURLResolver(RegexURLResolver):
         if language_code not in self._regex_dict:
             regex_compiled = (
                 re.compile('', re.UNICODE) if language_code == settings.LANGUAGE_CODE and
-                not getattr(settings, 'I18N_PREFIX_DEFAULT_LANGUAGE', True) else
+                not self.prefix_default_language else
                 re.compile('^%s/' % language_code, re.UNICODE)
             )
             self._regex_dict[language_code] = regex_compiled

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -184,7 +184,7 @@ Generic Views
 Internationalization
 ^^^^^^^^^^^^^^^^^^^^
 
-* ...
+* New parameter `prefix_default_language` for :func:`~django.conf.urls.i18n.i18n_patterns`.
 
 Management Commands
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1328,11 +1328,17 @@ Django provides two mechanisms to internationalize URL patterns:
 Language prefix in URL patterns
 -------------------------------
 
-.. function:: i18n_patterns(*pattern_list)
+.. function:: i18n_patterns(*pattern_list, prefix_default_language=True)
 
 This function can be used in your root URLconf and Django will automatically
 prepend the current active language code to all url patterns defined within
-:func:`~django.conf.urls.i18n.i18n_patterns`. Example URL patterns::
+:func:`~django.conf.urls.i18n.i18n_patterns`.
+
+Setting ``prefix_default_language`` to ``False`` will remove prefix from the
+default language. This can be useful when adding translations to existing site,
+so the current urls won't change.
+
+Example URL patterns::
 
     from django.conf.urls import include, url
     from django.conf.urls.i18n import i18n_patterns
@@ -1372,6 +1378,17 @@ function. Example::
     >>> activate('nl')
     >>> reverse('news:detail', kwargs={'slug': 'news-slug'})
     '/nl/news/news-slug/'
+
+With ``prefix_default_language`` set to ``False`` the urls will be::
+
+    >>> activate('en')
+    >>> reverse('news:index')
+    '/news/'
+
+    >>> activate('nl')
+    >>> reverse('news:index')
+    '/nl/news/'
+
 
 .. warning::
 


### PR DESCRIPTION
It's different than i18n_patterns by not prefixing the default language.

All other languages are prefixed similar to i18n_patterns.

It allows to add another language without changing the urls of the first
default language.