### PR TITLE
Fixed typo in Feed class reference where `item_enclosure_url` appeared

### DIFF
--- a/docs/ref/contrib/syndication.txt
+++ b/docs/ref/contrib/syndication.txt
@@ -759,7 +759,7 @@ This example illustrates all possible attributes and methods for a
             ``django.utils.feedgenerator.Enclosure`` objects.
             """
 
-        def item_enclosure_url(self):
+        def item_enclosures(self):
             """
             Returns the ``django.utils.feedgenerator.Enclosure`` list for every
             item in the feed.


### PR DESCRIPTION
incorrectly in place of `item_enclosures`.