### PR TITLE
[1.9.x] Fixed #25903 -- Fixed the admin's list_editable add/change buttons.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -566,9 +566,9 @@ class ModelAdmin(BaseModelAdmin):
         extra = '' if settings.DEBUG else '.min'
         js = [
             'core.js',
-            'admin/RelatedObjectLookups.js',
             'vendor/jquery/jquery%s.js' % extra,
             'jquery.init.js',
+            'admin/RelatedObjectLookups.js',
             'actions%s.js' % extra,
             'urlify.js',
             'prepopulate%s.js' % extra,

--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -2,7 +2,7 @@
 // Handles related-objects functionality: lookup link for raw_id_fields
 // and Add Another links.
 
-(function() {
+(function($) {
     'use strict';
 
     function html_unescape(text) {
@@ -157,4 +157,25 @@
     window.showAddAnotherPopup = showRelatedObjectPopup;
     window.dismissAddAnotherPopup = dismissAddRelatedObjectPopup;
 
-})();
+    $(document).ready(function() {
+        $('body').on('click', '.related-widget-wrapper-link', function(e) {
+            e.preventDefault();
+            if (this.href) {
+                var event = $.Event('django:show-related', {href: this.href});
+                $(this).trigger(event);
+                if (!event.isDefaultPrevented()) {
+                    showRelatedObjectPopup(this);
+                }
+            }
+        });
+        $('body').on('change', '.related-widget-wrapper select', function(e) {
+            var event = $.Event('django:update-related');
+            $(this).trigger(event);
+            if (!event.isDefaultPrevented()) {
+                updateRelatedObjectLinks(this);
+            }
+        });
+        $('.related-widget-wrapper select').trigger('change');
+    });
+
+})(django.jQuery);

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -87,24 +87,6 @@
                         showRelatedObjectLookupPopup(this);
                     }
                 });
-                $('body').on('click', '.related-widget-wrapper-link', function(e) {
-                    e.preventDefault();
-                    if (this.href) {
-                        var event = $.Event('django:show-related', {href: this.href});
-                        $(this).trigger(event);
-                        if (!event.isDefaultPrevented()) {
-                            showRelatedObjectPopup(this);
-                        }
-                    }
-                });
-                $('body').on('change', '.related-widget-wrapper select', function(e) {
-                    var event = $.Event('django:update-related');
-                    $(this).trigger(event);
-                    if (!event.isDefaultPrevented()) {
-                        updateRelatedObjectLinks(this);
-                    }
-                });
-                $('.related-widget-wrapper select').trigger('change');
 
             {% if adminform and add %}
                 $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -61,3 +61,6 @@ Bugfixes
 
 * Fixed ``migrate --fake-initial`` detection of many-to-many tables
   (:ticket:`25922`).
+
+* Restored the functionality of the admin's ``list_editable`` add and change
+  buttons (:ticket:`25903`).

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -87,8 +87,11 @@ class ChapterXtra1Admin(admin.ModelAdmin):
 
 
 class ArticleAdmin(admin.ModelAdmin):
-    list_display = ('content', 'date', callable_year, 'model_year',
-                    'modeladmin_year', 'model_year_reversed')
+    list_display = (
+        'content', 'date', callable_year, 'model_year', 'modeladmin_year',
+        'model_year_reversed', 'section',
+    )
+    list_editable = ('section',)
     list_filter = ('date', 'section')
     view_on_site = False
     fieldsets = (

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4541,6 +4541,34 @@ class SeleniumAdminViewsFirefoxTests(AdminSeleniumWebDriverTestCase):
         self.assertEqual(Pizza.objects.count(), 1)
         self.assertEqual(Topping.objects.count(), 2)
 
+    def test_list_editable_popups(self):
+        """
+        list_editable foreign keys have add/change popups.
+        """
+        s1 = Section.objects.create(name='Test section')
+        Article.objects.create(
+            content='<p>Middle content</p>',
+            date=datetime.datetime(2008, 3, 18, 11, 54, 58),
+            section=s1,
+        )
+        self.admin_login(username='super', password='secret', login_url=reverse('admin:index'))
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_article_changelist'))
+        # Change popup
+        self.selenium.find_element_by_id('change_id_form-0-section').click()
+        self.wait_for_popup()
+        self.selenium.switch_to.window(self.selenium.window_handles[-1])
+        self.wait_for_text('#content h1', 'Change section')
+        self.selenium.close()
+        self.selenium.switch_to.window(self.selenium.window_handles[0])
+
+        # Add popup
+        self.selenium.find_element_by_id('add_id_form-0-section').click()
+        self.wait_for_popup()
+        self.selenium.switch_to.window(self.selenium.window_handles[-1])
+        self.wait_for_text('#content h1', 'Add section')
+        self.selenium.close()
+        self.selenium.switch_to.window(self.selenium.window_handles[0])
+
 
 class SeleniumAdminViewsChromeTests(SeleniumAdminViewsFirefoxTests):
     webdriver_class = 'selenium.webdriver.chrome.webdriver.WebDriver'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25165

This doesn't backport cleanly from master due to d638cdc42acec608c1967f44af6be32a477c239f and I ran into [a different regression](https://code.djangoproject.com/ticket/25165#comment:4) from that commit so I'm submitting the fix for 1.9 separately.
