### PR TITLE
Remove a misleading comment on HTTPS

### DIFF
--- a/docs/topics/security.txt
+++ b/docs/topics/security.txt
@@ -120,11 +120,11 @@ for a small section of the site.
 SSL/HTTPS
 =========
 
-It is always better for security, though not always practical in all cases, to
-deploy your site behind HTTPS. Without this, it is possible for malicious
-network users to sniff authentication credentials or any other information
-transferred between client and server, and in some cases -- **active** network
-attackers -- to alter data that is sent in either direction.
+It is always better for security to deploy your site behind HTTPS. Without
+this, it is possible for malicious network users to sniff authentication
+credentials or any other information transferred between client and server, and
+in some cases -- **active** network attackers -- to alter data that is sent in
+either direction.
 
 If you want the protection that HTTPS provides, and have enabled it on your
 server, there are some additional steps you may need:


### PR DESCRIPTION
For all practical purposes there are no common cases for which a website cannot be deployed with HTTPS.