### PR TITLE
Fixed #21528 -- Document parent access in formfield_for_foreignkey

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1615,8 +1615,9 @@ templates used by the :class:`ModelAdmin` views:
                     kwargs["queryset"] = Car.objects.filter(owner=request.user)
                 return super(MyModelAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
 
-    This uses the ``HttpRequest`` instance to filter the ``Car`` foreign key
-    field to only display the cars owned by the ``User`` instance.
+    This uses the :class:`~django.http.HttpRequest` instance to filter the
+    ``Car`` foreign key field to only display the cars owned by the ``User``
+    instance.
 
 .. method:: ModelAdmin.formfield_for_manytomany(db_field, request, **kwargs)
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1619,6 +1619,18 @@ templates used by the :class:`ModelAdmin` views:
     ``Car`` foreign key field to only display the cars owned by the ``User``
     instance.
 
+    .. note::
+
+        To filter a field's :class:`~django.db.models.query.QuerySet` based on
+        an instance of your model, you can define a
+        :class:`~django.forms.ModelForm` using the
+        :attr:`~django.contrib.admin.ModelAdmin.form` attribute.
+
+        You can find an example of queryset filtering in
+        :ref:`fields-relationship-handling`. An introductory material for
+        :class:`~django.forms.ModelForm` is available at
+        :doc:`/topics/forms/modelforms`.
+
 .. method:: ModelAdmin.formfield_for_manytomany(db_field, request, **kwargs)
 
     Like the ``formfield_for_foreignkey`` method, the

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1063,6 +1063,8 @@ Slightly complex built-in ``Field`` classes
     If no ``input_time_formats`` argument is provided, the default input formats
     for :class:`TimeField` are used.
 
+.. _fields-relationship-handling:
+
 Fields which handle relationships
 ---------------------------------
 
@@ -1077,14 +1079,24 @@ objects (in the case of ``ModelMultipleChoiceField``) into the
 
 For more complex uses, you can specify ``queryset=None`` when declaring the
 form field and then populate the ``queryset`` in the form's ``__init__()``
-method::
+method:
 
-    class FooMultipleChoiceForm(forms.Form):
-        foo_select = forms.ModelMultipleChoiceField(queryset=None)
+.. code-block:: python
 
-        def __init__(self, *args, **kwargs):
-            super(FooMultipleChoiceForm, self).__init__(*args, **kwargs)
-            self.fields['foo_select'].queryset = ...
+    class Country(models.Model):
+        name = models.CharField(max_length=100)
+        capital = models.ForeignKey('City', on_delete=models.CASCADE)
+
+    class City(models.Model):
+        name = models.CharField(max_length=100)
+        country = models.ForeignKey(Country, on_delete=models.CASCADE)
+
+    class CountryForm(forms.Form):
+        capital = forms.ModelChoiceField(queryset=City.objects.none())
+
+        def __init__(*args, **kwargs):
+            super(CountryForm, self).__init__(*args, **kwargs)
+            self.fields['capital'].queryset = City.objects.filter(country=self.instance.pk)
 
 ``ModelChoiceField``
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -612,6 +612,16 @@ the field declaratively and setting its ``validators`` parameter::
     See the :doc:`form field documentation </ref/forms/fields>` for more information
     on fields and their arguments.
 
+Filtering fields that handle relationships
+------------------------------------------
+
+When instantiating a :class:`ModelForm`, you can filter the
+:class:`~django.db.models.query.QuerySet` for fields that handle relationships
+with other models (such as :class:`~django.forms.ModelChoiceField`,
+:class:`~django.forms.ModelMultipleChoiceField`, ...) based on the underlying
+:class:`~django.db.models.Model` instance.
+
+An example is available in the section :ref:`fields-relationship-handling`.
 
 Enabling localization of fields
 -------------------------------


### PR DESCRIPTION
Since this is my first commit to Django, I started with some documentation.

If it looks good to you, I'll try to implement a nicer way to retrieve parent's ID in ``ModelAdmin``.