### PR TITLE
Fixed #25958 -- Removed support for 'skip_validation' in BaseCommand.execute(**options).

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -334,9 +334,7 @@ class BaseCommand(object):
             translation.deactivate_all()
 
         try:
-            if (self.requires_system_checks and
-                    not options.get('skip_validation') and  # Remove at the end of deprecation for `skip_validation`.
-                    not options.get('skip_checks')):
+            if self.requires_system_checks and not options.get('skip_checks'):
                 self.check()
             output = self.handle(*args, **options)
             if output:

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -380,6 +380,9 @@ Miscellaneous
   is removed. This may affect query counts tested by
   ``TransactionTestCase.assertNumQueries()``.
 
+* Support for ``skip_validation`` in ``BaseCommand.execute(**options)`` is
+  removed. Use ``skip_checks`` (added in Django 1.7) instead.
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25958