### PR TITLE
Fixed #25965 -- Added removal of sql* commands to 1.9 release notes.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -327,6 +327,9 @@ details on these changes.
   become compulsory for all apps unless you pass the ``--run-syncdb`` option to
   ``migrate``.
 
+* The SQL management commands for apps without migrations, ``sql``, ``sqlall``,
+  ``sqlclear``, ``sqldropindexes``, and ``sqlindexes``, will be removed.
+
 * Support for automatic loading of ``initial_data`` fixtures and initial SQL
   data will be removed.
 

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -2067,7 +2067,7 @@ Example usage:
 .sp
 .nf
 .ft C
-django\-admin sqlall \-\-no\-color
+django\-admin runserver \-\-no\-color
 .ft P
 .fi
 .UNINDENT

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1556,7 +1556,7 @@ that ``django-admin`` should print to the console.
 
 Example usage::
 
-    django-admin sqlall --no-color
+    django-admin runserver --no-color
 
 By default, ``django-admin`` will format the output to be colorized. For
 example, errors will be printed to the console in red and SQL statements will

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1406,6 +1406,9 @@ removed in Django 1.9 (please see the :ref:`deprecation timeline
   compulsory for all apps unless you pass the :djadminopt:`--run-syncdb`
   option to ``migrate``.
 
+* The SQL management commands for apps without migrations, ``sql``, ``sqlall``,
+  ``sqlclear``, ``sqldropindexes``, and ``sqlindexes``, are removed.
+
 * Support for automatic loading of ``initial_data`` fixtures and initial SQL
   data is removed.
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25965