### PR TITLE
[1.9.x] Fixed #25963 -- Clarified render_to_response() context_instance deprecation.

### DIFF
--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1571,6 +1571,19 @@ pass a :class:`dict` in the ``context`` parameter instead. If you're passing a
 :class:`~django.template.RequestContext`, pass the request separately in the
 ``request`` parameter.
 
+If you're using ``context_instance=RequestContext(request))`` with
+``render_to_response()``, use :func:`django.shortcuts.render`, which always
+makes ``RequestContext`` available, instead. For example::
+
+    from django.shortcuts import render_to_response
+    from django.template import RequestContext
+    render_to_response('template.html', {...}, context_instance=RequestContext(request))
+
+becomes::
+
+    from django.shortcuts import render
+    render(request, 'template.html', {...})
+
 ``dirs`` argument of template-finding functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -158,7 +158,8 @@ Optional arguments
 
     .. deprecated:: 1.8
 
-       The ``context_instance`` argument is deprecated. Simply use ``context``.
+       The ``context_instance`` argument is deprecated. Use the :func:`render`
+       function instead which always makes ``RequestContext`` available.
 
 ``content_type``
     The MIME type to use for the resulting document. Defaults to the value of


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25963