### PR TITLE
[1.8.x] Fixed #13008 -- Added more Cache-Control headers to never_cache() decorator.

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -134,6 +134,7 @@ def add_never_cache_headers(response):
     Adds headers to a response to indicate that a page should never be cached.
     """
     patch_response_headers(response, cache_timeout=-1)
+    patch_cache_control(response, no_cache=True, no_store=True, must_revalidate=True)
 
 
 def patch_vary_headers(response, newheaders):

--- a/docs/releases/1.8.8.txt
+++ b/docs/releases/1.8.8.txt
@@ -40,3 +40,11 @@ Bugfixes
 
 * Fixed a regression which prevented using a language not in Django's default
   language list (:setting:`LANGUAGES`) (:ticket:`25915`).
+
+* ``django.views.decorators.cache.never_cache()`` now sends more persuasive
+  headers (added ``no-cache, no-store, must-revalidate`` to ``Cache-Control``)
+  to better prevent caching (:ticket:`13008`). This fixes a problem where a
+  page refresh in Firefox cleared the selected entries in the admin's
+  ``filter_horizontal`` and ``filter_vertical`` widgets, which could result
+  in inadvertent data loss if a user didn't notice that and then submitted the
+  form (:ticket:`22955`).

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -323,3 +323,15 @@ class XFrameOptionsDecoratorsTests(TestCase):
         # the middleware's functionality, let's make sure it actually works...
         r = XFrameOptionsMiddleware().process_response(req, resp)
         self.assertEqual(r.get('X-Frame-Options', None), None)
+
+
+class NeverCacheDecoratorTest(TestCase):
+    def test_never_cache_decorator(self):
+        @never_cache
+        def a_view(request):
+            return HttpResponse()
+        r = a_view(HttpRequest())
+        self.assertEqual(
+            set(r['Cache-Control'].split(', ')),
+            {'max-age=0', 'no-cache', 'no-store', 'must-revalidate'},
+        )


### PR DESCRIPTION
Seems safe for a backport. Any concerns?
https://code.djangoproject.com/ticket/22955

The regression test for the admin issue is in progress at https://github.com/django/django/pull/5757.