### PR TITLE
Discourage use of systemwide /tmp with predictable names

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -149,7 +149,7 @@ class FileDescriptor(object):
 
     Assigns a file object on assignment so you can do::
 
-        >>> with open('/tmp/hello.world', 'r') as f:
+        >>> with open('/path/to/hello.world', 'r') as f:
         ...     instance.file = File(f)
     """
     def __init__(self, field):

--- a/docs/howto/static-files/deployment.txt
+++ b/docs/howto/static-files/deployment.txt
@@ -95,7 +95,7 @@ Here's how this might look in a fabfile::
     from fabric.contrib import project
 
     # Where the static files get collected locally. Your STATIC_ROOT setting.
-    env.local_static_root = '/tmp/static'
+    env.local_static_root = '/path/to/static'
 
     # Where the static files should go remotely
     env.remote_static_root = '/home/www/static.example.com'

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -2404,7 +2404,7 @@ support the \fBstdout\fP and \fBstderr\fP options. For example, you could write:
 .sp
 .nf
 .ft C
-with open(\(aq/tmp/command_output\(aq) as f:
+with open(\(aq/path/to/command_output\(aq) as f:
     management.call_command(\(aqdumpdata\(aq, stdout=f)
 .ft P
 .fi

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1172,7 +1172,7 @@ blue.
             >>> rst = GDALRaster({'driver': 'GTiff', 'name': rstfile.name, 'srid': 4326,
             ...                   'width': 255, 'height': 255, 'nr_of_bands': 1})
             >>> rst.name
-            '/tmp/tmp7x9H4J.tif'           # The exact filename will be different on your computer
+            '/path/to/tmp7x9H4J.tif'           # The exact filename will be different on your computer
             >>> rst.driver.name
             'GTiff'
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1778,5 +1778,5 @@ Output redirection
 Note that you can redirect standard output and error streams as all commands
 support the ``stdout`` and ``stderr`` options. For example, you could write::
 
-    with open('/tmp/command_output') as f:
+    with open('/path/to/command_output') as f:
         management.call_command('dumpdata', stdout=f)

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -783,7 +783,7 @@ Python file object like this::
 
     from django.core.files import File
     # Open an existing file using Python's built-in open()
-    f = open('/tmp/hello.world')
+    f = open('/path/to/hello.world')
     myfile = File(f)
 
 Or you can construct one from a Python string like this::

--- a/docs/topics/files.txt
+++ b/docs/topics/files.txt
@@ -91,7 +91,7 @@ using a Python built-in ``file`` object::
     >>> from django.core.files import File
 
     # Create a Python file object using open()
-    >>> f = open('/tmp/hello.world', 'w')
+    >>> f = open('/path/to/hello.world', 'w')
     >>> myfile = File(f)
 
 Now you can use any of the documented attributes and methods
@@ -103,7 +103,7 @@ The following approach may be used to close files automatically::
     >>> from django.core.files import File
 
     # Create a Python file object using open() and the with statement
-    >>> with open('/tmp/hello.world', 'w') as f:
+    >>> with open('/path/to/hello.world', 'w') as f:
     ...     myfile = File(f)
     ...     myfile.write('Hello World')
     ...


### PR DESCRIPTION
The use of predictable filenames in /tmp often leads to symlink attacks
so lets at least discourage the most obvious use of them in the docs.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>