### PR TITLE
Fixed #25967 -- Indicated required fields in TabularInline headers in admin

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -272,6 +272,10 @@ tfoot td {
     border-top: 1px solid #eee;
 }
 
+thead th.required {
+    color: #000;
+}
+
 tr.alt {
     background: #f6f6f6;
 }


### PR DESCRIPTION
I have given black font-color to "required" class. Other fields have the default gray color.

Would that suffice our requirements ?