### PR TITLE
Fixed #26006 -- Fixed incorrect object reference in SingleObjectMixin.get_context_object_name().

### DIFF
--- a/django/views/generic/detail.py
+++ b/django/views/generic/detail.py
@@ -89,7 +89,7 @@ class SingleObjectMixin(ContextMixin):
         if self.context_object_name:
             return self.context_object_name
         elif isinstance(obj, models.Model):
-            if self.object._deferred:
+            if obj._deferred:
                 obj = obj._meta.proxy_for_model
             return obj._meta.model_name
         else:

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -70,3 +70,6 @@ Bugfixes
 
 * Fixed a regression in the admin which ignored line breaks in read-only fields
   instead of converting them to ``<br>`` (:ticket:`25465`).
+
+* Fixed incorrect object reference in
+  ``SingleObjectMixin.get_context_object_name()``. (:ticket:`26006`).

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -140,6 +140,14 @@ class DetailViewTest(TestCase):
         self.assertNotIn('author', res.context)
         self.assertTemplateUsed(res, 'generic_views/author_detail.html')
 
+    def test_custom_detail(self):
+        res = self.client.get('/detail/author/%s/custom_detail/' % self.author1.pk)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.context['custom_author'], self.author1)
+        self.assertNotIn('author', res.context)
+        self.assertNotIn('object', res.context)
+        self.assertTemplateUsed(res, 'generic_views/author_detail.html')
+
     def test_deferred_queryset_template_name(self):
         class FormContext(SingleObjectTemplateResponseMixin):
             request = RequestFactory().get('/')

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -50,6 +50,8 @@ urlpatterns = [
         views.AuthorDetail.as_view(template_name='generic_views/about.html')),
     url(r'^detail/author/(?P<pk>[0-9]+)/context_object_name/$',
         views.AuthorDetail.as_view(context_object_name='thingy')),
+    url(r'^detail/author/(?P<pk>[0-9]+)/custom_detail/$',
+        views.AuthorCustomDetail.as_view()),
     url(r'^detail/author/(?P<pk>[0-9]+)/dupe_context_object_name/$',
         views.AuthorDetail.as_view(context_object_name='object')),
     url(r'^detail/page/(?P<pk>[0-9]+)/field/$',

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -34,6 +34,17 @@ class AuthorDetail(generic.DetailView):
     queryset = Author.objects.all()
 
 
+class AuthorCustomDetail(generic.detail.TemplateResponseMixin,
+                         generic.detail.SingleObjectMixin, generic.View):
+    template_name = "generic_views/author_detail.html"
+    queryset = Author.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        author = self.get_object()
+        context = {"custom_" + self.get_context_object_name(author): author}
+        return self.render_to_response(context)
+
+
 class PageDetail(generic.DetailView):
     queryset = Page.objects.all()
     template_name_field = 'template'


### PR DESCRIPTION
Changed 'self.object' to 'obj' to be consistent with the rest
of the method. No impact on test cases.