### PR TITLE
Fixed #26007 - get_template_names returns complete stack of names.

### DIFF
--- a/docs/ref/class-based-views/mixins-single-object.txt
+++ b/docs/ref/class-based-views/mixins-single-object.txt
@@ -166,7 +166,8 @@ SingleObjectTemplateResponseMixin
 
         Returns a list of candidate template names. Returns the following list:
 
-        * the value of ``template_name`` on the view (if provided)
         * the contents of the ``template_name_field`` field on the
           object instance that the view is operating upon (if available)
-        * ``<app_label>/<model_name><template_name_suffix>.html``
+        * the value of ``template_name`` on the view (if provided)
+        * ``<app_label>/<model_name><template_name_suffix>.html`` from the model obtained
+          from ``self.object`` or ``self.model`` (if available)

--- a/tests/generic_views/templates/generic_views/page_detail.html
+++ b/tests/generic_views/templates/generic_views/page_detail.html
@@ -1,0 +1,1 @@
+This is some other content: {{ content }}

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -29,6 +29,9 @@ class DetailViewTest(TestCase):
         cls.page1 = Page.objects.create(
             content='I was once bitten by a moose.', template='generic_views/page_template.html'
         )
+        cls.page2 = Page.objects.create(
+            content='The moose came back for more.', template=''
+        )
 
     def test_simple_object(self):
         res = self.client.get('/detail/obj/')
@@ -124,6 +127,13 @@ class DetailViewTest(TestCase):
         self.assertEqual(res.context['object'], self.page1)
         self.assertEqual(res.context['page'], self.page1)
         self.assertTemplateUsed(res, 'generic_views/page_template.html')
+
+    def test_template_name_field_fallback_to_verbose_name(self):
+        res = self.client.get('/detail/page/%s/field/' % self.page2.pk)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.context['object'], self.page2)
+        self.assertEqual(res.context['page'], self.page2)
+        self.assertTemplateUsed(res, 'generic_views/page_detail.html')
 
     def test_context_object_name(self):
         res = self.client.get('/detail/author/%s/context_object_name/' % self.author1.pk)


### PR DESCRIPTION
SingleObjectTemplateResponseMixin.get_template_names() now returns a list of
names matching the documentation, rather than only template_name if that
was specified. Existing code implies that the name returned from
template_name_field should have been first, so doc was updated to change
the ordering. New test case added. Sphinx docs updated.