### PR TITLE
Fixed #26018 - Do not call get_form() if not needed in FormMixin.get_context_data()

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -89,7 +89,8 @@ class FormMixin(ContextMixin):
         """
         Insert the form into the context dict.
         """
-        kwargs.setdefault('form', self.get_form())
+        if 'form' not in kwargs:
+            kwargs['form'] = self.get_form()
         return super(FormMixin, self).get_context_data(**kwargs)
 
 

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -73,3 +73,6 @@ Bugfixes
 
 * Fixed incorrect object reference in
   ``SingleObjectMixin.get_context_object_name()`` (:ticket:`26006`).
+
+* Fixed possible unnecessary call to ``self.get_form()`` in
+  ``FormMixin.get_context_data()`` (:ticket:`26018`).

--- a/tests/generic_views/test_edit.py
+++ b/tests/generic_views/test_edit.py
@@ -232,6 +232,7 @@ class UpdateViewTests(TestCase):
         self.assertEqual(res.context['object'], Author.objects.get(pk=a.pk))
         self.assertEqual(res.context['author'], Author.objects.get(pk=a.pk))
         self.assertTemplateUsed(res, 'generic_views/author_form.html')
+        self.assertEqual(res.context['view'].get_form_called_count, 1)
 
         # Modification with both POST and PUT (browser compatible)
         res = self.client.post('/edit/author/%d/update/' % a.pk,
@@ -251,6 +252,7 @@ class UpdateViewTests(TestCase):
         self.assertTemplateUsed(res, 'generic_views/author_form.html')
         self.assertEqual(len(res.context['form'].errors), 1)
         self.assertQuerysetEqual(Author.objects.all(), ['<Author: Randall Munroe>'])
+        self.assertEqual(res.context['view'].get_form_called_count, 1)
 
     def test_update_with_object_url(self):
         a = Artist.objects.create(name='Rene Magritte')

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -147,9 +147,14 @@ class NaiveAuthorUpdate(generic.UpdateView):
 
 
 class AuthorUpdate(generic.UpdateView):
+    get_form_called_count = 0  # Used to ensure get form called only once. (see #26018)
     model = Author
     success_url = '/list/authors/'
     fields = '__all__'
+
+    def get_form(self, *args, **kwargs):
+        self.get_form_called_count += 1
+        return super(AuthorUpdate, self).get_form(*args, **kwargs)
 
 
 class OneAuthorUpdate(generic.UpdateView):


### PR DESCRIPTION
Changed "dict.setdefault" to "if x in dict" pattern so that get_form() would not
be called unnecessarily, specifically in the case where FormMixin.form_invalid()
calls get_context_data with the current form.