### PR TITLE
Fixed #23372 -- made loaddata faster in cases no fixtures match

### DIFF
--- a/docs/releases/1.8.8.txt
+++ b/docs/releases/1.8.8.txt
@@ -51,3 +51,6 @@ Bugfixes
 
 * Fixed a regression in the admin which ignored line breaks in read-only fields
   instead of converting them to ``<br>`` (:ticket:`25465`).
+
+* Made loaddata skip disabling and enabling constraints when loaddata doesn't
+  actually load any fixtures.

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -73,3 +73,6 @@ Bugfixes
 
 * Fixed incorrect object reference in
   ``SingleObjectMixin.get_context_object_name()`` (:ticket:`26006`).
+
+* Made loaddata skip disabling and enabling constraints when loaddata doesn't
+  actually load any fixtures.


### PR DESCRIPTION
Django's test suite often tries to load fixture files from apps that have
no fixtures at all. This leads to a lot of non-necessary disabling and
enabling of constraints which can be expensive on some database.

To speed up the above mentioned case, loaddata now first checks if any
fixture file matches. If no fixture file is matched, then the command
exits before disabling and enabling of constraints is done.

The main benefit of this change is seen on MSSQL, where tests on 1.8
run about a order of magnitude faster after this change.

This is a replacement for pull requests https://github.com/django/django/pull/5894 and https://github.com/django/django/pull/5801.