### PR TITLE
Fixed #25068 -- Adding migrations support for models with metaclasses.

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -575,25 +575,49 @@ class ModelState(object):
         meta_contents.update(self.options)
         meta = type(str("Meta"), tuple(), meta_contents)
         # Then, work out our bases
-        try:
-            bases = tuple(
-                (apps.get_model(base) if isinstance(base, six.string_types) else base)
-                for base in self.bases
-            )
-        except LookupError:
-            raise InvalidBasesError("Cannot resolve one or more bases from %r" % (self.bases,))
+        bases = list()
+        meta_class_bases = list()
+        meta_class_seen_supertypes = set()
+        for base in self.bases:
+            if isinstance(base, six.string_types):
+                try:
+                    base = apps.get_model(base)
+                except LookupError:
+                    raise InvalidBasesError(
+                        "Cannot resolve %s base %s" % (self.name, base)
+                    )
+            bases.append(base)
+            base_type = type(base)
+            # make a list in left-to-right order of the needed base types
+            if base_type not in meta_class_seen_supertypes:
+                for leftward_base_type in meta_class_bases:
+                    if issubclass(base_type, leftward_base_type):
+                        # leftward_base_type is unnecessary
+                        meta_class_bases.remove(leftward_base_type)
+                meta_class_bases.append(base_type)
+                # any super-type of this base type is already extended
+                # by this base type and so will never be needed
+                meta_class_seen_supertypes.update(base_type.__mro__)
         # Turn fields into a dict for the body, add other bits
         body = {name: field.clone() for name, field in self.fields}
         body['Meta'] = meta
         body['__module__'] = "__fake__"
-
+        # In most cases, there's only one type, 
+        # so, for performance reasons, simply re-use it.
+        if len(meta_class_bases) == 1:
+            MetaClass = meta_class_bases[0]
+        else:
+            MetaClass = type(
+                str(self.name + 'Metaclass'),
+                tuple(meta_class_bases),
+                {}
+            )
         # Restore managers
         body.update(self.construct_managers())
-
         # Then, make a Model object (apps.register_model is called in __new__)
-        return type(
+        return MetaClass(
             str(self.name),
-            bases,
+            tuple(bases),
             body,
         )
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -8,6 +8,7 @@ from django.db.migrations.operations import (
 from django.db.migrations.state import (
     ModelState, ProjectState, get_related_models_recursive,
 )
+from django.db.models.base import ModelBase
 from django.test import SimpleTestCase, override_settings
 from django.utils import six
 
@@ -907,6 +908,36 @@ class ModelStateTests(SimpleTestCase):
         # The default manager is used in migrations
         self.assertEqual([name for name, mgr in food_state.managers], ['food_mgr'])
         self.assertEqual(food_state.managers[0][1].args, ('a', 'b', 1, 2))
+
+    def test_metaclass_conflict(self):
+        """
+        Test making class with complex metadata inheritance
+        """
+        new_apps = Apps(['migrations'])
+
+        class DummyMetaClass(type):
+            pass
+
+        class Mixin(six.with_metaclass(DummyMetaClass, object)):
+            mixin_attr = True
+
+        class IntermediateMetaClass(ModelBase, DummyMetaClass):
+            pass
+
+        # Create the same Model without metaclassmaker as normal.
+        class MetaclassTestModel(six.with_metaclass(IntermediateMetaClass, models.Model, Mixin)):
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+
+        # Reset apps to be able to render __fake__ modules.
+        new_apps = Apps(['migrations'])
+        model_state = ModelState.from_model(MetaclassTestModel)
+
+        # This raises metaclass conflict if it's not done properly.
+        class_obj = model_state.render(new_apps)
+
+        self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)
 
 
 class RelatedModelsTests(SimpleTestCase):


### PR DESCRIPTION
Original ticket: https://code.djangoproject.com/ticket/25068
First proposed fix: https://github.com/django/django/pull/4968

I also encountered the same problem as kosz85. 
I have included the relevant test from the pull request 4968. 
It seems to make no difference to the test-run times compared to master.

Happy new year!