### PR TITLE
[1.9.x] Fixed #25068 -- Take care of metaclasses when rendering model state.

### DIFF
--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -8,6 +8,7 @@ from django.db.migrations.operations import (
 from django.db.migrations.state import (
     ModelState, ProjectState, get_related_models_recursive,
 )
+from django.db.models.base import ModelBase
 from django.test import SimpleTestCase, override_settings
 from django.utils import six
 
@@ -907,6 +908,37 @@ class ModelStateTests(SimpleTestCase):
         # The default manager is used in migrations
         self.assertEqual([name for name, mgr in food_state.managers], ['food_mgr'])
         self.assertEqual(food_state.managers[0][1].args, ('a', 'b', 1, 2))
+
+    def test_metaclass_conflict(self):
+        """
+        Test making class with complex metadata inheritance
+        """
+        new_apps = Apps(['migrations'])
+
+        class DummyMetaClass(type):
+            pass
+
+        class Mixin(six.with_metaclass(DummyMetaClass, object)):
+            mixin_attr = True
+
+        class ItermediateMetaClass(ModelBase, DummyMetaClass):
+            pass
+
+        # Create the same Model without metaclassmaker as normal.
+        class MetaclassTestModel(six.with_metaclass(ItermediateMetaClass, models.Model, Mixin)):
+            class Meta:
+                app_label = "migrations"
+                apps = new_apps
+                swappable = 'TEST_SWAPPABLE_MODEL'
+
+        # Reset apps to be able to render __fake__ modules.
+        new_apps = Apps(['migrations'])
+        model_state = ModelState.from_model(MetaclassTestModel)
+
+        # This raises metaclass conflict if it's not done properly.
+        class_obj = model_state.render(new_apps)
+
+        self.assertEqual(getattr(class_obj, 'mixin_attr', False), True)
 
 
 class RelatedModelsTests(SimpleTestCase):


### PR DESCRIPTION
Original ticket: https://code.djangoproject.com/ticket/25068
First proposed fix: #4968

I also encountered the same problem as kosz85. 
I have included the relevant test from the pull request 4968. 
It seems to make no difference to the test-run times compared to master.