### PR TITLE
Fixed #23372 -- Made loaddata faster if it doesn't find any fixtures.

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -85,6 +85,16 @@ class Command(BaseCommand):
         if has_bz2:
             self.compression_formats['bz2'] = (bz2.BZ2File, 'r')
 
+        # Django's test suite repeatedly tries to load initial_data fixtures
+        # from apps that don't have any fixtures. Because disabling constraint
+        # checks can be expensive on some database (especially MSSQL), bail
+        # out early if no fixtures are found.
+        for fixture_label in fixture_labels:
+            if self.find_fixtures(fixture_label):
+                break
+        else:
+            return
+
         with connection.constraint_checks_disabled():
             for fixture_label in fixture_labels:
                 self.load_label(fixture_label)

--- a/docs/releases/1.8.8.txt
+++ b/docs/releases/1.8.8.txt
@@ -51,3 +51,6 @@ Bugfixes
 
 * Fixed a regression in the admin which ignored line breaks in read-only fields
   instead of converting them to ``<br>`` (:ticket:`25465`).
+
+* Made ``loaddata`` skip disabling and enabling database constraints when it
+  doesn't load any fixtures (:ticket:`23372`).

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -73,3 +73,6 @@ Bugfixes
 
 * Fixed incorrect object reference in
   ``SingleObjectMixin.get_context_object_name()`` (:ticket:`26006`).
+
+* Made ``loaddata`` skip disabling and enabling database constraints when it
+  doesn't load any fixtures (:ticket:`23372`).


### PR DESCRIPTION
Django's test suite often tries to load fixture files from apps that have
no fixtures at all. This creates a lot of unnecessary disabling and
enabling of constraints which can be expensive on some database.

To speed this up, loaddata now first checks if any fixture file matches.
If no fixture file is matched, then the command exits before disabling
and enabling of constraints is done.

The main benefit of this change is seen on MSSQL, where tests on
Django 1.8 run hours faster.