### PR TITLE
Fixed #25316 -- Fixed a crash with order_by() and values() after annotate().

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -758,7 +758,8 @@ class When(Expression):
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
         c = self.copy()
         c.is_summary = summarize
-        c.condition = c.condition.resolve_expression(query, allow_joins, reuse, summarize, False)
+        if hasattr(c.condition, 'resolve_expression'):
+            c.condition = c.condition.resolve_expression(query, allow_joins, reuse, summarize, False)
         c.result = c.result.resolve_expression(query, allow_joins, reuse, summarize, for_save)
         return c
 

--- a/docs/releases/1.8.8.txt
+++ b/docs/releases/1.8.8.txt
@@ -54,3 +54,7 @@ Bugfixes
 
 * Made ``loaddata`` skip disabling and enabling database constraints when it
   doesn't load any fixtures (:ticket:`23372`).
+
+* Fixed a crash in ``QuerySet.values()/values_list()`` after an ``annotate()``
+  and ``order_by()`` when ``values()/values_list()`` includes a field not in
+  the ``order_by()`` (:ticket:`25316`).

--- a/docs/releases/1.9.1.txt
+++ b/docs/releases/1.9.1.txt
@@ -79,3 +79,7 @@ Bugfixes
 
 * Restored ``contrib.auth`` hashers compatibility with py-bcrypt
   (:ticket:`26016`).
+
+* Fixed a crash in ``QuerySet.values()/values_list()`` after an ``annotate()``
+  and ``order_by()`` when ``values()/values_list()`` includes a field not in
+  the ``order_by()`` (:ticket:`25316`).

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -252,6 +252,18 @@ class CaseExpressionTests(TestCase):
             transform=attrgetter('integer', 'test')
         )
 
+    def test_annotate_values_not_in_order_by(self):
+        self.assertEqual(
+            list(CaseTestModel.objects.annotate(test=Case(
+                When(integer=1, then=Value('one')),
+                When(integer=2, then=Value('two')),
+                When(integer=3, then=Value('three')),
+                default=Value('other'),
+                output_field=models.CharField(),
+            )).order_by('test').values_list('integer', flat=True)),
+            [1, 4, 3, 3, 3, 2, 2]
+        )
+
     def test_combined_expression(self):
         self.assertQuerysetEqual(
             CaseTestModel.objects.annotate(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25316