### PR TITLE
Added extra step to normalising squashed migration

### DIFF
--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -618,6 +618,8 @@ After this has been done, you must then transition the squashed migration to
 a normal initial migration, by:
 
 - Deleting all the migration files it replaces
+- Updating all migrations that depend on the deleted files to depend on
+  the squashed migration instead
 - Removing the ``replaces`` argument in the ``Migration`` class of the
   squashed migration (this is how Django tells that it is a squashed migration)
 


### PR DESCRIPTION
Added an extra step to clarify what needs to be done to transition from a squashed migration to a regular migration. It may not be obvious to everyone that this doesn't happen automatically! (Hopefully this will all be automated in the future with a `transitionsquashedmigrations` management command anyway..)

I'm guessing this is sufficiently trivial to not warrant a ticket.. (sorry if it's not, I'm new :P)