### PR TITLE
Checking of a string in pattern.regex

### DIFF
--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -23,8 +23,7 @@ def check_resolver(resolver):
             warnings.extend(check_resolver(pattern))
         elif isinstance(pattern, RegexURLPattern):
             warnings.extend(check_pattern_name(pattern))
-
-        warnings.extend(check_pattern_startswith_slash(pattern))
+            warnings.extend(check_pattern_startswith_slash(pattern))
 
     return warnings
 


### PR DESCRIPTION
You use the check_pattern_startswith_slash method on a string and the whole thing breaks. 
First you have to look if this "pattern" variable is a RegexURLPattern and then you can access in the method check_pattern_startswith_slash
pattern.regex.pattern