### PR TITLE
Typo in comment

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1113,7 +1113,7 @@ class Query(object):
         negated or not and this will be used to determine if IS NULL filtering
         is needed.
 
-        The difference between current_netageted and branch_negated is that
+        The difference between current_negated and branch_negated is that
         branch_negated is set on first negation, but current_negated is
         flipped for each negation.
 


### PR DESCRIPTION
It's also unclear what "that is done upper" means in the same comment, but I didn't want to guess in this pull request. Perhaps it means, "that is done earlier"?