### PR TITLE
Fixed #26035 -- Prevented user-tools from being visible on the admin logout page.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -641,6 +641,7 @@ answer newbie questions, and generally made Django that much better:
     schwank@gmail.com
     Scot Hacker <shacker@birdhouse.org>
     Scott Barr <scott@divisionbyzero.com.au>
+    Scott Pashley <github@scottpashley.co.uk>
     scott@staplefish.com
     Sean Brant
     Sebastian Hillig <sebastian.hillig@gmail.com>

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -24,7 +24,7 @@
         {% block branding %}{% endblock %}
         </div>
         {% block usertools %}
-        {% if has_permission %}
+        {% if has_permission and user.is_authenticated %}
         <div id="user-tools">
             {% block welcome-msg %}
                 {% trans 'Welcome,' %}

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5473,6 +5473,11 @@ class AdminViewLogoutTest(TestCase):
         self.assertEqual(response.request['PATH_INFO'], reverse('admin:login'))
         self.assertContains(response, '<input type="hidden" name="next" value="%s" />' % reverse('admin:index'))
 
+    def test_hide_user_tools_when_logged_out(self):
+        response = self.client.get(reverse('admin:logout'))
+        self.assertEqual(response.request['PATH_INFO'], reverse('admin:logout'))
+        self.assertNotContains(response, '<div id="user-tools">')
+
 
 @override_settings(PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'],
     ROOT_URLCONF="admin_views.urls")


### PR DESCRIPTION
The user-tools block is no longer visible on the "logged out" page when the user has logged out