### PR TITLE
 [wip] First stab at "new" middleware handling 2.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -433,7 +433,7 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.csrf.CsrfViewMiddleware',
 ]
 
-MIDDLEWARES = None
+MIDDLEWARE = None
 
 ############
 # SESSIONS #

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -433,6 +433,8 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.csrf.CsrfViewMiddleware',
 ]
 
+MIDDLEWARES = None
+
 ############
 # SESSIONS #
 ############

--- a/django/contrib/admindocs/middleware.py
+++ b/django/contrib/admindocs/middleware.py
@@ -1,8 +1,9 @@
 from django import http
 from django.conf import settings
+from django.core.handler.middleware import MiddlewareMixin
 
 
-class XViewMiddleware(object):
+class XViewMiddleware(MiddlewareMixin):
     """
     Adds an X-View header to internal HEAD requests -- used by the documentation system.
     """

--- a/django/contrib/admindocs/middleware.py
+++ b/django/contrib/admindocs/middleware.py
@@ -1,6 +1,6 @@
 from django import http
 from django.conf import settings
-from django.core.handler.middleware import MiddlewareMixin
+from django.core.handlers.middleware import MiddlewareMixin
 
 
 class XViewMiddleware(MiddlewareMixin):

--- a/django/contrib/auth/middleware.py
+++ b/django/contrib/auth/middleware.py
@@ -2,6 +2,7 @@ from django.contrib import auth
 from django.contrib.auth import load_backend
 from django.contrib.auth.backends import RemoteUserBackend
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.middleware import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
 
@@ -11,7 +12,7 @@ def get_user(request):
     return request._cached_user
 
 
-class AuthenticationMiddleware(object):
+class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
         assert hasattr(request, 'session'), (
             "The Django authentication middleware requires session middleware "
@@ -22,7 +23,7 @@ class AuthenticationMiddleware(object):
         request.user = SimpleLazyObject(lambda: get_user(request))
 
 
-class SessionAuthenticationMiddleware(object):
+class SessionAuthenticationMiddleware(MiddlewareMixin):
     """
     Formerly, a middleware for invalidating a user's sessions that don't
     correspond to the user's current session authentication hash. However, it
@@ -35,7 +36,7 @@ class SessionAuthenticationMiddleware(object):
         pass
 
 
-class RemoteUserMiddleware(object):
+class RemoteUserMiddleware(MiddlewareMixin):
     """
     Middleware for utilizing Web-server-provided authentication.
 

--- a/django/contrib/flatpages/middleware.py
+++ b/django/contrib/flatpages/middleware.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from django.contrib.flatpages.views import flatpage
+from django.core.handlers.middleware import MiddlewareMixin
 from django.http import Http404
 
 
-class FlatpageFallbackMiddleware(object):
+class FlatpageFallbackMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.status_code != 404:
             return response  # No need to check for a flatpage for non-404 responses.

--- a/django/contrib/messages/middleware.py
+++ b/django/contrib/messages/middleware.py
@@ -1,8 +1,9 @@
 from django.conf import settings
 from django.contrib.messages.storage import default_storage
+from django.core.handlers.middleware import MiddlewareMixin
 
 
-class MessageMiddleware(object):
+class MessageMiddleware(MiddlewareMixin):
     """
     Middleware that handles temporary messages.
     """

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -6,9 +6,10 @@ from django.conf import settings
 from django.contrib.redirects.models import Redirect
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.middleware import MiddlewareMixin
 
 
-class RedirectFallbackMiddleware(object):
+class RedirectFallbackMiddleware(MiddlewareMixin):
 
     # Defined as class-level attributes to be subclassing-friendly.
     response_gone_class = http.HttpResponseGone

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -15,15 +15,17 @@ class RedirectFallbackMiddleware(MiddlewareMixin):
     response_gone_class = http.HttpResponseGone
     response_redirect_class = http.HttpResponsePermanentRedirect
 
-    def __init__(self):
+    def __init__(self, get_response=None):
         if not apps.is_installed('django.contrib.sites'):
             raise ImproperlyConfigured(
                 "You cannot use RedirectFallbackMiddleware when "
                 "django.contrib.sites is not installed."
             )
+        super(RedirectFallbackMiddleware, self).__init__(get_response)
 
     def process_response(self, request, response):
         # No need to check for a redirect for non-404 responses.
+        print response, type(response), response.status_code
         if response.status_code != 404:
             return response
 

--- a/django/contrib/redirects/middleware.py
+++ b/django/contrib/redirects/middleware.py
@@ -25,7 +25,6 @@ class RedirectFallbackMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         # No need to check for a redirect for non-404 responses.
-        print response, type(response), response.status_code
         if response.status_code != 404:
             return response
 

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -10,7 +10,8 @@ from django.utils.http import cookie_date
 
 
 class SessionMiddleware(MiddlewareMixin):
-    def __init__(self):
+    def __init__(self, get_response=None):
+        super(SessionMiddleware, self).__init__(get_response)
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore
 

--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -3,12 +3,13 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
+from django.core.handlers.middleware import MiddlewareMixin
 from django.shortcuts import redirect
 from django.utils.cache import patch_vary_headers
 from django.utils.http import cookie_date
 
 
-class SessionMiddleware(object):
+class SessionMiddleware(MiddlewareMixin):
     def __init__(self):
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -24,6 +24,26 @@ from django.views import debug
 logger = logging.getLogger('django.request')
 
 
+def get_exception_response(request, status_code, exception):
+    resolver = get_resolver(get_urlconf())
+
+    callback, param_dict = resolver.resolve_error_handler(status_code)
+    # Unfortunately, inspect.getargspec result is not trustable enough
+    # depending on the callback wrapping in decorators (frequent for handlers).
+    # Falling back on try/except:
+    try:
+        response = callback(request, **dict(param_dict, exception=exception))
+    except TypeError:
+        warnings.warn(
+            "Error handlers should accept an exception parameter. Update "
+            "your code as this parameter will be required in Django 2.0",
+            RemovedInDjango20Warning, stacklevel=2
+        )
+        response = callback(request, **param_dict)
+
+    return response
+
+
 def handle_uncaught_exception(request, exc_info):
     resolver = get_resolver(get_urlconf())
     if settings.DEBUG_PROPAGATE_EXCEPTIONS:
@@ -48,35 +68,14 @@ def handle_uncaught_exception(request, exc_info):
     return callback(request, **param_dict)
 
 
-def get_exception_response(request, status_code, exception):
-    resolver = get_resolver(get_urlconf())
-    try:
-        callback, param_dict = resolver.resolve_error_handler(status_code)
-        # Unfortunately, inspect.getargspec result is not trustable enough
-        # depending on the callback wrapping in decorators (frequent for handlers).
-        # Falling back on try/except:
-        try:
-            response = callback(request, **dict(param_dict, exception=exception))
-        except TypeError:
-            warnings.warn(
-                "Error handlers should accept an exception parameter. Update "
-                "your code as this parameter will be required in Django 2.0",
-                RemovedInDjango20Warning, stacklevel=2
-            )
-            response = callback(request, **param_dict)
-    except Exception:
-        # FIXME: BaseHandler here as sender is not nice, but who cares?
-        signals.got_request_exception.send(sender=BaseHandler, request=request)
-        response = handle_uncaught_exception(request, sys.exc_info())
-
-    return response
-
-
 class ExceptionMiddleware(object):
     def __init__(self, get_response):
         self.get_response = get_response
 
-    def __call__(self, request):
+    def handle_uncaught_exception(self, request, exc_info):
+        return handle_uncaught_exception(request, exc_info)
+
+    def handle_response_exceptions(self, request):
         try:
             response = self.get_response(request)
         except http.Http404 as exc:
@@ -124,16 +123,20 @@ class ExceptionMiddleware(object):
 
             response = get_exception_response(request, 400, exc)
 
+        return response
+
+    def __call__(self, request):
+        try:
+            return self.handle_response_exceptions(request)
         except SystemExit:
             # Allow sys.exit() to actually exit. See tickets #1023 and #4701
             raise
 
         except Exception:  # Handle everything else.
             # Get the exception info now, in case another exception is thrown later.
+            # FIXME: BaseHandler here as sender is not nice, but who cares?
             signals.got_request_exception.send(sender=BaseHandler, request=request)
-            response = handle_uncaught_exception(request, sys.exc_info())
-
-        return response
+            return self.handle_uncaught_exception(request, sys.exc_info())
 
 
 class BaseHandler(object):

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -44,12 +44,11 @@ class BaseHandler(object):
 
         Must be called after the environment is fixed (see __call__ in subclasses).
         """
+        self._request_middleware = []
         self._view_middleware = []
         self._template_response_middleware = []
         self._response_middleware = []
         self._exception_middleware = []
-
-        request_middleware = []
 
         handler = self._get_response
 
@@ -67,7 +66,7 @@ class BaseHandler(object):
                     continue
 
                 if hasattr(mw_instance, 'process_request'):
-                    request_middleware.append(mw_instance.process_request)
+                    self._request_middleware.append(mw_instance.process_request)
                 if hasattr(mw_instance, 'process_view'):
                     self._view_middleware.append(mw_instance.process_view)
                 if hasattr(mw_instance, 'process_template_response'):
@@ -101,11 +100,9 @@ class BaseHandler(object):
 
                 handler = mw_instance
 
-        self._middleware_chain = handler
-
         # We only assign to this when initialization is complete as it is used
         # as a flag for initialization being complete.
-        self._request_middleware = request_middleware
+        self._middleware_chain = handler
 
     def make_view_atomic(self, view):
         non_atomic_requests = getattr(view, '_non_atomic_requests', set())

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -35,6 +35,7 @@ class BaseHandler(object):
         self._template_response_middleware = None
         self._response_middleware = None
         self._exception_middleware = None
+        self._middleware = None
 
     def load_middleware(self):
         """
@@ -46,8 +47,11 @@ class BaseHandler(object):
         self._template_response_middleware = []
         self._response_middleware = []
         self._exception_middleware = []
+        self._middleware = []
+        self._new_style_middleware = False
 
         request_middleware = []
+        middleware_count = 0
         for middleware_path in settings.MIDDLEWARE_CLASSES:
             mw_class = import_string(middleware_path)
             try:
@@ -59,6 +63,8 @@ class BaseHandler(object):
                     else:
                         logger.debug('MiddlewareNotUsed: %r', middleware_path)
                 continue
+            else:
+                middleware_count += 1
 
             if hasattr(mw_instance, 'process_request'):
                 request_middleware.append(mw_instance.process_request)
@@ -70,6 +76,11 @@ class BaseHandler(object):
                 self._response_middleware.insert(0, mw_instance.process_response)
             if hasattr(mw_instance, 'process_exception'):
                 self._exception_middleware.insert(0, mw_instance.process_exception)
+            if callable(mw_instance):
+                self._middleware.insert(0, mw_instance)
+
+        if middleware_count == len(self._middleware):
+            self._new_style_middleware = True
 
         # We only assign to this when initialization is complete as it is used
         # as a flag for initialization being complete.
@@ -105,6 +116,20 @@ class BaseHandler(object):
         return response
 
     def get_response(self, request):
+        if not self._new_style_middleware:
+            return self._get_response(request)
+
+        callables = self._middleware[:]
+
+        def response_factory(request):
+            if callables:
+                return callables.pop()(request, response_factory)
+            else:
+                return self._get_response(request)
+
+        return response_factory(request)
+
+    def _get_response(self, request):
         "Returns an HttpResponse object for the given HttpRequest"
 
         # Setup default url resolver for this thread, this code is outside
@@ -120,10 +145,11 @@ class BaseHandler(object):
         try:
             response = None
             # Apply request middleware
-            for middleware_method in self._request_middleware:
-                response = middleware_method(request)
-                if response:
-                    break
+            if not self._new_style_middleware:
+                for middleware_method in self._request_middleware:
+                    response = middleware_method(request)
+                    if response:
+                        break
 
             if response is None:
                 if hasattr(request, 'urlconf'):
@@ -230,20 +256,21 @@ class BaseHandler(object):
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
 
-        try:
-            # Apply response middleware, regardless of the response
-            for middleware_method in self._response_middleware:
-                response = middleware_method(request, response)
-                # Complain if the response middleware returned None (a common error).
-                if response is None:
-                    raise ValueError(
-                        "%s.process_response didn't return an "
-                        "HttpResponse object. It returned None instead."
-                        % (middleware_method.__self__.__class__.__name__))
-            response = self.apply_response_fixes(request, response)
-        except Exception:  # Any exception should be gathered and handled
-            signals.got_request_exception.send(sender=self.__class__, request=request)
-            response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
+        if not self._new_style_middleware:
+            try:
+                # Apply response middleware, regardless of the response
+                for middleware_method in self._response_middleware:
+                    response = middleware_method(request, response)
+                    # Complain if the response middleware returned None (a common error).
+                    if response is None:
+                        raise ValueError(
+                            "%s.process_response didn't return an "
+                            "HttpResponse object. It returned None instead."
+                            % (middleware_method.__self__.__class__.__name__))
+                response = self.apply_response_fixes(request, response)
+            except Exception:  # Any exception should be gathered and handled
+                signals.got_request_exception.send(sender=self.__class__, request=request)
+                response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
 
         response._closable_objects.append(request)
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -175,10 +175,10 @@ class BaseHandler(object):
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, sys.exc_info())
 
-        # This is a noop with new style middlewares!
-        response = self._apply_old_response_middleware(request, response)
 
         try:
+            # This is a noop with new style middlewares!
+            response = self._apply_old_response_middleware(request, response)
             response = self.apply_response_fixes(request, response)
         except Exception:  # Any exception should be gathered and handled
             signals.got_request_exception.send(sender=self.__class__, request=request)
@@ -313,19 +313,15 @@ class BaseHandler(object):
         raise
 
     def _apply_old_response_middleware(self, request, response):
-        try:
-            # Apply response middleware, regardless of the response
-            for middleware_method in self._response_middleware:
-                response = middleware_method(request, response)
-                # Complain if the response middleware returned None (a common error).
-                if response is None:
-                    raise ValueError(
-                        "%s.process_response didn't return an "
-                        "HttpResponse object. It returned None instead."
-                        % (middleware_method.__self__.__class__.__name__))
-        except Exception:  # Any exception should be gathered and handled
-            signals.got_request_exception.send(sender=self.__class__, request=request)
-            response = self.handle_uncaught_exception(request, sys.exc_info())
+        # Apply response middleware, regardless of the response
+        for middleware_method in self._response_middleware:
+            response = middleware_method(request, response)
+            # Complain if the response middleware returned None (a common error).
+            if response is None:
+                raise ValueError(
+                    "%s.process_response didn't return an "
+                    "HttpResponse object. It returned None instead."
+                    % (middleware_method.__self__.__class__.__name__))
 
         return response
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -216,6 +216,7 @@ class BaseHandler(object):
 
                 handler = mw_instance
 
+            # TODO: We could also wrap unconditionally here to catch exceptions raised from middlewares?
             if not exception_middleware_in_place:
                 handler = ExceptionMiddleware(handler)
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -50,6 +50,7 @@ class BaseHandler(object):
         self._response_middleware = []
         self._exception_middleware = []
 
+        settings.MIDDLEWARE = settings.MIDDLEWARE_CLASSES
         if settings.MIDDLEWARE is None:
             handler = self._get_response_old
             self._load_middleware_old()

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -53,28 +53,7 @@ class BaseHandler(object):
 
         if settings.MIDDLEWARE is None:
             handler = self._get_response_old
-            for middleware_path in settings.MIDDLEWARE_CLASSES:
-                mw_class = import_string(middleware_path)
-                try:
-                    mw_instance = mw_class()
-                except MiddlewareNotUsed as exc:
-                    if settings.DEBUG:
-                        if six.text_type(exc):
-                            logger.debug('MiddlewareNotUsed(%r): %s', middleware_path, exc)
-                        else:
-                            logger.debug('MiddlewareNotUsed: %r', middleware_path)
-                    continue
-
-                if hasattr(mw_instance, 'process_request'):
-                    self._request_middleware.append(mw_instance.process_request)
-                if hasattr(mw_instance, 'process_view'):
-                    self._view_middleware.append(mw_instance.process_view)
-                if hasattr(mw_instance, 'process_template_response'):
-                    self._template_response_middleware.insert(0, mw_instance.process_template_response)
-                if hasattr(mw_instance, 'process_response'):
-                    self._response_middleware.insert(0, mw_instance.process_response)
-                if hasattr(mw_instance, 'process_exception'):
-                    self._exception_middleware.insert(0, mw_instance.process_exception)
+            self._load_middleware_old()
         else:
             handler = self._get_response
             for middleware_path in settings.MIDDLEWARE[::-1]:
@@ -362,3 +341,27 @@ class BaseHandler(object):
         if response is None:
             response = self._get_response(request)
         return response
+
+    def _load_middleware_old(self):
+        for middleware_path in settings.MIDDLEWARE_CLASSES:
+            mw_class = import_string(middleware_path)
+            try:
+                mw_instance = mw_class()
+            except MiddlewareNotUsed as exc:
+                if settings.DEBUG:
+                    if six.text_type(exc):
+                        logger.debug('MiddlewareNotUsed(%r): %s', middleware_path, exc)
+                    else:
+                        logger.debug('MiddlewareNotUsed: %r', middleware_path)
+                continue
+
+            if hasattr(mw_instance, 'process_request'):
+                self._request_middleware.append(mw_instance.process_request)
+            if hasattr(mw_instance, 'process_view'):
+                self._view_middleware.append(mw_instance.process_view)
+            if hasattr(mw_instance, 'process_template_response'):
+                self._template_response_middleware.insert(0, mw_instance.process_template_response)
+            if hasattr(mw_instance, 'process_response'):
+                self._response_middleware.insert(0, mw_instance.process_response)
+            if hasattr(mw_instance, 'process_exception'):
+                self._exception_middleware.insert(0, mw_instance.process_exception)

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -169,7 +169,7 @@ class BaseHandler(object):
         self._response_middleware = []
         self._exception_middleware = []
 
-        #settings.MIDDLEWARE = settings.MIDDLEWARE_CLASSES
+        # settings.MIDDLEWARE = settings.MIDDLEWARE_CLASSES
         if settings.MIDDLEWARE is None:
             handler = self._legacy_get_response
             self._legacy_load_middleware()

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -117,8 +117,7 @@ class BaseHandler(object):
     def get_response(self, request):
         "Returns an HttpResponse object for the given HttpRequest"
         # Setup default url resolver for this thread
-        urlconf = settings.ROOT_URLCONF
-        set_urlconf(urlconf)
+        set_urlconf(settings.ROOT_URLCONF)
 
         try:
             response = self._middleware_chain(request)

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import contextlib
 import logging
 import sys
 import types
@@ -175,7 +174,6 @@ class BaseHandler(object):
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, sys.exc_info())
 
-
         try:
             # This is a noop with new style middlewares!
             response = self._apply_old_response_middleware(request, response)
@@ -252,9 +250,6 @@ class BaseHandler(object):
                 response = response.render()
             except Exception as e:
                 response = self.process_exception_by_middleware(e, request)
-
-        if response is None:
-            raise ValueError(msg)
 
         return response
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -171,16 +171,12 @@ class BaseHandler(object):
 
         #settings.MIDDLEWARE = settings.MIDDLEWARE_CLASSES
         if settings.MIDDLEWARE is None:
-            handler = ExceptionMiddleware(self._legacy_get_response)
+            handler = self._legacy_get_response
             self._legacy_load_middleware()
         else:
             handler = self._get_response
-            # TODO: Easier check to allow users to override where in the chain exceptions are transformed?
-            exception_middleware_in_place = False
             for middleware_path in reversed(settings.MIDDLEWARE):
                 middleware = import_string(middleware_path)
-                if isinstance(middleware, ExceptionMiddleware):
-                    exception_middleware_in_place = True
                 try:
                     mw_instance = middleware(handler)
                 except MiddlewareNotUsed as exc:
@@ -203,9 +199,7 @@ class BaseHandler(object):
 
                 handler = mw_instance
 
-            # TODO: We could also wrap unconditionally here to catch exceptions raised from middlewares?
-            if not exception_middleware_in_place:
-                handler = ExceptionMiddleware(handler)
+        handler = ExceptionMiddleware(handler)
 
         # We only assign to this when initialization is complete as it is used
         # as a flag for initialization being complete.

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -48,39 +48,56 @@ class BaseHandler(object):
         self._response_middleware = []
         self._exception_middleware = []
         self._middleware = []
-        self._new_style_middleware = False
 
         request_middleware = []
-        middleware_count = 0
-        for middleware_path in settings.MIDDLEWARE_CLASSES:
-            mw_class = import_string(middleware_path)
-            try:
-                mw_instance = mw_class()
-            except MiddlewareNotUsed as exc:
-                if settings.DEBUG:
-                    if six.text_type(exc):
-                        logger.debug('MiddlewareNotUsed(%r): %s', middleware_path, exc)
-                    else:
-                        logger.debug('MiddlewareNotUsed: %r', middleware_path)
-                continue
-            else:
-                middleware_count += 1
 
-            if hasattr(mw_instance, 'process_request'):
-                request_middleware.append(mw_instance.process_request)
-            if hasattr(mw_instance, 'process_view'):
-                self._view_middleware.append(mw_instance.process_view)
-            if hasattr(mw_instance, 'process_template_response'):
-                self._template_response_middleware.insert(0, mw_instance.process_template_response)
-            if hasattr(mw_instance, 'process_response'):
-                self._response_middleware.insert(0, mw_instance.process_response)
-            if hasattr(mw_instance, 'process_exception'):
-                self._exception_middleware.insert(0, mw_instance.process_exception)
-            if callable(mw_instance):
-                self._middleware.insert(0, mw_instance)
+        if settings.MIDDLEWARES is None:
+            for middleware_path in settings.MIDDLEWARE_CLASSES:
+                mw_class = import_string(middleware_path)
+                try:
+                    mw_instance = mw_class()
+                except MiddlewareNotUsed as exc:
+                    if settings.DEBUG:
+                        if six.text_type(exc):
+                            logger.debug('MiddlewareNotUsed(%r): %s', middleware_path, exc)
+                        else:
+                            logger.debug('MiddlewareNotUsed: %r', middleware_path)
+                    continue
 
-        if middleware_count == len(self._middleware):
-            self._new_style_middleware = True
+                if hasattr(mw_instance, 'process_request'):
+                    request_middleware.append(mw_instance.process_request)
+                if hasattr(mw_instance, 'process_view'):
+                    self._view_middleware.append(mw_instance.process_view)
+                if hasattr(mw_instance, 'process_template_response'):
+                    self._template_response_middleware.insert(0, mw_instance.process_template_response)
+                if hasattr(mw_instance, 'process_response'):
+                    self._response_middleware.insert(0, mw_instance.process_response)
+                if hasattr(mw_instance, 'process_exception'):
+                    self._exception_middleware.insert(0, mw_instance.process_exception)
+        else:
+            for middleware_path in settings.MIDDLEWARES:
+                middleware = import_string(middleware_path)
+                try:
+                    mw_instance = middleware(self._response_factory)
+                except MiddlewareNotUsed as exc:
+                    if settings.DEBUG:
+                        if six.text_type(exc):
+                            logger.debug('MiddlewareNotUsed(%r): %s', middleware_path, exc)
+                        else:
+                            logger.debug('MiddlewareNotUsed: %r', middleware_path)
+                    continue
+
+                if not mw_instance:  # If the factory returns None
+                    continue
+
+                self._middleware.append(mw_instance)
+
+                if hasattr(mw_instance, 'process_view'):
+                    self._view_middleware.append(mw_instance.process_view)
+                if hasattr(mw_instance, 'process_template_response'):
+                    self._template_response_middleware.insert(0, mw_instance.process_template_response)
+
+            self._middleware.reverse()
 
         # We only assign to this when initialization is complete as it is used
         # as a flag for initialization being complete.
@@ -115,19 +132,22 @@ class BaseHandler(object):
 
         return response
 
-    def get_response(self, request):
-        if not self._new_style_middleware:
+    def _response_factory(self, request):
+        middlewares = request.middlewares
+        if request.middlewares:
+            return middlewares.pop()(request)
+        else:
             return self._get_response(request)
 
-        callables = self._middleware[:]
+    def get_response(self, request):
+        if settings.MIDDLEWARES is None:
+            return self._get_response(request)
 
-        def response_factory(request):
-            if callables:
-                return callables.pop()(request, response_factory)
-            else:
-                return self._get_response(request)
+        # Prepare the request
+        request.middlewares = self._middleware[:]
+        # TODO: Put all middlewares onto the request? would allow for interesting stuff, ie adding middlewares per request?!
 
-        return response_factory(request)
+        return self._response_factory(request)
 
     def _get_response(self, request):
         "Returns an HttpResponse object for the given HttpRequest"
@@ -145,7 +165,7 @@ class BaseHandler(object):
         try:
             response = None
             # Apply request middleware
-            if not self._new_style_middleware:
+            if settings.MIDDLEWARES is None:
                 for middleware_method in self._request_middleware:
                     response = middleware_method(request)
                     if response:
@@ -256,7 +276,7 @@ class BaseHandler(object):
             signals.got_request_exception.send(sender=self.__class__, request=request)
             response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
 
-        if not self._new_style_middleware:
+        if settings.MIDDLEWARES is None:
             try:
                 # Apply response middleware, regardless of the response
                 for middleware_method in self._response_middleware:

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -51,6 +51,7 @@ class BaseHandler(object):
         self._exception_middleware = []
 
         settings.MIDDLEWARE = settings.MIDDLEWARE_CLASSES
+        print settings.MIDDLEWARE
         if settings.MIDDLEWARE is None:
             handler = self._get_response_old
             self._load_middleware_old()
@@ -58,6 +59,7 @@ class BaseHandler(object):
             handler = self._get_response
             for middleware_path in settings.MIDDLEWARE[::-1]:
                 middleware = import_string(middleware_path)
+                print middleware_path
                 try:
                     mw_instance = middleware(handler)
                 except MiddlewareNotUsed as exc:

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -266,15 +266,12 @@ class BaseHandler(object):
 
         wrapped_callback = self.make_view_atomic(callback)
 
-        # TODO: It would be nice if we could move the try/except in _legacy_get_response,
-        # but that would break semantics.
         try:
             response = wrapped_callback(request, *callback_args, **callback_kwargs)
         except Exception as e:
             response = self._legacy_process_exception_by_middleware(e, request)
 
         # Complain if the view returned None (a common error).
-        # TODO: New style middlewares will actually be able to handle that, good or not?!
         if response is None:
             if isinstance(callback, types.FunctionType):    # FBV
                 view_name = callback.__name__
@@ -290,13 +287,11 @@ class BaseHandler(object):
             for middleware_method in self._template_response_middleware:
                 response = middleware_method(request, response)
                 # Complain if the template response middleware returned None (a common error).
-                # TODO: See TODOs above this one.
                 if response is None:
                     raise ValueError("%s.process_template_response didn't return an "
                         "HttpResponse object. It returned None instead."
                         % (middleware_method.__self__.__class__.__name__))
 
-            # TODO: See TODOs above this one.
             try:
                 response = response.render()
             except Exception as e:

--- a/django/core/handlers/middleware.py
+++ b/django/core/handlers/middleware.py
@@ -8,7 +8,13 @@ class MiddlewareMixin(object):
         if hasattr(self, 'process_request'):
             response = self.process_request(request)
         if not response:
-            response = self.get_response(request)
+			try:
+				response = self.get_response(request)
+			except Exception as e:
+				if hasattr(self, 'process_exception'):
+					return self.process_exception(request, e)
+				else:
+					raise
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response

--- a/django/core/handlers/middleware.py
+++ b/django/core/handlers/middleware.py
@@ -1,0 +1,10 @@
+class MiddlewareMixin(object):
+    def __call__(self, request, response_factory):
+        response = None
+        if hasattr(self, 'process_request'):
+            response = self.process_request(request)
+        if not response:
+            response = response_factory(request)
+        if hasattr(self, 'process_response'):
+            response = self.process_response(request, response)
+        return response

--- a/django/core/handlers/middleware.py
+++ b/django/core/handlers/middleware.py
@@ -1,10 +1,14 @@
 class MiddlewareMixin(object):
-    def __call__(self, request, response_factory):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        super(MiddlewareMixin, self).__init__()
+
+    def __call__(self, request):
         response = None
         if hasattr(self, 'process_request'):
             response = self.process_request(request)
         if not response:
-            response = response_factory(request)
+            response = self.get_response(request)
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response

--- a/django/core/handlers/middleware.py
+++ b/django/core/handlers/middleware.py
@@ -8,13 +8,13 @@ class MiddlewareMixin(object):
         if hasattr(self, 'process_request'):
             response = self.process_request(request)
         if not response:
-			try:
-				response = self.get_response(request)
-			except Exception as e:
-				if hasattr(self, 'process_exception'):
-					return self.process_exception(request, e)
-				else:
-					raise
+            try:
+                response = self.get_response(request)
+            except Exception as e:
+                if hasattr(self, 'process_exception'):
+                    return self.process_exception(request, e)
+                else:
+                    raise
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response

--- a/django/core/handlers/middleware.py
+++ b/django/core/handlers/middleware.py
@@ -1,5 +1,5 @@
 class MiddlewareMixin(object):
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         self.get_response = get_response
         super(MiddlewareMixin, self).__init__()
 

--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -153,10 +153,10 @@ class WSGIHandler(base.BaseHandler):
     def __call__(self, environ, start_response):
         # Set up middleware if needed. We couldn't do this earlier, because
         # settings weren't available.
-        if self._request_middleware is None:
+        if self._middleware_chain is None:
             with self.initLock:
                 # Check that middleware is still uninitialized.
-                if self._request_middleware is None:
+                if self._middleware_chain is None:
                     self.load_middleware()
 
         set_script_prefix(get_script_name(environ))

--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -45,13 +45,14 @@ More details about how the caching works:
 
 from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
+from django.core.handlers.middleware import MiddlewareMixin
 from django.utils.cache import (
     get_cache_key, get_max_age, has_vary_header, learn_cache_key,
     patch_response_headers,
 )
 
 
-class UpdateCacheMiddleware(object):
+class UpdateCacheMiddleware(MiddlewareMixin):
     """
     Response-phase cache middleware that updates the cache if the response is
     cacheable.
@@ -104,7 +105,7 @@ class UpdateCacheMiddleware(object):
         return response
 
 
-class FetchFromCacheMiddleware(object):
+class FetchFromCacheMiddleware(MiddlewareMixin):
     """
     Request-phase cache middleware that fetches a page from the cache.
 

--- a/django/middleware/clickjacking.py
+++ b/django/middleware/clickjacking.py
@@ -6,9 +6,10 @@ malicious site loading resources from your site in a hidden frame.
 """
 
 from django.conf import settings
+from django.core.handlers.middleware import MiddlewareMixin
 
 
-class XFrameOptionsMiddleware(object):
+class XFrameOptionsMiddleware(MiddlewareMixin):
     """
     Middleware that sets the X-Frame-Options HTTP header in HTTP responses.
 

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -4,6 +4,7 @@ import re
 from django import http
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.core.handlers.middleware import MiddlewareMixin
 from django.core.mail import mail_managers
 from django.urls import is_valid_path
 from django.utils.cache import get_conditional_response, set_response_etag
@@ -14,7 +15,7 @@ from django.utils.six.moves.urllib.parse import urlparse
 logger = logging.getLogger('django.request')
 
 
-class CommonMiddleware(object):
+class CommonMiddleware(MiddlewareMixin):
     """
     "Common" middleware for taking care of some basic operations:
 
@@ -129,7 +130,7 @@ class CommonMiddleware(object):
         return response
 
 
-class BrokenLinkEmailsMiddleware(object):
+class BrokenLinkEmailsMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         """

--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -10,6 +10,7 @@ import logging
 import re
 
 from django.conf import settings
+from django.core.handlers.middleware import MiddlewareMixin
 from django.urls import get_callable
 from django.utils.cache import patch_vary_headers
 from django.utils.crypto import constant_time_compare, get_random_string
@@ -78,7 +79,7 @@ def _sanitize_token(token):
     return token
 
 
-class CsrfViewMiddleware(object):
+class CsrfViewMiddleware(MiddlewareMixin):
     """
     Middleware that requires a present and correct csrfmiddlewaretoken
     for POST requests that have a CSRF cookie, and sets an outgoing

--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -1,12 +1,13 @@
 import re
 
+from django.core.handlers.middleware import MiddlewareMixin
 from django.utils.cache import patch_vary_headers
 from django.utils.text import compress_sequence, compress_string
 
 re_accepts_gzip = re.compile(r'\bgzip\b')
 
 
-class GZipMiddleware(object):
+class GZipMiddleware(MiddlewareMixin):
     """
     This middleware compresses content if the browser allows gzip compression.
     It sets the Vary header accordingly, so that caches will base their storage

--- a/django/middleware/http.py
+++ b/django/middleware/http.py
@@ -1,8 +1,9 @@
+from django.core.handlers.middleware import MiddlewareMixin
 from django.utils.cache import get_conditional_response
 from django.utils.http import http_date, parse_http_date_safe, unquote_etag
 
 
-class ConditionalGetMiddleware(object):
+class ConditionalGetMiddleware(MiddlewareMixin):
     """
     Handles conditional GET operations. If the response has an ETag or
     Last-Modified header, and the request has If-None-Match or

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -2,13 +2,14 @@
 
 from django.conf import settings
 from django.conf.urls.i18n import is_language_prefix_patterns_used
+from django.core.handlers.middleware import MiddlewareMixin
 from django.http import HttpResponseRedirect
 from django.urls import get_script_prefix, is_valid_path
 from django.utils import translation
 from django.utils.cache import patch_vary_headers
 
 
-class LocaleMiddleware(object):
+class LocaleMiddleware(MiddlewareMixin):
     """
     This is a very simple middleware that parses a request
     and decides what translation object to install in the current

--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -1,10 +1,11 @@
 import re
 
 from django.conf import settings
+from django.core.handlers.middleware import MiddlewareMixin
 from django.http import HttpResponsePermanentRedirect
 
 
-class SecurityMiddleware(object):
+class SecurityMiddleware(MiddlewareMixin):
     def __init__(self):
         self.sts_seconds = settings.SECURE_HSTS_SECONDS
         self.sts_include_subdomains = settings.SECURE_HSTS_INCLUDE_SUBDOMAINS

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -106,7 +106,7 @@ class ClientHandler(BaseHandler):
     def __call__(self, environ):
         # Set up middleware if needed. We couldn't do this earlier, because
         # settings weren't available.
-        if self._request_middleware is None:
+        if self._middleware_chain is None:
             self.load_middleware()
 
         request_started.disconnect(close_old_connections)

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -480,8 +480,8 @@ class FileUploadTests(TestCase):
         """
         class POSTAccessingHandler(client.ClientHandler):
             """A handler that'll access POST during an exception."""
-            def handle_uncaught_exception(self, request, resolver, exc_info):
-                ret = super(POSTAccessingHandler, self).handle_uncaught_exception(request, resolver, exc_info)
+            def handle_uncaught_exception(self, request, exc_info):
+                ret = super(POSTAccessingHandler, self).handle_uncaught_exception(request, exc_info)
                 request.POST  # evaluate
                 return ret
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -722,7 +722,6 @@ class SessionMiddlewareTests(TestCase):
         # Simulate a request that ends the session
         request, response = self.run_middleware(request, modifier=modifier)
 
-
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header with a custom domain looks like:
         #  Set-Cookie: sessionid=; Domain=.example.local;
@@ -755,7 +754,6 @@ class SessionMiddlewareTests(TestCase):
         """
         request = RequestFactory().get('/')
         response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
 
         request, response = self.run_middleware()
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -616,33 +616,32 @@ class CacheSessionTests(SessionTestsMixin, unittest.TestCase):
 
 class SessionMiddlewareTests(TestCase):
 
+    def run_middleware(self, request=None, response=None, modifier=None):
+        request = request or RequestFactory().get('/')
+        response = response or HttpResponse('Session Test')
+
+        def response_factory(request):
+            if modifier:
+                modifier(request, response)
+            else:
+                request.session['hello'] = 'world'
+            return response
+
+        middleware = SessionMiddleware(response_factory)
+
+        return request, middleware(request)
+
     @override_settings(SESSION_COOKIE_SECURE=True)
     def test_secure_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        request, response = self.run_middleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['secure'])
 
     @override_settings(SESSION_COOKIE_HTTPONLY=True)
     def test_httponly_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        request, response = self.run_middleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
         self.assertIn(http_cookies.Morsel._reserved['httponly'],
@@ -650,33 +649,19 @@ class SessionMiddlewareTests(TestCase):
 
     @override_settings(SESSION_COOKIE_HTTPONLY=False)
     def test_no_httponly_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        request, response = self.run_middleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
         self.assertFalse(response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
 
         self.assertNotIn(http_cookies.Morsel._reserved['httponly'],
                          str(response.cookies[settings.SESSION_COOKIE_NAME]))
 
     def test_session_save_on_500(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Horrible error')
-        response.status_code = 500
-        middleware = SessionMiddleware()
+        def modifier(request, response):
+            request.session['hello'] = 'world'
+            response.status_code = 500
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(modifier=modifier)
 
         # Check that the value wasn't saved above.
         self.assertNotIn('hello', request.session.load())
@@ -702,18 +687,15 @@ class SessionMiddlewareTests(TestCase):
 
     def test_session_delete_on_end(self):
         request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
+        def modifier(request, response):
+            request.session.flush()
 
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        # Simulate a request that ends the session
+        request, response = self.run_middleware(request, modifier=modifier)
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header looks like:
@@ -730,18 +712,16 @@ class SessionMiddlewareTests(TestCase):
     @override_settings(SESSION_COOKIE_DOMAIN='.example.local')
     def test_session_delete_on_end_with_custom_domain(self):
         request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
+        def modifier(request, response):
+            request.session.flush()
 
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        # Simulate a request that ends the session
+        request, response = self.run_middleware(request, modifier=modifier)
+
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header with a custom domain looks like:
@@ -757,16 +737,11 @@ class SessionMiddlewareTests(TestCase):
         )
 
     def test_flush_empty_without_session_cookie_doesnt_set_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        def modifier(request, response):
+            request.session.flush()
 
         # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(modifier=modifier)
 
         # A cookie should not be set.
         self.assertEqual(response.cookies, {})
@@ -782,12 +757,9 @@ class SessionMiddlewareTests(TestCase):
         response = HttpResponse('Session test')
         middleware = SessionMiddleware()
 
-        # Set a session key and some data.
-        middleware.process_request(request)
-        request.session['foo'] = 'bar'
-        # Handle the response through the middleware.
-        response = middleware.process_response(request, response)
-        self.assertEqual(tuple(request.session.items()), (('foo', 'bar'),))
+        request, response = self.run_middleware()
+
+        self.assertEqual(tuple(request.session.items()), (('hello', 'world'),))
         # A cookie should be set, along with Vary: Cookie.
         self.assertIn(
             'Set-Cookie: sessionid=%s' % request.session.session_key,
@@ -795,11 +767,15 @@ class SessionMiddlewareTests(TestCase):
         )
         self.assertEqual(response['Vary'], 'Cookie')
 
-        # Empty the session data.
-        del request.session['foo']
-        # Handle the response through the middleware.
+        request.COOKIES[settings.SESSION_COOKIE_NAME] = request.session._session_key
+
+        def modifier(request, response):
+            # Empty the session data.
+            del request.session['hello']
+
         response = HttpResponse('Session test')
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(request, response, modifier)
+
         self.assertEqual(dict(request.session.values()), {})
         session = Session.objects.get(session_key=request.session.session_key)
         self.assertEqual(session.get_decoded(), {})

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -616,33 +616,32 @@ class CacheSessionTests(SessionTestsMixin, unittest.TestCase):
 
 class SessionMiddlewareTests(TestCase):
 
-    @override_settings(SESSION_COOKIE_SECURE=True)
-    def test_secure_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
+
+    def run_middleware(self, request=None, response=None, modifier=None):
+        request = request or RequestFactory().get('/')
+        response = response or HttpResponse('Session Test')
         middleware = SessionMiddleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
+        def response_factory(request):
+            if modifier:
+                modifier(request, response)
+            else:
+                request.session['hello'] = 'world'
+            return response
 
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        return request, middleware(request, response_factory)
+
+    @override_settings(SESSION_COOKIE_SECURE=True)
+    def test_secure_session_cookie(self):
+        request, response = self.run_middleware()
+
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['secure'])
 
     @override_settings(SESSION_COOKIE_HTTPONLY=True)
     def test_httponly_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        request, response = self.run_middleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
         self.assertIn(http_cookies.Morsel._reserved['httponly'],
@@ -650,33 +649,19 @@ class SessionMiddlewareTests(TestCase):
 
     @override_settings(SESSION_COOKIE_HTTPONLY=False)
     def test_no_httponly_session_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        request, response = self.run_middleware()
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
         self.assertFalse(response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
 
         self.assertNotIn(http_cookies.Morsel._reserved['httponly'],
                          str(response.cookies[settings.SESSION_COOKIE_NAME]))
 
     def test_session_save_on_500(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Horrible error')
-        response.status_code = 500
-        middleware = SessionMiddleware()
+        def modifier(request, response):
+            request.session['hello'] = 'world'
+            response.status_code = 500
 
-        # Simulate a request the modifies the session
-        middleware.process_request(request)
-        request.session['hello'] = 'world'
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(modifier=modifier)
 
         # Check that the value wasn't saved above.
         self.assertNotIn('hello', request.session.load())
@@ -702,18 +687,15 @@ class SessionMiddlewareTests(TestCase):
 
     def test_session_delete_on_end(self):
         request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
+        def modifier(request, response):
+            request.session.flush()
 
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        # Simulate a request that ends the session
+        request, response = self.run_middleware(request, modifier=modifier)
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header looks like:
@@ -730,18 +712,16 @@ class SessionMiddlewareTests(TestCase):
     @override_settings(SESSION_COOKIE_DOMAIN='.example.local')
     def test_session_delete_on_end_with_custom_domain(self):
         request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
+        def modifier(request, response):
+            request.session.flush()
 
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        # Simulate a request that ends the session
+        request, response = self.run_middleware(request, modifier=modifier)
+
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header with a custom domain looks like:
@@ -757,16 +737,11 @@ class SessionMiddlewareTests(TestCase):
         )
 
     def test_flush_empty_without_session_cookie_doesnt_set_cookie(self):
-        request = RequestFactory().get('/')
-        response = HttpResponse('Session test')
-        middleware = SessionMiddleware()
+        def modifier(request, response):
+            request.session.flush()
 
         # Simulate a request that ends the session
-        middleware.process_request(request)
-        request.session.flush()
-
-        # Handle the response through the middleware
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(modifier=modifier)
 
         # A cookie should not be set.
         self.assertEqual(response.cookies, {})
@@ -782,12 +757,9 @@ class SessionMiddlewareTests(TestCase):
         response = HttpResponse('Session test')
         middleware = SessionMiddleware()
 
-        # Set a session key and some data.
-        middleware.process_request(request)
-        request.session['foo'] = 'bar'
-        # Handle the response through the middleware.
-        response = middleware.process_response(request, response)
-        self.assertEqual(tuple(request.session.items()), (('foo', 'bar'),))
+        request, response = self.run_middleware()
+
+        self.assertEqual(tuple(request.session.items()), (('hello', 'world'),))
         # A cookie should be set, along with Vary: Cookie.
         self.assertIn(
             'Set-Cookie: sessionid=%s' % request.session.session_key,
@@ -795,11 +767,15 @@ class SessionMiddlewareTests(TestCase):
         )
         self.assertEqual(response['Vary'], 'Cookie')
 
-        # Empty the session data.
-        del request.session['foo']
-        # Handle the response through the middleware.
+        request.COOKIES[settings.SESSION_COOKIE_NAME] = request.session._session_key
+
+        def modifier(request, response):
+            # Empty the session data.
+            del request.session['hello']
+
         response = HttpResponse('Session test')
-        response = middleware.process_response(request, response)
+        request, response = self.run_middleware(request, response, modifier)
+
         self.assertEqual(dict(request.session.values()), {})
         session = Session.objects.get(session_key=request.session.session_key)
         self.assertEqual(session.get_decoded(), {})

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -616,32 +616,33 @@ class CacheSessionTests(SessionTestsMixin, unittest.TestCase):
 
 class SessionMiddlewareTests(TestCase):
 
-
-    def run_middleware(self, request=None, response=None, modifier=None):
-        request = request or RequestFactory().get('/')
-        response = response or HttpResponse('Session Test')
-        middleware = SessionMiddleware()
-
-        def response_factory(request):
-            if modifier:
-                modifier(request, response)
-            else:
-                request.session['hello'] = 'world'
-            return response
-
-        return request, middleware(request, response_factory)
-
     @override_settings(SESSION_COOKIE_SECURE=True)
     def test_secure_session_cookie(self):
-        request, response = self.run_middleware()
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
+        # Simulate a request the modifies the session
+        middleware.process_request(request)
+        request.session['hello'] = 'world'
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['secure'])
 
     @override_settings(SESSION_COOKIE_HTTPONLY=True)
     def test_httponly_session_cookie(self):
-        request, response = self.run_middleware()
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
+        # Simulate a request the modifies the session
+        middleware.process_request(request)
+        request.session['hello'] = 'world'
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
         self.assertTrue(
             response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
         self.assertIn(http_cookies.Morsel._reserved['httponly'],
@@ -649,19 +650,33 @@ class SessionMiddlewareTests(TestCase):
 
     @override_settings(SESSION_COOKIE_HTTPONLY=False)
     def test_no_httponly_session_cookie(self):
-        request, response = self.run_middleware()
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
+        # Simulate a request the modifies the session
+        middleware.process_request(request)
+        request.session['hello'] = 'world'
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
         self.assertFalse(response.cookies[settings.SESSION_COOKIE_NAME]['httponly'])
 
         self.assertNotIn(http_cookies.Morsel._reserved['httponly'],
                          str(response.cookies[settings.SESSION_COOKIE_NAME]))
 
     def test_session_save_on_500(self):
-        def modifier(request, response):
-            request.session['hello'] = 'world'
-            response.status_code = 500
+        request = RequestFactory().get('/')
+        response = HttpResponse('Horrible error')
+        response.status_code = 500
+        middleware = SessionMiddleware()
 
-        request, response = self.run_middleware(modifier=modifier)
+        # Simulate a request the modifies the session
+        middleware.process_request(request)
+        request.session['hello'] = 'world'
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
 
         # Check that the value wasn't saved above.
         self.assertNotIn('hello', request.session.load())
@@ -687,15 +702,18 @@ class SessionMiddlewareTests(TestCase):
 
     def test_session_delete_on_end(self):
         request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        def modifier(request, response):
-            request.session.flush()
-
         # Simulate a request that ends the session
-        request, response = self.run_middleware(request, modifier=modifier)
+        middleware.process_request(request)
+        request.session.flush()
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header looks like:
@@ -712,16 +730,18 @@ class SessionMiddlewareTests(TestCase):
     @override_settings(SESSION_COOKIE_DOMAIN='.example.local')
     def test_session_delete_on_end_with_custom_domain(self):
         request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
         # Before deleting, there has to be an existing cookie
         request.COOKIES[settings.SESSION_COOKIE_NAME] = 'abc'
 
-        def modifier(request, response):
-            request.session.flush()
-
         # Simulate a request that ends the session
-        request, response = self.run_middleware(request, modifier=modifier)
+        middleware.process_request(request)
+        request.session.flush()
 
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
 
         # Check that the cookie was deleted, not recreated.
         # A deleted cookie header with a custom domain looks like:
@@ -737,11 +757,16 @@ class SessionMiddlewareTests(TestCase):
         )
 
     def test_flush_empty_without_session_cookie_doesnt_set_cookie(self):
-        def modifier(request, response):
-            request.session.flush()
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        middleware = SessionMiddleware()
 
         # Simulate a request that ends the session
-        request, response = self.run_middleware(modifier=modifier)
+        middleware.process_request(request)
+        request.session.flush()
+
+        # Handle the response through the middleware
+        response = middleware.process_response(request, response)
 
         # A cookie should not be set.
         self.assertEqual(response.cookies, {})
@@ -757,9 +782,12 @@ class SessionMiddlewareTests(TestCase):
         response = HttpResponse('Session test')
         middleware = SessionMiddleware()
 
-        request, response = self.run_middleware()
-
-        self.assertEqual(tuple(request.session.items()), (('hello', 'world'),))
+        # Set a session key and some data.
+        middleware.process_request(request)
+        request.session['foo'] = 'bar'
+        # Handle the response through the middleware.
+        response = middleware.process_response(request, response)
+        self.assertEqual(tuple(request.session.items()), (('foo', 'bar'),))
         # A cookie should be set, along with Vary: Cookie.
         self.assertIn(
             'Set-Cookie: sessionid=%s' % request.session.session_key,
@@ -767,15 +795,11 @@ class SessionMiddlewareTests(TestCase):
         )
         self.assertEqual(response['Vary'], 'Cookie')
 
-        request.COOKIES[settings.SESSION_COOKIE_NAME] = request.session._session_key
-
-        def modifier(request, response):
-            # Empty the session data.
-            del request.session['hello']
-
+        # Empty the session data.
+        del request.session['foo']
+        # Handle the response through the middleware.
         response = HttpResponse('Session test')
-        request, response = self.run_middleware(request, response, modifier)
-
+        response = middleware.process_response(request, response)
         self.assertEqual(dict(request.session.values()), {})
         session = Session.objects.get(session_key=request.session.session_key)
         self.assertEqual(session.get_decoded(), {})


### PR DESCRIPTION
https://github.com/django/deps/blob/master/draft/0005-rethinking-middleware.rst

- [x] conversion mixin
- [x] handler updates
- [ ] deprecation path
- [ ] tests for handler updates
- [ ] add warning in checks framework if `MIDDLEWARE_CLASSES` and `MIDDLEWARE` are both set
- [ ] update `decorator_from_middleware`
- [ ] convert `SessionMiddleware`
- [ ] convert `AuthenticationMiddleware`
- [ ] convert `XViewMiddleware`
- [ ] convert `CommonMiddleware`
- [ ] convert `BrokenLinkEmailsMiddleware`
- [ ] convert `CsrfViewMiddleware`
- [ ] convert `SecurityMiddleware`
- [ ] convert `MessageMiddleware`
- [ ] convert `XFrameOptionsMiddleware`
- [ ] convert `RemoteUserMiddleware` and `PersistentRemoteUserMiddleware`
- [ ] convert `FlatpageFallbackMiddleware`
- [ ] convert `RedirectFallbackMiddleware`
- [ ] convert `ConditionalGetMiddleware`
- [ ] convert `CurrentSiteMiddleware`
- [ ] convert `UpdateCacheMiddleware`, `FetchFromCacheMiddleware`, and `CacheMiddleware`
- [ ] convert `LocaleMiddleware`
- [ ] convert `GZipMiddleware`
- [ ] documentation
- [ ] document that new-style middleware sees only the changes made by middleware upstream from it, and is skipped entirely if a downstream middleware short-circuits. whereas previously `process_response` would see all responses, even those returned from `process_request` or `process_exception` of other middleware.
- [ ] document that middleware which catches known exception types (e.g. 404 or 403) and converts them to responses, will bypass the usual exception handler systems
- [ ] document that middleware which wants to do something to all (e.g.) 404 responses needs to both catch `Http404` and look for regular 404 responses