### PR TITLE
Refs #25165 -- Removed redundant HTML unescaping in admin related popups.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -5,16 +5,6 @@
 (function($) {
     'use strict';
 
-    function html_unescape(text) {
-        // Unescape a string that was escaped using django.utils.html.escape.
-        text = text.replace(/&lt;/g, '<');
-        text = text.replace(/&gt;/g, '>');
-        text = text.replace(/&quot;/g, '"');
-        text = text.replace(/&#39;/g, "'");
-        text = text.replace(/&amp;/g, '&');
-        return text;
-    }
-
     // IE doesn't accept periods or dashes in the window name, but the element IDs
     // we use to generate popup window names may contain them, therefore we map them
     // to allowed characters in a reversible way so that we can locate the correct
@@ -84,10 +74,6 @@
     }
 
     function dismissAddRelatedObjectPopup(win, newId, newRepr) {
-        // newId and newRepr are expected to have previously been escaped by
-        // django.utils.html.escape.
-        newId = html_unescape(newId);
-        newRepr = html_unescape(newRepr);
         var name = windowname_to_id(win.name);
         var elem = document.getElementById(name);
         if (elem) {
@@ -113,8 +99,6 @@
     }
 
     function dismissChangeRelatedObjectPopup(win, objId, newRepr, newId) {
-        objId = html_unescape(objId);
-        newRepr = html_unescape(newRepr);
         var id = windowname_to_id(win.name).replace(/^edit_/, '');
         var selectsSelector = interpolate('#%s, #%s_from, #%s_to', [id, id, id]);
         var selects = $(selectsSelector);
@@ -128,7 +112,6 @@
     }
 
     function dismissDeleteRelatedObjectPopup(win, objId) {
-        objId = html_unescape(objId);
         var id = windowname_to_id(win.name).replace(/^delete_/, '');
         var selectsSelector = interpolate('#%s, #%s_from, #%s_to', [id, id, id]);
         var selects = $(selectsSelector);
@@ -141,7 +124,6 @@
     }
 
     // Global for testing purposes
-    window.html_unescape = html_unescape;
     window.id_to_windowname = id_to_windowname;
     window.windowname_to_id = windowname_to_id;
 

--- a/js_tests/admin/RelatedObjectLookups.test.js
+++ b/js_tests/admin/RelatedObjectLookups.test.js
@@ -1,20 +1,9 @@
-/* global module, test, html_unescape, id_to_windowname,
+/* global module, test, id_to_windowname,
    windowname_to_id */
 /* eslint global-strict: 0, strict: 0 */
 'use strict';
 
 module('admin.RelatedObjectLookups');
-
-test('html_unescape', function(assert) {
-    function assert_unescape(then, expected, message) {
-        assert.equal(html_unescape(then), expected, message);
-    }
-    assert_unescape('&lt;', '<', 'less thans are unescaped');
-    assert_unescape('&gt;', '>', 'greater thans are unescaped');
-    assert_unescape('&quot;', '"', 'double quotes are unescaped');
-    assert_unescape('&#39;', "'", 'single quotes are unescaped');
-    assert_unescape('&amp;', '&', 'ampersands are unescaped');
-});
 
 test('id_to_windowname', function(assert) {
     assert.equal(id_to_windowname('.test'), '__dot__test');


### PR DESCRIPTION
Because we now load data into the page via JSON, we don't need to
unescape that data anymore.