### PR TITLE
[1.8.x] Fixed #26071 -- Fixed crash with __in lookup in a Case expression.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -92,6 +92,10 @@ class Transform(RegisterLookupMixin):
             bilateral_transforms.append((self.__class__, self.init_lookups))
         return bilateral_transforms
 
+    @cached_property
+    def contains_aggregate(self):
+        return self.lhs.contains_aggregate
+
 
 class Lookup(RegisterLookupMixin):
     lookup_name = None
@@ -193,6 +197,10 @@ class Lookup(RegisterLookupMixin):
 
     def as_sql(self, compiler, connection):
         raise NotImplementedError
+
+    @cached_property
+    def contains_aggregate(self):
+        return self.lhs.contains_aggregate or getattr(self.rhs, 'contains_aggregate', False)
 
 
 class BuiltinLookup(Lookup):

--- a/docs/releases/1.8.9.txt
+++ b/docs/releases/1.8.9.txt
@@ -23,3 +23,6 @@ Bugfixes
   ``db_index=True`` or ``unique=True`` to a ``CharField`` or ``TextField`` that
   already had the other specified, or when removing one of them from a field
   that had both (:ticket:`26034`).
+
+* Fixed a crash when using an ``__in`` lookup inside a ``Case`` expression
+  (:ticket:`26071`).


### PR DESCRIPTION


This commit fixes https://code.djangoproject.com/ticket/26071#ticket for django's 1.8 branch

This changes were being picked from afe0bb7b13bb8dc4370f32225238012c873b0ee3.

This also adds a test for this specific scenario.