### PR TITLE
Fixed #23971 - Allow filtering of None on null date fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -636,6 +636,7 @@ answer newbie questions, and generally made Django that much better:
     ryankanno
     Ryan Kelly <ryan@rfk.id.au>
     Ryan Niemeyer <https://profiles.google.com/ryan.niemeyer/about>
+    Ryno Mathee <rmathee@gmail.com>
     Sam Newman <http://www.magpiebrain.com/>
     Sander Dijkhuis <sander.dijkhuis@gmail.com>
     Sarthak Mehrish <sarthakmeh03@gmail.com>

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -331,6 +331,15 @@ class DateFieldListFilter(FieldListFilter):
                 self.lookup_kwarg_until: str(next_year),
             }),
         )
+        if field.null:
+            self.links += (
+                (_('No date'), {
+                    self.field_generic + 'isnull': str(1),
+                }),
+                (_('Has valid date'), {
+                    self.field_generic + 'isnull': str(0)
+                }),
+            )
         super(DateFieldListFilter, self).__init__(
             field, request, params, model, model_admin, field_path)
 

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -332,19 +332,20 @@ class DateFieldListFilter(FieldListFilter):
             }),
         )
         if field.null:
+            self.lookup_kwarg_isnull = '%s__isnull' % field_path
             self.links += (
                 (_('No date'), {
-                    self.field_generic + 'isnull': str(1),
+                    self.field_generic + 'isnull': u'True'
                 }),
                 (_('Has valid date'), {
-                    self.field_generic + 'isnull': str(0)
+                    self.field_generic + 'isnull': u'False'
                 }),
             )
         super(DateFieldListFilter, self).__init__(
             field, request, params, model, model_admin, field_path)
 
     def expected_parameters(self):
-        return [self.lookup_kwarg_since, self.lookup_kwarg_until]
+        return [self.lookup_kwarg_since, self.lookup_kwarg_until] + ([self.lookup_kwarg_isnull] if self.field.null else [])
 
     def choices(self, changelist):
         for title, param_dict in self.links:

--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -345,7 +345,8 @@ class DateFieldListFilter(FieldListFilter):
             field, request, params, model, model_admin, field_path)
 
     def expected_parameters(self):
-        return [self.lookup_kwarg_since, self.lookup_kwarg_until] + ([self.lookup_kwarg_isnull] if self.field.null else [])
+        return [self.lookup_kwarg_since, self.lookup_kwarg_until] + (
+               [self.lookup_kwarg_isnull] if self.field.null else [])
 
     def choices(self, changelist):
         for title, param_dict in self.links:

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -403,9 +403,7 @@ class ListFiltersTests(TestCase):
             )
         )
 
-        request = self.request_factory.get('/', {
-            'date_registered__isnull': str(1),
-        })
+        request = self.request_factory.get('/', {'date_registered__isnull': True})
         changelist = self.get_changelist(request, Book, modeladmin)
 
         # Make sure the correct queryset is returned
@@ -418,11 +416,9 @@ class ListFiltersTests(TestCase):
         self.assertEqual(force_text(filterspec.title), 'date registered')
         choice = select_by(filterspec.choices(changelist), "display", "No date")
         self.assertEqual(choice['selected'], True)
-        self.assertEqual(choice['query_string'], '?date_registered__isnull=1')
+        self.assertEqual(choice['query_string'], '?date_registered__isnull=True')
 
-        request = self.request_factory.get('/', {
-            'date_registered__isnull': str(0),
-        })
+        request = self.request_factory.get('/', {'date_registered__isnull': False})
         changelist = self.get_changelist(request, Book, modeladmin)
 
         # Make sure the correct queryset is returned
@@ -435,7 +431,7 @@ class ListFiltersTests(TestCase):
         self.assertEqual(force_text(filterspec.title), 'date registered')
         choice = select_by(filterspec.choices(changelist), "display", "Has valid date")
         self.assertEqual(choice['selected'], True)
-        self.assertEqual(choice['query_string'], '?date_registered__isnull=0')
+        self.assertEqual(choice['query_string'], '?date_registered__isnull=False')
 
     @unittest.skipIf(
         sys.platform.startswith('win'),

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -403,6 +403,40 @@ class ListFiltersTests(TestCase):
             )
         )
 
+        request = self.request_factory.get('/', {
+            'date_registered__isnull': str(1),
+        })
+        changelist = self.get_changelist(request, Book, modeladmin)
+
+        # Make sure the correct queryset is returned
+        queryset = changelist.get_queryset(request)
+        self.assertEqual(queryset.count(), 1)
+        self.assertEqual(queryset[0], self.bio_book)
+
+        # Make sure the correct choice is selected
+        filterspec = changelist.get_filters(request)[0][4]
+        self.assertEqual(force_text(filterspec.title), 'date registered')
+        choice = select_by(filterspec.choices(changelist), "display", "No date")
+        self.assertEqual(choice['selected'], True)
+        self.assertEqual(choice['query_string'], '?date_registered__isnull=1')
+
+        request = self.request_factory.get('/', {
+            'date_registered__isnull': str(0),
+        })
+        changelist = self.get_changelist(request, Book, modeladmin)
+
+        # Make sure the correct queryset is returned
+        queryset = changelist.get_queryset(request)
+        self.assertEqual(queryset.count(), 3)
+        self.assertEqual(list(queryset), [self.gipsy_book, self.django_book, self.djangonaut_book])
+
+        # Make sure the correct choice is selected
+        filterspec = changelist.get_filters(request)[0][4]
+        self.assertEqual(force_text(filterspec.title), 'date registered')
+        choice = select_by(filterspec.choices(changelist), "display", "Has valid date")
+        self.assertEqual(choice['selected'], True)
+        self.assertEqual(choice['query_string'], '?date_registered__isnull=0')
+
     @unittest.skipIf(
         sys.platform.startswith('win'),
         "Windows doesn't support setting a timezone that differs from the "


### PR DESCRIPTION
Django doesn't allow use to filter by dates where the date field is null.
Added options for filtering Has validate date and No date, which will only be displayed when the date field is null.