### PR TITLE
Fixed #25848 -- Set template origin on each node.

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -225,6 +225,7 @@ class Template(object):
         tokens = lexer.tokenize()
         parser = Parser(
             tokens, self.engine.template_libraries, self.engine.template_builtins,
+            self.origin,
         )
 
         try:
@@ -445,7 +446,7 @@ class DebugLexer(Lexer):
 
 
 class Parser(object):
-    def __init__(self, tokens, libraries=None, builtins=None):
+    def __init__(self, tokens, libraries=None, builtins=None, origin=None):
         self.tokens = tokens
         self.tags = {}
         self.filters = {}
@@ -459,6 +460,8 @@ class Parser(object):
         self.libraries = libraries
         for builtin in builtins:
             self.add_library(builtin)
+
+        self.origin = origin
 
     def parse(self, parse_until=None):
         """
@@ -535,8 +538,10 @@ class Parser(object):
             )
         if isinstance(nodelist, NodeList) and not isinstance(node, TextNode):
             nodelist.contains_nontext = True
-        # Set token here since we can't modify the node __init__ method
+        # Set origin and token here since we can't modify the node __init__
+        # method
         node.token = token
+        node.origin = self.origin
         nodelist.append(node)
 
     def error(self, token, e):

--- a/docs/releases/1.9.2.txt
+++ b/docs/releases/1.9.2.txt
@@ -71,3 +71,9 @@ Bugfixes
 
 * Fixed a crash when using a reverse ``OneToOneField`` in
   ``ModelAdmin.readonly_fields`` (:ticket:`26060`).
+* Restored the ability for testing and debugging tools to determine the
+  template from which a node came from, even during template inheritance or
+  inclusion. Prior to Django 1.9, debugging tools could access the template
+  origin from the node via ``Node.token.source[0]``. This was an undocumented,
+  private API. The origin is now available directly on each node using the
+  ``Node.origin`` attribute (:ticket:`25848`).

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -140,3 +140,12 @@ class TemplateTests(SimpleTestCase):
         child = engine.from_string(
             '{% extends parent %}{% block content %}child{% endblock %}')
         self.assertEqual(child.render(Context({'parent': parent})), 'child')
+
+    def test_node_origin(self):
+        """
+        #25848 -- Set origin on Node so debugging tools can determine which
+        template the node came from even if extending or including templates.
+        """
+        template = Engine().from_string('content')
+        for node in template.nodelist:
+            self.assertEqual(node.origin, template.origin)


### PR DESCRIPTION
Prior to 55f12f8709, the template origin was available on each node via
`self.token.source[0]`. This behavior was removed when debug handling was
simplified, but 3rd-party debugging tools still depended on it's presence.
This updates the Parser to set origin on individual nodes. This enables the
source template to be determined even when template extending or including is
used.