### PR TITLE
Removed unnecessary NewLine from Textarea From Widget

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -438,7 +438,7 @@ class Textarea(Widget):
         if value is None:
             value = ''
         final_attrs = self.build_attrs(attrs, name=name)
-        return format_html('<textarea{}>\r\n{}</textarea>',
+        return format_html('<textarea{}>{}</textarea>',
                            flatatt(final_attrs),
                            force_text(value))
 


### PR DESCRIPTION
When building a form with Django and using a Textarea Widget, the value rendering is always prepended by a NewLine (`\r\n`).
This makes the textarea never empty when it is, and changes the value for the following submissions.

This commit fixes this behaviour with just a trivial change.

Explanation:

When there is no (or an empty) value defined for the textarea, it shall be rendered as

```html
<textarea></textarea>
```

and not as

```html
<textarea>
</textarea>
```

At least in XHTML5 documents, this is a major difference.

Let's see what happens with a value:

```text
This\nis\na\nvalue
```

This is currently rendered as this:

```html
<textarea>
This
is
a
value</textarea>
```

Which renders in the browser to:

```text
+-------------------------------------------+
|                                           |  <- empty line!
| This                                      |
| is                                        |
| a                                         |
| value                                     |
+-------------------------------------------+
```

After applying my patch, the rendering changes to this:

```html
<textarea>This
is
a
value</textarea>
```

Which (correctly) renders in the browser to:

```text
+-------------------------------------------+
| This                                      |
| is                                        |
| a                                         |
| value                                     |
+-------------------------------------------+
```

As a workaround to get around with the current implementation, I've overridden the `render` method of the original Widget class:

```python
from django import forms
from django.forms.utils import flatatt
from django.utils.encoding import force_text
from django.utils.html import format_html

class FixedTextarea(forms.Textarea):

    def render(self, name, value, attrs=None):
        if value is None:
            value = ''
        final_attrs = self.build_attrs(attrs, name=name)
        return format_html('<textarea{}>{}</textarea>',
                           flatatt(final_attrs),
                           force_text(value))
```