### PR TITLE
Fixed #26094 -- Fixed CSRF behind a proxy (settings.USE_X_FORWARDED_PORT=True).

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -174,7 +174,7 @@ class CsrfViewMiddleware(object):
                     good_referer = request.get_host()
                 else:
                     good_referer = settings.CSRF_COOKIE_DOMAIN
-                    server_port = request.META['SERVER_PORT']
+                    server_port = request.get_port()
                     if server_port not in ('443', '80'):
                         good_referer = '%s:%s' % (good_referer, server_port)
 

--- a/docs/releases/1.9.2.txt
+++ b/docs/releases/1.9.2.txt
@@ -35,3 +35,6 @@ Bugfixes
   using a string model name without an app_label no longer resolved that
   reference to the abstract model's app if using that model in another
   application (:ticket:`25858`).
+  
+* Fixed check of CSRF cookie on POST requests done by ``CsrfViewMiddleware``
+  when request comes via a proxy (:ticket:`26094`).

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -375,6 +375,22 @@ class CsrfViewMiddlewareTest(SimpleTestCase):
         req2 = CsrfViewMiddleware().process_view(req, post_form_view, (), {})
         self.assertIsNone(req2)
 
+    @override_settings(ALLOWED_HOSTS=['www.example.com'], CSRF_COOKIE_DOMAIN='.example.com', USE_X_FORWARDED_PORT=True)
+    def test_https_good_referer_behind_proxy(self):
+        """
+        Test that a POST HTTPS request accessed via proxy is accepted
+        """
+        req = self._get_POST_request_with_token()
+        req._is_secure_override = True
+        req.META['HTTP_HOST'] = '10.0.0.2'
+        req.META['HTTP_REFERER'] = 'https://www.example.com/somepage'
+        req.META['SERVER_PORT'] = '8080'
+        req.META['HTTP_X_FORWARDED_HOST'] = 'www.example.com'
+        req.META['HTTP_X_FORWARDED_PORT'] = '443'
+    
+        req2 = CsrfViewMiddleware().process_view(req, post_form_view, (), {})
+        self.assertIsNone(req2)
+
     @override_settings(ALLOWED_HOSTS=['www.example.com'], CSRF_TRUSTED_ORIGINS=['dashboard.example.com'])
     def test_https_csrf_trusted_origin_allowed(self):
         """


### PR DESCRIPTION
CSRF fails behind proxy because the request.META['SERVER_PORT'] returns the server port and not the real port used by the client to access the server.
Using the method request.get_port() will use HTTP_X_FORWARDED_PORT header if present. (settings.USE_X_FORWARDED_PORT must be enabled)