### PR TITLE
Fixed #26022 -- Cleaned up assertRaises* test assertions.

### DIFF
--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -13,7 +13,6 @@ from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
-from django.utils import six
 from django.utils.encoding import force_text
 
 from .models import Book, Bookmark, Department, Employee, TaggedItem
@@ -818,9 +817,11 @@ class ListFiltersTests(TestCase):
         """
         modeladmin = DecadeFilterBookAdminWithoutTitle(Book, site)
         request = self.request_factory.get('/', {})
-        six.assertRaisesRegex(self, ImproperlyConfigured,
-            "The list filter 'DecadeListFilterWithoutTitle' does not specify a 'title'.",
-            self.get_changelist, request, Book, modeladmin)
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+                "The list filter 'DecadeListFilterWithoutTitle' "
+                "does not specify a 'title'."):
+            self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter_without_parameter(self):
         """
@@ -828,9 +829,11 @@ class ListFiltersTests(TestCase):
         """
         modeladmin = DecadeFilterBookAdminWithoutParameter(Book, site)
         request = self.request_factory.get('/', {})
-        six.assertRaisesRegex(self, ImproperlyConfigured,
-            "The list filter 'DecadeListFilterWithoutParameter' does not specify a 'parameter_name'.",
-            self.get_changelist, request, Book, modeladmin)
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+                "The list filter 'DecadeListFilterWithoutParameter' "
+                "does not specify a 'parameter_name'."):
+            self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter_with_none_returning_lookups(self):
         """

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -817,10 +817,11 @@ class ListFiltersTests(TestCase):
         """
         modeladmin = DecadeFilterBookAdminWithoutTitle(Book, site)
         request = self.request_factory.get('/', {})
-        with self.assertRaisesMessage(
-            ImproperlyConfigured,
-                "The list filter 'DecadeListFilterWithoutTitle' "
-                "does not specify a 'title'."):
+        msg = (
+            "The list filter 'DecadeListFilterWithoutTitle' "
+            "does not specify a 'title'."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter_without_parameter(self):
@@ -829,10 +830,11 @@ class ListFiltersTests(TestCase):
         """
         modeladmin = DecadeFilterBookAdminWithoutParameter(Book, site)
         request = self.request_factory.get('/', {})
-        with self.assertRaisesMessage(
-            ImproperlyConfigured,
-                "The list filter 'DecadeListFilterWithoutParameter' "
-                "does not specify a 'parameter_name'."):
+        msg = (
+            "The list filter 'DecadeListFilterWithoutParameter' "
+            "does not specify a 'parameter_name'."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter_with_none_returning_lookups(self):

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -850,7 +850,8 @@ class ListFiltersTests(TestCase):
         """
         modeladmin = DecadeFilterBookAdminWithFailingQueryset(Book, site)
         request = self.request_factory.get('/', {})
-        self.assertRaises(ZeroDivisionError, self.get_changelist, request, Book, modeladmin)
+        with self.assertRaises(ZeroDivisionError):
+            self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter_with_queryset_based_lookups(self):
         modeladmin = DecadeFilterBookAdminWithQuerysetBasedLookups(Book, site)

--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -127,12 +127,12 @@ class TestRegistrationDecorator(SimpleTestCase):
         self.default_site.unregister(Place)
 
     def test_wrapped_class_not_a_model_admin(self):
-        self.assertRaisesMessage(ValueError, 'Wrapped class must subclass ModelAdmin.',
-            register(Person), CustomSite)
+        with self.assertRaisesMessage(ValueError, 'Wrapped class must subclass ModelAdmin.'):
+            register(Person)(CustomSite)
 
     def test_custom_site_not_an_admin_site(self):
-        self.assertRaisesMessage(ValueError, 'site must subclass AdminSite',
-            register(Person, site=Traveler), NameAdmin)
+        with self.assertRaisesMessage(ValueError, 'site must subclass AdminSite'):
+            register(Person, site=Traveler)(NameAdmin)
 
     def test_empty_models_list_registration_fails(self):
         with self.assertRaisesMessage(ValueError, 'At least one model must be passed to register.'):

--- a/tests/admin_registration/tests.py
+++ b/tests/admin_registration/tests.py
@@ -36,9 +36,8 @@ class TestRegistration(SimpleTestCase):
 
     def test_prevent_double_registration(self):
         self.site.register(Person)
-        self.assertRaises(admin.sites.AlreadyRegistered,
-                          self.site.register,
-                          Person)
+        with self.assertRaises(admin.sites.AlreadyRegistered):
+            self.site.register(Person)
 
     def test_registration_with_star_star_options(self):
         self.site.register(Person, search_fields=['name'])
@@ -68,7 +67,8 @@ class TestRegistration(SimpleTestCase):
         Exception is raised when trying to register an abstract model.
         Refs #12004.
         """
-        self.assertRaises(ImproperlyConfigured, self.site.register, Location)
+        with self.assertRaises(ImproperlyConfigured):
+            self.site.register(Location)
 
     def test_is_registered_model(self):
         "Checks for registered models should return true."

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -220,10 +220,8 @@ class UtilsTests(SimpleTestCase):
             str("article")
         )
 
-        self.assertRaises(
-            AttributeError,
-            lambda: label_for_field("unknown", Article)
-        )
+        with self.assertRaises(AttributeError):
+            label_for_field("unknown", Article)
 
         def test_callable(obj):
             return "nothing"

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -906,7 +906,10 @@ class AggregateTestCase(TestCase):
         self.assertEqual(book['price_sum'], Decimal("99999.80"))
 
     def test_nonaggregate_aggregation_throws(self):
-        with self.assertRaisesMessage(TypeError, 'fail is not an aggregate expression'):
+        with self.assertRaisesMessage(
+            TypeError,
+            'fail is not an aggregate expression'
+        ):
             Book.objects.aggregate(fail=F('price'))
 
     def test_nonfield_annotation(self):
@@ -918,7 +921,10 @@ class AggregateTestCase(TestCase):
         self.assertEqual(book.val, 2)
 
     def test_missing_output_field_raises_error(self):
-        with self.assertRaisesMessage(FieldError, 'Cannot resolve expression type, unknown output_field'):
+        with self.assertRaisesMessage(
+            FieldError,
+            'Cannot resolve expression type, unknown output_field'
+        ):
             Book.objects.annotate(val=Max(2)).first()
 
     def test_annotation_expressions(self):
@@ -962,7 +968,10 @@ class AggregateTestCase(TestCase):
         self.assertEqual(p2, {'avg_price': Approximate(53.39, places=2)})
 
     def test_combine_different_types(self):
-        with self.assertRaisesMessage(FieldError, 'Expression contains mixed types. You must set output_field'):
+        with self.assertRaisesMessage(
+            FieldError,
+            'Expression contains mixed types. You must set output_field'
+        ):
             Book.objects.annotate(sums=Sum('rating') + Sum('pages') + Sum('price')).get(pk=self.b4.pk)
 
         b1 = Book.objects.annotate(sums=Sum(F('rating') + F('pages') + F('price'),
@@ -1079,7 +1088,10 @@ class AggregateTestCase(TestCase):
         self.assertEqual(author.sum_age, other_author.sum_age)
 
     def test_annotated_aggregate_over_annotated_aggregate(self):
-        with self.assertRaisesMessage(FieldError, "Cannot compute Sum('id__max'): 'id__max' is an aggregate"):
+        with self.assertRaisesMessage(
+            FieldError,
+            "Cannot compute Sum('id__max'): 'id__max' is an aggregate"
+        ):
             Book.objects.annotate(Max('id')).annotate(Sum('id__max'))
 
         class MyMax(Max):
@@ -1087,7 +1099,10 @@ class AggregateTestCase(TestCase):
                 self.set_source_expressions(self.get_source_expressions()[0:1])
                 return super(MyMax, self).as_sql(compiler, connection)
 
-        with self.assertRaisesMessage(FieldError, "Cannot compute Max('id__max'): 'id__max' is an aggregate"):
+        with self.assertRaisesMessage(
+            FieldError,
+            "Cannot compute Max('id__max'): 'id__max' is an aggregate"
+        ):
             Book.objects.annotate(Max('id')).annotate(my_max=MyMax('id__max', 'price'))
 
     def test_multi_arg_aggregate(self):

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -12,7 +12,7 @@ from django.db.models import (
 )
 from django.test import TestCase
 from django.test.utils import Approximate, CaptureQueriesContext
-from django.utils import six, timezone
+from django.utils import timezone
 
 from .models import Author, Book, Publisher, Store
 
@@ -906,7 +906,7 @@ class AggregateTestCase(TestCase):
         self.assertEqual(book['price_sum'], Decimal("99999.80"))
 
     def test_nonaggregate_aggregation_throws(self):
-        with six.assertRaisesRegex(self, TypeError, 'fail is not an aggregate expression'):
+        with self.assertRaisesMessage(TypeError, 'fail is not an aggregate expression'):
             Book.objects.aggregate(fail=F('price'))
 
     def test_nonfield_annotation(self):
@@ -918,7 +918,7 @@ class AggregateTestCase(TestCase):
         self.assertEqual(book.val, 2)
 
     def test_missing_output_field_raises_error(self):
-        with six.assertRaisesRegex(self, FieldError, 'Cannot resolve expression type, unknown output_field'):
+        with self.assertRaisesMessage(FieldError, 'Cannot resolve expression type, unknown output_field'):
             Book.objects.annotate(val=Max(2)).first()
 
     def test_annotation_expressions(self):
@@ -962,7 +962,7 @@ class AggregateTestCase(TestCase):
         self.assertEqual(p2, {'avg_price': Approximate(53.39, places=2)})
 
     def test_combine_different_types(self):
-        with six.assertRaisesRegex(self, FieldError, 'Expression contains mixed types. You must set output_field'):
+        with self.assertRaisesMessage(FieldError, 'Expression contains mixed types. You must set output_field'):
             Book.objects.annotate(sums=Sum('rating') + Sum('pages') + Sum('price')).get(pk=self.b4.pk)
 
         b1 = Book.objects.annotate(sums=Sum(F('rating') + F('pages') + F('price'),
@@ -978,11 +978,11 @@ class AggregateTestCase(TestCase):
         self.assertEqual(b3.sums, Approximate(Decimal("383.69"), places=2))
 
     def test_complex_aggregations_require_kwarg(self):
-        with six.assertRaisesRegex(self, TypeError, 'Complex annotations require an alias'):
+        with self.assertRaisesMessage(TypeError, 'Complex annotations require an alias'):
             Author.objects.annotate(Sum(F('age') + F('friends__age')))
-        with six.assertRaisesRegex(self, TypeError, 'Complex aggregates require an alias'):
+        with self.assertRaisesMessage(TypeError, 'Complex aggregates require an alias'):
             Author.objects.aggregate(Sum('age') / Count('age'))
-        with six.assertRaisesRegex(self, TypeError, 'Complex aggregates require an alias'):
+        with self.assertRaisesMessage(TypeError, 'Complex aggregates require an alias'):
             Author.objects.aggregate(Sum(1))
 
     def test_aggregate_over_complex_annotation(self):

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -376,20 +376,14 @@ class AggregationTests(TestCase):
 
     def test_field_error(self):
         # Bad field requests in aggregates are caught and reported
-        self.assertRaises(
-            FieldError,
-            lambda: Book.objects.all().aggregate(num_authors=Count('foo'))
-        )
+        with self.assertRaises(FieldError):
+            Book.objects.all().aggregate(num_authors=Count('foo'))
 
-        self.assertRaises(
-            FieldError,
-            lambda: Book.objects.all().annotate(num_authors=Count('foo'))
-        )
+        with self.assertRaises(FieldError):
+            Book.objects.all().annotate(num_authors=Count('foo'))
 
-        self.assertRaises(
-            FieldError,
-            lambda: Book.objects.all().annotate(num_authors=Count('authors__id')).aggregate(Max('foo'))
-        )
+        with self.assertRaises(FieldError):
+            Book.objects.all().annotate(num_authors=Count('authors__id')).aggregate(Max('foo'))
 
     def test_more(self):
         # Old-style count aggregations can be mixed with new-style
@@ -698,21 +692,22 @@ class AggregationTests(TestCase):
 
     def test_duplicate_alias(self):
         # Regression for #11256 - duplicating a default alias raises ValueError.
-        self.assertRaises(
-            ValueError,
-            Book.objects.all().annotate,
-            Avg('authors__age'), authors__age__avg=Avg('authors__age')
-        )
+        with self.assertRaises(ValueError):
+            Book.objects.all().annotate(Avg('authors__age'),
+                authors__age__avg=Avg('authors__age')
+            )
 
     def test_field_name_conflict(self):
         # Regression for #11256 - providing an aggregate name
         # that conflicts with a field name on the model raises ValueError
-        self.assertRaises(ValueError, Author.objects.annotate, age=Avg('friends__age'))
+        with self.assertRaises(ValueError):
+            Author.objects.annotate(age=Avg('friends__age'))
 
     def test_m2m_name_conflict(self):
         # Regression for #11256 - providing an aggregate name
         # that conflicts with an m2m name on the model raises ValueError
-        self.assertRaises(ValueError, Author.objects.annotate, friends=Count('friends'))
+        with self.assertRaises(ValueError):
+            Author.objects.annotate(friends=Count('friends'))
 
     def test_values_queryset_non_conflict(self):
         # Regression for #14707 -- If you're using a values query set, some potential conflicts are avoided.
@@ -739,7 +734,8 @@ class AggregationTests(TestCase):
     def test_reverse_relation_name_conflict(self):
         # Regression for #11256 - providing an aggregate name
         # that conflicts with a reverse-related name on the model raises ValueError
-        self.assertRaises(ValueError, Author.objects.annotate, book_contact_set=Avg('friends__age'))
+        with self.assertRaises(ValueError):
+            Author.objects.annotate(book_contact_set=Avg('friends__age'))
 
     def test_pickle(self):
         # Regression for #10197 -- Queries with aggregates can be pickled.
@@ -900,10 +896,8 @@ class AggregationTests(TestCase):
 
         # Regression for #10766 - Shouldn't be able to reference an aggregate
         # fields in an aggregate() call.
-        self.assertRaises(
-            FieldError,
-            lambda: Book.objects.annotate(mean_age=Avg('authors__age')).annotate(Avg('mean_age'))
-        )
+        with self.assertRaises(FieldError):
+            Book.objects.annotate(mean_age=Avg('authors__age')).annotate(Avg('mean_age'))
 
     def test_empty_filter_count(self):
         self.assertEqual(

--- a/tests/app_loading/tests.py
+++ b/tests/app_loading/tests.py
@@ -5,7 +5,6 @@ import os
 from django.apps import apps
 from django.test import SimpleTestCase
 from django.test.utils import extend_sys_path
-from django.utils import six
 from django.utils._os import upath
 
 
@@ -57,7 +56,7 @@ class EggLoadingTest(SimpleTestCase):
         """Loading an app from an egg that has an import error in its models module raises that error"""
         egg_name = '%s/brokenapp.egg' % self.egg_dir
         with extend_sys_path(egg_name):
-            with six.assertRaisesRegex(self, ImportError, 'modelz'):
+            with self.assertRaisesMessage(ImportError, 'modelz'):
                 with self.settings(INSTALLED_APPS=['broken_app']):
                     pass
 

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -159,12 +159,12 @@ class AppsTests(SimpleTestCase):
         self.assertEqual(apps.get_app_config('relabeled').name, 'apps')
 
     def test_duplicate_labels(self):
-        with six.assertRaisesRegex(self, ImproperlyConfigured, "Application labels aren't unique"):
+        with self.assertRaisesMessage(ImproperlyConfigured, "Application labels aren't unique"):
             with self.settings(INSTALLED_APPS=['apps.apps.PlainAppsConfig', 'apps']):
                 pass
 
     def test_duplicate_names(self):
-        with six.assertRaisesRegex(self, ImproperlyConfigured, "Application names aren't unique"):
+        with self.assertRaisesMessage(ImproperlyConfigured, "Application names aren't unique"):
             with self.settings(INSTALLED_APPS=['apps.apps.RelabeledAppsConfig', 'apps']):
                 pass
 
@@ -172,7 +172,7 @@ class AppsTests(SimpleTestCase):
         """
         App discovery should preserve stack traces. Regression test for #22920.
         """
-        with six.assertRaisesRegex(self, ImportError, "Oops"):
+        with self.assertRaisesMessage(ImportError, "Oops"):
             with self.settings(INSTALLED_APPS=['import_error_package']):
                 pass
 

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -429,7 +429,8 @@ class NoBackendsTest(TestCase):
         self.user = User.objects.create_user('test', 'test@example.com', 'test')
 
     def test_raises_exception(self):
-        self.assertRaises(ImproperlyConfigured, self.user.has_perm, ('perm', TestObj(),))
+        with self.assertRaises(ImproperlyConfigured):
+            self.user.has_perm(('perm', TestObj(),))
 
 
 @override_settings(AUTHENTICATION_BACKENDS=['auth_tests.test_auth_backends.SimpleRowlevelBackend'])
@@ -575,7 +576,8 @@ class TypeErrorBackendTest(TestCase):
 
     @override_settings(AUTHENTICATION_BACKENDS=[backend])
     def test_type_error_raised(self):
-        self.assertRaises(TypeError, authenticate, username='test', password='test')
+        with self.assertRaises(TypeError):
+            authenticate(username='test', password='test')
 
 
 class ImproperlyConfiguredUserModelTest(TestCase):
@@ -598,7 +600,8 @@ class ImproperlyConfiguredUserModelTest(TestCase):
         request = HttpRequest()
         request.session = self.client.session
 
-        self.assertRaises(ImproperlyConfigured, get_user, request)
+        with self.assertRaises(ImproperlyConfigured):
+            get_user(request)
 
 
 class ImportedModelBackend(ModelBackend):

--- a/tests/auth_tests/test_decorators.py
+++ b/tests/auth_tests/test_decorators.py
@@ -115,4 +115,5 @@ class PermissionsRequiredDecoratorTest(TestCase):
             return HttpResponse()
         request = self.factory.get('/rand')
         request.user = self.user
-        self.assertRaises(PermissionDenied, a_view, request)
+        with self.assertRaises(PermissionDenied):
+            a_view(request)

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -219,7 +219,8 @@ class TestUtilsHashPass(SimpleTestCase):
         self.assertFalse(check_password('', encoded))
         self.assertFalse(check_password('lètmein', encoded))
         self.assertFalse(check_password('lètmeinz', encoded))
-        self.assertRaises(ValueError, identify_hasher, encoded)
+        with self.assertRaises(ValueError):
+            identify_hasher(encoded)
         # Assert that the unusable passwords actually contain a random part.
         # This might fail one day due to a hash collision.
         self.assertNotEqual(encoded, make_password(None), "Random password collision?")
@@ -234,7 +235,8 @@ class TestUtilsHashPass(SimpleTestCase):
     def test_bad_algorithm(self):
         with self.assertRaises(ValueError):
             make_password('lètmein', hasher='lolcat')
-        self.assertRaises(ValueError, identify_hasher, "lolcat$salt$hash")
+        with self.assertRaises(ValueError):
+            identify_hasher("lolcat$salt$hash")
 
     def test_bad_encoded(self):
         self.assertFalse(is_password_usable('lètmein_badencoded'))

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -659,10 +659,11 @@ class PermissionTestCase(TestCase):
         # check duplicated default permission
         models.Permission._meta.permissions = [
             ('change_permission', 'Can edit permission (duplicate)')]
-        six.assertRaisesRegex(self, CommandError,
-            "The permission codename 'change_permission' clashes with a "
-            "builtin permission for model 'auth.Permission'.",
-            create_permissions, auth_app_config, verbosity=0)
+        with self.assertRaisesMessage(
+            CommandError,
+                "The permission codename 'change_permission' clashes with a "
+                "builtin permission for model 'auth.Permission'."):
+            create_permissions(auth_app_config, verbosity=0)
 
         # check duplicated custom permissions
         models.Permission._meta.permissions = [
@@ -670,10 +671,11 @@ class PermissionTestCase(TestCase):
             ('other_one', 'Some other permission'),
             ('my_custom_permission', 'Some permission with duplicate permission code'),
         ]
-        six.assertRaisesRegex(self, CommandError,
-            "The permission codename 'my_custom_permission' is duplicated for model "
-            "'auth.Permission'.",
-            create_permissions, auth_app_config, verbosity=0)
+        with self.assertRaisesMessage(
+            CommandError,
+                "The permission codename 'my_custom_permission' is duplicated for model "
+                "'auth.Permission'."):
+            create_permissions(auth_app_config, verbosity=0)
 
         # should not raise anything
         models.Permission._meta.permissions = [
@@ -712,9 +714,10 @@ class PermissionTestCase(TestCase):
         models.Permission.objects.filter(content_type=permission_content_type).delete()
         models.Permission._meta.verbose_name = "some ridiculously long verbose name that is out of control" * 5
 
-        six.assertRaisesRegex(self, exceptions.ValidationError,
-            "The verbose_name of auth.permission is longer than 244 characters",
-            create_permissions, auth_app_config, verbosity=0)
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+                "The verbose_name of auth.permission is longer than 244 characters"):
+            create_permissions(auth_app_config, verbosity=0)
 
     def test_custom_permission_name_length(self):
         auth_app_config = apps.get_app_config('auth')

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -426,8 +426,10 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
         self.assertEqual(u.group, group)
 
         non_existent_email = 'mymail2@gmail.com'
-        with self.assertRaisesMessage(CommandError,
-                'email instance with email %r does not exist.' % non_existent_email):
+        with self.assertRaisesMessage(
+            CommandError,
+            'email instance with email %r does not exist.' % non_existent_email
+        ):
             call_command(
                 'createsuperuser',
                 interactive=False,
@@ -659,10 +661,11 @@ class PermissionTestCase(TestCase):
         # check duplicated default permission
         models.Permission._meta.permissions = [
             ('change_permission', 'Can edit permission (duplicate)')]
-        with self.assertRaisesMessage(
-            CommandError,
-                "The permission codename 'change_permission' clashes with a "
-                "builtin permission for model 'auth.Permission'."):
+        msg = (
+            "The permission codename 'change_permission' clashes with a "
+            "builtin permission for model 'auth.Permission'."
+        )
+        with self.assertRaisesMessage(CommandError, msg):
             create_permissions(auth_app_config, verbosity=0)
 
         # check duplicated custom permissions
@@ -671,10 +674,11 @@ class PermissionTestCase(TestCase):
             ('other_one', 'Some other permission'),
             ('my_custom_permission', 'Some permission with duplicate permission code'),
         ]
-        with self.assertRaisesMessage(
-            CommandError,
-                "The permission codename 'my_custom_permission' is duplicated for model "
-                "'auth.Permission'."):
+        msg = (
+            "The permission codename 'my_custom_permission' is duplicated for model "
+            "'auth.Permission'."
+        )
+        with self.assertRaisesMessage(CommandError, msg):
             create_permissions(auth_app_config, verbosity=0)
 
         # should not raise anything
@@ -716,7 +720,8 @@ class PermissionTestCase(TestCase):
 
         with self.assertRaisesMessage(
             exceptions.ValidationError,
-                "The verbose_name of auth.permission is longer than 244 characters"):
+            "The verbose_name of auth.permission is longer than 244 characters"
+        ):
             create_permissions(auth_app_config, verbosity=0)
 
     def test_custom_permission_name_length(self):

--- a/tests/auth_tests/test_mixins.py
+++ b/tests/auth_tests/test_mixins.py
@@ -135,7 +135,8 @@ class UserPassesTestTests(TestCase):
 
         request = self.factory.get('/rand')
         request.user = AnonymousUser()
-        self.assertRaises(PermissionDenied, AView.as_view(), request)
+        with self.assertRaises(PermissionDenied):
+            AView.as_view()(request)
 
     def test_raise_exception_custom_message(self):
         msg = "You don't have access here"
@@ -248,4 +249,5 @@ class PermissionsRequiredMixinTests(TestCase):
 
         request = self.factory.get('/rand')
         request.user = self.user
-        self.assertRaises(PermissionDenied, AView.as_view(), request)
+        with self.assertRaises(PermissionDenied):
+            AView.as_view()(request)

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -161,11 +161,8 @@ class UserManagerTestCase(TestCase):
         self.assertEqual(returned, 'email\ with_whitespace@d.com')
 
     def test_empty_username(self):
-        self.assertRaisesMessage(
-            ValueError,
-            'The given username must be set',
-            User.objects.create_user, username=''
-        )
+        with self.assertRaisesMessage(ValueError, 'The given username must be set'):
+            User.objects.create_user(username='')
 
     def test_create_user_is_staff(self):
         email = 'normal@normal.com'

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -63,6 +63,5 @@ class TokenGeneratorTest(TestCase):
         p0 = PasswordResetTokenGenerator()
 
         # This will put a 14-digit base36 timestamp into the token, which is too large.
-        self.assertRaises(ValueError,
-                          p0._make_token_with_timestamp,
-                          user, 175455491841851871349)
+        with self.assertRaises(ValueError):
+            p0._make_token_with_timestamp(user, 175455491841851871349)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -128,19 +128,15 @@ class SQLiteTests(TestCase):
         #19360: Raise NotImplementedError when aggregating on date/time fields.
         """
         for aggregate in (Sum, Avg, Variance, StdDev):
-            self.assertRaises(
-                NotImplementedError,
-                models.Item.objects.all().aggregate, aggregate('time'))
-            self.assertRaises(
-                NotImplementedError,
-                models.Item.objects.all().aggregate, aggregate('date'))
-            self.assertRaises(
-                NotImplementedError,
-                models.Item.objects.all().aggregate, aggregate('last_modified'))
-            self.assertRaises(
-                NotImplementedError,
-                models.Item.objects.all().aggregate,
-                **{'complex': aggregate('last_modified') + aggregate('last_modified')})
+            with self.assertRaises(NotImplementedError):
+                models.Item.objects.all().aggregate(aggregate('time'))
+            with self.assertRaises(NotImplementedError):
+                models.Item.objects.all().aggregate(aggregate('date'))
+            with self.assertRaises(NotImplementedError):
+                models.Item.objects.all().aggregate(aggregate('last_modified'))
+            with self.assertRaises(NotImplementedError):
+                models.Item.objects.all().aggregate(
+                    **{'complex': aggregate('last_modified') + aggregate('last_modified')})
 
     def test_memory_db_test_name(self):
         """
@@ -437,8 +433,10 @@ class ParameterHandlingTest(TestCase):
             connection.ops.quote_name('root'),
             connection.ops.quote_name('square')
         ))
-        self.assertRaises(Exception, cursor.executemany, query, [(1, 2, 3)])
-        self.assertRaises(Exception, cursor.executemany, query, [(1,)])
+        with self.assertRaises(Exception):
+            cursor.executemany(query, [(1, 2, 3)])
+        with self.assertRaises(Exception):
+            cursor.executemany(query, [(1,)])
 
 
 # Unfortunately, the following tests would be a good test to run on all
@@ -847,7 +845,8 @@ class FkConstraintsTests(TransactionTestCase):
         a2 = models.Article(headline='This is another test', reporter=self.r,
                             pub_date=datetime.datetime(2012, 8, 3),
                             reporter_proxy_id=30)
-        self.assertRaises(IntegrityError, a2.save)
+        with self.assertRaises(IntegrityError):
+            a2.save()
 
     def test_integrity_checks_on_update(self):
         """
@@ -875,7 +874,8 @@ class FkConstraintsTests(TransactionTestCase):
         # Retrieve the second article from the DB
         a2 = models.Article.objects.get(headline='Another article')
         a2.reporter_proxy_id = 30
-        self.assertRaises(IntegrityError, a2.save)
+        with self.assertRaises(IntegrityError):
+            a2.save()
 
     def test_disable_constraint_checks_manually(self):
         """

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -1188,11 +1188,9 @@ class BackendUtilTests(SimpleTestCase):
         equal('123.12', 5, None,
               '123.12')
         with self.assertRaises(Rounded):
-            equal('0.1234567890', 5, None,
-                  '0.12346')
+            equal('0.1234567890', 5, None, '0.12346')
         with self.assertRaises(Rounded):
-            equal('1234567890.1234', 5, None,
-                  '1234600000')
+            equal('1234567890.1234', 5, None, '1234600000')
 
 
 @unittest.skipUnless(connection.vendor == 'sqlite', 'SQLite specific test.')

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -71,7 +71,8 @@ class ModelInstanceCreationTests(TestCase):
     def test_cannot_create_instance_with_invalid_kwargs(self):
         with self.assertRaisesMessage(
             TypeError,
-                "'foo' is an invalid keyword argument for this function"):
+            "'foo' is an invalid keyword argument for this function"
+        ):
             Article(
                 id=None,
                 headline='Some headline',
@@ -143,7 +144,8 @@ class ModelTest(TestCase):
     def test_objects_attribute_is_only_available_on_the_class_itself(self):
         with self.assertRaisesMessage(
             AttributeError,
-                "Manager isn't accessible via Article instances"):
+            "Manager isn't accessible via Article instances"
+        ):
             getattr(Article(), "objects",)
         self.assertFalse(hasattr(Article(), 'objects'))
         self.assertTrue(hasattr(Article, 'objects'))
@@ -485,7 +487,8 @@ class ModelLookupTest(TestCase):
         # parameters don't match any object.
         with self.assertRaisesMessage(
             ObjectDoesNotExist,
-                "Article matching query does not exist."):
+            "Article matching query does not exist."
+        ):
             Article.objects.get(id__exact=2000,)
         # To avoid dict-ordering related errors check only one lookup
         # in single assert.
@@ -493,7 +496,8 @@ class ModelLookupTest(TestCase):
             Article.objects.get(pub_date__year=2005, pub_date__month=8)
         with self.assertRaisesMessage(
             ObjectDoesNotExist,
-                "Article matching query does not exist."):
+            "Article matching query does not exist."
+        ):
             Article.objects.get(pub_date__week_day=6,)
 
     def test_lookup_by_primary_key(self):
@@ -526,15 +530,18 @@ class ModelLookupTest(TestCase):
         # lookup matches more than one object
         with self.assertRaisesMessage(
             MultipleObjectsReturned,
-                "get() returned more than one Article -- it returned 2!"):
+            "get() returned more than one Article -- it returned 2!"
+        ):
             Article.objects.get(headline__startswith='Swallow',)
         with self.assertRaisesMessage(
             MultipleObjectsReturned,
-                "get() returned more than one Article -- it returned 2!"):
+            "get() returned more than one Article -- it returned 2!"
+        ):
             Article.objects.get(pub_date__year=2005,)
         with self.assertRaisesMessage(
             MultipleObjectsReturned,
-                "get() returned more than one Article -- it returned 2!"):
+            "get() returned more than one Article -- it returned 2!"
+        ):
             Article.objects.get(
                 pub_date__year=2005,
                 pub_date__month=7,

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -498,12 +498,8 @@ class ModelLookupTest(TestCase):
         )
         # To avoid dict-ordering related errors check only one lookup
         # in single assert.
-        self.assertRaises(
-            ObjectDoesNotExist,
-            Article.objects.get,
-            pub_date__year=2005,
-            pub_date__month=8,
-        )
+        with self.assertRaises(ObjectDoesNotExist):
+            Article.objects.get(pub_date__year=2005, pub_date__month=8)
         six.assertRaisesRegex(
             self,
             ObjectDoesNotExist,

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -12,7 +12,6 @@ from django.test import (
     SimpleTestCase, TestCase, TransactionTestCase, skipIfDBFeature,
     skipUnlessDBFeature,
 )
-from django.utils import six
 from django.utils.translation import ugettext_lazy
 
 from .models import Article, ArticleSelectOnSave, SelfRef
@@ -70,16 +69,15 @@ class ModelInstanceCreationTests(TestCase):
         self.assertEqual(a.headline, 'Fourth article')
 
     def test_cannot_create_instance_with_invalid_kwargs(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             TypeError,
-            "'foo' is an invalid keyword argument for this function",
-            Article,
-            id=None,
-            headline='Some headline',
-            pub_date=datetime(2005, 7, 31),
-            foo='bar',
-        )
+                "'foo' is an invalid keyword argument for this function"):
+            Article(
+                id=None,
+                headline='Some headline',
+                pub_date=datetime(2005, 7, 31),
+                foo='bar',
+            )
 
     def test_can_leave_off_value_for_autofield_and_it_gets_value_on_save(self):
         """
@@ -143,14 +141,10 @@ class ModelInstanceCreationTests(TestCase):
 
 class ModelTest(TestCase):
     def test_objects_attribute_is_only_available_on_the_class_itself(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AttributeError,
-            "Manager isn't accessible via Article instances",
-            getattr,
-            Article(),
-            "objects",
-        )
+                "Manager isn't accessible via Article instances"):
+            getattr(Article(), "objects",)
         self.assertFalse(hasattr(Article(), 'objects'))
         self.assertTrue(hasattr(Article, 'objects'))
 
@@ -489,24 +483,18 @@ class ModelLookupTest(TestCase):
     def test_does_not_exist(self):
         # Django raises an Article.DoesNotExist exception for get() if the
         # parameters don't match any object.
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             ObjectDoesNotExist,
-            "Article matching query does not exist.",
-            Article.objects.get,
-            id__exact=2000,
-        )
+                "Article matching query does not exist."):
+            Article.objects.get(id__exact=2000,)
         # To avoid dict-ordering related errors check only one lookup
         # in single assert.
         with self.assertRaises(ObjectDoesNotExist):
             Article.objects.get(pub_date__year=2005, pub_date__month=8)
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             ObjectDoesNotExist,
-            "Article matching query does not exist.",
-            Article.objects.get,
-            pub_date__week_day=6,
-        )
+                "Article matching query does not exist."):
+            Article.objects.get(pub_date__week_day=6,)
 
     def test_lookup_by_primary_key(self):
         # Lookup by a primary key is the most common case, so Django
@@ -536,28 +524,21 @@ class ModelLookupTest(TestCase):
 
         # Django raises an Article.MultipleObjectsReturned exception if the
         # lookup matches more than one object
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
-            Article.objects.get,
-            headline__startswith='Swallow',
-        )
-        six.assertRaisesRegex(
-            self,
+                "get() returned more than one Article -- it returned 2!"):
+            Article.objects.get(headline__startswith='Swallow',)
+        with self.assertRaisesMessage(
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
-            Article.objects.get,
-            pub_date__year=2005,
-        )
-        six.assertRaisesRegex(
-            self,
+                "get() returned more than one Article -- it returned 2!"):
+            Article.objects.get(pub_date__year=2005,)
+        with self.assertRaisesMessage(
             MultipleObjectsReturned,
-            "get\(\) returned more than one Article -- it returned 2!",
-            Article.objects.get,
-            pub_date__year=2005,
-            pub_date__month=7,
-        )
+                "get() returned more than one Article -- it returned 2!"):
+            Article.objects.get(
+                pub_date__year=2005,
+                pub_date__month=7,
+            )
 
 
 class ConcurrentSaveTests(TransactionTestCase):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -129,14 +129,18 @@ class DummyCacheTests(SimpleTestCase):
     def test_incr(self):
         "Dummy cache values can't be incremented"
         cache.set('answer', 42)
-        self.assertRaises(ValueError, cache.incr, 'answer')
-        self.assertRaises(ValueError, cache.incr, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr('answer')
+        with self.assertRaises(ValueError):
+            cache.incr('does_not_exist')
 
     def test_decr(self):
         "Dummy cache values can't be decremented"
         cache.set('answer', 42)
-        self.assertRaises(ValueError, cache.decr, 'answer')
-        self.assertRaises(ValueError, cache.decr, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.decr('answer')
+        with self.assertRaises(ValueError):
+            cache.decr('does_not_exist')
 
     def test_data_types(self):
         "All data types are ignored equally by the dummy cache"
@@ -193,14 +197,18 @@ class DummyCacheTests(SimpleTestCase):
     def test_incr_version(self):
         "Dummy cache versions can't be incremented"
         cache.set('answer', 42)
-        self.assertRaises(ValueError, cache.incr_version, 'answer')
-        self.assertRaises(ValueError, cache.incr_version, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr_version('answer')
+        with self.assertRaises(ValueError):
+            cache.incr_version('does_not_exist')
 
     def test_decr_version(self):
         "Dummy cache versions can't be decremented"
         cache.set('answer', 42)
-        self.assertRaises(ValueError, cache.decr_version, 'answer')
-        self.assertRaises(ValueError, cache.decr_version, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.decr_version('answer')
+        with self.assertRaises(ValueError):
+            cache.decr_version('does_not_exist')
 
     def test_get_or_set(self):
         self.assertEqual(cache.get_or_set('mykey', 'default'), 'default')
@@ -321,7 +329,8 @@ class BaseCacheTests(object):
         self.assertEqual(cache.incr('answer', 10), 52)
         self.assertEqual(cache.get('answer'), 52)
         self.assertEqual(cache.incr('answer', -10), 42)
-        self.assertRaises(ValueError, cache.incr, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr('does_not_exist')
 
     def test_decr(self):
         # Cache values can be decremented
@@ -331,7 +340,8 @@ class BaseCacheTests(object):
         self.assertEqual(cache.decr('answer', 10), 32)
         self.assertEqual(cache.get('answer'), 32)
         self.assertEqual(cache.decr('answer', -10), 42)
-        self.assertRaises(ValueError, cache.decr, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.decr('does_not_exist')
 
     def test_close(self):
         self.assertTrue(hasattr(cache, 'close'))
@@ -821,7 +831,8 @@ class BaseCacheTests(object):
         self.assertIsNone(caches['v2'].get('answer2', version=2))
         self.assertEqual(caches['v2'].get('answer2', version=3), 42)
 
-        self.assertRaises(ValueError, cache.incr_version, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            cache.incr_version('does_not_exist')
 
     def test_decr_version(self):
         cache.set('answer', 42, version=2)
@@ -844,7 +855,8 @@ class BaseCacheTests(object):
         self.assertEqual(caches['v2'].get('answer2', version=1), 42)
         self.assertIsNone(caches['v2'].get('answer2', version=2))
 
-        self.assertRaises(ValueError, cache.decr_version, 'does_not_exist', version=2)
+        with self.assertRaises(ValueError):
+            cache.decr_version('does_not_exist', version=2)
 
     def test_custom_key_func(self):
         # Two caches with different key functions aren't visible to each other
@@ -1138,9 +1150,11 @@ class MemcachedCacheTests(BaseCacheTests, TestCase):
         that a generic exception of some kind is raised.
         """
         # memcached does not allow whitespace or control characters in keys
-        self.assertRaises(Exception, cache.set, 'key with spaces', 'value')
+        with self.assertRaises(Exception):
+            cache.set('key with spaces', 'value')
         # memcached limits key length to 250
-        self.assertRaises(Exception, cache.set, 'a' * 251, 'value')
+        with self.assertRaises(Exception):
+            cache.set('a' * 251, 'value')
 
     # Explicitly display a skipped test if no configured cache uses MemcachedCache
     @unittest.skipUnless(

--- a/tests/check_framework/tests.py
+++ b/tests/check_framework/tests.py
@@ -159,7 +159,8 @@ class CheckCommandTests(SimpleTestCase):
 
     @override_system_checks([simple_system_check, tagged_system_check])
     def test_invalid_tag(self):
-        self.assertRaises(CommandError, call_command, 'check', tags=['missingtag'])
+        with self.assertRaises(CommandError):
+            call_command('check', tags=['missingtag'])
 
     @override_system_checks([simple_system_check])
     def test_list_tags_empty(self):

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -258,11 +258,11 @@ class ContentTypesTests(TestCase):
         def _test_message(mocked_method):
             for ExceptionClass in (IntegrityError, OperationalError, ProgrammingError):
                 mocked_method.side_effect = ExceptionClass
-                with self.assertRaisesMessage(
-                    RuntimeError,
+                msg = (
                     "Error creating new content types. Please make sure contenttypes "
                     "is migrated before trying to migrate apps individually."
-                ):
+                )
+                with self.assertRaisesMessage(RuntimeError, msg):
                     ContentType.objects.get_for_model(ContentType)
 
         _test_message(mocked_get)

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -208,7 +208,8 @@ class ContentTypesTests(TestCase):
         user_ct = ContentType.objects.get_for_model(FooWithoutUrl)
         obj = FooWithoutUrl.objects.create(name="john")
 
-        self.assertRaises(Http404, shortcut, request, user_ct.id, obj.id)
+        with self.assertRaises(Http404):
+            shortcut(request, user_ct.id, obj.id)
 
     def test_shortcut_view_with_broken_get_absolute_url(self):
         """
@@ -224,7 +225,8 @@ class ContentTypesTests(TestCase):
         user_ct = ContentType.objects.get_for_model(FooWithBrokenAbsoluteUrl)
         obj = FooWithBrokenAbsoluteUrl.objects.create(name="john")
 
-        self.assertRaises(AttributeError, shortcut, request, user_ct.id, obj.id)
+        with self.assertRaises(AttributeError):
+            shortcut(request, user_ct.id, obj.id)
 
     def test_missing_model(self):
         """

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -93,31 +93,22 @@ class CustomColumnsTests(TestCase):
         self.assertEqual(self.a1, Author.objects.get(first_name__exact='John'))
 
     def test_filter_on_nonexistent_field(self):
-        self.assertRaisesMessage(
-            FieldError,
+        msg = (
             "Cannot resolve keyword 'firstname' into field. Choices are: "
-            "Author_ID, article, first_name, last_name, primary_set",
-            Author.objects.filter,
-            firstname__exact='John'
+            "Author_ID, article, first_name, last_name, primary_set"
         )
+        with self.assertRaisesMessage(FieldError, msg):
+            Author.objects.filter(firstname__exact='John')
 
     def test_author_get_attributes(self):
         a = Author.objects.get(last_name__exact='Smith')
         self.assertEqual('John', a.first_name)
         self.assertEqual('Smith', a.last_name)
-        self.assertRaisesMessage(
-            AttributeError,
-            "'Author' object has no attribute 'firstname'",
-            getattr,
-            a, 'firstname'
-        )
+        with self.assertRaisesMessage(AttributeError, "'Author' object has no attribute 'firstname'"):
+            getattr(a, 'firstname')
 
-        self.assertRaisesMessage(
-            AttributeError,
-            "'Author' object has no attribute 'last'",
-            getattr,
-            a, 'last'
-        )
+        with self.assertRaisesMessage(AttributeError, "'Author' object has no attribute 'last'"):
+            getattr(a, 'last')
 
     def test_m2m_table(self):
         self.assertQuerysetEqual(

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -40,10 +40,8 @@ class CustomColumnsTests(TestCase):
         )
 
     def test_field_error(self):
-        self.assertRaises(
-            FieldError,
-            lambda: Author.objects.filter(firstname__exact="John")
-        )
+        with self.assertRaises(FieldError):
+            Author.objects.filter(firstname__exact="John")
 
     def test_attribute_error(self):
         with self.assertRaises(AttributeError):

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -102,14 +102,13 @@ class CustomColumnsTests(TestCase):
         a = Author.objects.get(last_name__exact='Smith')
         self.assertEqual('John', a.first_name)
         self.assertEqual('Smith', a.last_name)
-        with self.assertRaisesMessage(
-            AttributeError,
-                "'Author' object has no attribute 'firstname'"):
+
+        msg = "'Author' object has no attribute 'firstname'"
+        with self.assertRaisesMessage(AttributeError, msg):
             getattr(a, 'firstname')
 
-        with self.assertRaisesMessage(
-            AttributeError,
-                "'Author' object has no attribute 'last'"):
+        msg = "'Author' object has no attribute 'last'"
+        with self.assertRaisesMessage(AttributeError, msg):
             getattr(a, 'last')
 
     def test_m2m_table(self):

--- a/tests/custom_columns/tests.py
+++ b/tests/custom_columns/tests.py
@@ -102,10 +102,14 @@ class CustomColumnsTests(TestCase):
         a = Author.objects.get(last_name__exact='Smith')
         self.assertEqual('John', a.first_name)
         self.assertEqual('Smith', a.last_name)
-        with self.assertRaisesMessage(AttributeError, "'Author' object has no attribute 'firstname'"):
+        with self.assertRaisesMessage(
+            AttributeError,
+                "'Author' object has no attribute 'firstname'"):
             getattr(a, 'firstname')
 
-        with self.assertRaisesMessage(AttributeError, "'Author' object has no attribute 'last'"):
+        with self.assertRaisesMessage(
+            AttributeError,
+                "'Author' object has no attribute 'last'"):
             getattr(a, 'last')
 
     def test_m2m_table(self):

--- a/tests/custom_managers/tests.py
+++ b/tests/custom_managers/tests.py
@@ -115,7 +115,8 @@ class CustomManagerTests(TestCase):
         The default manager, "objects", doesn't exist, because a custom one
         was provided.
         """
-        self.assertRaises(AttributeError, lambda: Book.objects)
+        with self.assertRaises(AttributeError):
+            Book.objects
 
     def test_filtering(self):
         """

--- a/tests/custom_pk/tests.py
+++ b/tests/custom_pk/tests.py
@@ -131,10 +131,8 @@ class BasicCustomPKTests(TestCase):
         self.assertEqual(Employee.objects.get(pk=123), self.dan)
         self.assertEqual(Employee.objects.get(pk=456), self.fran)
 
-        self.assertRaises(
-            Employee.DoesNotExist,
-            lambda: Employee.objects.get(pk=42)
-        )
+        with self.assertRaises(Employee.DoesNotExist):
+            Employee.objects.get(pk=42)
 
         # Use the name of the primary key, rather than pk.
         self.assertEqual(Employee.objects.get(employee_code=123), self.dan)
@@ -151,7 +149,8 @@ class BasicCustomPKTests(TestCase):
         # Or we can use the real attribute name for the primary key:
         self.assertEqual(e.employee_code, 123)
 
-        self.assertRaises(AttributeError, lambda: e.id)
+        with self.assertRaises(AttributeError):
+            e.id
 
     def test_in_bulk(self):
         """

--- a/tests/datatypes/tests.py
+++ b/tests/datatypes/tests.py
@@ -82,7 +82,8 @@ class DataTypesTestCase(TestCase):
         an error if given a timezone-aware datetime object."""
         dt = datetime.datetime(2008, 8, 31, 16, 20, tzinfo=utc)
         d = Donut(name='Bear claw', consumed_at=dt)
-        self.assertRaises(ValueError, d.save)
+        with self.assertRaises(ValueError):
+            d.save()
         # ValueError: MySQL backend does not support timezone-aware datetimes.
 
     def test_datefield_auto_now_add(self):

--- a/tests/dates/tests.py
+++ b/tests/dates/tests.py
@@ -102,25 +102,23 @@ class DatesTests(TestCase):
         )
 
     def test_dates_fails_when_given_invalid_kind_argument(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AssertionError,
-            "'kind' must be one of 'year', 'month' or 'day'.",
-            Article.objects.dates,
-            "pub_date",
-            "bad_kind",
-        )
+                "'kind' must be one of 'year', 'month' or 'day'."):
+            Article.objects.dates(
+                "pub_date",
+                "bad_kind",
+            )
 
     def test_dates_fails_when_given_invalid_order_argument(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AssertionError,
-            "'order' must be either 'ASC' or 'DESC'.",
-            Article.objects.dates,
-            "pub_date",
-            "year",
-            order="bad order",
-        )
+                "'order' must be either 'ASC' or 'DESC'."):
+            Article.objects.dates(
+                "pub_date",
+                "year",
+                order="bad order",
+            )
 
     @override_settings(USE_TZ=False)
     def test_dates_trunc_datetime_fields(self):

--- a/tests/dates/tests.py
+++ b/tests/dates/tests.py
@@ -104,7 +104,8 @@ class DatesTests(TestCase):
     def test_dates_fails_when_given_invalid_kind_argument(self):
         with self.assertRaisesMessage(
             AssertionError,
-                "'kind' must be one of 'year', 'month' or 'day'."):
+            "'kind' must be one of 'year', 'month' or 'day'."
+        ):
             Article.objects.dates(
                 "pub_date",
                 "bad_kind",
@@ -113,7 +114,8 @@ class DatesTests(TestCase):
     def test_dates_fails_when_given_invalid_order_argument(self):
         with self.assertRaisesMessage(
             AssertionError,
-                "'order' must be either 'ASC' or 'DESC'."):
+            "'order' must be either 'ASC' or 'DESC'."
+        ):
             Article.objects.dates(
                 "pub_date",
                 "year",

--- a/tests/dates/tests.py
+++ b/tests/dates/tests.py
@@ -87,10 +87,8 @@ class DatesTests(TestCase):
         )
 
     def test_dates_fails_when_no_arguments_are_provided(self):
-        self.assertRaises(
-            TypeError,
-            Article.objects.dates,
-        )
+        with self.assertRaises(TypeError):
+            Article.objects.dates()
 
     def test_dates_fails_when_given_invalid_field_argument(self):
         six.assertRaisesRegex(

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -11,7 +11,7 @@ from django.db.models.functions import (
     Upper,
 )
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
-from django.utils import six, timezone
+from django.utils import timezone
 
 from .models import Article, Author, Fan
 
@@ -491,7 +491,7 @@ class FunctionTests(TestCase):
 
         self.assertEqual(a.name_part_1[1:], a.name_part_2)
 
-        with six.assertRaisesRegex(self, ValueError, "'pos' must be greater than 0"):
+        with self.assertRaisesMessage(ValueError, "'pos' must be greater than 0"):
             Author.objects.annotate(raises=Substr('name', 0))
 
     def test_substr_with_expressions(self):

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -63,7 +63,8 @@ class OnDeleteTests(TestCase):
 
     def test_protect(self):
         a = create_a('protect')
-        self.assertRaises(IntegrityError, a.protect.delete)
+        with self.assertRaises(IntegrityError):
+            a.protect.delete()
 
     def test_do_nothing(self):
         # Testing DO_NOTHING is a bit harder: It would raise IntegrityError for a normal model,

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -90,11 +90,8 @@ class DistinctOnTests(TestCase):
 
         # Combining queries with different distinct_fields is not allowed.
         base_qs = Celebrity.objects.all()
-        self.assertRaisesMessage(
-            AssertionError,
-            "Cannot combine queries with different distinct fields.",
-            lambda: (base_qs.distinct('id') & base_qs.distinct('name'))
-        )
+        with self.assertRaisesMessage(AssertionError, "Cannot combine queries with different distinct fields."):
+            base_qs.distinct('id') & base_qs.distinct('name')
 
         # Test join unreffing
         c1 = Celebrity.objects.distinct('greatest_fan__id', 'greatest_fan__fan_of')

--- a/tests/distinct_on_fields/tests.py
+++ b/tests/distinct_on_fields/tests.py
@@ -90,7 +90,9 @@ class DistinctOnTests(TestCase):
 
         # Combining queries with different distinct_fields is not allowed.
         base_qs = Celebrity.objects.all()
-        with self.assertRaisesMessage(AssertionError, "Cannot combine queries with different distinct fields."):
+
+        msg = "Cannot combine queries with different distinct fields."
+        with self.assertRaisesMessage(AssertionError, msg):
             base_qs.distinct('id') & base_qs.distinct('name')
 
         # Test join unreffing

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -281,7 +281,8 @@ class BasicExpressionsTests(TestCase):
 
     def test_object_create_with_aggregate(self):
         # Aggregates are not allowed when inserting new data
-        with self.assertRaisesMessage(FieldError, 'Aggregate functions are not allowed in this query'):
+        msg = 'Aggregate functions are not allowed in this query'
+        with self.assertRaisesMessage(FieldError, msg):
             Company.objects.create(
                 name='Company', num_employees=Max(Value(1)), num_chairs=1,
                 ceo=Employee.objects.create(firstname="Just", lastname="Doit", salary=30),

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -294,12 +294,14 @@ class BasicExpressionsTests(TestCase):
 
         def test():
             test_gmbh.point_of_contact = F("ceo")
-        self.assertRaises(ValueError, test)
+        with self.assertRaises(ValueError):
+            test()
 
         test_gmbh.point_of_contact = test_gmbh.ceo
         test_gmbh.save()
         test_gmbh.name = F("ceo__last_name")
-        self.assertRaises(FieldError, test_gmbh.save)
+        with self.assertRaises(FieldError):
+            test_gmbh.save()
 
     def test_object_update_unsaved_objects(self):
         # F expressions cannot be used to update attributes on objects which do

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -316,7 +316,8 @@ class BasicExpressionsTests(TestCase):
             'expressions.Company.num_employees. F() expressions can only be '
             'used to update, not to insert.'
         )
-        self.assertRaisesMessage(ValueError, msg, acme.save)
+        with self.assertRaisesMessage(ValueError, msg):
+            acme.save()
 
         acme.num_employees = 12
         acme.name = Lower(F('name'))
@@ -325,7 +326,8 @@ class BasicExpressionsTests(TestCase):
             'expressions.Company.name))" on expressions.Company.name. F() '
             'expressions can only be used to update, not to insert.'
         )
-        self.assertRaisesMessage(ValueError, msg, acme.save)
+        with self.assertRaisesMessage(ValueError, msg):
+            acme.save()
 
     def test_ticket_11722_iexact_lookup(self):
         Employee.objects.create(firstname="John", lastname="Doe")

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -52,8 +52,8 @@ class GetStorageClassTests(SimpleTestCase):
         """
         get_storage_class raises an error if the requested class don't exist.
         """
-        self.assertRaises(ImportError, get_storage_class,
-                          'django.core.files.storage.NonExistingStorage')
+        with self.assertRaises(ImportError):
+            get_storage_class('django.core.files.storage.NonExistingStorage')
 
     def test_get_nonexisting_storage_module(self):
         """
@@ -256,7 +256,8 @@ class FileStorageTests(unittest.TestCase):
             """/test_media_url/a/b/c.file""")
 
         self.storage.base_url = None
-        self.assertRaises(ValueError, self.storage.url, 'test.file')
+        with self.assertRaises(ValueError):
+            self.storage.url('test.file')
 
         # #22717: missing ending slash in base_url should be auto-corrected
         storage = self.storage_class(location=self.temp_dir,
@@ -292,8 +293,10 @@ class FileStorageTests(unittest.TestCase):
         File storage prevents directory traversal (files can only be accessed if
         they're below the storage location).
         """
-        self.assertRaises(SuspiciousOperation, self.storage.exists, '..')
-        self.assertRaises(SuspiciousOperation, self.storage.exists, '/etc/passwd')
+        with self.assertRaises(SuspiciousOperation):
+            self.storage.exists('..')
+        with self.assertRaises(SuspiciousOperation):
+            self.storage.exists('/etc/passwd')
 
     def test_file_storage_preserves_filename_case(self):
         """The storage backend should preserve case of filenames."""
@@ -342,8 +345,8 @@ class FileStorageTests(unittest.TestCase):
                 self.assertEqual(f.read(), b'saved with race')
 
             # Check that OSErrors aside from EEXIST are still raised.
-            self.assertRaises(OSError,
-                self.storage.save, 'error/test.file', ContentFile('not saved'))
+            with self.assertRaises(OSError):
+                self.storage.save('error/test.file', ContentFile('not saved'))
         finally:
             os.makedirs = real_makedirs
 
@@ -379,7 +382,8 @@ class FileStorageTests(unittest.TestCase):
 
             # Check that OSErrors aside from ENOENT are still raised.
             self.storage.save('error.file', ContentFile('delete with error'))
-            self.assertRaises(OSError, self.storage.delete, 'error.file')
+            with self.assertRaises(OSError):
+                self.storage.delete('error.file')
         finally:
             os.remove = real_remove
 
@@ -453,7 +457,8 @@ class FileFieldStorageTests(TestCase):
         # An object without a file has limited functionality.
         obj1 = Storage()
         self.assertEqual(obj1.normal.name, "")
-        self.assertRaises(ValueError, lambda: obj1.normal.size)
+        with self.assertRaises(ValueError):
+            obj1.normal.size
 
         # Saving a file enables full functionality.
         obj1.normal.save("django_test.txt", ContentFile("content"))

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -536,7 +536,8 @@ class FileFieldStorageTests(TestCase):
             # Testing exception is raised when filename is too short to truncate.
             filename = 'short.longext'
             objs[0].limited_length.save(filename, ContentFile('Same Content'))
-            with self.assertRaisesMessage(SuspiciousFileOperation, 'Storage can not find an available filename'):
+            msg = 'Storage can not find an available filename'
+            with self.assertRaisesMessage(SuspiciousFileOperation, msg):
                 objs[1].limited_length.save(*(filename, ContentFile('Same Content')))
         finally:
             for o in objs:

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -531,10 +531,8 @@ class FileFieldStorageTests(TestCase):
             # Testing exception is raised when filename is too short to truncate.
             filename = 'short.longext'
             objs[0].limited_length.save(filename, ContentFile('Same Content'))
-            self.assertRaisesMessage(
-                SuspiciousFileOperation, 'Storage can not find an available filename',
-                objs[1].limited_length.save, *(filename, ContentFile('Same Content'))
-            )
+            with self.assertRaisesMessage(SuspiciousFileOperation, 'Storage can not find an available filename'):
+                objs[1].limited_length.save(*(filename, ContentFile('Same Content')))
         finally:
             for o in objs:
                 o.delete()

--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -376,12 +376,8 @@ class FileUploadTests(TestCase):
             file.seek(0)
 
             # AttributeError: You cannot alter upload handlers after the upload has been processed.
-            self.assertRaises(
-                AttributeError,
-                self.client.post,
-                '/quota/broken/',
-                {'f': file}
-            )
+            with self.assertRaises(AttributeError):
+                self.client.post('/quota/broken/', {'f': file})
 
     def test_fileupload_getlist(self):
         file = tempfile.NamedTemporaryFile

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -287,7 +287,8 @@ class FileMoveSafeTests(unittest.TestCase):
         handle_b, self.file_b = tempfile.mkstemp()
 
         # file_move_safe should raise an IOError exception if destination file exists and allow_overwrite is False
-        self.assertRaises(IOError, lambda: file_move_safe(self.file_a, self.file_b, allow_overwrite=False))
+        with self.assertRaises(IOError):
+            file_move_safe(self.file_a, self.file_b, allow_overwrite=False)
 
         # should allow it and continue on if allow_overwrite is True
         self.assertIsNone(file_move_safe(self.file_a, self.file_b, allow_overwrite=True))

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -364,12 +364,12 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
         )
 
         # Excluding a bogus app should throw an error
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "No installed app with label 'foo_app'."):
             self._dumpdata_assert(['fixtures', 'sites'], '', exclude_list=['foo_app'])
 
         # Excluding a bogus model should throw an error
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "Unknown model in excludes: fixtures.FooModel"):
             self._dumpdata_assert(['fixtures', 'sites'], '', exclude_list=['fixtures.FooModel'])
 
@@ -415,7 +415,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             primary_keys='2'
         )
 
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "You can only use --pks option with one model"):
             self._dumpdata_assert(
                 ['fixtures'],
@@ -425,7 +425,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
                 primary_keys='2,3'
             )
 
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "You can only use --pks option with one model"):
             self._dumpdata_assert(
                 '',
@@ -435,7 +435,7 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
                 primary_keys='2,3'
             )
 
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "You can only use --pks option with one model"):
             self._dumpdata_assert(
                 ['fixtures.Article', 'fixtures.category'],

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -364,13 +364,17 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
         )
 
         # Excluding a bogus app should throw an error
-        with self.assertRaisesMessage(management.CommandError,
-                "No installed app with label 'foo_app'."):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "No installed app with label 'foo_app'."
+        ):
             self._dumpdata_assert(['fixtures', 'sites'], '', exclude_list=['foo_app'])
 
         # Excluding a bogus model should throw an error
-        with self.assertRaisesMessage(management.CommandError,
-                "Unknown model in excludes: fixtures.FooModel"):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "Unknown model in excludes: fixtures.FooModel"
+        ):
             self._dumpdata_assert(['fixtures', 'sites'], '', exclude_list=['fixtures.FooModel'])
 
     @unittest.skipIf(sys.platform.startswith('win'), "Windows doesn't support '?' in filenames.")
@@ -415,8 +419,10 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             primary_keys='2'
         )
 
-        with self.assertRaisesMessage(management.CommandError,
-                "You can only use --pks option with one model"):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "You can only use --pks option with one model"
+        ):
             self._dumpdata_assert(
                 ['fixtures'],
                 '[{"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", '
@@ -425,8 +431,10 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
                 primary_keys='2,3'
             )
 
-        with self.assertRaisesMessage(management.CommandError,
-                "You can only use --pks option with one model"):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "You can only use --pks option with one model"
+        ):
             self._dumpdata_assert(
                 '',
                 '[{"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", '
@@ -435,8 +443,10 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
                 primary_keys='2,3'
             )
 
-        with self.assertRaisesMessage(management.CommandError,
-                "You can only use --pks option with one model"):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "You can only use --pks option with one model"
+        ):
             self._dumpdata_assert(
                 ['fixtures.Article', 'fixtures.category'],
                 '[{"pk": 2, "model": "fixtures.article", "fields": {"headline": "Poker has no place on ESPN", '

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -201,7 +201,7 @@ class TestFixtures(TestCase):
         Test for ticket #4371 -- Loading data of an unknown format should fail
         Validate that error conditions are caught correctly
         """
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "Problem installing fixture 'bad_fixture1': "
                 "unkn is not a known serialization format."):
             management.call_command(
@@ -460,7 +460,7 @@ class TestFixtures(TestCase):
         """
         Regression for #3615 - Ensure data with nonexistent child key references raises error
         """
-        with six.assertRaisesRegex(self, IntegrityError,
+        with self.assertRaisesMessage(IntegrityError,
                 "Problem installing fixture"):
             management.call_command(
                 'loaddata',
@@ -489,7 +489,7 @@ class TestFixtures(TestCase):
         """
         Regression for #7043 - Error is quickly reported when no fixtures is provided in the command line.
         """
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "No database fixture specified. Please provide the path of "
                 "at least one fixture in the command line."):
             management.call_command(

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -537,14 +537,8 @@ class TestFixtures(TestCase):
         settings.FIXTURE_DIRS cannot contain duplicates in order to avoid
         repeated fixture loading.
         """
-        self.assertRaisesMessage(
-            ImproperlyConfigured,
-            "settings.FIXTURE_DIRS contains duplicates.",
-            management.call_command,
-            'loaddata',
-            'absolute.json',
-            verbosity=0,
-        )
+        with self.assertRaisesMessage(ImproperlyConfigured, "settings.FIXTURE_DIRS contains duplicates."):
+            management.call_command('loaddata', 'absolute.json', verbosity=0)
 
     @skipIfNonASCIIPath
     @override_settings(FIXTURE_DIRS=[os.path.join(_cur_dir, 'fixtures')])
@@ -553,16 +547,13 @@ class TestFixtures(TestCase):
         settings.FIXTURE_DIRS cannot contain a default fixtures directory
         for application (app/fixtures) in order to avoid repeated fixture loading.
         """
-        self.assertRaisesMessage(
-            ImproperlyConfigured,
+        msg = (
             "'%s' is a default fixture directory for the '%s' app "
             "and cannot be listed in settings.FIXTURE_DIRS."
-            % (os.path.join(_cur_dir, 'fixtures'), 'fixtures_regress'),
-            management.call_command,
-            'loaddata',
-            'absolute.json',
-            verbosity=0,
+            % (os.path.join(_cur_dir, 'fixtures'), 'fixtures_regress')
         )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            management.call_command('loaddata', 'absolute.json', verbosity=0)
 
     @override_settings(FIXTURE_DIRS=[os.path.join(_cur_dir, 'fixtures_1'),
                                      os.path.join(_cur_dir, 'fixtures_2')])
@@ -734,41 +725,33 @@ class NaturalKeyFixtureTests(TestCase):
         )
 
     def test_dependency_sorting_tight_circular(self):
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             RuntimeError,
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-            "fixtures_regress.Circle2 in serialized app list.",
-            serializers.sort_dependencies,
-            [('fixtures_regress', [Person, Circle2, Circle1, Store, Book])],
-        )
+                "fixtures_regress.Circle2 in serialized app list."):
+            serializers.sort_dependencies([('fixtures_regress', [Person, Circle2, Circle1, Store, Book])])
 
     def test_dependency_sorting_tight_circular_2(self):
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             RuntimeError,
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-            "fixtures_regress.Circle2 in serialized app list.",
-            serializers.sort_dependencies,
-            [('fixtures_regress', [Circle1, Book, Circle2])],
-        )
+                "fixtures_regress.Circle2 in serialized app list."):
+            serializers.sort_dependencies([('fixtures_regress', [Circle1, Book, Circle2])])
 
     def test_dependency_self_referential(self):
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             RuntimeError,
             "Can't resolve dependencies for fixtures_regress.Circle3 in "
-            "serialized app list.",
-            serializers.sort_dependencies,
-            [('fixtures_regress', [Book, Circle3])],
-        )
+                "serialized app list."):
+            serializers.sort_dependencies([('fixtures_regress', [Book, Circle3])])
 
     def test_dependency_sorting_long(self):
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             RuntimeError,
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-            "fixtures_regress.Circle2, fixtures_regress.Circle3 in serialized "
-            "app list.",
-            serializers.sort_dependencies,
-            [('fixtures_regress', [Person, Circle2, Circle1, Circle3, Store, Book])],
-        )
+                "fixtures_regress.Circle2, fixtures_regress.Circle3 in serialized "
+                "app list."):
+            serializers.sort_dependencies([('fixtures_regress', [Person, Circle2, Circle1, Circle3, Store, Book])])
 
     def test_dependency_sorting_normal(self):
         sorted_deps = serializers.sort_dependencies(
@@ -830,13 +813,11 @@ class M2MNaturalKeyFixtureTests(TestCase):
         Resolving circular M2M relations without explicit through models should
         fail loudly
         """
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             RuntimeError,
-            "Can't resolve dependencies for fixtures_regress.M2MSimpleCircularA, "
-            "fixtures_regress.M2MSimpleCircularB in serialized app list.",
-            serializers.sort_dependencies,
-            [('fixtures_regress', [M2MSimpleCircularA, M2MSimpleCircularB])]
-        )
+                "Can't resolve dependencies for fixtures_regress.M2MSimpleCircularA, "
+                "fixtures_regress.M2MSimpleCircularB in serialized app list."):
+            serializers.sort_dependencies([('fixtures_regress', [M2MSimpleCircularA, M2MSimpleCircularB])])
 
     def test_dependency_sorting_m2m_complex(self):
         """

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -201,9 +201,11 @@ class TestFixtures(TestCase):
         Test for ticket #4371 -- Loading data of an unknown format should fail
         Validate that error conditions are caught correctly
         """
-        with self.assertRaisesMessage(management.CommandError,
-                "Problem installing fixture 'bad_fixture1': "
-                "unkn is not a known serialization format."):
+        msg = (
+            "Problem installing fixture 'bad_fixture1': "
+            "unkn is not a known serialization format."
+        )
+        with self.assertRaisesMessage(management.CommandError, msg):
             management.call_command(
                 'loaddata',
                 'bad_fixture1.unkn',
@@ -216,8 +218,7 @@ class TestFixtures(TestCase):
         """
         Test that failing serializer import raises the proper error
         """
-        with six.assertRaisesRegex(self, ImportError,
-                r"No module named.*unexistent"):
+        with six.assertRaisesRegex(self, ImportError, r"No module named.*unexistent"):
             management.call_command(
                 'loaddata',
                 'bad_fixture1.unkn',
@@ -460,8 +461,7 @@ class TestFixtures(TestCase):
         """
         Regression for #3615 - Ensure data with nonexistent child key references raises error
         """
-        with self.assertRaisesMessage(IntegrityError,
-                "Problem installing fixture"):
+        with self.assertRaisesMessage(IntegrityError, "Problem installing fixture"):
             management.call_command(
                 'loaddata',
                 'forward_ref_bad_data.json',
@@ -489,9 +489,11 @@ class TestFixtures(TestCase):
         """
         Regression for #7043 - Error is quickly reported when no fixtures is provided in the command line.
         """
-        with self.assertRaisesMessage(management.CommandError,
-                "No database fixture specified. Please provide the path of "
-                "at least one fixture in the command line."):
+        msg = (
+            "No database fixture specified. Please provide the path of "
+            "at least one fixture in the command line."
+        )
+        with self.assertRaisesMessage(management.CommandError, msg):
             management.call_command(
                 'loaddata',
                 verbosity=0,
@@ -725,33 +727,40 @@ class NaturalKeyFixtureTests(TestCase):
         )
 
     def test_dependency_sorting_tight_circular(self):
-        with self.assertRaisesMessage(
-            RuntimeError,
+        msg = (
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-                "fixtures_regress.Circle2 in serialized app list."):
+            "fixtures_regress.Circle2 in serialized app list."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
             serializers.sort_dependencies([('fixtures_regress', [Person, Circle2, Circle1, Store, Book])])
 
     def test_dependency_sorting_tight_circular_2(self):
-        with self.assertRaisesMessage(
-            RuntimeError,
+        msg = (
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-                "fixtures_regress.Circle2 in serialized app list."):
+            "fixtures_regress.Circle2 in serialized app list."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
             serializers.sort_dependencies([('fixtures_regress', [Circle1, Book, Circle2])])
 
     def test_dependency_self_referential(self):
-        with self.assertRaisesMessage(
-            RuntimeError,
+        msg = (
             "Can't resolve dependencies for fixtures_regress.Circle3 in "
-                "serialized app list."):
+            "serialized app list."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
             serializers.sort_dependencies([('fixtures_regress', [Book, Circle3])])
 
     def test_dependency_sorting_long(self):
-        with self.assertRaisesMessage(
-            RuntimeError,
+        msg = (
             "Can't resolve dependencies for fixtures_regress.Circle1, "
-                "fixtures_regress.Circle2, fixtures_regress.Circle3 in serialized "
-                "app list."):
-            serializers.sort_dependencies([('fixtures_regress', [Person, Circle2, Circle1, Circle3, Store, Book])])
+            "fixtures_regress.Circle2, fixtures_regress.Circle3 in serialized "
+            "app list."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
+            serializers.sort_dependencies([(
+                'fixtures_regress',
+                [Person, Circle2, Circle1, Circle3, Store, Book]
+            )])
 
     def test_dependency_sorting_normal(self):
         sorted_deps = serializers.sort_dependencies(
@@ -813,11 +822,15 @@ class M2MNaturalKeyFixtureTests(TestCase):
         Resolving circular M2M relations without explicit through models should
         fail loudly
         """
-        with self.assertRaisesMessage(
-            RuntimeError,
-                "Can't resolve dependencies for fixtures_regress.M2MSimpleCircularA, "
-                "fixtures_regress.M2MSimpleCircularB in serialized app list."):
-            serializers.sort_dependencies([('fixtures_regress', [M2MSimpleCircularA, M2MSimpleCircularB])])
+        msg = (
+            "Can't resolve dependencies for fixtures_regress.M2MSimpleCircularA, "
+            "fixtures_regress.M2MSimpleCircularB in serialized app list."
+        )
+        with self.assertRaisesMessage(RuntimeError, msg):
+            serializers.sort_dependencies([(
+                'fixtures_regress',
+                [M2MSimpleCircularA, M2MSimpleCircularB]
+            )])
 
     def test_dependency_sorting_m2m_complex(self):
         """

--- a/tests/flatpages_tests/test_templatetags.py
+++ b/tests/flatpages_tests/test_templatetags.py
@@ -143,17 +143,17 @@ class FlatpageTemplateTagTests(TestCase):
         "There are various ways that the flatpages template tag won't parse"
         render = lambda t: Template(t).render(Context())
 
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages as %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages cheesecake flatpages %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages as flatpages asdf %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages cheesecake user as flatpages %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages for user as flatpages asdf %}")
-        self.assertRaises(TemplateSyntaxError, render,
-                          "{% load flatpages %}{% get_flatpages prefix for user as flatpages asdf %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages as %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages cheesecake flatpages %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages as flatpages asdf %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages cheesecake user as flatpages %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages for user as flatpages asdf %}")
+        with self.assertRaises(TemplateSyntaxError):
+            render("{% load flatpages %}{% get_flatpages prefix for user as flatpages asdf %}")

--- a/tests/foreign_object/tests.py
+++ b/tests/foreign_object/tests.py
@@ -57,7 +57,8 @@ class MultiColumnFKTests(TestCase):
         membership = Membership.objects.create(
             membership_country_id=self.usa.id, person_id=self.jane.id, group_id=self.cia.id)
 
-        self.assertRaises(Person.DoesNotExist, getattr, membership, 'person')
+        with self.assertRaises(Person.DoesNotExist):
+            getattr(membership, 'person')
 
     def test_reverse_query_returns_correct_result(self):
         # Creating a valid membership because it has the same country has the person

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -118,8 +118,10 @@ class FieldsTests(SimpleTestCase):
         f = CharField(max_length=10, required=False)
         self.assertEqual('12345', f.clean('12345'))
         self.assertEqual('1234567890', f.clean('1234567890'))
-        msg = "'Ensure this value has at most 10 characters (it has 11).'"
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at most 10 characters (it has 11).'"
+        ):
             f.clean('1234567890a')
         self.assertEqual(f.max_length, 10)
         self.assertEqual(f.min_length, None)
@@ -127,8 +129,10 @@ class FieldsTests(SimpleTestCase):
     def test_charfield_4(self):
         f = CharField(min_length=10, required=False)
         self.assertEqual('', f.clean(''))
-        msg = "'Ensure this value has at least 10 characters (it has 5).'"
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at least 10 characters (it has 5).'"
+        ):
             f.clean('12345')
         self.assertEqual('1234567890', f.clean('1234567890'))
         self.assertEqual('1234567890a', f.clean('1234567890a'))
@@ -139,8 +143,10 @@ class FieldsTests(SimpleTestCase):
         f = CharField(min_length=10, required=True)
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
-        msg = "'Ensure this value has at least 10 characters (it has 5).'"
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at least 10 characters (it has 5).'"
+        ):
             f.clean('12345')
         self.assertEqual('1234567890', f.clean('1234567890'))
         self.assertEqual('1234567890a', f.clean('1234567890a'))
@@ -242,10 +248,16 @@ class FieldsTests(SimpleTestCase):
             f.clean(None)
         self.assertEqual(1, f.clean(1))
         self.assertEqual(10, f.clean(10))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is less than or equal to 10.'"
+        ):
             f.clean(11)
         self.assertEqual(10, f.clean('10'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is less than or equal to 10.'"
+        ):
             f.clean('11')
         self.assertEqual(f.max_value, 10)
         self.assertEqual(f.min_value, None)
@@ -255,7 +267,10 @@ class FieldsTests(SimpleTestCase):
         self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is greater than or equal to 10.'"
+        ):
             f.clean(1)
         self.assertEqual(10, f.clean(10))
         self.assertEqual(11, f.clean(11))
@@ -269,14 +284,20 @@ class FieldsTests(SimpleTestCase):
         self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is greater than or equal to 10.'"
+        ):
             f.clean(1)
         self.assertEqual(10, f.clean(10))
         self.assertEqual(11, f.clean(11))
         self.assertEqual(10, f.clean('10'))
         self.assertEqual(11, f.clean('11'))
         self.assertEqual(20, f.clean(20))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 20.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is less than or equal to 20.'"
+        ):
             f.clean(21)
         self.assertEqual(f.max_value, 20)
         self.assertEqual(f.min_value, 10)
@@ -361,9 +382,15 @@ class FieldsTests(SimpleTestCase):
     def test_floatfield_3(self):
         f = FloatField(max_value=1.5, min_value=0.5)
         self.assertWidgetRendersTo(f, '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" />')
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is less than or equal to 1.5.'"
+        ):
             f.clean('1.6')
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 0.5.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is greater than or equal to 0.5.'"
+        ):
             f.clean('0.4')
         self.assertEqual(1.5, f.clean('1.5'))
         self.assertEqual(0.5, f.clean('0.5'))
@@ -422,22 +449,39 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(f.clean(' 1.0 '), Decimal("1.0"))
         with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
             f.clean('1.0a')
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 4 digits in total.'"
+        ):
             f.clean('123.45')
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 2 decimal places.'"
+        ):
             f.clean('1.234')
-        with self.assertRaisesMessage(ValidationError,
-                "'Ensure that there are no more than 2 digits before the decimal point.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 2 digits before the decimal point.'"
+        ):
             f.clean('123.4')
         self.assertEqual(f.clean('-12.34'), Decimal("-12.34"))
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 4 digits in total.'"
+        ):
             f.clean('-123.45')
         self.assertEqual(f.clean('-.12'), Decimal("-0.12"))
         self.assertEqual(f.clean('-00.12'), Decimal("-0.12"))
         self.assertEqual(f.clean('-000.12'), Decimal("-0.12"))
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 2 decimal places.'"
+        ):
             f.clean('-000.123')
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 4 digits in total.'"
+        ):
             f.clean('-000.12345')
         with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
             f.clean('--0.12')
@@ -459,9 +503,15 @@ class FieldsTests(SimpleTestCase):
     def test_decimalfield_3(self):
         f = DecimalField(max_digits=4, decimal_places=2, max_value=Decimal('1.5'), min_value=Decimal('0.5'))
         self.assertWidgetRendersTo(f, '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" />')
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is less than or equal to 1.5.'"
+        ):
             f.clean('1.6')
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 0.5.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value is greater than or equal to 0.5.'"
+        ):
             f.clean('0.4')
         self.assertEqual(f.clean('1.5'), Decimal("1.5"))
         self.assertEqual(f.clean('0.5'), Decimal("0.5"))
@@ -474,7 +524,10 @@ class FieldsTests(SimpleTestCase):
 
     def test_decimalfield_4(self):
         f = DecimalField(decimal_places=2)
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 2 decimal places.'"
+        ):
             f.clean('0.00000001')
 
     def test_decimalfield_5(self):
@@ -485,7 +538,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(f.clean('0000000.100'), Decimal("0.100"))
         # Only leading whole zeros "collapse" to one digit.
         self.assertEqual(f.clean('000000.02'), Decimal('0.02'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 3 digits in total.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure that there are no more than 3 digits in total.'"
+        ):
             f.clean('000000.0002')
         self.assertEqual(f.clean('.002'), Decimal("0.002"))
 
@@ -803,7 +859,10 @@ class FieldsTests(SimpleTestCase):
 
     def test_regexfield_5(self):
         f = RegexField('^[0-9]+$', min_length=5, max_length=10)
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 5 characters (it has 3).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at least 5 characters (it has 3).'"
+        ):
             f.clean('123')
         six.assertRaisesRegex(
             self, ValidationError,
@@ -813,7 +872,10 @@ class FieldsTests(SimpleTestCase):
         )
         self.assertEqual('12345', f.clean('12345'))
         self.assertEqual('1234567890', f.clean('1234567890'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (it has 11).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at most 10 characters (it has 11).'"
+        ):
             f.clean('12345678901')
         with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
             f.clean('12345a')
@@ -868,10 +930,16 @@ class FieldsTests(SimpleTestCase):
     def test_emailfield_min_max_length(self):
         f = EmailField(min_length=10, max_length=15)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="email" name="f" maxlength="15" />')
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 9).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at least 10 characters (it has 9).'"
+        ):
             f.clean('a@foo.com')
         self.assertEqual('alf@foo.com', f.clean('alf@foo.com'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 15 characters (it has 20).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at most 15 characters (it has 20).'"
+        ):
             f.clean('alf123456788@foo.com')
 
     # FileField ##################################################################
@@ -888,15 +956,21 @@ class FieldsTests(SimpleTestCase):
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None, '')
         self.assertEqual('files/test2.pdf', f.clean(None, 'files/test2.pdf'))
-        with self.assertRaisesMessage(ValidationError,
-                "'No file was submitted. Check the encoding type on the form.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'No file was submitted. Check the encoding type on the form.'"
+        ):
             f.clean(SimpleUploadedFile('', b''))
-        with self.assertRaisesMessage(ValidationError,
-                "'No file was submitted. Check the encoding type on the form.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'No file was submitted. Check the encoding type on the form.'"
+        ):
             f.clean(SimpleUploadedFile('', b''), '')
         self.assertEqual('files/test3.pdf', f.clean(None, 'files/test3.pdf'))
-        with self.assertRaisesMessage(ValidationError,
-                "'No file was submitted. Check the encoding type on the form.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'No file was submitted. Check the encoding type on the form.'"
+        ):
             f.clean('some content that is not a file')
         with self.assertRaisesMessage(ValidationError, "'The submitted file is empty.'"):
             f.clean(SimpleUploadedFile('name', None))
@@ -914,7 +988,10 @@ class FieldsTests(SimpleTestCase):
 
     def test_filefield_2(self):
         f = FileField(max_length=5)
-        with self.assertRaisesMessage(ValidationError, "'Ensure this filename has at most 5 characters (it has 18).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this filename has at most 5 characters (it has 18).'"
+        ):
             f.clean(SimpleUploadedFile('test_maxlength.txt', b'hello world'))
         self.assertEqual('files/test1.pdf', f.clean('', 'files/test1.pdf'))
         self.assertEqual('files/test2.pdf', f.clean(None, 'files/test2.pdf'))
@@ -1191,8 +1268,10 @@ class FieldsTests(SimpleTestCase):
             f.clean(None)
         self.assertEqual('1', f.clean(1))
         self.assertEqual('1', f.clean('1'))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean('3')
 
     def test_choicefield_2(self):
@@ -1201,15 +1280,19 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('', f.clean(None))
         self.assertEqual('1', f.clean(1))
         self.assertEqual('1', f.clean('1'))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean('3')
 
     def test_choicefield_3(self):
         f = ChoiceField(choices=[('J', 'John'), ('P', 'Paul')])
         self.assertEqual('J', f.clean('J'))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. John is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. John is not one of the available choices.'"
+        ):
             f.clean('John')
 
     def test_choicefield_4(self):
@@ -1225,8 +1308,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('3', f.clean('3'))
         self.assertEqual('5', f.clean(5))
         self.assertEqual('5', f.clean('5'))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 6 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 6 is not one of the available choices.'"
+        ):
             f.clean('6')
 
     def test_choicefield_callable(self):
@@ -1264,8 +1349,10 @@ class FieldsTests(SimpleTestCase):
     def test_typedchoicefield_1(self):
         f = TypedChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual(1, f.clean('1'))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 2 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 2 is not one of the available choices.'"
+        ):
             f.clean('2')
 
     def test_typedchoicefield_2(self):
@@ -1282,8 +1369,10 @@ class FieldsTests(SimpleTestCase):
         # Even more weirdness: if you have a valid choice but your coercion function
         # can't coerce, you'll still get a validation error. Don't do this!
         f = TypedChoiceField(choices=[('A', 'A'), ('B', 'B')], coerce=int)
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. B is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. B is not one of the available choices.'"
+        ):
             f.clean('B')
         # Required fields require values
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -1326,8 +1415,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(Decimal('1.2'), f.clean('2'))
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean('3')
 
     # NullBooleanField ############################################################
@@ -1411,8 +1502,10 @@ class FieldsTests(SimpleTestCase):
             f.clean([])
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(())
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean(['3'])
 
     def test_multiplechoicefield_2(self):
@@ -1428,8 +1521,10 @@ class FieldsTests(SimpleTestCase):
             f.clean('hello')
         self.assertEqual([], f.clean([]))
         self.assertEqual([], f.clean(()))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean(['3'])
 
     def test_multiplechoicefield_3(self):
@@ -1442,11 +1537,15 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(['1', '5'], f.clean([1, '5']))
         self.assertEqual(['1', '5'], f.clean(['1', 5]))
         self.assertEqual(['1', '5'], f.clean(['1', '5']))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 6 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 6 is not one of the available choices.'"
+        ):
             f.clean(['6'])
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 6 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 6 is not one of the available choices.'"
+        ):
             f.clean(['1', '6'])
 
     def test_multiplechoicefield_changed(self):
@@ -1466,8 +1565,10 @@ class FieldsTests(SimpleTestCase):
     def test_typedmultiplechoicefield_1(self):
         f = TypedMultipleChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual([1], f.clean(['1']))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 2 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 2 is not one of the available choices.'"
+        ):
             f.clean(['2'])
 
     def test_typedmultiplechoicefield_2(self):
@@ -1483,16 +1584,20 @@ class FieldsTests(SimpleTestCase):
     def test_typedmultiplechoicefield_4(self):
         f = TypedMultipleChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual([1, -1], f.clean(['1', '-1']))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 2 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 2 is not one of the available choices.'"
+        ):
             f.clean(['1', '2'])
 
     def test_typedmultiplechoicefield_5(self):
         # Even more weirdness: if you have a valid choice but your coercion function
         # can't coerce, you'll still get a validation error. Don't do this!
         f = TypedMultipleChoiceField(choices=[('A', 'A'), ('B', 'B')], coerce=int)
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. B is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. B is not one of the available choices.'"
+        ):
             f.clean(['B'])
         # Required fields require values
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -1526,8 +1631,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual([Decimal('1.2')], f.clean(['2']))
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean([])
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. 3 is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. 3 is not one of the available choices.'"
+        ):
             f.clean(['3'])
 
     # ComboField ##################################################################
@@ -1535,7 +1642,10 @@ class FieldsTests(SimpleTestCase):
     def test_combofield_1(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()])
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at most 20 characters (it has 28).'"
+        ):
             f.clean('longemailaddress@example.com')
         with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
             f.clean('not an email')
@@ -1547,7 +1657,10 @@ class FieldsTests(SimpleTestCase):
     def test_combofield_2(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()], required=False)
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Ensure this value has at most 20 characters (it has 28).'"
+        ):
             f.clean('longemailaddress@example.com')
         with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
             f.clean('not an email')
@@ -1580,8 +1693,10 @@ class FieldsTests(SimpleTestCase):
         for exp, got in zip(expected, fix_os_paths(f.choices)):
             self.assertEqual(exp[1], got[1])
             self.assertTrue(got[0].endswith(exp[0]))
-        with self.assertRaisesMessage(ValidationError,
-                "'Select a valid choice. fields.py is not one of the available choices.'"):
+        with self.assertRaisesMessage(
+            ValidationError,
+            "'Select a valid choice. fields.py is not one of the available choices.'"
+        ):
             f.clean('fields.py')
         assert fix_os_paths(f.clean(path + 'fields.py')).endswith('/django/forms/fields.py')
 

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -152,9 +152,12 @@ class FieldsTests(SimpleTestCase):
         Ensure that setting min_length or max_length to something that is not a
         number returns an exception.
         """
-        self.assertRaises(ValueError, CharField, min_length='a')
-        self.assertRaises(ValueError, CharField, max_length='a')
-        self.assertRaises(ValueError, CharField, 'a')
+        with self.assertRaises(ValueError):
+            CharField(min_length='a')
+        with self.assertRaises(ValueError):
+            CharField(max_length='a')
+        with self.assertRaises(ValueError):
+            CharField('a')
 
     def test_charfield_widget_attrs(self):
         """
@@ -1713,8 +1716,10 @@ class FieldsTests(SimpleTestCase):
     # GenericIPAddressField #######################################################
 
     def test_generic_ipaddress_invalid_arguments(self):
-        self.assertRaises(ValueError, GenericIPAddressField, protocol="hamster")
-        self.assertRaises(ValueError, GenericIPAddressField, protocol="ipv4", unpack_ipv4=True)
+        with self.assertRaises(ValueError):
+            GenericIPAddressField(protocol="hamster")
+        with self.assertRaises(ValueError):
+            GenericIPAddressField(protocol="ipv4", unpack_ipv4=True)
 
     def test_generic_ipaddress_as_generic(self):
         # The edge cases of the IPv6 validation code are not deeply tested

--- a/tests/forms_tests/tests/test_fields.py
+++ b/tests/forms_tests/tests/test_fields.py
@@ -96,8 +96,10 @@ class FieldsTests(SimpleTestCase):
         f = CharField()
         self.assertEqual('1', f.clean(1))
         self.assertEqual('hello', f.clean('hello'))
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
         self.assertEqual('[1, 2, 3]', f.clean([1, 2, 3]))
         self.assertEqual(f.max_length, None)
         self.assertEqual(f.min_length, None)
@@ -135,7 +137,8 @@ class FieldsTests(SimpleTestCase):
 
     def test_charfield_5(self):
         f = CharField(min_length=10, required=True)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
         msg = "'Ensure this value has at least 10 characters (it has 5).'"
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean('12345')
@@ -190,18 +193,23 @@ class FieldsTests(SimpleTestCase):
     def test_integerfield_1(self):
         f = IntegerField()
         self.assertWidgetRendersTo(f, '<input type="number" name="f" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(1, f.clean('1'))
         self.assertIsInstance(f.clean('1'), int)
         self.assertEqual(23, f.clean('23'))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, 'a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('a')
         self.assertEqual(42, f.clean(42))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, 3.14)
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean(3.14)
         self.assertEqual(1, f.clean('1 '))
         self.assertEqual(1, f.clean(' 1'))
         self.assertEqual(1, f.clean(' 1 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, '1a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('1a')
         self.assertEqual(f.max_value, None)
         self.assertEqual(f.min_value, None)
 
@@ -214,31 +222,38 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(1, f.clean('1'))
         self.assertIsInstance(f.clean('1'), int)
         self.assertEqual(23, f.clean('23'))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, 'a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('a')
         self.assertEqual(1, f.clean('1 '))
         self.assertEqual(1, f.clean(' 1'))
         self.assertEqual(1, f.clean(' 1 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, '1a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('1a')
         self.assertEqual(f.max_value, None)
         self.assertEqual(f.min_value, None)
 
     def test_integerfield_3(self):
         f = IntegerField(max_value=10)
         self.assertWidgetRendersTo(f, '<input max="10" type="number" name="f" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(1, f.clean(1))
         self.assertEqual(10, f.clean(10))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'", f.clean, 11)
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'"):
+            f.clean(11)
         self.assertEqual(10, f.clean('10'))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'", f.clean, '11')
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 10.'"):
+            f.clean('11')
         self.assertEqual(f.max_value, 10)
         self.assertEqual(f.min_value, None)
 
     def test_integerfield_4(self):
         f = IntegerField(min_value=10)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'", f.clean, 1)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
+            f.clean(1)
         self.assertEqual(10, f.clean(10))
         self.assertEqual(11, f.clean(11))
         self.assertEqual(10, f.clean('10'))
@@ -249,14 +264,17 @@ class FieldsTests(SimpleTestCase):
     def test_integerfield_5(self):
         f = IntegerField(min_value=10, max_value=20)
         self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'", f.clean, 1)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
+            f.clean(1)
         self.assertEqual(10, f.clean(10))
         self.assertEqual(11, f.clean(11))
         self.assertEqual(10, f.clean('10'))
         self.assertEqual(11, f.clean('11'))
         self.assertEqual(20, f.clean(20))
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 20.'", f.clean, 21)
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 20.'"):
+            f.clean(21)
         self.assertEqual(f.max_value, 20)
         self.assertEqual(f.min_value, 10)
 
@@ -275,8 +293,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(1, f.clean(' 1.0 '))
         self.assertEqual(1, f.clean('1.'))
         self.assertEqual(1, f.clean(' 1. '))
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, '1.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a whole number.'", f.clean, '…')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('1.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a whole number.'"):
+            f.clean('…')
 
     def test_integerfield_big_num(self):
         f = IntegerField()
@@ -301,24 +321,31 @@ class FieldsTests(SimpleTestCase):
     def test_floatfield_1(self):
         f = FloatField()
         self.assertWidgetRendersTo(f, '<input step="any" type="number" name="f" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(1.0, f.clean('1'))
         self.assertIsInstance(f.clean('1'), float)
         self.assertEqual(23.0, f.clean('23'))
         self.assertEqual(3.1400000000000001, f.clean('3.14'))
         self.assertEqual(3.1400000000000001, f.clean(3.14))
         self.assertEqual(42.0, f.clean(42))
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('a')
         self.assertEqual(1.0, f.clean('1.0 '))
         self.assertEqual(1.0, f.clean(' 1.0'))
         self.assertEqual(1.0, f.clean(' 1.0 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, '1.0a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('1.0a')
         self.assertEqual(f.max_value, None)
         self.assertEqual(f.min_value, None)
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'Infinity')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'NaN')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, '-Inf')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('Infinity')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('NaN')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('-Inf')
 
     def test_floatfield_2(self):
         f = FloatField(required=False)
@@ -331,11 +358,10 @@ class FieldsTests(SimpleTestCase):
     def test_floatfield_3(self):
         f = FloatField(max_value=1.5, min_value=0.5)
         self.assertWidgetRendersTo(f, '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'", f.clean, '1.6')
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value is greater than or equal to 0.5.'",
-            f.clean, '0.4'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
+            f.clean('1.6')
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 0.5.'"):
+            f.clean('0.4')
         self.assertEqual(1.5, f.clean('1.5'))
         self.assertEqual(0.5, f.clean('0.5'))
         self.assertEqual(f.max_value, 1.5)
@@ -368,52 +394,50 @@ class FieldsTests(SimpleTestCase):
     def test_decimalfield_1(self):
         f = DecimalField(max_digits=4, decimal_places=2)
         self.assertWidgetRendersTo(f, '<input id="id_f" step="0.01" type="number" name="f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(f.clean('1'), Decimal("1"))
         self.assertIsInstance(f.clean('1'), Decimal)
         self.assertEqual(f.clean('23'), Decimal("23"))
         self.assertEqual(f.clean('3.14'), Decimal("3.14"))
         self.assertEqual(f.clean(3.14), Decimal("3.14"))
         self.assertEqual(f.clean(Decimal('3.14')), Decimal("3.14"))
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'NaN')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'Inf')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, '-Inf')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'a')
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, 'łąść')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('NaN')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('Inf')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('-Inf')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('łąść')
         self.assertEqual(f.clean('1.0 '), Decimal("1.0"))
         self.assertEqual(f.clean(' 1.0'), Decimal("1.0"))
         self.assertEqual(f.clean(' 1.0 '), Decimal("1.0"))
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, '1.0a')
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 4 digits in total.'",
-            f.clean, '123.45'
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 2 decimal places.'",
-            f.clean, '1.234'
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 2 digits before the decimal point.'",
-            f.clean, '123.4'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('1.0a')
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+            f.clean('123.45')
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+            f.clean('1.234')
+        with self.assertRaisesMessage(ValidationError,
+                "'Ensure that there are no more than 2 digits before the decimal point.'"):
+            f.clean('123.4')
         self.assertEqual(f.clean('-12.34'), Decimal("-12.34"))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 4 digits in total.'",
-            f.clean, '-123.45'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+            f.clean('-123.45')
         self.assertEqual(f.clean('-.12'), Decimal("-0.12"))
         self.assertEqual(f.clean('-00.12'), Decimal("-0.12"))
         self.assertEqual(f.clean('-000.12'), Decimal("-0.12"))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 2 decimal places.'",
-            f.clean, '-000.123'
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 4 digits in total.'",
-            f.clean, '-000.12345'
-        )
-        self.assertRaisesMessage(ValidationError, "'Enter a number.'", f.clean, '--0.12')
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+            f.clean('-000.123')
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 4 digits in total.'"):
+            f.clean('-000.12345')
+        with self.assertRaisesMessage(ValidationError, "'Enter a number.'"):
+            f.clean('--0.12')
         self.assertEqual(f.max_digits, 4)
         self.assertEqual(f.decimal_places, 2)
         self.assertEqual(f.max_value, None)
@@ -432,11 +456,10 @@ class FieldsTests(SimpleTestCase):
     def test_decimalfield_3(self):
         f = DecimalField(max_digits=4, decimal_places=2, max_value=Decimal('1.5'), min_value=Decimal('0.5'))
         self.assertWidgetRendersTo(f, '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'", f.clean, '1.6')
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value is greater than or equal to 0.5.'",
-            f.clean, '0.4'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
+            f.clean('1.6')
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 0.5.'"):
+            f.clean('0.4')
         self.assertEqual(f.clean('1.5'), Decimal("1.5"))
         self.assertEqual(f.clean('0.5'), Decimal("0.5"))
         self.assertEqual(f.clean('.5'), Decimal("0.5"))
@@ -448,10 +471,8 @@ class FieldsTests(SimpleTestCase):
 
     def test_decimalfield_4(self):
         f = DecimalField(decimal_places=2)
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 2 decimal places.'",
-            f.clean, '0.00000001'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 2 decimal places.'"):
+            f.clean('0.00000001')
 
     def test_decimalfield_5(self):
         f = DecimalField(max_digits=3)
@@ -461,19 +482,16 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(f.clean('0000000.100'), Decimal("0.100"))
         # Only leading whole zeros "collapse" to one digit.
         self.assertEqual(f.clean('000000.02'), Decimal('0.02'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 3 digits in total.'",
-            f.clean, '000000.0002'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure that there are no more than 3 digits in total.'"):
+            f.clean('000000.0002')
         self.assertEqual(f.clean('.002'), Decimal("0.002"))
 
     def test_decimalfield_6(self):
         f = DecimalField(max_digits=2, decimal_places=2)
         self.assertEqual(f.clean('.01'), Decimal(".01"))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure that there are no more than 0 digits before the decimal point.'",
-            f.clean, '1.1'
-        )
+        msg = "'Ensure that there are no more than 0 digits before the decimal point.'"
+        with self.assertRaisesMessage(ValidationError, msg):
+            f.clean('1.1')
 
     def test_decimalfield_scientific(self):
         f = DecimalField(max_digits=2, decimal_places=2)
@@ -530,10 +548,14 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.date(2006, 10, 25), f.clean('October 25, 2006'))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean('25 October 2006'))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean('25 October, 2006'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '2006-4-31')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '200a-10-25')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '25/10/06')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('2006-4-31')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('200a-10-25')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('25/10/06')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
 
     def test_datefield_2(self):
         f = DateField(required=False)
@@ -547,9 +569,12 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(datetime.date(2006, 10, 25)))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(datetime.datetime(2006, 10, 25, 14, 30)))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean('2006 10 25'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '2006-10-25')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '10/25/2006')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '10/25/06')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('2006-10-25')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('10/25/2006')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('10/25/06')
 
     def test_datefield_4(self):
         # Test whitespace stripping behavior (#5714)
@@ -560,12 +585,14 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(' October  25 2006 '))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(' October 25, 2006 '))
         self.assertEqual(datetime.date(2006, 10, 25), f.clean(' 25 October 2006 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, '   ')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('   ')
 
     def test_datefield_5(self):
         # Test null bytes (#18982)
         f = DateField()
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, 'a\x00b')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean('a\x00b')
 
     def test_datefield_changed(self):
         format = '%d/%m/%Y'
@@ -591,8 +618,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.time(14, 25, 59), f.clean(datetime.time(14, 25, 59)))
         self.assertEqual(datetime.time(14, 25), f.clean('14:25'))
         self.assertEqual(datetime.time(14, 25, 59), f.clean('14:25:59'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, 'hello')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, '1:24 p.m.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean('hello')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean('1:24 p.m.')
 
     def test_timefield_2(self):
         f = TimeField(input_formats=['%I:%M %p'])
@@ -600,14 +629,16 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.time(14, 25, 59), f.clean(datetime.time(14, 25, 59)))
         self.assertEqual(datetime.time(4, 25), f.clean('4:25 AM'))
         self.assertEqual(datetime.time(16, 25), f.clean('4:25 PM'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, '14:30:45')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean('14:30:45')
 
     def test_timefield_3(self):
         f = TimeField()
         # Test whitespace stripping behavior (#5714)
         self.assertEqual(datetime.time(14, 25), f.clean(' 14:25 '))
         self.assertEqual(datetime.time(14, 25, 59), f.clean(' 14:25:59 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, '   ')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean('   ')
 
     def test_timefield_changed(self):
         t1 = datetime.time(12, 51, 34, 482548)
@@ -647,8 +678,10 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.datetime(2006, 10, 25, 14, 30), f.clean('10/25/06 14:30:00'))
         self.assertEqual(datetime.datetime(2006, 10, 25, 14, 30), f.clean('10/25/06 14:30'))
         self.assertEqual(datetime.datetime(2006, 10, 25, 0, 0), f.clean('10/25/06'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'", f.clean, 'hello')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'", f.clean, '2006-10-25 4:30 p.m.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'"):
+            f.clean('hello')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'"):
+            f.clean('2006-10-25 4:30 p.m.')
 
     def test_datetimefield_2(self):
         f = DateTimeField(input_formats=['%Y %m %d %I:%M %p'])
@@ -663,7 +696,8 @@ class FieldsTests(SimpleTestCase):
             f.clean(datetime.datetime(2006, 10, 25, 14, 30, 59, 200))
         )
         self.assertEqual(datetime.datetime(2006, 10, 25, 14, 30), f.clean('2006 10 25 2:30 PM'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'", f.clean, '2006-10-25 14:30:45')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'"):
+            f.clean('2006-10-25 14:30:45')
 
     def test_datetimefield_3(self):
         f = DateTimeField(required=False)
@@ -682,7 +716,8 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(datetime.datetime(2006, 10, 25, 0, 0), f.clean(' 10/25/2006 '))
         self.assertEqual(datetime.datetime(2006, 10, 25, 14, 30, 45), f.clean(' 10/25/06 14:30:45 '))
         self.assertEqual(datetime.datetime(2006, 10, 25, 0, 0), f.clean(' 10/25/06 '))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'", f.clean, '   ')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date/time.'"):
+            f.clean('   ')
 
     def test_datetimefield_5(self):
         f = DateTimeField(input_formats=['%Y.%m.%d %H:%M:%S.%f'])
@@ -735,32 +770,38 @@ class FieldsTests(SimpleTestCase):
         f = RegexField('^[0-9][A-F][0-9]$')
         self.assertEqual('2A2', f.clean('2A2'))
         self.assertEqual('3F3', f.clean('3F3'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '3G3')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, ' 2A2')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '2A2 ')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('3G3')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean(' 2A2')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('2A2 ')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
 
     def test_regexfield_2(self):
         f = RegexField('^[0-9][A-F][0-9]$', required=False)
         self.assertEqual('2A2', f.clean('2A2'))
         self.assertEqual('3F3', f.clean('3F3'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '3G3')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('3G3')
         self.assertEqual('', f.clean(''))
 
     def test_regexfield_3(self):
         f = RegexField(re.compile('^[0-9][A-F][0-9]$'))
         self.assertEqual('2A2', f.clean('2A2'))
         self.assertEqual('3F3', f.clean('3F3'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '3G3')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, ' 2A2')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '2A2 ')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('3G3')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean(' 2A2')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('2A2 ')
 
     def test_regexfield_5(self):
         f = RegexField('^[0-9]+$', min_length=5, max_length=10)
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at least 5 characters (it has 3).'",
-            f.clean, '123'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 5 characters (it has 3).'"):
+            f.clean('123')
         six.assertRaisesRegex(
             self, ValidationError,
             "'Ensure this value has at least 5 characters \(it has 3\)\.',"
@@ -769,11 +810,10 @@ class FieldsTests(SimpleTestCase):
         )
         self.assertEqual('12345', f.clean('12345'))
         self.assertEqual('1234567890', f.clean('1234567890'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at most 10 characters (it has 11).'",
-            f.clean, '12345678901'
-        )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, '12345a')
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 10 characters (it has 11).'"):
+            f.clean('12345678901')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('12345a')
 
     def test_regexfield_6(self):
         """
@@ -787,7 +827,8 @@ class FieldsTests(SimpleTestCase):
         f = RegexField('^[a-z]+$')
         f.regex = '^[0-9]+$'
         self.assertEqual('1234', f.clean('1234'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid value.'", f.clean, 'abcd')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid value.'"):
+            f.clean('abcd')
 
     # EmailField ##################################################################
     # See also validators tests for validate_email specific tests
@@ -795,10 +836,13 @@ class FieldsTests(SimpleTestCase):
     def test_emailfield_1(self):
         f = EmailField()
         self.assertWidgetRendersTo(f, '<input type="email" name="f" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual('person@example.com', f.clean('person@example.com'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
+            f.clean('foo')
         self.assertEqual('local@domain.with.idn.xyz\xe4\xf6\xfc\xdfabc.part.com',
             f.clean('local@domain.with.idn.xyzäöüßabc.part.com'))
 
@@ -815,52 +859,46 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('', f.clean(None))
         self.assertEqual('person@example.com', f.clean('person@example.com'))
         self.assertEqual('example@example.com', f.clean('      example@example.com  \t   \t '))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
+            f.clean('foo')
 
     def test_emailfield_min_max_length(self):
         f = EmailField(min_length=10, max_length=15)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="email" name="f" maxlength="15" />')
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at least 10 characters (it has 9).'",
-            f.clean, 'a@foo.com'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 9).'"):
+            f.clean('a@foo.com')
         self.assertEqual('alf@foo.com', f.clean('alf@foo.com'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at most 15 characters (it has 20).'",
-            f.clean, 'alf123456788@foo.com'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 15 characters (it has 20).'"):
+            f.clean('alf123456788@foo.com')
 
     # FileField ##################################################################
 
     def test_filefield_1(self):
         f = FileField()
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '', '')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('', '')
         self.assertEqual('files/test1.pdf', f.clean('', 'files/test1.pdf'))
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None, '')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None, '')
         self.assertEqual('files/test2.pdf', f.clean(None, 'files/test2.pdf'))
-        self.assertRaisesMessage(
-            ValidationError, "'No file was submitted. Check the encoding type on the form.'",
-            f.clean, SimpleUploadedFile('', b'')
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'No file was submitted. Check the encoding type on the form.'",
-            f.clean, SimpleUploadedFile('', b''), ''
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'No file was submitted. Check the encoding type on the form.'"):
+            f.clean(SimpleUploadedFile('', b''))
+        with self.assertRaisesMessage(ValidationError,
+                "'No file was submitted. Check the encoding type on the form.'"):
+            f.clean(SimpleUploadedFile('', b''), '')
         self.assertEqual('files/test3.pdf', f.clean(None, 'files/test3.pdf'))
-        self.assertRaisesMessage(
-            ValidationError, "'No file was submitted. Check the encoding type on the form.'",
-            f.clean, 'some content that is not a file'
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'The submitted file is empty.'",
-            f.clean, SimpleUploadedFile('name', None)
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'The submitted file is empty.'",
-            f.clean, SimpleUploadedFile('name', b'')
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'No file was submitted. Check the encoding type on the form.'"):
+            f.clean('some content that is not a file')
+        with self.assertRaisesMessage(ValidationError, "'The submitted file is empty.'"):
+            f.clean(SimpleUploadedFile('name', None))
+        with self.assertRaisesMessage(ValidationError, "'The submitted file is empty.'"):
+            f.clean(SimpleUploadedFile('name', b''))
         self.assertEqual(SimpleUploadedFile, type(f.clean(SimpleUploadedFile('name', b'Some File Content'))))
         self.assertIsInstance(
             f.clean(SimpleUploadedFile('我隻氣墊船裝滿晒鱔.txt', 'मेरी मँडराने वाली नाव सर्पमीनों से भरी ह'.encode('utf-8'))),
@@ -873,10 +911,8 @@ class FieldsTests(SimpleTestCase):
 
     def test_filefield_2(self):
         f = FileField(max_length=5)
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this filename has at most 5 characters (it has 18).'",
-            f.clean, SimpleUploadedFile('test_maxlength.txt', b'hello world')
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this filename has at most 5 characters (it has 18).'"):
+            f.clean(SimpleUploadedFile('test_maxlength.txt', b'hello world'))
         self.assertEqual('files/test1.pdf', f.clean('', 'files/test1.pdf'))
         self.assertEqual('files/test2.pdf', f.clean(None, 'files/test2.pdf'))
         self.assertEqual(SimpleUploadedFile, type(f.clean(SimpleUploadedFile('name', b'Some File Content'))))
@@ -955,8 +991,10 @@ class FieldsTests(SimpleTestCase):
     def test_urlfield_1(self):
         f = URLField()
         self.assertWidgetRendersTo(f, '<input type="url" name="f" id="id_f" />')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual('http://localhost', f.clean('http://localhost'))
         self.assertEqual('http://example.com', f.clean('http://example.com'))
         self.assertEqual('http://example.com.', f.clean('http://example.com.'))
@@ -966,17 +1004,28 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('http://subdomain.domain.com', f.clean('subdomain.domain.com'))
         self.assertEqual('http://200.8.9.10', f.clean('http://200.8.9.10'))
         self.assertEqual('http://200.8.9.10:8000/test', f.clean('http://200.8.9.10:8000/test'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://example')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://example.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'com.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, '.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://.com')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://invalid-.com')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://-invalid.com')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://inv-.alid-.com')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://inv-.-alid.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://example')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://example.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('com.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://invalid-.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://-invalid.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://inv-.alid-.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://inv-.-alid.com')
         self.assertEqual('http://valid-----hyphens.com', f.clean('http://valid-----hyphens.com'))
         self.assertEqual(
             'http://some.idn.xyz\xe4\xf6\xfc\xdfabc.domain.com:123/blah',
@@ -986,17 +1035,21 @@ class FieldsTests(SimpleTestCase):
             'http://www.example.com/s/http://code.djangoproject.com/ticket/13804',
             f.clean('www.example.com/s/http://code.djangoproject.com/ticket/13804')
         )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, '[a')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://[a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('[a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://[a')
 
     def test_url_regex_ticket11198(self):
         f = URLField()
         # hangs "forever" if catastrophic backtracking in ticket:#11198 not fixed
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://%s' % ("X" * 200,))
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://%s' % ("X" * 200,))
 
         # a second test, to make sure the problem is really addressed, even on
         # domains that don't fail the domain label length check in the regex
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://%s' % ("X" * 60,))
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://%s' % ("X" * 60,))
 
     def test_urlfield_2(self):
         f = URLField(required=False)
@@ -1004,24 +1057,25 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('', f.clean(None))
         self.assertEqual('http://example.com', f.clean('http://example.com'))
         self.assertEqual('http://www.example.com', f.clean('http://www.example.com'))
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://example')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://example.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 'http://.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://example')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://example.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean('http://.com')
 
     def test_urlfield_5(self):
         f = URLField(min_length=15, max_length=20)
         self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" />')
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at least 15 characters (it has 12).'",
-            f.clean, 'http://f.com'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 15 characters (it has 12).'"):
+            f.clean('http://f.com')
         self.assertEqual('http://example.com', f.clean('http://example.com'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at most 20 characters (it has 37).'",
-            f.clean, 'http://abcdefghijklmnopqrstuvwxyz.com'
-        )
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 37).'"):
+            f.clean('http://abcdefghijklmnopqrstuvwxyz.com')
 
     def test_urlfield_6(self):
         f = URLField(required=False)
@@ -1068,7 +1122,8 @@ class FieldsTests(SimpleTestCase):
 
     def test_urlfield_not_string(self):
         f = URLField(required=False)
-        self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'", f.clean, 23)
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid URL.'"):
+            f.clean(23)
 
     def test_urlfield_normalization(self):
         f = URLField()
@@ -1078,15 +1133,20 @@ class FieldsTests(SimpleTestCase):
 
     def test_booleanfield_1(self):
         f = BooleanField()
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(True, f.clean(True))
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, False)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(False)
         self.assertEqual(True, f.clean(1))
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, 0)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(0)
         self.assertEqual(True, f.clean('Django rocks'))
         self.assertEqual(True, f.clean('True'))
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, 'False')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('False')
 
     def test_booleanfield_2(self):
         f = BooleanField(required=False)
@@ -1122,14 +1182,15 @@ class FieldsTests(SimpleTestCase):
 
     def test_choicefield_1(self):
         f = ChoiceField(choices=[('1', 'One'), ('2', 'Two')])
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual('1', f.clean(1))
         self.assertEqual('1', f.clean('1'))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, '3'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean('3')
 
     def test_choicefield_2(self):
         f = ChoiceField(choices=[('1', 'One'), ('2', 'Two')], required=False)
@@ -1137,18 +1198,16 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('', f.clean(None))
         self.assertEqual('1', f.clean(1))
         self.assertEqual('1', f.clean('1'))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, '3'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean('3')
 
     def test_choicefield_3(self):
         f = ChoiceField(choices=[('J', 'John'), ('P', 'Paul')])
         self.assertEqual('J', f.clean('J'))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. John is not one of the available choices.'",
-            f.clean, 'John'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. John is not one of the available choices.'"):
+            f.clean('John')
 
     def test_choicefield_4(self):
         f = ChoiceField(
@@ -1163,10 +1222,9 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual('3', f.clean('3'))
         self.assertEqual('5', f.clean(5))
         self.assertEqual('5', f.clean('5'))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 6 is not one of the available choices.'",
-            f.clean, '6'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 6 is not one of the available choices.'"):
+            f.clean('6')
 
     def test_choicefield_callable(self):
         choices = lambda: [('J', 'John'), ('P', 'Paul')]
@@ -1203,10 +1261,9 @@ class FieldsTests(SimpleTestCase):
     def test_typedchoicefield_1(self):
         f = TypedChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual(1, f.clean('1'))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 2 is not one of the available choices.'",
-            f.clean, '2'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 2 is not one of the available choices.'"):
+            f.clean('2')
 
     def test_typedchoicefield_2(self):
         # Different coercion, same validation.
@@ -1222,12 +1279,12 @@ class FieldsTests(SimpleTestCase):
         # Even more weirdness: if you have a valid choice but your coercion function
         # can't coerce, you'll still get a validation error. Don't do this!
         f = TypedChoiceField(choices=[('A', 'A'), ('B', 'B')], coerce=int)
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. B is not one of the available choices.'",
-            f.clean, 'B'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. B is not one of the available choices.'"):
+            f.clean('B')
         # Required fields require values
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
 
     def test_typedchoicefield_5(self):
         # Non-required fields aren't required
@@ -1264,14 +1321,11 @@ class FieldsTests(SimpleTestCase):
 
         f = TypedChoiceField(choices=[(1, "1"), (2, "2")], coerce=coerce_func, required=True)
         self.assertEqual(Decimal('1.2'), f.clean('2'))
-        self.assertRaisesMessage(
-            ValidationError, "'This field is required.'",
-            f.clean, ''
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, '3'
-        )
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean('3')
 
     # NullBooleanField ############################################################
 
@@ -1339,20 +1393,24 @@ class FieldsTests(SimpleTestCase):
 
     def test_multiplechoicefield_1(self):
         f = MultipleChoiceField(choices=[('1', 'One'), ('2', 'Two')])
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(['1'], f.clean([1]))
         self.assertEqual(['1'], f.clean(['1']))
         self.assertEqual(['1', '2'], f.clean(['1', '2']))
         self.assertEqual(['1', '2'], f.clean([1, '2']))
         self.assertEqual(['1', '2'], f.clean((1, '2')))
-        self.assertRaisesMessage(ValidationError, "'Enter a list of values.'", f.clean, 'hello')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, [])
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, ())
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, ['3']
-        )
+        with self.assertRaisesMessage(ValidationError, "'Enter a list of values.'"):
+            f.clean('hello')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean([])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(())
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean(['3'])
 
     def test_multiplechoicefield_2(self):
         f = MultipleChoiceField(choices=[('1', 'One'), ('2', 'Two')], required=False)
@@ -1363,13 +1421,13 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(['1', '2'], f.clean(['1', '2']))
         self.assertEqual(['1', '2'], f.clean([1, '2']))
         self.assertEqual(['1', '2'], f.clean((1, '2')))
-        self.assertRaisesMessage(ValidationError, "'Enter a list of values.'", f.clean, 'hello')
+        with self.assertRaisesMessage(ValidationError, "'Enter a list of values.'"):
+            f.clean('hello')
         self.assertEqual([], f.clean([]))
         self.assertEqual([], f.clean(()))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, ['3']
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean(['3'])
 
     def test_multiplechoicefield_3(self):
         f = MultipleChoiceField(
@@ -1381,14 +1439,12 @@ class FieldsTests(SimpleTestCase):
         self.assertEqual(['1', '5'], f.clean([1, '5']))
         self.assertEqual(['1', '5'], f.clean(['1', 5]))
         self.assertEqual(['1', '5'], f.clean(['1', '5']))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 6 is not one of the available choices.'",
-            f.clean, ['6']
-        )
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 6 is not one of the available choices.'",
-            f.clean, ['1', '6']
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 6 is not one of the available choices.'"):
+            f.clean(['6'])
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 6 is not one of the available choices.'"):
+            f.clean(['1', '6'])
 
     def test_multiplechoicefield_changed(self):
         f = MultipleChoiceField(choices=[('1', 'One'), ('2', 'Two'), ('3', 'Three')])
@@ -1407,10 +1463,9 @@ class FieldsTests(SimpleTestCase):
     def test_typedmultiplechoicefield_1(self):
         f = TypedMultipleChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual([1], f.clean(['1']))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 2 is not one of the available choices.'",
-            f.clean, ['2']
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 2 is not one of the available choices.'"):
+            f.clean(['2'])
 
     def test_typedmultiplechoicefield_2(self):
         # Different coercion, same validation.
@@ -1425,21 +1480,20 @@ class FieldsTests(SimpleTestCase):
     def test_typedmultiplechoicefield_4(self):
         f = TypedMultipleChoiceField(choices=[(1, "+1"), (-1, "-1")], coerce=int)
         self.assertEqual([1, -1], f.clean(['1', '-1']))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. 2 is not one of the available choices.'",
-            f.clean, ['1', '2']
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 2 is not one of the available choices.'"):
+            f.clean(['1', '2'])
 
     def test_typedmultiplechoicefield_5(self):
         # Even more weirdness: if you have a valid choice but your coercion function
         # can't coerce, you'll still get a validation error. Don't do this!
         f = TypedMultipleChoiceField(choices=[('A', 'A'), ('B', 'B')], coerce=int)
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. B is not one of the available choices.'",
-            f.clean, ['B']
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. B is not one of the available choices.'"):
+            f.clean(['B'])
         # Required fields require values
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, [])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean([])
 
     def test_typedmultiplechoicefield_6(self):
         # Non-required fields aren't required
@@ -1467,33 +1521,33 @@ class FieldsTests(SimpleTestCase):
         f = TypedMultipleChoiceField(
             choices=[(1, "1"), (2, "2")], coerce=coerce_func, required=True)
         self.assertEqual([Decimal('1.2')], f.clean(['2']))
-        self.assertRaisesMessage(ValidationError,
-            "'This field is required.'", f.clean, [])
-        self.assertRaisesMessage(ValidationError,
-            "'Select a valid choice. 3 is not one of the available choices.'",
-            f.clean, ['3'])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean([])
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. 3 is not one of the available choices.'"):
+            f.clean(['3'])
 
     # ComboField ##################################################################
 
     def test_combofield_1(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()])
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at most 20 characters (it has 28).'",
-            f.clean, 'longemailaddress@example.com'
-        )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'not an email')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'"):
+            f.clean('longemailaddress@example.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
+            f.clean('not an email')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
 
     def test_combofield_2(self):
         f = ComboField(fields=[CharField(max_length=20), EmailField()], required=False)
         self.assertEqual('test@example.com', f.clean('test@example.com'))
-        self.assertRaisesMessage(
-            ValidationError, "'Ensure this value has at most 20 characters (it has 28).'",
-            f.clean, 'longemailaddress@example.com'
-        )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'", f.clean, 'not an email')
+        with self.assertRaisesMessage(ValidationError, "'Ensure this value has at most 20 characters (it has 28).'"):
+            f.clean('longemailaddress@example.com')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid email address.'"):
+            f.clean('not an email')
         self.assertEqual('', f.clean(''))
         self.assertEqual('', f.clean(None))
 
@@ -1523,10 +1577,9 @@ class FieldsTests(SimpleTestCase):
         for exp, got in zip(expected, fix_os_paths(f.choices)):
             self.assertEqual(exp[1], got[1])
             self.assertTrue(got[0].endswith(exp[0]))
-        self.assertRaisesMessage(
-            ValidationError, "'Select a valid choice. fields.py is not one of the available choices.'",
-            f.clean, 'fields.py'
-        )
+        with self.assertRaisesMessage(ValidationError,
+                "'Select a valid choice. fields.py is not one of the available choices.'"):
+            f.clean('fields.py')
         assert fix_os_paths(f.clean(path + 'fields.py')).endswith('/django/forms/fields.py')
 
     def test_filepathfield_3(self):
@@ -1607,15 +1660,20 @@ class FieldsTests(SimpleTestCase):
             datetime.datetime(2006, 1, 10, 7, 30),
             f.clean([datetime.date(2006, 1, 10), datetime.time(7, 30)])
         )
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'Enter a list of values.'", f.clean, 'hello')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'Enter a list of values.'"):
+            f.clean('hello')
         six.assertRaisesRegex(
             self, ValidationError, "'Enter a valid date\.', u?'Enter a valid time\.'",
             f.clean, ['hello', 'there']
         )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, ['2006-01-10', 'there'])
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, ['hello', '07:30'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean(['2006-01-10', 'there'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean(['hello', '07:30'])
 
     def test_splitdatetimefield_2(self):
         f = SplitDateTimeField(required=False)
@@ -1628,16 +1686,22 @@ class FieldsTests(SimpleTestCase):
         self.assertIsNone(f.clean(''))
         self.assertIsNone(f.clean(['']))
         self.assertIsNone(f.clean(['', '']))
-        self.assertRaisesMessage(ValidationError, "'Enter a list of values.'", f.clean, 'hello')
+        with self.assertRaisesMessage(ValidationError, "'Enter a list of values.'"):
+            f.clean('hello')
         six.assertRaisesRegex(
             self, ValidationError, "'Enter a valid date\.', u?'Enter a valid time\.'",
             f.clean, ['hello', 'there']
         )
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, ['2006-01-10', 'there'])
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, ['hello', '07:30'])
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, ['2006-01-10', ''])
-        self.assertRaisesMessage(ValidationError, "'Enter a valid time.'", f.clean, ['2006-01-10'])
-        self.assertRaisesMessage(ValidationError, "'Enter a valid date.'", f.clean, ['', '07:30'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean(['2006-01-10', 'there'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean(['hello', '07:30'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean(['2006-01-10', ''])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid time.'"):
+            f.clean(['2006-01-10'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid date.'"):
+            f.clean(['', '07:30'])
 
     def test_splitdatetimefield_changed(self):
         f = SplitDateTimeField(input_date_formats=['%d/%m/%Y'])
@@ -1656,75 +1720,106 @@ class FieldsTests(SimpleTestCase):
         # The edge cases of the IPv6 validation code are not deeply tested
         # here, they are covered in the tests for django.utils.ipv6
         f = GenericIPAddressField()
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(f.clean(' 127.0.0.1 '), '127.0.0.1')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '127.0.0.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '1.2.3.4.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '256.125.1.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('127.0.0.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('1.2.3.4.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('256.125.1.5')
         self.assertEqual(f.clean(' fe80::223:6cff:fe8a:2e8a '), 'fe80::223:6cff:fe8a:2e8a')
         self.assertEqual(f.clean(' 2a02::223:6cff:fe8a:2e8a '), '2a02::223:6cff:fe8a:2e8a')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '12345:2:3:4')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3::4')
-        self.assertRaisesMessage(
-            ValidationError, "'This is not a valid IPv6 address.'",
-            f.clean, 'foo::223:6cff:fe8a:2e8a'
-        )
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3:4:5:6:7:8')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1:2')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('12345:2:3:4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3::4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('foo::223:6cff:fe8a:2e8a')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3:4:5:6:7:8')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1:2')
 
     def test_generic_ipaddress_as_ipv4_only(self):
         f = GenericIPAddressField(protocol="IPv4")
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
         self.assertEqual(f.clean(' 127.0.0.1 '), '127.0.0.1')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, '127.0.0.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, '1.2.3.4.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, '256.125.1.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, 'fe80::223:6cff:fe8a:2e8a')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'", f.clean, '2a02::223:6cff:fe8a:2e8a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('127.0.0.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('1.2.3.4.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('256.125.1.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('fe80::223:6cff:fe8a:2e8a')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 address.'"):
+            f.clean('2a02::223:6cff:fe8a:2e8a')
 
     def test_generic_ipaddress_as_ipv6_only(self):
         f = GenericIPAddressField(protocol="IPv6")
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'", f.clean, '127.0.0.1')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'", f.clean, '127.0.0.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'", f.clean, '1.2.3.4.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'", f.clean, '256.125.1.5')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'"):
+            f.clean('127.0.0.1')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'"):
+            f.clean('127.0.0.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'"):
+            f.clean('1.2.3.4.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv6 address.'"):
+            f.clean('256.125.1.5')
         self.assertEqual(f.clean(' fe80::223:6cff:fe8a:2e8a '), 'fe80::223:6cff:fe8a:2e8a')
         self.assertEqual(f.clean(' 2a02::223:6cff:fe8a:2e8a '), '2a02::223:6cff:fe8a:2e8a')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '12345:2:3:4')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3::4')
-        self.assertRaisesMessage(
-            ValidationError, "'This is not a valid IPv6 address.'",
-            f.clean, 'foo::223:6cff:fe8a:2e8a'
-        )
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3:4:5:6:7:8')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1:2')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('12345:2:3:4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3::4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('foo::223:6cff:fe8a:2e8a')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3:4:5:6:7:8')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1:2')
 
     def test_generic_ipaddress_as_generic_not_required(self):
         f = GenericIPAddressField(required=False)
         self.assertEqual(f.clean(''), '')
         self.assertEqual(f.clean(None), '')
         self.assertEqual(f.clean('127.0.0.1'), '127.0.0.1')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, 'foo')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '127.0.0.')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '1.2.3.4.5')
-        self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'", f.clean, '256.125.1.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('foo')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('127.0.0.')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('1.2.3.4.5')
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid IPv4 or IPv6 address.'"):
+            f.clean('256.125.1.5')
         self.assertEqual(f.clean(' fe80::223:6cff:fe8a:2e8a '), 'fe80::223:6cff:fe8a:2e8a')
         self.assertEqual(f.clean(' 2a02::223:6cff:fe8a:2e8a '), '2a02::223:6cff:fe8a:2e8a')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '12345:2:3:4')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3::4')
-        self.assertRaisesMessage(
-            ValidationError, "'This is not a valid IPv6 address.'",
-            f.clean, 'foo::223:6cff:fe8a:2e8a'
-        )
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1::2:3:4:5:6:7:8')
-        self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'", f.clean, '1:2')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('12345:2:3:4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3::4')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('foo::223:6cff:fe8a:2e8a')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1::2:3:4:5:6:7:8')
+        with self.assertRaisesMessage(ValidationError, "'This is not a valid IPv6 address.'"):
+            f.clean('1:2')
 
     def test_generic_ipaddress_normalization(self):
         # Test the normalizing code

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2725,14 +2725,19 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         # An empty value for any field will raise a `required` error on a
         # required `MultiValueField`.
         f = PhoneField()
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, [])
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, ['+61'])
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, ['+61', '287654321', '123'])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean([])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(['+61'])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(['+61', '287654321', '123'])
         self.assertEqual('+61.287654321 ext. 123 (label: Home)', f.clean(['+61', '287654321', '123', 'Home']))
-        self.assertRaisesMessage(ValidationError,
-            "'Enter a valid country code.'", f.clean, ['61', '287654321', '123', 'Home'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid country code.'"):
+            f.clean(['61', '287654321', '123', 'Home'])
 
         # Empty values for fields will NOT raise a `required` error on an
         # optional `MultiValueField`
@@ -2743,23 +2748,27 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertEqual('+61. ext.  (label: )', f.clean(['+61']))
         self.assertEqual('+61.287654321 ext. 123 (label: )', f.clean(['+61', '287654321', '123']))
         self.assertEqual('+61.287654321 ext. 123 (label: Home)', f.clean(['+61', '287654321', '123', 'Home']))
-        self.assertRaisesMessage(ValidationError,
-            "'Enter a valid country code.'", f.clean, ['61', '287654321', '123', 'Home'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid country code.'"):
+            f.clean(['61', '287654321', '123', 'Home'])
 
         # For a required `MultiValueField` with `require_all_fields=False`, a
         # `required` error will only be raised if all fields are empty. Fields
         # can individually be required or optional. An empty value for any
         # required field will raise an `incomplete` error.
         f = PhoneField(require_all_fields=False)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, '')
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, None)
-        self.assertRaisesMessage(ValidationError, "'This field is required.'", f.clean, [])
-        self.assertRaisesMessage(ValidationError, "'Enter a complete value.'", f.clean, ['+61'])
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean('')
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean(None)
+        with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
+            f.clean([])
+        with self.assertRaisesMessage(ValidationError, "'Enter a complete value.'"):
+            f.clean(['+61'])
         self.assertEqual('+61.287654321 ext. 123 (label: )', f.clean(['+61', '287654321', '123']))
         six.assertRaisesRegex(self, ValidationError,
             "'Enter a complete value\.', u?'Enter an extension\.'", f.clean, ['', '', '', 'Home'])
-        self.assertRaisesMessage(ValidationError,
-            "'Enter a valid country code.'", f.clean, ['61', '287654321', '123', 'Home'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid country code.'"):
+            f.clean(['61', '287654321', '123', 'Home'])
 
         # For an optional `MultiValueField` with `require_all_fields=False`, we
         # don't get any `required` error but we still get `incomplete` errors.
@@ -2767,12 +2776,13 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertIsNone(f.clean(''))
         self.assertIsNone(f.clean(None))
         self.assertIsNone(f.clean([]))
-        self.assertRaisesMessage(ValidationError, "'Enter a complete value.'", f.clean, ['+61'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a complete value.'"):
+            f.clean(['+61'])
         self.assertEqual('+61.287654321 ext. 123 (label: )', f.clean(['+61', '287654321', '123']))
         six.assertRaisesRegex(self, ValidationError,
             "'Enter a complete value\.', u?'Enter an extension\.'", f.clean, ['', '', '', 'Home'])
-        self.assertRaisesMessage(ValidationError,
-            "'Enter a valid country code.'", f.clean, ['61', '287654321', '123', 'Home'])
+        with self.assertRaisesMessage(ValidationError, "'Enter a valid country code.'"):
+            f.clean(['61', '287654321', '123', 'Home'])
 
     def test_custom_empty_values(self):
         """

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -3229,7 +3229,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         """
         p = Person({'first_name': 'John', 'last_name': 'Lennon', 'birthday': 'fakedate'})
         repr(p)
-        self.assertRaises(AttributeError, lambda: p.cleaned_data)
+        with self.assertRaises(AttributeError):
+            p.cleaned_data
         self.assertFalse(p.is_valid())
         self.assertEqual(p.cleaned_data, {'first_name': 'John', 'last_name': 'Lennon'})
 

--- a/tests/forms_tests/tests/test_input_formats.py
+++ b/tests/forms_tests/tests/test_input_formats.py
@@ -19,7 +19,8 @@ class LocalizedTimeTests(SimpleTestCase):
         "TimeFields can parse dates in the default format"
         f = forms.TimeField()
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13:30:05')
@@ -45,7 +46,8 @@ class LocalizedTimeTests(SimpleTestCase):
         "Localized TimeFields act as unlocalized widgets"
         f = forms.TimeField(localize=True)
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13:30:05')
@@ -67,8 +69,10 @@ class LocalizedTimeTests(SimpleTestCase):
         "TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%H.%M.%S", "%H.%M"])
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13.30.05')
@@ -90,8 +94,10 @@ class LocalizedTimeTests(SimpleTestCase):
         "Localized TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%H.%M.%S", "%H.%M"], localize=True)
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13.30.05')
@@ -116,7 +122,8 @@ class CustomTimeInputFormatsTests(SimpleTestCase):
         "TimeFields can parse dates in the default format"
         f = forms.TimeField()
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('1:30:05 PM')
@@ -138,7 +145,8 @@ class CustomTimeInputFormatsTests(SimpleTestCase):
         "Localized TimeFields act as unlocalized widgets"
         f = forms.TimeField(localize=True)
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('1:30:05 PM')
@@ -160,8 +168,10 @@ class CustomTimeInputFormatsTests(SimpleTestCase):
         "TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%H.%M.%S", "%H.%M"])
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13.30.05')
@@ -183,8 +193,10 @@ class CustomTimeInputFormatsTests(SimpleTestCase):
         "Localized TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%H.%M.%S", "%H.%M"], localize=True)
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13.30.05')
@@ -208,7 +220,8 @@ class SimpleTimeFormatTests(SimpleTestCase):
         "TimeFields can parse dates in the default format"
         f = forms.TimeField()
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13:30:05')
@@ -230,7 +243,8 @@ class SimpleTimeFormatTests(SimpleTestCase):
         "Localized TimeFields in a non-localized environment act as unlocalized widgets"
         f = forms.TimeField()
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('13:30:05')
@@ -252,7 +266,8 @@ class SimpleTimeFormatTests(SimpleTestCase):
         "TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%I:%M:%S %p", "%I:%M %p"])
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('1:30:05 PM')
@@ -274,7 +289,8 @@ class SimpleTimeFormatTests(SimpleTestCase):
         "Localized TimeFields with manually specified input formats can accept those formats"
         f = forms.TimeField(input_formats=["%I:%M:%S %p", "%I:%M %p"], localize=True)
         # Parse a time in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05')
 
         # Parse a time in a valid format, get a parsed result
         result = f.clean('1:30:05 PM')
@@ -305,7 +321,8 @@ class LocalizedDateTests(SimpleTestCase):
         "DateFields can parse dates in the default format"
         f = forms.DateField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21/12/2010')
 
         # ISO formats are accepted, even if not specified in formats.py
         self.assertEqual(f.clean('2010-12-21'), date(2010, 12, 21))
@@ -330,7 +347,8 @@ class LocalizedDateTests(SimpleTestCase):
         "Localized DateFields act as unlocalized widgets"
         f = forms.DateField(localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21/12/2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010')
@@ -352,9 +370,12 @@ class LocalizedDateTests(SimpleTestCase):
         "DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%m.%d.%Y", "%m-%d-%Y"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
-        self.assertRaises(forms.ValidationError, f.clean, '21/12/2010')
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010')
@@ -376,9 +397,12 @@ class LocalizedDateTests(SimpleTestCase):
         "Localized DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%m.%d.%Y", "%m-%d-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
-        self.assertRaises(forms.ValidationError, f.clean, '21/12/2010')
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010')
@@ -403,7 +427,8 @@ class CustomDateInputFormatsTests(SimpleTestCase):
         "DateFields can parse dates in the default format"
         f = forms.DateField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010')
@@ -425,7 +450,8 @@ class CustomDateInputFormatsTests(SimpleTestCase):
         "Localized DateFields act as unlocalized widgets"
         f = forms.DateField(localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010')
@@ -447,8 +473,10 @@ class CustomDateInputFormatsTests(SimpleTestCase):
         "DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%m.%d.%Y", "%m-%d-%Y"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010')
@@ -470,8 +498,10 @@ class CustomDateInputFormatsTests(SimpleTestCase):
         "Localized DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%m.%d.%Y", "%m-%d-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010')
@@ -495,7 +525,8 @@ class SimpleDateFormatTests(SimpleTestCase):
         "DateFields can parse dates in the default format"
         f = forms.DateField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('2010-12-21')
@@ -517,7 +548,8 @@ class SimpleDateFormatTests(SimpleTestCase):
         "Localized DateFields in a non-localized environment act as unlocalized widgets"
         f = forms.DateField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('2010-12-21')
@@ -539,7 +571,8 @@ class SimpleDateFormatTests(SimpleTestCase):
         "DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%d.%m.%Y", "%d-%m-%Y"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010')
@@ -561,7 +594,8 @@ class SimpleDateFormatTests(SimpleTestCase):
         "Localized DateFields with manually specified input formats can accept those formats"
         f = forms.DateField(input_formats=["%d.%m.%Y", "%d-%m-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010')
@@ -592,7 +626,8 @@ class LocalizedDateTimeTests(SimpleTestCase):
         "DateTimeFields can parse dates in the default format"
         f = forms.DateTimeField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM 21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM 21/12/2010')
 
         # ISO formats are accepted, even if not specified in formats.py
         self.assertEqual(f.clean('2010-12-21 13:30:05'), datetime(2010, 12, 21, 13, 30, 5))
@@ -617,7 +652,8 @@ class LocalizedDateTimeTests(SimpleTestCase):
         "Localized DateTimeFields act as unlocalized widgets"
         f = forms.DateTimeField(localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM 21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM 21/12/2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('21.12.2010 13:30:05')
@@ -639,9 +675,12 @@ class LocalizedDateTimeTests(SimpleTestCase):
         "DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%H.%M.%S %m.%d.%Y", "%H.%M %m-%d-%Y"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05 13:30:05')
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM 21/12/2010')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM 21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('13.30.05 12.21.2010')
@@ -663,9 +702,12 @@ class LocalizedDateTimeTests(SimpleTestCase):
         "Localized DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%H.%M.%S %m.%d.%Y", "%H.%M %m-%d-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
-        self.assertRaises(forms.ValidationError, f.clean, '1:30:05 PM 21/12/2010')
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('1:30:05 PM 21/12/2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('13.30.05 12.21.2010')
@@ -690,7 +732,8 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         "DateTimeFields can parse dates in the default format"
         f = forms.DateTimeField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21/12/2010')
@@ -712,7 +755,8 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         "Localized DateTimeFields act as unlocalized widgets"
         f = forms.DateTimeField(localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21/12/2010')
@@ -734,8 +778,10 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         "DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%m.%d.%Y %H:%M:%S", "%m-%d-%Y %H:%M"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010 13:30:05')
@@ -757,8 +803,10 @@ class CustomDateTimeInputFormatsTests(SimpleTestCase):
         "Localized DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%m.%d.%Y %H:%M:%S", "%m-%d-%Y %H:%M"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('12.21.2010 13:30:05')
@@ -782,7 +830,8 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         "DateTimeFields can parse dates in the default format"
         f = forms.DateTimeField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('2010-12-21 13:30:05')
@@ -804,7 +853,8 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         "Localized DateTimeFields in a non-localized environment act as unlocalized widgets"
         f = forms.DateTimeField()
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '13:30:05 21.12.2010')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('13:30:05 21.12.2010')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('2010-12-21 13:30:05')
@@ -826,7 +876,8 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         "DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%I:%M:%S %p %d.%m.%Y", "%I:%M %p %d-%m-%Y"])
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21.12.2010')
@@ -848,7 +899,8 @@ class SimpleDateTimeFormatTests(SimpleTestCase):
         "Localized DateTimeFields with manually specified input formats can accept those formats"
         f = forms.DateTimeField(input_formats=["%I:%M:%S %p %d.%m.%Y", "%I:%M %p %d-%m-%Y"], localize=True)
         # Parse a date in an unaccepted format; get an error
-        self.assertRaises(forms.ValidationError, f.clean, '2010-12-21 13:30:05')
+        with self.assertRaises(forms.ValidationError):
+            f.clean('2010-12-21 13:30:05')
 
         # Parse a date in a valid format, get a parsed result
         result = f.clean('1:30:05 PM 21.12.2010')

--- a/tests/forms_tests/tests/test_validators.py
+++ b/tests/forms_tests/tests/test_validators.py
@@ -45,7 +45,8 @@ class TestFieldWithValidators(TestCase):
             'string': '2 is not correct',
             'ignore_case_string': "IgnORE Case strIng",
         })
-        self.assertRaises(ValidationError, form.fields['full_name'].clean, 'not int nor mail')
+        with self.assertRaises(ValidationError):
+            form.fields['full_name'].clean('not int nor mail')
 
         try:
             form.fields['full_name'].clean('not int nor mail')

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -251,7 +251,8 @@ class RelatedModelFormTests(SimpleTestCase):
             model = A
             fields = '__all__'
 
-        self.assertRaises(ValueError, ModelFormMetaclass, str('Form'), (ModelForm,), {'Meta': Meta})
+        with self.assertRaises(ValueError):
+            ModelFormMetaclass(str('Form'), (ModelForm,), {'Meta': Meta})
 
         class B(models.Model):
             pass

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -384,8 +384,8 @@ class SelectDateWidgetTest(WidgetTest):
             """,
         )
 
-        self.assertRaisesMessage(ValueError, 'empty_label list/tuple must have 3 elements.',
-            SelectDateWidget, years=('2014',), empty_label=('not enough', 'values'))
+        with self.assertRaisesMessage(ValueError, 'empty_label list/tuple must have 3 elements.'):
+            SelectDateWidget(years=('2014',), empty_label=('not enough', 'values'))
 
     @override_settings(USE_L10N=True)
     @translation.override('nl')

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -720,8 +720,10 @@ class TestInitWithNoneArgument(SimpleTestCase):
     def test_none_not_allowed(self):
         # TaggedItem requires a content_type, initializing with None should
         # raise a ValueError.
-        with self.assertRaisesMessage(ValueError,
-          'Cannot assign None: "TaggedItem.content_type" does not allow null values'):
+        with self.assertRaisesMessage(
+            ValueError,
+            'Cannot assign None: "TaggedItem.content_type" does not allow null values'
+        ):
             TaggedItem(content_object=None)
 
     def test_none_allowed(self):

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -7,7 +7,6 @@ from django.core.exceptions import FieldError
 from django.db import IntegrityError
 from django.db.models import Q
 from django.test import SimpleTestCase, TestCase
-from django.utils import six
 
 from .models import (
     AllowsNullGFK, Animal, Carrot, Comparison, ConcreteRelatedModel,
@@ -721,7 +720,7 @@ class TestInitWithNoneArgument(SimpleTestCase):
     def test_none_not_allowed(self):
         # TaggedItem requires a content_type, initializing with None should
         # raise a ValueError.
-        with six.assertRaisesRegex(self, ValueError,
+        with self.assertRaisesMessage(ValueError,
           'Cannot assign None: "TaggedItem.content_type" does not allow null values'):
             TaggedItem(content_object=None)
 

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -111,7 +111,8 @@ class GenericRelationTests(TestCase):
         # Fails with another, ORM-level error
         dev1 = Developer(name='Joe')
         note = Note(note='Deserves promotion', content_object=dev1)
-        self.assertRaises(IntegrityError, note.save)
+        with self.assertRaises(IntegrityError):
+            note.save()
 
     def test_target_model_len_zero(self):
         """Test for #13085 -- __len__() returns 0"""

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -145,12 +145,14 @@ class ViewTest(unittest.TestCase):
         # Check each of the allowed method names
         for method in SimpleView.http_method_names:
             kwargs = dict(((method, "value"),))
-            self.assertRaises(TypeError, SimpleView.as_view, **kwargs)
+            with self.assertRaises(TypeError):
+                SimpleView.as_view(**kwargs)
 
         # Check the case view argument is ok if predefined on the class...
         CustomizableView.as_view(parameter="value")
         # ...but raises errors otherwise.
-        self.assertRaises(TypeError, CustomizableView.as_view, foobar="value")
+        with self.assertRaises(TypeError):
+            CustomizableView.as_view(foobar="value")
 
     def test_calling_more_than_once(self):
         """
@@ -280,7 +282,8 @@ class TemplateViewTest(SimpleTestCase):
         """
         A template view must provide a template name.
         """
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/template/no_template/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/template/no_template/')
 
     @require_jinja2
     def test_template_engine(self):
@@ -527,4 +530,5 @@ class SingleObjectTemplateResponseMixinTest(unittest.TestCase):
         TemplateDoesNotExist.
         """
         view = views.TemplateResponseWithoutTemplate()
-        self.assertRaises(ImproperlyConfigured, view.get_template_names)
+        with self.assertRaises(ImproperlyConfigured):
+            view.get_template_names()

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -82,7 +82,8 @@ class ArchiveIndexViewTests(TestDataMixin, TestCase):
         self.assertTemplateUsed(res, 'generic_views/book_detail.html')
 
     def test_archive_view_invalid(self):
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/dates/books/invalid/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/dates/books/invalid/')
 
     def test_archive_view_by_month(self):
         res = self.client.get('/dates/books/by_month/')
@@ -664,7 +665,8 @@ class DateDetailViewTests(TestDataMixin, TestCase):
         self.assertTemplateUsed(res, 'generic_views/book_detail.html')
 
     def test_invalid_url(self):
-        self.assertRaises(AttributeError, self.client.get, "/dates/books/2008/oct/01/nopk/")
+        with self.assertRaises(AttributeError):
+            self.client.get("/dates/books/2008/oct/01/nopk/")
 
     def test_get_object_custom_queryset(self):
         """

--- a/tests/generic_views/test_detail.py
+++ b/tests/generic_views/test_detail.py
@@ -49,7 +49,8 @@ class DetailViewTest(TestCase):
         self.assertEqual(res.status_code, 404)
 
     def test_detail_object_does_not_exist(self):
-        self.assertRaises(ObjectDoesNotExist, self.client.get, '/detail/doesnotexist/1/')
+        with self.assertRaises(ObjectDoesNotExist):
+            self.client.get('/detail/doesnotexist/1/')
 
     def test_detail_by_custom_pk(self):
         res = self.client.get('/detail/author/bycustompk/%s/' % self.author1.pk)
@@ -173,10 +174,12 @@ class DetailViewTest(TestCase):
         self.assertEqual(form_context_data['author'], self.author1)
 
     def test_invalid_url(self):
-        self.assertRaises(AttributeError, self.client.get, '/detail/author/invalid/url/')
+        with self.assertRaises(AttributeError):
+            self.client.get('/detail/author/invalid/url/')
 
     def test_invalid_queryset(self):
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/detail/author/invalid/qs/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/detail/author/invalid/qs/')
 
     def test_non_model_object_with_meta(self):
         res = self.client.get('/detail/nonmodel/1/')

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -204,7 +204,8 @@ class ListViewTests(TestCase):
         self.assertTemplateUsed(res, 'generic_views/author_list.html')
 
     def test_missing_items(self):
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/list/authors/invalid/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/list/authors/invalid/')
 
     def test_paginated_list_view_does_not_load_entire_table(self):
         # Regression test for #17535

--- a/tests/get_earliest_or_latest/tests.py
+++ b/tests/get_earliest_or_latest/tests.py
@@ -57,12 +57,11 @@ class EarliestOrLatestTests(TestCase):
         # Ensure that error is raised if the user forgot to add a get_latest_by
         # in the Model.Meta
         Article.objects.model._meta.get_latest_by = None
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             AssertionError,
-            "earliest() and latest() require either a field_name parameter or "
-            "'get_latest_by' in the model",
-            lambda: Article.objects.earliest(),
-        )
+                "earliest() and latest() require either a field_name parameter or "
+                "'get_latest_by' in the model"):
+            Article.objects.earliest()
 
     def test_latest(self):
         # Because no Articles exist yet, latest() raises ArticleDoesNotExist.
@@ -107,12 +106,11 @@ class EarliestOrLatestTests(TestCase):
         # Ensure that error is raised if the user forgot to add a get_latest_by
         # in the Model.Meta
         Article.objects.model._meta.get_latest_by = None
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             AssertionError,
-            "earliest() and latest() require either a field_name parameter or "
-            "'get_latest_by' in the model",
-            lambda: Article.objects.latest(),
-        )
+                "earliest() and latest() require either a field_name parameter or "
+                "'get_latest_by' in the model"):
+            Article.objects.latest()
 
     def test_latest_manual(self):
         # You can still use latest() with a model that doesn't have

--- a/tests/get_earliest_or_latest/tests.py
+++ b/tests/get_earliest_or_latest/tests.py
@@ -17,7 +17,8 @@ class EarliestOrLatestTests(TestCase):
 
     def test_earliest(self):
         # Because no Articles exist yet, earliest() raises ArticleDoesNotExist.
-        self.assertRaises(Article.DoesNotExist, Article.objects.earliest)
+        with self.assertRaises(Article.DoesNotExist):
+            Article.objects.earliest()
 
         a1 = Article.objects.create(
             headline="Article 1", pub_date=datetime(2005, 7, 26),
@@ -65,7 +66,8 @@ class EarliestOrLatestTests(TestCase):
 
     def test_latest(self):
         # Because no Articles exist yet, latest() raises ArticleDoesNotExist.
-        self.assertRaises(Article.DoesNotExist, Article.objects.latest)
+        with self.assertRaises(Article.DoesNotExist):
+            Article.objects.latest()
 
         a1 = Article.objects.create(
             headline="Article 1", pub_date=datetime(2005, 7, 26),
@@ -117,7 +119,8 @@ class EarliestOrLatestTests(TestCase):
         # "get_latest_by" set -- just pass in the field name manually.
         Person.objects.create(name="Ralph", birthday=datetime(1950, 1, 1))
         p2 = Person.objects.create(name="Stephanie", birthday=datetime(1960, 2, 3))
-        self.assertRaises(AssertionError, Person.objects.latest)
+        with self.assertRaises(AssertionError):
+            Person.objects.latest()
         self.assertEqual(Person.objects.latest("birthday"), p2)
 
 
@@ -162,9 +165,12 @@ class TestFirstLast(TestCase):
         def check():
             # We know that we've broken the __iter__ method, so the queryset
             # should always raise an exception.
-            self.assertRaises(IndexError, lambda: IndexErrorArticle.objects.all()[0])
-            self.assertRaises(IndexError, IndexErrorArticle.objects.all().first)
-            self.assertRaises(IndexError, IndexErrorArticle.objects.all().last)
+            with self.assertRaises(IndexError):
+                IndexErrorArticle.objects.all()[0]
+            with self.assertRaises(IndexError):
+                IndexErrorArticle.objects.all().first()
+            with self.assertRaises(IndexError):
+                IndexErrorArticle.objects.all().last()
 
         check()
 

--- a/tests/get_earliest_or_latest/tests.py
+++ b/tests/get_earliest_or_latest/tests.py
@@ -58,10 +58,11 @@ class EarliestOrLatestTests(TestCase):
         # Ensure that error is raised if the user forgot to add a get_latest_by
         # in the Model.Meta
         Article.objects.model._meta.get_latest_by = None
-        with self.assertRaisesMessage(
-            AssertionError,
-                "earliest() and latest() require either a field_name parameter or "
-                "'get_latest_by' in the model"):
+        msg = (
+            "earliest() and latest() require either a field_name parameter or "
+            "'get_latest_by' in the model"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             Article.objects.earliest()
 
     def test_latest(self):
@@ -108,10 +109,11 @@ class EarliestOrLatestTests(TestCase):
         # Ensure that error is raised if the user forgot to add a get_latest_by
         # in the Model.Meta
         Article.objects.model._meta.get_latest_by = None
-        with self.assertRaisesMessage(
-            AssertionError,
-                "earliest() and latest() require either a field_name parameter or "
-                "'get_latest_by' in the model"):
+        msg = (
+            "earliest() and latest() require either a field_name parameter or "
+            "'get_latest_by' in the model"
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
             Article.objects.latest()
 
     def test_latest_manual(self):

--- a/tests/get_object_or_404/tests.py
+++ b/tests/get_object_or_404/tests.py
@@ -13,7 +13,8 @@ class GetObjectOr404Tests(TestCase):
         a2 = Author.objects.create(name="Patsy")
 
         # No Articles yet, so we should get a Http404 error.
-        self.assertRaises(Http404, get_object_or_404, Article, title="Foo")
+        with self.assertRaises(Http404):
+            get_object_or_404(Article, title="Foo")
 
         article = Article.objects.create(title="Run away!")
         article.authors.set([a1, a2])
@@ -30,10 +31,8 @@ class GetObjectOr404Tests(TestCase):
         )
 
         # No articles containing "Camelot".  This should raise a Http404 error.
-        self.assertRaises(
-            Http404,
-            get_object_or_404, a1.article_set, title__contains="Camelot"
-        )
+        with self.assertRaises(Http404):
+            get_object_or_404(a1.article_set, title__contains="Camelot")
 
         # Custom managers can be used too.
         self.assertEqual(
@@ -50,16 +49,12 @@ class GetObjectOr404Tests(TestCase):
         # Just as when using a get() lookup, you will get an error if more than
         # one object is returned.
 
-        self.assertRaises(
-            Author.MultipleObjectsReturned,
-            get_object_or_404, Author.objects.all()
-        )
+        with self.assertRaises(Author.MultipleObjectsReturned):
+            get_object_or_404(Author.objects.all())
 
         # Using an empty QuerySet raises a Http404 error.
-        self.assertRaises(
-            Http404,
-            get_object_or_404, Article.objects.none(), title__contains="Run"
-        )
+        with self.assertRaises(Http404):
+            get_object_or_404(Article.objects.none(), title__contains="Run")
 
         # get_list_or_404 can be used to get lists of objects
         self.assertEqual(
@@ -68,10 +63,8 @@ class GetObjectOr404Tests(TestCase):
         )
 
         # Http404 is returned if the list is empty.
-        self.assertRaises(
-            Http404,
-            get_list_or_404, a1.article_set, title__icontains="Shrubbery"
-        )
+        with self.assertRaises(Http404):
+            get_list_or_404(a1.article_set, title__icontains="Shrubbery")
 
         # Custom managers can be used too.
         self.assertEqual(

--- a/tests/get_object_or_404/tests.py
+++ b/tests/get_object_or_404/tests.py
@@ -88,27 +88,24 @@ class GetObjectOr404Tests(TestCase):
     def test_bad_class(self):
         # Given an argument klass that is not a Model, Manager, or Queryset
         # raises a helpful ValueError message
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             ValueError,
             "Object is of type 'str', but must be a Django Model, Manager, "
-            "or QuerySet",
-            get_object_or_404, str("Article"), title__icontains="Run"
-        )
+                "or QuerySet"):
+            get_object_or_404(str("Article"), title__icontains="Run")
 
         class CustomClass(object):
             pass
 
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             ValueError,
             "Object is of type 'CustomClass', but must be a Django Model, "
-            "Manager, or QuerySet",
-            get_object_or_404, CustomClass, title__icontains="Run"
-        )
+                "Manager, or QuerySet"):
+            get_object_or_404(CustomClass, title__icontains="Run")
 
         # Works for lists too
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             ValueError,
             "Object is of type 'list', but must be a Django Model, Manager, "
-            "or QuerySet",
-            get_list_or_404, [Article], title__icontains="Run"
-        )
+                "or QuerySet"):
+            get_list_or_404([Article], title__icontains="Run")

--- a/tests/get_object_or_404/tests.py
+++ b/tests/get_object_or_404/tests.py
@@ -81,24 +81,27 @@ class GetObjectOr404Tests(TestCase):
     def test_bad_class(self):
         # Given an argument klass that is not a Model, Manager, or Queryset
         # raises a helpful ValueError message
-        with self.assertRaisesMessage(
-            ValueError,
+        msg = (
             "Object is of type 'str', but must be a Django Model, Manager, "
-                "or QuerySet"):
+            "or QuerySet"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             get_object_or_404(str("Article"), title__icontains="Run")
 
         class CustomClass(object):
             pass
 
-        with self.assertRaisesMessage(
-            ValueError,
+        msg = (
             "Object is of type 'CustomClass', but must be a Django Model, "
-                "Manager, or QuerySet"):
+            "Manager, or QuerySet"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             get_object_or_404(CustomClass, title__icontains="Run")
 
         # Works for lists too
-        with self.assertRaisesMessage(
-            ValueError,
+        msg = (
             "Object is of type 'list', but must be a Django Model, Manager, "
-                "or QuerySet"):
+            "or QuerySet"
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             get_list_or_404([Article], title__icontains="Run")

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -62,10 +62,8 @@ class GetOrCreateTests(TestCase):
         If you don't specify a value or default value for all required
         fields, you will get an error.
         """
-        self.assertRaises(
-            IntegrityError,
-            Person.objects.get_or_create, first_name="Tom", last_name="Smith"
-        )
+        with self.assertRaises(IntegrityError):
+            Person.objects.get_or_create(first_name="Tom", last_name="Smith")
 
     def test_get_or_create_on_related_manager(self):
         p = Publisher.objects.create(name="Acme Publishing")
@@ -159,10 +157,8 @@ class GetOrCreateTestsWithManualPKs(TestCase):
         If you specify an existing primary key, but different other fields,
         then you will get an error and data will not be updated.
         """
-        self.assertRaises(
-            IntegrityError,
-            ManualPrimaryKeyTest.objects.get_or_create, id=1, data="Different"
-        )
+        with self.assertRaises(IntegrityError):
+            ManualPrimaryKeyTest.objects.get_or_create(id=1, data="Different")
         self.assertEqual(ManualPrimaryKeyTest.objects.get(id=1).data, "Original")
 
     def test_get_or_create_raises_IntegrityError_plus_traceback(self):
@@ -246,7 +242,8 @@ class GetOrCreateThroughManyToMany(TestCase):
     def test_something(self):
         Tag.objects.create(text='foo')
         a_thing = Thing.objects.create(name='a')
-        self.assertRaises(IntegrityError, a_thing.tags.get_or_create, text='foo')
+        with self.assertRaises(IntegrityError):
+            a_thing.tags.get_or_create(text='foo')
 
 
 class UpdateOrCreateTests(TestCase):
@@ -292,8 +289,8 @@ class UpdateOrCreateTests(TestCase):
         If you don't specify a value or default value for all required
         fields, you will get an error.
         """
-        self.assertRaises(IntegrityError,
-            Person.objects.update_or_create, first_name="Tom", last_name="Smith")
+        with self.assertRaises(IntegrityError):
+            Person.objects.update_or_create(first_name="Tom", last_name="Smith")
 
     def test_manual_primary_key_test(self):
         """
@@ -301,10 +298,8 @@ class UpdateOrCreateTests(TestCase):
         then you will get an error and data will not be updated.
         """
         ManualPrimaryKeyTest.objects.create(id=1, data="Original")
-        self.assertRaises(
-            IntegrityError,
-            ManualPrimaryKeyTest.objects.update_or_create, id=1, data="Different"
-        )
+        with self.assertRaises(IntegrityError):
+            ManualPrimaryKeyTest.objects.update_or_create(id=1, data="Different")
         self.assertEqual(ManualPrimaryKeyTest.objects.get(id=1).data, "Original")
 
     def test_error_contains_full_traceback(self):

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -95,7 +95,8 @@ class DistanceTest(TestCase):
             if type_error:
                 # A ValueError should be raised on PostGIS when trying to pass
                 # Distance objects into a DWithin query using a geodetic field.
-                self.assertRaises(ValueError, AustraliaCity.objects.filter(point__dwithin=(self.au_pnt, dist)).count)
+                with self.assertRaises(ValueError):
+                    AustraliaCity.objects.filter(point__dwithin=(self.au_pnt, dist)).count()
             else:
                 self.assertListEqual(au_cities, self.get_names(qs.filter(point__dwithin=(self.au_pnt, dist))))
 
@@ -289,11 +290,12 @@ class DistanceTest(TestCase):
 
         # Too many params (4 in this case) should raise a ValueError.
         queryset = AustraliaCity.objects.filter(point__distance_lte=('POINT(5 23)', D(km=100), 'spheroid', '4'))
-        self.assertRaises(ValueError, len, queryset)
+        with self.assertRaises(ValueError):
+            len(queryset)
 
         # Not enough params should raise a ValueError.
-        self.assertRaises(ValueError, len,
-                          AustraliaCity.objects.filter(point__distance_lte=('POINT(5 23)',)))
+        with self.assertRaises(ValueError):
+            len(AustraliaCity.objects.filter(point__distance_lte=('POINT(5 23)',)))
 
         # Getting all cities w/in 550 miles of Hobart.
         hobart = AustraliaCity.objects.get(name='Hobart')
@@ -382,7 +384,8 @@ class DistanceTest(TestCase):
             self.assertAlmostEqual(len_m1, qs[0].length.m, tol)
         else:
             # Does not support geodetic coordinate systems.
-            self.assertRaises(ValueError, Interstate.objects.length)
+            with self.assertRaises(ValueError):
+                Interstate.objects.length()
 
         # Now doing length on a projected coordinate system.
         i10 = SouthTexasInterstate.objects.length().get(name='I-10')

--- a/tests/gis_tests/gdal_tests/test_driver.py
+++ b/tests/gis_tests/gdal_tests/test_driver.py
@@ -40,7 +40,8 @@ class DriverTest(unittest.TestCase):
     def test02_invalid_driver(self):
         "Testing invalid GDAL/OGR Data Source Drivers."
         for i in invalid_drivers:
-            self.assertRaises(GDALException, Driver, i)
+            with self.assertRaises(GDALException):
+                Driver(i)
 
     def test03_aliases(self):
         "Testing driver aliases."

--- a/tests/gis_tests/gdal_tests/test_ds.py
+++ b/tests/gis_tests/gdal_tests/test_ds.py
@@ -87,7 +87,8 @@ class DataSourceTest(unittest.TestCase):
     def test02_invalid_shp(self):
         "Testing invalid SHP files for the Data Source."
         for source in bad_ds:
-            self.assertRaises(GDALException, DataSource, source.ds)
+            with self.assertRaises(GDALException):
+                DataSource(source.ds)
 
     def test03a_layers(self):
         "Testing Data Source Layers."
@@ -122,8 +123,10 @@ class DataSourceTest(unittest.TestCase):
                     self.assertIn(f, source.fields)
 
                 # Negative FIDs are not allowed.
-                self.assertRaises(OGRIndexError, layer.__getitem__, -1)
-                self.assertRaises(OGRIndexError, layer.__getitem__, 50000)
+                with self.assertRaises(OGRIndexError):
+                    layer.__getitem__(-1)
+                with self.assertRaises(OGRIndexError):
+                    layer.__getitem__(50000)
 
                 if hasattr(source, 'field_values'):
                     fld_names = source.field_values.keys()
@@ -233,11 +236,13 @@ class DataSourceTest(unittest.TestCase):
         self.assertIsNone(lyr.spatial_filter)
 
         # Must be set a/an OGRGeometry or 4-tuple.
-        self.assertRaises(TypeError, lyr._set_spatial_filter, 'foo')
+        with self.assertRaises(TypeError):
+            lyr._set_spatial_filter('foo')
 
         # Setting the spatial filter with a tuple/list with the extent of
         # a buffer centering around Pueblo.
-        self.assertRaises(ValueError, lyr._set_spatial_filter, list(range(5)))
+        with self.assertRaises(ValueError):
+            lyr._set_spatial_filter(list(range(5)))
         filter_extent = (-105.609252, 37.255001, -103.609252, 39.255001)
         lyr.spatial_filter = (-105.609252, 37.255001, -103.609252, 39.255001)
         self.assertEqual(OGRGeometry.from_bbox(filter_extent), lyr.spatial_filter)

--- a/tests/gis_tests/gdal_tests/test_envelope.py
+++ b/tests/gis_tests/gdal_tests/test_envelope.py
@@ -25,13 +25,20 @@ class EnvelopeTest(unittest.TestCase):
         Envelope(0, 0, 5, 5)
         Envelope(0, '0', '5', 5)  # Thanks to ww for this
         Envelope(e1._envelope)
-        self.assertRaises(GDALException, Envelope, (5, 5, 0, 0))
-        self.assertRaises(GDALException, Envelope, 5, 5, 0, 0)
-        self.assertRaises(GDALException, Envelope, (0, 0, 5, 5, 3))
-        self.assertRaises(GDALException, Envelope, ())
-        self.assertRaises(ValueError, Envelope, 0, 'a', 5, 5)
-        self.assertRaises(TypeError, Envelope, 'foo')
-        self.assertRaises(GDALException, Envelope, (1, 1, 0, 0))
+        with self.assertRaises(GDALException):
+            Envelope((5, 5, 0, 0))
+        with self.assertRaises(GDALException):
+            Envelope(5, 5, 0, 0)
+        with self.assertRaises(GDALException):
+            Envelope((0, 0, 5, 5, 3))
+        with self.assertRaises(GDALException):
+            Envelope(())
+        with self.assertRaises(ValueError):
+            Envelope(0, 'a', 5, 5)
+        with self.assertRaises(TypeError):
+            Envelope('foo')
+        with self.assertRaises(GDALException):
+            Envelope((1, 1, 0, 0))
         try:
             Envelope(0, 0, 0, 0)
         except GDALException:

--- a/tests/gis_tests/gdal_tests/test_geom.py
+++ b/tests/gis_tests/gdal_tests/test_geom.py
@@ -36,9 +36,12 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
         OGRGeomType('Unknown')
 
         # Should throw TypeError on this input
-        self.assertRaises(GDALException, OGRGeomType, 23)
-        self.assertRaises(GDALException, OGRGeomType, 'fooD')
-        self.assertRaises(GDALException, OGRGeomType, 9)
+        with self.assertRaises(GDALException):
+            OGRGeomType(23)
+        with self.assertRaises(GDALException):
+            OGRGeomType('fooD')
+        with self.assertRaises(GDALException):
+            OGRGeomType(9)
 
         # Equivalence can take strings, ints, and other OGRGeomTypes
         self.assertEqual(OGRGeomType(1), OGRGeomType(1))
@@ -168,7 +171,8 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
             self.assertEqual(ls.coords, linestr.tuple)
             self.assertEqual(linestr, OGRGeometry(ls.wkt))
             self.assertNotEqual(linestr, prev)
-            self.assertRaises(OGRIndexError, linestr.__getitem__, len(linestr))
+            with self.assertRaises(OGRIndexError):
+                linestr.__getitem__(len(linestr))
             prev = linestr
 
             # Testing the x, y properties.
@@ -192,7 +196,8 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
             for ls in mlinestr:
                 self.assertEqual(2, ls.geom_type)
                 self.assertEqual('LINESTRING', ls.geom_name)
-            self.assertRaises(OGRIndexError, mlinestr.__getitem__, len(mlinestr))
+            with self.assertRaises(OGRIndexError):
+                mlinestr.__getitem__(len(mlinestr))
 
     def test_linearring(self):
         "Testing LinearRing objects."
@@ -263,7 +268,8 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
             if mp.valid:
                 self.assertEqual(mp.n_p, mpoly.point_count)
                 self.assertEqual(mp.num_geom, len(mpoly))
-                self.assertRaises(OGRIndexError, mpoly.__getitem__, len(mpoly))
+                with self.assertRaises(OGRIndexError):
+                    mpoly.__getitem__(len(mpoly))
                 for p in mpoly:
                     self.assertEqual('POLYGON', p.geom_name)
                     self.assertEqual(3, p.geom_type)
@@ -415,7 +421,8 @@ class OGRGeomTest(unittest.TestCase, TestDataMixin):
         # Can't insert a Point into a MultiPolygon.
         mp = OGRGeometry('MultiPolygon')
         pnt = OGRGeometry('POINT(5 23)')
-        self.assertRaises(GDALException, mp.add, pnt)
+        with self.assertRaises(GDALException):
+            mp.add(pnt)
 
         # GeometryCollection.add may take an OGRGeometry (if another collection
         # of the same type all child geoms will be added individually) or WKT.

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -350,7 +350,8 @@ class GDALBandTests(unittest.TestCase):
         band = rs.bands[0]
 
         # Setting attributes in write mode raises exception in the _flush method
-        self.assertRaises(GDALException, setattr, band, 'nodata_value', 10)
+        with self.assertRaises(GDALException):
+            setattr(band, 'nodata_value', 10)
 
     def test_band_data_setters(self):
         # Create in-memory raster and get band

--- a/tests/gis_tests/gdal_tests/test_srs.py
+++ b/tests/gis_tests/gdal_tests/test_srs.py
@@ -249,8 +249,10 @@ class SpatialRefTest(unittest.TestCase):
     def test13_attr_value(self):
         "Testing the attr_value() method."
         s1 = SpatialReference('WGS84')
-        self.assertRaises(TypeError, s1.__getitem__, 0)
-        self.assertRaises(TypeError, s1.__getitem__, ('GEOGCS', 'foo'))
+        with self.assertRaises(TypeError):
+            s1.__getitem__(0)
+        with self.assertRaises(TypeError):
+            s1.__getitem__(('GEOGCS', 'foo'))
         self.assertEqual('WGS 84', s1['GEOGCS'])
         self.assertEqual('WGS_1984', s1['DATUM'])
         self.assertEqual('EPSG', s1['AUTHORITY'])

--- a/tests/gis_tests/geo3d/tests.py
+++ b/tests/gis_tests/geo3d/tests.py
@@ -157,8 +157,8 @@ class Geo3DTest(Geo3DLoadingHelper, TestCase):
 
         # The city shapefile is 2D, and won't be able to fill the coordinates
         # in the 3D model -- thus, a LayerMapError is raised.
-        self.assertRaises(LayerMapError, LayerMapping,
-                          Point3D, city_file, point_mapping, transform=False)
+        with self.assertRaises(LayerMapError):
+            LayerMapping(Point3D, city_file, point_mapping, transform=False)
 
         # 3D model should take 3D data just fine.
         lm = LayerMapping(Point3D, vrt_file, point_mapping, transform=False)

--- a/tests/gis_tests/geoapp/test_feeds.py
+++ b/tests/gis_tests/geoapp/test_feeds.py
@@ -86,5 +86,7 @@ class GeoFeedTest(TestCase):
             self.assertChildNodes(item, ['title', 'link', 'description', 'guid', 'geo:lat', 'geo:lon'])
 
         # Boxes and Polygons aren't allowed in W3C Geo feeds.
-        self.assertRaises(ValueError, self.client.get, '/feeds/w3cgeo2/')  # Box in <channel>
-        self.assertRaises(ValueError, self.client.get, '/feeds/w3cgeo3/')  # Polygons in <entry>
+        with self.assertRaises(ValueError):  # Box in <channel>
+            self.client.get('/feeds/w3cgeo2/')
+        with self.assertRaises(ValueError):  # Polygons in <entry>
+            self.client.get('/feeds/w3cgeo3/')

--- a/tests/gis_tests/geogapp/tests.py
+++ b/tests/gis_tests/geogapp/tests.py
@@ -56,13 +56,16 @@ class GeographyTest(TestCase):
         # http://postgis.refractions.net/documentation/manual-1.5/ch08.html#PostGIS_GeographyFunctions
         z = Zipcode.objects.get(code='77002')
         # ST_Within not available.
-        self.assertRaises(ValueError, City.objects.filter(point__within=z.poly).count)
+        with self.assertRaises(ValueError):
+            City.objects.filter(point__within=z.poly).count()
         # `@` operator not available.
-        self.assertRaises(ValueError, City.objects.filter(point__contained=z.poly).count)
+        with self.assertRaises(ValueError):
+            City.objects.filter(point__contained=z.poly).count()
 
         # Regression test for #14060, `~=` was never really implemented for PostGIS.
         htown = City.objects.get(name='Houston')
-        self.assertRaises(ValueError, City.objects.get, point__exact=htown.point)
+        with self.assertRaises(ValueError):
+            City.objects.get(point__exact=htown.point)
 
     @skipUnless(HAS_GDAL, "GDAL is required.")
     def test05_geography_layermapping(self):

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -63,7 +63,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         # a C method is given a NULL memory reference.
         for fg in (fg1, fg2):
             # Equivalent to `fg.ptr`
-            self.assertRaises(GEOSException, fg._get_ptr)
+            with self.assertRaises(GEOSException):
+                fg._get_ptr()
 
         # Anything that is either not None or the acceptable pointer type will
         # result in a TypeError when trying to assign it to the `ptr` property.
@@ -72,8 +73,10 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         bad_ptrs = (5, ctypes.c_char_p(b'foobar'))
         for bad_ptr in bad_ptrs:
             # Equivalent to `fg.ptr = bad_ptr`
-            self.assertRaises(TypeError, fg1._set_ptr, bad_ptr)
-            self.assertRaises(TypeError, fg2._set_ptr, bad_ptr)
+            with self.assertRaises(TypeError):
+                fg1._set_ptr(bad_ptr)
+            with self.assertRaises(TypeError):
+                fg2._set_ptr(bad_ptr)
 
     def test_wkt(self):
         "Testing WKT output."
@@ -135,15 +138,18 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 fromstr(err.wkt)
 
         # Bad WKB
-        self.assertRaises(GEOSException, GEOSGeometry, six.memoryview(b'0'))
+        with self.assertRaises(GEOSException):
+            GEOSGeometry(six.memoryview(b'0'))
 
         class NotAGeometry(object):
             pass
 
         # Some other object
-        self.assertRaises(TypeError, GEOSGeometry, NotAGeometry())
+        with self.assertRaises(TypeError):
+            GEOSGeometry(NotAGeometry())
         # None
-        self.assertRaises(TypeError, GEOSGeometry, None)
+        with self.assertRaises(TypeError):
+            GEOSGeometry(None)
 
     def test_wkb(self):
         "Testing WKB output."
@@ -289,7 +295,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
             self.assertAlmostEqual(mp.centroid[0], mpnt.centroid.tuple[0], 9)
             self.assertAlmostEqual(mp.centroid[1], mpnt.centroid.tuple[1], 9)
 
-            self.assertRaises(IndexError, mpnt.__getitem__, len(mpnt))
+            with self.assertRaises(IndexError):
+                mpnt.__getitem__(len(mpnt))
             self.assertEqual(mp.centroid, mpnt.centroid.tuple)
             self.assertEqual(mp.coords, tuple(m.tuple for m in mpnt))
             for p in mpnt:
@@ -315,7 +322,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
 
             self.assertEqual(ls, fromstr(l.wkt))
             self.assertEqual(False, ls == prev)  # Use assertEqual to test __eq__
-            self.assertRaises(IndexError, ls.__getitem__, len(ls))
+            with self.assertRaises(IndexError):
+                ls.__getitem__(len(ls))
             prev = ls
 
             # Creating a LineString from a tuple, list, and numpy array
@@ -362,7 +370,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertEqual(ls.geom_typeid, 1)
                 self.assertEqual(ls.empty, False)
 
-            self.assertRaises(IndexError, ml.__getitem__, len(ml))
+            with self.assertRaises(IndexError):
+                ml.__getitem__(len(ml))
             self.assertEqual(ml.wkt, MultiLineString(*tuple(s.clone() for s in ml)).wkt)
             self.assertEqual(ml, MultiLineString(*tuple(LineString(s.tuple) for s in ml)))
 
@@ -443,9 +452,12 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertEqual(p.ext_ring_cs, poly[0].tuple)  # Testing __getitem__
 
             # Testing __getitem__ and __setitem__ on invalid indices
-            self.assertRaises(IndexError, poly.__getitem__, len(poly))
-            self.assertRaises(IndexError, poly.__setitem__, len(poly), False)
-            self.assertRaises(IndexError, poly.__getitem__, -1 * len(poly) - 1)
+            with self.assertRaises(IndexError):
+                poly.__getitem__(len(poly))
+            with self.assertRaises(IndexError):
+                poly.__setitem__(len(poly), False)
+            with self.assertRaises(IndexError):
+                poly.__getitem__(-1 * len(poly) - 1)
 
             # Testing __iter__
             for r in poly:
@@ -453,8 +465,10 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertEqual(r.geom_typeid, 2)
 
             # Testing polygon construction.
-            self.assertRaises(TypeError, Polygon, 0, [1, 2, 3])
-            self.assertRaises(TypeError, Polygon, 'foo')
+            with self.assertRaises(TypeError):
+                Polygon(0, [1, 2, 3])
+            with self.assertRaises(TypeError):
+                Polygon('foo')
 
             # Polygon(shell, (hole1, ... holeN))
             rings = tuple(r for r in poly)
@@ -501,7 +515,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertEqual(mp.num_geom, mpoly.num_geom)
                 self.assertEqual(mp.n_p, mpoly.num_coords)
                 self.assertEqual(mp.num_geom, len(mpoly))
-                self.assertRaises(IndexError, mpoly.__getitem__, len(mpoly))
+                with self.assertRaises(IndexError):
+                    mpoly.__getitem__(len(mpoly))
                 for p in mpoly:
                     self.assertEqual(p.geom_type, 'Polygon')
                     self.assertEqual(p.geom_typeid, 3)
@@ -564,7 +579,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
     def test_relate_pattern(self):
         "Testing relate() and relate_pattern()."
         g = fromstr('POINT (0 0)')
-        self.assertRaises(GEOSException, g.relate_pattern, 0, 'invalid pattern, yo')
+        with self.assertRaises(GEOSException):
+            g.relate_pattern(0, 'invalid pattern, yo')
         for rg in self.geometries.relate_geoms:
             a = fromstr(rg.wkt_a)
             b = fromstr(rg.wkt_b)
@@ -640,7 +656,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
             width = bg.width
 
             # Can't use a floating-point for the number of quadsegs.
-            self.assertRaises(ctypes.ArgumentError, g.buffer, width, float(quadsegs))
+            with self.assertRaises(ctypes.ArgumentError):
+                g.buffer(width, float(quadsegs))
 
             # Constructing our buffer
             buf = g.buffer(width, quadsegs)
@@ -744,7 +761,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
             poly = fromstr(p.wkt)
 
             # Should only be able to use __setitem__ with LinearRing geometries.
-            self.assertRaises(TypeError, poly.__setitem__, 0, LineString((1, 1), (2, 2)))
+            with self.assertRaises(TypeError):
+                poly.__setitem__(0, LineString((1, 1), (2, 2)))
 
             # Constructing the new shell by adding 500 to every point in the old shell.
             shell_tup = poly.shell.tuple
@@ -876,7 +894,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         # Testing a 3D LineString
         ls = LineString((2., 3., 8.), (50., 250., -117.))
         self.assertEqual(((2., 3., 8.), (50., 250., -117.)), ls.tuple)
-        self.assertRaises(TypeError, ls.__setitem__, 0, (1., 2.))
+        with self.assertRaises(TypeError):
+            ls.__setitem__(0, (1., 2.))
         ls[0] = (1., 2., 3.)
         self.assertEqual((1., 2., 3.), ls[0])
 
@@ -962,9 +981,11 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
                 self.assertEqual('LINEARRING EMPTY', lr.wkt)
                 self.assertEqual(0, len(lr))
                 self.assertEqual(True, lr.empty)
-                self.assertRaises(IndexError, lr.__getitem__, 0)
+                with self.assertRaises(IndexError):
+                    lr.__getitem__(0)
             else:
-                self.assertRaises(IndexError, g.__getitem__, 0)
+                with self.assertRaises(IndexError):
+                    g.__getitem__(0)
 
     def test_collection_dims(self):
         gc = GeometryCollection([])
@@ -1090,25 +1111,31 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         """ Testing `transform` method (no SRID or negative SRID) """
 
         g = GEOSGeometry('POINT (-104.609 38.255)', srid=None)
-        self.assertRaises(GEOSException, g.transform, 2774)
+        with self.assertRaises(GEOSException):
+            g.transform(2774)
 
         g = GEOSGeometry('POINT (-104.609 38.255)', srid=None)
-        self.assertRaises(GEOSException, g.transform, 2774, clone=True)
+        with self.assertRaises(GEOSException):
+            g.transform(2774, clone=True)
 
         g = GEOSGeometry('POINT (-104.609 38.255)', srid=-1)
-        self.assertRaises(GEOSException, g.transform, 2774)
+        with self.assertRaises(GEOSException):
+            g.transform(2774)
 
         g = GEOSGeometry('POINT (-104.609 38.255)', srid=-1)
-        self.assertRaises(GEOSException, g.transform, 2774, clone=True)
+        with self.assertRaises(GEOSException):
+            g.transform(2774, clone=True)
 
     @mock.patch('django.contrib.gis.gdal.HAS_GDAL', False)
     def test_transform_nogdal(self):
         """ Testing `transform` method (GDAL not available) """
         g = GEOSGeometry('POINT (-104.609 38.255)', 4326)
-        self.assertRaises(GEOSException, g.transform, 2774)
+        with self.assertRaises(GEOSException):
+            g.transform(2774)
 
         g = GEOSGeometry('POINT (-104.609 38.255)', 4326)
-        self.assertRaises(GEOSException, g.transform, 2774, clone=True)
+        with self.assertRaises(GEOSException):
+            g.transform(2774, clone=True)
 
     def test_extent(self):
         "Testing `extent` method."

--- a/tests/gis_tests/geos_tests/test_geos_mutation.py
+++ b/tests/gis_tests/geos_tests/test_geos_mutation.py
@@ -82,8 +82,10 @@ class GEOSMutationTest(unittest.TestCase):
         p = Point(1, 2)
         for i in range(-2, 2):
             p._checkindex(i)
-        self.assertRaises(IndexError, p._checkindex, 2)
-        self.assertRaises(IndexError, p._checkindex, -3)
+        with self.assertRaises(IndexError):
+            p._checkindex(2)
+        with self.assertRaises(IndexError):
+            p._checkindex(-3)
 
     def test01_PointMutations(self):
         'Testing Point mutations'
@@ -100,8 +102,10 @@ class GEOSMutationTest(unittest.TestCase):
 
     def test02_PointExceptions(self):
         'Testing Point exceptions'
-        self.assertRaises(TypeError, Point, range(1))
-        self.assertRaises(TypeError, Point, range(4))
+        with self.assertRaises(TypeError):
+            Point(range(1))
+        with self.assertRaises(TypeError):
+            Point(range(4))
 
     def test03_PointApi(self):
         'Testing Point API'

--- a/tests/gis_tests/geos_tests/test_io.py
+++ b/tests/gis_tests/geos_tests/test_io.py
@@ -27,13 +27,16 @@ class GEOSIOTest(SimpleTestCase):
             self.assertEqual(ref, geom)
 
         # Should only accept six.string_types objects.
-        self.assertRaises(TypeError, wkt_r.read, 1)
-        self.assertRaises(TypeError, wkt_r.read, memoryview(b'foo'))
+        with self.assertRaises(TypeError):
+            wkt_r.read(1)
+        with self.assertRaises(TypeError):
+            wkt_r.read(memoryview(b'foo'))
 
     def test02_wktwriter(self):
         # Creating a WKTWriter instance, testing its ptr property.
         wkt_w = WKTWriter()
-        self.assertRaises(TypeError, wkt_w._set_ptr, WKTReader.ptr_type())
+        with self.assertRaises(TypeError):
+            wkt_w._set_ptr(WKTReader.ptr_type())
 
         ref = GEOSGeometry('POINT (5 23)')
         ref_wkt = 'POINT (5.0000000000000000 23.0000000000000000)'
@@ -56,7 +59,8 @@ class GEOSIOTest(SimpleTestCase):
 
         bad_input = (1, 5.23, None, False)
         for bad_wkb in bad_input:
-            self.assertRaises(TypeError, wkb_r.read, bad_wkb)
+            with self.assertRaises(TypeError):
+                wkb_r.read(bad_wkb)
 
     def test04_wkbwriter(self):
         wkb_w = WKBWriter()
@@ -75,7 +79,8 @@ class GEOSIOTest(SimpleTestCase):
         # Ensuring bad byteorders are not accepted.
         for bad_byteorder in (-1, 2, 523, 'foo', None):
             # Equivalent of `wkb_w.byteorder = bad_byteorder`
-            self.assertRaises(ValueError, wkb_w._set_byteorder, bad_byteorder)
+            with self.assertRaises(ValueError):
+                wkb_w._set_byteorder(bad_byteorder)
 
         # Setting the byteorder to 0 (for Big Endian)
         wkb_w.byteorder = 0
@@ -97,7 +102,8 @@ class GEOSIOTest(SimpleTestCase):
         # Ensuring bad output dimensions are not accepted
         for bad_outdim in (-1, 0, 1, 4, 423, 'foo', None):
             # Equivalent of `wkb_w.outdim = bad_outdim`
-            self.assertRaises(ValueError, wkb_w._set_outdim, bad_outdim)
+            with self.assertRaises(ValueError):
+                wkb_w._set_outdim(bad_outdim)
 
         # Now setting the output dimensions to be 3
         wkb_w.outdim = 3

--- a/tests/gis_tests/geos_tests/test_mutable_list.py
+++ b/tests/gis_tests/geos_tests/test_mutable_list.py
@@ -128,9 +128,11 @@ class ListMixinTest(unittest.TestCase):
                         self.assertEqual(pl, ul[:], 'set slice [%d:%d:%d]' % (i, j, k))
 
                         sliceLen = len(ul[i:j:k])
-                        self.assertRaises(ValueError, setfcn, ul, i, j, k, sliceLen + 1)
+                        with self.assertRaises(ValueError):
+                            setfcn(ul, i, j, k, sliceLen + 1)
                         if sliceLen > 2:
-                            self.assertRaises(ValueError, setfcn, ul, i, j, k, sliceLen - 1)
+                            with self.assertRaises(ValueError):
+                                setfcn(ul, i, j, k, sliceLen - 1)
 
                 for k in self.step_range():
                     ssl = nextRange(len(ul[i::k]))
@@ -223,9 +225,12 @@ class ListMixinTest(unittest.TestCase):
             del x[i]
         pl, ul = self.lists_of_len()
         for i in (-1 - self.limit, self.limit):
-            self.assertRaises(IndexError, setfcn, ul, i)  # 'set index %d' % i)
-            self.assertRaises(IndexError, getfcn, ul, i)  # 'get index %d' % i)
-            self.assertRaises(IndexError, delfcn, ul, i)  # 'del index %d' % i)
+            with self.assertRaises(IndexError):  # 'set index %d' % i)
+                setfcn(ul, i)
+            with self.assertRaises(IndexError):  # 'get index %d' % i)
+                getfcn(ul, i)
+            with self.assertRaises(IndexError):  # 'del index %d' % i)
+                delfcn(ul, i)
 
     def test06_list_methods(self):
         'List methods'
@@ -261,8 +266,10 @@ class ListMixinTest(unittest.TestCase):
 
         def popfcn(x, i):
             x.pop(i)
-        self.assertRaises(IndexError, popfcn, ul, self.limit)
-        self.assertRaises(IndexError, popfcn, ul, -1 - self.limit)
+        with self.assertRaises(IndexError):
+            popfcn(ul, self.limit)
+        with self.assertRaises(IndexError):
+            popfcn(ul, -1 - self.limit)
 
         pl, ul = self.lists_of_len()
         for val in range(self.limit):
@@ -282,8 +289,10 @@ class ListMixinTest(unittest.TestCase):
 
         def removefcn(x, v):
             return x.remove(v)
-        self.assertRaises(ValueError, indexfcn, ul, 40)
-        self.assertRaises(ValueError, removefcn, ul, 40)
+        with self.assertRaises(ValueError):
+            indexfcn(ul, 40)
+        with self.assertRaises(ValueError):
+            removefcn(ul, 40)
 
     def test07_allowed_types(self):
         'Type-restricted list'
@@ -294,8 +303,10 @@ class ListMixinTest(unittest.TestCase):
 
         def setfcn(x, i, v):
             x[i] = v
-        self.assertRaises(TypeError, setfcn, ul, 2, 'hello')
-        self.assertRaises(TypeError, setfcn, ul, slice(0, 3, 2), ('hello', 'goodbye'))
+        with self.assertRaises(TypeError):
+            setfcn(ul, 2, 'hello')
+        with self.assertRaises(TypeError):
+            setfcn(ul, slice(0, 3, 2), ('hello', 'goodbye'))
 
     def test08_min_length(self):
         'Length limits'
@@ -308,14 +319,17 @@ class ListMixinTest(unittest.TestCase):
         def setfcn(x, i):
             x[:i] = []
         for i in range(len(ul) - ul._minlength + 1, len(ul)):
-            self.assertRaises(ValueError, delfcn, ul, i)
-            self.assertRaises(ValueError, setfcn, ul, i)
+            with self.assertRaises(ValueError):
+                delfcn(ul, i)
+            with self.assertRaises(ValueError):
+                setfcn(ul, i)
         del ul[:len(ul) - ul._minlength]
 
         ul._maxlength = 4
         for i in range(0, ul._maxlength - len(ul)):
             ul.append(i)
-        self.assertRaises(ValueError, ul.append, 10)
+        with self.assertRaises(ValueError):
+            ul.append(10)
 
     def test09_iterable_check(self):
         'Error on assigning non-iterable to slice'
@@ -323,7 +337,8 @@ class ListMixinTest(unittest.TestCase):
 
         def setfcn(x, i, v):
             x[i] = v
-        self.assertRaises(TypeError, setfcn, ul, slice(0, 3, 2), 2)
+        with self.assertRaises(TypeError):
+            setfcn(ul, slice(0, 3, 2), 2)
 
     def test10_checkindex(self):
         'Index check'
@@ -335,7 +350,8 @@ class ListMixinTest(unittest.TestCase):
                 self.assertEqual(ul._checkindex(i), i, '_checkindex(pos index)')
 
         for i in (-self.limit - 1, self.limit):
-            self.assertRaises(IndexError, ul._checkindex, i)
+            with self.assertRaises(IndexError):
+                ul._checkindex(i)
 
     def test_11_sorting(self):
         'Sorting'

--- a/tests/gis_tests/layermap/tests.py
+++ b/tests/gis_tests/layermap/tests.py
@@ -156,11 +156,13 @@ class LayerMapTest(TestCase):
 
         # Testing invalid params for the `unique` keyword.
         for e, arg in ((TypeError, 5.0), (ValueError, 'foobar'), (ValueError, ('name', 'mpolygon'))):
-            self.assertRaises(e, LayerMapping, County, co_shp, co_mapping, transform=False, unique=arg)
+            with self.assertRaises(e):
+                LayerMapping(County, co_shp, co_mapping, transform=False, unique=arg)
 
         # No source reference system defined in the shapefile, should raise an error.
         if connection.features.supports_transform:
-            self.assertRaises(LayerMapError, LayerMapping, County, co_shp, co_mapping)
+            with self.assertRaises(LayerMapError):
+                LayerMapping(County, co_shp, co_mapping)
 
         # Passing in invalid ForeignKey mapping parameters -- must be a dictionary
         # mapping for the model the ForeignKey points to.
@@ -168,14 +170,17 @@ class LayerMapTest(TestCase):
         bad_fk_map1['state'] = 'name'
         bad_fk_map2 = copy(co_mapping)
         bad_fk_map2['state'] = {'nombre': 'State'}
-        self.assertRaises(TypeError, LayerMapping, County, co_shp, bad_fk_map1, transform=False)
-        self.assertRaises(LayerMapError, LayerMapping, County, co_shp, bad_fk_map2, transform=False)
+        with self.assertRaises(TypeError):
+            LayerMapping(County, co_shp, bad_fk_map1, transform=False)
+        with self.assertRaises(LayerMapError):
+            LayerMapping(County, co_shp, bad_fk_map2, transform=False)
 
         # There exist no State models for the ForeignKey mapping to work -- should raise
         # a MissingForeignKey exception (this error would be ignored if the `strict`
         # keyword is not set).
         lm = LayerMapping(County, co_shp, co_mapping, transform=False, unique='name')
-        self.assertRaises(MissingForeignKey, lm.save, silent=True, strict=True)
+        with self.assertRaises(MissingForeignKey):
+            lm.save(silent=True, strict=True)
 
         # Now creating the state models so the ForeignKey mapping may work.
         State.objects.bulk_create([
@@ -222,11 +227,13 @@ class LayerMapTest(TestCase):
         # Bad feature id ranges should raise a type error.
         bad_ranges = (5.0, 'foo', co_shp)
         for bad in bad_ranges:
-            self.assertRaises(TypeError, lm.save, fid_range=bad)
+            with self.assertRaises(TypeError):
+                lm.save(fid_range=bad)
 
         # Step keyword should not be allowed w/`fid_range`.
         fr = (3, 5)  # layer[3:5]
-        self.assertRaises(LayerMapError, lm.save, fid_range=fr, step=10)
+        with self.assertRaises(LayerMapError):
+            lm.save(fid_range=fr, step=10)
         lm.save(fid_range=fr)
 
         # Features IDs 3 & 4 are for Galveston County, Texas -- only

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -17,7 +17,8 @@ class GeometryFieldTest(SimpleTestCase):
         "Testing GeometryField initialization with defaults."
         fld = forms.GeometryField()
         for bad_default in ('blah', 3, 'FoO', None, 0):
-            self.assertRaises(ValidationError, fld.clean, bad_default)
+            with self.assertRaises(ValidationError):
+                fld.clean(bad_default)
 
     def test_srid(self):
         "Testing GeometryField with a SRID set."
@@ -59,7 +60,8 @@ class GeometryFieldTest(SimpleTestCase):
         # a WKT for any other geom_type will be properly transformed by `to_python`
         self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)'), pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
         # but rejected by `clean`
-        self.assertRaises(forms.ValidationError, pnt_fld.clean, 'LINESTRING(0 0, 1 1)')
+        with self.assertRaises(forms.ValidationError):
+            pnt_fld.clean('LINESTRING(0 0, 1 1)')
 
     def test_to_python(self):
         """
@@ -72,7 +74,8 @@ class GeometryFieldTest(SimpleTestCase):
             self.assertEqual(GEOSGeometry(wkt), fld.to_python(wkt))
         # but raises a ValidationError for any other string
         for wkt in ('POINT(5)', 'MULTI   POLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'BLAH(0 0, 1 1)'):
-            self.assertRaises(forms.ValidationError, fld.to_python, wkt)
+            with self.assertRaises(forms.ValidationError):
+                fld.to_python(wkt)
 
     def test_field_with_text_widget(self):
         class PointForm(forms.Form):

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -39,8 +39,10 @@ class GeometryFieldTest(SimpleTestCase):
         "Testing GeometryField's handling of null (None) geometries."
         # Form fields, by default, are required (`required=True`)
         fld = forms.GeometryField()
-        with self.assertRaisesMessage(forms.ValidationError,
-                "No geometry value provided."):
+        with self.assertRaisesMessage(
+            forms.ValidationError,
+            "No geometry value provided."
+        ):
             fld.clean(None)
 
         # This will clean None as a geometry (See #10660).

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -5,7 +5,6 @@ from django.contrib.gis.gdal import HAS_GDAL
 from django.contrib.gis.geos import GEOSGeometry
 from django.forms import ValidationError
 from django.test import SimpleTestCase, skipUnlessDBFeature
-from django.utils import six
 from django.utils.html import escape
 
 
@@ -40,7 +39,7 @@ class GeometryFieldTest(SimpleTestCase):
         "Testing GeometryField's handling of null (None) geometries."
         # Form fields, by default, are required (`required=True`)
         fld = forms.GeometryField()
-        with six.assertRaisesRegex(self, forms.ValidationError,
+        with self.assertRaisesMessage(forms.ValidationError,
                 "No geometry value provided."):
             fld.clean(None)
 

--- a/tests/gis_tests/test_geoip.py
+++ b/tests/gis_tests/test_geoip.py
@@ -66,23 +66,29 @@ class GeoIPTest(unittest.TestCase):
         # Improper parameters.
         bad_params = (23, 'foo', 15.23)
         for bad in bad_params:
-            self.assertRaises(GeoIPException, GeoIP, cache=bad)
+            with self.assertRaises(GeoIPException):
+                GeoIP(cache=bad)
             if isinstance(bad, six.string_types):
                 e = GeoIPException
             else:
                 e = TypeError
-            self.assertRaises(e, GeoIP, bad, 0)
+            with self.assertRaises(e):
+                GeoIP(bad, 0)
 
     def test02_bad_query(self):
         "Testing GeoIP query parameter checking."
         cntry_g = GeoIP(city='<foo>')
         # No city database available, these calls should fail.
-        self.assertRaises(GeoIPException, cntry_g.city, 'google.com')
-        self.assertRaises(GeoIPException, cntry_g.coords, 'yahoo.com')
+        with self.assertRaises(GeoIPException):
+            cntry_g.city('google.com')
+        with self.assertRaises(GeoIPException):
+            cntry_g.coords('yahoo.com')
 
         # Non-string query should raise TypeError
-        self.assertRaises(TypeError, cntry_g.country_code, 17)
-        self.assertRaises(TypeError, cntry_g.country_name, GeoIP)
+        with self.assertRaises(TypeError):
+            cntry_g.country_code(17)
+        with self.assertRaises(TypeError):
+            cntry_g.country_name(GeoIP)
 
     def test03_country(self):
         "Testing GeoIP country querying methods."

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -47,23 +47,29 @@ class GeoIPTest(unittest.TestCase):
         # Improper parameters.
         bad_params = (23, 'foo', 15.23)
         for bad in bad_params:
-            self.assertRaises(GeoIP2Exception, GeoIP2, cache=bad)
+            with self.assertRaises(GeoIP2Exception):
+                GeoIP2(cache=bad)
             if isinstance(bad, six.string_types):
                 e = GeoIP2Exception
             else:
                 e = TypeError
-            self.assertRaises(e, GeoIP2, bad, 0)
+            with self.assertRaises(e):
+                GeoIP2(bad, 0)
 
     def test02_bad_query(self):
         "GeoIP query parameter checking."
         cntry_g = GeoIP2(city='<foo>')
         # No city database available, these calls should fail.
-        self.assertRaises(GeoIP2Exception, cntry_g.city, 'tmc.edu')
-        self.assertRaises(GeoIP2Exception, cntry_g.coords, 'tmc.edu')
+        with self.assertRaises(GeoIP2Exception):
+            cntry_g.city('tmc.edu')
+        with self.assertRaises(GeoIP2Exception):
+            cntry_g.coords('tmc.edu')
 
         # Non-string query should raise TypeError
-        self.assertRaises(TypeError, cntry_g.country_code, 17)
-        self.assertRaises(TypeError, cntry_g.country_name, GeoIP2)
+        with self.assertRaises(TypeError):
+            cntry_g.country_code(17)
+        with self.assertRaises(TypeError):
+            cntry_g.country_name(GeoIP2)
 
     @mock.patch('socket.gethostbyname')
     def test03_country(self, gethostbyname):

--- a/tests/gis_tests/test_measure.py
+++ b/tests/gis_tests/test_measure.py
@@ -34,7 +34,8 @@ class DistanceTest(unittest.TestCase):
 
     def testInitInvalid(self):
         "Testing initialization from invalid units"
-        self.assertRaises(AttributeError, D, banana=100)
+        with self.assertRaises(AttributeError):
+            D(banana=100)
 
     def testAccess(self):
         "Testing access in different units"
@@ -161,7 +162,8 @@ class AreaTest(unittest.TestCase):
 
     def testInitInvaliA(self):
         "Testing initialization from invalid units"
-        self.assertRaises(AttributeError, A, banana=100)
+        with self.assertRaises(AttributeError):
+            A(banana=100)
 
     def testAccess(self):
         "Testing access in different units"

--- a/tests/gis_tests/tests.py
+++ b/tests/gis_tests/tests.py
@@ -92,5 +92,5 @@ class TestPostgisVersionCheck(unittest.TestCase):
 
     def test_no_version_number(self):
         ops = FakePostGISOperations()
-        with  self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured):
             ops.spatial_version

--- a/tests/gis_tests/tests.py
+++ b/tests/gis_tests/tests.py
@@ -87,8 +87,10 @@ class TestPostgisVersionCheck(unittest.TestCase):
 
         for version in versions:
             ops = FakePostGISOperations(version)
-            self.assertRaises(Exception, lambda: ops.spatial_version)
+            with self.assertRaises(Exception):
+                ops.spatial_version
 
     def test_no_version_number(self):
         ops = FakePostGISOperations()
-        self.assertRaises(ImproperlyConfigured, lambda: ops.spatial_version)
+        with  self.assertRaises(ImproperlyConfigured):
+            ops.spatial_version

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -508,9 +508,11 @@ class JsonResponseTests(SimpleTestCase):
         self.assertEqual(json.loads(response.content.decode()), data)
 
     def test_json_response_raises_type_error_with_default_setting(self):
-        with self.assertRaisesMessage(TypeError,
-                'In order to allow non-dict objects to be serialized set the '
-                'safe parameter to False'):
+        msg = (
+            'In order to allow non-dict objects to be serialized set the '
+            'safe parameter to False'
+        )
+        with self.assertRaisesMessage(TypeError, msg):
             JsonResponse([1, 2, 3])
 
     def test_json_response_text(self):

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -31,17 +31,25 @@ class QueryDictTests(unittest.TestCase):
 
     def test_missing_key(self):
         q = QueryDict()
-        self.assertRaises(KeyError, q.__getitem__, 'foo')
+        with self.assertRaises(KeyError):
+            q.__getitem__('foo')
 
     def test_immutability(self):
         q = QueryDict()
-        self.assertRaises(AttributeError, q.__setitem__, 'something', 'bar')
-        self.assertRaises(AttributeError, q.setlist, 'foo', ['bar'])
-        self.assertRaises(AttributeError, q.appendlist, 'foo', ['bar'])
-        self.assertRaises(AttributeError, q.update, {'foo': 'bar'})
-        self.assertRaises(AttributeError, q.pop, 'foo')
-        self.assertRaises(AttributeError, q.popitem)
-        self.assertRaises(AttributeError, q.clear)
+        with self.assertRaises(AttributeError):
+            q.__setitem__('something', 'bar')
+        with self.assertRaises(AttributeError):
+            q.setlist('foo', ['bar'])
+        with self.assertRaises(AttributeError):
+            q.appendlist('foo', ['bar'])
+        with self.assertRaises(AttributeError):
+            q.update({'foo': 'bar'})
+        with self.assertRaises(AttributeError):
+            q.pop('foo')
+        with self.assertRaises(AttributeError):
+            q.popitem()
+        with self.assertRaises(AttributeError):
+            q.clear()
 
     def test_immutable_get_with_default(self):
         q = QueryDict()
@@ -65,16 +73,20 @@ class QueryDictTests(unittest.TestCase):
 
         q = QueryDict(str('foo=bar'))
         self.assertEqual(q['foo'], 'bar')
-        self.assertRaises(KeyError, q.__getitem__, 'bar')
-        self.assertRaises(AttributeError, q.__setitem__, 'something', 'bar')
+        with self.assertRaises(KeyError):
+            q.__getitem__('bar')
+        with self.assertRaises(AttributeError):
+            q.__setitem__('something', 'bar')
 
         self.assertEqual(q.get('foo', 'default'), 'bar')
         self.assertEqual(q.get('bar', 'default'), 'default')
         self.assertEqual(q.getlist('foo'), ['bar'])
         self.assertEqual(q.getlist('bar'), [])
 
-        self.assertRaises(AttributeError, q.setlist, 'foo', ['bar'])
-        self.assertRaises(AttributeError, q.appendlist, 'foo', ['bar'])
+        with self.assertRaises(AttributeError):
+            q.setlist('foo', ['bar'])
+        with self.assertRaises(AttributeError):
+            q.appendlist('foo', ['bar'])
 
         if six.PY2:
             self.assertTrue(q.has_key('foo'))
@@ -89,11 +101,16 @@ class QueryDictTests(unittest.TestCase):
         self.assertEqual(list(six.itervalues(q)), ['bar'])
         self.assertEqual(len(q), 1)
 
-        self.assertRaises(AttributeError, q.update, {'foo': 'bar'})
-        self.assertRaises(AttributeError, q.pop, 'foo')
-        self.assertRaises(AttributeError, q.popitem)
-        self.assertRaises(AttributeError, q.clear)
-        self.assertRaises(AttributeError, q.setdefault, 'foo', 'bar')
+        with self.assertRaises(AttributeError):
+            q.update({'foo': 'bar'})
+        with self.assertRaises(AttributeError):
+            q.pop('foo')
+        with self.assertRaises(AttributeError):
+            q.popitem()
+        with self.assertRaises(AttributeError):
+            q.clear()
+        with self.assertRaises(AttributeError):
+            q.setdefault('foo', 'bar')
 
         self.assertEqual(q.urlencode(), 'foo=bar')
 
@@ -110,7 +127,8 @@ class QueryDictTests(unittest.TestCase):
     def test_mutable_copy(self):
         """A copy of a QueryDict is mutable."""
         q = QueryDict().copy()
-        self.assertRaises(KeyError, q.__getitem__, "foo")
+        with self.assertRaises(KeyError):
+            q.__getitem__("foo")
         q['name'] = 'john'
         self.assertEqual(q['name'], 'john')
 
@@ -169,16 +187,20 @@ class QueryDictTests(unittest.TestCase):
         q = QueryDict(str('vote=yes&vote=no'))
 
         self.assertEqual(q['vote'], 'no')
-        self.assertRaises(AttributeError, q.__setitem__, 'something', 'bar')
+        with self.assertRaises(AttributeError):
+            q.__setitem__('something', 'bar')
 
         self.assertEqual(q.get('vote', 'default'), 'no')
         self.assertEqual(q.get('foo', 'default'), 'default')
         self.assertEqual(q.getlist('vote'), ['yes', 'no'])
         self.assertEqual(q.getlist('foo'), [])
 
-        self.assertRaises(AttributeError, q.setlist, 'foo', ['bar', 'baz'])
-        self.assertRaises(AttributeError, q.setlist, 'foo', ['bar', 'baz'])
-        self.assertRaises(AttributeError, q.appendlist, 'foo', ['bar'])
+        with self.assertRaises(AttributeError):
+            q.setlist('foo', ['bar', 'baz'])
+        with self.assertRaises(AttributeError):
+            q.setlist('foo', ['bar', 'baz'])
+        with self.assertRaises(AttributeError):
+            q.appendlist('foo', ['bar'])
 
         if six.PY2:
             self.assertEqual(q.has_key('vote'), True)
@@ -192,12 +214,18 @@ class QueryDictTests(unittest.TestCase):
         self.assertEqual(list(six.itervalues(q)), ['no'])
         self.assertEqual(len(q), 1)
 
-        self.assertRaises(AttributeError, q.update, {'foo': 'bar'})
-        self.assertRaises(AttributeError, q.pop, 'foo')
-        self.assertRaises(AttributeError, q.popitem)
-        self.assertRaises(AttributeError, q.clear)
-        self.assertRaises(AttributeError, q.setdefault, 'foo', 'bar')
-        self.assertRaises(AttributeError, q.__delitem__, 'vote')
+        with self.assertRaises(AttributeError):
+            q.update({'foo': 'bar'})
+        with self.assertRaises(AttributeError):
+            q.pop('foo')
+        with self.assertRaises(AttributeError):
+            q.popitem()
+        with self.assertRaises(AttributeError):
+            q.clear()
+        with self.assertRaises(AttributeError):
+            q.setdefault('foo', 'bar')
+        with self.assertRaises(AttributeError):
+            q.__delitem__('vote')
 
     if six.PY2:
         def test_invalid_input_encoding(self):
@@ -295,8 +323,10 @@ class HttpResponseTests(unittest.TestCase):
         self.assertIsInstance(l[0][0], str)
 
         r = HttpResponse()
-        self.assertRaises(UnicodeError, r.__setitem__, 'føø', 'bar')
-        self.assertRaises(UnicodeError, r.__setitem__, 'føø'.encode('utf-8'), 'bar')
+        with self.assertRaises(UnicodeError):
+            r.__setitem__('føø', 'bar')
+        with self.assertRaises(UnicodeError):
+            r.__setitem__('føø'.encode('utf-8'), 'bar')
 
     def test_long_line(self):
         # Bug #20889: long lines trigger newlines to be added to headers
@@ -312,8 +342,10 @@ class HttpResponseTests(unittest.TestCase):
     def test_newlines_in_headers(self):
         # Bug #10188: Do not allow newlines in headers (CR or LF)
         r = HttpResponse()
-        self.assertRaises(BadHeaderError, r.__setitem__, 'test\rstr', 'test')
-        self.assertRaises(BadHeaderError, r.__setitem__, 'test\nstr', 'test')
+        with self.assertRaises(BadHeaderError):
+            r.__setitem__('test\rstr', 'test')
+        with self.assertRaises(BadHeaderError):
+            r.__setitem__('test\nstr', 'test')
 
     def test_dict_behavior(self):
         """
@@ -418,10 +450,10 @@ class HttpResponseTests(unittest.TestCase):
             'file:///etc/passwd',
         ]
         for url in bad_urls:
-            self.assertRaises(SuspiciousOperation,
-                              HttpResponseRedirect, url)
-            self.assertRaises(SuspiciousOperation,
-                              HttpResponsePermanentRedirect, url)
+            with self.assertRaises(SuspiciousOperation):
+                HttpResponseRedirect(url)
+            with self.assertRaises(SuspiciousOperation):
+                HttpResponsePermanentRedirect(url)
 
 
 class HttpResponseSubclassesTests(SimpleTestCase):

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -77,7 +77,8 @@ class URLPrefixTests(URLTestCaseBase):
 
     @override_settings(ROOT_URLCONF='i18n.patterns.urls.wrong')
     def test_invalid_prefix_use(self):
-        self.assertRaises(ImproperlyConfigured, lambda: reverse('account:register'))
+        with self.assertRaises(ImproperlyConfigured):
+            reverse('account:register')
 
 
 @override_settings(ROOT_URLCONF='i18n.patterns.urls.disabled')

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -754,7 +754,7 @@ class CustomLayoutExtractionTests(ExtractorTests):
 
     def test_no_locale_raises(self):
         os.chdir(self.test_dir)
-        with six.assertRaisesRegex(self, management.CommandError,
+        with self.assertRaisesMessage(management.CommandError,
                 "Unable to find a locale path to store translations for file"):
             management.call_command('makemessages', locale=LOCALE, verbosity=0)
 

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -754,8 +754,10 @@ class CustomLayoutExtractionTests(ExtractorTests):
 
     def test_no_locale_raises(self):
         os.chdir(self.test_dir)
-        with self.assertRaisesMessage(management.CommandError,
-                "Unable to find a locale path to store translations for file"):
+        with self.assertRaisesMessage(
+            management.CommandError,
+            "Unable to find a locale path to store translations for file"
+        ):
             management.call_command('makemessages', locale=LOCALE, verbosity=0)
 
     @override_settings(

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1848,7 +1848,8 @@ class TranslationFilesMissing(SimpleTestCase):
         '''
         self.patchGettextFind()
         trans_real._translations = {}
-        self.assertRaises(IOError, activate, 'en')
+        with self.assertRaises(IOError):
+            activate('en')
 
 
 class NonDjangoLanguageTests(SimpleTestCase):

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -135,11 +135,10 @@ class InlineFormsetFactoryTest(TestCase):
         If we specify fk_name, but it isn't a ForeignKey from the child model
         to the parent model, we should get an exception.
         """
-        self.assertRaises(
-            Exception,
-            "fk_name 'school' is not a ForeignKey to <class 'inline_formsets.models.Parent'>",
-            inlineformset_factory, Parent, Child, fk_name='school'
-        )
+        with self.assertRaises(Exception):
+            "fk_name 'school' is not a ForeignKey to <class 'inline_formsets.models.Parent'>"(
+                inlineformset_factory, Parent, Child, fk_name='school'
+            )
 
     def test_non_foreign_key_field(self):
         """

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -123,12 +123,11 @@ class InlineFormsetFactoryTest(TestCase):
         Child has two ForeignKeys to Parent, so if we don't specify which one
         to use for the inline formset, we should get an exception.
         """
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             ValueError,
-            "'inline_formsets.Child' has more than one ForeignKey to 'inline_formsets.Parent'.",
-            inlineformset_factory, Parent, Child
-        )
+                "'inline_formsets.Child' has more than one "
+                "ForeignKey to 'inline_formsets.Parent'."):
+            inlineformset_factory(Parent, Child)
 
     def test_fk_name_not_foreign_key_field_from_child(self):
         """
@@ -145,11 +144,10 @@ class InlineFormsetFactoryTest(TestCase):
         If the field specified in fk_name is not a ForeignKey, we should get an
         exception.
         """
-        six.assertRaisesRegex(
-            self, ValueError,
-            "'inline_formsets.Child' has no field named 'test'.",
-            inlineformset_factory, Parent, Child, fk_name='test'
-        )
+        with self.assertRaisesMessage(
+            ValueError,
+                "'inline_formsets.Child' has no field named 'test'."):
+            inlineformset_factory(Parent, Child, fk_name='test')
 
     def test_any_iterable_allowed_as_argument_to_exclude(self):
         # Regression test for #9171.

--- a/tests/inline_formsets/tests.py
+++ b/tests/inline_formsets/tests.py
@@ -123,10 +123,11 @@ class InlineFormsetFactoryTest(TestCase):
         Child has two ForeignKeys to Parent, so if we don't specify which one
         to use for the inline formset, we should get an exception.
         """
-        with self.assertRaisesMessage(
-            ValueError,
-                "'inline_formsets.Child' has more than one "
-                "ForeignKey to 'inline_formsets.Parent'."):
+        msg = (
+            "'inline_formsets.Child' has more than one "
+            "ForeignKey to 'inline_formsets.Parent'."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             inlineformset_factory(Parent, Child)
 
     def test_fk_name_not_foreign_key_field_from_child(self):
@@ -146,7 +147,8 @@ class InlineFormsetFactoryTest(TestCase):
         """
         with self.assertRaisesMessage(
             ValueError,
-                "'inline_formsets.Child' has no field named 'test'."):
+            "'inline_formsets.Child' has no field named 'test'."
+        ):
             inlineformset_factory(Parent, Child, fk_name='test')
 
     def test_any_iterable_allowed_as_argument_to_exclude(self):

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -1368,7 +1368,9 @@ class M2mThroughFieldsTests(IsolatedModelsTestCase):
             pass
 
         with self.assertRaisesMessage(
-                ValueError, 'Cannot specify through_fields without a through model'):
+            ValueError,
+            'Cannot specify through_fields without a through model'
+        ):
             models.ManyToManyField(Fan, through_fields=('f1', 'f2'))
 
     def test_invalid_order(self):

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -1367,9 +1367,9 @@ class M2mThroughFieldsTests(IsolatedModelsTestCase):
         class Fan(models.Model):
             pass
 
-        self.assertRaisesMessage(
-            ValueError, 'Cannot specify through_fields without a through model',
-            models.ManyToManyField, Fan, through_fields=('f1', 'f2'))
+        with self.assertRaisesMessage(
+                ValueError, 'Cannot specify through_fields without a through model'):
+            models.ManyToManyField(Fan, through_fields=('f1', 'f2'))
 
     def test_invalid_order(self):
         """

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -136,7 +136,8 @@ class LookupTests(TestCase):
         self.assertEqual(Article.objects.in_bulk([]), {})
         self.assertEqual(Article.objects.in_bulk(iter([self.a1.id])), {self.a1.id: self.a1})
         self.assertEqual(Article.objects.in_bulk(iter([])), {})
-        self.assertRaises(TypeError, Article.objects.in_bulk, headline__startswith='Blah')
+        with self.assertRaises(TypeError):
+            Article.objects.in_bulk(headline__startswith='Blah')
 
     def test_values(self):
         # values() returns a list of dictionaries instead of object instances --
@@ -259,9 +260,8 @@ class LookupTests(TestCase):
         # However, an exception FieldDoesNotExist will be thrown if you specify
         # a non-existent field name in values() (a field that is neither in the
         # model nor in extra(select)).
-        self.assertRaises(FieldError,
-            Article.objects.extra(select={'id_plus_one': 'id + 1'}).values,
-            'id', 'id_plus_two')
+        with self.assertRaises(FieldError):
+            Article.objects.extra(select={'id_plus_one': 'id + 1'}).values('id', 'id_plus_two')
         # If you don't specify field names to values(), all are returned.
         self.assertQuerysetEqual(Article.objects.filter(id=self.a5.id).values(),
             [{
@@ -342,7 +342,8 @@ class LookupTests(TestCase):
                 (self.au2.name, self.a6.headline, self.t3.name),
                 (self.au2.name, self.a7.headline, self.t3.name),
             ], transform=identity)
-        self.assertRaises(TypeError, Article.objects.values_list, 'id', 'headline', flat=True)
+        with self.assertRaises(TypeError):
+            Article.objects.values_list('id', 'headline', flat=True)
 
     def test_get_next_previous_by(self):
         # Every DateField and DateTimeField creates get_next_by_FOO() and
@@ -359,7 +360,8 @@ class LookupTests(TestCase):
                          '<Article: Article 7>')
         self.assertEqual(repr(self.a4.get_next_by_pub_date()),
                          '<Article: Article 6>')
-        self.assertRaises(Article.DoesNotExist, self.a5.get_next_by_pub_date)
+        with self.assertRaises(Article.DoesNotExist):
+            self.a5.get_next_by_pub_date()
         self.assertEqual(repr(self.a6.get_next_by_pub_date()),
                          '<Article: Article 5>')
         self.assertEqual(repr(self.a7.get_next_by_pub_date()),

--- a/tests/m2m_through_regress/tests.py
+++ b/tests/m2m_through_regress/tests.py
@@ -67,10 +67,12 @@ class M2MThroughTestCase(TestCase):
             self.roll.members.set([])
 
     def test_cannot_use_create_on_m2m_with_intermediary_model(self):
-        self.assertRaises(AttributeError, self.rock.members.create, name="Anne")
+        with self.assertRaises(AttributeError):
+            self.rock.members.create(name="Anne")
 
     def test_cannot_use_create_on_reverse_m2m_with_intermediary_model(self):
-        self.assertRaises(AttributeError, self.bob.group_set.create, name="Funk")
+        with self.assertRaises(AttributeError):
+            self.bob.group_set.create(name="Funk")
 
     def test_retrieve_reverse_m2m_items_via_custom_id_intermediary(self):
         self.assertQuerysetEqual(

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -143,11 +143,13 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
 
     def test_header_injection(self):
         email = EmailMessage('Subject\nInjection Test', 'Content', 'from@example.com', ['to@example.com'])
-        self.assertRaises(BadHeaderError, email.message)
+        with self.assertRaises(BadHeaderError):
+            email.message()
         email = EmailMessage(
             ugettext_lazy('Subject\nInjection Test'), 'Content', 'from@example.com', ['to@example.com']
         )
-        self.assertRaises(BadHeaderError, email.message)
+        with self.assertRaises(BadHeaderError):
+            email.message()
 
     def test_space_continuation(self):
         """
@@ -1193,7 +1195,8 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend()
         self.assertTrue(backend.use_ssl)
         try:
-            self.assertRaises(SSLError, backend.open)
+            with self.assertRaises(SSLError):
+                backend.open()
         finally:
             backend.close()
 

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1107,8 +1107,8 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend(
             username='not empty username', password='not empty password')
         try:
-            self.assertRaisesMessage(SMTPException,
-                'SMTP AUTH extension not supported by server.', backend.open)
+            with self.assertRaisesMessage(SMTPException, 'SMTP AUTH extension not supported by server.'):
+                backend.open()
         finally:
             backend.close()
 
@@ -1183,8 +1183,8 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         backend = smtp.EmailBackend()
         self.assertTrue(backend.use_tls)
         try:
-            self.assertRaisesMessage(SMTPException,
-                'STARTTLS extension not supported by server.', backend.open)
+            with self.assertRaisesMessage(SMTPException, 'STARTTLS extension not supported by server.'):
+                backend.open()
         finally:
             backend.close()
 

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -33,7 +33,8 @@ class ManyToManyTests(TestCase):
         # Create an Article.
         a5 = Article(id=None, headline='Django lets you reate Web apps easily')
         # You can't associate it with a Publication until it's been saved.
-        self.assertRaises(ValueError, getattr, a5, 'publications')
+        with self.assertRaises(ValueError):
+            getattr(a5, 'publications')
         # Save it!
         a5.save()
         # Associate the Article with a Publication.

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -455,8 +455,8 @@ class ManyToOneTests(TestCase):
         self.assertEqual(a3.reporter.id, self.r2.id)
 
         # Get should respect explicit foreign keys as well.
-        self.assertRaises(MultipleObjectsReturned,
-                          Article.objects.get, reporter_id=self.r.id)
+        with self.assertRaises(MultipleObjectsReturned):
+            Article.objects.get(reporter_id=self.r.id)
         self.assertEqual(repr(a3),
                          repr(Article.objects.get(reporter_id=self.r2.id,
                                              pub_date=datetime.date(2011, 5, 7))))
@@ -533,15 +533,19 @@ class ManyToOneTests(TestCase):
         self.assertIsNone(p.bestchild)
 
         # Assigning None fails: Child.parent is null=False.
-        self.assertRaises(ValueError, setattr, c, "parent", None)
+        with self.assertRaises(ValueError):
+            setattr(c, "parent", None)
 
         # You also can't assign an object of the wrong type here
-        self.assertRaises(ValueError, setattr, c, "parent", First(id=1, second=1))
+        with self.assertRaises(ValueError):
+            setattr(c, "parent", First(id=1, second=1))
 
         # Nor can you explicitly assign None to Child.parent during object
         # creation (regression for #9649).
-        self.assertRaises(ValueError, Child, name='xyzzy', parent=None)
-        self.assertRaises(ValueError, Child.objects.create, name='xyzzy', parent=None)
+        with self.assertRaises(ValueError):
+            Child(name='xyzzy', parent=None)
+        with self.assertRaises(ValueError):
+            Child.objects.create(name='xyzzy', parent=None)
 
         # Creation using keyword argument should cache the related object.
         p = Parent.objects.get(name="Parent")
@@ -598,7 +602,8 @@ class ManyToOneTests(TestCase):
 
         p = Parent.objects.create(name="Parent")
         c = Child.objects.create(name="Child", parent=p)
-        self.assertRaises(ValueError, Child.objects.create, name="Grandchild", parent=c)
+        with self.assertRaises(ValueError):
+            Child.objects.create(name="Grandchild", parent=c)
 
     def test_fk_instantiation_outside_model(self):
         # Regression for #12190 -- Should be able to instantiate a FK outside
@@ -646,7 +651,8 @@ class ManyToOneTests(TestCase):
         School.objects.use_for_related_fields = True
         try:
             private_student = Student.objects.get(pk=private_student.pk)
-            self.assertRaises(School.DoesNotExist, lambda: private_student.school)
+            with self.assertRaises(School.DoesNotExist):
+                private_student.school
         finally:
             School.objects.use_for_related_fields = False
 

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -491,16 +491,12 @@ class ManyToOneTests(TestCase):
     def test_values_list_exception(self):
         expected_message = "Cannot resolve keyword 'notafield' into field. Choices are: %s"
 
-        self.assertRaisesMessage(FieldError,
-                                 expected_message % ', '.join(sorted(f.name for f in Reporter._meta.get_fields())),
-                                 Article.objects.values_list,
-                                 'reporter__notafield')
-        self.assertRaisesMessage(
-            FieldError,
-            expected_message % ', '.join(['EXTRA'] + sorted(f.name for f in Article._meta.get_fields())),
-            Article.objects.extra(select={'EXTRA': 'EXTRA_SELECT'}).values_list,
-            'notafield'
-        )
+        with self.assertRaisesMessage(FieldError,
+                expected_message % ', '.join(sorted(f.name for f in Reporter._meta.get_fields()))):
+            Article.objects.values_list('reporter__notafield')
+        with self.assertRaisesMessage(FieldError,
+                expected_message % ', '.join(['EXTRA'] + sorted(f.name for f in Article._meta.get_fields()))):
+            Article.objects.extra(select={'EXTRA': 'EXTRA_SELECT'}).values_list('notafield')
 
     def test_fk_assignment_and_related_object_cache(self):
         # Tests of ForeignKey assignment and the related-object cache (see #6886).

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -58,7 +58,10 @@ class ManyToOneTests(TestCase):
 
         # Create a new article, and add it to the article set.
         new_article2 = Article(headline="Paul's story", pub_date=datetime.date(2006, 1, 17))
-        msg = "<Article: Paul's story> instance isn't saved. Use bulk=False or save the object first."
+        msg = (
+            "<Article: Paul's story> instance isn't saved. "
+            "Use bulk=False or save the object first."
+        )
         with self.assertRaisesMessage(ValueError, msg):
             self.r.article_set.add(new_article2)
 
@@ -491,11 +494,15 @@ class ManyToOneTests(TestCase):
     def test_values_list_exception(self):
         expected_message = "Cannot resolve keyword 'notafield' into field. Choices are: %s"
 
-        with self.assertRaisesMessage(FieldError,
-                expected_message % ', '.join(sorted(f.name for f in Reporter._meta.get_fields()))):
+        with self.assertRaisesMessage(
+            FieldError,
+            expected_message % ', '.join(sorted(f.name for f in Reporter._meta.get_fields()))
+        ):
             Article.objects.values_list('reporter__notafield')
-        with self.assertRaisesMessage(FieldError,
-                expected_message % ', '.join(['EXTRA'] + sorted(f.name for f in Article._meta.get_fields()))):
+        with self.assertRaisesMessage(
+            FieldError,
+            expected_message % ', '.join(['EXTRA'] + sorted(f.name for f in Article._meta.get_fields()))
+        ):
             Article.objects.extra(select={'EXTRA': 'EXTRA_SELECT'}).values_list('notafield')
 
     def test_fk_assignment_and_related_object_cache(self):

--- a/tests/many_to_one_null/tests.py
+++ b/tests/many_to_one_null/tests.py
@@ -44,7 +44,8 @@ class ManyToOneNullTests(TestCase):
         self.assertEqual(self.a3.reporter, None)
         # Need to reget a3 to refresh the cache
         a3 = Article.objects.get(pk=self.a3.pk)
-        self.assertRaises(AttributeError, getattr, a3.reporter, 'id')
+        with self.assertRaises(AttributeError):
+            getattr(a3.reporter, 'id')
         # Accessing an article's 'reporter' attribute returns None
         # if the reporter is set to None.
         self.assertEqual(a3.reporter, None)
@@ -71,7 +72,8 @@ class ManyToOneNullTests(TestCase):
     def test_remove_from_wrong_set(self):
         self.assertQuerysetEqual(self.r2.article_set.all(), ['<Article: Fourth>'])
         # Try to remove a4 from a set it does not belong to
-        self.assertRaises(Reporter.DoesNotExist, self.r.article_set.remove, self.a4)
+        with self.assertRaises(Reporter.DoesNotExist):
+            self.r.article_set.remove(self.a4)
         self.assertQuerysetEqual(self.r2.article_set.all(), ['<Article: Fourth>'])
 
     def test_set(self):

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -238,8 +238,8 @@ class BaseTests(object):
         reverse('show_message')
         for level in ('debug', 'info', 'success', 'warning', 'error'):
             add_url = reverse('add_message', args=(level,))
-            self.assertRaises(MessageFailure, self.client.post, add_url,
-                              data, follow=True)
+            with self.assertRaises(MessageFailure):
+                self.client.post(add_url, data, follow=True)
 
     @modify_settings(
         INSTALLED_APPS={'remove': 'django.contrib.messages'},

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -862,7 +862,8 @@ class RootUrlconfTests(SimpleTestCase):
         # Removing ROOT_URLCONF is safe, as override_settings will restore
         # the previously defined settings.
         del settings.ROOT_URLCONF
-        self.assertRaises(AttributeError, self.client.get, "/middleware_exceptions/view/")
+        with self.assertRaises(AttributeError):
+            self.client.get("/middleware_exceptions/view/")
 
 
 class MyMiddleware(object):

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -499,7 +499,7 @@ class MakeMigrationsTests(MigrationTestBase):
         apps.register_model('migrations', UnserializableModel)
 
         with self.temporary_migration_module() as migration_dir:
-            with six.assertRaisesRegex(self, ValueError, r'Cannot serialize'):
+            with self.assertRaisesMessage(ValueError, 'Cannot serialize'):
                 call_command("makemigrations", "migrations", verbosity=0)
 
             initial_file = os.path.join(migration_dir, "0001_initial.py")

--- a/tests/migrations/test_graph.py
+++ b/tests/migrations/test_graph.py
@@ -145,10 +145,8 @@ class GraphTests(SimpleTestCase):
         graph.add_dependency("app_b.0002", ("app_b", "0002"), ("app_b", "0001"))
         graph.add_dependency("app_b.0001", ("app_b", "0001"), ("app_a", "0003"))
         # Test whole graph
-        self.assertRaises(
-            CircularDependencyError,
-            graph.forwards_plan, ("app_a", "0003"),
-        )
+        with self.assertRaises(CircularDependencyError):
+            graph.forwards_plan(("app_a", "0003"), )
 
     def test_circular_graph_2(self):
         graph = MigrationGraph()
@@ -159,10 +157,8 @@ class GraphTests(SimpleTestCase):
         graph.add_dependency('B.0001', ('B', '0001'), ('A', '0001'))
         graph.add_dependency('C.0001', ('C', '0001'), ('B', '0001'))
 
-        self.assertRaises(
-            CircularDependencyError,
-            graph.forwards_plan, ('C', '0001')
-        )
+        with self.assertRaises(CircularDependencyError):
+            graph.forwards_plan(('C', '0001'))
 
     def test_graph_recursive(self):
         graph = MigrationGraph()

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -9,7 +9,6 @@ from django.db.models.fields import NOT_PROVIDED
 from django.db.transaction import atomic
 from django.db.utils import IntegrityError
 from django.test import override_settings, skipUnlessDBFeature
-from django.utils import six
 
 from .models import FoodManager, FoodQuerySet
 from .test_base import MigrationTestBase
@@ -1603,16 +1602,12 @@ class OperationTests(OperationTestBase):
         )
 
         with connection.schema_editor() as editor:
-            six.assertRaisesRegex(self, ValueError,
-                "Expected a 2-tuple but got 1",
-                operation.database_forwards,
-                "test_runsql", editor, project_state, new_state)
+            with self.assertRaisesMessage(ValueError, "Expected a 2-tuple but got 1"):
+                operation.database_forwards("test_runsql", editor, project_state, new_state)
 
         with connection.schema_editor() as editor:
-            six.assertRaisesRegex(self, ValueError,
-                "Expected a 2-tuple but got 3",
-                operation.database_backwards,
-                "test_runsql", editor, new_state, project_state)
+            with self.assertRaisesMessage(ValueError, "Expected a 2-tuple but got 3"):
+                operation.database_backwards("test_runsql", editor, new_state, project_state)
 
     def test_run_sql_noop(self):
         """

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -296,7 +296,7 @@ class WriterTests(SimpleTestCase):
         )
 
     def test_serialize_functions(self):
-        with six.assertRaisesRegex(self, ValueError, 'Cannot serialize function: lambda'):
+        with self.assertRaisesMessage(ValueError, 'Cannot serialize function: lambda'):
             self.assertSerializedEqual(lambda x: 42)
         self.assertSerializedEqual(models.SET_NULL)
         string, imports = MigrationWriter.serialize(models.SET(42))
@@ -461,8 +461,8 @@ class WriterTests(SimpleTestCase):
                 return "somewhere dynamic"
             thing = models.FileField(upload_to=upload_to)
 
-        with six.assertRaisesRegex(self, ValueError,
-                '^Could not find function upload_to in migrations.test_writer'):
+        with self.assertRaisesMessage(ValueError,
+                'Could not find function upload_to in migrations.test_writer'):
             self.serialize_round_trip(TestModel2.thing)
 
     def test_serialize_managers(self):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -412,7 +412,10 @@ class WriterTests(SimpleTestCase):
             MigrationWriter.serialize(validator)
 
         validator = deconstructible(path="django.core.validators.EmailValidator2")(EmailValidator)(message="hello")
-        with self.assertRaisesMessage(ValueError, "Could not find object EmailValidator2 in django.core.validators."):
+        with self.assertRaisesMessage(
+            ValueError,
+            "Could not find object EmailValidator2 in django.core.validators."
+        ):
             MigrationWriter.serialize(validator)
 
     def test_serialize_empty_nonempty_tuple(self):
@@ -461,8 +464,10 @@ class WriterTests(SimpleTestCase):
                 return "somewhere dynamic"
             thing = models.FileField(upload_to=upload_to)
 
-        with self.assertRaisesMessage(ValueError,
-                'Could not find function upload_to in migrations.test_writer'):
+        with self.assertRaisesMessage(
+            ValueError,
+            'Could not find function upload_to in migrations.test_writer'
+        ):
             self.serialize_round_trip(TestModel2.thing)
 
     def test_serialize_managers(self):

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -83,8 +83,10 @@ class ImageFieldTestMixin(SerializeMixin):
         field = getattr(instance, field_name)
         # Check height/width attributes of field.
         if width is None and height is None:
-            self.assertRaises(ValueError, getattr, field, 'width')
-            self.assertRaises(ValueError, getattr, field, 'height')
+            with self.assertRaises(ValueError):
+                getattr(field, 'width')
+            with self.assertRaises(ValueError):
+                getattr(field, 'height')
         else:
             self.assertEqual(field.width, width)
             self.assertEqual(field.height, height)

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -47,13 +47,11 @@ class TestSaveLoad(TestCase):
             PrimaryKeyUUIDModel.objects.get(pk=[])
 
     def test_wrong_value(self):
-        self.assertRaisesMessage(
-            ValueError, 'badly formed hexadecimal UUID string',
-            UUIDModel.objects.get, field='not-a-uuid')
+        with self.assertRaisesMessage(ValueError, 'badly formed hexadecimal UUID string'):
+            UUIDModel.objects.get(field='not-a-uuid')
 
-        self.assertRaisesMessage(
-            ValueError, 'badly formed hexadecimal UUID string',
-            UUIDModel.objects.create, field='not-a-uuid')
+        with self.assertRaisesMessage(ValueError, 'badly formed hexadecimal UUID string'):
+            UUIDModel.objects.create(field='not-a-uuid')
 
 
 class TestMigrations(SimpleTestCase):

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -129,7 +129,8 @@ class DecimalFieldTests(test.TestCase):
         f = models.DecimalField(max_digits=4, decimal_places=2)
         self.assertEqual(f.to_python(3), Decimal("3"))
         self.assertEqual(f.to_python("3.14"), Decimal("3.14"))
-        self.assertRaises(ValidationError, f.to_python, "abc")
+        with self.assertRaises(ValidationError):
+            f.to_python("abc")
 
     def test_default(self):
         f = models.DecimalField(default=Decimal("0.00"))
@@ -551,7 +552,8 @@ class SlugFieldTests(test.TestCase):
 class ValidationTest(test.SimpleTestCase):
     def test_charfield_raises_error_on_empty_string(self):
         f = models.CharField()
-        self.assertRaises(ValidationError, f.clean, "", None)
+        with self.assertRaises(ValidationError):
+            f.clean("", None)
 
     def test_charfield_cleans_empty_string_when_blank_true(self):
         f = models.CharField(blank=True)
@@ -563,7 +565,8 @@ class ValidationTest(test.SimpleTestCase):
 
     def test_integerfield_raises_error_on_invalid_intput(self):
         f = models.IntegerField()
-        self.assertRaises(ValidationError, f.clean, "a", None)
+        with self.assertRaises(ValidationError):
+            f.clean("a", None)
 
     def test_charfield_with_choices_cleans_valid_choice(self):
         f = models.CharField(max_length=1,
@@ -572,7 +575,8 @@ class ValidationTest(test.SimpleTestCase):
 
     def test_charfield_with_choices_raises_error_on_invalid_choice(self):
         f = models.CharField(choices=[('a', 'A'), ('b', 'B')])
-        self.assertRaises(ValidationError, f.clean, "not a", None)
+        with self.assertRaises(ValidationError):
+            f.clean("not a", None)
 
     def test_charfield_get_choices_with_blank_defined(self):
         f = models.CharField(choices=[('', '<><>'), ('a', 'A')])
@@ -592,7 +596,8 @@ class ValidationTest(test.SimpleTestCase):
 
     def test_nullable_integerfield_raises_error_with_blank_false(self):
         f = models.IntegerField(null=True, blank=False)
-        self.assertRaises(ValidationError, f.clean, None, None)
+        with self.assertRaises(ValidationError):
+            f.clean(None, None)
 
     def test_nullable_integerfield_cleans_none_on_null_and_blank_true(self):
         f = models.IntegerField(null=True, blank=True)
@@ -600,16 +605,20 @@ class ValidationTest(test.SimpleTestCase):
 
     def test_integerfield_raises_error_on_empty_input(self):
         f = models.IntegerField(null=False)
-        self.assertRaises(ValidationError, f.clean, None, None)
-        self.assertRaises(ValidationError, f.clean, '', None)
+        with self.assertRaises(ValidationError):
+            f.clean(None, None)
+        with self.assertRaises(ValidationError):
+            f.clean('', None)
 
     def test_integerfield_validates_zero_against_choices(self):
         f = models.IntegerField(choices=((1, 1),))
-        self.assertRaises(ValidationError, f.clean, '0', None)
+        with self.assertRaises(ValidationError):
+            f.clean('0', None)
 
     def test_charfield_raises_error_on_empty_input(self):
         f = models.CharField(null=False)
-        self.assertRaises(ValidationError, f.clean, None, None)
+        with self.assertRaises(ValidationError):
+            f.clean(None, None)
 
     def test_datefield_cleans_date(self):
         f = models.DateField()
@@ -617,7 +626,8 @@ class ValidationTest(test.SimpleTestCase):
 
     def test_boolean_field_doesnt_accept_empty_input(self):
         f = models.BooleanField()
-        self.assertRaises(ValidationError, f.clean, None, None)
+        with self.assertRaises(ValidationError):
+            f.clean(None, None)
 
 
 class IntegerFieldTests(test.TestCase):
@@ -817,7 +827,8 @@ class BinaryFieldTests(test.TestCase):
 
     def test_max_length(self):
         dm = DataModel(short_data=self.binary_data * 4)
-        self.assertRaises(ValidationError, dm.full_clean)
+        with self.assertRaises(ValidationError):
+            dm.full_clean()
 
 
 class GenericIPAddressFieldTests(test.TestCase):
@@ -828,10 +839,12 @@ class GenericIPAddressFieldTests(test.TestCase):
         """
         model_field = models.GenericIPAddressField(protocol='IPv4')
         form_field = model_field.formfield()
-        self.assertRaises(ValidationError, form_field.clean, '::1')
+        with self.assertRaises(ValidationError):
+            form_field.clean('::1')
         model_field = models.GenericIPAddressField(protocol='IPv6')
         form_field = model_field.formfield()
-        self.assertRaises(ValidationError, form_field.clean, '127.0.0.1')
+        with self.assertRaises(ValidationError):
+            form_field.clean('127.0.0.1')
 
     def test_null_value(self):
         """

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -177,7 +177,8 @@ class ModelFormBaseTest(TestCase):
     def test_no_model_class(self):
         class NoModelModelForm(forms.ModelForm):
             pass
-        self.assertRaises(ValueError, NoModelModelForm)
+        with self.assertRaises(ValueError):
+            NoModelModelForm()
 
     def test_empty_fields_to_fields_for_model(self):
         """
@@ -282,8 +283,8 @@ class ModelFormBaseTest(TestCase):
             self.fail('Declarative field raised FieldError incorrectly')
 
     def test_extra_field_modelform_factory(self):
-        self.assertRaises(FieldError, modelform_factory,
-                          Person, fields=['no-field', 'name'])
+        with self.assertRaises(FieldError):
+            modelform_factory(Person, fields=['no-field', 'name'])
 
     def test_replace_field(self):
         class ReplaceField(forms.ModelForm):
@@ -1836,7 +1837,8 @@ class FileAndImageFieldTests(TestCase):
         """
         f = forms.FileField(required=True)
         self.assertEqual(f.clean(False, 'initial'), 'initial')
-        self.assertRaises(ValidationError, f.clean, False)
+        with self.assertRaises(ValidationError):
+            f.clean(False)
 
     def test_full_clear(self):
         """
@@ -2682,8 +2684,8 @@ class FormFieldCallbackTests(SimpleTestCase):
 
     def test_bad_callback(self):
         # A bad callback provided by user still gives an error
-        self.assertRaises(TypeError, modelform_factory, Person, fields="__all__",
-                          formfield_callback='not a function or callable')
+        with self.assertRaises(TypeError):
+            modelform_factory(Person, fields="__all__", formfield_callback='not a function or callable')
 
 
 class LocalizedModelFormTest(TestCase):

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -56,7 +56,7 @@ class ModelInheritanceTests(TestCase):
         # Restaurant object cannot access that reverse relation, since it's not
         # part of the Place-Supplier Hierarchy.
         self.assertQuerysetEqual(Place.objects.filter(supplier__name="foo"), [])
-        with  self.assertRaises(FieldError):
+        with self.assertRaises(FieldError):
             Restaurant.objects.filter(supplier__name="foo")
 
     def test_model_with_distinct_accessors(self):

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -48,14 +48,16 @@ class ModelInheritanceTests(TestCase):
 
         # However, the CommonInfo class cannot be used as a normal model (it
         # doesn't exist as a model).
-        self.assertRaises(AttributeError, lambda: CommonInfo.objects.all())
+        with self.assertRaises(AttributeError):
+            CommonInfo.objects.all()
 
     def test_reverse_relation_for_different_hierarchy_tree(self):
         # Even though p.supplier for a Place 'p' (a parent of a Supplier), a
         # Restaurant object cannot access that reverse relation, since it's not
         # part of the Place-Supplier Hierarchy.
         self.assertQuerysetEqual(Place.objects.filter(supplier__name="foo"), [])
-        self.assertRaises(FieldError, Restaurant.objects.filter, supplier__name="foo")
+        with  self.assertRaises(FieldError):
+            Restaurant.objects.filter(supplier__name="foo")
 
     def test_model_with_distinct_accessors(self):
         # The Post model has distinct accessors for the Comment and Link models.
@@ -68,9 +70,8 @@ class ModelInheritanceTests(TestCase):
 
         # The Post model doesn't have an attribute called
         # 'attached_%(class)s_set'.
-        self.assertRaises(
-            AttributeError, getattr, post, "attached_%(class)s_set"
-        )
+        with self.assertRaises(AttributeError):
+            getattr(post, "attached_%(class)s_set")
 
     def test_meta_fields_and_ordering(self):
         # Make sure Restaurant and ItalianRestaurant have the right fields in
@@ -211,25 +212,19 @@ class ModelInheritanceDataTests(TestCase):
     def test_parent_child_one_to_one_link_on_nonrelated_objects(self):
         # This won't work because the Demon Dogs restaurant is not an Italian
         # restaurant.
-        self.assertRaises(
-            ItalianRestaurant.DoesNotExist,
-            lambda: Place.objects.get(name="Demon Dogs").restaurant.italianrestaurant
-        )
+        with self.assertRaises(ItalianRestaurant.DoesNotExist):
+            Place.objects.get(name="Demon Dogs").restaurant.italianrestaurant
 
     def test_inherited_does_not_exist_exception(self):
         # An ItalianRestaurant which does not exist is also a Place which does
         # not exist.
-        self.assertRaises(
-            Place.DoesNotExist,
-            ItalianRestaurant.objects.get, name="The Noodle Void"
-        )
+        with self.assertRaises(Place.DoesNotExist):
+            ItalianRestaurant.objects.get(name="The Noodle Void")
 
     def test_inherited_multiple_objects_returned_exception(self):
         # MultipleObjectsReturned is also inherited.
-        self.assertRaises(
-            Place.MultipleObjectsReturned,
-            Restaurant.objects.get, id__lt=12321
-        )
+        with self.assertRaises(Place.MultipleObjectsReturned):
+            Restaurant.objects.get(id__lt=12321)
 
     def test_related_objects_for_inherited_models(self):
         # Related objects work just as they normally do.
@@ -241,9 +236,8 @@ class ModelInheritanceDataTests(TestCase):
         # This won't work because the Place we select is not a Restaurant (it's
         # a Supplier).
         p = Place.objects.get(name="Joe's Chickens")
-        self.assertRaises(
-            Restaurant.DoesNotExist, lambda: p.restaurant
-        )
+        with self.assertRaises(Restaurant.DoesNotExist):
+            p.restaurant
 
         self.assertEqual(p.supplier, s1)
         self.assertQuerysetEqual(

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -171,14 +171,10 @@ class ModelInheritanceTest(TestCase):
         # the ItalianRestaurant.
         Restaurant.objects.all().delete()
 
-        self.assertRaises(
-            Place.DoesNotExist,
-            Place.objects.get,
-            pk=ident)
-        self.assertRaises(
-            ItalianRestaurant.DoesNotExist,
-            ItalianRestaurant.objects.get,
-            pk=ident)
+        with self.assertRaises(Place.DoesNotExist):
+            Place.objects.get(pk=ident)
+        with self.assertRaises(ItalianRestaurant.DoesNotExist):
+            ItalianRestaurant.objects.get(pk=ident)
 
     def test_issue_6755(self):
         """
@@ -241,14 +237,12 @@ class ModelInheritanceTest(TestCase):
 
         self.assertEqual(c1.get_next_by_pub_date(), c2)
         self.assertEqual(c2.get_next_by_pub_date(), c3)
-        self.assertRaises(
-            ArticleWithAuthor.DoesNotExist,
-            c3.get_next_by_pub_date)
+        with self.assertRaises(ArticleWithAuthor.DoesNotExist):
+            c3.get_next_by_pub_date()
         self.assertEqual(c3.get_previous_by_pub_date(), c2)
         self.assertEqual(c2.get_previous_by_pub_date(), c1)
-        self.assertRaises(
-            ArticleWithAuthor.DoesNotExist,
-            c1.get_previous_by_pub_date)
+        with self.assertRaises(ArticleWithAuthor.DoesNotExist):
+            c1.get_previous_by_pub_date()
 
     def test_inherited_fields(self):
         """

--- a/tests/model_regress/tests.py
+++ b/tests/model_regress/tests.py
@@ -225,7 +225,8 @@ class ModelValidationTest(TestCase):
     def test_pk_validation(self):
         NonAutoPK.objects.create(name="one")
         again = NonAutoPK(name="one")
-        self.assertRaises(ValidationError, again.validate_unique)
+        with self.assertRaises(ValidationError):
+            again.validate_unique()
 
 
 class EvaluateMethodTest(TestCase):

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -49,11 +49,8 @@ class QueryTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('"Pro Django" should exist on default database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('other').get,
-            title="Pro Django"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('other').get(title="Pro Django")
 
         try:
             Book.objects.get(title="Dive into Python")
@@ -61,11 +58,8 @@ class QueryTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('"Dive into Python" should exist on default database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('other').get,
-            title="Dive into Python"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('other').get(title="Dive into Python")
 
     def test_other_creation(self):
         "Objects created on another database don't leak onto the default database"
@@ -85,32 +79,20 @@ class QueryTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('"Pro Django" should exist on other database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.get,
-            title="Pro Django"
-        )
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('default').get,
-            title="Pro Django"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.get(title="Pro Django")
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(title="Pro Django")
 
         try:
             Book.objects.using('other').get(title="Dive into Python")
         except Book.DoesNotExist:
             self.fail('"Dive into Python" should exist on other database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.get,
-            title="Dive into Python"
-        )
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('default').get,
-            title="Dive into Python"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.get(title="Dive into Python")
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(title="Dive into Python")
 
     def test_refresh(self):
         dive = Book()
@@ -137,20 +119,24 @@ class QueryTestCase(TestCase):
 
         dive = Book.objects.using('other').get(published=datetime.date(2009, 5, 4))
         self.assertEqual(dive.title, "Dive into Python")
-        self.assertRaises(Book.DoesNotExist, Book.objects.using('default').get, published=datetime.date(2009, 5, 4))
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(published=datetime.date(2009, 5, 4))
 
         dive = Book.objects.using('other').get(title__icontains="dive")
         self.assertEqual(dive.title, "Dive into Python")
-        self.assertRaises(Book.DoesNotExist, Book.objects.using('default').get, title__icontains="dive")
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(title__icontains="dive")
 
         dive = Book.objects.using('other').get(title__iexact="dive INTO python")
         self.assertEqual(dive.title, "Dive into Python")
-        self.assertRaises(Book.DoesNotExist, Book.objects.using('default').get, title__iexact="dive INTO python")
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(title__iexact="dive INTO python")
 
         dive = Book.objects.using('other').get(published__year=2009)
         self.assertEqual(dive.title, "Dive into Python")
         self.assertEqual(dive.published, datetime.date(2009, 5, 4))
-        self.assertRaises(Book.DoesNotExist, Book.objects.using('default').get, published__year=2009)
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(published__year=2009)
 
         years = Book.objects.using('other').dates('published', 'year')
         self.assertEqual([o.year for o in years], [2009])
@@ -965,7 +951,8 @@ class QueryTestCase(TestCase):
         # When you call __str__ on the query object, it doesn't know about using
         # so it falls back to the default. If the subquery explicitly uses a
         # different database, an error should be raised.
-        self.assertRaises(ValueError, str, qs.query)
+        with self.assertRaises(ValueError):
+            str(qs.query)
 
         # Evaluating the query shouldn't work, either
         with self.assertRaises(ValueError):
@@ -1605,7 +1592,8 @@ class AuthTestCase(TestCase):
         self.assertEqual(alice.username, 'alice')
         self.assertEqual(alice._state.db, 'other')
 
-        self.assertRaises(User.DoesNotExist, User.objects.using('default').get, username='alice')
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.using('default').get(username='alice')
 
         # The second user only exists on the default database
         bob = User.objects.using('default').get(username='bob')
@@ -1613,7 +1601,8 @@ class AuthTestCase(TestCase):
         self.assertEqual(bob.username, 'bob')
         self.assertEqual(bob._state.db, 'default')
 
-        self.assertRaises(User.DoesNotExist, User.objects.using('other').get, username='bob')
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.using('other').get(username='bob')
 
         # That is... there is one user on each database
         self.assertEqual(User.objects.using('default').count(), 1)
@@ -1663,11 +1652,8 @@ class FixtureTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('"Pro Django" should exist on default database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('other').get,
-            title="Pro Django"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('other').get(title="Pro Django")
 
         # Check that "Dive into Python" exists on the default database, but not on other database
         try:
@@ -1675,16 +1661,10 @@ class FixtureTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('"Dive into Python" should exist on other database')
 
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.get,
-            title="Dive into Python"
-        )
-        self.assertRaises(
-            Book.DoesNotExist,
-            Book.objects.using('default').get,
-            title="Dive into Python"
-        )
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.get(title="Dive into Python")
+        with self.assertRaises(Book.DoesNotExist):
+            Book.objects.using('default').get(title="Dive into Python")
 
         # Check that "Definitive Guide" exists on the both databases
         try:
@@ -1846,7 +1826,8 @@ class RouterAttributeErrorTestCase(TestCase):
         b = Book.objects.create(title="Pro Django",
                                 published=datetime.date(2008, 12, 16))
         with self.override_router():
-            self.assertRaises(AttributeError, Book.objects.get, pk=b.pk)
+            with self.assertRaises(AttributeError):
+                Book.objects.get(pk=b.pk)
 
     def test_attribute_error_save(self):
         "Check that the AttributeError from AttributeErrorRouter bubbles up"
@@ -1854,7 +1835,8 @@ class RouterAttributeErrorTestCase(TestCase):
         dive.title = "Dive into Python"
         dive.published = datetime.date(2009, 5, 4)
         with self.override_router():
-            self.assertRaises(AttributeError, dive.save)
+            with self.assertRaises(AttributeError):
+                dive.save()
 
     def test_attribute_error_delete(self):
         "Check that the AttributeError from AttributeErrorRouter bubbles up"
@@ -1864,7 +1846,8 @@ class RouterAttributeErrorTestCase(TestCase):
         b.authors.set([p])
         b.editor = p
         with self.override_router():
-            self.assertRaises(AttributeError, b.delete)
+            with self.assertRaises(AttributeError):
+                b.delete()
 
     def test_attribute_error_m2m(self):
         "Check that the AttributeError from AttributeErrorRouter bubbles up"

--- a/tests/null_queries/tests.py
+++ b/tests/null_queries/tests.py
@@ -40,10 +40,12 @@ class NullQueriesTests(TestCase):
         )
 
         # Valid query, but fails because foo isn't a keyword
-        self.assertRaises(FieldError, Choice.objects.filter, foo__exact=None)
+        with self.assertRaises(FieldError):
+            Choice.objects.filter(foo__exact=None)
 
         # Can't use None on anything other than __exact and __iexact
-        self.assertRaises(ValueError, Choice.objects.filter, id__gt=None)
+        with self.assertRaises(ValueError):
+            Choice.objects.filter(id__gt=None)
 
         # Related managers use __exact=None implicitly if the object hasn't been saved.
         p2 = Poll(question="How?")

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -229,10 +229,12 @@ class OneToOneTests(TestCase):
         self.assertIsNone(ug_bar.place)
 
         # Assigning None fails: Place.restaurant is null=False
-        self.assertRaises(ValueError, setattr, p, 'restaurant', None)
+        with self.assertRaises(ValueError):
+            setattr(p, 'restaurant', None)
 
         # You also can't assign an object of the wrong type here
-        self.assertRaises(ValueError, setattr, p, 'restaurant', p)
+        with self.assertRaises(ValueError):
+            setattr(p, 'restaurant', p)
 
         # Creation using keyword argument should cache the related object.
         p = Place.objects.get(name="Demon Dogs")
@@ -459,14 +461,16 @@ class OneToOneTests(TestCase):
         School.objects.use_for_related_fields = True
         try:
             private_director = Director._base_manager.get(pk=private_director.pk)
-            self.assertRaises(School.DoesNotExist, lambda: private_director.school)
+            with self.assertRaises(School.DoesNotExist):
+                private_director.school
         finally:
             School.objects.use_for_related_fields = False
 
         Director.objects.use_for_related_fields = True
         try:
             private_school = School._base_manager.get(pk=private_school.pk)
-            self.assertRaises(Director.DoesNotExist, lambda: private_school.director)
+            with self.assertRaises(Director.DoesNotExist):
+                private_school.director
         finally:
             Director.objects.use_for_related_fields = False
 

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -114,9 +114,12 @@ class PaginationTests(unittest.TestCase):
         raised.
         """
         paginator = Paginator([1, 2, 3], 2)
-        self.assertRaises(InvalidPage, paginator.page, 3)
-        self.assertRaises(PageNotAnInteger, paginator.validate_number, None)
-        self.assertRaises(PageNotAnInteger, paginator.validate_number, 'x')
+        with self.assertRaises(InvalidPage):
+            paginator.page(3)
+        with self.assertRaises(PageNotAnInteger):
+            paginator.validate_number(None)
+        with self.assertRaises(PageNotAnInteger):
+            paginator.validate_number('x')
         # With no content and allow_empty_first_page=True, 1 is a valid page number
         paginator = Paginator([], 2)
         self.assertEqual(paginator.validate_number(1), 1)
@@ -203,9 +206,12 @@ class PaginationTests(unittest.TestCase):
             self.check_indexes(params, 'last', last)
 
         # When no items and no empty first page, we should get EmptyPage error.
-        self.assertRaises(EmptyPage, self.check_indexes, ([], 4, 0, False), 1, None)
-        self.assertRaises(EmptyPage, self.check_indexes, ([], 4, 1, False), 1, None)
-        self.assertRaises(EmptyPage, self.check_indexes, ([], 4, 2, False), 1, None)
+        with self.assertRaises(EmptyPage):
+            self.check_indexes(([], 4, 0, False), 1, None)
+        with self.assertRaises(EmptyPage):
+            self.check_indexes(([], 4, 1, False), 1, None)
+        with self.assertRaises(EmptyPage):
+            self.check_indexes(([], 4, 2, False), 1, None)
 
     def test_page_sequence(self):
         """
@@ -267,7 +273,8 @@ class ModelPaginationTests(TestCase):
         self.assertFalse(p.has_previous())
         self.assertTrue(p.has_other_pages())
         self.assertEqual(2, p.next_page_number())
-        self.assertRaises(InvalidPage, p.previous_page_number)
+        with self.assertRaises(InvalidPage):
+            p.previous_page_number()
         self.assertEqual(1, p.start_index())
         self.assertEqual(5, p.end_index())
 
@@ -286,7 +293,8 @@ class ModelPaginationTests(TestCase):
         self.assertFalse(p.has_next())
         self.assertTrue(p.has_previous())
         self.assertTrue(p.has_other_pages())
-        self.assertRaises(InvalidPage, p.next_page_number)
+        with self.assertRaises(InvalidPage):
+            p.next_page_number()
         self.assertEqual(1, p.previous_page_number())
         self.assertEqual(6, p.start_index())
         self.assertEqual(9, p.end_index())
@@ -302,7 +310,8 @@ class ModelPaginationTests(TestCase):
         # Make sure object_list queryset is not evaluated by an invalid __getitem__ call.
         # (this happens from the template engine when using eg: {% page_obj.has_previous %})
         self.assertIsNone(p.object_list._result_cache)
-        self.assertRaises(TypeError, lambda: p['has_previous'])
+        with self.assertRaises(TypeError):
+            p['has_previous']
         self.assertIsNone(p.object_list._result_cache)
         self.assertNotIsInstance(p.object_list, list)
 

--- a/tests/properties/tests.py
+++ b/tests/properties/tests.py
@@ -16,7 +16,8 @@ class PropertyTests(TestCase):
 
     def test_setter(self):
         # The "full_name" property hasn't provided a "set" method.
-        self.assertRaises(AttributeError, setattr, self.a, 'full_name', 'Paul McCartney')
+        with self.assertRaises(AttributeError):
+            setattr(self.a, 'full_name', 'Paul McCartney')
 
         # But "full_name_2" has, and it can be used to initialize the class.
         a2 = Person(full_name_2='Paul McCartney')

--- a/tests/proxy_models/tests.py
+++ b/tests/proxy_models/tests.py
@@ -93,31 +93,19 @@ class ProxyModelTests(TestCase):
         LowerStatusPerson.objects.create(status="low", name="homer")
         max_id = Person.objects.aggregate(max_id=models.Max('id'))['max_id']
 
-        self.assertRaises(
-            Person.DoesNotExist,
-            MyPersonProxy.objects.get,
-            name='Zathras'
-        )
-        self.assertRaises(
-            Person.MultipleObjectsReturned,
-            MyPersonProxy.objects.get,
-            id__lt=max_id + 1
-        )
-        self.assertRaises(
-            Person.DoesNotExist,
-            StatusPerson.objects.get,
-            name='Zathras'
-        )
+        with self.assertRaises(Person.DoesNotExist):
+            MyPersonProxy.objects.get(name='Zathras')
+        with self.assertRaises(Person.MultipleObjectsReturned):
+            MyPersonProxy.objects.get(id__lt=max_id + 1)
+        with self.assertRaises(Person.DoesNotExist):
+            StatusPerson.objects.get(name='Zathras')
 
         StatusPerson.objects.create(name='Bazza Jr.')
         StatusPerson.objects.create(name='Foo Jr.')
         max_id = Person.objects.aggregate(max_id=models.Max('id'))['max_id']
 
-        self.assertRaises(
-            Person.MultipleObjectsReturned,
-            StatusPerson.objects.get,
-            id__lt=max_id + 1
-        )
+        with self.assertRaises(Person.MultipleObjectsReturned):
+            StatusPerson.objects.get(id__lt=max_id + 1)
 
     def test_abc(self):
         """
@@ -127,7 +115,8 @@ class ProxyModelTests(TestCase):
             class NoAbstract(Abstract):
                 class Meta:
                     proxy = True
-        self.assertRaises(TypeError, build_abc)
+        with self.assertRaises(TypeError):
+            build_abc()
 
     def test_no_cbc(self):
         """
@@ -137,14 +126,16 @@ class ProxyModelTests(TestCase):
             class TooManyBases(Person, Abstract):
                 class Meta:
                     proxy = True
-        self.assertRaises(TypeError, build_no_cbc)
+        with self.assertRaises(TypeError):
+            build_no_cbc()
 
     def test_no_base_classes(self):
         def build_no_base_classes():
             class NoBaseClasses(models.Model):
                 class Meta:
                     proxy = True
-        self.assertRaises(TypeError, build_no_base_classes)
+        with self.assertRaises(TypeError):
+            build_no_base_classes()
 
     def test_new_fields(self):
         class NoNewFields(Person):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1362,7 +1362,7 @@ class Queries4Tests(BaseQuerysetTest):
 
     def test_ticket11811(self):
         unsaved_category = NamedCategory(name="Other")
-        with six.assertRaisesRegex(self, ValueError,
+        with self.assertRaisesMessage(ValueError,
                 'Unsaved model instance <NamedCategory: Other> '
                 'cannot be used in an ORM query.'):
             Tag.objects.filter(pk=self.t1.pk).update(category=unsaved_category)
@@ -2321,48 +2321,32 @@ class QuerySetSupportsPythonIdioms(TestCase):
              "<Article: Article 7>"])
 
     def test_slicing_cannot_filter_queryset_once_sliced(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AssertionError,
-            "Cannot filter a query once a slice has been taken.",
-            Article.objects.all()[0:5].filter,
-            id=1,
-        )
+                "Cannot filter a query once a slice has been taken."):
+            Article.objects.all()[0:5].filter(id=1, )
 
     def test_slicing_cannot_reorder_queryset_once_sliced(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AssertionError,
-            "Cannot reorder a query once a slice has been taken.",
-            Article.objects.all()[0:5].order_by,
-            'id',
-        )
+                "Cannot reorder a query once a slice has been taken."):
+            Article.objects.all()[0:5].order_by('id', )
 
     def test_slicing_cannot_combine_queries_once_sliced(self):
-        six.assertRaisesRegex(
-            self,
+        with self.assertRaisesMessage(
             AssertionError,
-            "Cannot combine queries once a slice has been taken.",
-            lambda: Article.objects.all()[0:1] & Article.objects.all()[4:5]
-        )
+                "Cannot combine queries once a slice has been taken."):
+            Article.objects.all()[0:1] & Article.objects.all()[4:5]
 
     def test_slicing_negative_indexing_not_supported_for_single_element(self):
         """hint: inverting your ordering might do what you need"""
-        six.assertRaisesRegex(
-            self,
-            AssertionError,
-            "Negative indexing is not supported.",
-            lambda: Article.objects.all()[-1]
-        )
+        with self.assertRaisesMessage(AssertionError, "Negative indexing is not supported."):
+            Article.objects.all()[-1]
 
     def test_slicing_negative_indexing_not_supported_for_range(self):
         """hint: inverting your ordering might do what you need"""
-        six.assertRaisesRegex(
-            self,
-            AssertionError,
-            "Negative indexing is not supported.",
-            lambda: Article.objects.all()[0:-5]
-        )
+        with self.assertRaisesMessage(AssertionError, "Negative indexing is not supported."):
+            Article.objects.all()[0:-5]
 
     def test_can_get_number_of_items_in_queryset_using_standard_len(self):
         self.assertEqual(len(Article.objects.filter(name__exact='Article 1')), 1)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -431,9 +431,15 @@ class Queries1Tests(BaseQuerysetTest):
     def test_heterogeneous_qs_combination(self):
         # Combining querysets built on different models should behave in a well-defined
         # fashion. We raise an error.
-        with self.assertRaisesMessage(AssertionError, 'Cannot combine queries on two different base models.'):
+        with self.assertRaisesMessage(
+            AssertionError,
+            'Cannot combine queries on two different base models.'
+        ):
             Author.objects.all() & Tag.objects.all()
-        with self.assertRaisesMessage(AssertionError, 'Cannot combine queries on two different base models.'):
+        with self.assertRaisesMessage(
+            AssertionError,
+            'Cannot combine queries on two different base models.'
+        ):
             Author.objects.all() | Tag.objects.all()
 
     def test_ticket3141(self):
@@ -460,7 +466,10 @@ class Queries1Tests(BaseQuerysetTest):
         )
 
     def test_error_raised_on_filter_with_dictionary(self):
-        with self.assertRaisesMessage(FieldError, 'Cannot parse keyword query as dict'):
+        with self.assertRaisesMessage(
+            FieldError,
+            'Cannot parse keyword query as dict'
+        ):
             Note.objects.filter({'note': 'n1', 'misc': 'foo'})
 
     def test_tickets_2076_7256(self):
@@ -753,7 +762,10 @@ class Queries1Tests(BaseQuerysetTest):
                 []
             )
             q.query.low_mark = 1
-            with self.assertRaisesMessage(AssertionError, 'Cannot change a query once a slice has been taken'):
+            with self.assertRaisesMessage(
+                AssertionError,
+                'Cannot change a query once a slice has been taken'
+            ):
                 q.extra(select={'foo': "1"})
             self.assertQuerysetEqual(q.reverse(), [])
             self.assertQuerysetEqual(q.defer('meal'), [])
@@ -781,9 +793,15 @@ class Queries1Tests(BaseQuerysetTest):
         )
 
         # Multi-valued values() and values_list() querysets should raise errors.
-        with self.assertRaisesMessage(TypeError, 'Cannot use multi-field values as a filter value.'):
+        with self.assertRaisesMessage(
+            TypeError,
+            'Cannot use multi-field values as a filter value.'
+        ):
             Tag.objects.filter(name__in=Tag.objects.filter(parent=self.t1).values('name', 'id'))
-        with self.assertRaisesMessage(TypeError, 'Cannot use multi-field values as a filter value.'):
+        with self.assertRaisesMessage(
+            TypeError,
+            'Cannot use multi-field values as a filter value.'
+        ):
             Tag.objects.filter(name__in=Tag.objects.filter(parent=self.t1).values_list('name', 'id'))
 
     def test_ticket9985(self):
@@ -1318,12 +1336,16 @@ class Queries3Tests(BaseQuerysetTest):
             Item.objects.datetimes('name', 'month')
 
     def test_ticket22023(self):
-        with self.assertRaisesMessage(TypeError,
-                "Cannot call only() after .values() or .values_list()"):
+        with self.assertRaisesMessage(
+            TypeError,
+            "Cannot call only() after .values() or .values_list()"
+        ):
             Valid.objects.values().only()
 
-        with self.assertRaisesMessage(TypeError,
-                "Cannot call defer() after .values() or .values_list()"):
+        with self.assertRaisesMessage(
+            TypeError,
+            "Cannot call defer() after .values() or .values_list()"
+        ):
             Valid.objects.values().defer()
 
 
@@ -1362,9 +1384,11 @@ class Queries4Tests(BaseQuerysetTest):
 
     def test_ticket11811(self):
         unsaved_category = NamedCategory(name="Other")
-        with self.assertRaisesMessage(ValueError,
-                'Unsaved model instance <NamedCategory: Other> '
-                'cannot be used in an ORM query.'):
+        msg = (
+            'Unsaved model instance <NamedCategory: Other> '
+            'cannot be used in an ORM query.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             Tag.objects.filter(pk=self.t1.pk).update(category=unsaved_category)
 
     def test_ticket14876(self):
@@ -2245,9 +2269,11 @@ class ValuesQuerysetTests(BaseQuerysetTest):
 
     def test_field_error_values_list(self):
         # see #23443
-        with self.assertRaisesMessage(FieldError,
-                "Cannot resolve keyword %r into field."
-                " Join on 'name' not permitted." % 'foo'):
+        msg = (
+            "Cannot resolve keyword %r into field."
+            " Join on 'name' not permitted." % 'foo'
+        )
+        with self.assertRaisesMessage(FieldError, msg):
             Tag.objects.values_list('name__foo')
 
 
@@ -2323,29 +2349,38 @@ class QuerySetSupportsPythonIdioms(TestCase):
     def test_slicing_cannot_filter_queryset_once_sliced(self):
         with self.assertRaisesMessage(
             AssertionError,
-                "Cannot filter a query once a slice has been taken."):
+            "Cannot filter a query once a slice has been taken."
+        ):
             Article.objects.all()[0:5].filter(id=1, )
 
     def test_slicing_cannot_reorder_queryset_once_sliced(self):
         with self.assertRaisesMessage(
             AssertionError,
-                "Cannot reorder a query once a slice has been taken."):
+            "Cannot reorder a query once a slice has been taken."
+        ):
             Article.objects.all()[0:5].order_by('id', )
 
     def test_slicing_cannot_combine_queries_once_sliced(self):
         with self.assertRaisesMessage(
             AssertionError,
-                "Cannot combine queries once a slice has been taken."):
+            "Cannot combine queries once a slice has been taken."
+        ):
             Article.objects.all()[0:1] & Article.objects.all()[4:5]
 
     def test_slicing_negative_indexing_not_supported_for_single_element(self):
         """hint: inverting your ordering might do what you need"""
-        with self.assertRaisesMessage(AssertionError, "Negative indexing is not supported."):
+        with self.assertRaisesMessage(
+            AssertionError,
+            "Negative indexing is not supported."
+        ):
             Article.objects.all()[-1]
 
     def test_slicing_negative_indexing_not_supported_for_range(self):
         """hint: inverting your ordering might do what you need"""
-        with self.assertRaisesMessage(AssertionError, "Negative indexing is not supported."):
+        with self.assertRaisesMessage(
+            AssertionError,
+            "Negative indexing is not supported."
+        ):
             Article.objects.all()[0:-5]
 
     def test_can_get_number_of_items_in_queryset_using_standard_len(self):
@@ -2379,7 +2414,10 @@ class WeirdQuerysetSlicingTests(BaseQuerysetTest):
         self.assertQuerysetEqual(Article.objects.all()[0:0], [])
         self.assertQuerysetEqual(Article.objects.all()[0:0][:10], [])
         self.assertEqual(Article.objects.all()[:0].count(), 0)
-        with self.assertRaisesMessage(AssertionError, 'Cannot change a query once a slice has been taken.'):
+        with self.assertRaisesMessage(
+            AssertionError,
+            'Cannot change a query once a slice has been taken.'
+        ):
             Article.objects.all()[:0].latest('created')
 
     def test_empty_resultset_sql(self):
@@ -3469,29 +3507,41 @@ class RelatedLookupTypeTests(TestCase):
         query lookup.
         """
         # Passing incorrect object type
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.wrong_type, ObjectA._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.wrong_type, ObjectA._meta.object_name)
+        ):
             ObjectB.objects.get(objecta=self.wrong_type)
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.wrong_type, ObjectA._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.wrong_type, ObjectA._meta.object_name)
+        ):
             ObjectB.objects.filter(objecta__in=[self.wrong_type])
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.wrong_type, ObjectA._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.wrong_type, ObjectA._meta.object_name)
+        ):
             ObjectB.objects.filter(objecta=self.wrong_type)
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.wrong_type, ObjectB._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.wrong_type, ObjectB._meta.object_name)
+        ):
             ObjectA.objects.filter(objectb__in=[self.wrong_type, self.ob])
 
         # Passing an object of the class on which query is done.
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.ob, ObjectA._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.ob, ObjectA._meta.object_name)
+        ):
             ObjectB.objects.filter(objecta__in=[self.poa, self.ob])
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.ob, ChildObjectA._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.ob, ChildObjectA._meta.object_name)
+        ):
             ObjectC.objects.exclude(childobjecta__in=[self.coa, self.ob])
 
     def test_wrong_backward_lookup(self):
@@ -3499,16 +3549,22 @@ class RelatedLookupTypeTests(TestCase):
         A ValueError is raised when the incorrect object type is passed to a
         query lookup for backward relations.
         """
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.oa, ObjectB._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.oa, ObjectB._meta.object_name)
+        ):
             ObjectA.objects.filter(objectb__in=[self.oa, self.ob])
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.oa, ObjectB._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.oa, ObjectB._meta.object_name)
+        ):
             ObjectA.objects.exclude(objectb=self.oa)
 
-        with self.assertRaisesMessage(ValueError,
-                self.error % (self.wrong_type, ObjectB._meta.object_name)):
+        with self.assertRaisesMessage(
+            ValueError,
+            self.error % (self.wrong_type, ObjectB._meta.object_name)
+        ):
             ObjectA.objects.get(objectb=self.wrong_type)
 
     def test_correct_lookup(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2903,7 +2903,8 @@ class WhereNodeTest(TestCase):
     def test_empty_full_handling_conjunction(self):
         compiler = WhereNodeTest.MockCompiler()
         w = WhereNode(children=[NothingNode()])
-        self.assertRaises(EmptyResultSet, w.as_sql, compiler, connection)
+        with self.assertRaises(EmptyResultSet):
+            w.as_sql(compiler, connection)
         w.negate()
         self.assertEqual(w.as_sql(compiler, connection), ('', []))
         w = WhereNode(children=[self.DummyNode(), self.DummyNode()])
@@ -2911,14 +2912,16 @@ class WhereNodeTest(TestCase):
         w.negate()
         self.assertEqual(w.as_sql(compiler, connection), ('NOT (dummy AND dummy)', []))
         w = WhereNode(children=[NothingNode(), self.DummyNode()])
-        self.assertRaises(EmptyResultSet, w.as_sql, compiler, connection)
+        with self.assertRaises(EmptyResultSet):
+            w.as_sql(compiler, connection)
         w.negate()
         self.assertEqual(w.as_sql(compiler, connection), ('', []))
 
     def test_empty_full_handling_disjunction(self):
         compiler = WhereNodeTest.MockCompiler()
         w = WhereNode(children=[NothingNode()], connector='OR')
-        self.assertRaises(EmptyResultSet, w.as_sql, compiler, connection)
+        with self.assertRaises(EmptyResultSet):
+            w.as_sql(compiler, connection)
         w.negate()
         self.assertEqual(w.as_sql(compiler, connection), ('', []))
         w = WhereNode(children=[self.DummyNode(), self.DummyNode()], connector='OR')
@@ -2960,8 +2963,10 @@ class IteratorExceptionsTest(TestCase):
         # Test for #19895 - second iteration over invalid queryset
         # raises errors.
         qs = Article.objects.order_by('invalid_column')
-        self.assertRaises(FieldError, list, qs)
-        self.assertRaises(FieldError, list, qs)
+        with self.assertRaises(FieldError):
+            list(qs)
+        with self.assertRaises(FieldError):
+            list(qs)
 
 
 class NullJoinPromotionOrTest(TestCase):

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -275,7 +275,8 @@ class RawQueryTests(TestCase):
         first_two = Author.objects.raw(query)[0:2]
         self.assertEqual(len(first_two), 2)
 
-        self.assertRaises(TypeError, lambda: Author.objects.raw(query)['test'])
+        with self.assertRaises(TypeError):
+            Author.objects.raw(query)['test']
 
     def test_inheritance(self):
         # date is the end of the Cuban Missile Crisis, I have no idea when

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -345,7 +345,8 @@ class RequestsTests(SimpleTestCase):
                                'CONTENT_LENGTH': len(payload),
                                'wsgi.input': payload})
         self.assertEqual(request.read(2), b'na')
-        self.assertRaises(RawPostDataException, lambda: request.body)
+        with self.assertRaises(RawPostDataException):
+            request.body
         self.assertEqual(request.POST, {})
 
     def test_non_ascii_POST(self):
@@ -390,7 +391,8 @@ class RequestsTests(SimpleTestCase):
                                'CONTENT_LENGTH': len(payload),
                                'wsgi.input': payload})
         self.assertEqual(request.POST, {'name': ['value']})
-        self.assertRaises(RawPostDataException, lambda: request.body)
+        with self.assertRaises(RawPostDataException):
+            request.body
 
     def test_body_after_POST_multipart_related(self):
         """

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -770,11 +770,8 @@ class HostValidationTests(SimpleTestCase):
         ]:
             request = HttpRequest()
             request.META = {'HTTP_HOST': host}
-            self.assertRaisesMessage(
-                SuspiciousOperation,
-                msg_suggestion % (host, host),
-                request.get_host
-            )
+            with self.assertRaisesMessage(SuspiciousOperation, msg_suggestion % (host, host)):
+                request.get_host()
 
         for domain, port in [  # Valid-looking hosts with a port number
             ('example.com', 80),
@@ -784,28 +781,19 @@ class HostValidationTests(SimpleTestCase):
             host = '%s:%s' % (domain, port)
             request = HttpRequest()
             request.META = {'HTTP_HOST': host}
-            self.assertRaisesMessage(
-                SuspiciousOperation,
-                msg_suggestion % (host, domain),
-                request.get_host
-            )
+            with self.assertRaisesMessage(SuspiciousOperation, msg_suggestion % (host, domain)):
+                request.get_host()
 
         for host in self.poisoned_hosts:
             request = HttpRequest()
             request.META = {'HTTP_HOST': host}
-            self.assertRaisesMessage(
-                SuspiciousOperation,
-                msg_invalid_host % host,
-                request.get_host
-            )
+            with self.assertRaisesMessage(SuspiciousOperation, msg_invalid_host % host):
+                request.get_host()
 
         request = HttpRequest()
         request.META = {'HTTP_HOST': "invalid_hostname.com"}
-        self.assertRaisesMessage(
-            SuspiciousOperation,
-            msg_suggestion2 % "invalid_hostname.com",
-            request.get_host
-        )
+        with self.assertRaisesMessage(SuspiciousOperation, msg_suggestion2 % "invalid_hostname.com"):
+            request.get_host()
 
 
 class BuildAbsoluteURITestCase(SimpleTestCase):

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -127,7 +127,8 @@ class HttpResponseTests(SimpleTestCase):
         generator = ("{}".format(i) for i in range(10))
         response = HttpResponse(content=generator)
         self.assertEqual(response.content, b'0123456789')
-        self.assertRaises(StopIteration, next, generator)
+        with self.assertRaises(StopIteration):
+            next(generator)
 
         cache.set('my-response-key', response)
         response = cache.get('my-response-key')

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -26,14 +26,23 @@ class HttpResponseBaseTests(SimpleTestCase):
         r = HttpResponseBase()
         self.assertIs(r.writable(), False)
 
-        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance is not writable'):
+        with self.assertRaisesMessage(
+            IOError,
+            'This HttpResponseBase instance is not writable'
+        ):
             r.write('asdf')
-        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance is not writable'):
+        with self.assertRaisesMessage(
+            IOError,
+            'This HttpResponseBase instance is not writable'
+        ):
             r.writelines(['asdf\n', 'qwer\n'])
 
     def test_tell(self):
         r = HttpResponseBase()
-        with self.assertRaisesMessage(IOError, 'This HttpResponseBase instance cannot tell its position'):
+        with self.assertRaisesMessage(
+            IOError,
+            'This HttpResponseBase instance cannot tell its position'
+        ):
             r.tell()
 
     def test_setdefault(self):

--- a/tests/reverse_lookup/tests.py
+++ b/tests/reverse_lookup/tests.py
@@ -48,5 +48,5 @@ class ReverseLookupTests(TestCase):
         """
         If a related_name is given you can't use the field name instead
         """
-        self.assertRaises(FieldError, Poll.objects.get,
-            choice__name__exact="This is the answer")
+        with self.assertRaises(FieldError):
+            Poll.objects.get(choice__name__exact="This is the answer")

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -131,10 +131,8 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.delete_model(Author)
         # Check that it's gone
-        self.assertRaises(
-            DatabaseError,
-            lambda: list(Author.objects.all()),
-        )
+        with self.assertRaises(DatabaseError):
+            list(Author.objects.all())
 
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_fk(self):
@@ -1017,7 +1015,8 @@ class SchemaTests(TransactionTestCase):
         new_field = M2MFieldClass("schema.TagM2MTest", related_name="authors")
         new_field.contribute_to_class(LocalAuthorWithM2M, "tags")
         # Ensure there's no m2m table there
-        self.assertRaises(DatabaseError, self.column_classes, new_field.remote_field.through)
+        with self.assertRaises(DatabaseError):
+            self.column_classes(new_field.remote_field.through)
         # Add the field
         with connection.schema_editor() as editor:
             editor.add_field(LocalAuthorWithM2M, new_field)
@@ -1033,7 +1032,8 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.remove_field(LocalAuthorWithM2M, new_field)
         # Ensure there's no m2m table there
-        self.assertRaises(DatabaseError, self.column_classes, new_field.remote_field.through)
+        with self.assertRaises(DatabaseError):
+            self.column_classes(new_field.remote_field.through)
 
         # Make sure the model state is coherent with the table one now that
         # we've removed the tags field.
@@ -1136,10 +1136,8 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.alter_field(LocalBookWithM2M, old_field, new_field)
         # Ensure old M2M is gone
-        self.assertRaises(
-            DatabaseError,
-            self.column_classes, LocalBookWithM2M._meta.get_field("tags").remote_field.through
-        )
+        with self.assertRaises(DatabaseError):
+            self.column_classes(LocalBookWithM2M._meta.get_field("tags").remote_field.through)
 
         # This model looks like the new model and is used for teardown.
         opts = LocalBookWithM2M._meta
@@ -1208,7 +1206,8 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Tag)
         # Ensure the field is unique to begin with
         Tag.objects.create(title="foo", slug="foo")
-        self.assertRaises(IntegrityError, Tag.objects.create, title="bar", slug="foo")
+        with self.assertRaises(IntegrityError):
+            Tag.objects.create(title="bar", slug="foo")
         Tag.objects.all().delete()
         # Alter the slug field to be non-unique
         old_field = Tag._meta.get_field("slug")
@@ -1227,7 +1226,8 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Tag, new_field, new_field2, strict=True)
         # Ensure the field is unique again
         Tag.objects.create(title="foo", slug="foo")
-        self.assertRaises(IntegrityError, Tag.objects.create, title="bar", slug="foo")
+        with self.assertRaises(IntegrityError):
+            Tag.objects.create(title="bar", slug="foo")
         Tag.objects.all().delete()
         # Rename the field
         new_field3 = SlugField(unique=True)
@@ -1236,7 +1236,8 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Tag, new_field2, new_field3, strict=True)
         # Ensure the field is still unique
         TagUniqueRename.objects.create(title="foo", slug2="foo")
-        self.assertRaises(IntegrityError, TagUniqueRename.objects.create, title="bar", slug2="foo")
+        with self.assertRaises(IntegrityError):
+            TagUniqueRename.objects.create(title="bar", slug2="foo")
         Tag.objects.all().delete()
 
     def test_unique_together(self):
@@ -1250,7 +1251,8 @@ class SchemaTests(TransactionTestCase):
         UniqueTest.objects.create(year=2012, slug="foo")
         UniqueTest.objects.create(year=2011, slug="foo")
         UniqueTest.objects.create(year=2011, slug="bar")
-        self.assertRaises(IntegrityError, UniqueTest.objects.create, year=2012, slug="foo")
+        with self.assertRaises(IntegrityError):
+            UniqueTest.objects.create(year=2012, slug="foo")
         UniqueTest.objects.all().delete()
         # Alter the model to its non-unique-together companion
         with connection.schema_editor() as editor:
@@ -1266,7 +1268,8 @@ class SchemaTests(TransactionTestCase):
             editor.alter_unique_together(UniqueTest, [], UniqueTest._meta.unique_together)
         # Ensure the fields are unique again
         UniqueTest.objects.create(year=2012, slug="foo")
-        self.assertRaises(IntegrityError, UniqueTest.objects.create, year=2012, slug="foo")
+        with self.assertRaises(IntegrityError):
+            UniqueTest.objects.create(year=2012, slug="foo")
         UniqueTest.objects.all().delete()
 
     def test_unique_together_with_fk(self):
@@ -1567,10 +1570,8 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.delete_model(Thing)
         # Check that it's gone
-        self.assertRaises(
-            DatabaseError,
-            lambda: list(Thing.objects.all()),
-        )
+        with self.assertRaises(DatabaseError):
+            list(Thing.objects.all())
 
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_remove_constraints_capital_letters(self):

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -110,11 +110,8 @@ class SelectForUpdateTests(TransactionTestCase):
         that supports FOR UPDATE but not NOWAIT, then we should find
         that a DatabaseError is raised.
         """
-        self.assertRaises(
-            DatabaseError,
-            list,
-            Person.objects.all().select_for_update(nowait=True)
-        )
+        with self.assertRaises(DatabaseError):
+            list(Person.objects.all().select_for_update(nowait=True))
 
     @skipUnlessDBFeature('has_select_for_update')
     def test_for_update_requires_transaction(self):

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -188,40 +188,73 @@ class SelectRelatedValidationTests(SimpleTestCase):
     invalid_error = "Invalid field name(s) given in select_related: '%s'. Choices are: %s"
 
     def test_non_relational_field(self):
-        with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', 'genus')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.non_relational_error % ('name', 'genus')
+        ):
             list(Species.objects.select_related('name__some_field'))
 
-        with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', 'genus')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.non_relational_error % ('name', 'genus')
+        ):
             list(Species.objects.select_related('name'))
 
-        with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', '(none)')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.non_relational_error % ('name', '(none)')
+        ):
             list(Domain.objects.select_related('name'))
 
     def test_non_relational_field_nested(self):
-        with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', 'family')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.non_relational_error % ('name', 'family')
+        ):
             list(Species.objects.select_related('genus__name'))
 
     def test_many_to_many_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('toppings', '(none)')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('toppings', '(none)')
+        ):
             list(Pizza.objects.select_related('toppings'))
 
     def test_reverse_relational_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('child_1', 'genus')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('child_1', 'genus')
+        ):
             list(Species.objects.select_related('child_1'))
 
     def test_invalid_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('invalid_field', 'genus')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('invalid_field', 'genus')
+        ):
             list(Species.objects.select_related('invalid_field'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('related_invalid_field', 'family')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('related_invalid_field', 'family')
+        ):
             list(Species.objects.select_related('genus__related_invalid_field'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('invalid_field', '(none)')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('invalid_field', '(none)')
+        ):
             list(Domain.objects.select_related('invalid_field'))
 
     def test_generic_relations(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('tags', '')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('tags', '')
+        ):
             list(Bookmark.objects.select_related('tags'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('content_object', 'content_type')):
+        with self.assertRaisesMessage(
+            FieldError,
+            self.invalid_error % ('content_object', 'content_type')
+        ):
             list(TaggedItem.objects.select_related('content_object'))

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -142,11 +142,8 @@ class SelectRelatedTests(TestCase):
             self.assertEqual(s, 'Diptera')
 
     def test_depth_fields_fails(self):
-        self.assertRaises(
-            TypeError,
-            Species.objects.select_related,
-            'genus__family__order', depth=4
-        )
+        with self.assertRaises(TypeError):
+            Species.objects.select_related('genus__family__order', depth=4)
 
     def test_none_clears_list(self):
         queryset = Species.objects.select_related('genus').select_related(None)

--- a/tests/serializers/test_yaml.py
+++ b/tests/serializers/test_yaml.py
@@ -72,11 +72,13 @@ class NoYamlSerializerTestCase(SimpleTestCase):
     def test_serializer_pyyaml_error_message(self):
         """Using yaml serializer without pyyaml raises ImportError"""
         jane = Author(name="Jane")
-        self.assertRaises(ImportError, serializers.serialize, "yaml", [jane])
+        with self.assertRaises(ImportError):
+            serializers.serialize("yaml", [jane])
 
     def test_deserializer_pyyaml_error_message(self):
         """Using yaml deserializer without pyyaml raises ImportError"""
-        self.assertRaises(ImportError, serializers.deserialize, "yaml", "")
+        with self.assertRaises(ImportError):
+            serializers.deserialize("yaml", "")
 
     def test_dumpdata_pyyaml_error_message(self):
         """Calling dumpdata produces an error when yaml package missing"""

--- a/tests/serializers/test_yaml.py
+++ b/tests/serializers/test_yaml.py
@@ -82,7 +82,7 @@ class NoYamlSerializerTestCase(SimpleTestCase):
 
     def test_dumpdata_pyyaml_error_message(self):
         """Calling dumpdata produces an error when yaml package missing"""
-        with six.assertRaisesRegex(self, management.CommandError, YAML_IMPORT_ERROR_MESSAGE):
+        with self.assertRaisesMessage(management.CommandError, YAML_IMPORT_ERROR_MESSAGE):
             management.call_command('dumpdata', format='yaml')
 
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -223,7 +223,8 @@ class SessionTestsMixin(object):
     def test_session_key_is_read_only(self):
         def set_session_key(session):
             session.session_key = session._get_new_session_key()
-        self.assertRaises(AttributeError, set_session_key, self.session)
+        with self.assertRaises(AttributeError):
+            set_session_key(self.session)
 
     # Custom session expiry
     def test_default_expiry(self):
@@ -474,7 +475,8 @@ class CacheDBSessionTests(SessionTestsMixin, TestCase):
     @override_settings(SESSION_CACHE_ALIAS='sessions')
     def test_non_default_cache(self):
         # 21000 - CacheDB backend should respect SESSION_CACHE_ALIAS.
-        self.assertRaises(InvalidCacheBackendError, self.backend)
+        with self.assertRaises(InvalidCacheBackendError):
+            self.backend()
 
 
 @override_settings(USE_TZ=True)
@@ -506,20 +508,21 @@ class FileSessionTests(SessionTestsMixin, unittest.TestCase):
     def test_configuration_check(self):
         del self.backend._storage_path
         # Make sure the file backend checks for a good storage dir
-        self.assertRaises(ImproperlyConfigured, self.backend)
+        with self.assertRaises(ImproperlyConfigured):
+            self.backend()
 
     def test_invalid_key_backslash(self):
         # Ensure we don't allow directory-traversal.
         # This is tested directly on _key_to_file, as load() will swallow
         # a SuspiciousOperation in the same way as an IOError - by creating
         # a new session, making it unclear whether the slashes were detected.
-        self.assertRaises(InvalidSessionKey,
-                          self.backend()._key_to_file, "a\\b\\c")
+        with self.assertRaises(InvalidSessionKey):
+            self.backend()._key_to_file("a\\b\\c")
 
     def test_invalid_key_forwardslash(self):
         # Ensure we don't allow directory-traversal
-        self.assertRaises(InvalidSessionKey,
-                          self.backend()._key_to_file, "a/b/c")
+        with self.assertRaises(InvalidSessionKey):
+            self.backend()._key_to_file("a/b/c")
 
     @override_settings(
         SESSION_ENGINE="django.contrib.sessions.backends.file",

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -179,24 +179,29 @@ class SettingsTests(SimpleTestCase):
         del settings.TEST
 
     def test_override_doesnt_leak(self):
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
         with self.settings(TEST='override'):
             self.assertEqual('override', settings.TEST)
             settings.TEST = 'test'
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
 
     @override_settings(TEST='override')
     def test_decorator(self):
         self.assertEqual('override', settings.TEST)
 
     def test_context_manager(self):
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
         override = override_settings(TEST='override')
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
         override.enable()
         self.assertEqual('override', settings.TEST)
         override.disable()
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
 
     def test_class_decorator(self):
         # SimpleTestCase can be decorated by override_settings, but not ut.TestCase
@@ -215,7 +220,8 @@ class SettingsTests(SimpleTestCase):
             decorated = override_settings(TEST='override')(UnittestTestCaseSubclass)
 
     def test_signal_callback_context_manager(self):
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
         with self.settings(TEST='override'):
             self.assertEqual(self.testvalue, 'override')
         self.assertEqual(self.testvalue, None)
@@ -232,10 +238,12 @@ class SettingsTests(SimpleTestCase):
         settings.TEST = 'test'
         self.assertEqual('test', settings.TEST)
         del settings.TEST
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
 
     def test_settings_delete_wrapped(self):
-        self.assertRaises(TypeError, delattr, settings, '_wrapped')
+        with self.assertRaises(TypeError):
+            delattr(settings, '_wrapped')
 
     def test_override_settings_delete(self):
         """
@@ -245,10 +253,12 @@ class SettingsTests(SimpleTestCase):
         previous_l10n = settings.USE_L10N
         with self.settings(USE_I18N=False):
             del settings.USE_I18N
-            self.assertRaises(AttributeError, getattr, settings, 'USE_I18N')
+            with self.assertRaises(AttributeError):
+                getattr(settings, 'USE_I18N')
             # Should also work for a non-overridden setting
             del settings.USE_L10N
-            self.assertRaises(AttributeError, getattr, settings, 'USE_L10N')
+            with self.assertRaises(AttributeError):
+                getattr(settings, 'USE_L10N')
         self.assertEqual(settings.USE_I18N, previous_i18n)
         self.assertEqual(settings.USE_L10N, previous_l10n)
 
@@ -258,8 +268,10 @@ class SettingsTests(SimpleTestCase):
         runtime, not when it was instantiated.
         """
 
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
-        self.assertRaises(AttributeError, getattr, settings, 'TEST2')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST2')
 
         inner = override_settings(TEST2='override')
         with override_settings(TEST='override'):
@@ -270,10 +282,13 @@ class SettingsTests(SimpleTestCase):
             # inner's __exit__ should have restored the settings of the outer
             # context manager, not those when the class was instantiated
             self.assertEqual('override', settings.TEST)
-            self.assertRaises(AttributeError, getattr, settings, 'TEST2')
+            with self.assertRaises(AttributeError):
+                getattr(settings, 'TEST2')
 
-        self.assertRaises(AttributeError, getattr, settings, 'TEST')
-        self.assertRaises(AttributeError, getattr, settings, 'TEST2')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST')
+        with self.assertRaises(AttributeError):
+            getattr(settings, 'TEST2')
 
 
 class TestComplexSettingOverride(SimpleTestCase):

--- a/tests/signed_cookies_tests/tests.py
+++ b/tests/signed_cookies_tests/tests.py
@@ -25,16 +25,16 @@ class SignedCookieTest(SimpleTestCase):
         request.COOKIES['a'] = response.cookies['a'].value
         value = request.get_signed_cookie('a', salt='one')
         self.assertEqual(value, 'hello')
-        self.assertRaises(signing.BadSignature,
-            request.get_signed_cookie, 'a', salt='two')
+        with self.assertRaises(signing.BadSignature):
+            request.get_signed_cookie('a', salt='two')
 
     def test_detects_tampering(self):
         response = HttpResponse()
         response.set_signed_cookie('c', 'hello')
         request = HttpRequest()
         request.COOKIES['c'] = response.cookies['c'].value[:-2] + '$$'
-        self.assertRaises(signing.BadSignature,
-            request.get_signed_cookie, 'c')
+        with self.assertRaises(signing.BadSignature):
+            request.get_signed_cookie('c')
 
     def test_default_argument_suppresses_exceptions(self):
         response = HttpResponse()
@@ -55,8 +55,8 @@ class SignedCookieTest(SimpleTestCase):
         with freeze_time(123456800):
             self.assertEqual(request.get_signed_cookie('c', max_age=12), value)
             self.assertEqual(request.get_signed_cookie('c', max_age=11), value)
-            self.assertRaises(signing.SignatureExpired,
-                request.get_signed_cookie, 'c', max_age=10)
+            with self.assertRaises(signing.SignatureExpired):
+                request.get_signed_cookie('c', max_age=10)
 
     @override_settings(SECRET_KEY=b'\xe7')
     def test_signed_cookies_with_binary_key(self):

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -70,8 +70,8 @@ class TestSigner(SimpleTestCase):
         )
         self.assertEqual(value, signer.unsign(signed_value))
         for transform in transforms:
-            self.assertRaises(
-                signing.BadSignature, signer.unsign, transform(signed_value))
+            with self.assertRaises(signing.BadSignature):
+                signer.unsign(transform(signed_value))
 
     def test_dumps_loads(self):
         "dumps and loads be reversible for any JSON serializable object"
@@ -103,8 +103,8 @@ class TestSigner(SimpleTestCase):
         encoded = signing.dumps(value)
         self.assertEqual(value, signing.loads(encoded))
         for transform in transforms:
-            self.assertRaises(
-                signing.BadSignature, signing.loads, transform(encoded))
+            with self.assertRaises(signing.BadSignature):
+                signing.loads(transform(encoded))
 
     def test_works_with_non_ascii_keys(self):
         binary_key = b'\xe7'  # Set some binary (non-ASCII key)
@@ -142,4 +142,5 @@ class TestTimestampSigner(SimpleTestCase):
             self.assertEqual(signer.unsign(ts, max_age=12), value)
             # max_age parameter can also accept a datetime.timedelta object
             self.assertEqual(signer.unsign(ts, max_age=datetime.timedelta(seconds=11)), value)
-            self.assertRaises(signing.SignatureExpired, signer.unsign, ts, max_age=10)
+            with self.assertRaises(signing.SignatureExpired):
+                signer.unsign(ts, max_age=10)

--- a/tests/sitemaps_tests/test_http.py
+++ b/tests/sitemaps_tests/test_http.py
@@ -144,7 +144,8 @@ class HTTPSitemapTests(SitemapTestsBase):
         Sitemap.get_urls and no Site objects exist
         """
         Site.objects.all().delete()
-        self.assertRaises(ImproperlyConfigured, Sitemap().get_urls)
+        with self.assertRaises(ImproperlyConfigured):
+            Sitemap().get_urls()
 
     @modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'})
     def test_sitemap_get_urls_no_site_2(self):
@@ -153,7 +154,8 @@ class HTTPSitemapTests(SitemapTestsBase):
         Sitemap.get_urls if Site objects exists, but the sites framework is not
         actually installed.
         """
-        self.assertRaises(ImproperlyConfigured, Sitemap().get_urls)
+        with self.assertRaises(ImproperlyConfigured):
+            Sitemap().get_urls()
 
     def test_sitemap_item(self):
         """

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -35,7 +35,8 @@ class SitesFrameworkTests(TestCase):
         s = Site.objects.get_current()
         self.assertIsInstance(s, Site)
         s.delete()
-        self.assertRaises(ObjectDoesNotExist, Site.objects.get_current)
+        with self.assertRaises(ObjectDoesNotExist):
+            Site.objects.get_current()
 
     def test_site_cache(self):
         # After updating a Site object (e.g. via the admin), we shouldn't return a
@@ -53,7 +54,8 @@ class SitesFrameworkTests(TestCase):
         # be cleared and get_current() should raise a DoesNotExist.
         self.assertIsInstance(Site.objects.get_current(), Site)
         Site.objects.all().delete()
-        self.assertRaises(Site.DoesNotExist, Site.objects.get_current)
+        with self.assertRaises(Site.DoesNotExist):
+            Site.objects.get_current()
 
     @override_settings(ALLOWED_HOSTS=['example.com'])
     def test_get_current_site(self):
@@ -70,7 +72,8 @@ class SitesFrameworkTests(TestCase):
         # Test that an exception is raised if the sites framework is installed
         # but there is no matching Site
         site.delete()
-        self.assertRaises(ObjectDoesNotExist, get_current_site, request)
+        with self.assertRaises(ObjectDoesNotExist):
+            get_current_site(request)
 
         # A RequestSite is returned if the sites framework is not installed
         with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
@@ -112,7 +115,8 @@ class SitesFrameworkTests(TestCase):
 
         # Host header with non-matching domain
         request.META = {'HTTP_HOST': 'example.net'}
-        self.assertRaises(ObjectDoesNotExist, get_current_site, request)
+        with self.assertRaises(ObjectDoesNotExist):
+            get_current_site(request)
 
         # Ensure domain for RequestSite always matches host header
         with self.modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'}):
@@ -128,11 +132,14 @@ class SitesFrameworkTests(TestCase):
         # Regression for #17320
         # Domain names are not allowed contain whitespace characters
         site = Site(name="test name", domain="test test")
-        self.assertRaises(ValidationError, site.full_clean)
+        with self.assertRaises(ValidationError):
+            site.full_clean()
         site.domain = "test\ttest"
-        self.assertRaises(ValidationError, site.full_clean)
+        with self.assertRaises(ValidationError):
+            site.full_clean()
         site.domain = "test\ntest"
-        self.assertRaises(ValidationError, site.full_clean)
+        with self.assertRaises(ValidationError):
+            site.full_clean()
 
     def test_clear_site_cache(self):
         request = HttpRequest()

--- a/tests/staticfiles_tests/cases.py
+++ b/tests/staticfiles_tests/cases.py
@@ -29,7 +29,8 @@ class BaseStaticFilesTestCase(object):
         )
 
     def assertFileNotFound(self, filepath):
-        self.assertRaises(IOError, self._get_file, filepath)
+        with self.assertRaises(IOError):
+            self._get_file(filepath)
 
     def render_template(self, template, **kwargs):
         if isinstance(template, six.string_types):
@@ -46,7 +47,8 @@ class BaseStaticFilesTestCase(object):
         self.assertEqual(self.render_template(template, **kwargs), result)
 
     def assertStaticRaises(self, exc, path, result, asvar=False, **kwargs):
-        self.assertRaises(exc, self.assertStaticRenders, path, result, **kwargs)
+        with self.assertRaises(exc):
+            self.assertStaticRenders(path, result, **kwargs)
 
 
 @override_settings(**TEST_SETTINGS)

--- a/tests/staticfiles_tests/test_finders.py
+++ b/tests/staticfiles_tests/test_finders.py
@@ -111,8 +111,10 @@ class TestMiscFinder(SimpleTestCase):
         We can't determine if STATICFILES_DIRS is set correctly just by
         looking at the type, but we can determine if it's definitely wrong.
         """
-        self.assertRaises(ImproperlyConfigured, finders.FileSystemFinder)
+        with self.assertRaises(ImproperlyConfigured):
+            finders.FileSystemFinder()
 
     @override_settings(MEDIA_ROOT='')
     def test_location_empty(self):
-        self.assertRaises(ImproperlyConfigured, finders.DefaultStorageFinder)
+        with self.assertRaises(ImproperlyConfigured):
+            finders.DefaultStorageFinder()

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -101,8 +101,8 @@ class TestConfiguration(StaticFilesTestCase):
         err = six.StringIO()
         for root in ['', None]:
             with override_settings(STATIC_ROOT=root):
-                with six.assertRaisesRegex(
-                        self, ImproperlyConfigured,
+                with self.assertRaisesMessage(
+                        ImproperlyConfigured,
                         'without having set the STATIC_ROOT setting to a filesystem path'):
                     call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
 

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -102,8 +102,9 @@ class TestConfiguration(StaticFilesTestCase):
         for root in ['', None]:
             with override_settings(STATIC_ROOT=root):
                 with self.assertRaisesMessage(
-                        ImproperlyConfigured,
-                        'without having set the STATIC_ROOT setting to a filesystem path'):
+                    ImproperlyConfigured,
+                    'without having set the STATIC_ROOT setting to a filesystem path'
+                ):
                     call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
 
     def test_local_storage_detection_helper(self):

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -461,9 +461,8 @@ class SyndicationFeedTest(FeedTestCase):
         Test that an ImproperlyConfigured is raised if no link could be found
         for the item(s).
         """
-        self.assertRaises(ImproperlyConfigured,
-                          self.client.get,
-                          '/syndication/articles/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/syndication/articles/')
 
     def test_template_feed(self):
         """

--- a/tests/syndication_tests/tests.py
+++ b/tests/syndication_tests/tests.py
@@ -195,10 +195,11 @@ class SyndicationFeedTest(FeedTestCase):
             self.assertEqual(len(enclosures), 1)
 
     def test_rss2_multiple_enclosures(self):
-        with self.assertRaisesMessage(ValueError, (
+        msg = (
             "RSS feed items may only have one enclosure, see "
             "http://www.rssboard.org/rss-profile#element-channel-item-enclosure"
-        )):
+        )
+        with self.assertRaisesMessage(ValueError, msg):
             self.client.get('/syndication/rss2/multiple-enclosure/')
 
     def test_rss091_feed(self):
@@ -530,9 +531,10 @@ class SyndicationFeedTest(FeedTestCase):
 class FeedgeneratorTestCase(TestCase):
     def test_add_item_warns_when_enclosure_kwarg_is_used(self):
         feed = SyndicationFeed(title='Example', link='http://example.com', description='Foo')
-        with self.assertRaisesMessage(RemovedInDjango20Warning, (
+        with self.assertRaisesMessage(
+            RemovedInDjango20Warning,
             'The enclosure keyword argument is deprecated, use enclosures instead.'
-        )):
+        ):
             feed.add_item(
                 title='Example Item',
                 link='https://example.com/item',

--- a/tests/template_tests/test_parser.py
+++ b/tests/template_tests/test_parser.py
@@ -44,7 +44,8 @@ class ParserTests(TestCase):
 
         # Filtered variables should reject access of attributes beginning with
         # underscores.
-        self.assertRaises(TemplateSyntaxError, FilterExpression, "article._hidden|upper", p)
+        with self.assertRaises(TemplateSyntaxError):
+            FilterExpression("article._hidden|upper", p)
 
     def test_variable_parsing(self):
         c = {"article": {"section": "News"}}
@@ -67,7 +68,8 @@ class ParserTests(TestCase):
 
         # Variables should reject access of attributes beginning with
         # underscores.
-        self.assertRaises(TemplateSyntaxError, Variable, "article._hidden")
+        with self.assertRaises(TemplateSyntaxError):
+            Variable("article._hidden")
 
         # Variables should raise on non string type
         with six.assertRaisesRegex(self, TypeError, "Variable must be a string or number, got <(class|type) 'dict'>"):

--- a/tests/template_tests/test_response.py
+++ b/tests/template_tests/test_response.py
@@ -77,7 +77,8 @@ class SimpleTemplateResponseTest(SimpleTestCase):
         def iteration():
             for x in response:
                 pass
-        self.assertRaises(ContentNotRenderedError, iteration)
+        with self.assertRaises(ContentNotRenderedError):
+            iteration()
         self.assertFalse(response.is_rendered)
 
     def test_iteration_rendered(self):
@@ -90,7 +91,8 @@ class SimpleTemplateResponseTest(SimpleTestCase):
         # unrendered response raises an exception when content is accessed
         response = self._response()
         self.assertFalse(response.is_rendered)
-        self.assertRaises(ContentNotRenderedError, lambda: response.content)
+        with self.assertRaises(ContentNotRenderedError):
+            response.content
         self.assertFalse(response.is_rendered)
 
     def test_content_access_rendered(self):
@@ -160,8 +162,8 @@ class SimpleTemplateResponseTest(SimpleTestCase):
             'value': 123,
             'fn': datetime.now,
         })
-        self.assertRaises(ContentNotRenderedError,
-                          pickle.dumps, response)
+        with self.assertRaises(ContentNotRenderedError):
+            pickle.dumps(response)
 
         # But if we render the response, we can pickle it.
         response.render()
@@ -188,8 +190,8 @@ class SimpleTemplateResponseTest(SimpleTestCase):
             'value': 123,
             'fn': datetime.now,
         })
-        self.assertRaises(ContentNotRenderedError,
-                          pickle.dumps, response)
+        with self.assertRaises(ContentNotRenderedError):
+            pickle.dumps(response)
 
         response.render()
         pickled_response = pickle.dumps(response)
@@ -274,8 +276,8 @@ class TemplateResponseTest(SimpleTestCase):
                 'fn': datetime.now,
             }
         )
-        self.assertRaises(ContentNotRenderedError,
-                          pickle.dumps, response)
+        with self.assertRaises(ContentNotRenderedError):
+            pickle.dumps(response)
 
         # But if we render the response, we can pickle it.
         response.render()
@@ -307,8 +309,8 @@ class TemplateResponseTest(SimpleTestCase):
             'value': 123,
             'fn': datetime.now,
         })
-        self.assertRaises(ContentNotRenderedError,
-                          pickle.dumps, response)
+        with self.assertRaises(ContentNotRenderedError):
+            pickle.dumps(response)
 
         response.render()
         pickled_response = pickle.dumps(response)

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -602,7 +602,8 @@ class ClientTest(TestCase):
 
     def test_view_with_exception(self):
         "Request a page that is known to throw an error"
-        self.assertRaises(KeyError, self.client.get, "/broken_view/")
+        with self.assertRaises(KeyError):
+            self.client.get("/broken_view/")
 
         # Try the same assertion, a different way
         try:

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -109,7 +109,8 @@ class DependencyOrderingTests(unittest.TestCase):
             'alpha': ['bravo'],
         }
 
-        self.assertRaises(ImproperlyConfigured, dependency_ordered, raw, dependencies=dependencies)
+        with self.assertRaises(ImproperlyConfigured):
+            dependency_ordered(raw, dependencies=dependencies)
 
     def test_own_alias_dependency(self):
         raw = [

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -125,7 +125,8 @@ class AssertNumQueriesTests(TestCase):
         def test_func():
             raise ValueError
 
-        self.assertRaises(ValueError, self.assertNumQueries, 2, test_func)
+        with self.assertRaises(ValueError):
+            self.assertNumQueries(2, test_func)
 
     def test_assert_num_queries_with_client(self):
         person = Person.objects.create(name='test')
@@ -864,22 +865,29 @@ class OverrideSettingsTests(SimpleTestCase):
         reverse('second')
 
     def test_urlconf_cache(self):
-        self.assertRaises(NoReverseMatch, lambda: reverse('first'))
-        self.assertRaises(NoReverseMatch, lambda: reverse('second'))
+        with self.assertRaises(NoReverseMatch):
+            reverse('first')
+        with self.assertRaises(NoReverseMatch):
+            reverse('second')
 
         with override_settings(ROOT_URLCONF=FirstUrls):
             self.client.get(reverse('first'))
-            self.assertRaises(NoReverseMatch, lambda: reverse('second'))
+            with self.assertRaises(NoReverseMatch):
+                reverse('second')
 
             with override_settings(ROOT_URLCONF=SecondUrls):
-                self.assertRaises(NoReverseMatch, lambda: reverse('first'))
+                with self.assertRaises(NoReverseMatch):
+                    reverse('first')
                 self.client.get(reverse('second'))
 
             self.client.get(reverse('first'))
-            self.assertRaises(NoReverseMatch, lambda: reverse('second'))
+            with self.assertRaises(NoReverseMatch):
+                reverse('second')
 
-        self.assertRaises(NoReverseMatch, lambda: reverse('first'))
-        self.assertRaises(NoReverseMatch, lambda: reverse('second'))
+        with self.assertRaises(NoReverseMatch):
+            reverse('first')
+        with self.assertRaises(NoReverseMatch):
+            reverse('second')
 
     def test_override_media_root(self):
         """

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -798,7 +798,8 @@ class AssertRaisesMsgTest(SimpleTestCase):
         """assertRaisesMessage shouldn't interpret RE special chars."""
         def func1():
             raise ValueError("[.*x+]y?")
-        self.assertRaisesMessage(ValueError, "[.*x+]y?", func1)
+        with self.assertRaisesMessage(ValueError, "[.*x+]y?"):
+            func1()
 
     @ignore_warnings(category=RemovedInDjango20Warning)
     def test_callable_obj_param(self):

--- a/tests/transactions/tests.py
+++ b/tests/transactions/tests.py
@@ -12,7 +12,6 @@ from django.db import (
 from django.test import (
     TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
 )
-from django.utils import six
 
 from .models import Reporter
 
@@ -45,7 +44,7 @@ class AtomicTests(TransactionTestCase):
         def make_reporter():
             Reporter.objects.create(first_name="Haddock")
             raise Exception("Oops, that's his last name")
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             make_reporter()
         self.assertQuerysetEqual(Reporter.objects.all(), [])
 
@@ -61,7 +60,7 @@ class AtomicTests(TransactionTestCase):
         def make_reporter():
             Reporter.objects.create(first_name="Haddock")
             raise Exception("Oops, that's his last name")
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             make_reporter()
         self.assertQuerysetEqual(Reporter.objects.all(), [])
 
@@ -71,7 +70,7 @@ class AtomicTests(TransactionTestCase):
         self.assertQuerysetEqual(Reporter.objects.all(), ['<Reporter: Tintin>'])
 
     def test_rollback(self):
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with transaction.atomic():
                 Reporter.objects.create(first_name="Haddock")
                 raise Exception("Oops, that's his last name")
@@ -88,14 +87,14 @@ class AtomicTests(TransactionTestCase):
     def test_nested_commit_rollback(self):
         with transaction.atomic():
             Reporter.objects.create(first_name="Tintin")
-            with six.assertRaisesRegex(self, Exception, "Oops"):
+            with self.assertRaisesMessage(Exception, "Oops"):
                 with transaction.atomic():
                     Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
         self.assertQuerysetEqual(Reporter.objects.all(), ['<Reporter: Tintin>'])
 
     def test_nested_rollback_commit(self):
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with transaction.atomic():
                 Reporter.objects.create(last_name="Tintin")
                 with transaction.atomic():
@@ -104,10 +103,10 @@ class AtomicTests(TransactionTestCase):
         self.assertQuerysetEqual(Reporter.objects.all(), [])
 
     def test_nested_rollback_rollback(self):
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with transaction.atomic():
                 Reporter.objects.create(last_name="Tintin")
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
                     with transaction.atomic():
                         Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
@@ -125,7 +124,7 @@ class AtomicTests(TransactionTestCase):
     def test_merged_commit_rollback(self):
         with transaction.atomic():
             Reporter.objects.create(first_name="Tintin")
-            with six.assertRaisesRegex(self, Exception, "Oops"):
+            with self.assertRaisesMessage(Exception, "Oops"):
                 with transaction.atomic(savepoint=False):
                     Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
@@ -133,7 +132,7 @@ class AtomicTests(TransactionTestCase):
         self.assertQuerysetEqual(Reporter.objects.all(), [])
 
     def test_merged_rollback_commit(self):
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with transaction.atomic():
                 Reporter.objects.create(last_name="Tintin")
                 with transaction.atomic(savepoint=False):
@@ -142,10 +141,10 @@ class AtomicTests(TransactionTestCase):
         self.assertQuerysetEqual(Reporter.objects.all(), [])
 
     def test_merged_rollback_rollback(self):
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with transaction.atomic():
                 Reporter.objects.create(last_name="Tintin")
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
                     with transaction.atomic(savepoint=False):
                         Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
@@ -165,7 +164,7 @@ class AtomicTests(TransactionTestCase):
         atomic = transaction.atomic()
         with atomic:
             Reporter.objects.create(first_name="Tintin")
-            with six.assertRaisesRegex(self, Exception, "Oops"):
+            with self.assertRaisesMessage(Exception, "Oops"):
                 with atomic:
                     Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
@@ -173,7 +172,7 @@ class AtomicTests(TransactionTestCase):
 
     def test_reuse_rollback_commit(self):
         atomic = transaction.atomic()
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with atomic:
                 Reporter.objects.create(last_name="Tintin")
                 with atomic:
@@ -183,10 +182,10 @@ class AtomicTests(TransactionTestCase):
 
     def test_reuse_rollback_rollback(self):
         atomic = transaction.atomic()
-        with six.assertRaisesRegex(self, Exception, "Oops"):
+        with self.assertRaisesMessage(Exception, "Oops"):
             with atomic:
                 Reporter.objects.create(last_name="Tintin")
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
                     with atomic:
                         Reporter.objects.create(first_name="Haddock")
                     raise Exception("Oops, that's his last name")
@@ -256,7 +255,7 @@ class AtomicMergeTests(TransactionTestCase):
             Reporter.objects.create(first_name="Tintin")
             with transaction.atomic(savepoint=False):
                 Reporter.objects.create(first_name="Archibald", last_name="Haddock")
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
                     with transaction.atomic(savepoint=False):
                         Reporter.objects.create(first_name="Calculus")
                         raise Exception("Oops, that's his last name")
@@ -280,7 +279,7 @@ class AtomicMergeTests(TransactionTestCase):
             Reporter.objects.create(first_name="Tintin")
             with transaction.atomic():
                 Reporter.objects.create(first_name="Archibald", last_name="Haddock")
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
                     with transaction.atomic(savepoint=False):
                         Reporter.objects.create(first_name="Calculus")
                         raise Exception("Oops, that's his last name")
@@ -383,7 +382,7 @@ class AtomicMySQLTests(TransactionTestCase):
         other_thread.start()
         other_thread_ready.wait()
 
-        with six.assertRaisesRegex(self, OperationalError, 'Deadlock found'):
+        with self.assertRaisesMessage(OperationalError, 'Deadlock found'):
             # Double atomic to enter a transaction and create a savepoint.
             with transaction.atomic():
                 with transaction.atomic():
@@ -419,7 +418,7 @@ class AtomicMiscTests(TransactionTestCase):
             with transaction.atomic():
 
                 # Swallow the intentional error raised in the sub-transaction.
-                with six.assertRaisesRegex(self, Exception, "Oops"):
+                with self.assertRaisesMessage(Exception, "Oops"):
 
                     # Start a sub-transaction with a savepoint.
                     with transaction.atomic():

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -123,8 +123,8 @@ class AdvancedTests(TestCase):
         We do not support update on already sliced query sets.
         """
         method = DataPoint.objects.all()[:2].update
-        self.assertRaises(AssertionError, method,
-                          another_value='another thing')
+        with self.assertRaises(AssertionError):
+            method(another_value='another thing')
 
     def test_update_respects_to_field(self):
         """

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -274,7 +274,8 @@ class URLPatternReverse(SimpleTestCase):
 
     def test_reverse_none(self):
         # Reversing None should raise an error, not return the last un-named view.
-        self.assertRaises(NoReverseMatch, reverse, None)
+        with self.assertRaises(NoReverseMatch):
+            reverse(None)
 
     @override_script_prefix('/{{invalid}}/')
     def test_prefix_braces(self):
@@ -371,10 +372,14 @@ class ResolverTests(unittest.TestCase):
 
         Regression for #10834.
         """
-        self.assertRaises(Resolver404, resolve, '')
-        self.assertRaises(Resolver404, resolve, 'a')
-        self.assertRaises(Resolver404, resolve, '\\')
-        self.assertRaises(Resolver404, resolve, '.')
+        with self.assertRaises(Resolver404):
+            resolve('')
+        with self.assertRaises(Resolver404):
+            resolve('a')
+        with self.assertRaises(Resolver404):
+            resolve('\\')
+        with self.assertRaises(Resolver404):
+            resolve('.')
 
     def test_404_tried_urls_have_names(self):
         """
@@ -492,7 +497,8 @@ class ReverseShortcutTests(SimpleTestCase):
         self.assertEqual(res.url, '/places/1/')
         res = redirect('headlines', year='2008', month='02', day='17')
         self.assertEqual(res.url, '/headlines/2008.02.17/')
-        self.assertRaises(NoReverseMatch, redirect, 'not-a-view')
+        with self.assertRaises(NoReverseMatch):
+            redirect('not-a-view')
 
     def test_redirect_to_url(self):
         res = redirect('/foo/')
@@ -523,7 +529,8 @@ class ReverseShortcutTests(SimpleTestCase):
         from .views import absolute_kwargs_view
         res = redirect(absolute_kwargs_view)
         self.assertEqual(res.url, '/absolute_arg_view/')
-        self.assertRaises(NoReverseMatch, redirect, absolute_kwargs_view, wrong_argument=None)
+        with self.assertRaises(NoReverseMatch):
+            redirect(absolute_kwargs_view, wrong_argument=None)
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls')
@@ -532,20 +539,28 @@ class NamespaceTests(SimpleTestCase):
 
     def test_ambiguous_object(self):
         "Names deployed via dynamic URL objects that require namespaces can't be resolved"
-        self.assertRaises(NoReverseMatch, reverse, 'urlobject-view')
-        self.assertRaises(NoReverseMatch, reverse, 'urlobject-view', args=[37, 42])
-        self.assertRaises(NoReverseMatch, reverse, 'urlobject-view', kwargs={'arg1': 42, 'arg2': 37})
+        with self.assertRaises(NoReverseMatch):
+            reverse('urlobject-view')
+        with self.assertRaises(NoReverseMatch):
+            reverse('urlobject-view', args=[37, 42])
+        with self.assertRaises(NoReverseMatch):
+            reverse('urlobject-view', kwargs={'arg1': 42, 'arg2': 37})
 
     def test_ambiguous_urlpattern(self):
         "Names deployed via dynamic URL objects that require namespaces can't be resolved"
-        self.assertRaises(NoReverseMatch, reverse, 'inner-nothing')
-        self.assertRaises(NoReverseMatch, reverse, 'inner-nothing', args=[37, 42])
-        self.assertRaises(NoReverseMatch, reverse, 'inner-nothing', kwargs={'arg1': 42, 'arg2': 37})
+        with self.assertRaises(NoReverseMatch):
+            reverse('inner-nothing')
+        with self.assertRaises(NoReverseMatch):
+            reverse('inner-nothing', args=[37, 42])
+        with self.assertRaises(NoReverseMatch):
+            reverse('inner-nothing', kwargs={'arg1': 42, 'arg2': 37})
 
     def test_non_existent_namespace(self):
         "Non-existent namespaces raise errors"
-        self.assertRaises(NoReverseMatch, reverse, 'blahblah:urlobject-view')
-        self.assertRaises(NoReverseMatch, reverse, 'test-ns1:blahblah:urlobject-view')
+        with self.assertRaises(NoReverseMatch):
+            reverse('blahblah:urlobject-view')
+        with self.assertRaises(NoReverseMatch):
+            reverse('test-ns1:blahblah:urlobject-view')
 
     def test_normal_name(self):
         "Normal lookups work as expected"
@@ -896,7 +911,8 @@ class DefaultErrorHandlerTests(SimpleTestCase):
             self.fail("Shouldn't get an AttributeError due to undefined 404 handler")
 
         try:
-            self.assertRaises(ValueError, self.client.get, '/bad_view/')
+            with self.assertRaises(ValueError):
+                self.client.get('/bad_view/')
         except AttributeError:
             self.fail("Shouldn't get an AttributeError due to undefined 500 handler")
 
@@ -906,7 +922,8 @@ class NoRootUrlConfTests(SimpleTestCase):
     """Tests for handler404 and handler500 if ROOT_URLCONF is None"""
 
     def test_no_handler_exception(self):
-        self.assertRaises(ImproperlyConfigured, self.client.get, '/test/me/')
+        with self.assertRaises(ImproperlyConfigured):
+            self.client.get('/test/me/')
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls')

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -252,13 +252,12 @@ class NoURLPatternsTests(SimpleTestCase):
         """
         resolver = RegexURLResolver(r'^$', settings.ROOT_URLCONF)
 
-        self.assertRaisesMessage(
+        with self.assertRaisesMessage(
             ImproperlyConfigured,
-            "The included URLconf 'urlpatterns_reverse.no_urls' does not "
-            "appear to have any patterns in it. If you see valid patterns in "
-            "the file then the issue is probably caused by a circular import.",
-            getattr, resolver, 'url_patterns'
-        )
+                "The included URLconf 'urlpatterns_reverse.no_urls' does not "
+                "appear to have any patterns in it. If you see valid patterns in "
+                "the file then the issue is probably caused by a circular import."):
+            getattr(resolver, 'url_patterns')
 
 
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -252,11 +252,13 @@ class NoURLPatternsTests(SimpleTestCase):
         """
         resolver = RegexURLResolver(r'^$', settings.ROOT_URLCONF)
 
-        with self.assertRaisesMessage(
-            ImproperlyConfigured,
-                "The included URLconf 'urlpatterns_reverse.no_urls' does not "
-                "appear to have any patterns in it. If you see valid patterns in "
-                "the file then the issue is probably caused by a circular import."):
+        msg = (
+            "The included URLconf 'urlpatterns_reverse.no_urls' does not "
+            "appear to have any patterns in it. If you see valid patterns in "
+            "the file then the issue is probably caused by a circular import."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+
             getattr(resolver, 'url_patterns')
 
 

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -44,7 +44,8 @@ class CommandTests(SimpleTestCase):
 
     def test_explode(self):
         """ Test that an unknown command raises CommandError """
-        self.assertRaises(CommandError, management.call_command, ('explode',))
+        with self.assertRaises(CommandError):
+            management.call_command(('explode',))
 
     def test_system_exit(self):
         """ Exception raised in a command should raise CommandError with
@@ -181,4 +182,5 @@ class CommandRunTests(AdminScriptTestCase):
 class UtilsTests(SimpleTestCase):
 
     def test_no_existent_external_program(self):
-        self.assertRaises(CommandError, popen_wrapper, ['a_42_command_that_doesnt_exist_42'])
+        with self.assertRaises(CommandError):
+            popen_wrapper(['a_42_command_that_doesnt_exist_42'])

--- a/tests/utils_tests/test_baseconv.py
+++ b/tests/utils_tests/test_baseconv.py
@@ -42,5 +42,6 @@ class TestBaseConv(TestCase):
         self.assertEqual(base7.decode('ghejd'), -1234)
 
     def test_exception(self):
-        self.assertRaises(ValueError, BaseConverter, 'abc', sign='a')
+        with self.assertRaises(ValueError):
+            BaseConverter('abc', sign='a')
         self.assertIsInstance(BaseConverter('abc', sign='d'), BaseConverter)

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -49,8 +49,8 @@ class MultiValueDictTests(SimpleTestCase):
             [('name', ['Adrian', 'Simon']), ('position', ['Developer'])]
         )
 
-        six.assertRaisesRegex(self, MultiValueDictKeyError, 'lastname',
-            d.__getitem__, 'lastname')
+        with self.assertRaisesMessage(MultiValueDictKeyError, 'lastname'):
+            d.__getitem__('lastname')
 
         self.assertEqual(d.get('lastname'), None)
         self.assertEqual(d.get('lastname', 'nonexistent'), 'nonexistent')

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -108,8 +108,8 @@ class ImmutableListTests(SimpleTestCase):
         d = ImmutableList(range(10))
 
         # AttributeError: ImmutableList object is immutable.
-        self.assertRaisesMessage(AttributeError,
-            'ImmutableList object is immutable.', d.sort)
+        with self.assertRaisesMessage(AttributeError, 'ImmutableList object is immutable.'):
+            d.sort()
 
         self.assertEqual(repr(d), '(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)')
 
@@ -119,8 +119,8 @@ class ImmutableListTests(SimpleTestCase):
         self.assertEqual(d[1], 1)
 
         # AttributeError: Object is immutable!
-        self.assertRaisesMessage(AttributeError,
-            'Object is immutable!', d.__setitem__, 1, 'test')
+        with self.assertRaisesMessage(AttributeError, 'Object is immutable!'):
+            d.__setitem__(1, 'test')
 
 
 class DictWrapperTests(SimpleTestCase):

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -17,7 +17,8 @@ class DateParseTests(unittest.TestCase):
         self.assertEqual(parse_date('2012-4-9'), date(2012, 4, 9))
         # Invalid inputs
         self.assertEqual(parse_date('20120423'), None)
-        self.assertRaises(ValueError, parse_date, '2012-04-56')
+        with self.assertRaises(ValueError):
+            parse_date('2012-04-56')
 
     def test_parse_time(self):
         # Valid inputs
@@ -27,7 +28,8 @@ class DateParseTests(unittest.TestCase):
         self.assertEqual(parse_time('4:8:16'), time(4, 8, 16))
         # Invalid inputs
         self.assertEqual(parse_time('091500'), None)
-        self.assertRaises(ValueError, parse_time, '09:15:90')
+        with self.assertRaises(ValueError):
+            parse_time('09:15:90')
 
     def test_parse_datetime(self):
         # Valid inputs
@@ -47,7 +49,8 @@ class DateParseTests(unittest.TestCase):
             datetime(2012, 4, 23, 10, 20, 30, 400000, get_fixed_timezone(-120)))
         # Invalid inputs
         self.assertEqual(parse_datetime('20120423091500'), None)
-        self.assertRaises(ValueError, parse_datetime, '2012-04-56T09:15:90')
+        with self.assertRaises(ValueError):
+            parse_datetime('2012-04-56T09:15:90')
 
 
 class DurationParseTests(unittest.TestCase):

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -27,7 +27,8 @@ class TestEncodingUtils(unittest.TestCase):
         # str(s) raises a TypeError on python 3 if the result is not a text type.
         # python 2 fails when it tries converting from str to unicode (via ASCII).
         exception = TypeError if six.PY3 else UnicodeError
-        self.assertRaises(exception, force_text, MyString())
+        with self.assertRaises(exception):
+            force_text(MyString())
 
     def test_force_text_lazy(self):
         s = SimpleLazyObject(lambda: 'x')

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -55,7 +55,8 @@ class FunctionalTestCase(unittest.TestCase):
             def _get_do(self):
                 return "DO IT"
 
-        self.assertRaises(NotImplementedError, lambda: A().do)
+        with self.assertRaises(NotImplementedError):
+            A().do
         self.assertEqual(B().do, 'DO IT')
 
     def test_lazy_object_to_string(self):

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -55,16 +55,21 @@ class TestUtilsHttp(unittest.TestCase):
             self.assertEqual(sys.maxint, http.base36_to_int(http.int_to_base36(sys.maxint)))
 
         # bad input
-        self.assertRaises(ValueError, http.int_to_base36, -1)
+        with self.assertRaises(ValueError):
+            http.int_to_base36(-1)
         if six.PY2:
-            self.assertRaises(ValueError, http.int_to_base36, sys.maxint + 1)
+            with self.assertRaises(ValueError):
+                http.int_to_base36(sys.maxint + 1)
         for n in ['1', 'foo', {1: 2}, (1, 2, 3), 3.141]:
-            self.assertRaises(TypeError, http.int_to_base36, n)
+            with self.assertRaises(TypeError):
+                http.int_to_base36(n)
 
         for n in ['#', ' ']:
-            self.assertRaises(ValueError, http.base36_to_int, n)
+            with self.assertRaises(ValueError):
+                http.base36_to_int(n)
         for n in [123, {1: 2}, (1, 2, 3), 3.141]:
-            self.assertRaises(TypeError, http.base36_to_int, n)
+            with self.assertRaises(TypeError):
+                http.base36_to_int(n)
 
         # more explicit output testing
         for n, b36 in [(0, '0'), (1, '1'), (42, '16'), (818469960, 'django')]:

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -34,15 +34,18 @@ class DefaultLoader(unittest.TestCase):
 
         # A child that exists, but will generate an import error if loaded
         self.assertTrue(module_has_submodule(test_module, 'bad_module'))
-        self.assertRaises(ImportError, import_module, 'utils_tests.test_module.bad_module')
+        with self.assertRaises(ImportError):
+            import_module('utils_tests.test_module.bad_module')
 
         # A child that doesn't exist
         self.assertFalse(module_has_submodule(test_module, 'no_such_module'))
-        self.assertRaises(ImportError, import_module, 'utils_tests.test_module.no_such_module')
+        with self.assertRaises(ImportError):
+            import_module('utils_tests.test_module.no_such_module')
 
         # A child that doesn't exist, but is the name of a package on the path
         self.assertFalse(module_has_submodule(test_module, 'django'))
-        self.assertRaises(ImportError, import_module, 'utils_tests.test_module.django')
+        with self.assertRaises(ImportError):
+            import_module('utils_tests.test_module.django')
 
         # Don't be confused by caching of import misses
         import types  # NOQA: causes attempted import of utils_tests.types
@@ -50,8 +53,8 @@ class DefaultLoader(unittest.TestCase):
 
         # A module which doesn't have a __path__ (so no submodules)
         self.assertFalse(module_has_submodule(test_no_submodule, 'anything'))
-        self.assertRaises(ImportError, import_module,
-            'utils_tests.test_no_submodule.anything')
+        with self.assertRaises(ImportError):
+            import_module('utils_tests.test_no_submodule.anything')
 
 
 class EggLoader(unittest.TestCase):
@@ -82,11 +85,13 @@ class EggLoader(unittest.TestCase):
 
             # A child that exists, but will generate an import error if loaded
             self.assertTrue(module_has_submodule(egg_module, 'bad_module'))
-            self.assertRaises(ImportError, import_module, 'egg_module.bad_module')
+            with self.assertRaises(ImportError):
+                import_module('egg_module.bad_module')
 
             # A child that doesn't exist
             self.assertFalse(module_has_submodule(egg_module, 'no_such_module'))
-            self.assertRaises(ImportError, import_module, 'egg_module.no_such_module')
+            with self.assertRaises(ImportError):
+                import_module('egg_module.no_such_module')
 
     def test_deep_loader(self):
         "Modules deep inside an egg can still be tested for existence"
@@ -101,11 +106,13 @@ class EggLoader(unittest.TestCase):
 
             # A child that exists, but will generate an import error if loaded
             self.assertTrue(module_has_submodule(egg_module, 'bad_module'))
-            self.assertRaises(ImportError, import_module, 'egg_module.sub1.sub2.bad_module')
+            with self.assertRaises(ImportError):
+                import_module('egg_module.sub1.sub2.bad_module')
 
             # A child that doesn't exist
             self.assertFalse(module_has_submodule(egg_module, 'no_such_module'))
-            self.assertRaises(ImportError, import_module, 'egg_module.sub1.sub2.no_such_module')
+            with self.assertRaises(ImportError):
+                import_module('egg_module.sub1.sub2.no_such_module')
 
 
 class ModuleImportTestCase(unittest.TestCase):
@@ -114,7 +121,8 @@ class ModuleImportTestCase(unittest.TestCase):
         self.assertEqual(cls, import_string)
 
         # Test exceptions raised
-        self.assertRaises(ImportError, import_string, 'no_dots_in_path')
+        with self.assertRaises(ImportError):
+            import_string('no_dots_in_path')
         msg = 'Module "utils_tests" does not define a "unexistent" attribute'
         with six.assertRaisesRegex(self, ImportError, msg):
             import_string('utils_tests.unexistent')

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -5,7 +5,7 @@ import unittest
 from importlib import import_module
 from zipimport import zipimporter
 
-from django.test import SimpleTestCase, modify_settings
+from django.test import SimpleTestCase, TestCase, modify_settings
 from django.test.utils import extend_sys_path
 from django.utils import six
 from django.utils._os import upath
@@ -115,7 +115,7 @@ class EggLoader(unittest.TestCase):
                 import_module('egg_module.sub1.sub2.no_such_module')
 
 
-class ModuleImportTestCase(unittest.TestCase):
+class ModuleImportTestCase(TestCase):
     def test_import_string(self):
         cls = import_string('django.utils.module_loading.import_string')
         self.assertEqual(cls, import_string)
@@ -124,7 +124,7 @@ class ModuleImportTestCase(unittest.TestCase):
         with self.assertRaises(ImportError):
             import_string('no_dots_in_path')
         msg = 'Module "utils_tests" does not define a "unexistent" attribute'
-        with six.assertRaisesRegex(self, ImportError, msg):
+        with self.assertRaisesMessage(ImportError, msg):
             import_string('utils_tests.unexistent')
 
 
@@ -164,13 +164,13 @@ class AutodiscoverModulesTestCase(SimpleTestCase):
 
     def test_validate_registry_keeps_intact(self):
         from .test_module import site
-        with six.assertRaisesRegex(self, Exception, "Some random exception."):
+        with self.assertRaisesMessage(Exception, "Some random exception."):
             autodiscover_modules('another_bad_module', register_to=site)
         self.assertEqual(site._registry, {})
 
     def test_validate_registry_resets_after_erroneous_module(self):
         from .test_module import site
-        with six.assertRaisesRegex(self, Exception, "Some random exception."):
+        with self.assertRaisesMessage(Exception, "Some random exception."):
             autodiscover_modules('another_good_module', 'another_bad_module', register_to=site)
         self.assertEqual(site._registry, {'lorem': 'ipsum'})
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -124,8 +124,8 @@ class DebugViewTests(LoggingCaptureMixin, SimpleTestCase):
 
     def test_view_exceptions(self):
         for n in range(len(except_args)):
-            self.assertRaises(BrokenException, self.client.get,
-                reverse('view_exception', args=(n,)))
+            with self.assertRaises(BrokenException):
+                self.client.get(reverse('view_exception', args=(n,)))
 
     def test_non_l10ned_numeric_ids(self):
         """
@@ -169,7 +169,8 @@ class DebugViewTests(LoggingCaptureMixin, SimpleTestCase):
         """
         Make sure if you don't specify a template, the debug view doesn't blow up.
         """
-        self.assertRaises(TemplateDoesNotExist, self.client.get, '/render_no_template/')
+        with self.assertRaises(TemplateDoesNotExist):
+            self.client.get('/render_no_template/')
 
     @override_settings(ROOT_URLCONF='view_tests.default_urls')
     def test_default_urlconf_template(self):


### PR DESCRIPTION
Convert `assertRaises` and `assertRaisesMessage` to ontext manager version.

Convert without regular experesion `six.assertRaisesRegex` tests to `assertRaisesMessage` .