### PR TITLE
Fixed #26109 -- Raised a helpful error if loader.select_tamplate() is passed a string.

### DIFF
--- a/django/template/loader.py
+++ b/django/template/loader.py
@@ -33,6 +33,13 @@ def select_template(template_name_list, using=None):
 
     Raises TemplateDoesNotExist if no such template exists.
     """
+    if isinstance(template_name_list, six.string_types):
+        raise TypeError(
+            "select_template() takes an iterable of template names. "
+            "Use get_template() if you want to load a single template "
+            "with its name."
+        )
+
     chain = []
     engines = _engine_list(using)
     for template_name in template_name_list:

--- a/tests/template_loader/tests.py
+++ b/tests/template_loader/tests.py
@@ -60,6 +60,15 @@ class TemplateLoaderTests(SimpleTestCase):
         with self.assertRaises(TemplateDoesNotExist):
             select_template([])
 
+    def test_select_template_string(self):
+        with self.assertRaisesMessage(
+            TypeError,
+            "select_template() takes an iterable of template names. "
+            "Use get_template() if you want to load a single template "
+            "with its name."
+        ):
+            select_template("template_loader/hello.html")
+
     def test_select_template_not_found(self):
         with self.assertRaises(TemplateDoesNotExist) as e:
             select_template(["template_loader/unknown.html",


### PR DESCRIPTION
Currently supplying a string to `select_template` raise an `IOError`, which is not meaningful. Here's a sample.

```
IOError at XXX
[Errno 21] Is a directory: u'xxx/site-packages/django/contrib/admin/templates'
```
It's better to check if `template_name_list` is actually a list (`Iterable`). If it is a string, suggest to use `get_template` function instead.

[Django ticket](https://code.djangoproject.com/ticket/26109)