### PR TITLE
Changed `action="."` to `action=""` in tests and docs.

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -40,7 +40,7 @@ To take advantage of CSRF protection in your views, follow these steps:
 2. In any template that uses a POST form, use the :ttag:`csrf_token` tag inside
    the ``<form>`` element if the form is for an internal URL, e.g.::
 
-       <form action="." method="post">{% csrf_token %}
+       <form action="" method="post">{% csrf_token %}
 
    This should not be done for POST forms that target external URLs, since
    that would cause the CSRF token to be leaked, leading to a vulnerability.

--- a/tests/forms_tests/templates/forms_tests/article_form.html
+++ b/tests/forms_tests/templates/forms_tests/article_form.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-  <form method="post" action=".">{% csrf_token %}
+  <form method="post" action="">{% csrf_token %}
     {{ form.as_p }}<br>
     <input id="submit" type="submit">
   </form>

--- a/tests/templates/form_view.html
+++ b/tests/templates/form_view.html
@@ -2,7 +2,7 @@
 {% block title %}Submit data{% endblock %}
 {% block content %}
 <h1>{{ message }}</h1>
-<form method='post' action='.'>
+<form method="post" action="">
 {% if form.errors %}
 <p class='warning'>Please correct the errors below:</p>
 {% endif %}

--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -5,7 +5,7 @@
 <p>Your username and password didn't match. Please try again.</p>
 {% endif %}
 
-<form method="post" action=".">
+<form method="post" action="">
 <table>
 <tr><td><label for="id_username">Username:</label></td><td>{{ form.username }}</td></tr>
 <tr><td><label for="id_password">Password:</label></td><td>{{ form.password }}</td></tr>


### PR DESCRIPTION
`action="."` strips query parameters from the URL, which is not usually what
you want.  Copy-paste coding of these examples could lead to difficult to
track down bugs, or even data loss if the query parameter was meant to alter
the scope of a form's POST request, so it is best fixed.