### PR TITLE
Fixed #25971 -- shouldn't send email if URL = Referer + '/'

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -167,8 +167,12 @@ class BrokenLinkEmailsMiddleware(object):
          - If a '?' in referer is identified as a search engine source.
          - If the referer is equal to the current URL, ignoring the scheme
            (assumed to be a poorly implemented bot).
+         - If the referer is equal to the current URL without trailing slash, ignoring the scheme
         """
         if not referer:
+            return True
+
+        if settings.APPEND_SLASH and uri.endswith("/") and referer == uri[:-1]:
             return True
 
         if not self.is_internal_request(domain, referer) and '?' in referer:

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -417,6 +417,20 @@ class BrokenLinkEmailsMiddlewareTest(SimpleTestCase):
         BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
         self.assertEqual(len(mail.outbox), 1)
 
+    @override_settings(APPEND_SLASH=True)
+    def test_referer_equal_to_requested_url_without_trailing_slash_when_append_slash_is_set(self):
+        self.req.path = self.req.path_info = '/regular_url/that/does/not/exist/'
+        self.req.META['HTTP_REFERER'] = self.req.path_info[:-1]
+        BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(APPEND_SLASH=False)
+    def test_referer_equal_to_requested_url_without_trailing_slash_when_append_slash_is_unset(self):
+        self.req.path = self.req.path_info = '/regular_url/that/does/not/exist/'
+        self.req.META['HTTP_REFERER'] = self.req.path_info[:-1]
+        BrokenLinkEmailsMiddleware().process_response(self.req, self.resp)
+        self.assertEqual(len(mail.outbox), 1)
+
 
 @override_settings(ROOT_URLCONF='middleware.cond_get_urls')
 class ConditionalGetMiddlewareTest(SimpleTestCase):


### PR DESCRIPTION
If APPEND_SLASH is set and the referer is the URL without a trailing '/' then BrokenLinkEmailsMiddleware shouldn't send broken link email.