### PR TITLE
Fixed #26119 -- Fixed URLValidator crash on values with square brackets.

### DIFF
--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -215,6 +215,8 @@ TEST_DATA = [
     (URLValidator(), 'http://www.asdasdasdasdsadfm.com.br ', ValidationError),
     (URLValidator(), 'http://www.asdasdasdasdsadfm.com.br z', ValidationError),
 
+    (URLValidator(), 'https://test.[com', ValidationError),
+
     (BaseValidator(True), True, None),
     (BaseValidator(True), False, ValidationError),
 


### PR DESCRIPTION
This references https://code.djangoproject.com/ticket/26119

There is probably a solution to update the regular expression for this specific case but I thought catching the `ValueError` might be a good idea nonetheless