### PR TITLE
Fixed #25910 - Don't accept read-only property names in model ctors.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -435,7 +435,8 @@ class Model(six.with_metaclass(ModelBase)):
             for prop in list(kwargs):
                 try:
                     if isinstance(getattr(self.__class__, prop), property):
-                        setattr(self, prop, kwargs.pop(prop))
+                        setattr(self, prop, kwargs[prop])
+                        del kwargs[prop]
                 except AttributeError:
                     pass
             if kwargs:

--- a/tests/properties/tests.py
+++ b/tests/properties/tests.py
@@ -18,6 +18,9 @@ class PropertyTests(TestCase):
         # The "full_name" property hasn't provided a "set" method.
         self.assertRaises(AttributeError, setattr, self.a, 'full_name', 'Paul McCartney')
 
+        # And cannot be used to initialize the class.
+        self.assertRaises(TypeError, Person, full_name='Paul McCartney')
+
         # But "full_name_2" has, and it can be used to initialize the class.
         a2 = Person(full_name_2='Paul McCartney')
         a2.save()


### PR DESCRIPTION
This fixes the problem by only removing the item from kwargs after it has been determined that AttributeError isn't raised (e.g. due to trying to assign to a read-only property).