### PR TITLE
Fixed #26116 -- Corrected schema's test_alter_implicit_id_to_explicit.

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -21,9 +21,6 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_delete_index = "DROP INDEX %(name)s ON %(table)s"
 
-    alter_string_set_null = 'MODIFY %(column)s %(type)s NULL;'
-    alter_string_drop_null = 'MODIFY %(column)s %(type)s NOT NULL;'
-
     sql_create_pk = "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s)"
     sql_delete_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -826,7 +826,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Author)
 
         old_field = Author._meta.get_field("id")
-        new_field = IntegerField(primary_key=True)
+        new_field = AutoField(primary_key=True)
         new_field.set_attributes_from_name("id")
         new_field.model = Author
         with connection.schema_editor() as editor:
@@ -834,6 +834,7 @@ class SchemaTests(TransactionTestCase):
         # This will fail if DROP DEFAULT is inadvertently executed on this
         # field which drops the id sequence, at least on PostgreSQL.
         Author.objects.create(name='Foo')
+        Author.objects.create(name='Bar')
 
     def test_alter_int_pk_to_autofield_pk(self):
         """


### PR DESCRIPTION
AUTOINCREMENT is dropped converting an AutoField to IntegerField
which isn't the point of this test. MySQL would warn or error about
this.

https://code.djangoproject.com/ticket/26116