### PR TITLE
Fix capitalisation in admin index sidebar

### DIFF
--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -52,8 +52,8 @@
 {% block sidebar %}
 <div id="content-related">
     <div class="module" id="recent-actions-module">
-        <h2>{% trans 'Recent Actions' %}</h2>
-        <h3>{% trans 'My Actions' %}</h3>
+        <h2>{% trans 'Recent actions' %}</h2>
+        <h3>{% trans 'My actions' %}</h3>
             {% load log %}
             {% get_admin_log 10 as admin_log for_user user %}
             {% if not admin_log %}


### PR DESCRIPTION
I think `action` should not have a capitol A here. 

Did not make a Trac ticket, but I had some IRC discussion with @funkybob, @mjtamlyn replied some time later with: `17:29 <+mjtamlyn> It's arguably wrong so a fair comment`
