### PR TITLE
Fixed #26093 -- Allowed escape sequences extraction by gettext on Python 3

### DIFF
--- a/tests/i18n/commands/templates/test.html
+++ b/tests/i18n/commands/templates/test.html
@@ -98,3 +98,5 @@ First `trans`, then `blocktrans` with a plural
 {% plural %}
 Plural for a `trans` and `blocktrans` collision case
 {% endblocktrans %}
+
+{% trans "Non-breaking space :" %}

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -204,6 +204,14 @@ class BasicExtractorTests(ExtractorTests):
                 po_contents
             )
 
+    def test_special_char_extracted(self):
+        os.chdir(self.test_dir)
+        management.call_command('makemessages', locale=[LOCALE], verbosity=0)
+        self.assertTrue(os.path.exists(self.PO_FILE))
+        with open(self.PO_FILE, 'r') as fp:
+            po_contents = force_text(fp.read())
+            self.assertMsgId("Non-breaking space\xa0:", po_contents)
+
     def test_blocktrans_trimmed(self):
         os.chdir(self.test_dir)
         management.call_command('makemessages', locale=[LOCALE], verbosity=0)


### PR DESCRIPTION
Thanks Sylvain Fankhauser for the report.