### PR TITLE
[wip] Proposal to change ModelAdmin API

### DIFF
--- a/django/contrib/admin/__init__.py
+++ b/django/contrib/admin/__init__.py
@@ -9,6 +9,8 @@ from django.contrib.admin.filters import (
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.admin.options import (
     HORIZONTAL, VERTICAL, ModelAdmin, StackedInline, TabularInline,
+    DefaultAdminField, ChoicesAdminField, ForeignKeyAdminField,
+    ManyToManyAdminField
 )
 from django.contrib.admin.sites import AdminSite, site
 from django.utils.module_loading import autodiscover_modules

--- a/tests/admin_widgets/widgetadmin.py
+++ b/tests/admin_widgets/widgetadmin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.admin.options import ForeignKeyAdminField
 
 from . import models
 
@@ -12,12 +13,17 @@ class CarAdmin(admin.ModelAdmin):
     list_editable = ['owner']
 
 
+class CarForeignKeyAdminField(ForeignKeyAdminField):
+    def formfield(self, **kwargs):
+        queryset = models.Car.objects.filter(owner=self.request.user) if self.db_field.name == 'car' else None
+        return super(CarForeignKeyAdminField, self).formfield(queryset=queryset, **kwargs)
+
+
 class CarTireAdmin(admin.ModelAdmin):
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        if db_field.name == "car":
-            kwargs["queryset"] = models.Car.objects.filter(owner=request.user)
-            return db_field.formfield(**kwargs)
-        return super(CarTireAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+    def _admin_fields(self):
+        admin_fields = super(CarTireAdmin, self)._admin_fields()
+        admin_fields.update({'foreignkey': CarForeignKeyAdminField})
+        return admin_fields
 
 
 class EventAdmin(admin.ModelAdmin):


### PR DESCRIPTION
PR for review purposes.

Currently the BaseModelAdmin class has a method called formfield_for_dbfield which has a conditional block that in turn calls different formfield_for_* methods depending on the type of database field it is handling. In order to do any custom logic to these fields we need to override these methods and/or pass in some arguments as kwargs to override attributes of the form field.

In my opinion, a more natural way is to let different objects handle the customization, rather than BaseModelAdmin. I'm proposing AdminField classes with a consistent API that others can subclass from and swap with the defaults if they desire. 