### PR TITLE
Fixed typo errors

### DIFF
--- a/tests/file_uploads/tests.py
+++ b/tests/file_uploads/tests.py
@@ -112,7 +112,7 @@ class FileUploadTests(TestCase):
         tdir = sys_tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tdir, True)
 
-        # This file contains chinese symbols and an accented char in the name.
+        # This file contains Chinese symbols and an accented char in the name.
         with open(os.path.join(tdir, UNICODE_FILENAME), 'w+b') as file1:
             file1.write(b'b' * (2 ** 10))
             file1.seek(0)

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -94,7 +94,7 @@ class GISFunctionsTests(TestCase):
 
     @skipUnlessDBFeature("has_AsGML_function")
     def test_asgml(self):
-        # Should throw a TypeError when tyring to obtain GML from a
+        # Should throw a TypeError when trying to obtain GML from a
         # non-geometry field.
         qs = City.objects.all()
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Fixed typo errors in /django/tests/gis_tests/geoapp/test_functions.py and /django/tests/file_uploads/tests.py