### PR TITLE
Fixed #26097 -- Added password_validators_help_text_html to UserCreationForm for consistency with other django.contrib.auth forms.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -187,7 +187,7 @@ p.mini {
     margin-top: -3px;
 }
 
-.help, p.help, form p.help {
+.help, p.help, form p.help, div.help, form div.help {
     font-size: 11px;
     color: #999;
 }
@@ -409,6 +409,9 @@ input, textarea, select, .form-row p, form .button {
     font-family: "Roboto", "Lucida Grande", Verdana, Arial, sans-serif;
     font-weight: normal;
     font-size: 13px;
+}
+.form-row div.help {
+    padding: 2px 3px;
 }
 
 textarea {

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -180,7 +180,7 @@ fieldset .field-box {
     width: 200px;
 }
 
-form .wide p, form .wide input + p.help {
+form .wide p, form .wide input + p.help, form .wide ul {
     margin-left: 200px;
 }
 

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -83,7 +83,7 @@ form ul.inline li {
     height: 26px;
 }
 
-.aligned label + p {
+.aligned label + p, .aligned label + div.help {
     padding: 6px 0;
     margin-top: 0;
     margin-bottom: 0;
@@ -115,26 +115,32 @@ form .aligned ul.radiolist {
     padding: 0;
 }
 
-form .aligned p.help {
+form .aligned p.help,
+form .aligned div.help {
     clear: left;
     margin-top: 0;
     margin-left: 160px;
     padding-left: 10px;
 }
 
-form .aligned label + p.help {
+form .aligned label + p.help,
+form .aligned label + div.help {
     margin-left: 0;
     padding-left: 0;
 }
 
-form .aligned p.help:last-child {
+form .aligned p.help:last-child,
+form .aligned div.help:last-child {
     margin-bottom: 0;
     padding-bottom: 0;
 }
 
 form .aligned input + p.help,
 form .aligned textarea + p.help,
-form .aligned select + p.help {
+form .aligned select + p.help,
+form .aligned input + div.help,
+form .aligned textarea + div.help,
+form .aligned select + div.help {
     margin-left: 160px;
     padding-left: 10px;
 }
@@ -156,7 +162,8 @@ form .aligned table p {
     padding: 0 0 5px 5px;
 }
 
-.aligned .vCheckboxLabel + p.help {
+.aligned .vCheckboxLabel + p.help,
+.aligned .vCheckboxLabel + div.help {
     margin-top: -4px;
 }
 
@@ -164,7 +171,8 @@ form .aligned table p {
     width: 610px;
 }
 
-.checkbox-row p.help {
+.checkbox-row p.help,
+.checkbox-row div.help {
     margin-left: 0;
     padding-left: 0;
 }
@@ -180,12 +188,20 @@ fieldset .field-box {
     width: 200px;
 }
 
-form .wide p, form .wide input + p.help, form .wide ul {
+form .wide p, form .wide ul,
+form .wide input + p.help,
+form .wide input + div.help {
     margin-left: 200px;
 }
 
-form .wide p.help {
+form .wide p.help,
+form .wide div.help {
     padding-left: 38px;
+}
+
+form div.help ul {
+    padding-left: 0;
+    margin-left: 0;
 }
 
 .colM fieldset.wide .vLargeTextField, .colM fieldset.wide .vXMLLargeTextField {

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -36,7 +36,7 @@
   {{ form.password1.errors }}
   {{ form.password1.label_tag }} {{ form.password1 }}
   {% if form.password1.help_text %}
-  <p class="help">{{ form.password1.help_text|safe }}</p>
+  <div class="help">{{ form.password1.help_text|safe }}</div>
   {% endif %}
 </div>
 
@@ -44,7 +44,7 @@
   {{ form.password2.errors }}
   {{ form.password2.label_tag }} {{ form.password2 }}
   {% if form.password2.help_text %}
-  <p class="help">{{ form.password2.help_text|safe }}</p>
+  <div class="help">{{ form.password2.help_text|safe }}</div>
   {% endif %}
 </div>
 

--- a/django/contrib/admin/templates/admin/includes/fieldset.html
+++ b/django/contrib/admin/templates/admin/includes/fieldset.html
@@ -20,7 +20,7 @@
                         {% endif %}
                     {% endif %}
                     {% if field.field.help_text %}
-                        <p class="help">{{ field.field.help_text|safe }}</p>
+                        <div class="help">{{ field.field.help_text|safe }}</div>
                     {% endif %}
                 </div>
             {% endfor %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -36,7 +36,7 @@
     {{ form.new_password1.errors }}
     {{ form.new_password1.label_tag }} {{ form.new_password1 }}
     {% if form.new_password1.help_text %}
-    <p class="help">{{ form.new_password1.help_text|safe }}</p>
+    <div class="help">{{ form.new_password1.help_text|safe }}</div>
     {% endif %}
 </div>
 
@@ -44,7 +44,7 @@
 {{ form.new_password2.errors }}
     {{ form.new_password2.label_tag }} {{ form.new_password2 }}
     {% if form.new_password2.help_text %}
-    <p class="help">{{ form.new_password2.help_text|safe }}</p>
+    <div class="help">{{ form.new_password2.help_text|safe }}</div>
     {% endif %}
 </div>
 

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -72,6 +72,7 @@ class UserCreationForm(forms.ModelForm):
         label=_("Password"),
         strip=False,
         widget=forms.PasswordInput,
+        help_text=password_validation.password_validators_help_text_html(),
     )
     password2 = forms.CharField(
         label=_("Password confirmation"),

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -734,6 +734,9 @@ Miscellaneous
   model, you must convert them to attributes or properties as described in
   :ref:`the deprecation note <user-is-auth-anon-deprecation>`.
 
+* In the admin templates, ``<p class="help">`` was replaced with a div tag to
+  allow including lists inside help messages
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -148,7 +148,7 @@ class TestInline(TestDataMixin, TestCase):
         Ref #8190.
         """
         response = self.client.get(reverse('admin:admin_inlines_holder4_add'))
-        self.assertContains(response, '<p class="help">Awesome stacked help text is awesome.</p>', 4)
+        self.assertContains(response, '<div class="help">Awesome stacked help text is awesome.</div>', 4)
         self.assertContains(
             response,
             '<img src="/static/admin/img/icon-unknown.svg" '

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4543,20 +4543,20 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         self.assertContains(response, '<div class="form-row field-posted">')
         self.assertContains(response, '<div class="form-row field-value">')
         self.assertContains(response, '<div class="form-row">')
-        self.assertContains(response, '<p class="help">', 3)
+        self.assertContains(response, '<div class="help">', 3)
         self.assertContains(
             response,
-            '<p class="help">Some help text for the title (with unicode ŠĐĆŽćžšđ)</p>',
+            '<div class="help">Some help text for the title (with unicode ŠĐĆŽćžšđ)</div>',
             html=True
         )
         self.assertContains(
             response,
-            '<p class="help">Some help text for the content (with unicode ŠĐĆŽćžšđ)</p>',
+            '<div class="help">Some help text for the content (with unicode ŠĐĆŽćžšđ)</div>',
             html=True
         )
         self.assertContains(
             response,
-            '<p class="help">Some help text for the date (with unicode ŠĐĆŽćžšđ)</p>',
+            '<div class="help">Some help text for the date (with unicode ŠĐĆŽćžšđ)</div>',
             html=True
         )
 
@@ -4659,7 +4659,7 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         """
         p = FieldOverridePost.objects.create(title="Test Post", content="Test Content")
         response = self.client.get(reverse('admin:admin_views_fieldoverridepost_change', args=(p.pk,)))
-        self.assertContains(response, '<p class="help">Overridden help text for the date</p>')
+        self.assertContains(response, '<div class="help">Overridden help text for the date</div>')
         self.assertContains(response, '<label for="id_public">Overridden public label:</label>', html=True)
         self.assertNotContains(response, "Some help text for the date (with unicode ŠĐĆŽćžšđ)")
 


### PR DESCRIPTION
Ticket - https://code.djangoproject.com/ticket/26097