### PR TITLE
Fixed #26117 -- Consulted database routers in initial migration detection.

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.apps.registry import apps as global_apps
-from django.db import migrations
+from django.db import migrations, router
 
 from .exceptions import InvalidMigrationPlan
 from .loader import MigrationLoader
@@ -274,7 +274,9 @@ class MigrationExecutor(object):
                     # We have to fetch the model to test with from the
                     # main app cache, as it's not a direct dependency.
                     model = global_apps.get_model(model._meta.swapped)
-                if model._meta.proxy or not model._meta.managed:
+                if model._meta.proxy or not model._meta.managed or not \
+                    router.allow_migrate(self.connection.alias, migration.app_label,
+                                         model_name=model._meta.model_name):
                     continue
                 if model._meta.db_table not in existing_table_names:
                     return False, project_state
@@ -285,7 +287,9 @@ class MigrationExecutor(object):
                     # We have to fetch the model to test with from the
                     # main app cache, as it's not a direct dependency.
                     model = global_apps.get_model(model._meta.swapped)
-                if model._meta.proxy or not model._meta.managed:
+                if model._meta.proxy or not model._meta.managed or not \
+                    router.allow_migrate(self.connection.alias, migration.app_label,
+                                         model_name=model._meta.model_name):
                     continue
 
                 table = model._meta.db_table

--- a/tests/migrations/models.py
+++ b/tests/migrations/models.py
@@ -72,3 +72,11 @@ class FoodManager(BaseFoodManager.from_queryset(FoodQuerySet)):
 
 class NoMigrationFoodManager(BaseFoodManager.from_queryset(FoodQuerySet)):
     pass
+
+
+class ExoPlanet(models.Model):
+    name = models.CharField(max_length=255)
+    inhabitable = models.BooleanField(default=False)
+
+    class Meta:
+        app_label = 'exoplanets'

--- a/tests/migrations/routers.py
+++ b/tests/migrations/routers.py
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+
+from .models import ExoPlanet
+
+
+class TestRouter(object):
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Make sure the exoplanets app only appears on the 'other' db, and is the only one to appear there.
+        """
+        if model_name == ExoPlanet._meta.model_name:
+            return db == 'other'
+        elif db == 'other':
+            return False
+        return None

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from importlib import import_module
 
 from django.apps import apps
-from django.db import connection
+from django.db import connections
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TransactionTestCase
 from django.test.utils import extend_sys_path
@@ -21,40 +21,43 @@ class MigrationTestBase(TransactionTestCase):
 
     def tearDown(self):
         # Reset applied-migrations state.
-        recorder = MigrationRecorder(connection)
-        recorder.migration_qs.filter(app='migrations').delete()
+        for db in connections:
+            recorder = MigrationRecorder(connections[db])
+            recorder.migration_qs.filter(app='migrations').delete()
 
-    def get_table_description(self, table):
-        with connection.cursor() as cursor:
-            return connection.introspection.get_table_description(cursor, table)
+    def get_table_description(self, table, using='default'):
+        with connections[using].cursor() as cursor:
+            return connections[using].introspection.get_table_description(cursor, table)
 
-    def assertTableExists(self, table):
-        with connection.cursor() as cursor:
-            self.assertIn(table, connection.introspection.table_names(cursor))
+    def assertTableExists(self, table, using='default'):
+        with connections[using].cursor() as cursor:
+            self.assertIn(table, connections[using].introspection.table_names(cursor))
 
-    def assertTableNotExists(self, table):
-        with connection.cursor() as cursor:
-            self.assertNotIn(table, connection.introspection.table_names(cursor))
+    def assertTableNotExists(self, table, using='default'):
+        with connections[using].cursor() as cursor:
+            self.assertNotIn(table, connections[using].introspection.table_names(cursor))
 
-    def assertColumnExists(self, table, column):
-        self.assertIn(column, [c.name for c in self.get_table_description(table)])
+    def assertColumnExists(self, table, column, using='default'):
+        self.assertIn(column, [c.name for c in self.get_table_description(table, using=using)])
 
-    def assertColumnNotExists(self, table, column):
-        self.assertNotIn(column, [c.name for c in self.get_table_description(table)])
+    def assertColumnNotExists(self, table, column, using='default'):
+        self.assertNotIn(column, [c.name for c in self.get_table_description(table, using=using)])
 
-    def assertColumnNull(self, table, column):
-        self.assertEqual([c.null_ok for c in self.get_table_description(table) if c.name == column][0], True)
+    def assertColumnNull(self, table, column, using='default'):
+        self.assertEqual([c.null_ok for c in self.get_table_description(table, using=using) if
+                          c.name == column][0], True)
 
-    def assertColumnNotNull(self, table, column):
-        self.assertEqual([c.null_ok for c in self.get_table_description(table) if c.name == column][0], False)
+    def assertColumnNotNull(self, table, column, using='default'):
+        self.assertEqual([c.null_ok for c in self.get_table_description(table, using=using) if
+                          c.name == column][0], False)
 
-    def assertIndexExists(self, table, columns, value=True):
-        with connection.cursor() as cursor:
+    def assertIndexExists(self, table, columns, value=True, using='default'):
+        with connections[using].cursor() as cursor:
             self.assertEqual(
                 value,
                 any(
                     c["index"]
-                    for c in connection.introspection.get_constraints(cursor, table).values()
+                    for c in connections[using].introspection.get_constraints(cursor, table).values()
                     if c['columns'] == list(columns)
                 ),
             )
@@ -62,13 +65,13 @@ class MigrationTestBase(TransactionTestCase):
     def assertIndexNotExists(self, table, columns):
         return self.assertIndexExists(table, columns, False)
 
-    def assertFKExists(self, table, columns, to, value=True):
-        with connection.cursor() as cursor:
+    def assertFKExists(self, table, columns, to, value=True, using='default'):
+        with connections[using].cursor() as cursor:
             self.assertEqual(
                 value,
                 any(
                     c["foreign_key"] == to
-                    for c in connection.introspection.get_constraints(cursor, table).values()
+                    for c in connections[using].introspection.get_constraints(cursor, table).values()
                     if c['columns'] == list(columns)
                 ),
             )

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -7,7 +7,7 @@ import os
 
 from django.apps import apps
 from django.core.management import CommandError, call_command
-from django.db import DatabaseError, connection, models
+from django.db import DatabaseError, connection, connections, models
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import ignore_warnings, mock, override_settings
 from django.utils import six
@@ -22,6 +22,7 @@ class MigrateTests(MigrationTestBase):
     """
     Tests running the migrate command.
     """
+    multi_db = True
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
     def test_migrate(self):
@@ -75,20 +76,31 @@ class MigrateTests(MigrationTestBase):
         self.assertTableNotExists("migrations_tribble")
         self.assertTableNotExists("migrations_book")
 
-    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"},
+                       DATABASE_ROUTERS=['migrations.routers.TestRouter'])
     def test_migrate_fake_initial(self):
         """
         #24184 - Tests that --fake-initial only works if all tables created in
         the initial migration of an app exists
+        #26117 - and that database routers are obeyed when doing that check
         """
         # Make sure no tables are created
-        self.assertTableNotExists("migrations_author")
-        self.assertTableNotExists("migrations_tribble")
+        for db in connections:
+            self.assertTableNotExists("migrations_author", using=db)
+            self.assertTableNotExists("migrations_tribble", using=db)
+            self.assertTableNotExists("migrations_exoplanet", using=db)
         # Run the migrations to 0001 only
         call_command("migrate", "migrations", "0001", verbosity=0)
+        call_command("migrate", "migrations", "0001", verbosity=0, database="other")
         # Make sure the right tables exist
         self.assertTableExists("migrations_author")
         self.assertTableExists("migrations_tribble")
+        self.assertTableNotExists("migrations_exoplanet")
+        # Also check the "other" database
+        self.assertTableNotExists("migrations_author", using='other')
+        self.assertTableNotExists("migrations_tribble", using='other')
+        self.assertTableExists("migrations_exoplanet", using='other')
+
         # Fake a roll-back
         call_command("migrate", "migrations", "zero", fake=True, verbosity=0)
         # Make sure the tables still exist
@@ -107,16 +119,24 @@ class MigrateTests(MigrationTestBase):
         )
         # Run migrations all the way
         call_command("migrate", verbosity=0)
+        call_command("migrate", verbosity=0, database="other")
         # Make sure the right tables exist
         self.assertTableExists("migrations_author")
         self.assertTableNotExists("migrations_tribble")
         self.assertTableExists("migrations_book")
+        self.assertTableNotExists("migrations_exoplanet")
+        self.assertTableNotExists("migrations_author", using="other")
+        self.assertTableNotExists("migrations_tribble", using="other")
+        self.assertTableNotExists("migrations_book", using="other")
+        self.assertTableExists("migrations_exoplanet", using="other")
         # Fake a roll-back
         call_command("migrate", "migrations", "zero", fake=True, verbosity=0)
+        call_command("migrate", "migrations", "zero", fake=True, verbosity=0, database="other")
         # Make sure the tables still exist
         self.assertTableExists("migrations_author")
         self.assertTableNotExists("migrations_tribble")
         self.assertTableExists("migrations_book")
+        self.assertTableExists("migrations_exoplanet", using="other")
         # Try to run initial migration
         with self.assertRaises(DatabaseError):
             call_command("migrate", "migrations", verbosity=0)
@@ -127,12 +147,16 @@ class MigrateTests(MigrationTestBase):
             call_command("migrate", "migrations", fake_initial=True, verbosity=0)
         # Fake a apply
         call_command("migrate", "migrations", fake=True, verbosity=0)
+        call_command("migrate", "migrations", fake=True, verbosity=0, database="other")
         # Unmigrate everything
         call_command("migrate", "migrations", "zero", verbosity=0)
+        call_command("migrate", "migrations", "zero", verbosity=0, database="other")
         # Make sure it's all gone
-        self.assertTableNotExists("migrations_author")
-        self.assertTableNotExists("migrations_tribble")
-        self.assertTableNotExists("migrations_book")
+        for db in connections:
+            self.assertTableNotExists("migrations_author", using=db)
+            self.assertTableNotExists("migrations_tribble", using=db)
+            self.assertTableNotExists("migrations_book", using=db)
+            self.assertTableNotExists("migrations_exoplanet", using=db)
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_fake_split_initial"})
     def test_migrate_fake_split_initial(self):
@@ -1053,7 +1077,7 @@ class SquashMigrationsTests(MigrationTestBase):
         out = six.StringIO()
         with self.temporary_migration_module(module="migrations.test_migrations"):
             call_command("squashmigrations", "migrations", "0002", interactive=False, verbosity=1, stdout=out)
-        self.assertIn("Optimized from 7 operations to 3 operations.", force_text(out.getvalue()))
+        self.assertIn("Optimized from 9 operations to 4 operations.", force_text(out.getvalue()))
 
     def test_ticket_23799_squashmigrations_no_optimize(self):
         """

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -66,7 +66,7 @@ class LoaderTests(TestCase):
         )
         # Now render it out!
         project_state = migration_loader.project_state(("migrations", "0002_second"))
-        self.assertEqual(len(project_state.models), 2)
+        self.assertEqual(len(project_state.models), 3)
 
         author_state = project_state.models["migrations", "author"]
         self.assertEqual(

--- a/tests/migrations/test_migrations/0001_initial.py
+++ b/tests/migrations/test_migrations/0001_initial.py
@@ -29,6 +29,21 @@ class Migration(migrations.Migration):
             ],
         ),
 
+        migrations.CreateModel(
+            "ExoPlanet",
+            [
+                ("id", models.AutoField(primary_key=True)),
+                ("name", models.CharField(max_length=255)),
+                ("inhabitable", models.BooleanField(default=False)),
+            ],
+        ),
+
+        migrations.AddField(
+            model_name='exoplanet',
+            name='colonized',
+            field=models.BooleanField(default=False),
+        ),
+
         migrations.AlterUniqueTogether(
             name='author',
             unique_together=set([('name', 'slug')]),


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/26117#ticket

The bug is that db.migrations.executor.py is always checking the default db when deciding if all tables existed in the initial migration. However, some of those models might not exist in that db if you've got a multi-db environment. This pull request updates the method to include a call to routers.py's `allow_migrate()` when checking migration for the model. Tests are included that fail without this fix and pass with it. 