### PR TITLE
Fixed #26134 -- Updated MySQL GIS function names to OpenGIS standard

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -244,7 +244,7 @@ answer newbie questions, and generally made Django that much better:
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
     Frank Tegtmeyer <fte@fte.to>
     Frank Wierzbicki
-    Frantisek Malina <vizualbod@vizualbod.com>
+    František Malina <fmalina@gmail.com>
     Fraser Nevett <mail@nevett.org>
     Gabriel Grant <g@briel.ca>
     Gabriel Hurley <gabriel@strikeawe.com>

--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -11,9 +11,9 @@ class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
 
     mysql = True
     name = 'mysql'
-    select = 'AsText(%s)'
-    from_wkb = 'GeomFromWKB'
-    from_text = 'GeomFromText'
+    select = 'ST_AsText(%s)'
+    from_wkb = 'ST_GeomFromWKB'
+    from_text = 'ST_GeomFromText'
 
     Adapter = WKTAdapter
 
@@ -36,7 +36,7 @@ class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
         'Difference': 'ST_Difference',
         'Distance': 'ST_Distance',
         'Intersection': 'ST_Intersection',
-        'Length': 'GLength',
+        'Length': 'ST_Length',
         'SymDifference': 'ST_SymDifference',
         'Union': 'ST_Union',
     }


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26134

Fix deprecation warnings such as:
    .../django/db/backends/mysql/base.py:112:
    Warning: 'GEOMFROMTEXT' is deprecated and will be removed in a future release.
    Please use ST_GEOMFROMTEXT instead

