### PR TITLE
SelectFilter2: remove inaccurate comment

### DIFF
--- a/django/contrib/admin/static/admin/js/SelectFilter2.js
+++ b/django/contrib/admin/static/admin/js/SelectFilter2.js
@@ -2,7 +2,7 @@
 /*
 SelectFilter2 - Turns a multiple-select box into a filter interface.
 
-Requires core.js, SelectBox.js and addevent.js.
+Requires core.js and SelectBox.js.
 */
 (function($) {
     'use strict';


### PR DESCRIPTION
There is no addevent.js file in the django repository, so SelectFilter2
doesn't depend on it.