### PR TITLE
Fixed #26138 -- Ensured geometry_field's geometry is always serialized

### DIFF
--- a/django/contrib/gis/serializers/geojson.py
+++ b/django/contrib/gis/serializers/geojson.py
@@ -18,6 +18,9 @@ class Serializer(JSONSerializer):
         super(Serializer, self)._init_options()
         self.geometry_field = self.json_kwargs.pop('geometry_field', None)
         self.srid = self.json_kwargs.pop('srid', 4326)
+        if (self.selected_fields is not None and self.geometry_field is not None
+                and self.geometry_field not in self.selected_fields):
+            self.selected_fields = list(self.selected_fields) + [self.geometry_field]
 
     def start_serialization(self):
         self._init_options()

--- a/docs/releases/1.9.2.txt
+++ b/docs/releases/1.9.2.txt
@@ -85,3 +85,6 @@ Bugfixes
 
 * Fixed a regression in Django 1.8.5 that broke copying a ``SimpleLazyObject``
   with ``copy.copy()`` (:ticket:`26122`).
+
+* Always included ``geometry_field`` in the GeoJSON serializer output regardless
+  of the ``fields`` parameter (:ticket:`26138`).

--- a/tests/gis_tests/geoapp/test_serializers.py
+++ b/tests/gis_tests/geoapp/test_serializers.py
@@ -47,8 +47,21 @@ class GeoJSONSerializerTests(TestCase):
         geodata = json.loads(geojson)
         self.assertEqual(geodata['features'][0]['geometry']['type'], 'Point')
 
-        geojson = serializers.serialize('geojson', MultiFields.objects.all(),
-            geometry_field='poly')
+        geojson = serializers.serialize(
+            'geojson',
+            MultiFields.objects.all(),
+            geometry_field='poly'
+        )
+        geodata = json.loads(geojson)
+        self.assertEqual(geodata['features'][0]['geometry']['type'], 'Polygon')
+
+        # geometry_field is considered even if not in fields (#26138).
+        geojson = serializers.serialize(
+            'geojson',
+            MultiFields.objects.all(),
+            geometry_field='poly',
+            fields=('city',)
+        )
         geodata = json.loads(geojson)
         self.assertEqual(geodata['features'][0]['geometry']['type'], 'Polygon')
 


### PR DESCRIPTION
Thanks Bernd Schlapsi for the report.