### PR TITLE
Fixed #24782 -- Added assertFormValid and assertFormNotValid methods

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -784,6 +784,48 @@ class SimpleTestCase(unittest.TestCase):
                 standardMsg = '%s == %s' % (safe_repr(xml1, True), safe_repr(xml2, True))
                 self.fail(self._formatMessage(msg, standardMsg))
 
+    def assertFormValid(self, form, msg=None):
+        """
+        Asserts that a form is valid
+        """
+        if not form.is_valid():
+            standardMsg = "Form validation failed. Error(s):\n"
+            for field, field_errors in form.errors.items():
+                standardMsg += "- %s:\n" % field
+                for error in field_errors:
+                    standardMsg += "    - %s\n" % error
+            self.fail(self._formatMessage(msg, standardMsg))
+
+    def assertFormNotValid(self, form, expected_errors=None,
+                           allow_other_errors=True, msg=None):
+        """
+        Asserts that a form is not valid
+        """
+        to_report = ""
+        if form.is_valid():
+            to_report = "Form is valid\n"
+        else:
+            for error in expected_errors:
+                # if test passes additional expected errors which are not
+                # found, fail the test
+                if not form.has_error(*error):
+                    to_report = "'{0}' expected error not found.\n".format(error[0])
+
+        if not to_report:
+            other_errors = [
+                verr for verr in form.errors.keys() if (
+                    verr not in [err[0] for err in expected_errors])]
+            if not allow_other_errors and other_errors:
+                to_report = 'Other errors reported:'
+                for error in other_errors:
+                    to_report += '\n- %s' % error
+                    for err_msg in form.errors[error]:
+                        to_report += "\n    - %s\n" % err_msg
+
+        if to_report:
+            self.fail(self._formatMessage(
+                msg, 'FormNotValid failed. Error(s):\n- %s' % to_report))
+
 
 class TransactionTestCase(SimpleTestCase):
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -301,7 +301,8 @@ Templates
 Tests
 ~~~~~
 
-* ...
+* Added methods :meth:`~django.test.SimpleTestCase.assertFormValid` and
+  :meth:`~django.test.SimpleTestCase.assertFormNotValid`.
 
 URLs
 ~~~~

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1552,6 +1552,29 @@ your test suite.
 
     Output in case of error can be customized with the ``msg`` argument.
 
+.. method:: SimpleTestCase.assertFormValid(form, msg=None)
+
+    .. versionadded:: 1.10
+
+    Asserts that a form is valid. If form is not valid, displays clean output
+    with form errors.
+
+    ``form`` is the form to be validated.
+
+.. method:: SimpleTestCase.assertFormNotValid(form, expected_errors=None, msg=None)
+
+    .. versionadded:: 1.10
+
+   Asserts that a form is not valid and that errors are ``expected_errors``.
+
+   ``form`` is the form to be validated.
+
+   ``expected_errors`` is a list of (field, code) errors that are expected on
+   the form.
+
+   ``allow_other_errors`` is a boolean that when set (by default) allows other
+   errors not within ``expected_errors`` to be raised by the form.
+
 .. method:: SimpleTestCase.assertInHTML(needle, haystack, count=None, msg_prefix='')
 
     Asserts that the HTML fragment ``needle`` is contained in the ``haystack`` one.

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -9,7 +9,7 @@ from django.contrib.staticfiles.finders import get_finder, get_finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.storage import default_storage
 from django.db import connection, models, router
-from django.forms import EmailField, IntegerField
+from django.forms import CharField, EmailField, Form, IntegerField
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.test import (
@@ -840,6 +840,98 @@ class AssertFieldOutputTests(SimpleTestCase):
                 'required': 'This is really required.',
             }
         self.assertFieldOutput(MyCustomField, {}, {}, empty_value=None)
+
+
+class AssertFormValidTests(SimpleTestCase):
+    class TestForm(Form):
+        name = CharField(label='Name', max_length=4)
+        age = IntegerField(label='Age')
+
+    def test_with_valid_form(self):
+        form = self.TestForm(data={
+            'name': 'John',
+            'age': 7,
+        })
+        self.assertFormValid(form)
+
+    def test_error_message_with_invalid_form(self):
+        form = self.TestForm(data={
+            'name': 'John',
+            'age': None,
+        })
+
+        expected_message = (
+            'Form validation failed. Error(s):\n'
+            '- age:\n'
+            '    - This field is required.\n')
+        with self.assertRaisesMessage(AssertionError, expected_message):
+            self.assertFormValid(form)
+
+
+class AssertFormNotValidTests(SimpleTestCase):
+    class TestForm(Form):
+        name = CharField(label='Name', max_length=4)
+        age = IntegerField(label='Age')
+
+    def test_with_valid_form(self):
+        form = self.TestForm(data={
+            'name': 'John',
+            'age': 7,
+        })
+        expected_message = (
+            'FormNotValid failed. Error(s):\n'
+            '- Form is valid\n')
+        with self.assertRaisesMessage(AssertionError, expected_message):
+            self.assertFormNotValid(form)
+
+    def test_with_invalid_form_with_redundant_expected_errors(self):
+        form = self.TestForm(data={
+            'name': 'John',
+            'age': None,
+        })
+        expected_message = (
+            'FormNotValid failed. Error(s):\n'
+            '- \'name\' expected error not found.\n')
+        with self.assertRaisesMessage(AssertionError, expected_message):
+            self.assertFormNotValid(
+                form,
+                expected_errors=[
+                    ('age', 'required'),
+                    ('name', 'max_length')])
+
+    def test_with_invalid_form_with_expected_errors_allow_other_errors(self):
+        form = self.TestForm(data={
+            'name': 'John',
+            'age': None,
+        })
+        self.assertFormNotValid(
+            form,
+            expected_errors=[('age', 'required'), ])
+
+    def test_with_invalid_form_with_unexpected_errors_allow_other_errors(self):
+        form = self.TestForm(data={
+            'name': 'Johnny',
+            'age': None,
+        })
+        self.assertFormNotValid(
+            form,
+            expected_errors=[('age', 'required'), ])
+
+    def test_with_invalid_form_with_unexpected_errors_disallow_other_errors(self):
+        form = self.TestForm(data={
+            'name': 'Johnny',
+            'age': None,
+        })
+        expected_message = (
+            'FormNotValid failed. Error(s):\n'
+            '- Other errors reported:\n'
+            '- name\n'
+            '    - Ensure this value has at most 4 characters (it has 6).\n')
+        with self.assertRaisesMessage(AssertionError, expected_message):
+            self.assertFormNotValid(
+                form,
+                expected_errors=[('age', 'required'), ],
+                allow_other_errors=False)
 
 
 class FirstUrls:


### PR DESCRIPTION
Adds two functions under `django.test.testcases.SimpleTestCase` as instructed in this #4645 that has so far been closed:
* `assertFormValid`
* `assertFormNotValid`

The two functions are inspired by [this comment](https://github.com/django/django/pull/4645#issuecomment-107254019) by @mjtamlyn .

Unit tests have also been added for each function covering the possible use cases.

Since this is my first PR to an open-source project *ever* I'm appreciative of feedback you will (should) have.

P.S. This PR has started off by applying user `delgiudices` work (1st commit).
Commits are however squashed.