### PR TITLE
Fixed #24974 -- Fixed inheritance from modelform_factory forms

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -203,7 +203,13 @@ class ModelFormOptions(object):
 
 class ModelFormMetaclass(DeclarativeFieldsMetaclass):
     def __new__(mcs, name, bases, attrs):
-        formfield_callback = attrs.pop('formfield_callback', None)
+        base_formfield_callback = None
+        for b in bases:
+            if hasattr(b, 'Meta') and hasattr(b.Meta, 'formfield_callback'):
+                base_formfield_callback = b.Meta.formfield_callback
+                break
+
+        formfield_callback = attrs.pop('formfield_callback', base_formfield_callback)
 
         new_class = super(ModelFormMetaclass, mcs).__new__(mcs, name, bases, attrs)
 
@@ -524,7 +530,8 @@ def modelform_factory(model, form=ModelForm, fields=None, exclude=None,
     if hasattr(form, 'Meta'):
         parent = (form.Meta, object)
     Meta = type(str('Meta'), parent, attrs)
-
+    if formfield_callback:
+        Meta.formfield_callback = staticmethod(formfield_callback)
     # Give this new form class a reasonable name.
     class_name = model.__name__ + str('Form')
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2685,6 +2685,28 @@ class FormFieldCallbackTests(SimpleTestCase):
         self.assertRaises(TypeError, modelform_factory, Person, fields="__all__",
                           formfield_callback='not a function or callable')
 
+    def test_inherit_after_custom_callback(self):
+        def callback(db_field, **kwargs):
+            if isinstance(db_field, models.CharField):
+                return forms.CharField(widget=forms.Textarea)
+            return db_field.formfield(**kwargs)
+
+        class BaseForm(forms.ModelForm):
+            class Meta:
+                model = Person
+                fields = "__all__"
+
+        NewForm = modelform_factory(Person, form=BaseForm, formfield_callback=callback)
+
+        class InheritedForm(NewForm):
+            pass
+
+        for name in NewForm.base_fields.keys():
+            self.assertEqual(
+                type(InheritedForm.base_fields[name].widget),
+                type(NewForm.base_fields[name].widget)
+            )
+
 
 class LocalizedModelFormTest(TestCase):
     def test_model_form_applies_localize_to_some_fields(self):


### PR DESCRIPTION
When a form created using modelform_factory is inherited, the
initialization of the subclass will be different from the base class.

Consider the case when formfield_callback is passed to modelform_factory.
The formfield_callback information is lost after initialization of the
base class.

This commit throws the formfield_callback into the Meta
class of the base class, so that the subclass can use it instead
of the default.