### PR TITLE
[WIP #26142] Check FormSet has as many bound forms as initial forms

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -425,8 +425,8 @@ class BaseFormSet(object):
 
 
 def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
-                    can_delete=False, max_num=None, validate_max=False,
-                    min_num=None, validate_min=False):
+                    can_delete=False, can_create=True, max_num=None,
+                    validate_max=False, min_num=None, validate_min=False):
     """Return a FormSet for the given form class."""
     if min_num is None:
         min_num = DEFAULT_MIN_NUM
@@ -438,6 +438,7 @@ def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,
     absolute_max = max_num + DEFAULT_MAX_NUM
     attrs = {'form': form, 'extra': extra,
              'can_order': can_order, 'can_delete': can_delete,
+             'can_create': can_create,
              'min_num': min_num, 'max_num': max_num,
              'absolute_max': absolute_max, 'validate_min': validate_min,
              'validate_max': validate_max}

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -65,6 +65,11 @@ class BaseFormSet(object):
         self.error_class = error_class
         self._errors = None
         self._non_form_errors = None
+        if not self.can_create:
+            self.max_num = len(self.initial) if self.initial else 0
+            self.min_num = self.max_num
+            self.validate_min = self.validate_max = True
+            self.extra = 0
 
     def __str__(self):
         return self.as_table()

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1121,6 +1121,24 @@ class FormsFormsetTestCase(SimpleTestCase):
         finally:
             formsets.DEFAULT_MAX_NUM = _old_DEFAULT_MAX_NUM
 
+    def test_can_create_false(self):
+        """A formset can disallow the addition of extra forms."""
+        ChoiceFormSet = formset_factory(Choice, can_create=False)
+        initial = [{'choice': 'Calexico', 'votes': 100}]
+        formset = ChoiceFormSet(
+            {
+                'choices-TOTAL_FORMS': '2',
+                'choices-INITIAL_FORMS': '2',
+                'choices-0-choice': 'Calexico',
+                'choices-0-votes': '100',
+                'choices-1-choice': 'Calexico',
+                'choices-1-votes': '200',
+            },
+            prefix='choices',
+            initial=initial,
+        )
+        self.assertFalse(formset.is_valid())
+
     def test_increase_hard_limit(self):
         """Can increase the built-in forms limit via a higher max_num."""
         # reduce the default limit of 1000 temporarily for testing


### PR DESCRIPTION
For https://code.djangoproject.com/ticket/26142, here's an initial attempt at supporting `can_create=False` on Formsets by validating that the number of submitted forms matches the number of initial forms.