### PR TITLE
Fixed #7923 -- Added links to objects displayed by ModelAdmin.raw_id_fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -288,6 +288,7 @@ answer newbie questions, and generally made Django that much better:
     Hiroki Kiyohara <hirokiky@gmail.com>
     Honza Král <honza.kral@gmail.com>
     Horst Gutmann <zerok@zerokspot.com>
+    Hugo Osvaldo Barrera <hugo@barrera.io>
     Hyun Mi Ae
     Iacopo Spalletti <i.spalletti@nephila.it>
     Ian A Wilson <http://ianawilson.com>

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -11,11 +11,10 @@ from django.forms.utils import flatatt
 from django.forms.widgets import RadioFieldRenderer
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 from django.utils import six
 from django.utils.encoding import force_text
-from django.utils.html import (
-    escape, format_html, format_html_join, smart_urlquote,
-)
+from django.utils.html import format_html, format_html_join, smart_urlquote
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
 from django.utils.translation import ugettext as _
@@ -194,9 +193,26 @@ class ForeignKeyRawIdWidget(forms.TextInput):
         key = self.rel.get_related_field().name
         try:
             obj = self.rel.model._default_manager.using(self.db).get(**{key: value})
-            return '&nbsp;<strong>%s</strong>' % escape(Truncator(obj).words(14, truncate='...'))
         except (ValueError, self.rel.model.DoesNotExist):
             return ''
+
+        label = "&nbsp;<strong>{}</strong>"
+        text = Truncator(obj).words(14, truncate='...')
+        try:
+            change_url = reverse(
+                '%s:%s_%s_change' % (
+                    self.admin_site.name,
+                    obj._meta.app_label,
+                    obj._meta.object_name.lower(),
+                ),
+                args=(obj.pk,)
+            )
+        except NoReverseMatch:
+            pass  # Admin not registered for target model:
+        else:
+            text = format_html('<a href="{}">{}</a>', change_url, text)
+
+        return format_html(label, text)
 
 
 class ManyToManyRawIdWidget(ForeignKeyRawIdWidget):

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -56,6 +56,9 @@ Minor features
   using the current active language. A new ``LogEntry.get_change_message()``
   method is now the preferred way of retrieving the change message.
 
+* Fields rendered with ``ModelAdmin.raw_id_fields`` will now have a link to the
+  target object's change form.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -480,8 +480,9 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             '<input type="text" name="test" value="%(bandpk)s" '
             'class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/band/?_to_field=id" class="related-lookup" '
-            'id="lookup_id_test" title="Lookup"></a>&nbsp;<strong>Linkin Park</strong>'
-            % {'bandpk': band.pk}
+            'id="lookup_id_test" title="Lookup"></a>&nbsp;<strong>'
+            '<a href="/admin_widgets/band/%(bandpk)s/change/">Linkin Park</a>'
+            '</strong>' % {'bandpk': band.pk}
         )
 
     def test_relations_to_non_primary_key(self):
@@ -500,7 +501,8 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             'class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/inventory/?_to_field=barcode" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
-            '&nbsp;<strong>Apple</strong>'
+            '&nbsp;<strong><a href="/admin_widgets/inventory/%(pk)s/change/">'
+            'Apple</a></strong>' % {'pk': apple.pk}
         )
 
     def test_fk_related_model_not_in_admin(self):
@@ -549,7 +551,8 @@ class ForeignKeyRawIdWidgetTest(TestCase):
             '<input type="text" name="test" value="93" class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/inventory/?_to_field=barcode" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
-            '&nbsp;<strong>Hidden</strong>'
+            '&nbsp;<strong><a href="/admin_widgets/inventory/%(pk)s/change/">'
+            'Hidden</a></strong>' % {'pk': hidden.pk}
         )
 
 


### PR DESCRIPTION
This is basically a rebase of existing patches from the original issue [(7923)](https://code.djangoproject.com/ticket/7923).

It also uses the current admin site for reversing URLs, rather than the default admin instance (which I noticed right away on my test app which uses several admin instances).

In case the user does not have permissions, a 403 will be returned when trying to follow the link. This is the same behaviour the magnifying glass has, and cannot be cleanly avoided.