### PR TITLE
Moved assert to a new test with a more descriptive name

### DIFF
--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -357,6 +357,8 @@ class WriterTests(SimpleTestCase):
             SettingsReference("someapp.model", "AUTH_USER_MODEL"),
             ("settings.AUTH_USER_MODEL", {"from django.conf import settings"})
         )
+
+    def test_serialize_iterators(self):
         self.assertSerializedResultEqual(
             ((x, x * x) for x in range(3)),
             ("((0, 0), (1, 1), (2, 4))", set())


### PR DESCRIPTION
For some reason this assert was in the settings reference test, which can be confusing.