### PR TITLE
Fixed #26129 -- Made invalid forms display initial values of disabled fields.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -167,6 +167,8 @@ class Field(object):
         For most fields, this will simply be data; FileFields need to handle it
         a bit differently.
         """
+        if self.disabled:
+            return initial
         return data
 
     def widget_attrs(self, widget):

--- a/docs/releases/1.9.2.txt
+++ b/docs/releases/1.9.2.txt
@@ -91,3 +91,6 @@ Bugfixes
 
 * Fixed the ``contrib.gis`` map widgets when using
   ``USE_THOUSAND_SEPARATOR=True`` (:ticket:`20415`).
+
+* Made invalid forms display the initial of values of their disabled fields
+  (:ticket:`26129`).

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -718,6 +718,14 @@ class FormsTestCase(SimpleTestCase):
                 {'birthday': datetime.date(1974, 8, 16), 'name': 'John Doe'}
             )
 
+        # Initial data remains present on invalid forms.
+        data = {}
+        f1 = PersonForm(data, initial={'birthday': datetime.date(1974, 8, 16)})
+        f2 = PersonFormFieldInitial(data)
+        for form in (f1, f2):
+            self.assertFalse(form.is_valid())
+            self.assertEqual(form['birthday'].value(), datetime.date(1974, 8, 16))
+
     def test_hidden_data(self):
         class SongForm(Form):
             name = CharField()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26129