### PR TITLE
feature: ModelChoiceField with whole obj

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1177,7 +1177,12 @@ class ModelChoiceField(ChoiceField):
         generate the labels for the choices presented by this object. Subclasses
         can override this method to customize the display of the choices.
         """
-        return smart_text(obj)
+        label = smart_text(obj)
+        def smart_unicode():
+            return label
+        obj.__str__ = smart_unicode
+        obj.__unicode__ = smart_unicode
+        return obj
 
     def _get_choices(self):
         # If self._choices is set, then somebody must have manually set


### PR DESCRIPTION
Allows template to use all available
model-properties, not just pk and unicode.

I like to tinker around with the HTML myself, so I usually need more information about the object than just its name/label. In my own django, I simply use

    def choice(self, obj):
        return (self.field.prepare_value(obj), obj)

I guess we need a sanitised __unicode__ method, which I used in this commit. I hope I didn't overlook any reason why we can't have the complete object in the template.