### PR TITLE
Fixed #26263 -- Deprecated Context.has_key().

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -1,5 +1,8 @@
+import warnings
 from contextlib import contextmanager
 from copy import copy
+
+from django.utils.deprecation import RemovedInDjango20Warning
 
 # Hard-coded processor for easier use of CSRF protection.
 _builtin_context_processors = ('django.template.context_processors.csrf',)
@@ -76,13 +79,17 @@ class BaseContext(object):
         del self.dicts[-1][key]
 
     def has_key(self, key):
+        warnings.warn(
+            "%s.has_key() is deprecated in favor of the 'in' operator." % self.__class__.__name__,
+            RemovedInDjango20Warning
+        )
+        return key in self
+
+    def __contains__(self, key):
         for d in self.dicts:
             if key in d:
                 return True
         return False
-
-    def __contains__(self, key):
-        return self.has_key(key)
 
     def get(self, key, otherwise=None):
         for d in reversed(self.dicts):
@@ -184,7 +191,7 @@ class RenderContext(BaseContext):
         for d in self.dicts[-1]:
             yield d
 
-    def has_key(self, key):
+    def __contains__(self, key):
         return key in self.dicts[-1]
 
     def get(self, key, otherwise=None):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -133,6 +133,8 @@ details on these changes.
 * The model ``CommaSeparatedIntegerField`` will be removed. A stub field will
   remain for compatibility with historical migrations.
 
+* Support for the template ``Context.has_key()`` method will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -678,6 +678,8 @@ Miscellaneous
 * Importing from the ``django.core.urlresolvers`` module is deprecated in
   favor of its new location, :mod:`django.urls`.
 
+* The template ``Context.has_key()`` method is deprecated in favor of ``in``.
+
 .. _removed-features-1.10:
 
 Features removed in 1.10


### PR DESCRIPTION
Doesn't seem to be documented, but might need to go through a deprecation anyway? (at least a mention in the release notes would be added)
https://groups.google.com/d/topic/django-developers/QoMsYiBo_80/discussion