### PR TITLE
Fixed #26155 -- Skip URL checks if no ROOTURL_CONF

### DIFF
--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -1,13 +1,17 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
+
 from . import Tags, Warning, register
 
 
 @register(Tags.urls)
 def check_url_config(app_configs, **kwargs):
-    from django.urls import get_resolver
-    resolver = get_resolver()
-    return check_resolver(resolver)
+    if getattr(settings, 'ROOT_URLCONF', None):
+        from django.urls import get_resolver
+        resolver = get_resolver()
+        return check_resolver(resolver)
+    return []
 
 
 def check_resolver(resolver):

--- a/docs/releases/1.9.2.txt
+++ b/docs/releases/1.9.2.txt
@@ -94,3 +94,7 @@ Bugfixes
 
 * Made invalid forms display the initial of values of their disabled fields
   (:ticket:`26129`).
+
+* Fixed an issue where if you don't have a ``ROOT_URLCONF`` and the full checks
+  framework is run you get an excpetion with the urls check. Now if no
+  ``ROOT_URLCONF`` setting is set the check is skipped (:ticket: `26155`).

--- a/tests/check_framework/test_urls.py
+++ b/tests/check_framework/test_urls.py
@@ -35,3 +35,9 @@ class CheckUrlsTest(SimpleTestCase):
         self.assertEqual(warning.id, 'urls.W003')
         expected_msg = "Your URL pattern '^$' [name='name_with:colon'] has a name including a ':'."
         self.assertIn(expected_msg, warning.msg)
+
+    def test_no_root_urlconf_in_settings(self):
+        from django.conf import settings
+        delattr(settings, 'ROOT_URLCONF')
+        result = check_url_config(None)
+        self.assertEqual(result, [])


### PR DESCRIPTION
If you try to create a migration with makemigrations it throws an error
because it is running the check_url_config system check. This fix skips
the check if there is no ROOT_URLCONF in the settings.