### PR TITLE
Fixed #26170 -- Made ModelAdmin run atomic transaction on the correct database.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1389,9 +1389,12 @@ class ModelAdmin(BaseModelAdmin):
                 initial[k] = initial[k].split(",")
         return initial
 
-    @csrf_protect_m
-    @transaction.atomic
     def changeform_view(self, request, object_id=None, form_url='', extra_context=None):
+        with transaction.atomic(using=router.db_for_write(self.model)):
+            return self._changeform_view(request, object_id, form_url, extra_context)
+
+    @csrf_protect_m
+    def _changeform_view(self, request, object_id, form_url, extra_context):
 
         to_field = request.POST.get(TO_FIELD_VAR, request.GET.get(TO_FIELD_VAR))
         if to_field and not self.to_field_allowed(request, to_field):
@@ -1655,9 +1658,12 @@ class ModelAdmin(BaseModelAdmin):
             'admin/change_list.html'
         ], context)
 
-    @csrf_protect_m
-    @transaction.atomic
     def delete_view(self, request, object_id, extra_context=None):
+        with transaction.atomic(using=router.db_for_write(self.model)):
+            return self._delete_view(request, object_id, extra_context)
+
+    @csrf_protect_m
+    def _delete_view(self, request, object_id, extra_context):
         "The 'delete' admin view for this model."
         opts = self.model._meta
         app_label = opts.app_label


### PR DESCRIPTION
When settings.DATABASES['default'] is set to empty dict Django Admin tries to perform transaction.atomic on dummy database, and it ends in raising exception, when trying to change, add or delete record. This patch specifies the "using" argument for transaction.atomic, taken from db routers.