### PR TITLE
Fixed #25872 -- Added `force_escape` argument for blocktrans template tag to force HTML escaping.

### DIFF
--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -15,7 +15,7 @@
      {% if header.sort_priority > 0 %}
        <div class="sortoptions">
          <a class="sortremove" href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}"></a>
-         {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktrans with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktrans %}">{{ header.sort_priority }}</span>{% endif %}
+         {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktrans with priority_number=header.sort_priority force_escape %}Sorting priority: {{ priority_number }}{% endblocktrans %}">{{ header.sort_priority }}</span>{% endif %}
          <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% trans "Toggle sorting" %}"></a>
        </div>
      {% endif %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -17,7 +17,7 @@
         <div class="app-{{ app.app_label }} module">
         <table>
         <caption>
-            <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+            <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name force_escape %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
         </caption>
         {% for model in app.models %}
             <tr class="model-{{ model.object_name|lower }}">

--- a/django/contrib/admin/templates/admin/related_widget_wrapper.html
+++ b/django/contrib/admin/templates/admin/related_widget_wrapper.html
@@ -5,21 +5,21 @@
         {% if can_change_related %}
         <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
             data-href-template="{{ change_related_template_url }}?{{ url_params }}"
-            title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
+            title="{% blocktrans force_escape %}Change selected {{ model }}{% endblocktrans %}">
             <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}"/>
         </a>
         {% endif %}
         {% if can_add_related %}
         <a class="related-widget-wrapper-link add-related" id="add_id_{{ name }}"
             href="{{ add_related_url }}?{{ url_params }}"
-            title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
+            title="{% blocktrans force_escape %}Add another {{ model }}{% endblocktrans %}">
             <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}"/>
         </a>
         {% endif %}
         {% if can_delete_related %}
         <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
             data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
-            title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
+            title="{% blocktrans force_escape %}Delete selected {{ model }}{% endblocktrans %}">
             <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}"/>
         </a>
         {% endif %}

--- a/django/templatetags/i18n.py
+++ b/django/templatetags/i18n.py
@@ -7,6 +7,7 @@ from django.template import Library, Node, TemplateSyntaxError, Variable
 from django.template.base import TOKEN_TEXT, TOKEN_VAR, render_value_in_context
 from django.template.defaulttags import token_kwargs
 from django.utils import six, translation
+from django.utils.html import escape
 from django.utils.safestring import SafeData, mark_safe
 
 register = Library()
@@ -102,7 +103,8 @@ class TranslateNode(Node):
 class BlockTranslateNode(Node):
 
     def __init__(self, extra_context, singular, plural=None, countervar=None,
-            counter=None, message_context=None, trimmed=False, asvar=None):
+            counter=None, message_context=None, trimmed=False, asvar=None,
+            force_escape=None):
         self.extra_context = extra_context
         self.singular = singular
         self.plural = plural
@@ -111,6 +113,7 @@ class BlockTranslateNode(Node):
         self.message_context = message_context
         self.trimmed = trimmed
         self.asvar = asvar
+        self.force_escape = force_escape
 
     def render_token_list(self, tokens):
         result = []
@@ -164,6 +167,10 @@ class BlockTranslateNode(Node):
 
         data = {v: render_value(v) for v in vars}
         context.pop()
+        # Escape HTML characters only in translatable string, context
+        # already escaped in `render_value_in_context`.
+        if self.force_escape:
+            result = escape(result)
         try:
             result = result % data
         except (KeyError, ValueError):
@@ -173,6 +180,7 @@ class BlockTranslateNode(Node):
                     "string returned by gettext: %r using %r" % (result, data))
             with translation.override(None):
                 result = self.render(context, nested=True)
+
         if self.asvar:
             context[self.asvar] = result
             return ''
@@ -485,7 +493,7 @@ def do_block_translate(parser, token):
                     '"context" in %r tag expected '
                     'exactly one argument.') % bits[0]
                 six.reraise(TemplateSyntaxError, TemplateSyntaxError(msg), sys.exc_info()[2])
-        elif option == "trimmed":
+        elif option in ("trimmed", "force_escape"):
             value = True
         elif option == "asvar":
             try:
@@ -510,6 +518,7 @@ def do_block_translate(parser, token):
     extra_context = options.get('with', {})
 
     trimmed = options.get("trimmed", False)
+    force_escape = options.get("force_escape", False)
 
     singular = []
     plural = []
@@ -533,7 +542,7 @@ def do_block_translate(parser, token):
 
     return BlockTranslateNode(extra_context, singular, plural, countervar,
                               counter, message_context, trimmed=trimmed,
-                              asvar=asvar)
+                              asvar=asvar, force_escape=force_escape)
 
 
 @register.tag

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -256,6 +256,9 @@ Internationalization
   :func:`~django.conf.urls.i18n.i18n_patterns` to ``False``, you can allow
   accessing the default language without a URL prefix.
 
+* ``{% blocktrans %}`` template tag now has `force_escape` option to force HTML
+  escaping for translated content.
+
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -730,6 +730,30 @@ will result in the entry ``"First sentence. Second paragraph."`` in the PO file,
 compared to ``"\n  First sentence.\n  Second sentence.\n"``, if the ``trimmed``
 option had not been specified.
 
+The `force_escape` ``{% blocktrans %}`` option forces HTML escaping for
+translated content. The option should be used only when it is absolutely
+necessary, for instance in HTML tag attributes, so unescaped characters
+won't break your HTML layout. It behaves the same as if you applied
+:tfilter:`force_escape` filter, e.g.::
+
+    <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
+        data-href-template="{{ change_related_template_url }}?{{ url_params }}"
+        title="{% blocktrans force_escape %}Change selected {{ model }}{% endblocktrans %}">
+        <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}"/>
+    </a>
+
+for model with verbose name "B&B Hotel" will produce::
+
+    <a class="related-widget-wrapper-link change-related" id="change_id_bbhotel"
+        data-href-template="/admin/accomodation/bbhotel/__fk__/change/?_to_field=id&amp;_popup=1"
+        title="Change selected B&amp;B Hotel">
+        <img src="/static/admin/img/icon-changelink.svg" alt="Change"/>
+    </a>
+
+.. versionchanged:: 1.10
+
+    The ``force_escape`` option was added.
+
 String literals passed to tags and filters
 ------------------------------------------
 

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -405,6 +405,22 @@ class TranslationTests(SimpleTestCase):
             rendered = t.render(Context())
             self.assertEqual(rendered, '2 andere Super-Ergebnisse')
 
+            # Using 'force_escape'
+            t = Template(
+                '{% load i18n %}{% blocktrans force_escape %}'
+                '<b>"Escaped content" - {{ context }}, to try \'force_escape\' argument & check '
+                'for errors.</b>{% endblocktrans %}'
+            )
+            context = Context(
+                {'context': 'context is <i>already</i> "escaped"'}
+            )
+            rendered = t.render(context)
+            self.assertEqual(
+                rendered,
+                '&lt;b&gt;&quot;Escaped content&quot; - context is &lt;i&gt;already&lt;/i&gt; &quot;escaped&quot;, '
+                'to try &#39;force_escape&#39; argument &amp; check for errors.&lt;/b&gt;'
+            )
+
             # Mis-uses
             with self.assertRaises(TemplateSyntaxError):
                 Template('{% load i18n %}{% blocktrans context with month="May" %}{{ month }}{% endblocktrans %}')


### PR DESCRIPTION
Ticket - https://code.djangoproject.com/ticket/25872
