### PR TITLE
Fixed #13875 -- Made submit_row templatetag pass whole Context

### DIFF
--- a/django/contrib/admin/templatetags/admin_modify.py
+++ b/django/contrib/admin/templatetags/admin_modify.py
@@ -1,6 +1,7 @@
 import json
 
 from django import template
+from django.template.context import Context
 
 register = template.Library()
 
@@ -43,14 +44,13 @@ def submit_row(context):
     """
     Displays the row of buttons for delete and save.
     """
-    opts = context['opts']
     change = context['change']
     is_popup = context['is_popup']
     save_as = context['save_as']
     show_save = context.get('show_save', True)
     show_save_and_continue = context.get('show_save_and_continue', True)
-    ctx = {
-        'opts': opts,
+    ctx = Context(context)
+    ctx.update({
         'show_delete_link': (
             not is_popup and context['has_delete_permission'] and
             change and context.get('show_delete', True)
@@ -61,12 +61,8 @@ def submit_row(context):
             (not save_as or context['add'])
         ),
         'show_save_and_continue': not is_popup and context['has_change_permission'] and show_save_and_continue,
-        'is_popup': is_popup,
         'show_save': show_save,
-        'preserved_filters': context.get('preserved_filters'),
-    }
-    if context.get('original') is not None:
-        ctx['original'] = context['original']
+    })
     return ctx
 
 

--- a/tests/admin_views/test_templatetags.py
+++ b/tests/admin_views/test_templatetags.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.admin.templatetags.admin_modify import submit_row
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+from django.urls import reverse
+
+from .admin import site
+from .tests import AdminViewBasicTestCase
+
+
+class AdminTemplateTagsTest(AdminViewBasicTestCase):
+    def test_submit_row(self):
+        """
+        submit_row template tag should pass whole context.
+        """
+        change_url = reverse('admin:auth_user_change', args=[self.superuser.pk])
+        factory = RequestFactory()
+        request = factory.get(change_url)
+        request.user = self.superuser
+        admin = UserAdmin(User, site)
+        extra_context = {'extra': True}
+        response = admin.change_view(request, str(self.superuser.pk), extra_context=extra_context)
+        template_context = submit_row(response.context_data)
+        self.assertEqual(template_context['extra'], True)
+        self.assertEqual(template_context['show_save'], True)


### PR DESCRIPTION
See [[#13875] submit_row templatetag should pass whole context](https://code.djangoproject.com/ticket/13875).