### PR TITLE
Remove "gypsy" slur from documentation.

### DIFF
--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -32,7 +32,7 @@ thrilled to be able to give something back to the open-source community.
 What does "Django" mean, and how do you pronounce it?
 =====================================================
 
-Django is named after `Django Reinhardt`_, a gypsy jazz guitarist from the 1930s
+Django is named after `Django Reinhardt`_, a jazz manouche guitarist from the 1930s
 to early 1950s. To this day, he's considered one of the best guitarists of all time.
 
 Listen to his music. You'll like it.

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -132,20 +132,20 @@ For application users
 ---------------------
 
 If you're using "Rock ’n’ roll" in a project called ``anthology``, but you
-want it to show up as "Gypsy jazz" instead, you can provide your own
+want it to show up as "Jazz Manouche" instead, you can provide your own
 configuration::
 
     # anthology/apps.py
 
     from rock_n_roll.apps import RockNRollConfig
 
-    class GypsyJazzConfig(RockNRollConfig):
-        verbose_name = "Gypsy jazz"
+    class JazzManoucheConfig(RockNRollConfig):
+        verbose_name = "Jazz Manouche"
 
     # anthology/settings.py
 
     INSTALLED_APPS = [
-        'anthology.apps.GypsyJazzConfig',
+        'anthology.apps.JazzManoucheConfig',
         # ...
     ]
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -455,6 +455,7 @@ Magee
 makemessages
 makemigrations
 Mako
+manouche
 Mapnik
 Marczewski
 Marino

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -279,11 +279,11 @@ class ListFiltersTests(TestCase):
             title='The Django Book', year=None, author=self.bob,
             is_best_seller=None, date_registered=self.today, no=103,
         )
-        self.gipsy_book = Book.objects.create(
-            title='Gipsy guitar for dummies', year=2002, is_best_seller=True,
+        self.guitar_book = Book.objects.create(
+            title='Guitar for dummies', year=2002, is_best_seller=True,
             date_registered=self.one_week_ago,
         )
-        self.gipsy_book.contributors.set([self.bob, self.lisa])
+        self.guitar_book.contributors.set([self.bob, self.lisa])
 
         # Departments
         self.dev = Department.objects.create(code='DEV', description='Development')
@@ -337,7 +337,7 @@ class ListFiltersTests(TestCase):
         queryset = changelist.get_queryset(request)
         if (self.today.year, self.today.month) == (self.one_week_ago.year, self.one_week_ago.month):
             # In case one week ago is in the same month.
-            self.assertEqual(list(queryset), [self.gipsy_book, self.django_book, self.djangonaut_book])
+            self.assertEqual(list(queryset), [self.guitar_book, self.django_book, self.djangonaut_book])
         else:
             self.assertEqual(list(queryset), [self.django_book, self.djangonaut_book])
 
@@ -362,7 +362,7 @@ class ListFiltersTests(TestCase):
         queryset = changelist.get_queryset(request)
         if self.today.year == self.one_week_ago.year:
             # In case one week ago is in the same year.
-            self.assertEqual(list(queryset), [self.gipsy_book, self.django_book, self.djangonaut_book])
+            self.assertEqual(list(queryset), [self.guitar_book, self.django_book, self.djangonaut_book])
         else:
             self.assertEqual(list(queryset), [self.django_book, self.djangonaut_book])
 
@@ -387,7 +387,7 @@ class ListFiltersTests(TestCase):
 
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
-        self.assertEqual(list(queryset), [self.gipsy_book, self.django_book, self.djangonaut_book])
+        self.assertEqual(list(queryset), [self.guitar_book, self.django_book, self.djangonaut_book])
 
         # Make sure the correct choice is selected
         filterspec = changelist.get_filters(request)[0][4]
@@ -424,7 +424,7 @@ class ListFiltersTests(TestCase):
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
         self.assertEqual(queryset.count(), 3)
-        self.assertEqual(list(queryset), [self.gipsy_book, self.django_book, self.djangonaut_book])
+        self.assertEqual(list(queryset), [self.guitar_book, self.django_book, self.djangonaut_book])
 
         # Make sure the correct choice is selected
         filterspec = changelist.get_filters(request)[0][4]
@@ -502,7 +502,7 @@ class ListFiltersTests(TestCase):
 
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
-        self.assertEqual(list(queryset), [self.gipsy_book])
+        self.assertEqual(list(queryset), [self.guitar_book])
 
         # Make sure the last choice is None and is selected
         filterspec = changelist.get_filters(request)[0][1]
@@ -711,7 +711,7 @@ class ListFiltersTests(TestCase):
 
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
-        self.assertEqual(list(queryset), [self.gipsy_book, self.djangonaut_book])
+        self.assertEqual(list(queryset), [self.guitar_book, self.djangonaut_book])
 
         # Make sure the correct choice is selected
         filterspec = changelist.get_filters(request)[0][3]
@@ -807,7 +807,7 @@ class ListFiltersTests(TestCase):
 
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
-        self.assertEqual(list(queryset), [self.gipsy_book, self.djangonaut_book])
+        self.assertEqual(list(queryset), [self.guitar_book, self.djangonaut_book])
 
         # Make sure the correct choice is selected
         filterspec = changelist.get_filters(request)[0][1]


### PR DESCRIPTION
Gypsy is considered a slur by the Romani people whom it refers to. "manouche jazz" is used in place of "gypsy jazz" and is an accepted term for the same genre of music.