### PR TITLE
Fixed #26169 -- Fixed tutorial reference in reusable apps tutorial.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -87,7 +87,7 @@ After the previous tutorials, our project should look like this::
             admin/
                 base_site.html
 
-You created ``mysite/templates`` in :doc:`Tutorial 2 </intro/tutorial02>`,
+You created ``mysite/templates`` in :doc:`Tutorial 7 </intro/tutorial07>`,
 and ``polls/templates`` in :doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps
 it is clearer why we chose to have separate template directories for the
 project and application: everything that is part of the polls application is in


### PR DESCRIPTION
 mysite/templates was created in Tutorial 07, not in Tutorial 02.

Current Documentation:
You created mysite/templates in :doc:Tutorial 2 </intro/tutorial02>,
and polls/templates in :doc:Tutorial 3 </intro/tutorial03>.

Corrected Documentation:
You created mysite/templates in :doc:Tutorial 7 </intro/tutorial07>,
and polls/templates in :doc:Tutorial 3 </intro/tutorial03>.