### PR TITLE
Fixed #26177 -- Fixed a PostgreSQL crash with TIME_ZONE=None and USE_TZ=False.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -197,7 +197,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         conn_timezone_name = self.connection.get_parameter_status('TimeZone')
 
-        if conn_timezone_name != self.timezone_name:
+        if self.timezone_name and conn_timezone_name != self.timezone_name:
             cursor = self.connection.cursor()
             try:
                 cursor.execute(self.ops.set_time_zone_sql(), [self.timezone_name])

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -69,7 +69,7 @@ def update_connections_time_zone(**kwargs):
             except AttributeError:
                 pass
             tz_sql = conn.ops.set_time_zone_sql()
-            if tz_sql:
+            if tz_sql and conn.timezone_name:
                 with conn.cursor() as cursor:
                     cursor.execute(tz_sql, [conn.timezone_name])
 

--- a/docs/releases/1.8.10.txt
+++ b/docs/releases/1.8.10.txt
@@ -9,4 +9,5 @@ Django 1.8.10 fixes several bugs in 1.8.9.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash on PostgreSQL that prevented using ``TIME_ZONE=None`` and
+  ``USE_TZ=False`` (:ticket:`26177`).

--- a/docs/releases/1.9.3.txt
+++ b/docs/releases/1.9.3.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Skipped URL checks (new in 1.9) if the ``ROOT_URLCONF`` setting isn't defined
   (:ticket:`26155`).
+
+* Fixed a crash on PostgreSQL that prevented using ``TIME_ZONE=None`` and
+  ``USE_TZ=False`` (:ticket:`26177`).

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -825,6 +825,11 @@ class BackendTestCase(TransactionTestCase):
             BaseDatabaseWrapper.queries_limit = old_queries_limit
             new_connection.close()
 
+    def test_timezone_none_use_tz_false(self):
+        connection.ensure_connection()
+        with self.settings(TIME_ZONE=None, USE_TZ=False):
+            connection.init_connection_state()
+
 
 # We don't make these tests conditional because that means we would need to
 # check and differentiate between:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26177