### PR TITLE
Fixed #26154 -- Deprecated CommaSeparatedIntegerField.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1144,6 +1144,17 @@ class CharField(Field):
 class CommaSeparatedIntegerField(CharField):
     default_validators = [validators.validate_comma_separated_integer_list]
     description = _("Comma-separated integers")
+    system_check_deprecated_details = {
+        'msg': (
+            'CommaSeparatedIntegerField has been deprecated. Support '
+            'for it (except in historical migrations) will be removed '
+            'in Django 2.0.'
+        ),
+        'hint': (
+            'Use CharField(validators=[validate_comma_separated_integer_list]) instead.'
+        ),
+        'id': 'fields.W901',
+    }
 
     def formfield(self, **kwargs):
         defaults = {

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -130,6 +130,9 @@ details on these changes.
 
 * The ``django.core.urlresolvers`` module will be removed.
 
+* The model ``CommaSeparatedIntegerField`` will be removed. A stub field will
+  remain for compatibility with historical migrations.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -165,6 +165,8 @@ Fields
 * **fields.W900**: ``IPAddressField`` has been deprecated. Support for it
   (except in historical migrations) will be removed in Django 1.9. *This check
   appeared in Django 1.7 and 1.8*.
+* **fields.W901**: ``CommaSeparatedIntegerField`` has been deprecated. Support
+  for it (except in historical migrations) will be removed in Django 2.0.
 
 File Fields
 ~~~~~~~~~~~

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -471,11 +471,16 @@ The default form widget for this field is a :class:`~django.forms.TextInput`.
     of. Refer to the :ref:`MySQL database notes <mysql-collation>` for
     details.
 
-
 ``CommaSeparatedIntegerField``
 ------------------------------
 
 .. class:: CommaSeparatedIntegerField(max_length=None, **options)
+
+.. deprecated:: 1.9
+
+    This field is deprecated in favor of :class:`~django.db.models.CharField`
+    with ``validators=[``\ :func:`validate_comma_separated_integer_list
+    <django.core.validators.validate_comma_separated_integer_list>`\ ``]``.
 
 A field of integers separated by commas. As in :class:`CharField`, the
 :attr:`~CharField.max_length` argument is required and the note about database

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -544,6 +544,30 @@ This prevents confusion about an assignment resulting in an implicit save.
   :class:`~django.contrib.gis.geos.MultiPolygon` is deprecated in favor of the
   :attr:`~django.contrib.gis.geos.GEOSGeometry.unary_union` property.
 
+``CommaSeparatedIntegerField`` model field
+------------------------------------------
+
+``CommaSeparatedIntegerField`` is deprecated in favor of
+:class:`~django.db.models.CharField` with the
+:func:`~django.core.validators.validate_comma_separated_integer_list`
+validator::
+
+    from django.core.validators import validate_comma_separated_integer_list
+    from django.db import models
+
+    class MyModel(models.Model):
+        numbers = models.CharField(..., validators=[validate_comma_separated_integer_list])
+
+If you're using Oracle, ``CharField`` uses a different database field 
+type (``NVARCHAR2``) than ``CommaSeparatedIntegerField`` (``VARCHAR2``). 
+Depending on your database settings, this might imply a different 
+encoding, and thus a different length (in bytes) for the same contents. 
+If your stored values are longer than the 4000 byte limit of 
+``NVARCHAR2``, you should use ``TextField`` (``NCLOB``) instead. In this 
+case, if you have any queries that group by the field (e.g. annotating 
+the model with an aggregation or using ``distinct()``) you will need to 
+change them (to defer the field).
+
 Miscellaneous
 -------------
 

--- a/tests/invalid_models_tests/test_deprecated_fields.py
+++ b/tests/invalid_models_tests/test_deprecated_fields.py
@@ -21,3 +21,20 @@ class DeprecatedFieldsTests(SimpleTestCase):
                 id='fields.E900',
             )],
         )
+
+    def test_CommaSeparatedIntegerField_deprecated(self):
+        class CommaSeparatedIntegerModel(models.Model):
+            csi = models.CommaSeparatedIntegerField(max_length=64)
+
+        model = CommaSeparatedIntegerModel()
+        self.assertEqual(
+            model.check(),
+            [checks.Warning(
+                'CommaSeparatedIntegerField has been deprecated. Support '
+                'for it (except in historical migrations) will be removed '
+                'in Django 2.0.',
+                hint='Use CharField(validators=[validate_comma_separated_integer_list]) instead.',
+                obj=CommaSeparatedIntegerModel._meta.get_field('csi'),
+                id='fields.W901',
+            )],
+        )


### PR DESCRIPTION
Began the deprecation of `CommaSeparatedIntegerField`. This is my first django contribution, so I'm sure I missed something in the documentation. Let me know if anything needs fixing, thanks!

 - Added deprecation warning to model
 - Added `ignore_warnings` to relevant tests
 - Added a test for the warning itself
 - Updated documentation

[Ticket #26154](https://code.djangoproject.com/ticket/26154)

Edit: realized my branch is misnamed. If that's an issue, let me know and I'll fix it