### PR TITLE
Fixed #25790 -- Added option to disable column sort in admin changelist.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -109,6 +109,7 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
     formfield_overrides = {}
     readonly_fields = ()
     ordering = None
+    sortable_by = None
     view_on_site = True
     show_full_result_count = True
     checks_class = BaseModelAdminChecks
@@ -471,6 +472,9 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         `ModelAdmin.has_(add|change|delete)_permission` for that.
         """
         return request.user.has_module_perms(self.opts.app_label)
+
+    def get_sortable_by(self, request):
+        return self.sortable_by or self.get_list_display(request)
 
 
 @python_2_unicode_compatible
@@ -1519,6 +1523,7 @@ class ModelAdmin(BaseModelAdmin):
         list_filter = self.get_list_filter(request)
         search_fields = self.get_search_fields(request)
         list_select_related = self.get_list_select_related(request)
+        sortable_by = self.get_sortable_by(request)
 
         # Check actions to see if any are available on this changelist
         actions = self.get_actions(request)
@@ -1533,6 +1538,7 @@ class ModelAdmin(BaseModelAdmin):
                 list_display_links, list_filter, self.date_hierarchy,
                 search_fields, list_select_related, self.list_per_page,
                 self.list_max_show_all, self.list_editable, self,
+                sortable_by,
             )
         except IncorrectLookupParameters:
             # Wacky lookup parameters were given, so redirect to the main

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -103,6 +103,7 @@ def result_headers(cl):
             model_admin=cl.model_admin,
             return_attr=True
         )
+        is_field_sortable = not cl.sortable_by or field_name in cl.sortable_by
         if attr:
             field_name = _coerce_field_name(field_name, i)
             # Potentially not sortable
@@ -118,13 +119,16 @@ def result_headers(cl):
 
             admin_order_field = getattr(attr, "admin_order_field", None)
             if not admin_order_field:
-                # Not sortable
-                yield {
-                    "text": text,
-                    "class_attrib": format_html(' class="column-{}"', field_name),
-                    "sortable": False,
-                }
-                continue
+                is_field_sortable = False
+
+        if not is_field_sortable:
+            # Not sortable
+            yield {
+                "text": text,
+                "class_attrib": format_html(' class="column-{}"', field_name),
+                "sortable": False,
+            }
+            continue
 
         # OK, it is sortable if we got this far
         th_classes = ['sortable', 'column-{}'.format(field_name)]

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -37,7 +37,7 @@ IGNORED_PARAMS = (
 class ChangeList(object):
     def __init__(self, request, model, list_display, list_display_links,
                  list_filter, date_hierarchy, search_fields, list_select_related,
-                 list_per_page, list_max_show_all, list_editable, model_admin):
+                 list_per_page, list_max_show_all, list_editable, model_admin, sortable_by):
         self.model = model
         self.opts = model._meta
         self.lookup_opts = self.opts
@@ -52,6 +52,7 @@ class ChangeList(object):
         self.list_max_show_all = list_max_show_all
         self.model_admin = model_admin
         self.preserved_filters = model_admin.get_preserved_filters(request)
+        self.sortable_by = sortable_by
 
         # Get search parameters from the query string.
         try:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1012,6 +1012,20 @@ subclass::
     If you need to specify a dynamic value based on the request, you can
     implement a :meth:`~ModelAdmin.get_list_select_related` method.
 
+.. attribute:: ModelAdmin.sortable_by
+
+    .. versionadded:: 1.10
+
+    By default, Django admin allows to sort by all model fields and callables,
+    that have ``admin_order_field`` property set. However, you might want to
+    disable interactive sorting for any of them.
+
+    ``sortable_by`` is a list of fields and callables you would like to be
+    available for sorting in the changelist header.
+
+    If you need to specify this list dynamically - you can implement a
+    :meth:`~ModelAdmin.get_sortable_by` method.
+
 .. attribute:: ModelAdmin.ordering
 
     Set ``ordering`` to specify how lists of objects should be ordered in the
@@ -1367,6 +1381,23 @@ templates used by the :class:`ModelAdmin` views:
                     return ['name', 'rank']
                 else:
                     return ['name']
+
+.. method:: ModelAdmin.get_sortable_by(request)
+
+    .. versionadded:: 1.10
+
+    The ``get_sortable_by`` method is given the ``HttpRequest`` and is expected
+    to return a list or tuple of field names that will be available for the
+    interactive ordering in changelist header. If :attr:`sortable_by` is not
+    set, it returns field names from :meth:`get_list_display` method. You
+    could exclude one or more fields from ordering by overriding this
+    method::
+
+        class PersonAdmin(admin.ModelAdmin):
+
+            def get_sortable_by(self, request):
+                return set(self.get_list_display(request)) - {'rank'}
+
 
 .. method:: ModelAdmin.get_search_results(request, queryset, search_term)
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -46,6 +46,7 @@ def get_changelist_args(modeladmin, **kwargs):
         kwargs.pop('list_max_show_all', m.list_max_show_all),
         kwargs.pop('list_editable', m.list_editable),
         m,
+        kwargs.pop('sortable_by', m.sortable_by),
     )
     assert not kwargs, "Unexpected kwarg %s" % kwargs
     return args

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -300,6 +300,7 @@ class ListFiltersTests(TestCase):
             modeladmin.date_hierarchy, modeladmin.search_fields,
             modeladmin.list_select_related, modeladmin.list_per_page,
             modeladmin.list_max_show_all, modeladmin.list_editable, modeladmin,
+            modeladmin.sortable_by
         )
 
     def test_datefieldlistfilter(self):

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -105,6 +105,7 @@ class ArticleAdmin(admin.ModelAdmin):
             'fields': ('date', 'section', 'sub_section')
         })
     )
+    sortable_by = ('date', callable_year)
 
     def changelist_view(self, request):
         "Test that extra_context works"

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -883,6 +883,20 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertEqual(response.context['site_url'], '/my-site-url/')
         self.assertContains(response, '<a href="/my-site-url/">View site</a>')
 
+    def test_sortable_by(self):
+        expected_sortable_field_names = ('date', 'callable_year')
+        expected_not_sortable_field_name = (
+            'content', 'model_year', 'modeladmin_year',
+            'model_year_reversed', 'section', 'lambda8'
+        )
+
+        response = self.client.get(reverse('admin:admin_views_article_changelist'))
+        for field_name in expected_sortable_field_names:
+            self.assertContains(response, '<th scope="col"  class="sortable column-%s">' % field_name)
+
+        for field_name in expected_not_sortable_field_name:
+            self.assertContains(response, '<th scope="col"  class="column-%s">' % field_name)
+
 
 @override_settings(TEMPLATES=[{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
Ticket - https://code.djangoproject.com/ticket/25790
