### PR TITLE
Fixed #26200 - ModelForm integrity violation on excluded ForeignKey

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,6 +252,7 @@ answer newbie questions, and generally made Django that much better:
     gandalf@owca.info
     Garry Polley <garrympolley@gmail.com>
     Garth Kidd <http://www.deadlybloodyserious.com/>
+    Gary Reynolds <gary@touch.asn.au>
     Gary Wilson <gary.wilson@gmail.com>
     Gasper Koren
     Gasper Zejn <zejn@kiberpipa.org>

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -303,6 +303,17 @@ class BaseModelForm(BaseForm):
         excluded from model validation. See the following tickets for
         details: #12507, #12521, #12553
         """
+        from django.db import models
+        # Build up a list of ForeignKey fields that can't be excluded due to
+        # their use in one or more unique_together declarations. Not doing so
+        # will result in referential integrity constraint violations at the
+        # database.
+        unique_together_fk = set([
+            field_name
+            for together in self.instance._meta.unique_together
+            for field_name in together
+            if isinstance(self.instance._meta.get_field(field_name), models.ForeignKey)
+        ])
         exclude = []
         # Build up a list of fields that should be excluded from model field
         # validation and unique checks.
@@ -311,7 +322,8 @@ class BaseModelForm(BaseForm):
             # Exclude fields that aren't on the form. The developer may be
             # adding these values to the model after form validation.
             if field not in self.fields:
-                exclude.append(f.name)
+                if field not in unique_together_fk:
+                    exclude.append(f.name)
 
             # Don't perform model validation on fields that were defined
             # manually on the form and excluded via the ModelForm's Meta

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -65,6 +65,12 @@ class BookForm(forms.ModelForm):
         fields = '__all__'
 
 
+class BookTitleForm(forms.ModelForm):
+    class Meta:
+        model = Book
+        fields = ('title',)
+
+
 class DerivedBookForm(forms.ModelForm):
     class Meta:
         model = DerivedBook
@@ -715,6 +721,14 @@ class UniqueTest(TestCase):
         form.save()
         form = BookForm({'title': title})
         self.assertTrue(form.is_valid())
+
+    def test_unique_together_without_related_field(self):
+        title = 'I May Be Wrong But I Doubt It'
+        Book.objects.create(title=title, author=self.writer)
+        book = Book.objects.create(title='A Very Different Title', author=self.writer)
+        form = BookTitleForm(instance=book, data={'title': title})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['__all__'], ['Book with this Title and Author already exists.'])
 
     def test_inherited_unique(self):
         title = 'Boss'


### PR DESCRIPTION
Updated `BaseModelForm._get_validation_exclusions` so that when a `ModelForm` is declared without a `ForeignKey` field which forms part of a `unique_together` constraint it is _not_ excluded from validation checks.

Applies cleanly on `1.8.x` branch.