### PR TITLE
Fixed #26179 -- Remove null assignment check for non-nullable foreign…

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -471,6 +471,14 @@ creates the possibility of a deadlock. To adapt your code in the case of RQ,
 you can `provide your own worker script <http://python-rq.org/docs/workers/>`_
 that calls ``django.setup()``.
 
+Removed null assignment check for non-nullable foreign key fields
+----------------------------------------------------------------------------------
+
+Before 1.10 assign None to a non-nullable foreign key field with raise ValueError.
+This check has been removed in 1.10 and the check will be left to database. So if
+a non-nullable foreign key is assigned None. An IntegrityError will be raised when
+trying to save the instance.
+
 Miscellaneous
 -------------
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -717,12 +717,6 @@ class ProxyRelatedModelTest(TestCase):
 
 
 class TestInitWithNoneArgument(SimpleTestCase):
-    def test_none_not_allowed(self):
-        # TaggedItem requires a content_type, initializing with None should
-        # raise a ValueError.
-        msg = 'Cannot assign None: "TaggedItem.content_type" does not allow null values'
-        with self.assertRaisesMessage(ValueError, msg):
-            TaggedItem(content_object=None)
 
     def test_none_allowed(self):
         # AllowsNullGFK doesn't require a content_type, so None argument should

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -722,3 +722,5 @@ class TestInitWithNoneArgument(SimpleTestCase):
         # AllowsNullGFK doesn't require a content_type, so None argument should
         # also be allowed.
         AllowsNullGFK(content_object=None)
+        # TaggedItem requires a content_type, initializing with None should also be allowed (#26179)
+        TaggedItem(content_object=None)

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -486,20 +486,9 @@ class ManyToOneTests(TestCase):
         p = Parent.objects.get(name="Parent")
         self.assertIsNone(p.bestchild)
 
-        # Assigning None fails: Child.parent is null=False.
-        with self.assertRaises(ValueError):
-            setattr(c, "parent", None)
-
         # You also can't assign an object of the wrong type here
         with self.assertRaises(ValueError):
             setattr(c, "parent", First(id=1, second=1))
-
-        # Nor can you explicitly assign None to Child.parent during object
-        # creation (regression for #9649).
-        with self.assertRaises(ValueError):
-            Child(name='xyzzy', parent=None)
-        with self.assertRaises(ValueError):
-            Child.objects.create(name='xyzzy', parent=None)
 
         # Creation using keyword argument should cache the related object.
         p = Parent.objects.get(name="Parent")

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -228,10 +228,6 @@ class OneToOneTests(TestCase):
         ug_bar.place = None
         self.assertIsNone(ug_bar.place)
 
-        # Assigning None fails: Place.restaurant is null=False
-        with self.assertRaises(ValueError):
-            setattr(p, 'restaurant', None)
-
         # You also can't assign an object of the wrong type here
         with self.assertRaises(ValueError):
             setattr(p, 'restaurant', p)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -228,6 +228,9 @@ class OneToOneTests(TestCase):
         ug_bar.place = None
         self.assertIsNone(ug_bar.place)
 
+        # Assigning None will not fail: Place.restaurant is null=False
+        setattr(p, 'restaurant', None)
+
         # You also can't assign an object of the wrong type here
         with self.assertRaises(ValueError):
             setattr(p, 'restaurant', p)


### PR DESCRIPTION
Removed check value=None and raise ValueError in ForwardManyToOneDescriptor and
ReverseOneToOneDescriptor.None can always be assigned now and integrity check
is left to database.

Removed rasing ValueError tests for fk=None in generic_relations.test,
many_to_one.tests, and one_to_one.tests

https://code.djangoproject.com/ticket/26179