### PR TITLE
Fixed #26207 -- New implementation for deferred fields

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -165,8 +165,7 @@ class AppConfig(object):
             raise LookupError(
                 "App '%s' doesn't have a '%s' model." % (self.label, model_name))
 
-    def get_models(self, include_auto_created=False,
-                   include_deferred=False, include_swapped=False):
+    def get_models(self, include_auto_created=False, include_swapped=False):
         """
         Returns an iterable of models.
 
@@ -182,8 +181,6 @@ class AppConfig(object):
         """
         self.check_models_ready()
         for model in self.models.values():
-            if model._deferred and not include_deferred:
-                continue
             if model._meta.auto_created and not include_auto_created:
                 continue
             if model._meta.swapped and not include_swapped:

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -156,8 +156,7 @@ class Apps(object):
 
     # This method is performance-critical at least for Django's test suite.
     @lru_cache.lru_cache(maxsize=None)
-    def get_models(self, include_auto_created=False,
-                   include_deferred=False, include_swapped=False):
+    def get_models(self, include_auto_created=False, include_swapped=False):
         """
         Returns a list of all installed models.
 
@@ -175,7 +174,7 @@ class Apps(object):
         result = []
         for app_config in self.app_configs.values():
             result.extend(list(app_config.get_models(
-                include_auto_created, include_deferred, include_swapped)))
+                include_auto_created, include_swapped)))
         return result
 
     def get_model(self, app_label, model_name=None):

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -25,8 +25,6 @@ class ContentTypeManager(models.Manager):
     def _get_opts(self, model, for_concrete_model):
         if for_concrete_model:
             model = model._meta.concrete_model
-        elif model._deferred:
-            model = model._meta.proxy_for_model
         return model._meta
 
     def _get_from_cache(self, opts):

--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -37,7 +37,7 @@ class Serializer(base.Serializer):
         self._current = None
 
     def get_dump_object(self, obj):
-        model = obj._meta.proxy_for_model if obj._deferred else obj.__class__
+        model = obj.__class__
         data = OrderedDict([('model', force_text(model._meta))])
         if not self.use_natural_primary_keys or not hasattr(obj, 'natural_key'):
             data["pk"] = force_text(obj._get_pk_val(), strings_only=True)

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -52,7 +52,7 @@ class Serializer(base.Serializer):
             raise base.SerializationError("Non-model object (%s) encountered during serialization" % type(obj))
 
         self.indent(1)
-        model = obj._meta.proxy_for_model if obj._deferred else obj.__class__
+        model = obj.__class__
         attrs = OrderedDict([("model", smart_text(model._meta))])
         if not self.use_natural_primary_keys or not hasattr(obj, 'natural_key'):
             obj_pk = obj._get_pk_val()

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -17,7 +17,7 @@ from django.db.models.manager import Manager  # NOQA
 from django.db.models.query import Q, Prefetch, QuerySet  # NOQA
 
 # Imports that would create circular imports if sorted
-from django.db.models.base import Model  # NOQA isort:skip
+from django.db.models.base import DEFERRED, Model  # NOQA isort:skip
 from django.db.models.fields.related import (  # NOQA isort:skip
     ForeignKey, ForeignObject, OneToOneField, ManyToManyField,
     ManyToOneRel, ManyToManyRel, OneToOneRel,

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -27,9 +27,6 @@ from django.db.models.fields.related import (
 from django.db.models.manager import ensure_default_manager
 from django.db.models.options import Options
 from django.db.models.query import Q
-from django.db.models.query_utils import (
-    DeferredAttribute, deferred_class_factory,
-)
 from django.db.models.utils import make_model_tuple
 from django.utils import six
 from django.utils.encoding import force_str, force_text
@@ -38,6 +35,12 @@ from django.utils.six.moves import zip
 from django.utils.text import capfirst, get_text_list
 from django.utils.translation import ugettext_lazy as _
 from django.utils.version import get_version
+
+DEFERRED = object()
+
+
+class Empty(object):
+    pass
 
 
 def subclass_exception(name, parents, module, attached_to=None):
@@ -369,11 +372,15 @@ class Model(six.with_metaclass(ModelBase)):
             # is *not* consumed. We rely on this, so don't change the order
             # without changing the logic.
             for val, field in zip(args, fields_iter):
+                if val is DEFERRED:
+                    continue
                 setattr(self, field.attname, val)
         else:
             # Slower, kwargs-ready version.
             fields_iter = iter(self._meta.fields)
             for val, field in zip(args, fields_iter):
+                if val is DEFERRED:
+                    continue
                 setattr(self, field.attname, val)
                 kwargs.pop(field.name, None)
                 # Maintain compatibility with existing calls.
@@ -385,13 +392,8 @@ class Model(six.with_metaclass(ModelBase)):
 
         for field in fields_iter:
             is_related_object = False
-            # This slightly odd construct is so that we can access any
-            # data-descriptor object (DeferredAttribute) without triggering its
-            # __get__ method.
-            if (field.attname not in kwargs and
-                    (isinstance(self.__class__.__dict__.get(field.attname), DeferredAttribute)
-                     or field.column is None)):
-                # This field will be populated on request.
+            # Virtual field
+            if field.attname not in kwargs and field.column is None:
                 continue
             if kwargs:
                 if isinstance(field.remote_field, ForeignObjectRel):
@@ -427,15 +429,18 @@ class Model(six.with_metaclass(ModelBase)):
                 # field.name instead of field.attname (e.g. "user" instead of
                 # "user_id") so that the object gets properly cached (and type
                 # checked) by the RelatedObjectDescriptor.
-                setattr(self, field.name, rel_obj)
+                if rel_obj is not DEFERRED:
+                    setattr(self, field.name, rel_obj)
             else:
-                setattr(self, field.attname, val)
+                if val is not DEFERRED:
+                    setattr(self, field.attname, val)
 
         if kwargs:
             for prop in list(kwargs):
                 try:
                     if isinstance(getattr(self.__class__, prop), property):
-                        setattr(self, prop, kwargs[prop])
+                        if kwargs[prop] is not DEFERRED:
+                            setattr(self, prop, kwargs[prop])
                         del kwargs[prop]
                 except AttributeError:
                     pass
@@ -446,10 +451,12 @@ class Model(six.with_metaclass(ModelBase)):
 
     @classmethod
     def from_db(cls, db, field_names, values):
-        if cls._deferred:
-            new = cls(**dict(zip(field_names, values)))
-        else:
-            new = cls(*values)
+        # TODO - make QuerySet iterator fill the missing fields.
+        if len(values) != len(cls._meta.concrete_fields):
+            values = list(values)
+            values.reverse()
+            values = [values.pop() if f.attname in field_names else DEFERRED for f in cls._meta.concrete_fields]
+        new = cls(*values)
         new._state.adding = False
         new._state.db = db
         return new
@@ -493,17 +500,8 @@ class Model(six.with_metaclass(ModelBase)):
         """
         data = self.__dict__
         data[DJANGO_VERSION_PICKLE_KEY] = get_version()
-        if not self._deferred:
-            class_id = self._meta.app_label, self._meta.object_name
-            return model_unpickle, (class_id, [], simple_class_factory), data
-        defers = []
-        for field in self._meta.fields:
-            if isinstance(self.__class__.__dict__.get(field.attname),
-                          DeferredAttribute):
-                defers.append(field.attname)
-        model = self._meta.proxy_for_model
-        class_id = model._meta.app_label, model._meta.object_name
-        return (model_unpickle, (class_id, defers, deferred_class_factory), data)
+        class_id = self._meta.app_label, self._meta.object_name
+        return model_unpickle, (class_id,), data
 
     def __setstate__(self, state):
         msg = None
@@ -538,7 +536,7 @@ class Model(six.with_metaclass(ModelBase)):
         """
         return {
             f.attname for f in self._meta.concrete_fields
-            if isinstance(self.__class__.__dict__.get(f.attname), DeferredAttribute)
+            if f.attname not in self.__dict__
         }
 
     def refresh_from_db(self, using=None, fields=None, **kwargs):
@@ -565,18 +563,15 @@ class Model(six.with_metaclass(ModelBase)):
                     'are not allowed in fields.' % LOOKUP_SEP)
 
         db = using if using is not None else self._state.db
-        if self._deferred:
-            non_deferred_model = self._meta.proxy_for_model
-        else:
-            non_deferred_model = self.__class__
-        db_instance_qs = non_deferred_model._default_manager.using(db).filter(pk=self.pk)
+        model = self.__class__
+        db_instance_qs = model._default_manager.using(db).filter(pk=self.pk)
 
         # Use provided fields, if not set then reload all non-deferred fields.
+        deferred_fields = self.get_deferred_fields()
         if fields is not None:
             fields = list(fields)
             db_instance_qs = db_instance_qs.only(*fields)
-        elif self._deferred:
-            deferred_fields = self.get_deferred_fields()
+        elif deferred_fields:
             fields = [f.attname for f in self._meta.concrete_fields
                       if f.attname not in deferred_fields]
             db_instance_qs = db_instance_qs.only(*fields)
@@ -655,6 +650,7 @@ class Model(six.with_metaclass(ModelBase)):
         if force_insert and (force_update or update_fields):
             raise ValueError("Cannot force both insert and updating in model saving.")
 
+        deferred_fields = self.get_deferred_fields()
         if update_fields is not None:
             # If update_fields is empty, skip the save. We do also check for
             # no-op saves later on for inheritance cases. This bailout is
@@ -681,17 +677,11 @@ class Model(six.with_metaclass(ModelBase)):
 
         # If saving to the same database, and this model is deferred, then
         # automatically do a "update_fields" save on the loaded fields.
-        elif not force_insert and self._deferred and using == self._state.db:
+        elif not force_insert and deferred_fields and using == self._state.db:
             field_names = set()
             for field in self._meta.concrete_fields:
                 if not field.primary_key and not hasattr(field, 'through'):
                     field_names.add(field.attname)
-            deferred_fields = [
-                f.attname for f in self._meta.fields
-                if (f.attname not in self.__dict__ and
-                    isinstance(self.__class__.__dict__[f.attname], DeferredAttribute))
-            ]
-
             loaded_fields = field_names.difference(deferred_fields)
             if loaded_fields:
                 update_fields = frozenset(loaded_fields)
@@ -1682,14 +1672,7 @@ def make_foreign_order_accessors(model, related_model):
 ########
 
 
-def simple_class_factory(model, attrs):
-    """
-    Needed for dynamic classes.
-    """
-    return model
-
-
-def model_unpickle(model_id, attrs, factory):
+def model_unpickle(model_id):
     """
     Used to unpickle Model subclasses with deferred fields.
     """
@@ -1698,8 +1681,7 @@ def model_unpickle(model_id, attrs, factory):
     else:
         # Backwards compat - the model was cached directly in earlier versions.
         model = model_id
-    cls = factory(model, attrs)
-    return cls.__new__(cls)
+    return model.__new__(model)
 model_unpickle.__safe_for_unpickle__ = True
 
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -19,7 +19,7 @@ from django.db.models.deletion import Collector
 from django.db.models.expressions import F, Date, DateTime
 from django.db.models.fields import AutoField
 from django.db.models.query_utils import (
-    Q, InvalidQuery, check_rel_lookup_compatibility, deferred_class_factory,
+    Q, InvalidQuery, check_rel_lookup_compatibility
 )
 from django.db.models.sql.constants import CURSOR
 from django.utils import six, timezone
@@ -59,11 +59,6 @@ class ModelIterable(BaseIterable):
         model_fields_start, model_fields_end = select_fields[0], select_fields[-1] + 1
         init_list = [f[0].target.attname
                      for f in select[model_fields_start:model_fields_end]]
-        if len(init_list) != len(model_cls._meta.concrete_fields):
-            init_set = set(init_list)
-            skip = [f.attname for f in model_cls._meta.concrete_fields
-                    if f.attname not in init_set]
-            model_cls = deferred_class_factory(model_cls, skip)
         related_populators = get_related_populators(klass_info, select, db)
         for row in compiler.results_iter(results):
             obj = model_cls.from_db(db, init_list, row[model_fields_start:model_fields_end])
@@ -1230,9 +1225,7 @@ class RawQuerySet(object):
             if skip:
                 if self.model._meta.pk.attname in skip:
                     raise InvalidQuery('Raw query must include the primary key')
-                model_cls = deferred_class_factory(self.model, skip)
-            else:
-                model_cls = self.model
+            model_cls = self.model
             fields = [self.model_fields.get(c) for c in self.columns]
             converters = compiler.get_converters([
                 f.get_col(f.model._meta.db_table) if f else None for f in fields
@@ -1692,13 +1685,6 @@ class RelatedPopulator(object):
 
     def get_deferred_cls(self, klass_info, init_list):
         model_cls = klass_info['model']
-        if len(init_list) != len(model_cls._meta.concrete_fields):
-            init_set = set(init_list)
-            skip = [
-                f.attname for f in model_cls._meta.concrete_fields
-                if f.attname not in init_set
-            ]
-            model_cls = deferred_class_factory(model_cls, skip)
         return model_cls
 
     def populate(self, row, from_obj):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3568,7 +3568,7 @@ class AdminCustomQuerysetTest(TestCase):
         self.assertContains(
             response,
             '<li class="success">The short message "<a href="%s">'
-            'ShortMessage_Deferred_timestamp object</a>" was changed successfully.</li>' %
+            'ShortMessage object</a>" was changed successfully.</li>' %
             reverse('admin:admin_views_shortmessage_change', args=(sm.pk,)), html=True
         )
 
@@ -3617,7 +3617,7 @@ class AdminCustomQuerysetTest(TestCase):
         self.assertContains(
             response,
             '<li class="success">The paper "<a href="%s">'
-            'Paper_Deferred_author object</a>" was changed successfully.</li>' %
+            'Paper object</a>" was changed successfully.</li>' %
             reverse('admin:admin_views_paper_change', args=(p.pk,)), html=True
         )
 


### PR DESCRIPTION
The implementation is based on non-data descriptors. Dynamically created deferred classes are gone.

The new implementation is much cleaner and much faster (around 30% faster for query_raw_deferred). There is still some cleanup to do in QuerySet iterators.

One can also do the following after the patch:
```
    obj = MyModel(pk=1, field=models.DEFERRED); 
    obj.field # <- Loads the field from DB
```
or
```
    obj = MyModel.objects.first()
    del obj.field
    obj.field  # <- Loads the field from DB
```

There are various backwards incompatibilities we can't easily work around:
  1) `Model.__init__()` will be called with value DEFERRED for those fields which are deferred. Previously those fields were not given to `__init__()` at all.
  2) The class level attribute Model._deferred must be removed (we can't have class level attribute as we don't have dynamic classes any more)
  3) A field name clashing with a classmethod will now either hide the classmethod or disallow usage of deferred loading for that field. The patch takes the latter approach, though I think a loud failure might be better in this case. Notably if one used a *deferred* instance earlier the shadowing would have happened *only for the deferred instance's class*.

Of these only 1) seem like a possible stopper. Personally I don't care, as overriding `Model.__init__()` is a sure way for trouble.