### PR TITLE
Fixed sql_create_index for mysql

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -24,6 +24,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_create_pk = "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s PRIMARY KEY (%(columns)s)"
     sql_delete_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
 
+    sql_create_index = "ALTER TABLE %(table)s ADD KEY %(name)s (%(columns)s) %(extra)s"
+
     def quote_value(self, value):
         # Inner import to allow module to fail to load gracefully
         import MySQLdb.converters


### PR DESCRIPTION
This needs to use "alter table" instead of "create index" due to this 6 year old bug in mysql:
https://bugs.mysql.com/bug.php?id=48875

This is a fixed duplicate pull request (I had left whitespace in the previous request). I'm not sure why github did not give me the new version of the file when I tried to edit it, forcing me to do this extra request.

Previous request: https://github.com/django/django/pull/6113