### PR TITLE
Fixed #26204 -- Reallowed dashes in top-level domains for URLValidator.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -86,7 +86,14 @@ class URLValidator(RegexValidator):
     hostname_re = r'[a-z' + ul + r'0-9](?:[a-z' + ul + r'0-9-]{0,61}[a-z' + ul + r'0-9])?'
     # Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
     domain_re = r'(?:\.(?!-)[a-z' + ul + r'0-9-]{1,63}(?<!-))*'
-    tld_re = r'\.(?:[a-z' + ul + r']{2,63}|xn--[a-z0-9]{1,59})\.?'
+    tld_re = (
+        '\.'                                # dot
+        '(?!-)'                             # can't start with a dash
+        '(?:[a-z' + ul + '-]{2,63}'         # domain label
+        '|xn--[a-z0-9]{1,59})'              # or punycode label
+        '(?<!-)'                            # can't end with a dash
+        '\.?'                               # may have a trailing dot
+    )
     host_re = '(' + hostname_re + domain_re + tld_re + '|localhost)'
 
     regex = _lazy_re_compile(

--- a/docs/releases/1.8.10.txt
+++ b/docs/releases/1.8.10.txt
@@ -21,3 +21,6 @@ Bugfixes
 * Fixed :class:`~django.contrib.postgres.fields.RangeField` and
   :class:`~django.contrib.postgres.fields.ArrayField` serialization with
   ``None`` values (:ticket:`26215`).
+
+* Reallowed dashes in top-level domain names of URLs checked by
+  ``URLValidator`` to fix a regression in Django 1.8 (:ticket:`26204`).

--- a/docs/releases/1.9.3.txt
+++ b/docs/releases/1.9.3.txt
@@ -34,3 +34,6 @@ Bugfixes
 
 * Fixed a crash when filtering by a ``Decimal`` in ``RawQuery``
   (:ticket:`26219`).
+
+* Reallowed dashes in top-level domain names of URLs checked by
+  ``URLValidator`` to fix a regression in Django 1.8 (:ticket:`26204`).

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -6,7 +6,7 @@ http://.com
 http://invalid-.com
 http://-invalid.com
 http://invalid.com-
-http://invalid.c-m
+http://invalid.-com
 http://inv-.alid-.com
 http://inv-.-alid.com
 file://localhost/path
@@ -33,6 +33,8 @@ http:// shouldfail.com
 :// should fail
 http://foo.bar/foo(bar)baz quux
 http://-error-.invalid/
+http://dashinpunytld.trailingdot.xn--.
+http://dashinpunytld.xn---
 http://-a.b.co
 http://a.b-.co
 http://a.-b.co

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -67,3 +67,7 @@ http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.c
 http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com
 http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaa
+http://dashintld.c-m
+http://multipledashintld.a-b-c
+http://evenmoredashintld.a---c
+http://dashinpunytld.xn---c


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26204