### PR TITLE
Clarified "database column type" explanation.

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -111,7 +111,7 @@ Each field in your model should be an instance of the appropriate
 :class:`~django.db.models.Field` class. Django uses the field class types to
 determine a few things:
 
-* The database column type (e.g. ``INTEGER``, ``VARCHAR``).
+* The column type, which tells the database what kind of data to store (e.g. ``INTEGER``, ``VARCHAR``,  ``TEXT``).
 
 * The default HTML :doc:`widget </ref/forms/widgets>` to use when rendering a form
   field (e.g. ``<input type="text">``, ``<select>``).


### PR DESCRIPTION
On line 113, clarified the sentence a little to more succinctly describe what a column type is.  I found this sentence confusing when I was first learning - if someone hasn't used frameworks or programmed before this point can be a little confusing.  Also added one additional example in parens.