### PR TITLE
Fixed #25251 -- Made data migrations available in TransactionTestCase.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -928,6 +928,16 @@ class TransactionTestCase(SimpleTestCase):
                          allow_cascade=self.available_apps is not None,
                          inhibit_post_migrate=inhibit_post_migrate)
 
+            # If there was some initial data from migrated apps, restore them for the next test.
+            if self.serialized_rollback and hasattr(connections[db_name], "_test_serialized_contents"):
+                if self.available_apps is not None:
+                    apps.unset_available_apps()
+                connections[db_name].creation.deserialize_db_from_string(
+                    connections[db_name]._test_serialized_contents
+                )
+                if self.available_apps is not None:
+                    apps.set_available_apps(self.available_apps)
+
     def assertQuerysetEqual(self, qs, values, transform=repr, ordered=True, msg=None):
         items = six.moves.map(transform, qs)
         if not ordered:

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -600,6 +600,17 @@ You can check if your database has any of the removed hashers like this::
     # Unsalted MD5 passwords might not have an 'md5$$' prefix:
     User.objects.filter(password__length=32)
 
+``TransactionTestCase`` serialized data loading
+-----------------------------------------------
+
+Initial data migrations are now loaded in ``TransactionTestCase`` at the end of
+the test, after the database flush.
+In older versions, these data were loaded at the beginning of the test, but
+this behavior was preventing ``--keepdb`` option to work properly (the
+database was empty at the end of the whole test suite).
+It shouldn't have any impact on your test suite if you have not customized
+``TransactionTestCase`` internal logic.
+
 Miscellaneous
 -------------
 

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -259,6 +259,13 @@ To prevent serialized data from being loaded twice, setting
 :data:`~django.db.models.signals.post_migrate` signal when flushing the test
 database.
 
+.. versionchanged:: 1.10
+
+Data are now loaded at the end of a ``TransactionTestCase``, after
+the database flush (it was previously loaded at the beginning of the test).
+This change makes ``--keepdb`` option work properly if your test suite
+contains ``TransactionTestCase`` tests.
+
 Other test conditions
 ---------------------
 

--- a/tests/test_utils/test_transactiontestcase.py
+++ b/tests/test_utils/test_transactiontestcase.py
@@ -1,7 +1,46 @@
+import json
+
+from django.apps import apps
+from django.db import connections
 from django.test import TransactionTestCase, mock
 
+from .models import Car
 
-class TestSerializedRollbackInhibitsPostMigrate(TransactionTestCase):
+
+class TestSerializedContentMockMixin(object):
+    """
+    This mixin should be used every time we want to test something involving
+    TransactionTestCase and serialized_rollback = True option to avoid test dependencies.
+    We mock what would be serialized by Django after initial data migrations, and restore it
+    at the end of the test.
+    """
+    initial_data_migration = '[]'
+    _connections_test_serialized_content = {}
+
+    def _pre_setup(self):
+        for db_name in self._databases_names(include_mirrors=False):
+            self._connections_test_serialized_content[db_name] = connections[db_name]._test_serialized_contents
+            connections[db_name]._test_serialized_contents = self.initial_data_migration
+        super(TestSerializedContentMockMixin, self)._pre_setup()
+
+    def _post_teardown(self):
+        super(TestSerializedContentMockMixin, self)._post_teardown()
+        for db_name in self._databases_names(include_mirrors=False):
+            connections[db_name]._test_serialized_contents = self._connections_test_serialized_content[db_name]
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestSerializedContentMockMixin, cls).tearDownClass()
+
+        # Cleaning any data that has been created by our mixin class
+        # to not impact any other django suite test.
+        json_data = json.loads(cls.initial_data_migration)
+        for data in json_data:
+            Klass = apps.get_model(*data['model'].split('.'))
+            Klass.objects.get(pk=data['pk']).delete()
+
+
+class TestSerializedRollbackInhibitsPostMigrate(TestSerializedContentMockMixin, TransactionTestCase):
     """
     TransactionTestCase._fixture_teardown() inhibits the post_migrate signal
     for test classes with serialized_rollback=True.
@@ -26,3 +65,20 @@ class TestSerializedRollbackInhibitsPostMigrate(TransactionTestCase):
             reset_sequences=False, inhibit_post_migrate=True,
             database='default', verbosity=0,
         )
+
+
+class TestDataConsistencyOnTearDown(TestSerializedContentMockMixin, TransactionTestCase):
+    """
+    Initial data should be recreated in TransactionTestCase._fixture_teardown()
+    after the database is flushed so it's available in all tests.
+    """
+    available_apps = ['test_utils']
+    serialized_rollback = True
+    initial_data_migration = '[{"model": "test_utils.car", "pk": 666, "fields": {"name": "K 2000"}}]'
+
+    def _post_teardown(self):
+        super(TestDataConsistencyOnTearDown, self)._post_teardown()
+        self.assertTrue(Car.objects.exists())
+
+    def test_that_should_be_the_only_one_in_this_test_case(self):
+        pass


### PR DESCRIPTION
Data loaded in migrations are restored at the beginning of each `TransactionTestCase` and all the tables are truncated at the end of these test cases.

It means that, at the end of your whole test suite, if there was at least one `TransactionTestCase`, the migrated data are no more in the database, specially surprising when using `--keepdb` option.

I propose to restore data at the end of a `TransactionTestCase` (just after the `flush`), to be sure that the next test will be in the expected environment (data loaded from initial migrations) and the database will be in the expected state at the end of the test running suite.

This PR follows the discussion related to https://code.djangoproject.com/ticket/25251 with @timgraham.
