### PR TITLE
Fixed #26107 -- Added option to int_list_validator to allow negatives

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -283,8 +283,10 @@ def ip_address_validators(protocol, unpack_ipv4):
                          % (protocol, list(ip_address_validator_map)))
 
 
-def int_list_validator(sep=',', message=None, code='invalid'):
-    regexp = _lazy_re_compile('^\d+(?:%s\d+)*\Z' % re.escape(sep))
+def int_list_validator(sep=',', message=None, code='invalid', allow_negative=False):
+    regexp = _lazy_re_compile(
+        '^%(neg)s\d+(?:%(sep)s%(neg)s\d+)*\Z' % ({'neg': '(-)?' if allow_negative else '', 'sep': re.escape(sep)})
+    )
     return RegexValidator(regexp, message=message, code=code)
 
 

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -222,12 +222,17 @@ to, or in lieu of custom ``field.clean()`` methods.
 ``int_list_validator``
 ----------------------
 
-.. function:: int_list_validator(sep=',', message=None, code='invalid')
+.. function:: int_list_validator(sep=',', message=None, code='invalid', allow_negative=False)
 
     .. versionadded:: 1.9
 
     Returns a :class:`RegexValidator` instance that ensures a string
-    consists of integers separated by ``sep``.
+    consists of integers separated by ``sep``. It allows negative integers when
+    ``allow_negative`` is ``True``.
+
+    .. versionchanged:: 1.10
+
+    The ``allow_negative`` parameter was added.
 
 ``MaxValueValidator``
 ---------------------

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -351,6 +351,10 @@ Validators
   domain name labels to 63 characters and the total length of domain
   names to 253 characters per :rfc:`1034`.
 
+* :func:`~django.core.validators.int_list_validator` now accepts an optional
+  boolean parameter ``allow_negative``, defaulting to False, to allow negative
+  integers.
+
 Backwards incompatible changes in 1.10
 ======================================
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -172,6 +172,11 @@ TEST_DATA = [
     (validate_comma_separated_integer_list, '1,,2', ValidationError),
 
     (int_list_validator(sep='.'), '1.2.3', None),
+    (int_list_validator(sep='.', allow_negative=True), '1.2.3', None),
+    (int_list_validator(allow_negative=True), '-1,-2,3', None),
+    (int_list_validator(allow_negative=True), '1,-2,-12', None),
+
+    (int_list_validator(), '-1,2,3', ValidationError),
     (int_list_validator(sep='.'), '1,2,3', ValidationError),
     (int_list_validator(sep='.'), '1.2.3\n', ValidationError),
 


### PR DESCRIPTION
The new boolean allow_negative option will let the list contain negative
 integers.