### PR TITLE
Fixed #26219 -- Allowed filtering by Decimal parameter in RawQuery.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -486,7 +486,7 @@ class BaseDatabaseOperations(object):
             raise ValueError("Django does not support timezone-aware times.")
         return six.text_type(value)
 
-    def adapt_decimalfield_value(self, value, max_digits, decimal_places):
+    def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
         """
         Transforms a decimal.Decimal value to an object compatible with what is
         expected by the backend driver for decimal (numeric) columns.

--- a/docs/releases/1.9.3.txt
+++ b/docs/releases/1.9.3.txt
@@ -31,3 +31,5 @@ Bugfixes
 * Fixed :class:`~django.contrib.postgres.fields.RangeField` and
   :class:`~django.contrib.postgres.fields.ArrayField` serialization with
   ``None`` values (:ticket:`26215`).
+* Fixed a regression where filtering by ``Decimal`` parameter in ``RawQuery`` was
+  raising ``TypeError`` (:ticket:`26219`).

--- a/tests/raw_query/models.py
+++ b/tests/raw_query/models.py
@@ -29,6 +29,7 @@ class BookFkAsPk(models.Model):
 
 class Coffee(models.Model):
     brand = models.CharField(max_length=255, db_column="name")
+    price = models.DecimalField(max_digits=10, decimal_places=2, default=0, blank=True)
 
 
 class Reviewer(models.Model):

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from datetime import date
+from decimal import Decimal
 
 from django.db.models.query_utils import InvalidQuery
 from django.test import TestCase, skipUnlessDBFeature
@@ -307,3 +308,10 @@ class RawQueryTests(TestCase):
         """
         b = BookFkAsPk.objects.create(book=self.b1)
         self.assertEqual(list(BookFkAsPk.objects.raw('SELECT not_the_default FROM raw_query_bookfkaspk')), [b])
+
+    def test_decimal_parameter(self):
+        c = Coffee.objects.create(brand='starbucks', price=20.5)
+        self.assertEqual(list(Coffee.objects.raw(
+            "SELECT * FROM raw_query_coffee WHERE price >= %s",
+            params=[Decimal(20)]
+        )), [c])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26219