### PR TITLE
Changed documentation to follow recommended ValidationError use.

### DIFF
--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -474,6 +474,7 @@ instances::
 
     from django.core.exceptions import ValidationError
     from django.db import models
+    from django.utils.translation import ugettext_lazy as _
 
     def parse_hand(hand_string):
         """Takes a string of cards and splits into a full hand."""
@@ -481,7 +482,7 @@ instances::
         p2 = re.compile('..')
         args = [p2.findall(x) for x in p1.findall(hand_string)]
         if len(args) != 4:
-            raise ValidationError("Invalid input for a Hand instance")
+            raise ValidationError(_("Invalid input for a Hand instance"))
         return Hand(*args)
 
     class HandField(models.Field):

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -16,10 +16,14 @@ different types of fields.
 For example, here's a validator that only allows even numbers::
 
     from django.core.exceptions import ValidationError
+    from django.utils.translation import ugettext_lazy as _
 
     def validate_even(value):
         if value % 2 != 0:
-            raise ValidationError('%s is not an even number' % value)
+            raise ValidationError(
+                _('%(value)s is not an even number'),
+                params={'value': value},
+            )
 
 You can add this to a model field via the field's :attr:`~django.db.models.Field.validators`
 argument::


### PR DESCRIPTION
While reading the [Validators documentation](https://docs.djangoproject.com/en/1.9/ref/validators/), I noticed it did not raise a `ValidationError` in the manner recommended by the [Raising `ValidationError` documentation](https://docs.djangoproject.com/en/1.9/ref/forms/validation/#raising-validationerror). The lack of `params` was most obvious to me.