### PR TITLE
Fixed #26231 -- Used `.get_username` in admin login template.

### DIFF
--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -34,7 +34,7 @@
 
 {% if user.is_authenticated %}
 <p class="errornote">
-{% blocktrans with username=request.user.username trimmed %}
+{% blocktrans with username=request.user.get_username trimmed %}
     You are authenticated as {{ username }}, but are not authorized to
     access this page. Would you like to login to a different account?
 {% endblocktrans %}


### PR DESCRIPTION
On a custom user object, `.username` does not necessarily have to exist.
By using `.get_username`, the proper accessor in `AbstractBaseUser`
can retrieve the proper attribute instead.