### PR TITLE
Fixed #26226 -- Made related managers honor the queryset used for prefetching their results.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -144,6 +144,9 @@ details on these changes.
 * The ``__search`` query lookup and the
   ``DatabaseOperations.fulltext_search_sql()`` method will be removed.
 
+* The shim for supporting custom related manager classes without a
+  ``_apply_rel_filters()`` method will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -762,6 +762,17 @@ features, is deprecated. Replace it with a custom lookup::
     models.CharField.register_lookup(Search)
     models.TextField.register_lookup(Search)
 
+Custom manager classes available through ``prefetch_related`` must define a ``_apply_rel_filters()`` method
+-----------------------------------------------------------------------------------------------------------
+
+If you defined a custom manager class available through
+:meth:`~django.db.models.query.QuerySet.prefetch_related` you must make sure
+it defines a ``_apply_rel_filters()`` method.
+
+This method must accept a :class:`~django.db.models.query.QuerySet` instance
+as its single argument and return a filtered version of the queryset for the
+model instance the manager is bound to.
+
 Miscellaneous
 -------------
 

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -836,6 +836,19 @@ class GenericRelationTests(TestCase):
             self.assertEqual(sorted([i.tag for i in bookmark.tags.all()]), ["django", "python"])
             self.assertEqual([i.tag for i in bookmark.favorite_tags.all()], ["python"])
 
+    def test_custom_queryset(self):
+        bookmark = Bookmark.objects.create(url='http://www.djangoproject.com/')
+        django_tag = TaggedItem.objects.create(content_object=bookmark, tag='django')
+        TaggedItem.objects.create(content_object=bookmark, tag='python')
+
+        with self.assertNumQueries(2):
+            bookmark = Bookmark.objects.prefetch_related(
+                Prefetch('tags', TaggedItem.objects.filter(tag='django')),
+            ).get()
+
+        with self.assertNumQueries(0):
+            self.assertEqual(list(bookmark.tags.all()), [django_tag])
+
 
 class MultiTableInheritanceTest(TestCase):
 


### PR DESCRIPTION
@loic I'd like to have your feedback about this slightly backward incompatible change.

If I remember correctly such an issue was discussed during the implementation of the `Prefetch` object.