### PR TITLE
Refs #6148 -- Meta table api

### DIFF
--- a/django/contrib/gis/db/backends/spatialite/schema.py
+++ b/django/contrib/gis/db/backends/spatialite/schema.py
@@ -119,9 +119,10 @@ class SpatialiteSchemaEditor(DatabaseSchemaEditor):
         else:
             super(SpatialiteSchemaEditor, self).remove_field(model, field)
 
-    def alter_db_table(self, model, old_db_table, new_db_table):
+    def alter_db_table(self, model, old_table_cls, new_table_cls):
         from django.contrib.gis.db.models.fields import GeometryField
         # Remove geometry-ness from temp table
+        old_db_table, new_db_table = self.compile_table(old_table_cls), self.compile_table(new_table_cls)
         for field in model._meta.local_fields:
             if isinstance(field, GeometryField):
                 self.execute(
@@ -131,7 +132,7 @@ class SpatialiteSchemaEditor(DatabaseSchemaEditor):
                     }
                 )
         # Alter table
-        super(SpatialiteSchemaEditor, self).alter_db_table(model, old_db_table, new_db_table)
+        super(SpatialiteSchemaEditor, self).alter_db_table(model, old_table_cls, new_table_cls)
         # Repoint any straggler names
         for geom_table in self.geometry_tables:
             try:

--- a/django/contrib/gis/db/backends/spatialite/schema.py
+++ b/django/contrib/gis/db/backends/spatialite/schema.py
@@ -122,7 +122,7 @@ class SpatialiteSchemaEditor(DatabaseSchemaEditor):
     def alter_db_table(self, model, old_table_cls, new_table_cls):
         from django.contrib.gis.db.models.fields import GeometryField
         # Remove geometry-ness from temp table
-        old_db_table, new_db_table = self.compile_table(old_table_cls), self.compile_table(new_table_cls)
+        old_db_table, new_db_table = old_table_cls.table, new_table_cls.table
         for field in model._meta.local_fields:
             if isinstance(field, GeometryField):
                 self.execute(

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                     constraints = {}
                 used_column_names = []  # Holds column names used in the table so far
                 column_to_field_name = {}  # Maps column names to names of model fields
-                for row in connection.introspection.get_table_description(cursor, table_name):
+                for row in connection.introspection.get_table_description(cursor, None, table_name):
                     comment_notes = []  # Holds Field notes, to be displayed in a Python comment.
                     extra_params = OrderedDict()  # Holds Field parameters such as 'db_column'.
                     column_name = row[0]

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
                 except NotImplementedError:
                     indexes = {}
                 try:
-                    constraints = connection.introspection.get_constraints(cursor, table_name)
+                    constraints = connection.introspection.get_constraints(cursor, None, table_name)
                 except NotImplementedError:
                     constraints = {}
                 used_column_names = []  # Holds column names used in the table so far

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from django.utils import six
 
 # Structure returned by DatabaseIntrospection.get_table_list()
-TableInfo = namedtuple('TableInfo', ['name', 'type'])
+TableInfo = namedtuple('TableInfo', ['name', 'type', 'schema'])
 
 # Structure returned by the DB-API cursor.description interface (PEP 249)
 FieldInfo = namedtuple('FieldInfo',
@@ -42,22 +42,32 @@ class BaseDatabaseIntrospection(object):
         """
         return self.table_name_converter(name)
 
-    def table_names(self, cursor=None, include_views=False):
+    def table_names(self, cursor=None, include_views=False, include_schema=False):
         """
         Returns a list of names of all tables that exist in the database.
         The returned table list is sorted by Python's default sorting. We
         do NOT use database's ORDER BY here to avoid subtle differences
         in sorting order between databases.
+
+        If include_schema is True, then all tables in the DB must be returned in
+        format (schema, db_table). In addition all visible tables must be returned
+        in format (None, db_table).
         """
         def get_names(cursor):
-            return sorted(ti.name for ti in self.get_table_list(cursor)
-                          if include_views or ti.type == 't')
+            if include_schema:
+                return sorted((ti.schema, ti.name)
+                              for ti in self.get_table_list(cursor, include_schema=include_schema)
+                              if include_views or ti.type == 't')
+            else:
+                return sorted(ti.name for ti in self.get_table_list(cursor)
+                              if include_views or ti.type == 't')
+
         if cursor is None:
             with self.connection.cursor() as cursor:
                 return get_names(cursor)
         return get_names(cursor)
 
-    def get_table_list(self, cursor):
+    def get_table_list(self, cursor, include_schema=False):
         """
         Returns an unsorted list of TableInfo named tuples of all tables and
         views that exist in the database.

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -157,7 +157,7 @@ class BaseDatabaseIntrospection(object):
         """
         raise NotImplementedError('subclasses of BaseDatabaseIntrospection may require a get_indexes() method')
 
-    def get_constraints(self, cursor, table_name):
+    def get_constraints(self, cursor, schema, table_name):
         """
         Retrieves any constraints or keys (unique, pk, fk, check, index)
         across one or more columns.

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -34,7 +34,7 @@ class BaseDatabaseOperations(object):
         self.connection = connection
         self._cache = None
 
-    def autoinc_sql(self, table, column):
+    def autoinc_sql(self, schema, table, column):
         """
         Returns any SQL needed to support auto-incrementing primary keys, or
         None if no SQL is necessary.

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -806,8 +806,9 @@ class BaseDatabaseSchemaEditor(object):
         """
         # Rename the through table
         if old_field.remote_field.through._meta.table_cls != new_field.remote_field.through._meta.table_cls:
-            self.alter_db_table(old_field.remote_field.through, old_field.remote_field.through._meta,
-                                new_field.remote_field.through._meta)
+            self.alter_db_table(old_field.remote_field.through,
+                                old_field.remote_field.through._meta.table_cls,
+                                new_field.remote_field.through._meta.table_cls)
         # Repoint the FK to the other side
         self.alter_field(
             new_field.remote_field.through,

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -154,10 +154,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             return self.connection.features._mysql_storage_engine
         return result[0]
 
-    def get_constraints(self, cursor, table_name):
+    def get_constraints(self, cursor, schema, table_name):
         """
         Retrieves any constraints or keys (unique, pk, fk, check, index) across one or more columns.
         """
+        assert schema is None, "Schema-qualified tables not supported on MySQL"
         constraints = {}
         # Get the actual constraint names and columns
         name_query = """

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -46,15 +46,15 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         return field_type
 
-    def get_table_list(self, cursor):
+    def get_table_list(self, cursor, include_schemas=False):
         """
         Returns a list of table and view names in the current database.
         """
         cursor.execute("SHOW FULL TABLES")
-        return [TableInfo(row[0], {'BASE TABLE': 't', 'VIEW': 'v'}.get(row[1]))
+        return [TableInfo(row[0], {'BASE TABLE': 't', 'VIEW': 'v'}.get(row[1]), None)
                 for row in cursor.fetchall()]
 
-    def get_table_description(self, cursor, table_name):
+    def get_table_description(self, cursor, schema, table_name):
         """
         Returns a description of the table, with the DB-API cursor.description interface."
         """
@@ -63,6 +63,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         #   not visible length (#5725)
         # - precision and scale (for decimal fields) (#5014)
         # - auto_increment is not available in cursor.description
+        assert schema is None, "No schema support for MySQL"
         cursor.execute("""
             SELECT column_name, data_type, character_maximum_length, numeric_precision,
                    numeric_scale, extra, column_default

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -94,9 +94,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             new_type += " NOT NULL"
         return new_type
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+    def _alter_column_type_sql(self, schema, table, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)
-        return super(DatabaseSchemaEditor, self)._alter_column_type_sql(table, old_field, new_field, new_type)
+        return super(DatabaseSchemaEditor, self)._alter_column_type_sql(schema, table, old_field, new_field, new_type)
 
     def _rename_field_sql(self, table, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -146,10 +146,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                                'unique': bool(row[2])}
         return indexes
 
-    def get_constraints(self, cursor, table_name):
+    def get_constraints(self, cursor, schema, table_name):
         """
         Retrieves any constraints or keys (unique, pk, fk, check, index) across one or more columns.
         """
+        assert schema is None, "Not implemented yet!"
         constraints = {}
         # Loop over the constraints, getting PKs and uniques
         cursor.execute("""

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -53,10 +53,12 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """
         cursor.execute("SELECT TABLE_NAME, 't' FROM USER_TABLES UNION ALL "
                        "SELECT VIEW_NAME, 'v' FROM USER_VIEWS")
-        return [TableInfo(row[0].lower(), row[1]) for row in cursor.fetchall()]
+        return [TableInfo(row[0].lower(), row[1], None) for row in cursor.fetchall()]
 
-    def get_table_description(self, cursor, table_name):
+    def get_table_description(self, cursor, schema, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."
+        if schema:
+            raise NotImplementedError("TODO")
         self.cache_bust_counter += 1
         cursor.execute("SELECT * FROM {} WHERE ROWNUM < 2 AND {} > 0".format(
             self.connection.ops.quote_name(table_name),

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -41,9 +41,10 @@ BEGIN
 END;
 /"""
 
-    def autoinc_sql(self, table, column):
+    def autoinc_sql(self, schema, table, column):
         # To simulate auto-incrementing primary keys in Oracle, we have to
         # create a sequence and a trigger.
+        assert schema is None
         args = {
             'sq_name': self._get_sequence_name(table),
             'tr_name': self._get_trigger_name(table),

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -139,10 +139,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 indexes[row[0]]['unique'] = True
         return indexes
 
-    def get_constraints(self, cursor, table_name):
+    def get_constraints(self, cursor, schema, table_name):
         """
         Retrieves any constraints or keys (unique, pk, fk, check, index) across one or more columns.
         """
+        assert schema is None, "Not implemented yet!"
         constraints = {}
         # Loop over the key table, collecting things as constraints
         # This will get PKs, FKs, and uniques, but not CHECK

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -53,7 +53,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 return 'BigAutoField'
         return field_type
 
-    def get_table_list(self, cursor):
+    def get_table_list(self, cursor, include_schema=False):
         """
         Returns a list of table and view names in the current database.
         """
@@ -64,20 +64,39 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             WHERE c.relkind IN ('r', 'v')
                 AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
                 AND pg_catalog.pg_table_is_visible(c.oid)""")
-        return [TableInfo(row[0], {'r': 't', 'v': 'v'}.get(row[1]))
+        tables = [TableInfo(row[0], {'r': 't', 'v': 'v'}.get(row[1]), None)
                 for row in cursor.fetchall()
                 if row[0] not in self.ignored_tables]
+        if include_schema:
+            cursor.execute("""
+                SELECT c.relname, c.relkind, n.nspname
+                FROM pg_catalog.pg_class c
+                LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind IN ('r', 'v')
+                    AND n.nspname NOT IN ('pg_catalog', 'pg_toast')""")
+            tables.extend([TableInfo(row[0], {'r': 't', 'v': 'v'}.get(row[1]), row[2])
+                    for row in cursor.fetchall()
+                    if row[0] not in self.ignored_tables])
+        return tables
 
-    def get_table_description(self, cursor, table_name):
+    def get_table_description(self, cursor, schema, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."
         # As cursor.description does not return reliably the nullable property,
         # we have to query the information_schema (#7783)
-        cursor.execute("""
-            SELECT column_name, is_nullable, column_default
-            FROM information_schema.columns
-            WHERE table_name = %s""", [table_name])
+        if schema is None:
+            cursor.execute("""
+                SELECT column_name, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_name = %s""", [table_name])
+        else:
+            cursor.execute("""
+                SELECT column_name, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_name = %s and table_schema = %s""", [table_name, schema])
         field_map = {line[0]: line[1:] for line in cursor.fetchall()}
-        cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
+        cursor.execute("SELECT * FROM %s%s LIMIT 1" % (
+            (self.connection.ops.quote_name(schema) + '.') if schema else '',
+            self.connection.ops.quote_name(table_name)))
         return [FieldInfo(*((force_text(line[0]),) + line[1:6]
                             + (field_map[force_text(line[0])][0] == 'YES', field_map[force_text(line[0])][1])))
                 for line in cursor.description]

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -50,10 +50,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 return self._create_index_sql(model, [field], suffix='_like', sql=self.sql_create_text_index)
         return None
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+    def _alter_column_type_sql(self, schema, table, old_field, new_field, new_type):
         """
         Makes ALTER TYPE with SERIAL make sense.
         """
+        assert schema is None, "Not supported yet!"
         if new_type.lower() in ("serial", "bigserial"):
             column = new_field.column
             sequence_name = "%s_%s_seq" % (table, column)
@@ -101,7 +102,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             )
         else:
             return super(DatabaseSchemaEditor, self)._alter_column_type_sql(
-                table, old_field, new_field, new_type
+                schema, table, old_field, new_field, new_type
             )
 
     def _alter_field(self, model, old_field, new_field, old_type, new_type,

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -56,7 +56,7 @@ class FlexibleFieldLookupDict(object):
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     data_types_reverse = FlexibleFieldLookupDict()
 
-    def get_table_list(self, cursor):
+    def get_table_list(self, cursor, include_schema=False):
         """
         Returns a list of table and view names in the current database.
         """
@@ -66,10 +66,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             SELECT name, type FROM sqlite_master
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
-        return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
+        return [TableInfo(row[0], row[1][0], None) for row in cursor.fetchall()]
 
-    def get_table_description(self, cursor, table_name):
+    def get_table_description(self, cursor, schema, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."
+        assert schema is None, "No schema support for SQLite"
         return [
             FieldInfo(
                 info['name'],

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -231,10 +231,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             'pk': field[5],  # undocumented
         } for field in cursor.fetchall()]
 
-    def get_constraints(self, cursor, table_name):
+    def get_constraints(self, cursor, schema, table_name):
         """
         Retrieves any constraints or keys (unique, pk, fk, check, index) across one or more columns.
         """
+        assert schema is None, "No schema support on sqlite3"
         constraints = {}
         # Get the index info
         cursor.execute("PRAGMA index_list(%s)" % self.connection.ops.quote_name(table_name))

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -173,7 +173,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
         with altered_table_name(model, model._meta.db_table + "__old"):
             # Rename the old table to make way for the new
-            self.alter_db_table(model, temp_model._meta.db_table, model._meta.db_table)
+            self.alter_db_table(model, temp_model._meta.table_cls, model._meta.table_cls)
 
             # Create a new table with the updated schema. We remove things
             # from the deferred SQL that match our table name, too

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -967,12 +967,22 @@ class MigrationAutodetector(object):
             new_model_state = self.to_state.models[app_label, model_name]
             old_db_table_name = old_model_state.options.get('db_table')
             new_db_table_name = new_model_state.options.get('db_table')
+            old_table_cls = old_model_state.options.get('table_cls')
+            new_table_cls = new_model_state.options.get('table_cls')
             if old_db_table_name != new_db_table_name:
                 self.add_operation(
                     app_label,
                     operations.AlterModelTable(
                         name=model_name,
                         table=new_db_table_name,
+                    )
+                )
+            if old_table_cls != new_table_cls:
+                self.add_operation(
+                    app_label,
+                    operations.AlterModelTable(
+                        name=model_name,
+                        table=new_table_cls
                     )
                 )
 

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -250,6 +250,7 @@ class MigrationExecutor(object):
         tables or columns it would create exist. This is intended only for use
         on initial migrations (as it only looks for CreateModel and AddField).
         """
+        # TODO: we need schema-aware introspection for this case.
         if migration.initial is None:
             # Bail if the migration isn't the first one in its app
             if any(app == migration.app_label for app, name in migration.dependencies):

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -397,7 +397,10 @@ class AlterModelTable(ModelOperation):
         )
 
     def state_forwards(self, app_label, state):
-        state.models[app_label, self.name_lower].options["db_table"] = self.table
+        if isinstance(self.table, models.ModelTable):
+            state.models[app_label, self.name_lower].options["table_cls"] = self.table
+        else:
+            state.models[app_label, self.name_lower].options["db_table"] = self.table
         state.reload_model(app_label, self.name_lower)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -297,8 +297,8 @@ class RenameModel(ModelOperation):
             # Move the main table
             schema_editor.alter_db_table(
                 new_model,
-                old_model._meta.db_table,
-                new_model._meta.db_table,
+                old_model._meta.table_cls,
+                new_model._meta.table_cls,
             )
             # Alter the fields pointing to us
             for related_object in old_model._meta.related_objects:
@@ -330,8 +330,8 @@ class RenameModel(ModelOperation):
                 new_m2m_model = new_field.remote_field.through
                 schema_editor.alter_db_table(
                     new_m2m_model,
-                    old_m2m_model._meta.db_table,
-                    new_m2m_model._meta.db_table,
+                    old_m2m_model._meta.table_cls,
+                    new_m2m_model._meta.table_cls,
                 )
                 # Rename the column in the M2M table that's based on this
                 # model's name.
@@ -409,16 +409,16 @@ class AlterModelTable(ModelOperation):
             old_model = from_state.apps.get_model(app_label, self.name)
             schema_editor.alter_db_table(
                 new_model,
-                old_model._meta.db_table,
-                new_model._meta.db_table,
+                old_model._meta.table_cls,
+                new_model._meta.table_cls,
             )
             # Rename M2M fields whose name is based on this model's db_table
             for (old_field, new_field) in zip(old_model._meta.local_many_to_many, new_model._meta.local_many_to_many):
                 if new_field.remote_field.through._meta.auto_created:
                     schema_editor.alter_db_table(
                         new_field.remote_field.through,
-                        old_field.remote_field.through._meta.db_table,
-                        new_field.remote_field.through._meta.db_table,
+                        old_field.remote_field.through._meta.table_cls,
+                        new_field.remote_field.through._meta.table_cls,
                     )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -47,7 +47,6 @@ class MigrationRecorder(object):
         """
         Ensures the table exists and has the correct schema.
         """
-        # TODO: we need schema-aware introspection for this case.
         # If the table's there, that's fine - we've never changed its schema
         # in the codebase.
         if self.Migration._meta.db_table in self.connection.introspection.table_names(self.connection.cursor()):

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -47,6 +47,7 @@ class MigrationRecorder(object):
         """
         Ensures the table exists and has the correct schema.
         """
+        # TODO: we need schema-aware introspection for this case.
         # If the table's there, that's fine - we've never changed its schema
         # in the codebase.
         if self.Migration._meta.db_table in self.connection.introspection.table_names(self.connection.cursor()):

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -22,6 +22,7 @@ from django.db.models.fields.related import (  # NOQA isort:skip
     ForeignKey, ForeignObject, OneToOneField, ManyToManyField,
     ManyToOneRel, ManyToManyRel, OneToOneRel,
 )
+from django.db.models.options import ModelTable  # NOQA isort:skip
 
 
 def permalink(func):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1221,6 +1221,34 @@ class Model(six.with_metaclass(ModelBase)):
                         id='models.E017',
                     )
                 )
+        if cls._meta.table_cls.schema and cls._meta.managed:
+            errors.append(
+                checks.Error(
+                    "Schema qualified model table for model '%s' requires setting managed to False." % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+        if not cls._meta.table_cls.plain_table_ref and cls._meta.managed:
+            errors.append(
+                checks.Error(
+                    "The table_cls attribute for model '%s' requires setting managed to False." % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+        if 'table_cls' in cls._meta.original_attrs and 'db_table' in cls._meta.original_attrs:
+            errors.append(
+                checks.Error(
+                    "Both table_cls and db_table set for model '%s'" % cls.__name__,
+                    hint=None,
+                    obj=None,
+                    id="models.EXXX"
+                )
+            )
+
         return errors
 
     @classmethod

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1221,24 +1221,6 @@ class Model(six.with_metaclass(ModelBase)):
                         id='models.E017',
                     )
                 )
-        if cls._meta.table_cls.schema and cls._meta.managed:
-            errors.append(
-                checks.Error(
-                    "Schema qualified model table for model '%s' requires setting managed to False." % cls.__name__,
-                    hint=None,
-                    obj=None,
-                    id="models.EXXX"
-                )
-            )
-        if not cls._meta.table_cls.plain_table_ref and cls._meta.managed:
-            errors.append(
-                checks.Error(
-                    "The table_cls attribute for model '%s' requires setting managed to False." % cls.__name__,
-                    hint=None,
-                    obj=None,
-                    id="models.EXXX"
-                )
-            )
         if 'table_cls' in cls._meta.original_attrs and 'db_table' in cls._meta.original_attrs:
             errors.append(
                 checks.Error(

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1056,7 +1056,7 @@ def create_many_to_many_intermediary_model(field, klass):
         from_ = 'from_%s' % from_
 
     meta = type(str('Meta'), (object,), {
-        'db_table': field._get_m2m_db_table(klass._meta),
+        'table_cls': field._get_m2m_table_cls(klass._meta),
         'auto_created': klass,
         'app_label': klass._meta.app_label,
         'db_tablespace': klass._meta.db_tablespace,
@@ -1454,6 +1454,14 @@ class ManyToManyField(RelatedField):
 
     def get_choices_default(self):
         return Field.get_choices(self, include_blank=False)
+
+    def _get_m2m_table_cls(self, opts):
+        # TODO: m2m table cls
+        if self.remote_field.through is not None:
+            return self.remote_field.through._meta.table_cls
+        else:
+            from django.db.models import ModelTable
+            return ModelTable(opts.table_cls.schema, self._get_m2m_db_table(opts))
 
     def _get_m2m_db_table(self, opts):
         """

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -65,9 +65,20 @@ def make_immutable_fields_list(name, data):
 
 
 class ModelTable(object):
+    """
+    The _meta.table_cls can hold either a regular table reference,
+    or anything else usable in a subquery. If table_cls is a
+    regular table reference, then plain_table_ref should be set
+    to True, and the table_cls must contain table and schema
+    attributes.
+
+    Note that currently there is no support for schema qualified
+    tables for migrations.
+    """
     plain_table_ref = True
 
-    def __init__(self, table):
+    def __init__(self, schema, table):
+        self.schema = schema
         self.table = table
         # Cache for the quoted table name per connection.
         self.cache = {}
@@ -77,27 +88,37 @@ class ModelTable(object):
             sql, params = self.cache[connection.vendor]
             return sql, params[:]
         except KeyError:
-            sql, params = connection.ops.quote_name(self.table), []
-            self.cache[connection.vendor] = (sql, params)
-            return sql, params[:]
+            if self.schema:
+                sql = '%s.%s' % (connection.ops.quote_name(self.schema),
+                                 connection.ops.quote_name(self.table))
+            else:
+                sql = connection.ops.quote_name(self.table)
+            self.cache[connection.vendor] = (sql, [])
+            return sql, []
 
     @cached_property
     def default_alias(self):
+        """
+        String to use as default alias for this table.
+        """
         return self.table
 
     def requires_alias(self, table_alias, compiler):
-        return table_alias != self.default_alias
+        """
+        Does this table require usage of aliases always?
+        """
+        return self.schema is not None or table_alias != self.default_alias
 
     def __eq__(self, other):
         if isinstance(other, ModelTable):
-            return self.table == other.table
+            return self.schema == other.schema and self.table == other.table
         return False
 
     def __hash__(self):
-        return hash(self.table)
+        return hash((self.schema, self.table))
 
     def deconstruct(self):
-        return ("django.db.models.ModelTable", [self.table], {})
+        return ("django.db.models.ModelTable", [self.table, self.schema], {})
 
 
 @python_2_unicode_compatible
@@ -273,7 +294,7 @@ class Options(object):
             raise TypeError("Can't assign a class to db_table property. "
                             "Use table_cls instead.")
         else:
-            self.table_cls = ModelTable(table)
+            self.table_cls = ModelTable(None, table)
 
     def _prepare(self, model):
         if self.order_with_respect_to:

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -114,11 +114,20 @@ class ModelTable(object):
             return self.schema == other.schema and self.table == other.table
         return False
 
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
         return hash((self.schema, self.table))
 
     def deconstruct(self):
-        return ("django.db.models.ModelTable", [self.table, self.schema], {})
+        return ("django.db.models.ModelTable", [self.schema, self.table], {})
+
+    def __str__(self):
+        if self.schema:
+            return "%s.%s" % (self.schema, self.table)
+        else:
+            return "%s" % self.table
 
 
 @python_2_unicode_compatible

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -28,13 +28,14 @@ IMMUTABLE_WARNING = (
     "for your own use, make a copy first."
 )
 
-DEFAULT_NAMES = ('verbose_name', 'verbose_name_plural', 'db_table', 'ordering',
+DEFAULT_NAMES = ('verbose_name', 'verbose_name_plural', 'ordering',
                  'unique_together', 'permissions', 'get_latest_by',
                  'order_with_respect_to', 'app_label', 'db_tablespace',
                  'abstract', 'managed', 'proxy', 'swappable', 'auto_created',
                  'index_together', 'apps', 'default_permissions',
                  'select_on_save', 'default_related_name',
-                 'required_db_features', 'required_db_vendor')
+                 'required_db_features', 'required_db_vendor', 'db_table',
+                 'table_cls')
 
 
 def normalize_together(option_together):
@@ -63,6 +64,42 @@ def make_immutable_fields_list(name, data):
     return ImmutableList(data, warning=IMMUTABLE_WARNING % name)
 
 
+class ModelTable(object):
+    plain_table_ref = True
+
+    def __init__(self, table):
+        self.table = table
+        # Cache for the quoted table name per connection.
+        self.cache = {}
+
+    def as_sql(self, compiler, connection):
+        try:
+            sql, params = self.cache[connection.vendor]
+            return sql, params[:]
+        except KeyError:
+            sql, params = connection.ops.quote_name(self.table), []
+            self.cache[connection.vendor] = (sql, params)
+            return sql, params[:]
+
+    @cached_property
+    def default_alias(self):
+        return self.table
+
+    def requires_alias(self, table_alias, compiler):
+        return table_alias != self.default_alias
+
+    def __eq__(self, other):
+        if isinstance(other, ModelTable):
+            return self.table == other.table
+        return False
+
+    def __hash__(self):
+        return hash(self.table)
+
+    def deconstruct(self):
+        return ("django.db.models.ModelTable", [self.table], {})
+
+
 @python_2_unicode_compatible
 class Options(object):
     FORWARD_PROPERTIES = {'fields', 'many_to_many', 'concrete_fields',
@@ -79,7 +116,8 @@ class Options(object):
         self.model_name = None
         self.verbose_name = None
         self.verbose_name_plural = None
-        self.db_table = ''
+        # Note - db_table is assigned to table_cls.
+        self.table_cls = None
         self.ordering = []
         self._ordering_clash = False
         self.unique_together = []
@@ -162,9 +200,6 @@ class Options(object):
         ]
 
     def contribute_to_class(self, cls, name):
-        from django.db import connection
-        from django.db.backends.utils import truncate_name
-
         cls._meta = self
         self.model = cls
         # First, construct the default values for these options.
@@ -213,8 +248,32 @@ class Options(object):
 
         # If the db_table wasn't provided, use the app_label + model_name.
         if not self.db_table:
-            self.db_table = "%s_%s" % (self.app_label, self.model_name)
-            self.db_table = truncate_name(self.db_table, connection.ops.max_name_length())
+            from django.db import connection
+            from django.db.backends.utils import truncate_name
+            db_table = "%s_%s" % (self.app_label, self.model_name)
+            self.db_table = truncate_name(db_table, connection.ops.max_name_length())
+
+    @property
+    def db_table(self):
+        """
+        Provide db_table as a backwards compatibility property. The actual value is
+        always stored in table_cls. When table_cls is a plain_table_ref, then the
+        db_table property is usable. For other cases, the table_cls must be accessed
+        directly.
+        """
+        if self.table_cls is None:
+            return ''
+        if self.table_cls.plain_table_ref:
+            return self.table_cls.table
+        raise AttributeError("This class has a table_cls that can't be returned directly as a string.")
+
+    @db_table.setter
+    def db_table(self, table):
+        if hasattr(table, 'plain_table_ref'):
+            raise TypeError("Can't assign a class to db_table property. "
+                            "Use table_cls instead.")
+        else:
+            self.table_cls = ModelTable(table)
 
     def _prepare(self, model):
         if self.order_with_respect_to:
@@ -295,7 +354,7 @@ class Options(object):
         """
         self.pk = target._meta.pk
         self.proxy_for_model = target
-        self.db_table = target._meta.db_table
+        self.table_cls = target._meta.table_cls
 
     def __repr__(self):
         return '<Options for %s>' % self.object_name

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -336,7 +336,7 @@ class SQLCompiler(object):
         """
         if name in self.quote_cache:
             return self.quote_cache[name]
-        tables = [getattr(t, 'table', None) for t in self.query.table_map]
+        tables = set(getattr(t, 'table', None) for t in self.query.table_map)
         if ((name in self.query.alias_map and name not in tables) or
                 name in self.query.extra_select or (
                     name in self.query.external_aliases and name not in tables)):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -135,7 +135,7 @@ class Query(object):
         # a result of split_exclude). Correct alias quoting needs to know these
         # aliases too.
         self.external_aliases = set()
-        self.table_map = {}     # Maps table names to list of aliases.
+        self.table_map = {}     # Maps table objects to list of aliases.
         self.default_cols = True
         self.default_ordering = True
         self.standard_ordering = True
@@ -677,7 +677,7 @@ class Query(object):
             for model, values in six.iteritems(seen):
                 callback(target, model, values)
 
-    def table_alias(self, table_name, create=False):
+    def table_alias(self, table, create=False):
         """
         Returns a table alias for the given table_name and whether this is a
         new alias or not.
@@ -685,7 +685,7 @@ class Query(object):
         If 'create' is true, a new alias is always created. Otherwise, the
         most recently created alias for the table (if one exists) is reused.
         """
-        alias_list = self.table_map.get(table_name)
+        alias_list = self.table_map.get(table)
         if not create and alias_list:
             alias = alias_list[0]
             self.alias_refcount[alias] += 1
@@ -697,8 +697,8 @@ class Query(object):
             alias_list.append(alias)
         else:
             # The first occurrence of a table uses the table name directly.
-            alias = table_name
-            self.table_map[alias] = [alias]
+            alias = table.default_alias
+            self.table_map[table] = [alias]
         self.alias_refcount[alias] = 1
         self.tables.append(alias)
         return alias, True
@@ -809,7 +809,7 @@ class Query(object):
             del self.alias_refcount[old_alias]
             del self.alias_map[old_alias]
 
-            table_aliases = self.table_map[alias_data.table_name]
+            table_aliases = self.table_map[alias_data.table]
             for pos, alias in enumerate(table_aliases):
                 if alias == old_alias:
                     table_aliases[pos] = new_alias
@@ -877,7 +877,7 @@ class Query(object):
             alias = self.tables[0]
             self.ref_alias(alias)
         else:
-            alias = self.join(BaseTable(self.get_meta().db_table, None))
+            alias = self.join(BaseTable(self.get_meta().table_cls, None))
         return alias
 
     def count_active_tables(self):
@@ -919,7 +919,7 @@ class Query(object):
             return reuse[0]
 
         # No reuse is possible, so we need a new alias.
-        alias, _ = self.table_alias(join.table_name, create=True)
+        alias, _ = self.table_alias(join.table, create=True)
         if join.join_type:
             if self.alias_map[join.parent_alias].join_type == LOUTER or join.nullable:
                 join_type = LOUTER
@@ -1398,7 +1398,7 @@ class Query(object):
                 nullable = self.is_nullable(join.join_field)
             else:
                 nullable = True
-            connection = Join(opts.db_table, alias, None, INNER, join.join_field, nullable)
+            connection = Join(opts.table_cls, alias, None, INNER, join.join_field, nullable)
             reuse = can_reuse if join.m2m else None
             alias = self.join(connection, reuse=reuse)
             joins.append(alias)
@@ -1730,7 +1730,9 @@ class Query(object):
         if where or params:
             self.where.add(ExtraWhere(where, params), AND)
         if tables:
-            self.extra_tables += tuple(tables)
+            # TODO - resolve circular import
+            from django.db.models import ModelTable
+            self.extra_tables += tuple(ModelTable(t) for t in tables)
         if order_by:
             self.extra_order_by = order_by
 
@@ -1930,7 +1932,7 @@ class Query(object):
         # But the first entry in the query's FROM clause must not be a JOIN.
         for table in self.tables:
             if self.alias_refcount[table] > 0:
-                self.alias_map[table] = BaseTable(self.alias_map[table].table_name, table)
+                self.alias_map[table] = BaseTable(self.alias_map[table].table, table)
                 break
         self.set_select([f.get_col(select_alias) for f in select_fields])
         return trimmed_prefix, contains_louter

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1732,7 +1732,7 @@ class Query(object):
         if tables:
             # TODO - resolve circular import
             from django.db.models import ModelTable
-            self.extra_tables += tuple(ModelTable(t) for t in tables)
+            self.extra_tables += tuple(ModelTable(None, t) for t in tables)
         if order_by:
             self.extra_order_by = order_by
 

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -23,7 +23,8 @@ class DeleteQuery(Query):
     compiler = 'SQLDeleteCompiler'
 
     def do_query(self, table, where, using):
-        self.tables = [table]
+        assert table.plain_table_ref, "Can only delete from plain tables"
+        self.tables = [table.table]
         self.where = where
         cursor = self.get_compiler(using).execute_sql(CURSOR)
         return cursor.rowcount if cursor else 0
@@ -43,7 +44,7 @@ class DeleteQuery(Query):
             self.where = self.where_class()
             self.add_q(Q(
                 **{field.attname + '__in': pk_list[offset:offset + GET_ITERATOR_CHUNK_SIZE]}))
-            num_deleted += self.do_query(self.get_meta().db_table, self.where, using=using)
+            num_deleted += self.do_query(self.get_meta().table_cls, self.where, using=using)
         return num_deleted
 
     def delete_qs(self, query, using):

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -31,7 +31,7 @@ class OperationTests(TransactionTestCase):
 
     def get_table_description(self, table):
         with connection.cursor() as cursor:
-            return connection.introspection.get_table_description(cursor, table)
+            return connection.introspection.get_table_description(cursor, None, table)
 
     def assertColumnExists(self, table, column):
         self.assertIn(column, [c.name for c in self.get_table_description(table)])

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -66,13 +66,13 @@ class IntrospectionTests(TransactionTestCase):
 
     def test_get_table_description_names(self):
         with connection.cursor() as cursor:
-            desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)
+            desc = connection.introspection.get_table_description(cursor, None, Reporter._meta.db_table)
         self.assertEqual([r[0] for r in desc],
                          [f.column for f in Reporter._meta.fields])
 
     def test_get_table_description_types(self):
         with connection.cursor() as cursor:
-            desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)
+            desc = connection.introspection.get_table_description(cursor, None, Reporter._meta.db_table)
         self.assertEqual(
             [datatype(r[1], r) for r in desc],
             ['AutoField' if connection.features.can_introspect_autofield else 'IntegerField',
@@ -87,7 +87,7 @@ class IntrospectionTests(TransactionTestCase):
     @skipUnlessDBFeature('can_introspect_max_length')
     def test_get_table_description_col_lengths(self):
         with connection.cursor() as cursor:
-            desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)
+            desc = connection.introspection.get_table_description(cursor, None, Reporter._meta.db_table)
         self.assertEqual(
             [r[3] for r in desc if datatype(r[1], r) == 'CharField'],
             [30, 30, 254]
@@ -96,7 +96,7 @@ class IntrospectionTests(TransactionTestCase):
     @skipUnlessDBFeature('can_introspect_null')
     def test_get_table_description_nullable(self):
         with connection.cursor() as cursor:
-            desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)
+            desc = connection.introspection.get_table_description(cursor, None, Reporter._meta.db_table)
         nullable_by_backend = connection.features.interprets_empty_strings_as_nulls
         self.assertEqual(
             [r[6] for r in desc],
@@ -106,7 +106,7 @@ class IntrospectionTests(TransactionTestCase):
     @skipUnlessDBFeature('can_introspect_autofield')
     def test_bigautofield(self):
         with connection.cursor() as cursor:
-            desc = connection.introspection.get_table_description(cursor, City._meta.db_table)
+            desc = connection.introspection.get_table_description(cursor, None, City._meta.db_table)
         self.assertIn('BigAutoField', [datatype(r[1], r) for r in desc])
 
     # Regression test for #9991 - 'real' types in postgres
@@ -114,7 +114,7 @@ class IntrospectionTests(TransactionTestCase):
     def test_postgresql_real_type(self):
         with connection.cursor() as cursor:
             cursor.execute("CREATE TABLE django_ixn_real_test_table (number REAL);")
-            desc = connection.introspection.get_table_description(cursor, 'django_ixn_real_test_table')
+            desc = connection.introspection.get_table_description(cursor, None, 'django_ixn_real_test_table')
             cursor.execute('DROP TABLE django_ixn_real_test_table;')
         self.assertEqual(datatype(desc[0][1], desc[0]), 'FloatField')
 

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -54,7 +54,7 @@ class MigrationTestBase(TransactionTestCase):
                 value,
                 any(
                     c["index"]
-                    for c in connection.introspection.get_constraints(cursor, table).values()
+                    for c in connection.introspection.get_constraints(cursor, None, table).values()
                     if c['columns'] == list(columns)
                 ),
             )
@@ -68,7 +68,7 @@ class MigrationTestBase(TransactionTestCase):
                 value,
                 any(
                     c["foreign_key"] == to
-                    for c in connection.introspection.get_constraints(cursor, table).values()
+                    for c in connection.introspection.get_constraints(cursor, None, table).values()
                     if c['columns'] == list(columns)
                 ),
             )

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -26,7 +26,7 @@ class MigrationTestBase(TransactionTestCase):
 
     def get_table_description(self, table):
         with connection.cursor() as cursor:
-            return connection.introspection.get_table_description(cursor, table)
+            return connection.introspection.get_table_description(cursor, None, table)
 
     def assertTableExists(self, table):
         with connection.cursor() as cursor:

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -313,7 +313,7 @@ class ExecutorTests(MigrationTestBase):
         # it wouldn't be there in a normal run, and ensure migrations.Author
         # exists in the global app registry temporarily.
         old_table_names = connection.introspection.table_names
-        connection.introspection.table_names = lambda c: [x for x in old_table_names(c) if x != "auth_user"]
+        connection.introspection.table_names = lambda c, include_schema: [(None, x) for x in old_table_names(c) if x != "auth_user"]
         migrations_apps = executor.loader.project_state(("migrations", "0001_initial")).apps
         global_apps.get_app_config("migrations").models["author"] = migrations_apps.get_model("migrations", "author")
         try:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1138,12 +1138,12 @@ class OperationTests(OperationTestBase):
             with connection.cursor() as cursor:
                 id_type, id_null = [
                     (c.type_code, c.null_ok)
-                    for c in connection.introspection.get_table_description(cursor, "test_alflpkfk_pony")
+                    for c in connection.introspection.get_table_description(cursor, None, "test_alflpkfk_pony")
                     if c.name == "id"
                 ][0]
                 fk_type, fk_null = [
                     (c.type_code, c.null_ok)
-                    for c in connection.introspection.get_table_description(cursor, "test_alflpkfk_rider")
+                    for c in connection.introspection.get_table_description(cursor, None, "test_alflpkfk_rider")
                     if c.name == "pony_id"
                 ][0]
             self.assertEqual(id_type, fk_type)

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -430,7 +430,7 @@ class TestMigrations(TransactionTestCase):
         with connection.cursor() as cursor:
             like_constraint_field_names = [
                 c.rsplit('_', 2)[0][len(table_name) + 1:]
-                for c in connection.introspection.get_constraints(cursor, table_name)
+                for c in connection.introspection.get_constraints(cursor, None, table_name)
                 if c.endswith('_like')
             ]
         # Only the CharField should have a LIKE index.

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -739,22 +739,11 @@ class RelatedIndividual(models.Model):
         db_table = 'RelatedIndividual'
 
 
-class SchemaQualified(models.ModelTable):
-    def __init__(self, schema, table):
-        self.schema = schema
-        self.table = table
-
-    def as_sql(self, compiler, connection):
-        # Note that it would be easy to change the schema using thread locals
-        # if wanted.
-        return '%s.%s' % (connection.ops.quote_name(self.schema), connection.ops.quote_name(self.table)), []
-
-
 class SchemaQualified(models.Model):
     val = models.TextField()
 
     class Meta:
-        table_cls = SchemaQualified('other_schema', 'schema_qualified')
+        table_cls = models.ModelTable('other_schema', 'schema_qualified')
         managed = False
 
 
@@ -779,7 +768,7 @@ class Table(models.Model):
     val = models.TextField()
 
     class Meta:
-        table_cls = DynamicQuery('queries_table')
+        table_cls = DynamicQuery(None, 'queries_table')
 
 
 class ShadowTable(models.Model):

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -749,7 +749,7 @@ class SchemaQualified(models.Model):
 
 class DynamicQuery(models.ModelTable):
     def as_sql(self, compiler, connection):
-        db_time = compiler.query.context.get('db_time')
+        db_time = compiler.query.context.get('db_time') if hasattr(compiler, 'query') else None
         if db_time:
             return (
                 '(select * from shadow_queries_table '

--- a/tests/schema/fields.py
+++ b/tests/schema/fields.py
@@ -52,6 +52,7 @@ class CustomManyToManyField(RelatedField):
     _get_m2m_attr = ManyToManyField.__dict__['_get_m2m_attr']
     _get_m2m_reverse_attr = ManyToManyField.__dict__['_get_m2m_reverse_attr']
     _get_m2m_db_table = ManyToManyField.__dict__['_get_m2m_db_table']
+    _get_m2m_table_cls = ManyToManyField.__dict__['_get_m2m_table_cls']
 
 
 class InheritedManyToManyField(ManyToManyField):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -114,7 +114,7 @@ class SchemaTests(TransactionTestCase):
         Get the constraints on a table using a new cursor.
         """
         with connection.cursor() as cursor:
-            return connection.introspection.get_constraints(cursor, table)
+            return connection.introspection.get_constraints(cursor, None, table)
 
     def get_constraints_for_column(self, model, column_name):
         constraints = self.get_constraints(model._meta.db_table)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -6,7 +6,7 @@ from copy import copy
 from django.db import (
     DatabaseError, IntegrityError, OperationalError, connection,
 )
-from django.db.models import Model
+from django.db.models import Model, ModelTable
 from django.db.models.deletion import CASCADE
 from django.db.models.fields import (
     AutoField, BigIntegerField, BinaryField, BooleanField, CharField,
@@ -1410,15 +1410,17 @@ class SchemaTests(TransactionTestCase):
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], "CharField")
         # Alter the table
+        old_table = ModelTable(None, "schema_author")
+        new_table = ModelTable(None, "schema_otherauthor")
         with connection.schema_editor() as editor:
-            editor.alter_db_table(Author, "schema_author", "schema_otherauthor")
+            editor.alter_db_table(Author, old_table, new_table)
         # Ensure the table is there afterwards
         Author._meta.db_table = "schema_otherauthor"
         columns = self.column_classes(Author)
         self.assertEqual(columns['name'][0], "CharField")
         # Alter the table again
         with connection.schema_editor() as editor:
-            editor.alter_db_table(Author, "schema_otherauthor", "schema_author")
+            editor.alter_db_table(Author, new_table, old_table)
         # Ensure the table is still there
         Author._meta.db_table = "schema_author"
         columns = self.column_classes(Author)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -90,6 +90,7 @@ class SchemaTests(TransactionTestCase):
                 d[0]: (connection.introspection.get_field_type(d[1], d), d)
                 for d in connection.introspection.get_table_description(
                     cursor,
+                    None,
                     model._meta.db_table,
                 )
             }
@@ -1679,7 +1680,7 @@ class SchemaTests(TransactionTestCase):
             self.assertEqual(item[0], 'surname default')
             # And that the default is no longer set in the database.
             field = next(
-                f for f in connection.introspection.get_table_description(cursor, "schema_author")
+                f for f in connection.introspection.get_table_description(cursor, None, "schema_author")
                 if f.name == "surname"
             )
             if connection.features.can_introspect_default:
@@ -1702,7 +1703,7 @@ class SchemaTests(TransactionTestCase):
         # The database default should be removed.
         with connection.cursor() as cursor:
             field = next(
-                f for f in connection.introspection.get_table_description(cursor, "schema_author")
+                f for f in connection.introspection.get_table_description(cursor, None, "schema_author")
                 if f.name == "height"
             )
             if connection.features.can_introspect_default:


### PR DESCRIPTION
Add Model._meta.table_cls attribute to represent table-like objects. Add schema qualified table support.

Continuation from https://github.com/django/django/pull/5278.

TODO:
 - [ ] PostgreSQL support (we are nearly there)
 - [ ] tests in Django's test suite (test project attached)
 - [ ] docs
 - [x] introspection support as needed by migrations (get_constraints(), table_names())
 - [ ] Nice failures for cases where schemas are used for Oracle, MySQL and SQLite
 - [ ] Remove a couple of TODOs and temporary asserts


Not going to be implemented in this PR:
  - MySQL support (in mysql schemas are a synonym for database. This is going to cause problems for testing, where production and test database schemas would conflict)
  - SQLite support (no schemas on SQLite)
  - Oracle support (we use Oracle schemas to differentiate between test and production, so similar problems as with MySQL are preventing support for Oracle in initial implementation)
  - Inspectdb support
  - Dynamic schemas (same model on multiple schemas will not be supported by Django)
  - Ability to configure default schema for project or apps

Test project for PostgreSQL here:
[schema_test.tar.gz](https://github.com/django/django/files/137903/schema_test.tar.gz)
