### PR TITLE
Fixed #26242 -- Allowed models with app_label at import stage.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -90,10 +90,9 @@ class ModelBase(type):
 
         app_label = None
 
-        # Look for an application configuration to attach the model to.
-        app_config = apps.get_containing_app_config(module)
-
         if getattr(meta, 'app_label', None) is None:
+            # Look for an application configuration to attach the model to.
+            app_config = apps.get_containing_app_config(module)
             if app_config is None:
                 if not abstract:
                     raise RuntimeError(


### PR DESCRIPTION
get_containing_app_config raised exception if  ran at import stage. On the other hand app_config is only needed to get app_label. If app_label is provided in Meta then there is no need to prevent model from being created before all apps are initialized.