### PR TITLE
Fixed #26243 -- Added a note to deployment checklist

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -255,7 +255,8 @@ Python Options
 
 It's strongly recommended that you invoke the Python process running your
 Django application using the `-R`_ option or with the
-:envvar:`PYTHONHASHSEED` environment variable set to ``random``.
+:envvar:`PYTHONHASHSEED` environment variable set to ``random``. This option
+is enabled by default starting with Python 3.3.
 
 These options help protect your site from denial-of-service (DoS)
 attacks triggered by carefully crafted inputs. Such an attack can


### PR DESCRIPTION
This part of the deployment checklist is no longer relevant as of Python 3.3, so we can save users the effort of looking that up and configuring that if they use Python 3.3 or later.

One could discuss whether we should also link to the Python 3 documentation explicitly which states this in a nice way and still has all the information of the Python 2 documentation in it.