### PR TITLE
Refs #26250 -- Added str.format() placeholder support to ValidationError

### DIFF
--- a/django/contrib/admin/forms.py
+++ b/django/contrib/admin/forms.py
@@ -10,7 +10,7 @@ class AdminAuthenticationForm(AuthenticationForm):
     A custom authentication form used in the admin app.
     """
     error_messages = {
-        'invalid_login': _("Please enter the correct %(username)s and password "
+        'invalid_login': _("Please enter the correct {username} and password "
                            "for a staff account. Note that both fields may be "
                            "case-sensitive."),
     }

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1909,9 +1909,9 @@ class InlineModelAdmin(BaseModelAdmin):
                         params = {'class_name': self._meta.model._meta.verbose_name,
                                   'instance': self.instance,
                                   'related_objects': get_text_list(objs, _('and'))}
-                        msg = _("Deleting %(class_name)s %(instance)s would require "
+                        msg = _("Deleting {class_name} {instance} would require "
                                 "deleting the following protected related objects: "
-                                "%(related_objects)s")
+                                "{related_objects}")
                         raise ValidationError(msg, code='deleting_protected', params=params)
 
             def is_valid(self):

--- a/django/contrib/admindocs/tests/test_fields.py
+++ b/django/contrib/admindocs/tests/test_fields.py
@@ -5,6 +5,8 @@ import unittest
 from django.contrib.admindocs import views
 from django.db import models
 from django.db.models import fields
+from django.test import ignore_warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.translation import ugettext as _
 
 
@@ -14,6 +16,11 @@ class CustomField(models.Field):
 
 class DescriptionLackingField(models.Field):
     pass
+
+
+# Removedindjango20warning
+class PercentDescriptionField(models.CharField):
+    description = _('String (up to %(max_length)s)')
 
 
 class TestFieldType(unittest.TestCase):
@@ -42,4 +49,17 @@ class TestFieldType(unittest.TestCase):
             _('Field of type: %(field_type)s') % {
                 'field_type': 'DescriptionLackingField'
             }
+        )
+
+    def test_format_description(self):
+        self.assertEqual(
+            views.get_readable_field_data_type(models.CharField(max_length=100)),
+            'String (up to 100)',
+        )
+
+    @ignore_warnings(category=RemovedInDjango20Warning)
+    def test_format_description_percent_placeholder(self):
+        self.assertEqual(
+            views.get_readable_field_data_type(PercentDescriptionField(max_length=100)),
+            'String (up to 100)',
         )

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -137,7 +137,7 @@ class AuthenticationForm(forms.Form):
     password = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
 
     error_messages = {
-        'invalid_login': _("Please enter a correct %(username)s and password. "
+        'invalid_login': _("Please enter a correct {username} and password. "
                            "Note that both fields may be case-sensitive."),
         'inactive': _("This account is inactive."),
     }

--- a/django/contrib/auth/password_validation.py
+++ b/django/contrib/auth/password_validation.py
@@ -98,8 +98,8 @@ class MinimumLengthValidator(object):
         if len(password) < self.min_length:
             raise ValidationError(
                 ungettext(
-                    "This password is too short. It must contain at least %(min_length)d character.",
-                    "This password is too short. It must contain at least %(min_length)d characters.",
+                    "This password is too short. It must contain at least {min_length:d} character.",
+                    "This password is too short. It must contain at least {min_length:d} characters.",
                     self.min_length
                 ),
                 code='password_too_short',
@@ -144,7 +144,7 @@ class UserAttributeSimilarityValidator(object):
                 if SequenceMatcher(a=password.lower(), b=value_part.lower()).quick_ratio() > self.max_similarity:
                     verbose_name = force_text(user._meta.get_field(attribute_name).verbose_name)
                     raise ValidationError(
-                        _("The password is too similar to the %(verbose_name)s."),
+                        _("The password is too similar to the {verbose_name}."),
                         code='password_too_similar',
                         params={'verbose_name': verbose_name},
                     )

--- a/django/contrib/flatpages/forms.py
+++ b/django/contrib/flatpages/forms.py
@@ -50,7 +50,7 @@ class FlatpageForm(forms.ModelForm):
             for site in sites:
                 if same_url.filter(sites=site).exists():
                     raise forms.ValidationError(
-                        _('Flatpage with url %(url)s already exists for site %(site)s'),
+                        _('Flatpage with url {url} already exists for site {site}'),
                         code='duplicate_url',
                         params={'url': url, 'site': site},
                     )

--- a/django/contrib/messages/views.py
+++ b/django/contrib/messages/views.py
@@ -1,4 +1,9 @@
+import warnings
+
 from django.contrib import messages
+from django.utils.deprecation import (
+    PERCENT_PLACEHOLDER_RE, RemovedInDjango20Warning,
+)
 
 
 class SuccessMessageMixin(object):
@@ -15,4 +20,14 @@ class SuccessMessageMixin(object):
         return response
 
     def get_success_message(self, cleaned_data):
-        return self.success_message % cleaned_data
+        if PERCENT_PLACEHOLDER_RE.search(self.success_message):
+            warnings.warn(
+                'Legacy % placeholder syntax in success_message is deprecated. '
+                'Use the Python str.format() syntax instead.',
+                RemovedInDjango20Warning,
+                stacklevel=2,
+            )
+            message = self.success_message % cleaned_data
+        else:
+            message = self.success_message.format(**cleaned_data)
+        return message

--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -18,7 +18,7 @@ __all__ = ['ArrayField']
 class ArrayField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'item_invalid': _('Item %(nth)s in the array did not validate: '),
+        'item_invalid': _('Item {nth} in the array did not validate: '),
         'nested_array_mismatch': _('Nested arrays must have the same length.'),
     }
 

--- a/django/contrib/postgres/fields/hstore.py
+++ b/django/contrib/postgres/fields/hstore.py
@@ -15,7 +15,7 @@ class HStoreField(Field):
     empty_strings_allowed = False
     description = _('Map of strings to strings')
     default_error_messages = {
-        'not_a_string': _('The value of "%(key)s" is not a string.'),
+        'not_a_string': _('The value of "{key}" is not a string.'),
     }
 
     def db_type(self, connection):

--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -15,7 +15,7 @@ from ..utils import prefix_validation_error
 
 class SimpleArrayField(forms.CharField):
     default_error_messages = {
-        'item_invalid': _('Item %(nth)s in the array did not validate: '),
+        'item_invalid': _('Item {nth} in the array did not validate: '),
     }
 
     def __init__(self, base_field, delimiter=',', max_length=None, min_length=None, *args, **kwargs):
@@ -145,7 +145,7 @@ class SplitArrayWidget(forms.Widget):
 
 class SplitArrayField(forms.Field):
     default_error_messages = {
-        'item_invalid': _('Item %(nth)s in the array did not validate: '),
+        'item_invalid': _('Item {nth} in the array did not validate: '),
     }
 
     def __init__(self, base_field, size, remove_trailing_nulls=False, **kwargs):

--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -8,7 +8,7 @@ __all__ = ['JSONField']
 
 class JSONField(forms.CharField):
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be valid JSON."),
+        'invalid': _("'{value}' value must be valid JSON."),
     }
 
     def __init__(self, **kwargs):

--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -11,15 +11,15 @@ from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 
 class ArrayMaxLengthValidator(MaxLengthValidator):
     message = ungettext_lazy(
-        'List contains %(show_value)d item, it should contain no more than %(limit_value)d.',
-        'List contains %(show_value)d items, it should contain no more than %(limit_value)d.',
+        'List contains {show_value:d} item, it should contain no more than {limit_value:d}.',
+        'List contains {show_value:d} items, it should contain no more than {limit_value:d}.',
         'limit_value')
 
 
 class ArrayMinLengthValidator(MinLengthValidator):
     message = ungettext_lazy(
-        'List contains %(show_value)d item, it should contain no fewer than %(limit_value)d.',
-        'List contains %(show_value)d items, it should contain no fewer than %(limit_value)d.',
+        'List contains {show_value:d} item, it should contain no fewer than {limit_value:d}.',
+        'List contains {show_value:d} items, it should contain no fewer than {limit_value:d}.',
         'limit_value')
 
 
@@ -28,8 +28,8 @@ class KeysValidator(object):
     """A validator designed for HStore to require/restrict keys."""
 
     messages = {
-        'missing_keys': _('Some keys were missing: %(keys)s'),
-        'extra_keys': _('Some unknown keys were provided: %(keys)s'),
+        'missing_keys': _('Some keys were missing: {keys}'),
+        'extra_keys': _('Some unknown keys were provided: {keys}'),
     }
     strict = False
 
@@ -71,10 +71,10 @@ class KeysValidator(object):
 class RangeMaxValueValidator(MaxValueValidator):
     def compare(self, a, b):
         return a.upper > b
-    message = _('Ensure that this range is completely less than or equal to %(limit_value)s.')
+    message = _('Ensure that this range is completely less than or equal to {limit_value}.')
 
 
 class RangeMinValueValidator(MinValueValidator):
     def compare(self, a, b):
         return a.lower < b
-    message = _('Ensure that this range is completely greater than or equal to %(limit_value)s.')
+    message = _('Ensure that this range is completely greater than or equal to {limit_value}.')

--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -4,7 +4,9 @@ Global Django exception and warning classes.
 import warnings
 
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango20Warning, PERCENT_PLACEHOLDER_RE
+from django.utils.deprecation import (
+    PERCENT_PLACEHOLDER_RE, RemovedInDjango20Warning,
+)
 from django.utils.encoding import force_text
 
 

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -305,7 +305,7 @@ validate_comma_separated_integer_list = int_list_validator(
 
 @deconstructible
 class BaseValidator(object):
-    message = _('Ensure this value is %(limit_value)s (it is %(show_value)s).')
+    message = _('Ensure this value is {limit_value} (it is {show_value}).')
     code = 'limit_value'
 
     def __init__(self, limit_value, message=None):
@@ -336,7 +336,7 @@ class BaseValidator(object):
 
 @deconstructible
 class MaxValueValidator(BaseValidator):
-    message = _('Ensure this value is less than or equal to %(limit_value)s.')
+    message = _('Ensure this value is less than or equal to {limit_value}.')
     code = 'max_value'
 
     def compare(self, a, b):
@@ -345,7 +345,7 @@ class MaxValueValidator(BaseValidator):
 
 @deconstructible
 class MinValueValidator(BaseValidator):
-    message = _('Ensure this value is greater than or equal to %(limit_value)s.')
+    message = _('Ensure this value is greater than or equal to {limit_value}.')
     code = 'min_value'
 
     def compare(self, a, b):
@@ -355,8 +355,8 @@ class MinValueValidator(BaseValidator):
 @deconstructible
 class MinLengthValidator(BaseValidator):
     message = ungettext_lazy(
-        'Ensure this value has at least %(limit_value)d character (it has %(show_value)d).',
-        'Ensure this value has at least %(limit_value)d characters (it has %(show_value)d).',
+        'Ensure this value has at least {limit_value:d} character (it has {show_value:d}).',
+        'Ensure this value has at least {limit_value:d} characters (it has {show_value:d}).',
         'limit_value')
     code = 'min_length'
 
@@ -370,8 +370,8 @@ class MinLengthValidator(BaseValidator):
 @deconstructible
 class MaxLengthValidator(BaseValidator):
     message = ungettext_lazy(
-        'Ensure this value has at most %(limit_value)d character (it has %(show_value)d).',
-        'Ensure this value has at most %(limit_value)d characters (it has %(show_value)d).',
+        'Ensure this value has at most {limit_value:d} character (it has {show_value:d}).',
+        'Ensure this value has at most {limit_value:d} characters (it has {show_value:d}).',
         'limit_value')
     code = 'max_length'
 
@@ -390,18 +390,18 @@ class DecimalValidator(object):
     """
     messages = {
         'max_digits': ungettext_lazy(
-            'Ensure that there are no more than %(max)s digit in total.',
-            'Ensure that there are no more than %(max)s digits in total.',
+            'Ensure that there are no more than {max} digit in total.',
+            'Ensure that there are no more than {max} digits in total.',
             'max'
         ),
         'max_decimal_places': ungettext_lazy(
-            'Ensure that there are no more than %(max)s decimal place.',
-            'Ensure that there are no more than %(max)s decimal places.',
+            'Ensure that there are no more than {max} decimal place.',
+            'Ensure that there are no more than {max} decimal places.',
             'max'
         ),
         'max_whole_digits': ungettext_lazy(
-            'Ensure that there are no more than %(max)s digit before the decimal point.',
-            'Ensure that there are no more than %(max)s digits before the decimal point.',
+            'Ensure that there are no more than {max} digit before the decimal point.',
+            'Ensure that there are no more than {max} digits before the decimal point.',
             'max'
         ),
     }

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1094,7 +1094,7 @@ class Model(six.with_metaclass(ModelBase)):
             field_labels = [capfirst(opts.get_field(f).verbose_name) for f in unique_check]
             params['field_labels'] = six.text_type(get_text_list(field_labels, _('and')))
             return ValidationError(
-                message=_("%(model_name)s with this %(field_labels)s already exists."),
+                message=_("{model_name} with this {field_labels} already exists."),
                 code='unique_together',
                 params=params,
             )

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1080,7 +1080,7 @@ class BooleanField(Field):
 
 
 class CharField(Field):
-    description = _("String (up to %(max_length)s)")
+    description = _("String (up to {max_length})")
 
     def __init__(self, *args, **kwargs):
         super(CharField, self).__init__(*args, **kwargs)
@@ -2130,7 +2130,7 @@ class PositiveSmallIntegerField(PositiveIntegerRelDbTypeMixin, IntegerField):
 
 class SlugField(CharField):
     default_validators = [validators.validate_slug]
-    description = _("Slug (up to %(max_length)s)")
+    description = _("Slug (up to {max_length})")
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = kwargs.get('max_length', 50)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -107,15 +107,15 @@ class Field(RegisterLookupMixin):
     auto_creation_counter = -1
     default_validators = []  # Default set of validators
     default_error_messages = {
-        'invalid_choice': _('Value %(value)r is not a valid choice.'),
+        'invalid_choice': _('Value {value!r} is not a valid choice.'),
         'null': _('This field cannot be null.'),
         'blank': _('This field cannot be blank.'),
-        'unique': _('%(model_name)s with this %(field_label)s '
+        'unique': _('{model_name} with this {field_label} '
                     'already exists.'),
         # Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
         # Eg: "Title must be unique for pub_date year"
-        'unique_for_date': _("%(field_label)s must be unique for "
-                             "%(date_field_label)s %(lookup_type)s."),
+        'unique_for_date': _("{field_label} must be unique for "
+                             "{date_field_label} {lookup_type}."),
     }
     system_check_deprecated_details = None
     system_check_removed_details = None
@@ -916,7 +916,7 @@ class AutoField(Field):
 
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be an integer."),
+        'invalid': _("'{value}' value must be an integer."),
     }
 
     def __init__(self, *args, **kwargs):
@@ -1003,7 +1003,7 @@ class BigAutoField(AutoField):
 class BooleanField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be either True or False."),
+        'invalid': _("'{value}' value must be either True or False."),
     }
     description = _("Boolean (Either True or False)")
 
@@ -1193,9 +1193,9 @@ class DateTimeCheckMixin(object):
 class DateField(DateTimeCheckMixin, Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value has an invalid date format. It must be "
+        'invalid': _("'{value}' value has an invalid date format. It must be "
                      "in YYYY-MM-DD format."),
-        'invalid_date': _("'%(value)s' value has the correct format (YYYY-MM-DD) "
+        'invalid_date': _("'{value}' value has the correct format (YYYY-MM-DD) "
                           "but it is an invalid date."),
     }
     description = _("Date (without time)")
@@ -1336,11 +1336,11 @@ class DateField(DateTimeCheckMixin, Field):
 class DateTimeField(DateField):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value has an invalid format. It must be in "
+        'invalid': _("'{value}' value has an invalid format. It must be in "
                      "YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ] format."),
-        'invalid_date': _("'%(value)s' value has the correct format "
+        'invalid_date': _("'{value}' value has the correct format "
                           "(YYYY-MM-DD) but it is an invalid date."),
-        'invalid_datetime': _("'%(value)s' value has the correct format "
+        'invalid_datetime': _("'{value}' value has the correct format "
                               "(YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ]) "
                               "but it is an invalid date/time."),
     }
@@ -1496,7 +1496,7 @@ class DateTimeField(DateField):
 class DecimalField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be a decimal number."),
+        'invalid': _("'{value}' value must be a decimal number."),
     }
     description = _("Decimal number")
 
@@ -1650,7 +1650,7 @@ class DurationField(Field):
     """
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value has an invalid format. It must be in "
+        'invalid': _("'{value}' value has an invalid format. It must be in "
                      "[DD] [HH:[MM:]]ss[.uuuuuu] format.")
     }
     description = _("Duration")
@@ -1794,7 +1794,7 @@ class FilePathField(Field):
 class FloatField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be a float."),
+        'invalid': _("'{value}' value must be a float."),
     }
     description = _("Floating point number")
 
@@ -1828,7 +1828,7 @@ class FloatField(Field):
 class IntegerField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be an integer."),
+        'invalid': _("'{value}' value must be an integer."),
     }
     description = _("Integer")
 
@@ -2026,7 +2026,7 @@ class GenericIPAddressField(Field):
 class NullBooleanField(Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value must be either None, True or False."),
+        'invalid': _("'{value}' value must be either None, True or False."),
     }
     description = _("Boolean (Either True, False or None)")
 
@@ -2197,9 +2197,9 @@ class TextField(Field):
 class TimeField(DateTimeCheckMixin, Field):
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _("'%(value)s' value has an invalid format. It must be in "
+        'invalid': _("'{value}' value has an invalid format. It must be in "
                      "HH:MM[:ss[.uuuuuu]] format."),
-        'invalid_time': _("'%(value)s' value has the correct format "
+        'invalid_time': _("'{value}' value has the correct format "
                           "(HH:MM[:ss[.uuuuuu]]) but it is an invalid time."),
     }
     description = _("Time")
@@ -2397,7 +2397,7 @@ class BinaryField(Field):
 
 class UUIDField(Field):
     default_error_messages = {
-        'invalid': _("'%(value)s' is not a valid UUID."),
+        'invalid': _("'{value}' is not a valid UUID."),
     }
     description = 'Universally unique identifier'
     empty_strings_allowed = False

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -13,7 +13,9 @@ from django.db.models.deletion import CASCADE, SET_DEFAULT, SET_NULL
 from django.db.models.query_utils import PathInfo
 from django.db.models.utils import make_model_tuple
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.deprecation import (
+    PERCENT_PLACEHOLDER_RE, RemovedInDjango20Warning,
+)
 from django.utils.encoding import force_text, smart_text
 from django.utils.functional import cached_property, curry
 from django.utils.translation import ugettext_lazy as _
@@ -289,18 +291,27 @@ class RelatedField(Field):
         self.opts = cls._meta
 
         if not cls._meta.abstract:
+            fmt_kwargs = {
+                'class': cls.__name__.lower(),
+                'app_label': cls._meta.app_label.lower(),
+            }
+
             if self.remote_field.related_name:
-                related_name = force_text(self.remote_field.related_name) % {
-                    'class': cls.__name__.lower(),
-                    'app_label': cls._meta.app_label.lower()
-                }
+                related_name = force_text(self.remote_field.related_name)
+                if PERCENT_PLACEHOLDER_RE.search(related_name):
+                    warnings.warn(
+                        'Legacy % placeholder syntax in related_name is deprecated. '
+                        'Use the Python str.format() syntax instead.',
+                        RemovedInDjango20Warning,
+                        stacklevel=2,
+                    )
+                    related_name %= fmt_kwargs
+                else:
+                    related_name = related_name.format(**fmt_kwargs)
                 self.remote_field.related_name = related_name
 
             if self.remote_field.related_query_name:
-                related_query_name = force_text(self.remote_field.related_query_name) % {
-                    'class': cls.__name__.lower(),
-                    'app_label': cls._meta.app_label.lower(),
-                }
+                related_query_name = force_text(self.remote_field.related_query_name).format(**fmt_kwargs)
                 self.remote_field.related_query_name = related_query_name
 
             def resolve_related_class(model, related, field):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -737,7 +737,7 @@ class ForeignKey(ForeignObject):
 
     empty_strings_allowed = False
     default_error_messages = {
-        'invalid': _('%(model)s instance with %(field)s %(value)r does not exist.')
+        'invalid': _('{model} instance with {field} {value!r} does not exist.')
     }
     description = _("Foreign Key (type determined by related field)")
 

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -538,8 +538,8 @@ class FileField(Field):
         'missing': _("No file was submitted."),
         'empty': _("The submitted file is empty."),
         'max_length': ungettext_lazy(
-            'Ensure this filename has at most %(max)d character (it has %(length)d).',
-            'Ensure this filename has at most %(max)d characters (it has %(length)d).',
+            'Ensure this filename has at most {max:d} character (it has {length:d}).',
+            'Ensure this filename has at most {max:d} characters (it has {length:d}).',
             'max'),
         'contradiction': _('Please either submit a file or check the clear checkbox, not both.')
     }
@@ -770,7 +770,7 @@ class CallableChoiceIterator(object):
 class ChoiceField(Field):
     widget = Select
     default_error_messages = {
-        'invalid_choice': _('Select a valid choice. %(value)s is not one of the available choices.'),
+        'invalid_choice': _('Select a valid choice. {value} is not one of the available choices.'),
     }
 
     def __init__(self, choices=(), required=True, widget=None, label=None,
@@ -864,7 +864,7 @@ class MultipleChoiceField(ChoiceField):
     hidden_widget = MultipleHiddenInput
     widget = SelectMultiple
     default_error_messages = {
-        'invalid_choice': _('Select a valid choice. %(value)s is not one of the available choices.'),
+        'invalid_choice': _('Select a valid choice. {value} is not one of the available choices.'),
         'invalid_list': _('Enter a list of values.'),
     }
 

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1229,9 +1229,9 @@ class ModelMultipleChoiceField(ModelChoiceField):
     hidden_widget = MultipleHiddenInput
     default_error_messages = {
         'list': _('Enter a list of values.'),
-        'invalid_choice': _('Select a valid choice. %(value)s is not one of the'
+        'invalid_choice': _('Select a valid choice. {value} is not one of the'
                             ' available choices.'),
-        'invalid_pk_value': _('"%(pk)s" is not a valid value for a primary key.')
+        'invalid_pk_value': _('"{pk}" is not a valid value for a primary key.')
     }
 
     def __init__(self, queryset, required=True, widget=None, label=None,

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -169,8 +169,8 @@ def from_current_timezone(value):
             return timezone.make_aware(value, current_timezone)
         except Exception:
             message = _(
-                '%(datetime)s couldn\'t be interpreted '
-                'in time zone %(current_timezone)s; it '
+                '{datetime} couldn\'t be interpreted '
+                'in time zone {current_timezone}; it '
                 'may be ambiguous or it may not exist.'
             )
             params = {'datetime': value, 'current_timezone': current_timezone}

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import inspect
+import re
 import warnings
 
 
@@ -79,3 +80,16 @@ class DeprecationInstanceCheck(type):
             self.deprecation_warning, 2
         )
         return super(DeprecationInstanceCheck, self).__instancecheck__(instance)
+
+
+# RemovedInDjango20Warning
+# https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
+PERCENT_PLACEHOLDER_RE = re.compile(
+    r'%'                     # Start of conversion specifier
+    r'(?:\(.*?\))?'          # Optional mapping key
+    r'[#0 +-]*'              # Optional conversion flags
+    r'(?:[0-9]+|\*)?'        # Optional minimum field width
+    r'(?:\.(?:[0-9]+|\*))?'  # Optional precision
+    r'[hlL]?'                # Optional length modifier
+    r'[diouxXeEfFgGcrsa%]'   # Conversion type
+)

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -135,6 +135,27 @@ def lazy_number(func, resultclass, number=None, **kwargs):
                     pass
                 return translated
 
+            def format(self, *fmt_args, **fmt_kwargs):
+                try:
+                    number_value = fmt_kwargs[number]
+                except KeyError:
+                    msg = (
+                        'Missing keyword argument "{}". '
+                        'Please provide it, because it is required to '
+                        'determine whether string is singular or plural.'
+                    )
+                    raise KeyError(msg.format(number))
+                kwargs['number'] = number_value
+                translated = func(**kwargs)
+                return translated.format(*fmt_args, **fmt_kwargs)
+
+            # RemovedInDjango20Warning
+            #
+            # __str__() can be removed with the deprecation warning in
+            # ValidationError.__iter__().
+            def __str__(self):
+                return kwargs['singular']
+
         proxy = lazy(lambda **kwargs: NumberAwareString(), NumberAwareString)(**kwargs)
         proxy.__reduce__ = lambda: (_lazy_number_unpickle, (func, resultclass, number, original_kwargs))
     return proxy

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -328,7 +328,13 @@ interpolated with ``field.__dict__`` which allows the description to
 incorporate arguments of the field. For example, the description for
 :class:`~django.db.models.CharField` is::
 
-    description = _("String (up to %(max_length)s)")
+    description = _("String (up to {max_length})")
+
+.. versionchanged:: 1.10
+
+   Support for Python :py:meth:`str.format()` placeholder syntax has been
+   added. The legacy ``%(max_length)s`` placeholder syntax has been deprecated
+   and will be removed in Django 2.0.
 
 Useful methods
 --------------

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -298,6 +298,9 @@ Miscellaneous
   change to the ``AUTHORS`` file in your patch if you make more than a
   single trivial change.
 
+* For user facing APIs, use Python :py:meth:`str.format()` placeholder syntax
+  in favor of the legacy ``%(<foo>)s`` syntax.
+
 JavaScript style
 ================
 

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -139,6 +139,9 @@ details on these changes.
 * The legacy ``%(app_label)s`` and ``%(class)s`` placeholder syntax will be
   removed from ``related_name``.
 
+* The legacy ``%(app_label)s`` and ``%(model_name)s`` placeholder syntax will
+  be removed from ``default_related_name``.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -136,6 +136,9 @@ details on these changes.
 * The legacy ``%(<foo>)s`` placeholder syntax will be removed from
   ``ValidationError``.
 
+* The legacy ``%(app_label)s`` and ``%(class)s`` placeholder syntax will be
+  removed from ``related_name``.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -145,6 +145,9 @@ details on these changes.
 * The legacy ``%(field_name)s`` placeholder syntax will be removed from
   ``SuccessMessageMixin.success_message``.
 
+* The legacy ``%(field_name)s`` placeholder syntax will be removed from
+  ``Field.description``.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -133,6 +133,9 @@ details on these changes.
 * The model ``CommaSeparatedIntegerField`` will be removed. A stub field will
   remain for compatibility with historical migrations.
 
+* The legacy ``%(<foo>)s`` placeholder syntax will be removed from
+  ``ValidationError``.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -142,6 +142,9 @@ details on these changes.
 * The legacy ``%(app_label)s`` and ``%(model_name)s`` placeholder syntax will
   be removed from ``default_related_name``.
 
+* The legacy ``%(field_name)s`` placeholder syntax will be removed from
+  ``SuccessMessageMixin.success_message``.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/contrib/messages.txt
+++ b/docs/ref/contrib/messages.txt
@@ -368,11 +368,11 @@ Adding messages in class-based views
     class AuthorCreate(SuccessMessageMixin, CreateView):
         model = Author
         success_url = '/success/'
-        success_message = "%(name)s was created successfully"
+        success_message = "{name} was created successfully"
 
 The cleaned data from the ``form`` is available for string interpolation using
-the ``%(field_name)s`` syntax. For ModelForms, if you need access to fields
-from the saved ``object`` override the
+the :py:meth:`str.format()` syntax. For ModelForms, if you need access to
+fields from the saved ``object`` override the
 :meth:`~django.contrib.messages.views.SuccessMessageMixin.get_success_message`
 method.
 
@@ -385,13 +385,19 @@ method.
     class ComplicatedCreate(SuccessMessageMixin, CreateView):
         model = ComplicatedModel
         success_url = '/success/'
-        success_message = "%(calculated_field)s was created successfully"
+        success_message = "{calculated_field} was created successfully"
 
         def get_success_message(self, cleaned_data):
-            return self.success_message % dict(
-                cleaned_data,
+            return self.success_message.format(
                 calculated_field=self.object.calculated_field,
+                **cleaned_data,
             )
+
+.. versionchanged:: 1.10
+
+   Support for Python :py:meth:`str.format()` placeholder syntax has been
+   added. The legacy ``%(field_name)s`` placeholder syntax has been deprecated
+   and will be removed in Django 2.0.
 
 Expiration of messages
 ======================

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -395,7 +395,7 @@ For each field, we describe the default widget used if you don't specify
     * Validates that the given value exists in the list of choices.
     * Error message keys: ``required``, ``invalid_choice``
 
-    The ``invalid_choice`` error message may contain ``%(value)s``, which will be
+    The ``invalid_choice`` error message may contain ``{value}``, which will be
     replaced with the selected choice.
 
     Takes one extra required argument:
@@ -408,6 +408,12 @@ For each field, we describe the default widget used if you don't specify
         model field. See the :ref:`model field reference documentation on
         choices <field-choices>` for more details. If the argument is a
         callable, it is evaluated each time the field's form is initialized.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``invalid_choice`` has been added. The legacy ``%(value)s`` placeholder
+       syntax has been deprecated and will be removed in Django 2.0.
 
 ``TypedChoiceField``
 --------------------
@@ -529,9 +535,9 @@ For each field, we describe the default widget used if you don't specify
       ``max_whole_digits``
 
     The ``max_value`` and ``min_value`` error messages may contain
-    ``%(limit_value)s``, which will be substituted by the appropriate limit.
+    ``{limit_value}``, which will be substituted by the appropriate limit.
     Similarly, the ``max_digits``, ``max_decimal_places`` and
-    ``max_whole_digits`` error messages may contain ``%(max)s``.
+    ``max_whole_digits`` error messages may contain ``{max}``.
 
     Takes four optional arguments:
 
@@ -550,6 +556,13 @@ For each field, we describe the default widget used if you don't specify
     .. attribute:: decimal_places
 
         The maximum number of decimal places permitted.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``max_value`` and ``min_value`` has been added. The legacy
+       ``%(limit_value)s`` and ``%(max)s`` placeholder syntax has been
+       deprecated and will be removed in Django 2.0.
 
 ``DurationField``
 -----------------
@@ -607,8 +620,16 @@ For each field, we describe the default widget used if you don't specify
     :ref:`bind the file data to the form <binding-uploaded-files>`.
 
     The ``max_length`` error refers to the length of the filename. In the error
-    message for that key, ``%(max)d`` will be replaced with the maximum filename
-    length and ``%(length)d`` will be replaced with the current filename length.
+    message for that key, ``{max:d}`` will be replaced with the maximum
+    filename length and ``{length:d}`` will be replaced with the current
+    filename length.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``max_length`` has been added. The legacy ``%(max)d`` and ``%(length)d``
+       placeholder syntax has been deprecated and will be removed in Django
+       2.0.
 
 ``FilePathField``
 -----------------
@@ -717,7 +738,7 @@ For each field, we describe the default widget used if you don't specify
       ``min_value``
 
     The ``max_value`` and ``min_value`` error messages may contain
-    ``%(limit_value)s``, which will be substituted by the appropriate limit.
+    ``{limit_value}``, which will be substituted by the appropriate limit.
 
     Takes two optional arguments for validation:
 
@@ -725,6 +746,12 @@ For each field, we describe the default widget used if you don't specify
     .. attribute:: min_value
 
     These control the range of values permitted in the field.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``max_value`` has been added. The legacy ``%(limit_value)s`` placeholder
+       syntax has been deprecated and will be removed in Django 2.0.
 
 ``GenericIPAddressField``
 -------------------------
@@ -773,10 +800,16 @@ For each field, we describe the default widget used if you don't specify
       of choices.
     * Error message keys: ``required``, ``invalid_choice``, ``invalid_list``
 
-    The ``invalid_choice`` error message may contain ``%(value)s``, which will be
+    The ``invalid_choice`` error message may contain ``{value}``, which will be
     replaced with the selected choice.
 
     Takes one extra required argument, ``choices``, as for :class:`ChoiceField`.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``invalid_choice`` has been added. The legacy ``%(value)s`` placeholder
+       syntax has been deprecated and will be removed in Django 2.0.
 
 ``TypedMultipleChoiceField``
 ----------------------------
@@ -794,11 +827,17 @@ For each field, we describe the default widget used if you don't specify
       coerced.
     * Error message keys: ``required``, ``invalid_choice``
 
-    The ``invalid_choice`` error message may contain ``%(value)s``, which will be
+    The ``invalid_choice`` error message may contain ``{value}``, which will be
     replaced with the selected choice.
 
     Takes two extra arguments, ``coerce`` and ``empty_value``, as for
     :class:`TypedChoiceField`.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``invalid_choice`` has been added. The legacy ``%(value)s`` placeholder
+       syntax has been deprecated and will be removed in Django 2.0.
 
 ``NullBooleanField``
 --------------------
@@ -1192,8 +1231,8 @@ method::
     * Error message keys: ``required``, ``list``, ``invalid_choice``,
       ``invalid_pk_value``
 
-    The ``invalid_choice`` message may contain ``%(value)s`` and the
-    ``invalid_pk_value`` message may contain ``%(pk)s``, which will be
+    The ``invalid_choice`` message may contain ``{value}`` and the
+    ``invalid_pk_value`` message may contain ``{pk}``, which will be
     substituted by the appropriate values.
 
     Allows the selection of one or more model objects, suitable for
@@ -1206,6 +1245,13 @@ method::
         A ``QuerySet`` of model objects from which the choices for the
         field will be derived, and which will be used to validate the
         user's selection.
+
+    .. versionchanged:: 1.10
+
+       Support for Python :py:meth:`str.format()` placeholder syntax in
+       ``invalid_choice`` and ``invalid_pk_value`` has been added. The legacy
+       ``%(value)s`` and ``%(pk)s`` placeholder syntax has been deprecated and
+       will be removed in Django 2.0.
 
 Creating custom fields
 ======================

--- a/docs/ref/forms/validation.txt
+++ b/docs/ref/forms/validation.txt
@@ -129,12 +129,12 @@ following guidelines:
 
       # Good
       ValidationError(
-          _('Invalid value: %(value)s'),
+          _('Invalid value: {value}'),
           params={'value': '42'},
       )
 
       # Bad
-      ValidationError(_('Invalid value: %s') % value)
+      ValidationError(_('Invalid value: {}').format(value))
 
 * Use mapping keys instead of positional formatting. This enables putting
   the variables in any order or omitting them altogether when rewriting the
@@ -142,7 +142,7 @@ following guidelines:
 
       # Good
       ValidationError(
-          _('Invalid value: %(value)s'),
+          _('Invalid value: {value}'),
           params={'value': '42'},
       )
 
@@ -150,6 +150,21 @@ following guidelines:
       ValidationError(
           _('Invalid value: %s'),
           params=('42',),
+      )
+
+* Use Python :py:meth:`str.format()` placeholder syntax instead of the legacy
+  ``%(<foo>)s`` syntax::
+
+      # Good
+      ValidationError(
+          _('Invalid value: {value}'),
+          params={'value': '42'},
+      )
+
+      # Bad
+      ValidationError(
+          _('Invalid value: %(value)s'),
+          params={'value': '42'},
       )
 
 * Wrap the message with ``gettext`` to enable translation::
@@ -163,7 +178,7 @@ following guidelines:
 Putting it all together::
 
     raise ValidationError(
-        _('Invalid value: %(value)s'),
+        _('Invalid value: {value}'),
         code='invalid',
         params={'value': '42'},
     )
@@ -175,12 +190,18 @@ While not recommended, if you are at the end of the validation chain
 (i.e. your form ``clean()`` method) and you know you will *never* need
 to override your error message you can still opt for the less verbose::
 
-    ValidationError(_('Invalid value: %s') % value)
+    ValidationError(_('Invalid value: {}').format(value))
 
 The :meth:`Form.errors.as_data() <django.forms.Form.errors.as_data()>` and
 :meth:`Form.errors.as_json() <django.forms.Form.errors.as_json()>` methods
 greatly benefit from fully featured ``ValidationError``\s (with a ``code`` name
 and a ``params`` dictionary).
+
+.. versionchanged:: 1.10
+
+   Support for Python :py:meth:`str.format()` placeholder syntax has been
+   added. The legacy ``%(value)s`` placeholder syntax has been deprecated and
+   will be removed in Django 2.0.
 
 Raising multiple errors
 -----------------------

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1711,7 +1711,7 @@ Field API reference
 
         The description can be of the form::
 
-            description = _("String (up to %(max_length)s)")
+            description = _("String (up to {max_length})")
 
         where the arguments are interpolated from the field's ``__dict__``.
 

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -105,10 +105,16 @@ Django quotes column and table names behind the scenes.
 
     As the reverse name for a field should be unique, be careful if you intend
     to subclass your model. To work around name collisions, part of the name
-    should contain ``'%(app_label)s'`` and ``'%(model_name)s'``, which are
+    should contain ``'{app_label}'`` and ``'{model_name}'``, which are
     replaced respectively by the name of the application the model is in,
     and the name of the model, both lowercased. See the paragraph on
     :ref:`related names for abstract models <abstract-related-name>`.
+
+.. versionchanged:: 1.10
+
+   Support for Python :py:meth:`str.format()` placeholder syntax has been added
+   for ``default_related_name``. The legacy ``%(app_label)s`` and ``%(class)s``
+   placeholder syntax has been deprecated and will be removed in Django 2.0.
 
 ``get_latest_by``
 -----------------

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -21,7 +21,7 @@ For example, here's a validator that only allows even numbers::
     def validate_even(value):
         if value % 2 != 0:
             raise ValidationError(
-                _('%(value)s is not an even number'),
+                _('{value} is not an even number'),
                 params={'value': value},
             )
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -216,6 +216,10 @@ Forms
 * Form and widget ``Media`` is now served using
   :mod:`django.contrib.staticfiles` if installed.
 
+* Placeholders in :class:`~django.core.exceptions.ValidationError` now support
+  the Python :py:meth:`str.format()` syntax. The legacy ``%(<foo>)s`` syntax is
+  still supported but will be removed in Django 2.0.
+
 Generic Views
 ~~~~~~~~~~~~~
 
@@ -630,6 +634,10 @@ Miscellaneous
 
 * Importing from the ``django.core.urlresolvers`` module is deprecated in
   favor of its new location, :mod:`django.urls`.
+
+* In :class:`~django.core.exceptions.ValidationError`, The legacy ``%(<foo>)s``
+  placeholder syntax is deprecated in favor of Python :py:meth:`str.format()`
+  syntax.
 
 .. _removed-features-1.10:
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -296,8 +296,13 @@ Models
   may be called without any arguments to return all objects in the queryset.
 
 * :attr:`~django.db.models.ForeignKey.related_query_name` now supports
-  app label and class interpolation using the ``'%(app_label)s'`` and
-  ``'%(class)s'`` strings.
+  app label and class interpolation using the ``'{app_label}'`` and
+  ``'{class}'`` strings.
+
+* The app label and class interpolation in
+  :attr:`~django.db.models.ForeignKey.related_name` now supports the Python
+  :py:meth:`str.format()` syntax. The legacy ``'%(app_label)s'`` and
+  ``'%(class)s'`` syntax is still supported but will be removed in Django 2.0.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -638,6 +643,10 @@ Miscellaneous
 * In :class:`~django.core.exceptions.ValidationError`, The legacy ``%(<foo>)s``
   placeholder syntax is deprecated in favor of Python :py:meth:`str.format()`
   syntax.
+
+* For :attr:`~django.db.models.ForeignKey.related_name`, the legacy
+  ``%(app_label)s`` and ``%(class)s`` interpolation syntax is deprecated in
+  favor of Python :py:meth:`str.format()` syntax.
 
 .. _removed-features-1.10:
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -65,7 +65,10 @@ Minor features
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Interpolation of the ``description`` property of
+  :class:`~django.db.models.Field` now supports the Python
+  :py:meth:`str.format()` syntax. The legacy ``%(<foo>)s`` syntax is still
+  supported but will be removed in Django 2.0.
 
 :mod:`django.contrib.auth`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -664,6 +667,10 @@ Miscellaneous
 * For the ``success_message`` property of
   :class:`~django.contrib.messages.views.SuccessMessageMixin`, the legacy
   ``%(field_name)s`` placeholder syntax is deprecated in favor of Python
+  :py:meth:`str.format()` syntax.
+
+* For the ``description`` property of :class:`~django.db.models.Field`,
+  the legacy ``%(<foo>)s`` placeholder syntax is deprecated in favor of Python
   :py:meth:`str.format()` syntax.
 
 .. _removed-features-1.10:

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -304,6 +304,12 @@ Models
   :py:meth:`str.format()` syntax. The legacy ``'%(app_label)s'`` and
   ``'%(class)s'`` syntax is still supported but will be removed in Django 2.0.
 
+* The app label and model name placeholders in
+  :attr:`~django.db.models.Options.default_related_name` now supports the Python
+  :py:meth:`str.format()` syntax. The legacy ``'%(app_label)s'`` and
+  ``'%(model_name)s'`` syntax is still supported but will be removed in Django
+  2.0.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -646,6 +652,10 @@ Miscellaneous
 
 * For :attr:`~django.db.models.ForeignKey.related_name`, the legacy
   ``%(app_label)s`` and ``%(class)s`` interpolation syntax is deprecated in
+  favor of Python :py:meth:`str.format()` syntax.
+
+* For :attr:`~django.db.models.Options.default_related_name` the legacy
+  ``%(app_label)s`` and ``%(model_name)s`` placeholder syntax is deprecated in
   favor of Python :py:meth:`str.format()` syntax.
 
 .. _removed-features-1.10:

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -134,7 +134,10 @@ Minor features
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The ``success_message`` property of
+  :class:`~django.contrib.messages.views.SuccessMessageMixin` now supports the
+  Python :py:meth:`str.format()` syntax. The legacy ``%(field_name)s`` syntax is
+  still supported but will be removed in Django 2.0.
 
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -657,6 +660,11 @@ Miscellaneous
 * For :attr:`~django.db.models.Options.default_related_name` the legacy
   ``%(app_label)s`` and ``%(model_name)s`` placeholder syntax is deprecated in
   favor of Python :py:meth:`str.format()` syntax.
+
+* For the ``success_message`` property of
+  :class:`~django.contrib.messages.views.SuccessMessageMixin`, the legacy
+  ``%(field_name)s`` placeholder syntax is deprecated in favor of Python
+  :py:meth:`str.format()` syntax.
 
 .. _removed-features-1.10:
 

--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -452,7 +452,7 @@ Here's a basic example of a validator, with one optional setting::
         def validate(self, password, user=None):
             if len(password) < self.min_length:
                 raise ValidationError(
-                    _("This password must contain at least %(min_length)d characters."),
+                    _("This password must contain at least {min_length:d} characters."),
                     code='password_too_short',
                     params={'min_length': self.min_length},
                 )

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -979,12 +979,12 @@ classes, with exactly the same values for the attributes (including
 To work around this problem, when you are using
 :attr:`~django.db.models.ForeignKey.related_name` or
 :attr:`~django.db.models.ForeignKey.related_query_name` in an abstract base
-class (only), part of the value should contain ``'%(app_label)s'`` and
-``'%(class)s'``.
+class (only), part of the value should contain ``'{app_label}'`` and
+``'{class}'``.
 
-- ``'%(class)s'`` is replaced by the lower-cased name of the child class
+- ``'{class}'`` is replaced by the lower-cased name of the child class
   that the field is used in.
-- ``'%(app_label)s'`` is replaced by the lower-cased name of the app the child
+- ``'{app_label}'`` is replaced by the lower-cased name of the app the child
   class is contained within. Each installed application name must be unique
   and the model class names within each app must also be unique, therefore the
   resulting name will end up being different.
@@ -996,8 +996,8 @@ For example, given an app ``common/models.py``::
     class Base(models.Model):
         m2m = models.ManyToManyField(
             OtherModel,
-            related_name="%(app_label)s_%(class)s_related",
-            related_query_name="%(app_label)s_%(class)ss",
+            related_name="{app_label}_{class}_related",
+            related_query_name="{app_label}_{class}s",
         )
 
         class Meta:
@@ -1022,8 +1022,8 @@ The reverse name of the ``common.ChildB.m2m`` field will be
 ``common_childb_related`` and the reverse query name will be
 ``common_childbs``. Finally, the reverse name of the ``rare.ChildB.m2m`` field
 will be ``rare_childb_related`` and the reverse query name will be
-``rare_childbs``. It's up to you how you use the `'%(class)s'`` and
-``'%(app_label)s`` portion to construct your related name or related query name
+``rare_childbs``. It's up to you how you use the `'{class}'`` and
+``'{app_label}`` portion to construct your related name or related query name
 but if you forget to use it, Django will raise errors when you perform system
 checks (or run :djadmin:`migrate`).
 
@@ -1038,8 +1038,15 @@ field.
 
 .. versionchanged:: 1.10
 
-   Interpolation of  ``'%(app_label)s'`` and ``'%(class)s'`` for
+   Interpolation of  ``'{app_label}'`` and ``'{class}'`` for
    ``related_query_name`` was added.
+
+.. versionchanged:: 1.10
+
+   Support for Python :py:meth:`str.format()` placeholder syntax has
+   been added for the interpolation of ``related_name``. The legacy
+   ``%(app_label)s`` and ``%(class)s`` placeholder syntax has been
+   deprecated and will be removed in Django 2.0.
 
 .. _multi-table-inheritance:
 

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -293,7 +293,7 @@ to the ``error_messages`` dictionary of the ``ModelForm``’s inner ``Meta`` cla
         class Meta:
             error_messages = {
                 NON_FIELD_ERRORS: {
-                    'unique_together': "%(model_name)s's %(field_labels)s are not unique.",
+                    'unique_together': "{model_name}'s {field_labels} are not unique.",
                 }
             }
 

--- a/tests/admin_utils/models.py
+++ b/tests/admin_utils/models.py
@@ -72,7 +72,7 @@ class VehicleMixin(Vehicle):
         Vehicle,
         models.CASCADE,
         parent_link=True,
-        related_name='vehicle_%(app_label)s_%(class)s',
+        related_name='vehicle_{app_label}_{class}',
     )
 
     class Meta:

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -85,7 +85,7 @@ class NestedObjectsTests(TestCase):
         """
         #21846 -- Check that `NestedObjects.collect()` doesn't trip
         (AttributeError) on the special notation for relations on abstract
-        models (related_name that contains %(app_label)s and/or %(class)s).
+        models (related_name that contains {app_label} and/or {class}).
         """
         n = NestedObjects(using=DEFAULT_DB_ALIAS)
         Car.objects.create()

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -151,10 +151,16 @@ class AuthenticationFormTest(TestDataMixin, TestCase):
         }
         form = AuthenticationForm(None, data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.non_field_errors(),
-                [force_text(form.error_messages['invalid_login'] % {
-                    'username': User._meta.get_field('username').verbose_name
-                })])
+        self.assertEqual(
+            form.non_field_errors(),
+            [
+                force_text(
+                    form.error_messages['invalid_login'].format(
+                        username=User._meta.get_field('username').verbose_name,
+                    )
+                )
+            ]
+        )
 
     def test_inactive_user(self):
         # The user is inactive.

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -387,9 +387,12 @@ class ChangePasswordTest(AuthViewsTestCase):
             'username': 'testclient',
             'password': password,
         })
-        self.assertFormError(response, AuthenticationForm.error_messages['invalid_login'] % {
-            'username': User._meta.get_field('username').verbose_name
-        })
+        self.assertFormError(
+            response,
+            AuthenticationForm.error_messages['invalid_login'].format(
+                username=User._meta.get_field('username').verbose_name,
+            )
+        )
 
     def logout(self):
         self.client.get('/logout/')

--- a/tests/forms_tests/tests/test_error_messages.py
+++ b/tests/forms_tests/tests/test_error_messages.py
@@ -27,8 +27,8 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
     def test_charfield(self):
         e = {
             'required': 'REQUIRED',
-            'min_length': 'LENGTH %(show_value)s, MIN LENGTH %(limit_value)s',
-            'max_length': 'LENGTH %(show_value)s, MAX LENGTH %(limit_value)s',
+            'min_length': 'LENGTH {show_value}, MIN LENGTH {limit_value}',
+            'max_length': 'LENGTH {show_value}, MAX LENGTH {limit_value}',
         }
         f = CharField(min_length=5, max_length=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -39,8 +39,8 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'min_value': 'MIN VALUE IS %(limit_value)s',
-            'max_value': 'MAX VALUE IS %(limit_value)s',
+            'min_value': 'MIN VALUE IS {limit_value}',
+            'max_value': 'MAX VALUE IS {limit_value}',
         }
         f = IntegerField(min_value=5, max_value=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -52,8 +52,8 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'min_value': 'MIN VALUE IS %(limit_value)s',
-            'max_value': 'MAX VALUE IS %(limit_value)s',
+            'min_value': 'MIN VALUE IS {limit_value}',
+            'max_value': 'MAX VALUE IS {limit_value}',
         }
         f = FloatField(min_value=5, max_value=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -65,11 +65,11 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'min_value': 'MIN VALUE IS %(limit_value)s',
-            'max_value': 'MAX VALUE IS %(limit_value)s',
-            'max_digits': 'MAX DIGITS IS %(max)s',
-            'max_decimal_places': 'MAX DP IS %(max)s',
-            'max_whole_digits': 'MAX DIGITS BEFORE DP IS %(max)s',
+            'min_value': 'MIN VALUE IS {limit_value}',
+            'max_value': 'MAX VALUE IS {limit_value}',
+            'max_digits': 'MAX DIGITS IS {max}',
+            'max_decimal_places': 'MAX DP IS {max}',
+            'max_whole_digits': 'MAX DIGITS BEFORE DP IS {max}',
         }
         f = DecimalField(min_value=5, max_value=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -113,8 +113,8 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'min_length': 'LENGTH %(show_value)s, MIN LENGTH %(limit_value)s',
-            'max_length': 'LENGTH %(show_value)s, MAX LENGTH %(limit_value)s',
+            'min_length': 'LENGTH {show_value}, MIN LENGTH {limit_value}',
+            'max_length': 'LENGTH {show_value}, MAX LENGTH {limit_value}',
         }
         f = RegexField(r'^[0-9]+$', min_length=5, max_length=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -126,8 +126,8 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'min_length': 'LENGTH %(show_value)s, MIN LENGTH %(limit_value)s',
-            'max_length': 'LENGTH %(show_value)s, MAX LENGTH %(limit_value)s',
+            'min_length': 'LENGTH {show_value}, MIN LENGTH {limit_value}',
+            'max_length': 'LENGTH {show_value}, MAX LENGTH {limit_value}',
         }
         f = EmailField(min_length=8, max_length=10, error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -152,7 +152,7 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
         e = {
             'required': 'REQUIRED',
             'invalid': 'INVALID',
-            'max_length': '"%(value)s" has more than %(limit_value)d characters.',
+            'max_length': '"{value}" has more than {limit_value:d} characters.',
         }
         f = URLField(error_messages=e, max_length=17)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -173,7 +173,7 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
     def test_choicefield(self):
         e = {
             'required': 'REQUIRED',
-            'invalid_choice': '%(value)s IS INVALID CHOICE',
+            'invalid_choice': '{value} IS INVALID CHOICE',
         }
         f = ChoiceField(choices=[('a', 'aye')], error_messages=e)
         self.assertFormErrors(['REQUIRED'], f.clean, '')
@@ -182,7 +182,7 @@ class FormsErrorMessagesTestCase(SimpleTestCase, AssertFormErrorsMixin):
     def test_multiplechoicefield(self):
         e = {
             'required': 'REQUIRED',
-            'invalid_choice': '%(value)s IS INVALID CHOICE',
+            'invalid_choice': '{value} IS INVALID CHOICE',
             'invalid_list': 'NOT A LIST',
         }
         f = MultipleChoiceField(choices=[('a', 'aye')], error_messages=e)
@@ -265,7 +265,7 @@ class ModelChoiceFieldErrorMessagesTestCase(TestCase, AssertFormErrorsMixin):
         # ModelMultipleChoiceField
         e = {
             'required': 'REQUIRED',
-            'invalid_choice': '%(value)s IS INVALID CHOICE',
+            'invalid_choice': '{value} IS INVALID CHOICE',
             'list': 'NOT A LIST OF VALUES',
         }
         f = ModelMultipleChoiceField(queryset=ChoiceModel.objects.all(), error_messages=e)

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -3079,7 +3079,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
     def test_error_list(self):
         e = ErrorList()
         e.append('Foo')
-        e.append(ValidationError('Foo%(bar)s', code='foobar', params={'bar': 'bar'}))
+        e.append(ValidationError('Foo{bar}', code='foobar', params={'bar': 'bar'}))
 
         self.assertIsInstance(e, list)
         self.assertIn('Foo', e)
@@ -3103,7 +3103,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
     def test_error_list_class_not_specified(self):
         e = ErrorList()
         e.append('Foo')
-        e.append(ValidationError('Foo%(bar)s', code='foobar', params={'bar': 'bar'}))
+        e.append(ValidationError('Foo{bar}', code='foobar', params={'bar': 'bar'}))
         self.assertEqual(
             e.as_ul(),
             '<ul class="errorlist"><li>Foo</li><li>Foobar</li></ul>'
@@ -3112,7 +3112,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
     def test_error_list_class_has_one_class_specified(self):
         e = ErrorList(error_class='foobar-error-class')
         e.append('Foo')
-        e.append(ValidationError('Foo%(bar)s', code='foobar', params={'bar': 'bar'}))
+        e.append(ValidationError('Foo{bar}', code='foobar', params={'bar': 'bar'}))
         self.assertEqual(
             e.as_ul(),
             '<ul class="errorlist foobar-error-class"><li>Foo</li><li>Foobar</li></ul>'

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -138,11 +138,11 @@ class FormsUtilsTestCase(SimpleTestCase):
         e = ErrorDict()
         e['__all__'] = ErrorList([
             ValidationError(
-                message='message %(i)s',
+                message='message {i}',
                 params={'i': 1},
             ),
             ValidationError(
-                message='message %(i)s',
+                message='message {i}',
                 params={'i': 2},
             ),
         ])

--- a/tests/messages_tests/test_mixins.py
+++ b/tests/messages_tests/test_mixins.py
@@ -1,7 +1,8 @@
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, ignore_warnings, override_settings
 from django.urls import reverse
+from django.utils.deprecation import RemovedInDjango20Warning
 
-from .urls import ContactFormViewWithMsg
+from .urls import ContactFormViewWithLegacyMsg, ContactFormViewWithMsg
 
 
 @override_settings(ROOT_URLCONF='messages_tests.urls')
@@ -12,5 +13,20 @@ class SuccessMessageMixinTests(SimpleTestCase):
                   'slug': 'success-msg'}
         add_url = reverse('add_success_msg')
         req = self.client.post(add_url, author)
-        self.assertIn(ContactFormViewWithMsg.success_message % author,
-                      req.cookies['messages'].value)
+        self.assertIn(
+            ContactFormViewWithMsg.success_message.format(**author),
+            req.cookies['messages'].value,
+        )
+
+    @ignore_warnings(category=RemovedInDjango20Warning)
+    def test_set_messages_success_percent_placeholder(self):
+        author = {
+            'name': 'John Doe',
+            'slug': 'success-msg',
+        }
+        add_url = reverse('add_success_legacy_msg')
+        req = self.client.post(add_url, author)
+        self.assertIn(
+            ContactFormViewWithLegacyMsg.success_message % author,
+            req.cookies['messages'].value,
+        )

--- a/tests/messages_tests/urls.py
+++ b/tests/messages_tests/urls.py
@@ -67,12 +67,19 @@ class ContactForm(forms.Form):
 class ContactFormViewWithMsg(SuccessMessageMixin, FormView):
     form_class = ContactForm
     success_url = show
+    success_message = "{name} was created successfully"
+
+
+class ContactFormViewWithLegacyMsg(SuccessMessageMixin, FormView):
+    form_class = ContactForm
+    success_url = show
     success_message = "%(name)s was created successfully"
 
 
 urlpatterns = [
     url('^add/(debug|info|success|warning|error)/$', add, name='add_message'),
     url('^add/msg/$', ContactFormViewWithMsg.as_view(), name='add_success_msg'),
+    url('^add/legacymsg/$', ContactFormViewWithLegacyMsg.as_view(), name='add_success_legacy_msg'),
     url('^show/$', show, name='show_message'),
     url('^template_response/add/(debug|info|success|warning|error)/$',
         add_template_response, name='add_template_response'),

--- a/tests/model_fields/test_durationfield.py
+++ b/tests/model_fields/test_durationfield.py
@@ -67,7 +67,7 @@ class TestValidation(SimpleTestCase):
             field.clean('not a datetime', None)
         self.assertEqual(cm.exception.code, 'invalid')
         self.assertEqual(
-            cm.exception.message % cm.exception.params,
+            cm.exception.message.format(**cm.exception.params),
             "'not a datetime' value has an invalid format. "
             "It must be in [DD] [HH:[MM:]]ss[.uuuuuu] format."
         )

--- a/tests/model_fields/test_uuid.py
+++ b/tests/model_fields/test_uuid.py
@@ -105,7 +105,7 @@ class TestValidation(SimpleTestCase):
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean('550e8400', None)
         self.assertEqual(cm.exception.code, 'invalid')
-        self.assertEqual(cm.exception.message % cm.exception.params, "'550e8400' is not a valid UUID.")
+        self.assertEqual(cm.exception.message.format(**cm.exception.params), "'550e8400' is not a valid UUID.")
 
     def test_uuid_instance_ok(self):
         field = models.UUIDField()

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -173,19 +173,19 @@ class DecimalFieldTests(test.TestCase):
 
     def test_max_digits_validation(self):
         field = models.DecimalField(max_digits=2)
-        expected_message = validators.DecimalValidator.messages['max_digits'] % {'max': 2}
+        expected_message = validators.DecimalValidator.messages['max_digits'].format(max=2)
         with self.assertRaisesMessage(ValidationError, expected_message):
             field.clean(100, None)
 
     def test_max_decimal_places_validation(self):
         field = models.DecimalField(decimal_places=1)
-        expected_message = validators.DecimalValidator.messages['max_decimal_places'] % {'max': 1}
+        expected_message = validators.DecimalValidator.messages['max_decimal_places'].format(max=1)
         with self.assertRaisesMessage(ValidationError, expected_message):
             field.clean(Decimal('0.99'), None)
 
     def test_max_whole_digits_validation(self):
         field = models.DecimalField(max_digits=3, decimal_places=1)
-        expected_message = validators.DecimalValidator.messages['max_whole_digits'] % {'max': 2}
+        expected_message = validators.DecimalValidator.messages['max_whole_digits'].format(max=2)
         with self.assertRaisesMessage(ValidationError, expected_message):
             field.clean(Decimal('999'), None)
 
@@ -739,9 +739,9 @@ class IntegerFieldTests(test.TestCase):
 
         if min_value is not None:
             instance = self.model(value=min_value - 1)
-            expected_message = validators.MinValueValidator.message % {
-                'limit_value': min_value
-            }
+            expected_message = validators.MinValueValidator.message.format(
+                limit_value=min_value,
+            )
             with self.assertRaisesMessage(ValidationError, expected_message):
                 instance.full_clean()
             instance.value = min_value
@@ -749,9 +749,9 @@ class IntegerFieldTests(test.TestCase):
 
         if max_value is not None:
             instance = self.model(value=max_value + 1)
-            expected_message = validators.MaxValueValidator.message % {
-                'limit_value': max_value
-            }
+            expected_message = validators.MaxValueValidator.message.format(
+                limit_value=max_value,
+            )
             with self.assertRaisesMessage(ValidationError, expected_message):
                 instance.full_clean()
             instance.value = max_value

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -906,7 +906,7 @@ class UniqueTest(TestCase):
             class Meta(ProductForm.Meta):
                 error_messages = {
                     'slug': {
-                        'unique': "%(model_name)s's %(field_label)s not unique.",
+                        'unique': "{model_name}'s {field_label} not unique.",
                     }
                 }
 
@@ -920,7 +920,7 @@ class UniqueTest(TestCase):
             class Meta(PriceForm.Meta):
                 error_messages = {
                     NON_FIELD_ERRORS: {
-                        'unique_together': "%(model_name)s's %(field_labels)s not unique.",
+                        'unique_together': "{model_name}'s {field_labels} not unique.",
                     }
                 }
 
@@ -935,8 +935,8 @@ class UniqueTest(TestCase):
                 error_messages = {
                     'title': {
                         'unique_for_date': (
-                            "%(model_name)s's %(field_label)s not unique "
-                            "for %(date_field_label)s date."
+                            "{model_name}'s {field_label} not unique "
+                            "for {date_field_label} date."
                         ),
                     }
                 }

--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -14,6 +14,8 @@ Both styles are demonstrated here.
 from __future__ import unicode_literals
 
 from django.db import models
+from django.test import ignore_warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import python_2_unicode_compatible
 
 
@@ -59,8 +61,8 @@ class Attachment(models.Model):
     post = models.ForeignKey(
         Post,
         models.CASCADE,
-        related_name='attached_%(class)s_set',
-        related_query_name='attached_%(app_label)s_%(class)ss',
+        related_name='attached_{class}_set',
+        related_query_name='attached_{app_label}_{class}s',
     )
     content = models.TextField()
 
@@ -77,6 +79,28 @@ class Comment(Attachment):
 
 class Link(Attachment):
     url = models.URLField()
+
+
+with ignore_warnings(category=RemovedInDjango20Warning):
+    class LegacyPost(models.Model):
+        title = models.CharField(max_length=50)
+
+    class LegacyAttachment(models.Model):
+        post = models.ForeignKey(
+            LegacyPost,
+            models.CASCADE,
+            related_name='attached_%(class)s_set',
+        )
+        content = models.TextField()
+
+        class Meta:
+            abstract = True
+
+    class LegacyComment(LegacyAttachment):
+        is_spam = models.BooleanField(default=False)
+
+    class LegacyLink(LegacyAttachment):
+        url = models.URLField()
 
 
 #
@@ -161,7 +185,7 @@ class Title(models.Model):
 
 
 class NamedURL(models.Model):
-    title = models.ForeignKey(Title, models.CASCADE, related_name='attached_%(app_label)s_%(class)s_set')
+    title = models.ForeignKey(Title, models.CASCADE, related_name='attached_{app_label}_{class}_set')
     url = models.URLField()
 
     class Meta:

--- a/tests/model_inheritance/same_model_name/models.py
+++ b/tests/model_inheritance/same_model_name/models.py
@@ -1,7 +1,7 @@
 """
 
 Model inheritance across apps can result in models with the same name,
-requiring an %(app_label)s format string. This app tests this feature by
+requiring an {app_label} format string. This app tests this feature by
 redefining the Copy model from model_inheritance/models.py.
 """
 

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -11,8 +11,8 @@ from django.utils import six
 
 from .models import (
     Base, Chef, CommonInfo, Copy, GrandChild, GrandParent, ItalianRestaurant,
-    MixinModel, ParkingLot, Place, Post, Restaurant, Student, SubBase,
-    Supplier, Title, Worker,
+    LegacyPost, MixinModel, ParkingLot, Place, Post, Restaurant, Student,
+    SubBase, Supplier, Title, Worker,
 )
 
 
@@ -69,9 +69,22 @@ class ModelInheritanceTests(TestCase):
         )
 
         # The Post model doesn't have an attribute called
-        # 'attached_%(class)s_set'.
+        # 'attached_{class}_set'.
         with self.assertRaises(AttributeError):
-            getattr(post, "attached_%(class)s_set")
+            getattr(post, "attached_{class}_set")
+
+    def test_related_name_with_percent_placeholder(self):
+        # The Post model has distinct accessors for the Comment and Link models.
+        post = LegacyPost.objects.create(title="Lorem Ipsum")
+        post.attached_legacycomment_set.create(content="Save $ on V1agr@", is_spam=True)
+        post.attached_legacylink_set.create(
+            content="The Web framework for perfections with deadlines.",
+            url="http://www.djangoproject.com/",
+        )
+
+        # The Post model doesn't have an attribute called
+        # 'attached_%(class)s_set'.
+        self.assertFalse(hasattr(post, "attached_%(class)_set"))
 
     def test_model_with_distinct_related_query_name(self):
         self.assertQuerysetEqual(Post.objects.filter(attached_model_inheritance_comments__is_spam=True), [])
@@ -425,8 +438,8 @@ class InheritanceSameModelNameTests(TransactionTestCase):
             copy.delete()
 
     def test_related_name_attribute_exists(self):
-        # The Post model doesn't have an attribute called 'attached_%(app_label)s_%(class)s_set'.
-        self.assertFalse(hasattr(self.title, 'attached_%(app_label)s_%(class)s_set'))
+        # The Post model doesn't have an attribute called 'attached_{app_label}_{class}_set'.
+        self.assertFalse(hasattr(self.title, 'attached_{app_label}_{class}_set'))
 
 
 class InheritanceUniqueTests(TestCase):

--- a/tests/model_inheritance_regress/models.py
+++ b/tests/model_inheritance_regress/models.py
@@ -188,7 +188,7 @@ class Person(models.Model):
 @python_2_unicode_compatible
 class AbstractEvent(models.Model):
     name = models.CharField(max_length=100)
-    attendees = models.ManyToManyField(Person, related_name="%(class)s_set")
+    attendees = models.ManyToManyField(Person, related_name="{class}_set")
 
     class Meta:
         abstract = True

--- a/tests/model_options/models/default_related_name.py
+++ b/tests/model_options/models/default_related_name.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.test import ignore_warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 
 
 class Author(models.Model):
@@ -26,7 +28,7 @@ class Store(models.Model):
 
     class Meta:
         abstract = True
-        default_related_name = "%(app_label)s_%(model_name)ss"
+        default_related_name = "{app_label}_{model_name}s"
 
 
 class BookStore(Store):
@@ -39,3 +41,23 @@ class EditorStore(Store):
 
     class Meta:
         default_related_name = "editor_stores"
+
+
+with ignore_warnings(category=RemovedInDjango20Warning):
+    class LegacyStore(models.Model):
+        name = models.CharField(max_length=128)
+        address = models.CharField(max_length=128)
+
+        class Meta:
+            abstract = True
+            default_related_name = '%(app_label)s_%(model_name)ss'
+
+    class LegacyBookStore(LegacyStore):
+        available_books = models.ManyToManyField(Book)
+
+    class LegacyEditorStore(LegacyStore):
+        editor = models.ForeignKey(Editor, models.CASCADE)
+        available_books = models.ManyToManyField(Book)
+
+        class Meta:
+            default_related_name = 'legacy_editor_stores'

--- a/tests/model_options/test_default_related_name.py
+++ b/tests/model_options/test_default_related_name.py
@@ -44,3 +44,11 @@ class DefaultRelatedNameTests(TestCase):
             self.book.editor_stores
         except AttributeError:
             self.fail("Book should have a editor_stores relation.")
+
+    def test_inheritance_percent_placeholder(self):
+        # Here model_options corresponds to the name of the
+        # application used in this test
+        self.assertTrue(hasattr(self.book, 'model_options_legacybookstores'))
+
+    def test_inheritance_with_overridden_default_related_name_percent_placeholder(self):
+        self.assertTrue(hasattr(self.book, 'legacy_editor_stores'))

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -469,7 +469,7 @@ class TestValidation(PostgreSQLTestCase):
             field.clean([1, None], None)
         self.assertEqual(cm.exception.code, 'item_invalid')
         self.assertEqual(
-            cm.exception.message % cm.exception.params,
+            cm.exception.message.format(**cm.exception.params),
             'Item 1 in the array did not validate: This field cannot be null.'
         )
 
@@ -500,7 +500,7 @@ class TestValidation(PostgreSQLTestCase):
         self.assertEqual(len(cm.exception.error_list), 1)
         exception = cm.exception.error_list[0]
         self.assertEqual(
-            exception.message,
+            exception.message.format(**exception.params),
             'Item 0 in the array did not validate: Ensure this value has at most 2 characters (it has 3).'
         )
         self.assertEqual(exception.code, 'item_invalid')
@@ -514,7 +514,7 @@ class TestValidation(PostgreSQLTestCase):
         self.assertEqual(len(cm.exception.error_list), 1)
         exception = cm.exception.error_list[0]
         self.assertEqual(
-            exception.message,
+            exception.message.format(**exception.params),
             'Item 0 in the array did not validate: Ensure this value is greater than or equal to 1.'
         )
         self.assertEqual(exception.code, 'item_invalid')
@@ -548,14 +548,14 @@ class TestSimpleFormField(PostgreSQLTestCase):
         self.assertEqual(len(errors), 2)
         first_error = errors[0]
         self.assertEqual(
-            first_error.message,
+            first_error.message.format(**first_error.params),
             'Item 0 in the array did not validate: Ensure this value has at most 2 characters (it has 3).'
         )
         self.assertEqual(first_error.code, 'item_invalid')
         self.assertEqual(first_error.params, {'nth': 0, 'value': 'abc', 'limit_value': 2, 'show_value': 3})
         second_error = errors[1]
         self.assertEqual(
-            second_error.message,
+            second_error.message.format(**second_error.params),
             'Item 2 in the array did not validate: Ensure this value has at most 2 characters (it has 4).'
         )
         self.assertEqual(second_error.code, 'item_invalid')

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -191,7 +191,7 @@ class TestValidation(PostgreSQLTestCase):
         with self.assertRaises(exceptions.ValidationError) as cm:
             field.clean({'a': 1}, None)
         self.assertEqual(cm.exception.code, 'not_a_string')
-        self.assertEqual(cm.exception.message % cm.exception.params, 'The value of "a" is not a string.')
+        self.assertEqual(cm.exception.message.format(**cm.exception.params), 'The value of "a" is not a string.')
 
 
 class TestFormField(PostgreSQLTestCase):

--- a/tests/test_exceptions/test_validation_error.py
+++ b/tests/test_exceptions/test_validation_error.py
@@ -1,6 +1,8 @@
 import unittest
 
 from django.core.exceptions import ValidationError
+from django.test import ignore_warnings
+from django.utils.deprecation import RemovedInDjango20Warning
 
 
 class TestValidationError(unittest.TestCase):
@@ -14,3 +16,48 @@ class TestValidationError(unittest.TestCase):
         message_dict['field2'] = ['E3', 'E4']
         exception = ValidationError(message_dict)
         self.assertEqual(sorted(exception.messages), ['E1', 'E2', 'E3', 'E4'])
+
+    @ignore_warnings(category=RemovedInDjango20Warning)
+    def test_percent_placeholders(self):
+        e = ValidationError(
+            'Invalid value: %s',
+            params=('42',),
+        )
+        self.assertEqual(list(e), ['Invalid value: 42'])
+        e = ValidationError(
+            'Invalid value: %s, %s',
+            params=('foo', 'bar'),
+        )
+        self.assertEqual(list(e), ['Invalid value: foo, bar'])
+        e = ValidationError(
+            'Invalid value: %(value)s',
+            params={'value': '42'},
+        )
+        self.assertEqual(list(e), ['Invalid value: 42'])
+        e = ValidationError(
+            'Invalid value: %(value)d',
+            params={'value': 42},
+        )
+        self.assertEqual(list(e), ['Invalid value: 42'])
+        e = ValidationError(
+            'Invalid value: %(value1)s, %(value2)s',
+            params={'value1': 'foo', 'value2': 'bar'},
+        )
+        self.assertEqual(list(e), ['Invalid value: foo, bar'])
+
+    def test_str_format_placeholders(self):
+        e = ValidationError(
+            'Invalid value: {value}',
+            params={'value': '42'},
+        )
+        self.assertEqual(list(e), ['Invalid value: 42'])
+        e = ValidationError(
+            'Invalid value: {value:d}',
+            params={'value': 42},
+        )
+        self.assertEqual(list(e), ['Invalid value: 42'])
+        e = ValidationError(
+            'Invalid value: {value1}, {value2}',
+            params={'value1': 'foo', 'value2': 'bar'},
+        )
+        self.assertEqual(list(e), ['Invalid value: foo, bar'])

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -316,7 +316,7 @@ class TestSimpleValidators(SimpleTestCase):
             self.fail("TypeError not raised when flags and pre-compiled regex in RegexValidator")
 
     def test_max_length_validator_message(self):
-        v = MaxLengthValidator(16, message='"%(value)s" has more than %(limit_value)d characters.')
+        v = MaxLengthValidator(16, message='"{value}" has more than {limit_value:d} characters.')
         with self.assertRaisesMessage(ValidationError, '"djangoproject.com" has more than 16 characters.'):
             v('djangoproject.com')
 


### PR DESCRIPTION
Deprecated legacy `%(<foo>)s` placeholder support.

<https://code.djangoproject.com/ticket/26250>