### PR TITLE
Fixed #10506, #13793, #14891, #20932, #25201, #25897 -- Refactored managers inheritance

### DIFF
--- a/django/contrib/gis/db/models/manager.py
+++ b/django/contrib/gis/db/models/manager.py
@@ -13,6 +13,10 @@ class GeoManager(Manager.from_queryset(GeoQuerySet)):
     # properly.
     use_for_related_fields = True
 
+    # No need to bother users with the use_for_related_fields
+    # deprecation for this manager which is itself deprecated.
+    silence_use_for_related_fields_deprecation = True
+
     def __init__(self, *args, **kwargs):
         warnings.warn(
             "The GeoManager class is deprecated. Simply use a normal manager "

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -500,8 +500,7 @@ class ModelState(object):
             else:
                 # Force this manager to be the first and thus default
                 managers_mapping[default_manager_name] = (0, models.Manager())
-            # Sort all managers by their creation counter
-            for _, manager, _ in sorted(model._meta.managers):
+            for manager in model._meta.managers:
                 if manager.name == "_base_manager" or not manager.use_in_migrations:
                     continue
                 reconstruct_manager(manager)

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -151,18 +151,6 @@ class ModelBase(type):
         if is_proxy and base_meta and base_meta.swapped:
             raise TypeError("%s cannot proxy the swapped model '%s'." % (name, base_meta.swapped))
 
-        if getattr(new_class, '_default_manager', None):
-            if not is_proxy:
-                # Multi-table inheritance doesn't inherit default manager from
-                # parents.
-                new_class._default_manager = None
-                new_class._base_manager = None
-            else:
-                # Proxy classes do inherit parent's default manager, if none is
-                # set explicitly.
-                new_class._default_manager = new_class._default_manager._copy_to_model(new_class)
-                new_class._base_manager = new_class._base_manager._copy_to_model(new_class)
-
         # Add all attributes to the class.
         for obj_name, obj in attrs.items():
             new_class.add_to_class(obj_name, obj)
@@ -217,7 +205,6 @@ class ModelBase(type):
         inherited_attributes = set()
         # Do the appropriate setup for any model parents.
         for base in new_class.mro():
-            original_base = base
             if base not in parents or not hasattr(base, '_meta'):
                 # Things without _meta aren't functional models, so they're
                 # uninteresting parents.
@@ -294,14 +281,6 @@ class ModelBase(type):
                 # Pass any non-abstract parent classes onto child.
                 new_class._meta.parents.update(base_parents)
 
-            # Inherit managers from the abstract base classes.
-            new_class.copy_managers(base._meta.abstract_managers)
-
-            # Proxy models inherit the non-abstract managers from their base,
-            # unless they have redefined any of them.
-            if is_proxy:
-                new_class.copy_managers(original_base._meta.concrete_managers)
-
             # Inherit private fields (like GenericForeignKey) from the parent
             # class
             for field in base._meta.private_fields:
@@ -329,15 +308,6 @@ class ModelBase(type):
         new_class._prepare()
         new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
         return new_class
-
-    def copy_managers(cls, base_managers):
-        # This is in-place sorting of an Options attribute, but that's fine.
-        base_managers.sort()
-        for _, mgr_name, manager in base_managers:  # NOQA (redefinition of _)
-            val = getattr(cls, mgr_name, None)
-            if not val or val is manager:
-                new_manager = manager._copy_to_model(cls)
-                cls.add_to_class(mgr_name, new_manager)
 
     def add_to_class(cls, name, value):
         # We should call the contribute_to_class method only if it's bound
@@ -376,6 +346,7 @@ class ModelBase(type):
             setattr(cls, 'get_absolute_url', get_absolute_url_override)
 
         ensure_default_manager(cls)
+
         signals.class_prepared.send(sender=cls)
 
 
@@ -1263,7 +1234,7 @@ class Model(six.with_metaclass(ModelBase)):
         """ Perform all manager checks. """
 
         errors = []
-        for __, manager, __ in cls._meta.managers:
+        for manager in cls._meta.managers:
             errors.extend(manager.check(**kwargs))
         return errors
 

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -24,11 +24,12 @@ from django.db.models.fields.related import (
     ForeignObjectRel, ManyToOneRel, OneToOneField, lazy_related_operation,
     resolve_relation,
 )
-from django.db.models.manager import ensure_default_manager
+from django.db.models.manager import Manager
 from django.db.models.options import Options
 from django.db.models.query import Q
 from django.db.models.utils import make_model_tuple
 from django.utils import six
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import (
     force_str, force_text, python_2_unicode_compatible,
 )
@@ -345,9 +346,98 @@ class ModelBase(type):
         if get_absolute_url_override:
             setattr(cls, 'get_absolute_url', get_absolute_url_override)
 
-        ensure_default_manager(cls)
+        if not opts.managers or cls._requires_legacy_default_manager():
+            if any(f.name == 'objects' for f in opts.fields):
+                raise ValueError(
+                    "Model %s must specify a custom Manager, because it has a "
+                    "field named 'objects'." % cls.__name__
+                )
+            manager = Manager()
+            manager.auto_created = True
+            cls.add_to_class('objects', manager)
 
         signals.class_prepared.send(sender=cls)
+
+    def _requires_legacy_default_manager(cls):  # RemovedInDjango20Warning
+        opts = cls._meta
+
+        if opts.manager_inheritance_from_future:
+            return False
+
+        future_default_manager = opts.default_manager
+
+        # Step 1: Locate a manager that would have been promoted
+        # to default manager with the legacy system.
+        for manager in opts.managers:
+            originating_model = manager._originating_model
+            if (cls is originating_model or cls._meta.proxy or
+                    originating_model._meta.abstract):
+
+                if manager is not cls._default_manager and not opts.default_manager_name:
+                    warnings.warn(
+                        "Managers from concrete parents will soon qualify as default "
+                        "managers if they appear before any other managers in the "
+                        "MRO. As a result, '{legacy_default_manager}' declared on "
+                        "'{legacy_default_manager_model}' will no longer be the "
+                        "default manager for '{model}' in favor of "
+                        "'{future_default_manager}' declared on "
+                        "'{future_default_manager_model}'. "
+                        "You can redeclare '{legacy_default_manager}' on '{cls}' "
+                        "to keep things the way they are or you can switch to the new "
+                        "behavior right away by setting "
+                        "`Meta.manager_inheritance_from_future` to `True`.".format(
+                            cls=cls.__name__,
+                            model=opts.label,
+                            legacy_default_manager=manager.name,
+                            legacy_default_manager_model=manager._originating_model._meta.label,
+                            future_default_manager=future_default_manager.name,
+                            future_default_manager_model=future_default_manager._originating_model._meta.label,
+                        ),
+                        RemovedInDjango20Warning, 2
+                    )
+
+                    opts.default_manager_name = manager.name
+                    opts._expire_cache()
+
+                break
+
+        # Step 2: Since there are managers but none of them qualified as
+        # default managers under the legacy system (meaning that there are
+        # managers from concrete parents that would be promoted under the
+        # new system), we need to create a new Manager instance for the
+        # 'objects' attribute as a deprecation shim.
+        else:
+            # If the "future" default manager was auto created there is no
+            # point warning the user since it's basically the same manager.
+            if not future_default_manager.auto_created:
+                warnings.warn(
+                    "Managers from concrete parents will soon qualify as "
+                    "default managers. As a result, the 'objects' manager "
+                    "won't be created (or recreated) automatically "
+                    "anymore on '{model}' and '{future_default_manager}' "
+                    "declared on '{future_default_manager_model}' will be "
+                    "promoted to default manager. You can declare "
+                    "explicitly `objects = models.Manager()` on '{cls}' "
+                    "to keep things the way they are or you can switch "
+                    "to the new behavior right away by setting "
+                    "`Meta.manager_inheritance_from_future` to `True`.".format(
+                        cls=cls.__name__,
+                        model=opts.label,
+                        future_default_manager=future_default_manager.name,
+                        future_default_manager_model=future_default_manager._originating_model._meta.label,
+                    ),
+                    RemovedInDjango20Warning, 2
+                )
+
+            return True
+
+    @property
+    def _base_manager(cls):
+        return cls._meta.base_manager
+
+    @property
+    def _default_manager(cls):
+        return cls._meta.default_manager
 
 
 class ModelState(object):
@@ -896,8 +986,8 @@ class Model(six.with_metaclass(ModelBase)):
             order = '_order' if is_next else '-_order'
             order_field = self._meta.order_with_respect_to
             filter_args = order_field.get_filter_kwargs_for_object(self)
-            obj = self._default_manager.filter(**filter_args).filter(**{
-                '_order__%s' % op: self._default_manager.values('_order').filter(**{
+            obj = self.__class__._default_manager.filter(**filter_args).filter(**{
+                '_order__%s' % op: self.__class__._default_manager.values('_order').filter(**{
                     self._meta.pk.name: self.pk
                 })
             }).order_by(order)[:1].get()

--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -8,43 +8,40 @@ from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 
 
-def ensure_default_manager(cls):
+def can_use_for_related_field(manager_class):
+    return manager_class is Manager or getattr(manager_class, 'use_for_related_fields', False)
+
+
+def ensure_default_manager(model):
     """
-    Ensures that a Model subclass contains a default manager  and sets the
-    _default_manager attribute on the class. Also sets up the _base_manager
-    points to a plain Manager instance (which could be the same as
-    _default_manager if it's not a subclass of Manager).
+    Ensures that a Model subclass contains a default manager and sets the
+    _default_manager and _base_manager attributes on the class.
     """
-    if cls._meta.swapped:
-        setattr(cls, 'objects', SwappedManagerDescriptor(cls))
-        return
-    if not getattr(cls, '_default_manager', None):
-        if any(f.name == 'objects' for f in cls._meta.fields):
+
+    if not model._meta.managers:
+        if any(f.name == 'objects' for f in model._meta.fields):
             raise ValueError(
                 "Model %s must specify a custom Manager, because it has a "
-                "field named 'objects'" % cls.__name__
+                "field named 'objects'" % model.__name__
             )
-        # Create the default manager, if needed.
-        cls.add_to_class('objects', Manager())
-        cls._base_manager = cls.objects
-    elif not getattr(cls, '_base_manager', None):
-        default_mgr = cls._default_manager.__class__
-        if (default_mgr is Manager or
-                getattr(default_mgr, "use_for_related_fields", False)):
-            cls._base_manager = cls._default_manager
+        model.add_to_class('objects', Manager())
+
+    model._default_manager = model._meta.managers[0]
+
+    # Just alias _base_manager if default manager is suitable.
+    if can_use_for_related_field(model._default_manager.__class__):
+        model._base_manager = model._default_manager
+
+    # Otherwise search for a suitable manager type in the default manager MRO.
+    else:
+        for base_manager_class in model._default_manager.__class__.mro()[1:]:
+            if can_use_for_related_field(base_manager_class):
+                model._base_manager = base_manager_class()
+                model._base_manager.name = '_base_manager'
+                model._base_manager.model = model
+                break
         else:
-            # Default manager isn't a plain Manager class, or a suitable
-            # replacement, so we walk up the base class hierarchy until we hit
-            # something appropriate.
-            for base_class in default_mgr.mro()[1:]:
-                if (base_class is Manager or
-                        getattr(base_class, "use_for_related_fields", False)):
-                    cls.add_to_class('_base_manager', base_class())
-                    return
-            raise AssertionError(
-                "Should never get here. Please report a bug, including your "
-                "model and model manager setup."
-            )
+            raise ValueError("Could not find a suitable base manager.")
 
 
 @python_2_unicode_compatible
@@ -67,7 +64,6 @@ class BaseManager(object):
         self._set_creation_counter()
         self.model = None
         self.name = None
-        self._inherited = False
         self._db = None
         self._hints = {}
 
@@ -150,26 +146,13 @@ class BaseManager(object):
         return type(class_name, (cls,), class_dict)
 
     def contribute_to_class(self, model, name):
-        # TODO: Use weakref because of possible memory leak / circular reference.
-        self.model = model
         if not self.name:
             self.name = name
-        # Only contribute the manager if the model is concrete
-        if model._meta.abstract:
-            setattr(model, name, AbstractManagerDescriptor(model))
-        elif model._meta.swapped:
-            setattr(model, name, SwappedManagerDescriptor(model))
-        else:
-            # if not model._meta.abstract and not model._meta.swapped:
-            setattr(model, name, ManagerDescriptor(self))
-        if (not getattr(model, '_default_manager', None) or
-                self.creation_counter < model._default_manager.creation_counter):
-            model._default_manager = self
+        self.model = model
 
-        abstract = False
-        if model._meta.abstract or (self._inherited and not self.model._meta.proxy):
-            abstract = True
-        model._meta.managers.append((self.creation_counter, self, abstract))
+        setattr(model, name, ManagerDescriptor(self))
+
+        model._meta.add_manager(self)
 
     def _set_creation_counter(self):
         """
@@ -178,19 +161,6 @@ class BaseManager(object):
         """
         self.creation_counter = BaseManager.creation_counter
         BaseManager.creation_counter += 1
-
-    def _copy_to_model(self, model):
-        """
-        Makes a copy of the manager and assigns it to 'model', which should be
-        a child of the existing model (used when inheriting a manager from an
-        abstract base class).
-        """
-        assert issubclass(model, self.model)
-        mgr = copy.copy(self)
-        mgr._set_creation_counter()
-        mgr.model = model
-        mgr._inherited = True
-        return mgr
 
     def db_manager(self, using=None, hints=None):
         obj = copy.copy(self)
@@ -240,43 +210,29 @@ class Manager(BaseManager.from_queryset(QuerySet)):
 
 
 class ManagerDescriptor(object):
-    # This class ensures managers aren't accessible via model instances.
-    # For example, Poll.objects works, but poll_obj.objects raises AttributeError.
+
     def __init__(self, manager):
         self.manager = manager
 
     def __get__(self, instance, cls=None):
         if instance is not None:
             raise AttributeError("Manager isn't accessible via %s instances" % cls.__name__)
-        return self.manager
 
+        if cls._meta.abstract:
+            raise AttributeError("Manager isn't available; %s is abstract" % (
+                cls._meta.object_name,
+            ))
 
-class AbstractManagerDescriptor(object):
-    # This class provides a better error message when you try to access a
-    # manager on an abstract model.
-    def __init__(self, model):
-        self.model = model
-
-    def __get__(self, instance, cls=None):
-        raise AttributeError("Manager isn't available; %s is abstract" % (
-            self.model._meta.object_name,
-        ))
-
-
-class SwappedManagerDescriptor(object):
-    # This class provides a better error message when you try to access a
-    # manager on a swapped model.
-    def __init__(self, model):
-        self.model = model
-
-    def __get__(self, instance, cls=None):
-        raise AttributeError(
-            "Manager isn't available; '%s.%s' has been swapped for '%s'" % (
-                self.model._meta.app_label,
-                self.model._meta.object_name,
-                self.model._meta.swapped,
+        if cls._meta.swapped:
+            raise AttributeError(
+                "Manager isn't available; '%s.%s' has been swapped for '%s'" % (
+                    cls._meta.app_label,
+                    cls._meta.object_name,
+                    cls._meta.swapped,
+                )
             )
-        )
+
+        return cls._meta.managers_map[self.manager.name]
 
 
 class EmptyManager(Manager):

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -10,6 +10,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db import connections
+from django.db.models import Manager
 from django.db.models.fields import AutoField
 from django.db.models.fields.proxy import OrderWrt
 from django.utils import six
@@ -41,7 +42,8 @@ DEFAULT_NAMES = (
     'app_label', 'db_tablespace', 'abstract', 'managed', 'proxy', 'swappable',
     'auto_created', 'index_together', 'apps', 'default_permissions',
     'select_on_save', 'default_related_name', 'required_db_features',
-    'required_db_vendor',
+    'required_db_vendor', 'base_manager_name', 'default_manager_name',
+    'manager_inheritance_from_future',
 )
 
 
@@ -73,9 +75,11 @@ def make_immutable_fields_list(name, data):
 
 @python_2_unicode_compatible
 class Options(object):
-    FORWARD_PROPERTIES = {'fields', 'many_to_many', 'concrete_fields',
-                          'local_concrete_fields', '_forward_fields_map',
-                          'managers', 'managers_map'}
+    FORWARD_PROPERTIES = {
+        'fields', 'many_to_many', 'concrete_fields', 'local_concrete_fields',
+        '_forward_fields_map', 'managers', 'managers_map', 'base_manager',
+        'default_manager',
+    }
     REVERSE_PROPERTIES = {'related_objects', 'fields_map', '_relation_tree'}
 
     default_apps = apps
@@ -85,7 +89,10 @@ class Options(object):
         self.local_fields = []
         self.local_many_to_many = []
         self.private_fields = []
+        self.manager_inheritance_from_future = False
         self.local_managers = []
+        self.base_manager_name = None
+        self.default_manager_name = None
         self.model_name = None
         self.verbose_name = None
         self.verbose_name_plural = None
@@ -368,6 +375,10 @@ class Options(object):
                 manager.model = self.model
                 managers.append((depth, manager.creation_counter, manager))
 
+                # Used for deprecation of legacy manager inheritance,
+                # remove afterwards. (RemovedInDjango20Warning)
+                manager._originating_model = base
+
         return make_immutable_fields_list(
             "managers",
             (m[2] for m in sorted(managers)),
@@ -376,6 +387,77 @@ class Options(object):
     @cached_property
     def managers_map(self):
         return {manager.name: manager for manager in reversed(self.managers)}
+
+    @cached_property
+    def base_manager(self):
+        base_manager_name = self.base_manager_name
+        if not base_manager_name:
+            # Get the first parent's base_manager_name if there's one.
+            for parent in self.model.mro()[1:]:
+                if hasattr(parent, '_meta'):
+                    if parent._base_manager.name != '_base_manager':
+                        base_manager_name = parent._base_manager.name
+                    break
+
+        if base_manager_name:
+            try:
+                return self.managers_map[base_manager_name]
+            except KeyError:
+                raise ValueError(
+                    "%s has no manager named %r" % (
+                        self.object_name,
+                        base_manager_name,
+                    )
+                )
+
+        # Deprecation shim for `use_for_related_fields`.
+        for i, base_manager_class in enumerate(self.default_manager.__class__.mro()):
+            if getattr(base_manager_class, 'use_for_related_fields', False):
+                if not getattr(base_manager_class, 'silence_use_for_related_fields_deprecation', False):
+                    warnings.warn(
+                        "use_for_related_fields is deprecated, instead "
+                        "set Meta.base_manager_name on '{}'.".format(self.model._meta.label),
+                        RemovedInDjango20Warning, 2
+                    )
+
+                if i == 0:
+                    manager = self.default_manager
+                else:
+                    manager = base_manager_class()
+                    manager.name = '_base_manager'
+                    manager.model = self.model
+
+                return manager
+
+        manager = Manager()
+        manager.name = '_base_manager'
+        manager.model = self.model
+        manager.auto_created = True
+        return manager
+
+    @cached_property
+    def default_manager(self):
+        default_manager_name = self.default_manager_name
+        if not default_manager_name and not self.local_managers:
+            # Get the first parent's default_manager_name if there's one.
+            for parent in self.model.mro()[1:]:
+                if hasattr(parent, '_meta'):
+                    default_manager_name = parent._meta.default_manager_name
+                    break
+
+        if default_manager_name:
+            try:
+                return self.managers_map[default_manager_name]
+            except KeyError:
+                raise ValueError(
+                    "%s has no manager named %r" % (
+                        self.object_name,
+                        default_manager_name,
+                    )
+                )
+
+        if self.managers:
+            return self.managers[0]
 
     @cached_property
     def fields(self):

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import copy
 import warnings
 from bisect import bisect
 from collections import OrderedDict, defaultdict
@@ -73,7 +74,8 @@ def make_immutable_fields_list(name, data):
 @python_2_unicode_compatible
 class Options(object):
     FORWARD_PROPERTIES = {'fields', 'many_to_many', 'concrete_fields',
-                          'local_concrete_fields', '_forward_fields_map'}
+                          'local_concrete_fields', '_forward_fields_map',
+                          'managers', 'managers_map'}
     REVERSE_PROPERTIES = {'related_objects', 'fields_map', '_relation_tree'}
 
     default_apps = apps
@@ -83,6 +85,7 @@ class Options(object):
         self.local_fields = []
         self.local_many_to_many = []
         self.private_fields = []
+        self.local_managers = []
         self.model_name = None
         self.verbose_name = None
         self.verbose_name_plural = None
@@ -122,12 +125,6 @@ class Options(object):
         self.parents = OrderedDict()
         self.auto_created = False
 
-        # To handle various inheritance situations, we need to track where
-        # managers came from (concrete or abstract base classes). `managers`
-        # keeps a list of 3-tuples of the form:
-        # (creation_counter, instance, abstract(=True))
-        self.managers = []
-
         # List of all lookups defined in ForeignKey 'limit_choices_to' options
         # from *other* models. Needed for some admin checks. Internal use only.
         self.related_fkey_lookups = []
@@ -153,20 +150,6 @@ class Options(object):
     @property
     def installed(self):
         return self.app_config is not None
-
-    @property
-    def abstract_managers(self):
-        return [
-            (counter, instance.name, instance) for counter, instance, abstract
-            in self.managers if abstract
-        ]
-
-    @property
-    def concrete_managers(self):
-        return [
-            (counter, instance.name, instance) for counter, instance, abstract
-            in self.managers if not abstract
-        ]
 
     def contribute_to_class(self, cls, name):
         from django.db import connection
@@ -263,6 +246,10 @@ class Options(object):
             else:
                 auto = AutoField(verbose_name='ID', primary_key=True, auto_created=True)
                 model.add_to_class('id', auto)
+
+    def add_manager(self, manager):
+        self.local_managers.append(manager)
+        self._expire_cache()
 
     def add_field(self, field, private=False, virtual=NOT_PROVIDED):
         if virtual is not NOT_PROVIDED:
@@ -370,6 +357,25 @@ class Options(object):
                 if '%s.%s' % (swapped_label, swapped_object.lower()) != self.label_lower:
                     return swapped_for
         return None
+
+    @cached_property
+    def managers(self):
+        managers = []
+        bases = (b for b in self.model.mro() if hasattr(b, '_meta'))
+        for depth, base in enumerate(bases):
+            for manager in base._meta.local_managers:
+                manager = copy.copy(manager)
+                manager.model = self.model
+                managers.append((depth, manager.creation_counter, manager))
+
+        return make_immutable_fields_list(
+            "managers",
+            (m[2] for m in sorted(managers)),
+        )
+
+    @cached_property
+    def managers_map(self):
+        return {manager.name: manager for manager in reversed(self.managers)}
 
     @cached_property
     def fields(self):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -175,6 +175,12 @@ details on these changes.
 * The ``escape`` filter will change to use
   ``django.utils.html.conditional_escape()``.
 
+* ``Manager.use_for_related_fields`` will be removed.
+
+* Model ``Manager`` inheritance will follow MRO inheritance rules and the
+  ``Meta.manager_inheritance_from_future`` to opt-in to this behavior will be
+  removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -35,6 +35,16 @@ Available ``Meta`` options
     or ``app_label.model_name`` you can use ``model._meta.label``
     or ``model._meta.label_lower`` respectively.
 
+``base_manager_name``
+---------------------
+
+.. attribute:: Options.base_manager_name
+
+.. versionadded:: 1.10
+
+The name of the manager to use for the model's
+:attr:`~django.db.models.Model._base_manager`.
+
 ``db_table``
 ------------
 
@@ -94,6 +104,16 @@ Django quotes column and table names behind the scenes.
     for this model. The default is the project's :setting:`DEFAULT_TABLESPACE`
     setting, if set. If the backend doesn't support tablespaces, this option is
     ignored.
+
+``default_manager_name``
+------------------------
+
+.. attribute:: Options.default_manager_name
+
+.. versionadded:: 1.10
+
+The name of the manager to use for the model's
+:attr:`~django.db.models.Model._default_manager`.
 
 ``default_related_name``
 ------------------------

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -432,6 +432,13 @@ Models
 * ``Model.__init__()`` now sets values of virtual fields from its keyword
   arguments.
 
+* The new :attr:`Meta.base_manager_name
+  <django.db.models.Options.base_manager_name>` and
+  :attr:`Meta.default_manager_name
+  <django.db.models.Options.default_manager_name>` options allow controlling
+  the :attr:`~django.db.models.Model._base_manager` and
+  :attr:`~django.db.models.Model._default_manager`, respectively.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1062,6 +1069,22 @@ As a result, the "lazy" behavior of the ``escape`` filter (where it would
 always be applied as the last filter no matter where in the filter chain it
 appeared) is deprecated. The filter will change to immediately apply
 :func:`~django.utils.html.conditional_escape` in Django 2.0.
+
+``Manager.use_for_related_fields`` and inheritance changes
+----------------------------------------------------------
+
+``Manager.use_for_related_fields`` is deprecated in favor of setting
+:attr:`Meta.base_manager_name <django.db.models.Options.base_manager_name>` on
+the model.
+
+Model ``Manager`` inheritance will follow MRO inheritance rules in Django 2.0,
+changing the current behavior where managers defined on non-abstract base
+classes aren't inherited by child classes. A deprecating warning with
+instructions on how to adapt your code is raised if you have any affected
+managers. You'll either redeclare a manager from an abstract model on the child
+class to override the manager from the concrete model, or you'll set the
+model's ``Meta.manager_inheritance_from_future=True`` option to opt-in to the
+new inheritance behavior.
 
 Miscellaneous
 -------------

--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -321,33 +321,26 @@ You may also store the generated class into a variable::
 Custom managers and model inheritance
 -------------------------------------
 
-Class inheritance and model managers aren't quite a perfect match for each
-other. Managers are often specific to the classes they are defined on and
-inheriting them in subclasses isn't necessarily a good idea. Also, because the
-first manager declared is the *default manager*, it is important to allow that
-to be controlled. So here's how Django handles custom managers and
+Here's how Django handles custom managers and
 :ref:`model inheritance <model-inheritance>`:
 
-1. Managers defined on non-abstract base classes are *not* inherited by
-   child classes. If you want to reuse a manager from a non-abstract base,
-   redeclare it explicitly on the child class. These sorts of managers are
-   likely to be fairly specific to the class they are defined on, so
-   inheriting them can often lead to unexpected results (particularly as
-   far as the default manager goes). Therefore, they aren't passed onto
-   child classes.
-
-2. Managers from abstract base classes are always inherited by the child
-   class, using Python's normal name resolution order (names on the child
+1. Managers from base classes are always inherited by the child class,
+   using Python's normal name resolution order (names on the child
    class override all others; then come names on the first parent class,
-   and so on). Abstract base classes are designed to capture information
-   and behavior that is common to their child classes. Defining common
-   managers is an appropriate part of this common information.
+   and so on).
 
-3. The default manager on a class is either the first manager declared on
-   the class, if that exists, or the default manager of the first abstract
-   base class in the parent hierarchy, if that exists. If no default
-   manager is explicitly declared, Django's normal default manager is
-   used.
+2. The default manager on a class is either the first manager declared on the
+   class, if that exists, or the default manager of the first parent class in
+   the parent hierarchy, if that exists. If no manager is explicitly declared,
+   Django automatically creates the `objects` manager and it becomes the default
+   manager.
+
+.. versionchanged:: 1.10
+
+    In older versions, manager inheritance varied depending on the type of
+    model inheritance (i.e. :ref:`abstract-base-classes`,
+    :ref:`multi-table-inheritance`, or :ref:`proxy-models`), especially
+    with regards to electing the default manager.
 
 These rules provide the necessary flexibility if you want to install a
 collection of custom managers on a group of models, via an abstract base

--- a/docs/topics/db/managers.txt
+++ b/docs/topics/db/managers.txt
@@ -172,35 +172,59 @@ and ``Person.people.all()``, yielding predictable results.
 .. _default-managers:
 
 Default managers
-~~~~~~~~~~~~~~~~
+----------------
+
+.. attribute:: Model._default_manager
 
 If you use custom ``Manager`` objects, take note that the first ``Manager``
 Django encounters (in the order in which they're defined in the model) has a
 special status. Django interprets the first ``Manager`` defined in a class as
-the "default" ``Manager``, and several parts of Django
-(including :djadmin:`dumpdata`) will use that ``Manager``
-exclusively for that model. As a result, it's a good idea to be careful in
-your choice of default manager in order to avoid a situation where overriding
-``get_queryset()`` results in an inability to retrieve objects you'd like to
-work with.
+the "default" ``Manager``, and several parts of Django (including
+:djadmin:`dumpdata`) will use that ``Manager`` exclusively for that model. As a
+result, it's a good idea to be careful in your choice of default manager in
+order to avoid a situation where overriding ``get_queryset()`` results in an
+inability to retrieve objects you'd like to work with.
+
+You can specify a custom default manager using :attr:`Meta.base_manager_name
+<django.db.models.Options.base_manager_name>`.
+
+If you're writing some code that must handle an unknown model, for example, in
+a third-party app that implements a generic view, use this manager (or
+:attr:`~Model._base_manager`) rather than assuming the model has an ``objects``
+manager.
+
+Base managers
+-------------
+
+.. attribute:: Model._base_manager
 
 .. _managers-for-related-objects:
 
 Using managers for related object access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Django uses an instance of a "plain" manager class when accessing
-related objects (i.e. ``choice.poll``), not the default manager on the related
-object. This is because Django needs to be able to retrieve the related
-object, even if it would otherwise be filtered out (and hence be inaccessible)
-by the default manager.
+By default, Django uses an instance of the ``Model._base_manager`` manager
+class when accessing related objects (i.e. ``choice.poll``), not the
+``_default_manager`` on the related object. This is because Django needs to be
+able to retrieve the related object, even if it would otherwise be filtered out
+(and hence be inaccessible) by the default manager.
 
-If the normal plain manager class (:class:`django.db.models.Manager`) is not
-appropriate for your circumstances, you can force Django to use the same class
-as the default manager for your model by setting the ``use_for_related_fields``
-attribute on the manager class. This is documented fully below_.
+If the normal base manager class (:class:`django.db.models.Manager`) isn't
+appropriate for your circumstances, you can tell Django which class to use by
+setting :attr:`Meta.base_manager_name
+<django.db.models.Options.base_manager_name>`.
 
-.. _below: manager-types_
+Don't filter away any results in this type of manager subclass
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This manager is used to access objects that are related to from some other
+model. In those situations, Django has to be able to see all the objects for
+the model it is fetching, so that *anything* which is referred to can be
+retrieved.
+
+If you override the ``get_queryset()`` method and filter out any rows, Django
+will return incorrect results. Don't do that. A manager that filters results
+in ``get_queryset()`` is not appropriate for use as a default manager.
 
 .. _calling-custom-queryset-methods-from-manager:
 
@@ -321,19 +345,21 @@ You may also store the generated class into a variable::
 Custom managers and model inheritance
 -------------------------------------
 
-Here's how Django handles custom managers and
-:ref:`model inheritance <model-inheritance>`:
+Here's how Django handles custom managers and :ref:`model inheritance
+<model-inheritance>`:
 
-1. Managers from base classes are always inherited by the child class,
+#. Managers from base classes are always inherited by the child class,
    using Python's normal name resolution order (names on the child
    class override all others; then come names on the first parent class,
    and so on).
 
-2. The default manager on a class is either the first manager declared on the
-   class, if that exists, or the default manager of the first parent class in
-   the parent hierarchy, if that exists. If no manager is explicitly declared,
-   Django automatically creates the `objects` manager and it becomes the default
-   manager.
+#. If no managers are declared on a model and/or its parents, Django
+   automatically creates the ``objects`` manager.
+
+#. The default manager on a class is either the one chosen with
+   :attr:`Meta.default_manager_name
+   <django.db.models.Options.default_manager_name>`, or the first manager
+   declared on the model, or the default manager of the first parent model.
 
 .. versionchanged:: 1.10
 
@@ -428,99 +454,3 @@ However, if you're overriding ``__getattr__`` or some other private
 method of your ``Manager`` object that controls object state, you
 should ensure that you don't affect the ability of your ``Manager`` to
 be copied.
-
-.. _manager-types:
-
-Controlling automatic manager types
-===================================
-
-This document has already mentioned a couple of places where Django creates a
-manager class for you: `default managers`_ and the "plain" manager used to
-`access related objects`_. There are other places in the implementation of
-Django where temporary plain managers are needed. Those automatically created
-managers will normally be instances of the :class:`django.db.models.Manager`
-class.
-
-.. _default managers: manager-names_
-.. _access related objects: managers-for-related-objects_
-
-Throughout this section, we will use the term "automatic manager" to mean a
-manager that Django creates for you -- either as a default manager on a model
-with no managers, or to use temporarily when accessing related objects.
-
-Sometimes this default class won't be the right choice. The default manager
-may not have all the methods you need to work with your data. A custom manager
-class of your own will allow you to create custom ``QuerySet`` objects to give
-you the information you need.
-
-Django provides a way for custom manager developers to say that their manager
-class should be used for automatic managers whenever it is the default manager
-on a model. This is done by setting the ``use_for_related_fields`` attribute on
-the manager class::
-
-    class MyManager(models.Manager):
-        use_for_related_fields = True
-        # ...
-
-If this attribute is set on the *default* manager for a model (only the
-default manager is considered in these situations), Django will use that class
-whenever it needs to automatically create a manager for the class.  Otherwise,
-it will use :class:`django.db.models.Manager`.
-
-.. admonition:: Historical Note
-
-    Given the purpose for which it's used, the name of this attribute
-    (``use_for_related_fields``) might seem a little odd. Originally, the
-    attribute only controlled the type of manager used for related field
-    access, which is where the name came from. As it became clear the concept
-    was more broadly useful, the name hasn't been changed. This is primarily
-    so that existing code will :doc:`continue to work </misc/api-stability>` in
-    future Django versions.
-
-Writing correct managers for use in automatic manager instances
----------------------------------------------------------------
-
-The ``use_for_related_fields`` feature is primarily for managers that need to
-return a custom ``QuerySet`` subclass. In providing this functionality in your
-manager, there are a couple of things to remember.
-
-Do not filter away any results in this type of manager subclass
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One reason an automatic manager is used is to access objects that are related
-to from some other model. In those situations, Django has to be able to see
-all the objects for the model it is fetching, so that *anything* which is
-referred to can be retrieved.
-
-If you override the ``get_queryset()`` method and filter out any rows, Django
-will return incorrect results. Don't do that. A manager that filters results
-in ``get_queryset()`` is not appropriate for use as an automatic manager.
-
-Set ``use_for_related_fields`` when you define the class
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``use_for_related_fields`` attribute must be set on the manager *class*, not
-on an *instance* of the class. The earlier example shows the correct way to set
-it, whereas the following will not work::
-
-    # BAD: Incorrect code
-    class MyManager(models.Manager):
-        # ...
-        pass
-
-    # Sets the attribute on an instance of MyManager. Django will
-    # ignore this setting.
-    mgr = MyManager()
-    mgr.use_for_related_fields = True
-
-    class MyModel(models.Model):
-        # ...
-        objects = mgr
-
-    # End of incorrect code.
-
-You also shouldn't change the attribute on the class object after it has been
-used in a model, since the attribute's value is processed when the model class
-is created and not subsequently reread. Set the attribute on the manager class
-when it is first defined, as in the initial example of this section and
-everything will work smoothly.

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1287,33 +1287,19 @@ Differences between proxy inheritance and unmanaged models
 
 Proxy model inheritance might look fairly similar to creating an unmanaged
 model, using the :attr:`~django.db.models.Options.managed` attribute on a
-model's ``Meta`` class. The two alternatives are not quite the same and it's
-worth considering which one you should use.
+model's ``Meta`` class.
 
-One difference is that you can (and, in fact, must unless you want an empty
-model) specify model fields on models with ``Meta.managed=False``. You could,
-with careful setting of :attr:`Meta.db_table
-<django.db.models.Options.db_table>` create an unmanaged model that shadowed
-an existing model and add Python methods to it. However, that would be very
-repetitive and fragile as you need to keep both copies synchronized if you
+With careful setting of :attr:`Meta.db_table
+<django.db.models.Options.db_table>` you could create an unmanaged model that
+shadows an existing model and adds Python methods to it. However, that would be
+very repetitive and fragile as you need to keep both copies synchronized if you
 make any changes.
 
-The other difference that is more important for proxy models, is how model
-managers are handled. Proxy models are intended to behave exactly like the
-model they are proxying for. So they inherit the parent model's managers,
-including the default manager. In the normal multi-table model inheritance
-case, children do not inherit managers from their parents as the custom
-managers aren't always appropriate when extra fields are involved. The
-:ref:`manager documentation <custom-managers-and-inheritance>` has more
-details about this latter case.
+On the other hand, proxy models are intended to behave exactly like the model
+they are proxying for. They are always in sync with the parent model since they
+directly inherit its fields and managers.
 
-When these two features were implemented, attempts were made to squash them
-into a single option. It turned out that interactions with inheritance, in
-general, and managers, in particular, made the API very complicated and
-potentially difficult to understand and use. It turned out that two options
-were needed in any case, so the current separation arose.
-
-So, the general rules are:
+The general rules are:
 
 1. If you are mirroring an existing model or database table and don't want
    all the original database table columns, use ``Meta.managed=False``.

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -3,27 +3,14 @@ from __future__ import unicode_literals
 
 import warnings
 
-from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
-from django.dispatch import receiver
 from django.test import TestCase, override_settings
-from django.test.signals import setting_changed
 from django.utils import translation
 
 from .models import CustomUser
-
-
-@receiver(setting_changed)
-def user_model_swapped(**kwargs):
-    if kwargs['setting'] == 'AUTH_USER_MODEL':
-        from django.db.models.manager import ensure_default_manager
-        # Reset User manager
-        setattr(User, 'objects', User._default_manager)
-        ensure_default_manager(User)
-        apps.clear_cache()
 
 
 class BasicTestCase(TestCase):

--- a/tests/custom_managers/models.py
+++ b/tests/custom_managers/models.py
@@ -172,6 +172,18 @@ class Car(models.Model):
         return self.name
 
 
+class FastCarAsBase(Car):
+    class Meta:
+        proxy = True
+        base_manager_name = 'fast_cars'
+
+
+class FastCarAsDefault(Car):
+    class Meta:
+        proxy = True
+        default_manager_name = 'fast_cars'
+
+
 class RestrictedManager(models.Manager):
     def get_queryset(self):
         return super(RestrictedManager, self).get_queryset().filter(is_public=True)

--- a/tests/custom_managers/tests.py
+++ b/tests/custom_managers/tests.py
@@ -6,8 +6,9 @@ from django.utils import six
 
 from .models import (
     Book, Car, CustomManager, CustomQuerySet, DeconstructibleCustomManager,
-    FunPerson, OneToOneRestrictedModel, Person, PersonFromAbstract,
-    PersonManager, PublishedBookManager, RelatedModel, RestrictedModel,
+    FastCarAsBase, FastCarAsDefault, FunPerson, OneToOneRestrictedModel,
+    Person, PersonFromAbstract, PersonManager, PublishedBookManager,
+    RelatedModel, RestrictedModel,
 )
 
 
@@ -554,6 +555,34 @@ class TestCars(TestCase):
         # alternate manager
         self.assertQuerysetEqual(
             Car.fast_cars.all(), [
+                "Corvette",
+            ],
+            lambda c: c.name
+        )
+        # explicit default manager
+        self.assertQuerysetEqual(
+            FastCarAsDefault.cars.order_by("name"), [
+                "Corvette",
+                "Neon",
+            ],
+            lambda c: c.name
+        )
+        self.assertQuerysetEqual(
+            FastCarAsDefault._default_manager.all(), [
+                "Corvette",
+            ],
+            lambda c: c.name
+        )
+        # explicit base manager
+        self.assertQuerysetEqual(
+            FastCarAsBase.cars.order_by("name"), [
+                "Corvette",
+                "Neon",
+            ],
+            lambda c: c.name
+        )
+        self.assertQuerysetEqual(
+            FastCarAsBase._base_manager.all(), [
                 "Corvette",
             ],
             lambda c: c.name

--- a/tests/managers_regress/models.py
+++ b/tests/managers_regress/models.py
@@ -115,14 +115,12 @@ class Child5(AbstractBase3):
         return self.name
 
 
-# Will inherit managers from AbstractBase1, but not Child4.
 class Child6(Child4):
     value = models.IntegerField()
 
 
-# Will not inherit default manager from parent.
 class Child7(Parent):
-    pass
+    objects = models.Manager()
 
 
 # RelatedManagers

--- a/tests/managers_regress/models.py
+++ b/tests/managers_regress/models.py
@@ -118,6 +118,9 @@ class Child5(AbstractBase3):
 class Child6(Child4):
     value = models.IntegerField()
 
+    class Meta:
+        manager_inheritance_from_future = True
+
 
 class Child7(Parent):
     objects = models.Manager()

--- a/tests/managers_regress/tests.py
+++ b/tests/managers_regress/tests.py
@@ -50,7 +50,7 @@ class ManagersRegressionTests(TestCase):
         ])
         self.assertQuerysetEqual(Child4.manager1.all(), ["<Child4: d1>", "<Child4: f1>"], ordered=False)
         self.assertQuerysetEqual(Child5._default_manager.all(), ["<Child5: fred>"])
-        self.assertQuerysetEqual(Child6._default_manager.all(), ["<Child6: f1>"])
+        self.assertQuerysetEqual(Child6._default_manager.all(), ["<Child6: f1>", "<Child6: f2>"], ordered=False)
         self.assertQuerysetEqual(
             Child7._default_manager.order_by('name'),
             ["<Child7: barney>", "<Child7: fred>"]

--- a/tests/managers_regress/tests.py
+++ b/tests/managers_regress/tests.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from django.db import models
+from django.db.utils import DatabaseError
 from django.template import Context, Template
 from django.test import TestCase, override_settings
 from django.test.utils import isolate_apps
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 
 from .models import (
@@ -160,3 +164,385 @@ class ManagersRegressionTests(TestCase):
         related = RelatedModel.objects.create(exact=False)
         relation = related.test_fk.create()
         self.assertEqual(related.test_fk.get(), relation)
+
+
+@isolate_apps('managers_regress')
+class TestManagerInheritance(TestCase):
+    def test_implicit_inheritance(self):
+        class CustomManager(models.Manager):
+            pass
+
+        class AbstractModel(models.Model):
+            custom_manager = CustomManager()
+
+            class Meta:
+                abstract = True
+
+        class PlainModel(models.Model):
+            custom_manager = CustomManager()
+
+        self.assertIsInstance(PlainModel._base_manager, models.Manager)
+        self.assertIsInstance(PlainModel._default_manager, CustomManager)
+
+        class ModelWithAbstractParent(AbstractModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(ModelWithAbstractParent._base_manager, models.Manager)
+        self.assertIsInstance(ModelWithAbstractParent._default_manager, CustomManager)
+
+        class ProxyModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+                proxy = True
+
+        self.assertIsInstance(ProxyModel._base_manager, models.Manager)
+        self.assertIsInstance(ProxyModel._default_manager, CustomManager)
+
+        class MTIModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(MTIModel._base_manager, models.Manager)
+        self.assertIsInstance(MTIModel._default_manager, CustomManager)
+
+    def test_default_manager_inheritance(self):
+        class CustomManager(models.Manager):
+            pass
+
+        class AbstractModel(models.Model):
+            another_manager = models.Manager()
+            custom_manager = CustomManager()
+
+            class Meta:
+                default_manager_name = 'custom_manager'
+                abstract = True
+
+        class PlainModel(models.Model):
+            another_manager = models.Manager()
+            custom_manager = CustomManager()
+
+            class Meta:
+                default_manager_name = 'custom_manager'
+
+        self.assertIsInstance(PlainModel._default_manager, CustomManager)
+
+        class ModelWithAbstractParent(AbstractModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(ModelWithAbstractParent._default_manager, CustomManager)
+
+        class ProxyModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+                proxy = True
+
+        self.assertIsInstance(ProxyModel._default_manager, CustomManager)
+
+        class MTIModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(MTIModel._default_manager, CustomManager)
+
+    def test_base_manager_inheritance(self):
+        class CustomManager(models.Manager):
+            pass
+
+        class AbstractModel(models.Model):
+            another_manager = models.Manager()
+            custom_manager = CustomManager()
+
+            class Meta:
+                base_manager_name = 'custom_manager'
+                abstract = True
+
+        class PlainModel(models.Model):
+            another_manager = models.Manager()
+            custom_manager = CustomManager()
+
+            class Meta:
+                base_manager_name = 'custom_manager'
+
+        self.assertIsInstance(PlainModel._base_manager, CustomManager)
+
+        class ModelWithAbstractParent(AbstractModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(ModelWithAbstractParent._base_manager, CustomManager)
+
+        class ProxyModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+                proxy = True
+
+        self.assertIsInstance(ProxyModel._base_manager, CustomManager)
+
+        class MTIModel(PlainModel):
+            class Meta:
+                manager_inheritance_from_future = True
+
+        self.assertIsInstance(MTIModel._base_manager, CustomManager)
+
+
+@isolate_apps('managers_regress')
+class TestManagerDeprecations(TestCase):
+    def test_use_for_related_fields_on_geomanager(self):
+        from django.contrib.gis.db.models import GeoManager
+
+        class MyModel(models.Model):
+            objects = GeoManager()
+
+        # Shouldn't issue any warnings, since GeoManager itself will be
+        # deprecated at the same time as use_for_related_fields, there
+        # is no point annoying users with this deprecation.
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            MyModel._base_manager
+        self.assertEqual(len(warns), 0)
+
+    def test_use_for_related_fields_for_base_manager(self):
+        class MyManager(models.Manager):
+            use_for_related_fields = True
+
+        class MyModel(models.Model):
+            objects = MyManager()
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            MyModel._base_manager
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            "use_for_related_fields is deprecated, "
+            "instead set Meta.base_manager_name on "
+            "'managers_regress.MyModel'.",
+        )
+
+        # With the new base_manager_name API there shouldn't be any warnings.
+        class MyModel2(models.Model):
+            objects = MyManager()
+
+            class Meta:
+                base_manager_name = 'objects'
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            MyModel2._base_manager
+        self.assertEqual(len(warns), 0)
+
+    def test_use_for_related_fields_for_many_to_one(self):
+        class MyManager(models.Manager):
+            use_for_related_fields = True
+
+        class MyRelModel(models.Model):
+            objects = MyManager()
+
+        class MyModel(models.Model):
+            fk = models.ForeignKey(MyRelModel, on_delete=models.DO_NOTHING)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            try:
+                MyModel(fk_id=42).fk
+            except DatabaseError:
+                pass
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            "use_for_related_fields is deprecated, "
+            "instead set Meta.base_manager_name on "
+            "'managers_regress.MyRelModel'.",
+        )
+
+        # With the new base_manager_name API there shouldn't be any warnings.
+        class MyRelModel2(models.Model):
+            objects = MyManager()
+
+            class Meta:
+                base_manager_name = 'objects'
+
+        class MyModel2(models.Model):
+            fk = models.ForeignKey(MyRelModel2, on_delete=models.DO_NOTHING)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            try:
+                MyModel2(fk_id=42).fk
+            except DatabaseError:
+                pass
+        self.assertEqual(len(warns), 0)
+
+    def test_use_for_related_fields_for_one_to_one(self):
+        class MyManager(models.Manager):
+            use_for_related_fields = True
+
+        class MyRelModel(models.Model):
+            objects = MyManager()
+
+        class MyModel(models.Model):
+            o2o = models.OneToOneField(MyRelModel, on_delete=models.DO_NOTHING)
+            objects = MyManager()
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            try:
+                MyModel(o2o_id=42).o2o
+            except DatabaseError:
+                pass
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            "use_for_related_fields is deprecated, "
+            "instead set Meta.base_manager_name on "
+            "'managers_regress.MyRelModel'.",
+        )
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            try:
+                MyRelModel(pk=42).mymodel
+            except DatabaseError:
+                pass
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            "use_for_related_fields is deprecated, "
+            "instead set Meta.base_manager_name on "
+            "'managers_regress.MyModel'.",
+        )
+
+        # With the new base_manager_name API there shouldn't be any warnings.
+        class MyRelModel2(models.Model):
+            objects = MyManager()
+
+            class Meta:
+                base_manager_name = 'objects'
+
+        class MyModel2(models.Model):
+            o2o = models.OneToOneField(MyRelModel2, on_delete=models.DO_NOTHING)
+            objects = MyManager()
+
+            class Meta:
+                base_manager_name = 'objects'
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+            try:
+                MyModel2(o2o_id=42).o2o
+            except DatabaseError:
+                pass
+            try:
+                MyRelModel2(pk=42).mymodel2
+            except DatabaseError:
+                pass
+        self.assertEqual(len(warns), 0)
+
+    def test_legacy_objects_is_created(self):
+        class ConcreteParentWithoutManager(models.Model):
+            pass
+
+        class ConcreteParentWithManager(models.Model):
+            default = models.Manager()
+
+        class AbstractParent(models.Model):
+            default = models.Manager()
+
+            class Meta:
+                abstract = True
+
+        # Shouldn't complain since the inherited manager
+        # is basically the same that would have been created.
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+
+            class MyModel(ConcreteParentWithoutManager):
+                    pass
+            self.assertEqual(len(warns), 0)
+
+        # Should create 'objects' (set as default) and warn that
+        # it will no longer be the case in the future.
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+
+            class MyModel2(ConcreteParentWithManager):
+                pass
+            self.assertEqual(len(warns), 1)
+            self.assertEqual(
+                str(warns[0].message),
+                "Managers from concrete parents will soon qualify as default "
+                "managers. As a result, the 'objects' manager won't be created "
+                "(or recreated) automatically anymore on "
+                "'managers_regress.MyModel2' and 'default' declared on "
+                "'managers_regress.ConcreteParentWithManager' will be promoted "
+                "to default manager. You can declare explicitly "
+                "`objects = models.Manager()` on 'MyModel2' to keep things the "
+                "way they are or you can switch to the new behavior right away "
+                "by setting `Meta.manager_inheritance_from_future` to `True`.",
+            )
+
+            self.assertIs(MyModel2.objects, MyModel2._default_manager)
+
+        # When there is a local manager we shouldn't get any warning
+        # and 'objects' shouldn't be created.
+        class MyModel3(ConcreteParentWithManager):
+            default = models.Manager()
+        self.assertIs(MyModel3.default, MyModel3._default_manager)
+        self.assertIsNone(getattr(MyModel3, 'objects', None))
+
+        # When there is an inherited manager we shouldn't get any warning
+        # and 'objects' shouldn't be created.
+        class MyModel4(AbstractParent, ConcreteParentWithManager):
+            pass
+        self.assertIs(MyModel4.default, MyModel4._default_manager)
+        self.assertIsNone(getattr(MyModel4, 'objects', None))
+
+        # With `manager_inheritance_from_future = True` 'objects'
+        # shouldn't be created.
+        class MyModel5(ConcreteParentWithManager):
+            class Meta:
+                manager_inheritance_from_future = True
+        self.assertIs(MyModel5.default, MyModel5._default_manager)
+        self.assertIsNone(getattr(MyModel5, 'objects', None))
+
+    def test_legacy_default_manager_promotion(self):
+        class ConcreteParent(models.Model):
+            concrete = models.Manager()
+
+        class AbstractParent(models.Model):
+            abstract = models.Manager()
+
+            class Meta:
+                abstract = True
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always', RemovedInDjango20Warning)
+
+            class MyModel(ConcreteParent, AbstractParent):
+                pass
+            self.assertEqual(len(warns), 1)
+            self.assertEqual(
+                str(warns[0].message),
+                "Managers from concrete parents will soon qualify as default "
+                "managers if they appear before any other managers in the "
+                "MRO. As a result, 'abstract' declared on "
+                "'managers_regress.AbstractParent' will no longer be the "
+                "default manager for 'managers_regress.MyModel' in favor of "
+                "'concrete' declared on 'managers_regress.ConcreteParent'. "
+                "You can redeclare 'abstract' on 'MyModel' to keep things the "
+                "way they are or you can switch to the new behavior right "
+                "away by setting `Meta.manager_inheritance_from_future` to "
+                "`True`.",
+            )
+            self.assertIs(MyModel.abstract, MyModel._default_manager)
+
+        class MyModel2(ConcreteParent, AbstractParent):
+            abstract = models.Manager()
+        self.assertIs(MyModel2.abstract, MyModel2._default_manager)
+
+        class MyModel3(ConcreteParent, AbstractParent):
+            class Meta:
+                manager_inheritance_from_future = True
+        self.assertIs(MyModel3.concrete, MyModel3._default_manager)

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -600,13 +600,13 @@ class ManyToOneTests(TestCase):
         # If the manager is marked "use_for_related_fields", it'll get used instead
         # of the "bare" queryset. Usually you'd define this as a property on the class,
         # but this approximates that in a way that's easier in tests.
-        School.objects.use_for_related_fields = True
+        School._default_manager.use_for_related_fields = True
         try:
             private_student = Student.objects.get(pk=private_student.pk)
             with self.assertRaises(School.DoesNotExist):
                 private_student.school
         finally:
-            School.objects.use_for_related_fields = False
+            School._default_manager.use_for_related_fields = False
 
     def test_hasattr_related_object(self):
         # The exception raised on attribute access when a related object

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from django.core.exceptions import FieldError, MultipleObjectsReturned
 from django.db import models, transaction
 from django.db.utils import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, ignore_warnings
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.translation import ugettext_lazy
@@ -580,6 +580,7 @@ class ManyToOneTests(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(th.child_set.count(), 0)
 
+    @ignore_warnings(category=RemovedInDjango20Warning)  # for use_for_related_fields deprecation
     def test_related_object(self):
         public_school = School.objects.create(is_public=True)
         public_student = Student.objects.create(school=public_school)
@@ -607,6 +608,16 @@ class ManyToOneTests(TestCase):
                 private_student.school
         finally:
             School._default_manager.use_for_related_fields = False
+
+        School._meta.base_manager_name = 'objects'
+        School._meta._expire_cache()
+        try:
+            private_student = Student.objects.get(pk=private_student.pk)
+            with self.assertRaises(School.DoesNotExist):
+                private_student.school
+        finally:
+            School._meta.base_manager_name = None
+            School._meta._expire_cache()
 
     def test_hasattr_related_object(self):
         # The exception raised on attribute access when a related object

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -262,13 +262,11 @@ class StateTests(SimpleTestCase):
         self.assertEqual(len(new_apps.get_model("migrations", "SubTag")._meta.local_fields), 2)
 
         Food = new_apps.get_model("migrations", "Food")
-        managers = sorted(Food._meta.managers)
-        self.assertEqual([mgr.name for _, mgr, _ in managers],
+        self.assertEqual([mgr.name for mgr in Food._meta.managers],
                          ['default', 'food_mgr1', 'food_mgr2'])
-        self.assertTrue(all(isinstance(mgr.name, six.text_type) for _, mgr, _ in managers))
-        self.assertEqual([mgr.__class__ for _, mgr, _ in managers],
+        self.assertTrue(all(isinstance(mgr.name, six.text_type) for mgr in Food._meta.managers))
+        self.assertEqual([mgr.__class__ for mgr in Food._meta.managers],
                          [models.Manager, FoodManager, FoodManager])
-        self.assertIs(managers[0][1], Food._default_manager)
 
     def test_render_model_inheritance(self):
         class Book(models.Model):

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -457,21 +457,21 @@ class OneToOneTests(TestCase):
         # If the manager is marked "use_for_related_fields", it'll get used instead
         # of the "bare" queryset. Usually you'd define this as a property on the class,
         # but this approximates that in a way that's easier in tests.
-        School.objects.use_for_related_fields = True
+        School._default_manager.use_for_related_fields = True
         try:
             private_director = Director._base_manager.get(pk=private_director.pk)
             with self.assertRaises(School.DoesNotExist):
                 private_director.school
         finally:
-            School.objects.use_for_related_fields = False
+            School._default_manager.use_for_related_fields = False
 
-        Director.objects.use_for_related_fields = True
+        Director._default_manager.use_for_related_fields = True
         try:
             private_school = School._base_manager.get(pk=private_school.pk)
             with self.assertRaises(Director.DoesNotExist):
                 private_school.director
         finally:
-            Director.objects.use_for_related_fields = False
+            Director._default_manager.use_for_related_fields = False
 
     def test_hasattr_related_object(self):
         # The exception raised on attribute access when a related object

--- a/tests/proxy_models/models.py
+++ b/tests/proxy_models/models.py
@@ -85,6 +85,8 @@ class StatusPerson(MyPerson):
     """
     status = models.CharField(max_length=80)
 
+    objects = models.Manager()
+
 # We can even have proxies of proxies (and subclass of those).
 
 
@@ -95,6 +97,8 @@ class MyPersonProxy(MyPerson):
 
 class LowerStatusPerson(MyPersonProxy):
     status = models.CharField(max_length=80)
+
+    objects = models.Manager()
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Refactor managers inheritance and introduce new APIs for specifying the default and base manager of a given model. Also deprecate `use_for_related_fields`.

- [x] Reimplement 515a8a37d83dd758cf9ca402d3526b245c782483 using the `_base_manager` and `_default_manager` properties.
- [x] Write tests for the 2 deprecations (`use_for_related_fields`, and legacy manager inheritance)
- [x] Document `_base_manager` and `_default_manager`, they've always existed but should be public APIs (so 3rd party apps use them).
- [x] Write docs + release notes for the new meta APIs.
- [x] Document the deprecations.
- [x] Decide on https://github.com/django/django/pull/6175#issuecomment-219223027.