### PR TITLE
Fixed import location of check_password() function in docs.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -127,7 +127,7 @@ variable defined in your ``settings.py`` file and creates a Django ``User``
 object the first time a user authenticates::
 
     from django.conf import settings
-    from django.contrib.auth.models import User, check_password
+    from django.contrib.auth.models import User
 
     class SettingsBackend(object):
         """
@@ -141,7 +141,7 @@ object the first time a user authenticates::
 
         def authenticate(self, username=None, password=None):
             login_valid = (settings.ADMIN_LOGIN == username)
-            pwd_valid = check_password(password, settings.ADMIN_PASSWORD)
+            pwd_valid = User.check_password(password, settings.ADMIN_PASSWORD)
             if login_valid and pwd_valid:
                 try:
                     user = User.objects.get(username=username)

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -128,6 +128,7 @@ object the first time a user authenticates::
 
     from django.conf import settings
     from django.contrib.auth.models import User
+    from django.contrib.auth.hashers import check_password
 
     class SettingsBackend(object):
         """
@@ -141,7 +142,7 @@ object the first time a user authenticates::
 
         def authenticate(self, username=None, password=None):
             login_valid = (settings.ADMIN_LOGIN == username)
-            pwd_valid = User.check_password(password, settings.ADMIN_PASSWORD)
+            pwd_valid = check_password(password, settings.ADMIN_PASSWORD)
             if login_valid and pwd_valid:
                 try:
                     user = User.objects.get(username=username)


### PR DESCRIPTION
The code provided in the example will fail with an import error since `check_password()` isn't there anymore.  As best I can tell, it's part of `User` now, so I've amended the example to show this.