### PR TITLE
Fixed #26253 -- Fixed crashing deprecation shims in SimpleTemplateResponse.

### DIFF
--- a/django/template/response.py
+++ b/django/template/response.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango110Warning
 
-from .backends.django import Template as BackendTemplate
+from .backends.django import DjangoTemplates, Template as BackendTemplate
 from .base import Template
 from .context import Context, RequestContext, _current_app_undefined
 from .loader import get_template, select_template
@@ -25,7 +25,7 @@ class SimpleTemplateResponse(HttpResponse):
                 "anymore. It may be a backend-specific template like those "
                 "created by get_template().".format(self.__class__.__name__),
                 RemovedInDjango110Warning, stacklevel=2)
-            template = BackendTemplate(template)
+            template = BackendTemplate(template, DjangoTemplates)
 
         # It would seem obvious to call these next two members 'template' and
         # 'context', but those names are reserved as part of the test Client
@@ -95,7 +95,7 @@ class SimpleTemplateResponse(HttpResponse):
                 "{}.".format(
                     self.__class__.__name__, new_template.__class__.__name__),
                 RemovedInDjango110Warning, stacklevel=2)
-            new_template = BackendTemplate(new_template)
+            new_template = BackendTemplate(new_template, DjangoTemplates)
         return new_template
 
     def resolve_context(self, context):

--- a/docs/releases/1.8.10.txt
+++ b/docs/releases/1.8.10.txt
@@ -24,3 +24,6 @@ Bugfixes
 
 * Reallowed dashes in top-level domain names of URLs checked by
   ``URLValidator`` to fix a regression in Django 1.8 (:ticket:`26204`).
+
+* Fixed some crashing deprecation shims in ``SimpleTemplateResponse``
+  and ``TemplateResponse`` introduced in Django 1.8 (:ticket:`26253`).

--- a/docs/releases/1.9.3.txt
+++ b/docs/releases/1.9.3.txt
@@ -37,3 +37,6 @@ Bugfixes
 
 * Reallowed dashes in top-level domain names of URLs checked by
   ``URLValidator`` to fix a regression in Django 1.8 (:ticket:`26204`).
+
+* Fixed some crashing deprecation shims in ``SimpleTemplateResponse``
+  and ``TemplateResponse`` introduced in Django 1.8 (:ticket:`26253`).

--- a/tests/template_tests/test_response_deprecations.py
+++ b/tests/template_tests/test_response_deprecations.py
@@ -1,0 +1,42 @@
+import warnings
+
+from django.http import HttpRequest
+from django.template import Template
+from django.template.response import TemplateResponse
+from django.test import SimpleTestCase
+
+
+class MyTemplateResponse(TemplateResponse):
+    def resolve_template(self, template_name):
+        return Template(template_name)
+
+
+class DeprecationTests(SimpleTestCase):
+
+    def test_template_response(self):
+        msg = (
+            "TemplateResponse's template argument cannot be a "
+            "django.template.Template anymore. It may be a backend-specific "
+            "template like those created by get_template()."
+        )
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+            response = TemplateResponse(HttpRequest(), Template('foo'))
+        response.render()
+        self.assertEqual(response.content, b'foo')
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(str(warns[0].message), msg)
+
+    def test_custom_template_response(self):
+        response = MyTemplateResponse(HttpRequest(), 'baz')
+        msg = (
+            "MyTemplateResponse.resolve_template() must return a "
+            "backend-specific template like those created by get_template(), "
+            "not a Template."
+        )
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+            response.render()
+        self.assertEqual(response.content, b'baz')
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(str(warns[0].message), msg)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26253