### PR TITLE
Attempt to confirm that to-one descriptor don't require special handling for use_for_related_fields

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -104,11 +104,7 @@ class ForwardManyToOneDescriptor(object):
         return hasattr(instance, self.cache_name)
 
     def get_queryset(self, **hints):
-        manager = self.field.remote_field.model._default_manager
-        # If the related manager indicates that it should be used for
-        # related fields, respect that.
-        if not getattr(manager, 'use_for_related_fields', False):
-            manager = self.field.remote_field.model._base_manager
+        manager = self.field.remote_field.model._base_manager
         return manager.db_manager(hints=hints).all()
 
     def get_prefetch_queryset(self, instances, queryset=None):
@@ -287,11 +283,7 @@ class ReverseOneToOneDescriptor(object):
         return hasattr(instance, self.cache_name)
 
     def get_queryset(self, **hints):
-        manager = self.related.related_model._default_manager
-        # If the related manager indicates that it should be used for
-        # related fields, respect that.
-        if not getattr(manager, 'use_for_related_fields', False):
-            manager = self.related.related_model._base_manager
+        manager = self.related.related_model._base_manager
         return manager.db_manager(hints=hints).all()
 
     def get_prefetch_queryset(self, instances, queryset=None):

--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -105,6 +105,8 @@ class Relation(models.Model):
 
 # Test related objects visibility.
 class SchoolManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         return super(SchoolManager, self).get_queryset().filter(is_public=True)
 

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -599,13 +599,9 @@ class ManyToOneTests(TestCase):
         # If the manager is marked "use_for_related_fields", it'll get used instead
         # of the "bare" queryset. Usually you'd define this as a property on the class,
         # but this approximates that in a way that's easier in tests.
-        School.objects.use_for_related_fields = True
-        try:
-            private_student = Student.objects.get(pk=private_student.pk)
-            with self.assertRaises(School.DoesNotExist):
-                private_student.school
-        finally:
-            School.objects.use_for_related_fields = False
+        private_student = Student.objects.get(pk=private_student.pk)
+        with self.assertRaises(School.DoesNotExist):
+            private_student.school
 
     def test_hasattr_related_object(self):
         # The exception raised on attribute access when a related object

--- a/tests/one_to_one/models.py
+++ b/tests/one_to_one/models.py
@@ -100,6 +100,8 @@ class HiddenPointer(models.Model):
 
 # Test related objects visibility.
 class SchoolManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         return super(SchoolManager, self).get_queryset().filter(is_public=True)
 
@@ -110,6 +112,8 @@ class School(models.Model):
 
 
 class DirectorManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         return super(DirectorManager, self).get_queryset().filter(is_temp=False)
 

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -425,10 +425,10 @@ class OneToOneTests(TestCase):
 
     def test_related_object(self):
         public_school = School.objects.create(is_public=True)
-        public_director = Director.objects.create(school=public_school, is_temp=False)
+        public_director = Director.objects.create(school=public_school, is_temp=True)
 
         private_school = School.objects.create(is_public=False)
-        private_director = Director.objects.create(school=private_school, is_temp=True)
+        private_director = Director.objects.create(school=private_school, is_temp=False)
 
         # Only one school is available via all() due to the custom default manager.
         self.assertQuerysetEqual(
@@ -458,21 +458,13 @@ class OneToOneTests(TestCase):
         # If the manager is marked "use_for_related_fields", it'll get used instead
         # of the "bare" queryset. Usually you'd define this as a property on the class,
         # but this approximates that in a way that's easier in tests.
-        School.objects.use_for_related_fields = True
-        try:
-            private_director = Director._base_manager.get(pk=private_director.pk)
-            with self.assertRaises(School.DoesNotExist):
-                private_director.school
-        finally:
-            School.objects.use_for_related_fields = False
+        private_director = Director._base_manager.get(pk=private_director.pk)
+        with self.assertRaises(School.DoesNotExist):
+            private_director.school
 
-        Director.objects.use_for_related_fields = True
-        try:
-            private_school = School._base_manager.get(pk=private_school.pk)
-            with self.assertRaises(Director.DoesNotExist):
-                private_school.director
-        finally:
-            Director.objects.use_for_related_fields = False
+        public_school = School._base_manager.get(pk=public_school.pk)
+        with self.assertRaises(Director.DoesNotExist):
+            public_school.director
 
     def test_hasattr_related_object(self):
         # The exception raised on attribute access when a related object


### PR DESCRIPTION
*PR for CI only*