### PR TITLE
Fixed #26230 -- Use default_related_name as related_name in QuerySet lookup

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -289,7 +289,6 @@ class RelatedField(Field):
         self.opts = cls._meta
 
         if not cls._meta.abstract:
-
             if self.remote_field.related_name:
                 related_name = self.remote_field.related_name
             else:

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -289,9 +289,15 @@ class RelatedField(Field):
         self.opts = cls._meta
 
         if not cls._meta.abstract:
+
             if self.remote_field.related_name:
-                related_name = force_text(self.remote_field.related_name) % {
+                related_name = self.remote_field.related_name
+            else:
+                related_name = self.opts.default_related_name
+            if related_name:
+                related_name = force_text(related_name) % {
                     'class': cls.__name__.lower(),
+                    'model_name': cls._meta.model_name.lower(),
                     'app_label': cls._meta.app_label.lower()
                 }
                 self.remote_field.related_name = related_name

--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -187,11 +187,6 @@ class ForeignObjectRel(object):
                 return None
         if self.related_name:
             return self.related_name
-        if opts.default_related_name:
-            return opts.default_related_name % {
-                'model_name': opts.model_name.lower(),
-                'app_label': opts.app_label.lower(),
-            }
         return opts.model_name + ('_set' if self.multiple else '')
 
     def get_cache_name(self):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -7,6 +7,7 @@ databases). The abstraction barrier only works one way: this module has to know
 all about the internals of models in order to get the information it needs.
 """
 import copy
+import warnings
 from collections import Counter, Iterator, Mapping, OrderedDict
 from itertools import chain, count, product
 from string import ascii_uppercase
@@ -30,6 +31,7 @@ from django.db.models.sql.where import (
     AND, OR, ExtraWhere, NothingNode, WhereNode,
 )
 from django.utils import six
+from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 from django.utils.tree import Node
 
@@ -1288,6 +1290,27 @@ class Query(object):
             except FieldDoesNotExist:
                 if name in self.annotation_select:
                     field = self.annotation_select[name].output_field
+                elif pos == 0:
+                    # Deprecated Behavior: When the `default_related_name` was set
+                    # and we didn't pass `related_name` kwarg in Field ctor,
+                    # in Django 1.9 we still use model name as lookup string
+                    # but default_related_name.
+                    # The right way to query is using default_related_name as lookup string
+                    # See #26230 and the test case
+                    # `test_show_deprecated_message_when_model_name_in_queryset_lookup`
+                    # in tests/model_options/test_default_related_name.py
+                    # to get this deprecated use case
+                    for rel in opts.related_objects:
+                        if (name == rel.related_model._meta.model_name and
+                        rel.related_name == rel.related_model._meta.default_related_name):
+                            related_name = rel.related_name
+                            field = opts.get_field(related_name)
+                            warnings.warn(
+                                "Query lookup '%s' is deprecated in favor of"
+                                " Meta.default_related_name '%s'."
+                                % (name, related_name),
+                                RemovedInDjango20Warning, 2)
+                            break
 
             if field is not None:
                 # Fields that contain one-to-many relations with a generic

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -138,6 +138,9 @@ details on these changes.
 * Support for the ``django.core.files.storage.Storage.accessed_time()``,
   ``created_time()``, and ``modified_time()`` methods will be removed.
 
+* Support for querying related object by model name in query lookup
+  when ``Meta.default_related_name`` is set will be removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -110,6 +110,33 @@ Django quotes column and table names behind the scenes.
     and the name of the model, both lowercased. See the paragraph on
     :ref:`related names for abstract models <abstract-related-name>`.
 
+.. deprecated:: 1.10
+
+    When this attribute is set, you should use the name in lookup string when
+    querying related model.
+
+    Example::
+
+        # Given following models:
+        
+        from django.db import models
+        
+        class Foo(models.Model):
+            a = models.IntegerField(default=0)
+        
+        class Bar(models.Model):
+            foo = models.ForeignKey(Foo)
+        
+            class Meta:
+                default_related_name = 'bars'
+
+        >>> foo = models.Foo.object.create()
+        >>> bar = models.Bar.object.create(foo=foo)
+        # Using model name "bar" as lookup string is deprecated.
+        >>> models.Foo.object.get(bar=bar)
+        # You should use default_related_name "bars".
+        >>> models.Foo.object.get(bars=bar)
+
 ``get_latest_by``
 -----------------
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -622,6 +622,36 @@ Miscellaneous
 Features deprecated in 1.10
 ===========================
 
+Use model name as query lookup in related field when ``default_related_name`` is set
+------------------------------------------------------------------------------------
+
+Assume we have following models::
+
+    from django.db import models
+
+    class Foo(models.Model):
+        a = models.IntegerField(default=0)
+    
+    class Bar(models.Model):
+        foo = models.ForeignKey(Foo)
+        
+        class Meta:
+            default_related_name = 'bars'
+
+With created instance::
+
+    >>> foo = models.Foo.object.create()
+    >>> bar = models.Bar.object.create(foo=foo)
+
+Since we have set ``default_related_name`` in model ``Bar``,
+instead of using model name ``bar`` as related name in lookup string::
+
+    >>> models.Foo.object.get(bar=bar)
+
+use the default_related_name ``bars``::
+
+    >>> models.Foo.object.get(bars=bar)
+
 Direct assignment to a reverse foreign key or many-to-many relation
 -------------------------------------------------------------------
 

--- a/tests/model_options/test_default_related_name.py
+++ b/tests/model_options/test_default_related_name.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import FieldError
 from django.test import TestCase
 
 from .models.default_related_name import Author, Book, Editor
@@ -17,6 +18,12 @@ class DefaultRelatedNameTests(TestCase):
 
     def test_default_related_name(self):
         self.assertEqual(list(self.author.books.all()), [self.book])
+
+    def test_default_related_name_in_queryset_lookup(self):
+        try:
+            Author.objects.get(books=self.book)
+        except FieldError:
+            self.fail("Book should have 'books' related name in query function")
 
     def test_related_name_overrides_default_related_name(self):
         self.assertEqual(list(self.editor.edited_books.all()), [self.book])

--- a/tests/model_options/test_default_related_name.py
+++ b/tests/model_options/test_default_related_name.py
@@ -1,5 +1,7 @@
-from django.core.exceptions import FieldError
+import warnings
+
 from django.test import TestCase
+from django.utils.deprecation import RemovedInDjango20Warning
 
 from .models.default_related_name import Author, Book, Editor
 
@@ -20,10 +22,19 @@ class DefaultRelatedNameTests(TestCase):
         self.assertEqual(list(self.author.books.all()), [self.book])
 
     def test_default_related_name_in_queryset_lookup(self):
-        try:
-            Author.objects.get(books=self.book)
-        except FieldError:
-            self.fail("Book should have 'books' related name in query function")
+        self.assertEqual(Author.objects.get(books=self.book), self.author)
+
+    def test_show_deprecated_message_when_model_name_in_queryset_lookup(self):
+        msg = ("Query lookup '%s' is deprecated in favor of"
+               " Meta.default_related_name '%s'."
+               % ('book', 'books'))
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('once')
+            Author.objects.get(book=self.book)
+        self.assertEqual(len(warns), 1)
+        warning = warns.pop()
+        self.assertEqual(warning.category, RemovedInDjango20Warning)
+        self.assertEqual(str(warning.message), msg)
 
     def test_related_name_overrides_default_related_name(self):
         self.assertEqual(list(self.editor.edited_books.all()), [self.book])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26230
* Fix the behavior that QuerySet failed to get default_related_name as related_name in lookup string.
* Used the default_related_name to set related_name in RelatedField.contribute_to_class.
* Remove unused codes which return default_related_name as accessor name in ForeignObjectRel.get_accessor_name.