### PR TITLE
Fixed #26269 -- Prohibited spaces in is_valid_ipv6_address().

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -313,7 +313,7 @@ class Field(RegisterLookupMixin):
     def _check_backend_specific_checks(self, **kwargs):
         app_label = self.model._meta.app_label
         for db in connections:
-            if router.allow_migrate(db, app_label, model=self.model):
+            if router.allow_migrate(db, app_label, model_name=self.model._meta.model_name):
                 return connections[db].validation.check_field(self, **kwargs)
         return []
 

--- a/docs/topics/db/multi-db.txt
+++ b/docs/topics/db/multi-db.txt
@@ -308,7 +308,7 @@ send queries for the ``auth`` app to ``auth_db``::
                return True
             return None
 
-        def allow_migrate(self, db, app_label, model=None, **hints):
+        def allow_migrate(self, db, app_label, model_name=None, **hints):
             """
             Make sure the auth app only appears in the 'auth_db'
             database.
@@ -346,7 +346,7 @@ from::
                 return True
             return None
 
-        def allow_migrate(self, db, app_label, model=None, **hints):
+        def allow_migrate(self, db, app_label, model_name=None, **hints):
             """
             All non-auth models end up in this pool.
             """

--- a/tests/check_framework/test_multi_db.py
+++ b/tests/check_framework/test_multi_db.py
@@ -7,8 +7,8 @@ class TestRouter(object):
     """
     Routes to the 'other' database if the model name starts with 'Other'.
     """
-    def allow_migrate(self, db, app_label, model=None, **hints):
-        return db == ('other' if model._meta.verbose_name.startswith('other') else 'default')
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        return db == ('other' if model_name.startswith('other') else 'default')
 
 
 @override_settings(DATABASE_ROUTERS=[TestRouter()])


### PR DESCRIPTION
I've got an issue when user posted an IPv6 address with spaces right after a colon (like this: `fe80::2000:f8ff: fe21:67cf`) and Django passed that value to database and user got DataError exception. This fix prevents the issue.