### PR TITLE
Fixed #26280 -- Fixed cached template loader crash when loading nonexistent template.

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -131,7 +131,7 @@ class Loader(BaseLoader):
         template_tuple = self.template_cache.get(key)
         # A cached previous failure:
         if template_tuple is TemplateDoesNotExist:
-            raise TemplateDoesNotExist
+            raise TemplateDoesNotExist(template_name)
         elif template_tuple is None:
             template, origin = self.find_template(template_name, template_dirs)
             if not hasattr(template, 'render'):

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -87,6 +87,19 @@ class CachedLoaderTests(SimpleTestCase):
             "Cached loader failed to cache the TemplateDoesNotExist exception",
         )
 
+    @ignore_warnings(category=RemovedInDjango20Warning)
+    def test_load_non_existent_cached_template(self):
+        """
+        #26280 -- Cached template loader crash when loading nonexistent template
+        """
+        loader = self.engine.template_loaders[0]
+
+        with self.assertRaises(TemplateDoesNotExist):
+            loader.find_template('non_existent.html')
+
+        with self.assertRaises(TemplateDoesNotExist):
+            loader.load_template("non_existent.html")
+
     def test_templatedir_caching(self):
         """
         #13573 -- Template directories should be part of the cache key.

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -93,12 +93,13 @@ class CachedLoaderTests(SimpleTestCase):
         #26280 -- Cached template loader crash when loading nonexistent template
         """
         loader = self.engine.template_loaders[0]
+        template_name = "non_existent.html"
 
         with self.assertRaises(TemplateDoesNotExist):
-            loader.find_template('non_existent.html')
+            loader.find_template(template_name)
 
-        with self.assertRaises(TemplateDoesNotExist):
-            loader.load_template("non_existent.html")
+        with self.assertRaisesMessage(TemplateDoesNotExist, template_name):
+            loader.load_template(template_name)
 
     def test_templatedir_caching(self):
         """


### PR DESCRIPTION
If you use cached loader to load non-existing template, then you will get `TypeError: __init__() takes at least 2 arguments (1 given)`, because `TemplateDoesNotExist` raised without message