### PR TITLE
Refs #26265 -- Added composite_id attribute for BoundField

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -216,6 +216,21 @@ class BoundField(object):
         return ''
 
     @property
+    def auto_or_attr_id(self):
+        widget = self.field.widget
+        id_ = widget.attrs.get('id') or self.auto_id
+        return id_
+
+    @property
+    def composite_id(self):
+        """
+        Gets ID for wrapping elements of complex widgets,
+        for example for <ul/> element
+        which wraps choice elements for RadioSelect.
+        """
+        return self.auto_or_attr_id
+
+    @property
     def id_for_label(self):
         """
         Wrapper around the field widget's `id_for_label` method.
@@ -223,5 +238,4 @@ class BoundField(object):
         it has a single widget or a MultiWidget.
         """
         widget = self.field.widget
-        id_ = widget.attrs.get('id') or self.auto_id
-        return widget.id_for_label(id_)
+        return widget.id_for_label(self.auto_or_attr_id)

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -630,6 +630,23 @@ class FormsTestCase(SimpleTestCase):
 <input id="id_language_1" name="language" type="radio" value="J" /> Java</label></div>"""
         )
 
+        # Test manual templating of radio
+        t = Template("""
+            <label for="{{ form.language.id_for_label }}">{{ form.language.label }}:</label>
+            <ul id="{{ form.language.composite_id }}">
+                {% for choice in form.language %} <li>
+                    <label for="{{ choice.id_for_label }}">{{ choice.tag }}{{ choice.choice_label }}</label>
+                </li>{% endfor %}
+            </ul>""")
+        self.assertHTMLEqual(
+            t.render(Context({'form': f})),
+            """<label for="id_language_0">Language:</label>
+            <ul id="id_language">
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" /> Python</label></li>
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" /> Java</label></li>
+</ul>"""
+        )
+
     def test_form_with_iterable_boundfield(self):
         class BeatleForm(Form):
             name = ChoiceField(


### PR DESCRIPTION
Where is an established behaviour and structure for how `RadioSelect`s are rendered via shorthands, like `{{ form.as_p }}`:

```
<ul id="id_field-field">
  <li><label for="id_field-field_0">
      <input id="id_field-field_0" type="radio" value="1" name="field-field">
      ...
      </label>
  </li>
  <li><label for="id_field-field_1">...
  </li>
  ...
</ul>
```

On other hand, when trying to get the same output without the shorthand,

```
<ul id=" ? ">
  {% for choice in field %}
    <li><label for="{{ choice.id_for_label }}">{{ choice.tag }}</li>
  {% endfor %}
</ul>
```

there is no way to procure correct and unique `id` attribute for `<ul/>` element of `RadioSelect`.

This branch adds `composite_id` property to `BoundField`, This new property can be used in template to get correct and unique `id` for `<ul/>` (or other wrapper) element for `RadioSelect`:

```
<ul id="{{ field.composite_id }}">
  {% for choice in field %}
    <li><label for="{{ choice.id_for_label }}">{{ choice.tag }}</li>
  {% endfor %}
</ul>
``` 

Test is attached, but no docs yet, because I'm sure @timgraham's review is a must here.