### PR TITLE
[WIP] Prevented post_migrate receivers from running if the required migrations are not applied.

### DIFF
--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django.apps import apps
 from django.db import models
-from django.db.utils import IntegrityError, OperationalError, ProgrammingError
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -48,24 +47,15 @@ class ContentTypeManager(models.Manager):
         # The ContentType entry was not found in the cache, therefore we
         # proceed to load or create it.
         try:
-            try:
-                # We start with get() and not get_or_create() in order to use
-                # the db_for_read (see #20401).
-                ct = self.get(app_label=opts.app_label, model=opts.model_name)
-            except self.model.DoesNotExist:
-                # Not found in the database; we proceed to create it.  This time we
-                # use get_or_create to take care of any race conditions.
-                ct, created = self.get_or_create(
-                    app_label=opts.app_label,
-                    model=opts.model_name,
-                )
-        except (OperationalError, ProgrammingError, IntegrityError):
-            # It's possible to migrate a single app before contenttypes,
-            # as it's not a required initial dependency (it's contrib!)
-            # Have a nice error for this.
-            raise RuntimeError(
-                "Error creating new content types. Please make sure contenttypes "
-                "is migrated before trying to migrate apps individually."
+            # We start with get() and not get_or_create() in order to use
+            # the db_for_read (see #20401).
+            ct = self.get(app_label=opts.app_label, model=opts.model_name)
+        except self.model.DoesNotExist:
+            # Not found in the database; we proceed to create it.  This time we
+            # use get_or_create to take care of any race conditions.
+            ct, created = self.get_or_create(
+                app_label=opts.app_label,
+                model=opts.model_name,
             )
         self._add_to_cache(self.db, ct)
         return ct

--- a/django/contrib/sites/management.py
+++ b/django/contrib/sites/management.py
@@ -17,6 +17,15 @@ def create_default_site(app_config, verbosity=2, interactive=True, using=DEFAULT
     if not router.allow_migrate_model(using, Site):
         return
 
+    # Make sure either the `sites` app is either not managed by the
+    # migrations framework or has its initial migration applied.
+    from django.db.migrations.loader import MigrationLoader
+    from django.db.migrations.recorder import MigrationRecorder
+    migrations_import_path = MigrationLoader.migrations_module('sites')
+    recorder = MigrationRecorder(connections[using])
+    if migrations_import_path and not recorder.migration_is_applied('sites', '0001_initial'):
+        return
+
     if not Site.objects.using(using).exists():
         # The default settings set SITE_ID = 1, and some tests in Django's test
         # suite rely on this value. However, if database sequences are reused

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -65,6 +65,10 @@ class MigrationRecorder(object):
         self.ensure_schema()
         return set(tuple(x) for x in self.migration_qs.values_list("app", "name"))
 
+    def migration_is_applied(self, app, name):
+        self.ensure_schema()
+        return self.migration_qs.filter(app=app, name=name).exists()
+
     def record_applied(self, app, name):
         """
         Records that a migration was applied.

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -3,9 +3,8 @@ from __future__ import unicode_literals
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.shortcuts import get_current_site
-from django.db.utils import IntegrityError, OperationalError, ProgrammingError
 from django.http import Http404, HttpRequest
-from django.test import TestCase, mock, override_settings
+from django.test import TestCase, override_settings
 from django.utils import six
 
 from .models import (
@@ -246,26 +245,3 @@ class ContentTypesTests(TestCase):
         # Instead, just return the ContentType object and let the app detect stale states.
         ct_fetched = ContentType.objects.get_for_id(ct.pk)
         self.assertIsNone(ct_fetched.model_class())
-
-    @mock.patch('django.contrib.contenttypes.models.ContentTypeManager.get_or_create')
-    @mock.patch('django.contrib.contenttypes.models.ContentTypeManager.get')
-    def test_message_if_get_for_model_fails(self, mocked_get, mocked_get_or_create):
-        """
-        Check that `RuntimeError` with nice error message is raised if
-        `get_for_model` fails because of database errors.
-        """
-
-        def _test_message(mocked_method):
-            for ExceptionClass in (IntegrityError, OperationalError, ProgrammingError):
-                mocked_method.side_effect = ExceptionClass
-                with self.assertRaisesMessage(
-                    RuntimeError,
-                    "Error creating new content types. Please make sure contenttypes "
-                    "is migrated before trying to migrate apps individually."
-                ):
-                    ContentType.objects.get_for_model(ContentType)
-
-        _test_message(mocked_get)
-
-        mocked_get.side_effect = ContentType.DoesNotExist
-        _test_message(mocked_get_or_create)


### PR DESCRIPTION
This is related to multiple bug such as:

[#24299](https://code.djangoproject.com/ticket/24299), [#22411](https://code.djangoproject.com/ticket/22411) and [#24524](https://code.djangoproject.com/ticket/24524).