### PR TITLE
Fixed #26265 -- Added BoundField.id_for_wrapper

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -247,6 +247,7 @@ answer newbie questions, and generally made Django that much better:
     Frank Wierzbicki
     František Malina <fmalina@gmail.com>
     Fraser Nevett <mail@nevett.org>
+    Fyodor Ananiev <tedmx@ya.ru>
     Gabriel Grant <g@briel.ca>
     Gabriel Hurley <gabriel@strikeawe.com>
     gandalf@owca.info

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -225,3 +225,14 @@ class BoundField(object):
         widget = self.field.widget
         id_ = widget.attrs.get('id') or self.auto_id
         return widget.id_for_label(id_)
+
+    @property
+    def id_for_wrapper(self):
+        """
+        Gets ID for wrapping elements of complex widgets,
+        for example for <ul/> element
+        which wraps choice elements for RadioSelect.
+        """
+        widget = self.field.widget
+        id_ = widget.attrs.get('id') or self.auto_id
+        return id_

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -901,6 +901,19 @@ Attributes of ``BoundField``
 
         <label for="myFIELD">...</label><input id="myFIELD" type="text" name="my_field" />
 
+.. attribute:: BoundField.id_for_wrapper
+
+    .. versionadded:: 1.10
+
+    Provides ``id`` for ``<ul>`` or other wrapper elements for fields
+    implemented with more complex widgets,
+    like a :class:`~django.forms.ChoiceField`
+    based on :class:`~django.forms.RadioSelect` widget.
+
+    This attribute, along with :attr:`~django.forms.BoundField.id_for_label`,
+    is useful if you want to manually implement ``{{ form }}`` output for
+    :class:`~django.forms.RadioSelect` using only template variables and loop.
+
 .. attribute:: BoundField.is_hidden
 
     Returns ``True`` if this :class:`~django.forms.BoundField`'s widget is

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -230,6 +230,11 @@ Forms
 * Form and widget ``Media`` is now served using
   :mod:`django.contrib.staticfiles` if installed.
 
+* :class:`~django.forms.BoundField` has new
+  :attr:`~django.forms.BoundField.id_for_wrapper` attribute
+  for getting ``id`` in templates for wrapper elements
+  of complex widgets.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2905,6 +2905,27 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertEqual(form['field'].id_for_label, 'myCustomID')
         self.assertEqual(form['field_none'].id_for_label, 'id_field_none')
 
+    def test_boundfield_id_for_wrapper(self):
+        class SomeForm(Form):
+            field = ChoiceField(widget=RadioSelect, choices=[('P', 'Python'), ('J', 'Java')])
+
+        self.assertEqual(SomeForm()['field'].id_for_wrapper, 'id_field')
+
+    def test_boundfield_id_for_wrapper_override_by_attrs(self):
+        """
+        If an id is provided in `Widget.attrs`, it overrides the generated ID,
+        unless it is `None`.
+        """
+        class SomeForm(Form):
+            field = ChoiceField(widget=RadioSelect(attrs={'id': 'myCustomID'}),
+                                choices=[('P', 'Python'), ('J', 'Java')])
+            field_none = ChoiceField(widget=RadioSelect(attrs={'id': None}),
+                                     choices=[('P', 'Python'), ('J', 'Java')])
+
+        form = SomeForm()
+        self.assertEqual(form['field'].id_for_wrapper, 'myCustomID')
+        self.assertEqual(form['field_none'].id_for_wrapper, 'id_field_none')
+
     def test_label_tag_override(self):
         """
         BoundField label_suffix (if provided) overrides Form label_suffix


### PR DESCRIPTION
This is redirected and reworked PR based on [this one](https://github.com/django/django/pull/6199), with [corrections](https://github.com/django/django/pull/6199#issuecomment-188922746) by @timgraham applied -- thank you for review!

To quickly recap again, we're solving situation in which Django users can't accurately replicate `{{ form }}` (or similar) logic by more fine-grained template statements. In particular, we have no means to get correct `id` value on a wrapping `<ul> `element (or other of that kind):

```
<ul id=" ? ">
  {% for choice in field %}
    <li><label for="{{ choice.id_for_label }}">{{ choice.tag }}</li>
  {% endfor %}
</ul>
```

To solve the issue, this branch introduces new attribute for `BoundField` giving us that desired template variable:

```
<ul id="{{ field.id_for_wrapper }}">
  {% for choice in field %}
    <li><label for="{{ choice.id_for_label }}">{{ choice.tag }}</li>
  {% endfor %}
</ul>
``` 

As timgraham suggested, I've moved tests to lower abstractions, closer to other `BoundField` tests. There are two new tests, and they follow existing `id_for_label` tests very closely.

I've checked tests to pass, and docs `make` to finish without errors.