### PR TITLE
Fixed #26275 -- Added a note about difference between o and Y date format specifiers

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1296,6 +1296,9 @@ N                 Month abbreviation in Associated Press    ``'Jan.'``, ``'Feb.'
 o                 ISO-8601 week-numbering year,             ``'1999'``
                   corresponding to
                   the ISO-8601 week number (W)
+                  (Note: This corresponds to leap-week
+                  years which have 53 weeks in a year. 
+                  You probably want Y.)
 O                 Difference to Greenwich time in hours.    ``'+0200'``
 P                 Time, in 12-hour hours, minutes and       ``'1 a.m.'``, ``'1:30 p.m.'``, ``'midnight'``, ``'noon'``, ``'12:30 p.m.'``
                   'a.m.'/'p.m.', with minutes left off


### PR DESCRIPTION
Adds a note to the `o` format specifier documentation that explains it is used for leap-week years and that usually specifying `Y` is more appropriate.