### PR TITLE
Fixed #26288 -- Added support for relative imports in django.conf.urls.include().

### DIFF
--- a/django/conf/urls/__init__.py
+++ b/django/conf/urls/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from importlib import import_module
 
@@ -47,7 +48,11 @@ def include(arg, namespace=None, app_name=None):
         urlconf_module = arg
 
     if isinstance(urlconf_module, six.string_types):
-        urlconf_module = import_module(urlconf_module)
+        # Calculate for relative import, if any.
+        package = None
+        if urlconf_module.startswith('.'):
+            package = inspect.getmodule(inspect.stack()[1][0]).__package__
+        urlconf_module = import_module(urlconf_module, package=package)
     patterns = getattr(urlconf_module, 'urlpatterns', urlconf_module)
     app_name = getattr(urlconf_module, 'app_name', app_name)
     if namespace and not app_name:

--- a/tests/urlpatterns_reverse/included_relative_namespace_urls.py
+++ b/tests/urlpatterns_reverse/included_relative_namespace_urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import include, url
+
+from .views import empty_view
+
+urlpatterns = [
+    url(r'^normal/$', empty_view, name='inc-relative-normal-view'),
+]

--- a/tests/urlpatterns_reverse/namespace_urls.py
+++ b/tests/urlpatterns_reverse/namespace_urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     url(r'^app-included/', include('urlpatterns_reverse.included_namespace_urls', 'inc-app', 'inc-app')),
 
     url(r'^included/', include('urlpatterns_reverse.included_namespace_urls')),
+    url(r'^relative/', include('.included_relative_namespace_urls')),
     url(r'^inc(?P<outer>[0-9]+)/', include('urlpatterns_reverse.included_urls', namespace='inc-ns5')),
     url(r'^included/([0-9]+)/', include('urlpatterns_reverse.included_namespace_urls')),
 


### PR DESCRIPTION
For example, within ``myproject.urls``::

    urlpatterns = (
        url(r'', include('.myapp.urls')),
    )

.. becomes equivalent to::

    urlpatterns = (
        url(r'', include('myproject.myapp.urls')),
    )

Whilst a contrived example, this can make heavy-nested apps look far, far
cleaner. For example, within ``myproject.foo.foo_bar.foo_bar_baz.urls``,
one only needs to include ``.foo_bar_baz_qux.urls`` to get to the "next"
level, rather than the significantly more unwieldy
``myproject.foo.foo_bar.foo_bar_baz.foo.bar_baz_qux.urls``.

https://code.djangoproject.com/ticket/26288

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>