### PR TITLE
Fixed #26315 -- Cleaned up usage of argparse options in commands and tests.

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             help='Specifies the database to use. Default is "default".')
 
     def handle(self, *args, **options):
-        if options.get('username'):
+        if options['username']:
             username = options['username']
         else:
             username = getpass.getuser()
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         UserModel = get_user_model()
 
         try:
-            u = UserModel._default_manager.using(options.get('database')).get(**{
+            u = UserModel._default_manager.using(options['database']).get(**{
                 UserModel.USERNAME_FIELD: username
             })
         except UserModel.DoesNotExist:

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -53,8 +53,8 @@ class Command(BaseCommand):
         return super(Command, self).execute(*args, **options)
 
     def handle(self, *args, **options):
-        username = options.get(self.UserModel.USERNAME_FIELD)
-        database = options.get('database')
+        username = options[self.UserModel.USERNAME_FIELD]
+        database = options['database']
 
         # If not provided, create the user with an unusable password
         password = None
@@ -72,7 +72,7 @@ class Command(BaseCommand):
                 username = self.username_field.clean(username, None)
 
                 for field_name in self.UserModel.REQUIRED_FIELDS:
-                    if options.get(field_name):
+                    if options[field_name]:
                         field = self.UserModel._meta.get_field(field_name)
                         user_data[field_name] = field.clean(options[field_name], None)
                     else:
@@ -118,7 +118,7 @@ class Command(BaseCommand):
 
                 for field_name in self.UserModel.REQUIRED_FIELDS:
                     field = self.UserModel._meta.get_field(field_name)
-                    user_data[field_name] = options.get(field_name)
+                    user_data[field_name] = options[field_name]
                     while user_data[field_name] is None:
                         message = force_str('%s%s: ' % (
                             capfirst(field.verbose_name),

--- a/django/contrib/staticfiles/management/commands/runserver.py
+++ b/django/contrib/staticfiles/management/commands/runserver.py
@@ -21,8 +21,8 @@ class Command(RunserverCommand):
         handler.
         """
         handler = super(Command, self).get_handler(*args, **options)
-        use_static_handler = options.get('use_static_handler', True)
-        insecure_serving = options.get('insecure_serving', False)
+        use_static_handler = options['use_static_handler']
+        insecure_serving = options['insecure_serving']
         if use_static_handler and (settings.DEBUG or insecure_serving):
             return StaticFilesHandler(handler)
         return handler

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -314,13 +314,13 @@ class BaseCommand(object):
         controlled by the ``requires_system_checks`` attribute, except if
         force-skipped).
         """
-        if options.get('no_color'):
+        if options['no_color']:
             self.style = no_style()
             self.stderr.style_func = None
         if options.get('stdout'):
             self.stdout = OutputWrapper(options['stdout'])
         if options.get('stderr'):
-            self.stderr = OutputWrapper(options.get('stderr'), self.stderr.style_func)
+            self.stderr = OutputWrapper(options['stderr'], self.stderr.style_func)
 
         saved_locale = None
         if not self.leave_locale_alone:

--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
 
     def handle(self, *app_labels, **options):
         include_deployment_checks = options['deploy']
-        if options.get('list_tags'):
+        if options['list_tags']:
             self.stdout.write('\n'.join(sorted(registry.tags_available(include_deployment_checks))))
             return
 
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         else:
             app_configs = None
 
-        tags = options.get('tags')
+        tags = options['tags']
         if tags:
             try:
                 invalid_tag = next(

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -45,10 +45,10 @@ class Command(BaseCommand):
             help='Use fuzzy translations.')
 
     def handle(self, **options):
-        locale = options.get('locale')
-        exclude = options.get('exclude')
-        self.verbosity = int(options.get('verbosity'))
-        if options.get('fuzzy'):
+        locale = options['locale']
+        exclude = options['exclude']
+        self.verbosity = options['verbosity']
+        if options['fuzzy']:
             self.program_options = self.program_options + ['-f']
 
         if find_command(self.program) is None:

--- a/django/core/management/commands/createcachetable.py
+++ b/django/core/management/commands/createcachetable.py
@@ -27,9 +27,9 @@ class Command(BaseCommand):
             'be run.')
 
     def handle(self, *tablenames, **options):
-        db = options.get('database')
-        self.verbosity = int(options.get('verbosity'))
-        dry_run = options.get('dry_run')
+        db = options['database']
+        self.verbosity = options['verbosity']
+        dry_run = options['dry_run']
         if len(tablenames):
             # Legacy behavior, tablename specified as argument
             for tablename in tablenames:

--- a/django/core/management/commands/dbshell.py
+++ b/django/core/management/commands/dbshell.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             'open a shell. Defaults to the "default" database.')
 
     def handle(self, **options):
-        connection = connections[options.get('database')]
+        connection = connections[options['database']]
         try:
             connection.client.runshell()
         except OSError:

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -45,16 +45,16 @@ class Command(BaseCommand):
             help='Specifies file to which the output is written.')
 
     def handle(self, *app_labels, **options):
-        format = options.get('format')
-        indent = options.get('indent')
-        using = options.get('database')
-        excludes = options.get('exclude')
-        output = options.get('output')
-        show_traceback = options.get('traceback')
-        use_natural_foreign_keys = options.get('use_natural_foreign_keys')
-        use_natural_primary_keys = options.get('use_natural_primary_keys')
-        use_base_manager = options.get('use_base_manager')
-        pks = options.get('primary_keys')
+        format = options['format']
+        indent = options['indent']
+        using = options['database']
+        excludes = options['exclude']
+        output = options['output']
+        show_traceback = options['traceback']
+        use_natural_foreign_keys = options['use_natural_foreign_keys']
+        use_natural_primary_keys = options['use_natural_primary_keys']
+        use_base_manager = options['use_base_manager']
+        pks = options['primary_keys']
 
         if pks:
             primary_keys = pks.split(',')

--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -25,10 +25,10 @@ class Command(BaseCommand):
             help='Nominates a database to flush. Defaults to the "default" database.')
 
     def handle(self, **options):
-        database = options.get('database')
+        database = options['database']
         connection = connections[database]
-        verbosity = options.get('verbosity')
-        interactive = options.get('interactive')
+        verbosity = options['verbosity']
+        interactive = options['interactive']
         # The following are stealth options used by Django's internals.
         reset_sequences = options.get('reset_sequences', True)
         allow_cascade = options.get('allow_cascade', False)

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -50,10 +50,10 @@ class Command(BaseCommand):
 
     def handle(self, *fixture_labels, **options):
 
-        self.ignore = options.get('ignore')
-        self.using = options.get('database')
-        self.app_label = options.get('app_label')
-        self.verbosity = options.get('verbosity')
+        self.ignore = options['ignore']
+        self.using = options['database']
+        self.app_label = options['app_label']
+        self.verbosity = options['verbosity']
 
         with transaction.atomic(using=self.using):
             self.loaddata(fixture_labels)

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -212,13 +212,13 @@ class Command(BaseCommand):
             default=False, help="Keep .pot file after making messages. Useful when debugging.")
 
     def handle(self, *args, **options):
-        locale = options.get('locale')
-        exclude = options.get('exclude')
-        self.domain = options.get('domain')
-        self.verbosity = options.get('verbosity')
-        process_all = options.get('all')
-        extensions = options.get('extensions')
-        self.symlinks = options.get('symlinks')
+        locale = options['locale']
+        exclude = options['exclude']
+        self.domain = options['domain']
+        self.verbosity = options['verbosity']
+        process_all = options['all']
+        extensions = options['extensions']
+        self.symlinks = options['symlinks']
 
         # Need to ensure that the i18n framework is enabled
         if settings.configured:
@@ -226,25 +226,25 @@ class Command(BaseCommand):
         else:
             settings.configure(USE_I18N=True)
 
-        ignore_patterns = options.get('ignore_patterns')
-        if options.get('use_default_ignore_patterns'):
+        ignore_patterns = options['ignore_patterns']
+        if options['use_default_ignore_patterns']:
             ignore_patterns += ['CVS', '.*', '*~', '*.pyc']
         self.ignore_patterns = list(set(ignore_patterns))
 
         # Avoid messing with mutable class variables
-        if options.get('no_wrap'):
+        if options['no_wrap']:
             self.msgmerge_options = self.msgmerge_options[:] + ['--no-wrap']
             self.msguniq_options = self.msguniq_options[:] + ['--no-wrap']
             self.msgattrib_options = self.msgattrib_options[:] + ['--no-wrap']
             self.xgettext_options = self.xgettext_options[:] + ['--no-wrap']
-        if options.get('no_location'):
+        if options['no_location']:
             self.msgmerge_options = self.msgmerge_options[:] + ['--no-location']
             self.msguniq_options = self.msguniq_options[:] + ['--no-location']
             self.msgattrib_options = self.msgattrib_options[:] + ['--no-location']
             self.xgettext_options = self.xgettext_options[:] + ['--no-location']
 
-        self.no_obsolete = options.get('no_obsolete')
-        self.keep_pot = options.get('keep_pot')
+        self.no_obsolete = options['no_obsolete']
+        self.keep_pot = options['keep_pot']
 
         if self.domain not in ('django', 'djangojs'):
             raise CommandError("currently makemessages only supports domains "

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -43,13 +43,13 @@ class Command(BaseCommand):
             help='Exit with a non-zero status if model changes are missing migrations.')
 
     def handle(self, *app_labels, **options):
-        self.verbosity = options.get('verbosity')
-        self.interactive = options.get('interactive')
-        self.dry_run = options.get('dry_run', False)
-        self.merge = options.get('merge', False)
-        self.empty = options.get('empty', False)
-        self.migration_name = options.get('name')
-        self.exit_code = options.get('exit_code', False)
+        self.verbosity = options['verbosity']
+        self.interactive = options['interactive']
+        self.dry_run = options['dry_run']
+        self.merge = options['merge']
+        self.empty = options['empty']
+        self.migration_name = options['name']
+        self.exit_code = options['exit_code']
         check_changes = options['check_changes']
 
         if self.exit_code:

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -47,8 +47,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        self.verbosity = options.get('verbosity')
-        self.interactive = options.get('interactive')
+        self.verbosity = options['verbosity']
+        self.interactive = options['interactive']
 
         # Import the 'management' module within each installed app, to register
         # dispatcher events.
@@ -57,7 +57,7 @@ class Command(BaseCommand):
                 import_module('.management', app_config.name)
 
         # Get the database we're operating from
-        db = options.get('database')
+        db = options['database']
         connection = connections[db]
 
         # Hook for backends needing any database preparation
@@ -114,7 +114,7 @@ class Command(BaseCommand):
             targets = executor.loader.graph.leaf_nodes()
 
         plan = executor.migration_plan(targets)
-        run_syncdb = options.get('run_syncdb') and executor.loader.unmigrated_apps
+        run_syncdb = options['run_syncdb'] and executor.loader.unmigrated_apps
 
         # Print some useful info
         if self.verbosity >= 1:
@@ -172,8 +172,8 @@ class Command(BaseCommand):
                         "apply them."
                     ))
         else:
-            fake = options.get("fake")
-            fake_initial = options.get("fake_initial")
+            fake = options['fake']
+            fake_initial = options['fake_initial']
             executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
 
         # Send the post_migrate signal, so individual apps can do whatever they need

--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             help='Tells Django to NOT use the auto-reloader.')
 
     def execute(self, *args, **options):
-        if options.get('no_color'):
+        if options['no_color']:
             # We rely on the environment because it's currently the only
             # way to reach WSGIRequestHandler. This seems an acceptable
             # compromise considering `runserver` runs indefinitely.
@@ -61,11 +61,11 @@ class Command(BaseCommand):
         if not settings.DEBUG and not settings.ALLOWED_HOSTS:
             raise CommandError('You must set settings.ALLOWED_HOSTS if DEBUG is False.')
 
-        self.use_ipv6 = options.get('use_ipv6')
+        self.use_ipv6 = options['use_ipv6']
         if self.use_ipv6 and not socket.has_ipv6:
             raise CommandError('Your Python does not support IPv6.')
         self._raw_ipv6 = False
-        if not options.get('addrport'):
+        if not options['addrport']:
             self.addr = ''
             self.port = self.default_port
         else:
@@ -85,14 +85,14 @@ class Command(BaseCommand):
                     raise CommandError('"%s" is not a valid IPv6 address.' % self.addr)
         if not self.addr:
             self.addr = '::1' if self.use_ipv6 else '127.0.0.1'
-            self._raw_ipv6 = bool(self.use_ipv6)
+            self._raw_ipv6 = self.use_ipv6
         self.run(**options)
 
     def run(self, **options):
         """
         Runs the server, using the autoreloader if needed
         """
-        use_reloader = options.get('use_reloader')
+        use_reloader = options['use_reloader']
 
         if use_reloader:
             autoreload.main(self.inner_run, None, options)
@@ -104,7 +104,8 @@ class Command(BaseCommand):
         # to be raised in the child process, raise it now.
         autoreload.raise_last_exception()
 
-        threading = options.get('use_threading')
+        threading = options['use_threading']
+        # 'shutdown_message' is a stealth option.
         shutdown_message = options.get('shutdown_message', '')
         quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
 

--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -24,10 +24,10 @@ class Command(BaseCommand):
         parser.set_defaults(format='list')
 
     def handle(self, *args, **options):
-        self.verbosity = options.get('verbosity')
+        self.verbosity = options['verbosity']
 
         # Get the database we're operating from
-        db = options.get('database')
+        db = options['database']
         connection = connections[db]
 
         if options['format'] == "plan":

--- a/django/core/management/commands/sqlsequencereset.py
+++ b/django/core/management/commands/sqlsequencereset.py
@@ -18,7 +18,7 @@ class Command(AppCommand):
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             return
-        connection = connections[options.get('database')]
+        connection = connections[options['database']]
         models = app_config.get_models(include_auto_created=True)
         statements = connection.ops.sequence_reset_sql(self.style, models)
         return '\n'.join(statements)

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -27,8 +27,8 @@ class Command(BaseCommand):
 
     def handle(self, **options):
 
-        self.verbosity = options.get('verbosity')
-        self.interactive = options.get('interactive')
+        self.verbosity = options['verbosity']
+        self.interactive = options['interactive']
         app_label = options['app_label']
         start_migration_name = options['start_migration_name']
         migration_name = options['migration_name']

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -57,9 +57,9 @@ class Command(BaseCommand):
         from django.conf import settings
         from django.test.utils import get_runner
 
-        TestRunner = get_runner(settings, options.get('testrunner'))
+        TestRunner = get_runner(settings, options['testrunner'])
 
-        if options.get('liveserver') is not None:
+        if options['liveserver'] is not None:
             os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = options['liveserver']
         del options['liveserver']
 

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
 
         if options.get('liveserver') is not None:
             os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = options['liveserver']
-            del options['liveserver']
+        del options['liveserver']
 
         test_runner = TestRunner(**options)
         failures = test_runner.run_tests(test_labels)

--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -20,8 +20,8 @@ class Command(BaseCommand):
             help='Tells Django to use an IPv6 address.')
 
     def handle(self, *fixture_labels, **options):
-        verbosity = options.get('verbosity')
-        interactive = options.get('interactive')
+        verbosity = options['verbosity']
+        interactive = options['interactive']
 
         # Create a test database.
         db_name = connection.creation.create_test_db(verbosity=verbosity, autoclobber=not interactive, serialize=False)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1760,7 +1760,8 @@ Running management commands from your code
 To call a management command from code use ``call_command``.
 
 ``name``
-  the name of the command to call.
+  the name of the command to call or a command object. Passing the name of the
+  command is preferred unless the object is required for testing.
 
 ``*args``
   a list of arguments accepted by the command.
@@ -1771,8 +1772,12 @@ To call a management command from code use ``call_command``.
 Examples::
 
       from django.core import management
+      from django.core.management.commands import flush, loaddata
+
       management.call_command('flush', verbosity=0, interactive=False)
+      management.call_command(flush.Command(), verbosity=0, interactive=False)
       management.call_command('loaddata', 'test_data', verbosity=0)
+      management.call_command(loaddata.Command(), 'test_data', verbosity=0)
 
 Note that command options that take no arguments are passed as keywords
 with ``True`` or ``False``, as you can see with the ``interactive`` option above.
@@ -1800,6 +1805,8 @@ value of the ``handle()`` method of the command.
 
     ``call_command()`` now returns the value received from the
     ``command.handle()`` method.
+
+    ``call_command()`` now also accepts a command object as the first argument.
 
 Output redirection
 ==================

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -278,6 +278,9 @@ Management Commands
   :djadmin:`runserver` does, if the set of migrations on disk don't match the
   migrations in the database.
 
+* To assist with testing, :func:`~django.core.management.call_command` now also
+  accepts a command object as the first argument.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1269,10 +1269,6 @@ class CustomTestRunner(DiscoverRunner):
 
 
 class ManageTestCommand(AdminScriptTestCase):
-    def setUp(self):
-        from django.core.management.commands.test import Command as TestCommand
-        self.cmd = TestCommand()
-
     def test_liveserver(self):
         """
         Ensure that the --liveserver option sets the environment variable
@@ -1284,14 +1280,13 @@ class ManageTestCommand(AdminScriptTestCase):
         address_predefined = 'DJANGO_LIVE_TEST_SERVER_ADDRESS' in os.environ
         old_address = os.environ.get('DJANGO_LIVE_TEST_SERVER_ADDRESS')
 
-        self.cmd.handle(verbosity=0, testrunner='admin_scripts.tests.CustomTestRunner')
+        call_command('test', verbosity=0, testrunner='admin_scripts.tests.CustomTestRunner')
 
         # Original state hasn't changed
         self.assertEqual('DJANGO_LIVE_TEST_SERVER_ADDRESS' in os.environ, address_predefined)
         self.assertEqual(os.environ.get('DJANGO_LIVE_TEST_SERVER_ADDRESS'), old_address)
 
-        self.cmd.handle(verbosity=0, testrunner='admin_scripts.tests.CustomTestRunner',
-                        liveserver='blah')
+        call_command('test', verbosity=0, testrunner='admin_scripts.tests.CustomTestRunner', liveserver='blah')
 
         # Variable was correctly set
         self.assertEqual(os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'], 'blah')
@@ -1314,52 +1309,52 @@ class ManageRunserver(AdminScriptTestCase):
         self.cmd = Command(stdout=self.output)
         self.cmd.run = monkey_run
 
-    def assertServerSettings(self, addr, port, ipv6=None, raw_ipv6=False):
+    def assertServerSettings(self, addr, port, ipv6=False, raw_ipv6=False):
         self.assertEqual(self.cmd.addr, addr)
         self.assertEqual(self.cmd.port, port)
         self.assertEqual(self.cmd.use_ipv6, ipv6)
         self.assertEqual(self.cmd._raw_ipv6, raw_ipv6)
 
     def test_runserver_addrport(self):
-        self.cmd.handle()
+        call_command(self.cmd)
         self.assertServerSettings('127.0.0.1', '8000')
 
-        self.cmd.handle(addrport="1.2.3.4:8000")
+        call_command(self.cmd, addrport="1.2.3.4:8000")
         self.assertServerSettings('1.2.3.4', '8000')
 
-        self.cmd.handle(addrport="7000")
+        call_command(self.cmd, addrport="7000")
         self.assertServerSettings('127.0.0.1', '7000')
 
     @unittest.skipUnless(socket.has_ipv6, "platform doesn't support IPv6")
     def test_runner_addrport_ipv6(self):
-        self.cmd.handle(addrport="", use_ipv6=True)
+        call_command(self.cmd, addrport="", use_ipv6=True)
         self.assertServerSettings('::1', '8000', ipv6=True, raw_ipv6=True)
 
-        self.cmd.handle(addrport="7000", use_ipv6=True)
+        call_command(self.cmd, addrport="7000", use_ipv6=True)
         self.assertServerSettings('::1', '7000', ipv6=True, raw_ipv6=True)
 
-        self.cmd.handle(addrport="[2001:0db8:1234:5678::9]:7000")
+        call_command(self.cmd, addrport="[2001:0db8:1234:5678::9]:7000")
         self.assertServerSettings('2001:0db8:1234:5678::9', '7000', ipv6=True, raw_ipv6=True)
 
     def test_runner_hostname(self):
-        self.cmd.handle(addrport="localhost:8000")
+        call_command(self.cmd, addrport="localhost:8000")
         self.assertServerSettings('localhost', '8000')
 
-        self.cmd.handle(addrport="test.domain.local:7000")
+        call_command(self.cmd, addrport="test.domain.local:7000")
         self.assertServerSettings('test.domain.local', '7000')
 
     @unittest.skipUnless(socket.has_ipv6, "platform doesn't support IPv6")
     def test_runner_hostname_ipv6(self):
-        self.cmd.handle(addrport="test.domain.local:7000", use_ipv6=True)
+        call_command(self.cmd, addrport="test.domain.local:7000", use_ipv6=True)
         self.assertServerSettings('test.domain.local', '7000', ipv6=True)
 
     def test_runner_ambiguous(self):
         # Only 4 characters, all of which could be in an ipv6 address
-        self.cmd.handle(addrport="beef:7654")
+        call_command(self.cmd, addrport="beef:7654")
         self.assertServerSettings('beef', '7654')
 
         # Uses only characters that could be in an ipv6 address
-        self.cmd.handle(addrport="deadbeef:7654")
+        call_command(self.cmd, addrport="deadbeef:7654")
         self.assertServerSettings('deadbeef', '7654')
 
     def test_no_database(self):
@@ -1535,7 +1530,7 @@ class CommandTypes(AdminScriptTestCase):
         out = StringIO()
         err = StringIO()
         command = Command(stdout=out, stderr=err)
-        command.execute()
+        call_command(command)
         if color.supports_color():
             self.assertIn('Hello, world!\n', out.getvalue())
             self.assertIn('Hello, world!\n', err.getvalue())
@@ -1557,14 +1552,14 @@ class CommandTypes(AdminScriptTestCase):
         out = StringIO()
         err = StringIO()
         command = Command(stdout=out, stderr=err, no_color=True)
-        command.execute()
+        call_command(command)
         self.assertEqual(out.getvalue(), 'Hello, world!\n')
         self.assertEqual(err.getvalue(), 'Hello, world!\n')
 
         out = StringIO()
         err = StringIO()
         command = Command(stdout=out, stderr=err)
-        command.execute(no_color=True)
+        call_command(command, no_color=True)
         self.assertEqual(out.getvalue(), 'Hello, world!\n')
         self.assertEqual(err.getvalue(), 'Hello, world!\n')
 
@@ -1577,11 +1572,11 @@ class CommandTypes(AdminScriptTestCase):
 
         out = StringIO()
         command = Command(stdout=out)
-        command.execute()
+        call_command(command)
         self.assertEqual(out.getvalue(), "Hello, World!\n")
         out.truncate(0)
         new_out = StringIO()
-        command.execute(stdout=new_out)
+        call_command(command, stdout=new_out)
         self.assertEqual(out.getvalue(), "")
         self.assertEqual(new_out.getvalue(), "Hello, World!\n")
 
@@ -1594,11 +1589,11 @@ class CommandTypes(AdminScriptTestCase):
 
         err = StringIO()
         command = Command(stderr=err)
-        command.execute()
+        call_command(command)
         self.assertEqual(err.getvalue(), "Hello, World!\n")
         err.truncate(0)
         new_err = StringIO()
-        command.execute(stderr=new_err)
+        call_command(command, stderr=new_err)
         self.assertEqual(err.getvalue(), "")
         self.assertEqual(new_err.getvalue(), "Hello, World!\n")
 

--- a/tests/createsuperuser/tests.py
+++ b/tests/createsuperuser/tests.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import models
 from django.contrib.auth.management.commands import changepassword
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, mock
 from django.utils.six import StringIO
 
 
@@ -11,17 +11,16 @@ class MultiDBChangepasswordManagementCommandTestCase(TestCase):
     def setUp(self):
         self.user = models.User.objects.db_manager('other').create_user(username='joe', password='qwerty')
 
-    def test_that_changepassword_command_with_database_option_uses_given_db(self):
+    @mock.patch.object(changepassword.Command, '_get_pass', return_value='not qwerty')
+    def test_that_changepassword_command_with_database_option_uses_given_db(self, mock_get_pass):
         """
         Executing the changepassword management command with a database option
         should operate on the specified DB
         """
         self.assertTrue(self.user.check_password('qwerty'))
-        command = changepassword.Command()
-        command._get_pass = lambda *args: 'not qwerty'
 
         out = StringIO()
-        command.execute(username="joe", database='other', stdout=out)
+        call_command('changepassword', username="joe", database='other', stdout=out)
         command_output = out.getvalue().strip()
 
         self.assertEqual(


### PR DESCRIPTION
Options specified to argparse are always set and have a default value
and type. This eliminates the need for a number of patterns throughout
the management command code.

The pattern "options.get('name')" was removed in favor of direct
indexing.

The pattern "options.get('dry_run', False)" was removed in favor of
argparse's default value.

The pattern "int(options['verbosity'])" was removed in favor of
argparse's type coercion.

With this change, tests calling commands' execute() function directly
would now need to specify all options. To better handle this, these
commands were converted to call_command(). For tests that inspect a
command instance, call_command() now accepts a command instance as the
first argument.