### PR TITLE
Removed unused 'Between' lookup.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -341,11 +341,6 @@ class IEndsWith(PatternLookup):
 Field.register_lookup(IEndsWith)
 
 
-class Between(BuiltinLookup):
-    def get_rhs_op(self, connection, rhs):
-        return "BETWEEN %s AND %s" % (rhs, rhs)
-
-
 class Range(BuiltinLookup):
     lookup_name = 'range'
 


### PR DESCRIPTION
It has no references in code or docs. It was added in the Big ORM refactor in 20bab2cf9d02a5c6477d8aac066a635986e0d3f3, but stopped being used for `Range` in 00aa562884a418c4ee20e223ab82c3455997ee7d when `bilateral` was added to `Transform`.