### PR TITLE
Fixed #20892 -- Allowed setting memcached Client options through CACHES 'OPTIONS'.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -24,7 +24,8 @@ class BaseMemcachedCache(BaseCache):
         self.LibraryValueNotFoundException = value_not_found_exception
 
         self._lib = library
-        self._options = params.get('OPTIONS')
+        self._options = params.get('OPTIONS') or {}
+        self._options.setdefault('CLIENT_OPTIONS', {})
 
     @property
     def _cache(self):
@@ -32,12 +33,9 @@ class BaseMemcachedCache(BaseCache):
         Implements transparent thread-safe access to a memcached client.
         """
         if getattr(self, '_client', None) is None:
-            if self._options and 'CLIENT_OPTIONS' in self._options:
-                client_options = dict(servers=self._servers)
-                client_options.update(self._options['CLIENT_OPTIONS'])
-                self._client = self._lib.Client(**client_options)
-            else:
-                self._client = self._lib.Client(self._servers)
+            client_options = dict(servers=self._servers)
+            client_options.update(self._options['CLIENT_OPTIONS'])
+            self._client = self._lib.Client(**client_options)
 
         return self._client
 
@@ -168,12 +166,9 @@ class MemcachedCache(BaseMemcachedCache):
     @property
     def _cache(self):
         if getattr(self, '_client', None) is None:
-            if self._options and 'CLIENT_OPTIONS' in self._options:
-                client_options = dict(servers=self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
-                client_options.update(self._options['CLIENT_OPTIONS'])
-                self._client = self._lib.Client(**client_options)
-            else:
-                self._client = self._lib.Client(self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
+            client_options = dict(servers=self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
+            client_options.update(self._options['CLIENT_OPTIONS'])
+            self._client = self._lib.Client(**client_options)
         return self._client
 
 
@@ -187,12 +182,9 @@ class PyLibMCCache(BaseMemcachedCache):
 
     @cached_property
     def _cache(self):
-        if self._options and 'CLIENT_OPTIONS' in self._options:
-            client_options = dict(servers=self._servers)
-            client_options.update(self._options['CLIENT_OPTIONS'])
-            client = self._lib.Client(**client_options)
-        else:
-            client = self._lib.Client(self._servers)
+        client_options = dict(servers=self._servers)
+        client_options.update(self._options['CLIENT_OPTIONS'])
+        client = self._lib.Client(**client_options)
         if self._options:
             client.behaviors = self._options
 

--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -32,7 +32,12 @@ class BaseMemcachedCache(BaseCache):
         Implements transparent thread-safe access to a memcached client.
         """
         if getattr(self, '_client', None) is None:
-            self._client = self._lib.Client(self._servers)
+            if self._options and 'CLIENT_OPTIONS' in self._options:
+                client_options = dict(servers=self._servers)
+                client_options.update(self._options['CLIENT_OPTIONS'])
+                self._client = self._lib.Client(**client_options)
+            else:
+                self._client = self._lib.Client(self._servers)
 
         return self._client
 
@@ -163,7 +168,12 @@ class MemcachedCache(BaseMemcachedCache):
     @property
     def _cache(self):
         if getattr(self, '_client', None) is None:
-            self._client = self._lib.Client(self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
+            if self._options and 'CLIENT_OPTIONS' in self._options:
+                client_options = dict(servers=self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
+                client_options.update(self._options['CLIENT_OPTIONS'])
+                self._client = self._lib.Client(**client_options)
+            else:
+                self._client = self._lib.Client(self._servers, pickleProtocol=pickle.HIGHEST_PROTOCOL)
         return self._client
 
 
@@ -177,7 +187,12 @@ class PyLibMCCache(BaseMemcachedCache):
 
     @cached_property
     def _cache(self):
-        client = self._lib.Client(self._servers)
+        if self._options and 'CLIENT_OPTIONS' in self._options:
+            client_options = dict(servers=self._servers)
+            client_options.update(self._options['CLIENT_OPTIONS'])
+            client = self._lib.Client(**client_options)
+        else:
+            client = self._lib.Client(self._servers)
         if self._options:
             client.behaviors = self._options
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -190,6 +190,8 @@ Cache
 ~~~~~
 
 * The file-based cache backend now uses the highest pickling protocol.
+* ``CLIENT_OPTIONS`` can be used to pass settings to memcached client instance.
+  See :ref:`memcached <memcached>` for example.
 
 CSRF
 ~~~~

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -123,6 +123,27 @@ When using the ``pylibmc`` binding, do not include the ``unix:/`` prefix::
         }
     }
 
+You can set CLIENT_OPTIONS in OPTIONS setting to pass additional parameter
+to memcached client. For example::
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': '127.0.0.1:11211',
+            'OPTIONS': {
+                'CLIENT_OPTIONS': {
+                    'socket_timeout': 1
+                }
+            }
+        }
+    }
+
+will pass socket_timeout option to memcached client instance, limiting time
+spent waiting for connection with potentially unavailable memcached server
+to 1 second instead of default 3.
+Consult client ``__init__`` method to get list of available options
+that can be passed this way.
+
 One excellent feature of Memcached is its ability to share a cache over
 multiple servers. This means you can run Memcached daemons on multiple
 machines, and the program will treat the group of machines as a *single*

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -123,26 +123,26 @@ When using the ``pylibmc`` binding, do not include the ``unix:/`` prefix::
         }
     }
 
-You can set CLIENT_OPTIONS in OPTIONS setting to pass additional parameter
-to memcached client. For example::
+.. versionchanged:: 1.10
 
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-            'LOCATION': '127.0.0.1:11211',
-            'OPTIONS': {
-                'CLIENT_OPTIONS': {
-                    'socket_timeout': 1
+    You can set ``CLIENT_OPTIONS`` in ``OPTIONS`` setting to pass additional parameter
+    to memcached client. The following example will pass socket_timeout option to 
+    memcached client instance, limiting time spent waiting for connection with
+    potentially unavailable memcached server to 1 second instead of default 3.
+    Consult client ``__init__`` method to get list of available options
+    that can be passed this way.::
+    
+        CACHES = {
+            'default': {
+                'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+                'LOCATION': '127.0.0.1:11211',
+                'OPTIONS': {
+                    'CLIENT_OPTIONS': {
+                        'socket_timeout': 1,
+                    }
                 }
             }
         }
-    }
-
-will pass socket_timeout option to memcached client instance, limiting time
-spent waiting for connection with potentially unavailable memcached server
-to 1 second instead of default 3.
-Consult client ``__init__`` method to get list of available options
-that can be passed this way.
 
 One excellent feature of Memcached is its ability to share a cache over
 multiple servers. This means you can run Memcached daemons on multiple

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1135,6 +1135,8 @@ memcached_never_expiring_params['TIMEOUT'] = None
 memcached_far_future_params = memcached_params.copy()
 memcached_far_future_params['TIMEOUT'] = 31536000  # 60*60*24*365, 1 year
 
+memcached_client_options_params = memcached_params.copy()
+memcached_client_options_params['OPTIONS'] = {'CLIENT_OPTIONS': {'socket_timeout': 0.5}}
 
 @unittest.skipUnless(memcached_params, "memcached not available")
 @override_settings(CACHES=caches_setting_for_tests(base=memcached_params))
@@ -1178,6 +1180,12 @@ class MemcachedCacheTests(BaseCacheTests, TestCase):
         # Regression test for #22845
         cache.set('future_foo', 'bar')
         self.assertEqual(cache.get('future_foo'), 'bar')
+
+    @override_settings(CACHES=caches_setting_for_tests(base=memcached_client_options_params))
+    def test_passing_client_options(self):
+        cache.set('foo', 'bar')
+        self.assertEqual(cache._client.socket_timeout, 0.5)
+   
 
     def test_cull(self):
         # culling isn't implemented, memcached deals with it.

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1138,6 +1138,7 @@ memcached_far_future_params['TIMEOUT'] = 31536000  # 60*60*24*365, 1 year
 memcached_client_options_params = memcached_params.copy()
 memcached_client_options_params['OPTIONS'] = {'CLIENT_OPTIONS': {'socket_timeout': 0.5}}
 
+
 @unittest.skipUnless(memcached_params, "memcached not available")
 @override_settings(CACHES=caches_setting_for_tests(base=memcached_params))
 class MemcachedCacheTests(BaseCacheTests, TestCase):
@@ -1185,7 +1186,6 @@ class MemcachedCacheTests(BaseCacheTests, TestCase):
     def test_passing_client_options(self):
         cache.set('foo', 'bar')
         self.assertEqual(cache._client.socket_timeout, 0.5)
-   
 
     def test_cull(self):
         # culling isn't implemented, memcached deals with it.


### PR DESCRIPTION
Allow to set memcached client options
Ticket https://code.djangoproject.com/ticket/20892