### PR TITLE
Fixed #26309 -- Updated docs for login url settings

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -173,6 +173,9 @@ details on these changes.
 
 * The ability to reverse URLs using a dotted Python path will be removed.
 
+* The ability to use a dotted Python path for the ``LOGIN_URL`` and
+  ``LOGIN_REDIRECT_URL`` settings will be removed.
+
 * Support for :py:mod:`optparse` will be dropped for custom management commands
   (replaced by :py:mod:`argparse`).
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2624,9 +2624,9 @@ The URL where requests are redirected after login when the
 This is used by the :func:`~django.contrib.auth.decorators.login_required`
 decorator, for example.
 
-This setting also accepts view function names and :ref:`named URL patterns
-<naming-url-patterns>` which can be used to reduce configuration duplication
-since you don't have to define the URL in two places (``settings`` and URLconf).
+This setting also accepts :ref:`named URL patterns <naming-url-patterns>` which
+can be used to reduce configuration duplication since you don't have to define
+the URL in two places (``settings`` and URLconf).
 
 .. setting:: LOGIN_URL
 
@@ -2638,9 +2638,9 @@ Default: ``'/accounts/login/'``
 The URL where requests are redirected for login, especially when using the
 :func:`~django.contrib.auth.decorators.login_required` decorator.
 
-This setting also accepts view function names and :ref:`named URL patterns
-<naming-url-patterns>` which can be used to reduce configuration duplication
-since you don't have to define the URL in two places (``settings`` and URLconf).
+This setting also accepts :ref:`named URL patterns <naming-url-patterns>` which
+can be used to reduce configuration duplication since you don't have to define
+the URL in two places (``settings`` and URLconf).
 
 .. setting:: LOGOUT_REDIRECT_URL
 
@@ -2658,9 +2658,9 @@ The URL where requests are redirected after a user logs out using the
 If ``None``, no redirect will be performed and the logout view will be
 rendered.
 
-This setting also accepts view function names and :ref:`named URL patterns
-<naming-url-patterns>` which can be used to reduce configuration duplication
-since you don't have to define the URL in two places (``settings`` and URLconf).
+This setting also accepts :ref:`named URL patterns <naming-url-patterns>` which
+can be used to reduce configuration duplication since you don't have to define
+the URL in two places (``settings`` and URLconf).
 
 .. setting:: PASSWORD_RESET_TIMEOUT_DAYS
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -819,6 +819,9 @@ removed in Django 1.10 (please see the :ref:`deprecation timeline
 * The ability to :func:`~django.urls.reverse` URLs using a dotted Python path
   is removed.
 
+* The ability to use a dotted Python path for the ``LOGIN_URL`` and
+  ``LOGIN_REDIRECT_URL`` settings will be removed.
+
 * Support for ``optparse`` is dropped for custom management commands.
 
 * The class ``django.core.management.NoArgsCommand`` is removed.

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1351,6 +1351,10 @@ to ensure compatibility when reversing by Python path is removed in Django 1.10.
 Similarly for GIS sitemaps, add ``name='django.contrib.gis.sitemaps.views.kml'``
 or ``name='django.contrib.gis.sitemaps.views.kmz'``.
 
+If you are using a Python path for the :setting:`LOGIN_URL` or
+:setting:`LOGIN_REDIRECT_URL` settings, use the name of the ``url()`` pattern
+instead.
+
 .. _security issue: https://www.djangoproject.com/weblog/2014/apr/21/security/#s-issue-unexpected-code-execution-using-reverse
 
 Aggregate methods and modules


### PR DESCRIPTION
The ability to reverse urls using Python dotted paths is deprecated in Django 1.8 and removed in 1.10. This pull request updates the docs for the LOGIN_URL and LOGIN_REDIRECT_URL settings, and adds notes to the 1.8 release notes and deprecation timeline.

If we backport this patch to 1.9 or 1.8, we should add a `.. deprecated:: 1.10` note for both settings.