### PR TITLE
Fixed #26310 -- Documented that a queryset ordering must be specified to ensure ordered results.

### DIFF
--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -288,6 +288,12 @@ Django quotes column and table names behind the scenes.
     incurs a cost to your database. Each foreign key you add will
     implicitly include all of its default orderings as well.
 
+    If a query doesn't have an ordering specified, results are returned from
+    the database in an unspecified order. A particular ordering is guaranteed
+    only when ordering by a set of fields that uniquely identify each object in
+    the results. For example, if a ``name`` field isn't unique, ordering by it
+    won't guarantee objects with the same name always appear in the same order.
+
 ``permissions``
 ---------------
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -387,6 +387,12 @@ query will be ordered by ``pub_date`` and not ``headline``::
     incurs a cost to your database. Each foreign key you add will
     implicitly include all of its default orderings as well.
 
+    If a query doesn't have an ordering specified, results are returned from
+    the database in an unspecified order. A particular ordering is guaranteed
+    only when ordering by a set of fields that uniquely identify each object in
+    the results. For example, if a ``name`` field isn't unique, ordering by it
+    won't guarantee objects with the same name always appear in the same order.
+
 ``reverse()``
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26310