### PR TITLE
Refs #25653 -- Clarify help text for --selenium option

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -397,7 +397,7 @@ if __name__ == "__main__":
              'is localhost:8081-8179.')
     parser.add_argument(
         '--selenium', action='store_true', dest='selenium', default=False,
-        help='Run the Selenium tests as well (if Selenium is installed).')
+        help='Run only the Selenium tests (equivalent to "--tag selenium").')
     parser.add_argument(
         '--debug-sql', action='store_true', dest='debug_sql', default=False,
         help='Turn on the SQL query logger within tests.')


### PR DESCRIPTION
[Ticket #25653](https://code.djangoproject.com/ticket/25653) changed the behaviour of `runtests.py --selenium` to only run the Selenium tests instead of running them additionally but the help message for `--selenium` still says "Run the Selenium tests as well".