### PR TITLE
Fixed #26316 -- Remove repetition of code in models and fields of migrations.operations

### DIFF
--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -26,6 +26,12 @@ class FieldOperation(Operation):
     def is_same_field_operation(self, operation):
         return self.is_same_model_operation(operation) and self.name_lower == operation.name_lower
 
+    def references_model(self, name, app_label=None):
+        return name.lower() == self.model_name_lower
+
+    def references_field(self, model_name, name, app_label=None):
+        return self.references_model(model_name) and name.lower() == self.name_lower
+
     def reduce(self, operation, in_between, app_label=None):
         return (
             super(FieldOperation, self).reduce(operation, in_between, app_label=app_label) or
@@ -89,12 +95,6 @@ class AddField(FieldOperation):
     def describe(self):
         return "Add field %s to %s" % (self.name, self.model_name)
 
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.model_name_lower
-
-    def references_field(self, model_name, name, app_label=None):
-        return self.references_model(model_name) and name.lower() == self.name_lower
-
     def reduce(self, operation, in_between, app_label=None):
         if isinstance(operation, FieldOperation) and self.is_same_field_operation(operation):
             if isinstance(operation, AlterField):
@@ -155,12 +155,6 @@ class RemoveField(FieldOperation):
 
     def describe(self):
         return "Remove field %s from %s" % (self.name, self.model_name)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.model_name_lower
-
-    def references_field(self, model_name, name, app_label=None):
-        return self.references_model(model_name) and name.lower() == self.name_lower
 
 
 class AlterField(FieldOperation):
@@ -225,12 +219,6 @@ class AlterField(FieldOperation):
 
     def describe(self):
         return "Alter field %s on %s" % (self.name, self.model_name)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.model_name_lower
-
-    def references_field(self, model_name, name, app_label=None):
-        return self.references_model(model_name) and name.lower() == self.name_lower
 
     def reduce(self, operation, in_between, app_label=None):
         if isinstance(operation, RemoveField) and self.is_same_field_operation(operation):
@@ -315,9 +303,6 @@ class RenameField(FieldOperation):
 
     def describe(self):
         return "Rename field %s on %s to %s" % (self.old_name, self.model_name, self.new_name)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.model_name_lower
 
     def references_field(self, model_name, name, app_label=None):
         return self.references_model(model_name) and (

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -20,6 +20,9 @@ class ModelOperation(Operation):
     def name_lower(self):
         return self.name.lower()
 
+    def references_model(self, name, app_label=None):
+        return name.lower() == self.name_lower
+
     def reduce(self, operation, in_between, app_label=None):
         return (
             super(ModelOperation, self).reduce(operation, in_between, app_label=app_label) or
@@ -216,9 +219,6 @@ class DeleteModel(ModelOperation):
         model = to_state.apps.get_model(app_label, self.name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
             schema_editor.create_model(model)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
 
     def describe(self):
         return "Delete model %s" % (self.name, )
@@ -421,9 +421,6 @@ class AlterModelTable(ModelOperation):
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         return self.database_forwards(app_label, schema_editor, from_state, to_state)
 
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
-
     def describe(self):
         return "Rename table for %s to %s" % (self.name, self.table)
 
@@ -490,9 +487,6 @@ class AlterUniqueTogether(FieldRelatedOptionOperation):
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         return self.database_forwards(app_label, schema_editor, from_state, to_state)
 
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
-
     def references_field(self, model_name, name, app_label=None):
         return (
             self.references_model(model_name, app_label) and
@@ -546,9 +540,6 @@ class AlterIndexTogether(FieldRelatedOptionOperation):
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         return self.database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
 
     def references_field(self, model_name, name, app_label=None):
         return (
@@ -608,9 +599,6 @@ class AlterOrderWithRespectTo(FieldRelatedOptionOperation):
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         self.database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
 
     def references_field(self, model_name, name, app_label=None):
         return (
@@ -674,9 +662,6 @@ class AlterModelOptions(ModelOptionOperation):
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         pass
 
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
-
     def describe(self):
         return "Change Meta options on %s" % (self.name, )
 
@@ -709,9 +694,6 @@ class AlterModelManagers(ModelOptionOperation):
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         pass
-
-    def references_model(self, name, app_label=None):
-        return name.lower() == self.name_lower
 
     def describe(self):
         return "Change managers on %s" % (self.name, )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26316

Implemented `ModelOperation.references_model`, `FieldOperation.references_model`
and `FieldOperation.references_field`.