### PR TITLE
Fixed #26312 -- Added information about testing databases to tutorial 2.

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -45,7 +45,13 @@ For more details, see the reference documentation for :setting:`DATABASES`.
 
     If you're using PostgreSQL or MySQL, make sure you've created a database by
     this point. Do that with "``CREATE DATABASE database_name;``" within your
-    database's interactive prompt.
+    database's interactive prompt.  Create another database for use in testing.
+    If your first database was named ``my_database``, name this one
+    ``test_my_database``.
+
+    In the case of MySQL, make sure that whatever database user you have
+    provided in :file:`mysite/settings.py` has been granted all privileges for
+    **both** of these databases. (e.g. "``GRANT ALL my_database.* TO 'user'@'localhost';``")
 
     If you're using SQLite, you don't need to create anything beforehand - the
     database file will be created automatically when it is needed.

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -45,13 +45,10 @@ For more details, see the reference documentation for :setting:`DATABASES`.
 
     If you're using PostgreSQL or MySQL, make sure you've created a database by
     this point. Do that with "``CREATE DATABASE database_name;``" within your
-    database's interactive prompt.  Create another database for use in testing.
-    If your first database was named ``my_database``, name this one
-    ``test_my_database``.
-
-    In the case of MySQL, make sure that whatever database user you have
-    provided in :file:`mysite/settings.py` has been granted all privileges for
-    **both** of these databases. (e.g. "``GRANT ALL my_database.* TO 'user'@'localhost';``")
+    database's interactive prompt.  Make sure that the database user you have
+    provided in :file:`mysite/settings.py` has create database privileges.  This
+    becomes important down the line for allowing the automatic creation of a
+    :ref:`test database <the-test-database>`.
 
     If you're using SQLite, you don't need to create anything beforehand - the
     database file will be created automatically when it is needed.


### PR DESCRIPTION
I added to the note about non-sqlite databases to suggest creating a
test_ database while creating the main database to avoid errors in
tutorial section 5 on tests.

I also added information on making sure that the user provided to the
settings file has privileges for the two databases.  I don't have
enough experience with PostgreSQL to know whether the privileges
section applies there too, but I don't think it does.  For now it, that
part is labeled MySQL specific.