### PR TITLE
Fixed #26331 - Tests functions with typos are not detected by test runner

### DIFF
--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1351,7 +1351,7 @@ class DefaultNonExpiringCacheKeyTests(SimpleTestCase):
         self.assertIsNotNone(cache._expire_info[cache_key])
 
     @override_settings(CACHES=NEVER_EXPIRING_CACHES_SETTINGS)
-    def text_caches_set_with_timeout_as_none_set_non_expiring_key(self):
+    def test_caches_set_with_timeout_as_none_set_non_expiring_key(self):
         """Memory caches that have the TIMEOUT parameter set to `None` will set
         a non expiring key by default.
         """

--- a/tests/signing/tests.py
+++ b/tests/signing/tests.py
@@ -57,7 +57,7 @@ class TestSigner(SimpleTestCase):
             self.assertNotEqual(force_str(example), signed)
             self.assertEqual(example, signer.unsign(signed))
 
-    def unsign_detects_tampering(self):
+    def test_unsign_detects_tampering(self):
         "unsign should raise an exception if the value has been tampered with"
         signer = signing.Signer('predictable-secret')
         value = 'Another string'


### PR DESCRIPTION
[#26331](https://code.djangoproject.com/ticket/26331)