### PR TITLE
Fixed #26306 -- Memory leak in cached template loader

### DIFF
--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -97,13 +97,24 @@ class Template(object):
             reraise(exc, self.backend)
 
 
+def copy_exception(exc, backend=None):
+    """
+    Create a new TemplateDoesNotExist, preserving its declared attributes and
+    template debug data but discarding __traceback__, __context__ and __cause__
+    to make this object suitable for keeping around (in a cache, for example).
+    """
+    backend = backend or exc.backend
+    new = exc.__class__(*exc.args, tried=exc.tried, backend=backend, chain=exc.chain)
+    if hasattr(exc, 'template_debug'):
+        new.template_debug = exc.template_debug
+    return new
+
+
 def reraise(exc, backend):
     """
     Reraise TemplateDoesNotExist while maintaining template debug information.
     """
-    new = exc.__class__(*exc.args, tried=exc.tried, backend=backend)
-    if hasattr(exc, 'template_debug'):
-        new.template_debug = exc.template_debug
+    new = copy_exception(exc, backend)
     six.reraise(exc.__class__, new, sys.exc_info()[2])
 
 

--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -99,8 +99,8 @@ class Template(object):
 
 def copy_exception(exc, backend=None):
     """
-    Create a new TemplateDoesNotExist, preserving its declared attributes and
-    template debug data but discarding __traceback__, __context__ and __cause__
+    Create a new TemplateDoesNotExist. Preserve its declared attributes and
+    template debug data but discard __traceback__, __context__, and __cause__
     to make this object suitable for keeping around (in a cache, for example).
     """
     backend = backend or exc.backend

--- a/docs/releases/1.9.5.txt
+++ b/docs/releases/1.9.5.txt
@@ -19,3 +19,6 @@ Bugfixes
 
 * Fixed data loss on SQLite where ``DurationField`` values with fractional
   seconds could be saved as ``None`` (:ticket:`26324`).
+
+* Fixed a memory use regression in the cached template loader
+  (:ticket:`26306`).

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -63,8 +63,8 @@ class CachedLoaderTests(SimpleTestCase):
 
     def test_get_template_missing_debug_on(self):
         """
-        With template debugging enabled, ensure that a TemplateDoesNotExist
-        instance is cached when a template is missing.
+        With template debugging enabled, a TemplateDoesNotExist instance
+        should be cached when a template is missing.
         """
         self.engine.debug = True
         with self.assertRaises(TemplateDoesNotExist):
@@ -76,9 +76,9 @@ class CachedLoaderTests(SimpleTestCase):
     @unittest.skipIf(six.PY2, "Python 2 doesn't set extra exception attributes")
     def test_cached_exception_no_traceback(self):
         """
-        Ensure the exception cached when template debugging is enabled doesn't
-        contain the traceback or context information that Python sets when an
-        exception is raised in Python 3.
+        When a TemplateDoesNotExist instance is cached, the cached instance
+        should not contain the __traceback__, __context__, or __cause__
+        attributes that Python sets when raising exceptions.
         """
         self.engine.debug = True
         with self.assertRaises(TemplateDoesNotExist):


### PR DESCRIPTION
This fixes two related issues in the caching template loader, a memory leak bug and a memory use regression.

In 1.8, the thing that is cached when a template isn't found is the TemplateDoesNotExist class itself. When the debug view wants to know which paths were searched while looking for the template, it consults the rendering engine again. In 1.9, that debug information is stored on an exception instance, and those exceptions are cached.

The memory leak comes from the repeated re-raising of the same cached exception, which results in references to the `TemplateResponse` for each failed request persisting deep in the exception's context/stack information. The fix is to raise a new exception each cache hit, instead of repeatedly raising the cached exception.

The memory use regression comes from the intentional caching of every checked template path for each failed template, for debug purposes. In some projects that can end up eating all your memory. This is fixed by reverting to the 1.8 behaviour – simply caching the `TemplateDoesNotExist` class – when template debugging is not enabled.
