### PR TITLE
Fixed #26342 -- Bug with NodeNotFoundError repr

### DIFF
--- a/django/db/migrations/exceptions.py
+++ b/django/db/migrations/exceptions.py
@@ -53,7 +53,7 @@ class NodeNotFoundError(LookupError):
         return self.message
 
     def __repr__(self):
-        return "NodeNotFoundError(%r)" % self.node
+        return "NodeNotFoundError(%r)" % (self.node, )
 
 
 class MigrationSchemaMissing(DatabaseError):

--- a/tests/migrations/test_exceptions.py
+++ b/tests/migrations/test_exceptions.py
@@ -1,0 +1,12 @@
+from django.db.migrations.exceptions import NodeNotFoundError
+from django.test import SimpleTestCase
+
+
+class ExceptionTests(SimpleTestCase):
+    def test_node_not_found_error_repr(self):
+        node = ('some_app_label', 'some_migration_label')
+        error_repr = repr(NodeNotFoundError('some message', node))
+        self.assertEqual(
+            error_repr,
+            "NodeNotFoundError(('some_app_label', 'some_migration_label'))"
+        )


### PR DESCRIPTION
[Ticket #26342](https://code.djangoproject.com/ticket/26342#ticket)

`NodeNotFoundError.node` is a tuple. Feeding it as a single argument to a formatter attempts to unpack it. We don't want that!