### PR TITLE
Refs #25933 -- Fixed i18n_patterns() prefix_default_language=False with HTTP_ACCEPT_LANGUAGE header.

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -22,7 +22,8 @@ class LocaleMiddleware(object):
         urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
         i18n_patterns_used, prefixed_default_language = is_language_prefix_patterns_used(urlconf)
         language = translation.get_language_from_request(request, check_path=i18n_patterns_used)
-        if not language and i18n_patterns_used and not prefixed_default_language:
+        language_from_path = translation.get_language_from_path(request.path_info)
+        if not language_from_path and i18n_patterns_used and not prefixed_default_language:
             language = settings.LANGUAGE_CODE
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
@@ -32,9 +33,6 @@ class LocaleMiddleware(object):
         language_from_path = translation.get_language_from_path(request.path_info)
         urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
         i18n_patterns_used, prefixed_default_language = is_language_prefix_patterns_used(urlconf)
-
-        if not language_from_path and i18n_patterns_used and not prefixed_default_language:
-            language_from_path = settings.LANGUAGE_CODE
 
         if response.status_code == 404 and not language_from_path and i18n_patterns_used:
             language_path = '/%s%s' % (language, request.path_info)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1808,6 +1808,10 @@ class UnprefixedDefaultLanguageTests(SimpleTestCase):
         response = self.client.get('/fr/simple/')
         self.assertEqual(response.content, b'Oui')
 
+    def test_unprefixed_language_other_than_accept_language(self):
+        response = self.client.get('/simple/', HTTP_ACCEPT_LANGUAGE='fr')
+        self.assertEqual(response.content, b'Yes')
+
     def test_unexpected_kwarg_to_i18n_patterns(self):
         with self.assertRaisesMessage(AssertionError, "Unexpected kwargs for i18n_patterns(): {'foo':"):
             i18n_patterns(object(), foo='bar')


### PR DESCRIPTION
That's a fix and test against one issue found in #6222 (#25933 -- Allowed an unprefixed default language in i18n_patterns()).

The bug causes 404 when user with Accept-Encoding header different than default (settings.LANGUAGE_CODE) accessed the page.