### PR TITLE
Fixed #25865 -- Made OSMGeoAdmin require GDAL only if transformation is needed.

### DIFF
--- a/django/contrib/gis/admin/options.py
+++ b/django/contrib/gis/admin/options.py
@@ -59,6 +59,12 @@ class GeoModelAdmin(ModelAdmin):
         3D editing).
         """
         if isinstance(db_field, models.GeometryField) and db_field.dim < 3:
+            if not HAS_GDAL and db_field.srid != self.map_srid:
+                raise ImproperlyConfigured(
+                    "Map SRID is %s and SRID of `%s` is %s. GDAL must be "
+                    "installed to perform the transformation."
+                    % (self.map_srid, db_field, db_field.srid)
+                )
             # Setting the widget with the newly defined widget.
             kwargs['widget'] = self.get_map_widget(db_field)
             return db_field.formfield(**kwargs)
@@ -134,8 +140,3 @@ class OSMGeoAdmin(GeoModelAdmin):
     max_resolution = '156543.0339'
     point_zoom = num_zoom - 6
     units = 'm'
-
-    def __init__(self, *args):
-        if not HAS_GDAL:
-            raise ImproperlyConfigured("OSMGeoAdmin is not usable without GDAL libs installed")
-        super(OSMGeoAdmin, self).__init__(*args)

--- a/tests/gis_tests/geoadmin/models.py
+++ b/tests/gis_tests/geoadmin/models.py
@@ -1,4 +1,3 @@
-from django.contrib.gis.gdal import HAS_GDAL
 from django.utils.encoding import python_2_unicode_compatible
 
 from ..admin import admin
@@ -19,6 +18,18 @@ class City(models.Model):
     def __str__(self):
         return self.name
 
+
+@python_2_unicode_compatible
+class CityMercator(models.Model):
+    name = models.CharField(max_length=30)
+    point = models.PointField(srid=3857)
+
+    class Meta:
+        required_db_features = ['gis_enabled']
+
+    def __str__(self):
+        return self.name
+
 site = admin.AdminSite(name='admin_gis')
-if HAS_GDAL:
-    site.register(City, admin.OSMGeoAdmin)
+site.register(City, admin.OSMGeoAdmin)
+site.register(CityMercator, admin.OSMGeoAdmin)

--- a/tests/gis_tests/geoadmin/tests.py
+++ b/tests/gis_tests/geoadmin/tests.py
@@ -1,11 +1,15 @@
 from __future__ import unicode_literals
 
+from unittest import skipUnless
+
 from django.contrib.gis import admin
+from django.contrib.gis.gdal import HAS_GDAL
 from django.contrib.gis.geos import Point
-from django.test import TestCase, override_settings, skipUnlessDBFeature
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, mock, override_settings, skipUnlessDBFeature
 
 from .admin import UnmodifiableAdmin
-from .models import City, site
+from .models import City, CityMercator, site
 
 
 @skipUnlessDBFeature("gis_enabled")
@@ -52,6 +56,22 @@ class GeoAdminTest(TestCase):
             """"http://vmap0.tiles.osgeo.org/wms/vmap0", {layers: 'basic', format: 'image/jpeg'});""",
             result)
 
+    @mock.patch('django.contrib.gis.admin.options.HAS_GDAL', False)
+    def test_no_gdal_admin_model_diffent_srid(self):
+        msg = (
+            'Map SRID is 3857 and SRID of `geoadmin.City.point` is 4326. '
+            'GDAL must be installed to perform the transformation.'
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            geoadmin = site._registry[City]
+            geoadmin.get_changelist_form(None)()
+
+    @mock.patch('django.contrib.gis.admin.options.HAS_GDAL', False)
+    def test_no_gdal_admin_model_same_srid(self):
+        geoadmin = site._registry[CityMercator]
+        geoadmin.get_changelist_form(None)()
+
+    @skipUnless(HAS_GDAL, "GDAL is required.")
     def test_olwidget_has_changed(self):
         """
         Check that changes are accurately noticed by OpenLayersWidget.


### PR DESCRIPTION
Rebased from https://github.com/django/django/pull/5770.