### PR TITLE
Correct a spelling error: "aggretates"

### DIFF
--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -198,7 +198,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
 
     def convert_geom(self, hex, geo_field):
         """
-        Converts the geometry returned from PostGIS aggretates.
+        Converts the geometry returned from PostGIS aggregates.
         """
         if hex:
             return Geometry(hex, srid=geo_field.srid)


### PR DESCRIPTION
I am no English professor, but this PR fixes a spelling error: "aggregates"-> "aggregates".