### PR TITLE
Fixed #26343 -- Sent user_login_failed signal if an auth backend raises PermissionDenied.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -74,7 +74,7 @@ def authenticate(**credentials):
             user = backend.authenticate(**credentials)
         except PermissionDenied:
             # This backend says to stop in our tracks - this user should not be allowed in at all.
-            return None
+            break
         if user is None:
             continue
         # Annotate the user object with the path of the backend.

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 
 from django.contrib.auth import (
-    BACKEND_SESSION_KEY, SESSION_KEY, authenticate, get_user,
+    BACKEND_SESSION_KEY, SESSION_KEY, authenticate, get_user, signals
 )
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.hashers import MD5PasswordHasher
@@ -473,14 +473,25 @@ class PermissionDeniedBackendTest(TestCase):
     """
     backend = 'auth_tests.test_auth_backends.PermissionDeniedBackend'
 
+    def listener_user_login_failed(self, sender, credentials, **kwargs):
+        self.user_login_failed.append(credentials)
+
     def setUp(self):
         self.user1 = User.objects.create_user('test', 'test@example.com', 'test')
         self.user1.save()
+        self.user_login_failed = []
+        signals.user_login_failed.connect(self.listener_user_login_failed)
+
+    def tearDown(self):
+        """Disconnect the listener"""
+        signals.user_login_failed.disconnect(self.listener_user_login_failed)
 
     @modify_settings(AUTHENTICATION_BACKENDS={'prepend': backend})
     def test_permission_denied(self):
         "user is not authenticated after a backend raises permission denied #2550"
+        "user_login_failed signal is sent on PermissionDenied #26343"
         self.assertEqual(authenticate(username='test', password='test'), None)
+        self.assertEqual(len(self.user_login_failed), 1)
 
     @modify_settings(AUTHENTICATION_BACKENDS={'append': backend})
     def test_authenticates(self):


### PR DESCRIPTION
Break from loop instead of returning None when PermissionDenied to ensure user_login_failed signal is sent.  Implicit return of None follows the signal.