### PR TITLE
Fixed #26283 -- Fixed removal of trailing nulls for `SplitArrayField`.

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -183,7 +183,7 @@ class SplitArrayField(forms.Field):
                     null_index = i
                 else:
                     break
-            if null_index:
+            if null_index is not None:
                 cleaned_data = cleaned_data[:null_index]
                 errors = errors[:null_index]
         errors = list(filter(None, errors))

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -663,6 +663,20 @@ class TestSplitFormField(PostgreSQLTestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.cleaned_data, {'array': ['a', '', 'b']})
 
+    def test_remove_trailing_nulls_not_required(self):
+        class SplitForm(forms.Form):
+            array = SplitArrayField(
+                forms.CharField(required=False),
+                size=2,
+                remove_trailing_nulls=True,
+                required=False,
+            )
+
+        data = {'array_0': '', 'array_1': ''}
+        form = SplitForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data, {'array': []})
+
     def test_required_field(self):
         class SplitForm(forms.Form):
             array = SplitArrayField(forms.CharField(), size=3)


### PR DESCRIPTION
Updated the clean's `null_index` check to not mistake a `0` index for no trailing nulls.