### PR TITLE
Fixed #26294 -- Clarified call_command()'s handling of args and options.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1764,10 +1764,15 @@ To call a management command from code use ``call_command``.
   preferred unless the object is required for testing.
 
 ``*args``
-  a list of arguments accepted by the command.
+  a list of arguments accepted by the command. Arguments are passed to the
+  argument parser, so you can use the same style as you would on the command
+  line. For example, ``call_command('flush', 'verbosity=0')``.
 
 ``**options``
-  named options accepted on the command-line.
+  named options accepted on the command-line. Options are passed to the command
+  without triggering the argument parser, which means you'll need to pass the
+  correct type. For example, ``call_command('flush', verbosity=0)`` (zero must
+  be an integer rather than a string).
 
 Examples::
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26294