### PR TITLE
Removed unnecessary filter kwarg from .get() in a test.

### DIFF
--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -233,7 +233,7 @@ class ModelInheritanceDataTests(TestCase):
     def test_inherited_multiple_objects_returned_exception(self):
         # MultipleObjectsReturned is also inherited.
         with self.assertRaises(Place.MultipleObjectsReturned):
-            Restaurant.objects.get(id__lt=12321)
+            Restaurant.objects.get()
 
     def test_related_objects_for_inherited_models(self):
         # Related objects work just as they normally do.


### PR DESCRIPTION
It appears that this filter was added because the original author thought that `.get()`` required at least one filter kwarg (or maybe it did when this test was written).

The filter is unnecessary as there's only one object anyway, and it causes an error if the DB's auto-increment is too high or if the DB uses random IDs.