### PR TITLE
[1.9.x] Fixed #26334 -- Removed whitespace stripping from contrib.auth password fields.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -69,9 +69,11 @@ class UserCreationForm(forms.ModelForm):
         'password_mismatch': _("The two password fields didn't match."),
     }
     password1 = forms.CharField(label=_("Password"),
+        strip=False,
         widget=forms.PasswordInput)
     password2 = forms.CharField(label=_("Password confirmation"),
         widget=forms.PasswordInput,
+        strip=False,
         help_text=_("Enter the same password as before, for verification."))
 
     class Meta:
@@ -127,7 +129,9 @@ class AuthenticationForm(forms.Form):
     username/password logins.
     """
     username = forms.CharField(max_length=254)
-    password = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
+    password = forms.CharField(label=_("Password"),
+        strip=False,
+        widget=forms.PasswordInput)
 
     error_messages = {
         'invalid_login': _("Please enter a correct %(username)s and password. "
@@ -269,8 +273,10 @@ class SetPasswordForm(forms.Form):
     }
     new_password1 = forms.CharField(label=_("New password"),
                                     widget=forms.PasswordInput,
+                                    strip=False,
                                     help_text=password_validation.password_validators_help_text_html())
     new_password2 = forms.CharField(label=_("New password confirmation"),
+                                    strip=False,
                                     widget=forms.PasswordInput)
 
     def __init__(self, user, *args, **kwargs):
@@ -307,6 +313,7 @@ class PasswordChangeForm(SetPasswordForm):
                                 "Please enter it again."),
     })
     old_password = forms.CharField(label=_("Old password"),
+                                   strip=False,
                                    widget=forms.PasswordInput)
 
     field_order = ['old_password', 'new_password1', 'new_password2']
@@ -335,11 +342,13 @@ class AdminPasswordChangeForm(forms.Form):
     password1 = forms.CharField(
         label=_("Password"),
         widget=forms.PasswordInput,
+        strip=False,
         help_text=password_validation.password_validators_help_text_html(),
     )
     password2 = forms.CharField(
         label=_("Password (again)"),
         widget=forms.PasswordInput,
+        strip=False,
         help_text=_("Enter the same password as before, for verification."),
     )
 

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -169,6 +169,16 @@ class UserCreationFormTest(TestDataMixin, TestCase):
         form = CustomUserCreationForm(data)
         self.assertTrue(form.is_valid())
 
+    def test_password_whitespace_not_stripped(self):
+        data = {
+            'username': 'testuser',
+            'password1': '   testpassword   ',
+            'password2': '   testpassword   ',
+        }
+        form = UserCreationForm(data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['password1'], data['password1'])
+
 
 @override_settings(USE_TZ=False, PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'])
 class AuthenticationFormTest(TestDataMixin, TestCase):
@@ -279,6 +289,15 @@ class AuthenticationFormTest(TestDataMixin, TestCase):
         form = CustomAuthenticationForm()
         self.assertEqual(form.fields['username'].label, "")
 
+    def test_password_whitespace_not_stripped(self):
+        data = {
+            'username': 'testuser',
+            'password': ' pass ',
+        }
+        form = AuthenticationForm(None, data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['password'], data['password'])
+
 
 @override_settings(USE_TZ=False, PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'])
 class SetPasswordFormTest(TestDataMixin, TestCase):
@@ -330,6 +349,17 @@ class SetPasswordFormTest(TestDataMixin, TestCase):
             form["new_password2"].errors
         )
 
+    def test_password_whitespace_not_stripped(self):
+        user = User.objects.get(username='testclient')
+        data = {
+            'new_password1': '   password   ',
+            'new_password2': '   password   ',
+        }
+        form = SetPasswordForm(user, data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['new_password1'], data['new_password1'])
+        self.assertEqual(form.cleaned_data['new_password2'], data['new_password2'])
+
 
 @override_settings(USE_TZ=False, PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'])
 class PasswordChangeFormTest(TestDataMixin, TestCase):
@@ -380,6 +410,18 @@ class PasswordChangeFormTest(TestDataMixin, TestCase):
         user = User.objects.get(username='testclient')
         self.assertEqual(list(PasswordChangeForm(user, {}).fields),
                          ['old_password', 'new_password1', 'new_password2'])
+
+    def test_password_whitespace_not_stripped(self):
+        user = User.objects.get(username='testclient')
+        data = {
+            'old_password': 'password',
+            'new_password1': ' pass ',
+            'new_password2': ' pass ',
+        }
+        form = PasswordChangeForm(user, data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['new_password1'], data['new_password1'])
+        self.assertEqual(form.cleaned_data['new_password2'], data['new_password2'])
 
 
 @override_settings(USE_TZ=False, PASSWORD_HASHERS=['django.contrib.auth.hashers.SHA1PasswordHasher'])
@@ -673,3 +715,14 @@ class AdminPasswordChangeFormTest(TestDataMixin, TestCase):
         self.assertEqual(password_changed.call_count, 0)
         form.save()
         self.assertEqual(password_changed.call_count, 1)
+
+    def test_password_whitespace_not_stripped(self):
+        user = User.objects.get(username='testclient')
+        data = {
+            'password1': ' pass ',
+            'password2': ' pass ',
+        }
+        form = AdminPasswordChangeForm(user, data)
+        form.is_valid()
+        self.assertEqual(form.cleaned_data['password1'], data['password1'])
+        self.assertEqual(form.cleaned_data['password2'], data['password2'])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26334