### PR TITLE
Fixed #25251 -- Made data migrations available in TransactionTestCase (2)

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -4,7 +4,7 @@ import time
 from django.apps import apps
 from django.conf import settings
 from django.core import serializers
-from django.db import router
+from django.db import connections, router
 from django.utils.six import StringIO
 from django.utils.six.moves import input
 
@@ -243,6 +243,10 @@ class BaseDatabaseCreation(object):
         Destroy a test database, prompting the user for confirmation if the
         database already exists.
         """
+        if keepdb:
+            # Restore initial data migrations that may have be cleaned by TransactionTestCase flush
+            self._restore_initial_data_migrations()
+
         self.connection.close()
         if number is None:
             test_database_name = self.connection.settings_dict['NAME']
@@ -267,6 +271,26 @@ class BaseDatabaseCreation(object):
         if old_database_name is not None:
             settings.DATABASES[self.connection.alias]["NAME"] = old_database_name
             self.connection.settings_dict["NAME"] = old_database_name
+
+    def _restore_initial_data_migrations(self):
+        # Load initial data migrations, if any.
+        if hasattr(connections[self.connection.alias], "_test_serialized_contents"):
+            self._flush_db()
+
+            connections[self.connection.alias].creation.deserialize_db_from_string(
+                connections[self.connection.alias]._test_serialized_contents
+            )
+
+    def _flush_db(self):
+        # Don't import django.core.management if it isn't needed.
+        from django.core.management import call_command
+
+        # Flush database, in case of any data created after
+        # emit_post_migrate_signal
+        call_command('flush', verbosity=0, interactive=False,
+                     database=self.connection.alias, reset_sequences=True,
+                     inhibit_post_migrate=True
+                     )
 
     def _destroy_test_db(self, test_database_name, verbosity):
         """

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -751,6 +751,10 @@ database into an in-memory JSON string before running tests (used to restore
 the database state between tests if you don't have transactions). You can set
 this to ``False`` to speed up creation time if you don't have any test classes
 with :ref:`serialized_rollback=True <test-case-serialized-rollback>`.
+If you have data migrations and use :class:`~django.test.TransactionTestCase`
+along with the :option:`test --keepdb` option, you won't see data from
+migrations in subsequent ``--keepdb`` test runs if you set ``SERIALIZE`` to
+``False``.
 
 .. setting:: TEST_CREATE
 

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -11,6 +11,7 @@ from django import db
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
+from django.db.backends.base.creation import BaseDatabaseCreation
 from django.test import (
     TestCase, TransactionTestCase, mock, skipUnlessDBFeature, testcases,
 )
@@ -295,7 +296,8 @@ class SetupDatabasesTests(unittest.TestCase):
                 self.runner_instance.teardown_databases(old_config)
         mocked_db_creation.return_value.destroy_test_db.assert_called_once_with('dbname', 0, False)
 
-    def test_destroy_test_db_restores_db_name(self):
+    @mock.patch.object(BaseDatabaseCreation, '_flush_db')
+    def test_destroy_test_db_restores_db_name(self, mock_flush_db):
         tested_connections = db.ConnectionHandler({
             'default': {
                 'ENGINE': settings.DATABASES[db.DEFAULT_DB_ALIAS]["ENGINE"],
@@ -305,8 +307,29 @@ class SetupDatabasesTests(unittest.TestCase):
         # Using the real current name as old_name to not mess with the test suite.
         old_name = settings.DATABASES[db.DEFAULT_DB_ALIAS]["NAME"]
         with mock.patch('django.db.connections', new=tested_connections):
-            tested_connections['default'].creation.destroy_test_db(old_name, verbosity=0, keepdb=True)
-            self.assertEqual(tested_connections['default'].settings_dict["NAME"], old_name)
+            default_connection = tested_connections['default']
+            default_connection.creation.destroy_test_db(old_name, verbosity=0, keepdb=True)
+            self.assertEqual(default_connection.settings_dict["NAME"], old_name)
+
+    @mock.patch.object(BaseDatabaseCreation, 'deserialize_db_from_string')
+    @mock.patch.object(BaseDatabaseCreation, '_flush_db')
+    def test_destroy_test_db_with_keepdb_restores_initial_data_migrations(self, mock_flush_db, mock_deserialize_db):
+        tested_connections = db.ConnectionHandler({
+            'default': {
+                'ENGINE': settings.DATABASES[db.DEFAULT_DB_ALIAS]["ENGINE"],
+                'NAME': 'xxx_test_database',
+            },
+        })
+        # Using the real current name as old_name to not mess with the test suite.
+        old_name = settings.DATABASES[db.DEFAULT_DB_ALIAS]["NAME"]
+
+        serialized_content = '[{"model": "test_utils.car", "pk": 666, "fields": {"name": "K 2000"}}]'
+        with mock.patch('django.db.backends.base.creation.connections', new=tested_connections):
+            default_connection = tested_connections['default']
+            default_connection._test_serialized_contents = serialized_content
+            default_connection.creation.destroy_test_db(old_name, verbosity=0, keepdb=True)
+            # If keepdb is True, connection _test_serialized_contents should have been deserialized.
+            mock_deserialize_db.assert_called_once_with(serialized_content)
 
     def test_serialization(self):
         tested_connections = db.ConnectionHandler({


### PR DESCRIPTION
@timgraham Proposing another solution for #6137.

Flushing and loading initial data migration on the `destroy_test_db` step.
