### PR TITLE
Fixed #25005 - Made date and time fields with auto_now/auto_now_add use effective default

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1,9 +1,10 @@
 import hashlib
 import logging
+from datetime import datetime
 
 from django.db.backends.utils import truncate_name
 from django.db.transaction import atomic
-from django.utils import six
+from django.utils import six, timezone
 from django.utils.encoding import force_bytes
 
 logger = logging.getLogger('django.db.backends.schema')
@@ -201,6 +202,15 @@ class BaseDatabaseSchemaEditor(object):
                 default = six.binary_type()
             else:
                 default = six.text_type()
+        elif getattr(field, 'auto_now', False) or getattr(field, 'auto_now_add', False):
+            default = datetime.now()
+            internal_type = field.get_internal_type()
+            if internal_type == 'DateField':
+                default = default.date
+            elif internal_type == 'TimeField':
+                default = default.time
+            elif internal_type == 'DateTimeField':
+                default = timezone.now
         else:
             default = None
         # If it's a callable, call it

--- a/tests/migrations/test_auto_now_add/0001_initial.py
+++ b/tests/migrations/test_auto_now_add/0001_initial.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    operations = [
+        migrations.CreateModel(
+            name='Entry',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=255)),
+            ],
+        ),
+    ]

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -61,6 +61,18 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default='Ada Lovelace')),
     ])
+    author_dates_of_birth_auto_now = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("date_of_birth", models.DateField(auto_now=True)),
+        ("date_time_of_birth", models.DateTimeField(auto_now=True)),
+        ("time_of_birth", models.TimeField(auto_now=True)),
+    ])
+    author_dates_of_birth_auto_now_add = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("date_of_birth", models.DateField(auto_now_add=True)),
+        ("date_time_of_birth", models.DateTimeField(auto_now_add=True)),
+        ("time_of_birth", models.TimeField(auto_now_add=True)),
+    ])
     author_name_deconstructible_1 = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject())),
@@ -633,6 +645,51 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AddField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name")
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition',
+                side_effect=AssertionError("Should not have prompted for not null addition"))
+    def test_add_date_fields_with_auto_now_not_asking_for_default(self, mocked_ask_method):
+        # Make state
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_dates_of_birth_auto_now])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField", "AddField"])
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now=True)
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition',
+                side_effect=AssertionError("Should not have prompted for not null addition"))
+    def test_add_date_fields_with_auto_now_add_not_asking_for_null_addition(self, mocked_ask_method):
+        # Make state
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_dates_of_birth_auto_now_add])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField", "AddField"])
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+
+    @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_auto_now_add_addition')
+    def test_add_date_fields_with_auto_now_add_asking_for_default(self, mocked_ask_method):
+        # Make state
+        before = self.make_project_state([self.author_empty])
+        after = self.make_project_state([self.author_dates_of_birth_auto_now_add])
+        autodetector = MigrationAutodetector(before, after)
+        changes = autodetector._detect_changes()
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, 'testapp', 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField", "AddField"])
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 1, auto_now_add=True)
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 2, auto_now_add=True)
+        self.assertEqual(mocked_ask_method.call_count, 3)
 
     def test_remove_field(self):
         """Tests autodetection of removed fields."""

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -18,8 +18,9 @@ from django.db.models.fields.related import (
 )
 from django.db.transaction import atomic
 from django.test import (
-    TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
+    TransactionTestCase, mock, skipIfDBFeature, skipUnlessDBFeature,
 )
+from django.utils.timezone import UTC
 
 from .fields import (
     CustomManyToManyField, InheritedManyToManyField, MediumBlobField,
@@ -124,8 +125,17 @@ class SchemaTests(TransactionTestCase):
                 constraints_for_column.append(name)
         return sorted(constraints_for_column)
 
-    # Tests
+    def check_added_field_default(self, schema_editor, model, field, field_name, expected_default,
+                                  cast_function=None):
+        with connection.cursor() as cursor:
+            schema_editor.add_field(model, field)
+            cursor.execute("SELECT {} FROM {};".format(field_name, model._meta.db_table))
+            database_default = cursor.fetchall()[0][0]
+            if cast_function and not type(database_default) == type(expected_default):
+                database_default = cast_function(database_default)
+            self.assertEqual(database_default, expected_default)
 
+    # Tests
     def test_creation_deletion(self):
         """
         Tries creating a model's table, and then deleting it.
@@ -1833,3 +1843,68 @@ class SchemaTests(TransactionTestCase):
         new_field.set_attributes_from_name('id')
         with connection.schema_editor() as editor:
             editor.alter_field(Node, old_field, new_field)
+
+    @mock.patch('django.db.backends.base.schema.datetime')
+    @mock.patch('django.db.backends.base.schema.timezone')
+    def test_add_datefield_and_datetimefield_use_effective_default(self, mocked_datetime, mocked_tz):
+        """
+        effective_default() should be used for DateField, DateTimeField, and
+        TimeField if auto_now or auto_add_now is set (#25005).
+        """
+        now = datetime.datetime(month=1, day=1, year=2000, hour=1, minute=1)
+        now_tz = datetime.datetime(month=1, day=1, year=2000, hour=1, minute=1, tzinfo=UTC())
+        mocked_datetime.now = mock.MagicMock(return_value=now)
+        mocked_tz.now = mock.MagicMock(return_value=now_tz)
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        # Check auto_now/auto_now_add attributes are not defined
+        columns = self.column_classes(Author)
+        self.assertNotIn("dob_auto_now", columns)
+        self.assertNotIn("dob_auto_now_add", columns)
+        self.assertNotIn("dtob_auto_now", columns)
+        self.assertNotIn("dtob_auto_now_add", columns)
+        self.assertNotIn("tob_auto_now", columns)
+        self.assertNotIn("tob_auto_now_add", columns)
+        # Create a row
+        Author.objects.create(name='Anonymous1')
+        # Ensure fields were added with the correct defaults
+        dob_auto_now = DateField(auto_now=True)
+        dob_auto_now.set_attributes_from_name('dob_auto_now')
+        self.check_added_field_default(
+            editor, Author, dob_auto_now, 'dob_auto_now', now.date(),
+            lambda x: x.date()
+        )
+
+        dob_auto_now_add = DateField(auto_now_add=True)
+        dob_auto_now_add.set_attributes_from_name('dob_auto_now_add')
+        self.check_added_field_default(
+            editor, Author, dob_auto_now_add, 'dob_auto_now_add', now.date(),
+            lambda x: x.date()
+        )
+
+        dtob_auto_now = DateTimeField(auto_now=True)
+        dtob_auto_now.set_attributes_from_name('dtob_auto_now')
+        self.check_added_field_default(
+            editor, Author, dtob_auto_now, 'dtob_auto_now', now
+        )
+
+        dt_tm_of_birth_auto_now_add = DateTimeField(auto_now_add=True)
+        dt_tm_of_birth_auto_now_add.set_attributes_from_name('dtob_auto_now_add')
+        self.check_added_field_default(
+            editor, Author, dt_tm_of_birth_auto_now_add, 'dtob_auto_now_add', now
+        )
+
+        tob_auto_now = TimeField(auto_now=True)
+        tob_auto_now.set_attributes_from_name('tob_auto_now')
+        self.check_added_field_default(
+            editor, Author, tob_auto_now, 'tob_auto_now', now.time(),
+            lambda x: x.time()
+        )
+
+        tob_auto_now_add = TimeField(auto_now_add=True)
+        tob_auto_now_add.set_attributes_from_name('tob_auto_now_add')
+        self.check_added_field_default(
+            editor, Author, tob_auto_now_add, 'tob_auto_now_add', now.time(),
+            lambda x: x.time()
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25005

Also fixed autodetector in migrations to skip promt for default for these fields.

Rebase / fix of #4902 