### PR TITLE
Fixed #25759 -- Added keyword arguments to various Expressions.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -534,7 +534,7 @@ class Func(Expression):
             c.source_expressions[pos] = arg.resolve_expression(query, allow_joins, reuse, summarize, for_save)
         return c
 
-    def as_sql(self, compiler, connection, function=None, template=None):
+    def as_sql(self, compiler, connection, function=None, template=None, arg_joiner=None, **extra_context):
         connection.ops.check_expression_support(self)
         sql_parts = []
         params = []
@@ -542,16 +542,24 @@ class Func(Expression):
             arg_sql, arg_params = compiler.compile(arg)
             sql_parts.append(arg_sql)
             params.extend(arg_params)
-        if function is None:
-            self.extra['function'] = self.extra.get('function', self.function)
-        else:
-            self.extra['function'] = function
-        self.extra['expressions'] = self.extra['field'] = self.arg_joiner.join(sql_parts)
-        template = template or self.extra.get('template', self.template)
-        return template % self.extra, params
+        data = self.extra.copy()
+        data.update(**extra_context)
+        # we add to the data dict because these values could have been supplied
+        # in self.extra also
+        if function is not None:
+            data['function'] = function
+        if template is not None:
+            data['template'] = template
+        if arg_joiner is not None:
+            data['arg_joiner'] = arg_joiner
+        data.setdefault('function', self.function)
+        template = data.get('template', self.template)
+        arg_joiner = data.get('arg_joiner', self.arg_joiner)
+        data['expressions'] = data['field'] = arg_joiner.join(sql_parts)
+        return template % data, params
 
-    def as_sqlite(self, *args, **kwargs):
-        sql, params = self.as_sql(*args, **kwargs)
+    def as_sqlite(self, compiler, connection):
+        sql, params = self.as_sql(compiler, connection)
         try:
             if self.output_field.get_internal_type() == 'DecimalField':
                 sql = 'CAST(%s AS NUMERIC)' % sql
@@ -778,9 +786,9 @@ class When(Expression):
         c.result = c.result.resolve_expression(query, allow_joins, reuse, summarize, for_save)
         return c
 
-    def as_sql(self, compiler, connection, template=None):
+    def as_sql(self, compiler, connection, template=None, **extra_context):
         connection.ops.check_expression_support(self)
-        template_params = {}
+        template_params = extra_context
         sql_params = []
         condition_sql, condition_params = compiler.compile(self.condition)
         template_params['condition'] = condition_sql
@@ -849,22 +857,24 @@ class Case(Expression):
         c.cases = c.cases[:]
         return c
 
-    def as_sql(self, compiler, connection, template=None, extra=None):
+    def as_sql(self, compiler, connection, template=None, case_joiner=None, **extra_context):
         connection.ops.check_expression_support(self)
         if not self.cases:
             return compiler.compile(self.default)
-        template_params = dict(extra) if extra else {}
+        template_params = self.extra.copy()
+        template_params.update(extra_context)
         case_parts = []
         sql_params = []
         for case in self.cases:
             case_sql, case_params = compiler.compile(case)
             case_parts.append(case_sql)
             sql_params.extend(case_params)
-        template_params['cases'] = self.case_joiner.join(case_parts)
+        case_joiner = case_joiner or self.case_joiner
+        template_params['cases'] = case_joiner.join(case_parts)
         default_sql, default_params = compiler.compile(self.default)
         template_params['default'] = default_sql
         sql_params.extend(default_params)
-        template = template or self.template
+        template = template_params.get('template', self.template)
         sql = template % template_params
         if self._output_field_or_none is not None:
             sql = connection.ops.unification_cast_sql(self.output_field) % sql
@@ -995,14 +1005,16 @@ class OrderBy(BaseExpression):
     def get_source_expressions(self):
         return [self.expression]
 
-    def as_sql(self, compiler, connection):
+    def as_sql(self, compiler, connection, template=None, **extra_context):
         connection.ops.check_expression_support(self)
         expression_sql, params = compiler.compile(self.expression)
         placeholders = {
             'expression': expression_sql,
             'ordering': 'DESC' if self.descending else 'ASC',
         }
-        return (self.template % placeholders).rstrip(), params
+        placeholders.update(extra_context)
+        template = template or self.template
+        return (template % placeholders).rstrip(), params
 
     def get_group_by_cols(self):
         cols = []

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -261,6 +261,18 @@ The ``Func`` API is as follows:
         different number of expressions, ``TypeError`` will be raised. Defaults
         to ``None``.
 
+    .. method:: as_sql(compiler, connection, function=None, template=None, arg_joiner=None, **extra_context)
+
+        .. versionchanged:: 1.10
+
+            Added support for key-word arguments.
+
+        Provides additional key-word arguments that allow users or subclasses
+        to override data used to construct the generated SQL string for this
+        particular invocation. Providing data at this time helps to prevent
+        mutating attributes on ``self`` in ``as_vendorname`` methods which can
+        affect future invocations on different backends.
+
 The ``*expressions`` argument is a list of positional expressions that the
 function will be applied to. The expressions will be converted to strings,
 joined together with ``arg_joiner``, and then interpolated into the ``template``
@@ -271,10 +283,11 @@ assumed to be column references and will be wrapped in ``F()`` expressions
 while other values will be wrapped in ``Value()`` expressions.
 
 The ``**extra`` kwargs are ``key=value`` pairs that can be interpolated
-into the ``template`` attribute. Note that the keywords ``function`` and
-``template`` can be used to replace the ``function`` and ``template``
-attributes respectively, without having to define your own class.
-``output_field`` can be used to define the expected return type.
+into the ``template`` attribute. Note that the keywords ``function``,
+``template`` and ``arg_joiner`` can be used to replace the ``function``,
+``template`` and ``arg_joiner`` attributes respectively, without having to
+define your own class. ``output_field`` can be used to define the expected
+return type.
 
 ``Aggregate()`` expressions
 ---------------------------
@@ -560,7 +573,7 @@ an ``__init__()`` method to set some attributes::
   class Coalesce(Expression):
       template = 'COALESCE( %(expressions)s )'
 
-      def __init__(self, expressions, output_field, **extra):
+      def __init__(self, expressions, output_field):
         super(Coalesce, self).__init__(output_field=output_field)
         if len(expressions) < 2:
             raise ValueError('expressions must have at least 2 elements')
@@ -568,7 +581,6 @@ an ``__init__()`` method to set some attributes::
             if not hasattr(expression, 'resolve_expression'):
                 raise TypeError('%r is not an Expression' % expression)
         self.expressions = expressions
-        self.extra = extra
 
 We do some basic validation on the parameters, including requiring at least
 2 columns or values, and ensuring they are expressions. We are requiring
@@ -588,22 +600,30 @@ expressions::
 
 Next, we write the method responsible for generating the SQL::
 
-    def as_sql(self, compiler, connection):
+    def as_sql(self, compiler, connection, template=None):
         sql_expressions, sql_params = [], []
         for expression in self.expressions:
             sql, params = compiler.compile(expression)
             sql_expressions.append(sql)
             sql_params.extend(params)
-        self.extra['expressions'] = ','.join(sql_expressions)
-        return self.template % self.extra, sql_params
+        template = template or self.template
+        data = {'expressions': ','.join(sql_expressions)}
+        return template % data, params
 
     def as_oracle(self, compiler, connection):
         """
         Example of vendor specific handling (Oracle in this case).
         Let's make the function name lowercase.
         """
-        self.template = 'coalesce( %(expressions)s )'
-        return self.as_sql(compiler, connection)
+        return self.as_sql(compiler, connection, template='coalesce( %(expressions)s )')
+
+``as_sql`` methods can support custom key-word arguments, allowing
+``as_vendorname`` methods to override data used to generate the SQL string.
+Allowing changes at run time via ``as_sql`` key-word arguments is preferable to
+mutating ``self`` within ``as_vendorname`` methods, because mutating ``self``
+can lead to errors when running on multiple database backends. If your class
+relies on class attributes to define data, consider allowing overrides in your
+``as_sql`` method.
 
 We generate the SQL for each of the ``expressions`` by using the
 ``compiler.compile()`` method, and join the result together with commas.

--- a/docs/ref/models/lookups.txt
+++ b/docs/ref/models/lookups.txt
@@ -94,6 +94,29 @@ following methods:
     ``compiler.compile(expression)`` should be used. The ``compiler.compile()``
     method will take care of calling vendor-specific methods of the expression.
 
+    Custom key-word arguments may be defined if it's likely that
+    ``as_vendorname`` methods or subclasses will need to supply data to override
+    the generation of the SQL string.
+
+    The following example is taken from the Django ConcatPair-expression that
+    shows the use of key-word arguments, defined by ``Func``, for overriding
+    ``as_sql``-methods.  By providing key-word arguments the ``as_mysql``
+    method is able to change the name of the function being called, as well as
+    the template used to generate the SQL string.
+
+    .. snippet::
+        :filename: django/db/models/functions.py
+
+        class ConcatPair(Func):
+            ...
+            function = 'CONCAT'
+            ...
+
+            def as_mysql(self, compiler, connection):
+                return super(ConcatPair, self).as_sql(
+                    compiler, connection, function='CONCAT_WS', template="%(function)s('', %(expressions)s)"
+                )
+
 .. method:: as_vendorname(self, compiler, connection)
 
     Works like ``as_sql()`` method. When an expression is compiled by

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -207,6 +207,10 @@ Database backends
 
 * Temporal data subtraction was unified on all backends.
 
+* Added key-word arguments to ``as_sql`` methods of various Expressions to
+  prevent mutating ``self``, which is not safe when using multiple database
+  backends.
+
 * If the database supports it, backends can set
   ``DatabaseFeatures.can_return_ids_from_bulk_insert=True`` and implement
   ``DatabaseOperations.fetch_returned_insert_ids()`` to set primary keys


### PR DESCRIPTION
Takes over from #6147 which got a little confusing. I've removed `**kwargs` from most `as_sql` methods, and added explicit key word parameters where it made sense. The changes I've made have been rebased onto the original commit made by @kaifeldhoff.