### PR TITLE
Fixed #26373 -- Fixed reverse lookup crash with a ForeignKey to_field in a subquery.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1132,7 +1132,7 @@ class QuerySet(object):
             # if they are set up to select only a single field.
             if len(self._fields or self.model._meta.concrete_fields) > 1:
                 raise TypeError('Cannot use multi-field values as a filter value.')
-        else:
+        elif self.model != field.model:
             # If the query is used as a subquery for a ForeignKey with non-pk
             # target field, make sure to select the target field in the subquery.
             foreign_fields = getattr(field, 'foreign_related_fields', ())

--- a/docs/releases/1.9.5.txt
+++ b/docs/releases/1.9.5.txt
@@ -27,3 +27,6 @@ Bugfixes
   earlier versions of Django.
 
 * Fixed a memory leak in the cached template loader (:ticket:`26306`).
+
+* Fixed a crash when using a reverse lookup with a subquery when the ``ForeignKey``
+  has a ``to_field`` set to something other than the primary key. (:ticket:`26373`)

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2427,6 +2427,10 @@ class ToFieldTests(TestCase):
             set(Eaten.objects.filter(food__in=Food.objects.filter(name='apple').values('eaten__meal'))),
             set()
         )
+        self.assertEqual(
+            set(Food.objects.filter(eaten__in=Eaten.objects.filter(meal='lunch'))),
+            {apple}
+        )
 
     def test_reverse_in(self):
         apple = Food.objects.create(name="apple")


### PR DESCRIPTION
This fixes a regression from #6117. 

I haven't looked too deep in to the details of this. So forgive me if the fix is a bit quick and hacky (if it's fine then great!).

Any feedback is welcome.