### PR TITLE
Refs #26367 -- Removed obsolete _size cache on FieldField.

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -87,9 +87,6 @@ class FieldFile(File):
         name = self.field.generate_filename(self.instance, name)
         self.name = self.storage.save(name, content, max_length=self.field.max_length)
         setattr(self.instance, self.field.name, self.name)
-
-        # Update the filesize cache
-        self._size = content.size
         self._committed = True
 
         # Save the object because it has changed, unless save is False
@@ -110,10 +107,6 @@ class FieldFile(File):
 
         self.name = None
         setattr(self.instance, self.field.name, self.name)
-
-        # Delete the filesize cache
-        if hasattr(self, '_size'):
-            del self._size
         self._committed = False
 
         if save:


### PR DESCRIPTION
The _size attribute is used in File.size but FieldFile overrides it.