### PR TITLE
Fixed #26265 -- Clarified RadioSelect container's HTML id.

### DIFF
--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -826,6 +826,11 @@ The field-specific output honors the form object's ``auto_id`` setting::
 Attributes of ``BoundField``
 ----------------------------
 
+.. attribute:: BoundField.auto_id
+
+    The HTML ID attribute for this ``BoundField``. Returns an empty string
+    if :attr:`Form.auto_id` is ``False``.
+
 .. attribute:: BoundField.data
 
     This property returns the data for this :class:`~django.forms.BoundField`

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -680,8 +680,8 @@ Selector and checkbox widgets
     simply includes ``{{ myform.beatles }}`` -- they'll be output in a ``<ul>``
     with ``<li>`` tags, as above.
 
-    The outer ``<ul>`` container will receive the ``id`` attribute defined on
-    the widget.
+    The outer ``<ul>`` container receives the ``id`` attribute of the widget,
+    if defined, or :attr:`BoundField.auto_id` otherwise.
 
     When looping over the radio buttons, the ``label`` and ``input`` tags include
     ``for`` and ``id`` attributes, respectively. Each radio button has an
@@ -702,8 +702,8 @@ Selector and checkbox widgets
           ...
         </ul>
 
-    The outer ``<ul>`` container will receive the ``id`` attribute defined on
-    the widget.
+    The outer ``<ul>`` container receives the ``id`` attribute of the widget,
+    if defined, or :attr:`BoundField.auto_id` otherwise.
 
 Like :class:`RadioSelect`, you can now loop over the individual checkboxes making
 up the lists. See the documentation of :class:`RadioSelect` for more details.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26265