### PR TITLE
Fixed #26293 - Moved append_slash logic outside of prepend_www logic

### DIFF
--- a/docs/releases/1.9.5.txt
+++ b/docs/releases/1.9.5.txt
@@ -34,3 +34,6 @@ Bugfixes
 * Fixed a crash when using a reverse lookup with a subquery when a
   ``ForeignKey`` has a ``to_field`` set to something other than the primary key
   (:ticket:`26373`).
+* Fixed a regression that caused a redirect to not be returned by
+  ``CommonMiddleware.process_request()`` for a missing trailing slash unless
+  it was already occurring due to prepending www. (:ticket:`26293`).


### PR DESCRIPTION
Moving logic required dynamically building the redirect_url as well as updating test_non_ascii_query_string_does_not_crash to expect a 301 from process_request instead of expecting no redirect.

Also added a regression test (and renamed another test to differentiate the two).