### PR TITLE
A humanized ImportError message in manage.py

### DIFF
--- a/django/conf/project_template/manage.py-tpl
+++ b/django/conf/project_template/manage.py-tpl
@@ -5,6 +5,10 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
-    from django.core.management import execute_from_command_line
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        raise ImportError("Django could not be imported. Are you sure it is \
+installed and available on your PATH variable?")
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
I've been teaching Django for several years in classes [like this](http://first-django-admin.readthedocs.org/). 

Again and again I've seen newbies flounder when they receive this error after running ``manage.py``.

```python
 % python manage.py
Traceback (most recent call last):
  File "manage.py", line 7, in <module>
    from django.core.management import execute_from_command_line
ImportError: No module named django.core.management
```

The root cause is almost always simple, like forgetting install Django with pip or neglecting to "activate" a virtual environment. But the Python jargon doesn't do much to help people new to our world connect the dots. 

My proposal: Catch that error and print out a more verbose message that explains to the user exactly what's wrong. Here's my draft. I'd welcome any changes, but I think something along these lines could better welcome new people into Django.

```python
 % python manage.py              
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    installed and available on your PATH variable?")
ImportError: Django could not be imported. Are you sure it is installed and available on your PATH variable?
```