### PR TITLE
Fixed #26381 -- Made UserCreationForm reusable with custom user models that define USERNAME_FIELD.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -82,7 +82,7 @@ class UserCreationForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(UserCreationForm, self).__init__(*args, **kwargs)
-        self.fields['username'].widget.attrs.update({'autofocus': ''})
+        self.fields[self._meta.model.USERNAME_FIELD].widget.attrs.update({'autofocus': ''})
 
     def clean_password2(self):
         password1 = self.cleaned_data.get("password1")

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -20,7 +20,7 @@ from django.utils.encoding import force_text
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
-from .models.custom_user import ExtensionUser
+from .models.custom_user import CustomUser, ExtensionUser
 from .settings import AUTH_TEMPLATES
 
 
@@ -132,6 +132,21 @@ class UserCreationFormTest(TestDataMixin, TestCase):
 
         data = {
             'username': 'testclient',
+            'password1': 'testclient',
+            'password2': 'testclient',
+            'date_of_birth': '1988-02-24',
+        }
+        form = CustomUserCreationForm(data)
+        self.assertTrue(form.is_valid())
+
+    def test_custom_form_with_different_username_field(self):
+        class CustomUserCreationForm(UserCreationForm):
+            class Meta(UserCreationForm.Meta):
+                model = CustomUser
+                fields = ('email', 'date_of_birth')
+
+        data = {
+            'email': 'test@client222.com',
             'password1': 'testclient',
             'password2': 'testclient',
             'date_of_birth': '1988-02-24',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26381