### PR TITLE
Fixed #26378 -- Fixed incorrect behavior in GenericIPAdressField

### DIFF
--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -54,7 +54,8 @@ def clean_ipv6_address(ip_str, unpack_ipv4=False,
 
     for index in range(len(hextets)):
         # Remove leading zeroes
-        hextets[index] = hextets[index].lstrip('0')
+        if '.' not in hextets[index]:
+            hextets[index] = hextets[index].lstrip('0')
         if not hextets[index]:
             hextets[index] = '0'
 

--- a/tests/utils_tests/test_ipv6.py
+++ b/tests/utils_tests/test_ipv6.py
@@ -50,6 +50,8 @@ class TestUtilsIPv6(unittest.TestCase):
         self.assertEqual(clean_ipv6_address('::ffff:0a0a:0a0a'), '::ffff:10.10.10.10')
         self.assertEqual(clean_ipv6_address('::ffff:1234:1234'), '::ffff:18.52.18.52')
         self.assertEqual(clean_ipv6_address('::ffff:18.52.18.52'), '::ffff:18.52.18.52')
+        self.assertEqual(clean_ipv6_address('::ffff:0.52.18.52'), '::ffff:0.52.18.52')
+        self.assertEqual(clean_ipv6_address('::ffff:0.0.0.0'), '::ffff:0.0.0.0')
 
     def test_unpacks_ipv4(self):
         self.assertEqual(clean_ipv6_address('::ffff:0a0a:0a0a', unpack_ipv4=True), '10.10.10.10')


### PR DESCRIPTION
Mixed IPv4 and IPv6 representation is not accepted if unpack_ipv4=False and the first byte of the IPv4 is "0"

References this: https://code.djangoproject.com/ticket/26378