### PR TITLE
Fixed #26391 -- Limited JSONField empty_values to None.

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -11,6 +11,7 @@ __all__ = ['JSONField']
 
 
 class JSONField(Field):
+    empty_values = [None]
     empty_strings_allowed = False
     description = _('A JSON object')
     default_error_messages = {

--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -7,6 +7,7 @@ __all__ = ['JSONField']
 
 
 class JSONField(forms.CharField):
+    empty_values = [None]
     default_error_messages = {
         'invalid': _("'%(value)s' value must be valid JSON."),
     }


### PR DESCRIPTION
In case of JSON, only None (null) should be considered an empty value.
Fix to https://code.djangoproject.com/ticket/26391