### PR TITLE
Fixed #26058 -- Delegated FileField's filename generation to the Storage.

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -156,6 +156,9 @@ details on these changes.
   ``Field.contribute_to_class()`` and ``virtual`` in
   ``Model._meta.add_field()`` will be removed.
 
+* ``FileField`` methods ``get_directory_name()`` and ``get_filename()`` will be
+  removed.
+
 .. _deprecation-removed-in-1.10:
 
 1.10

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -164,6 +164,16 @@ The ``Storage`` class
         Returns a filename based on the ``name`` parameter that's suitable
         for use on the target storage system.
 
+    .. method:: generate_filename(filename, instance, upload_to)
+
+        .. versionadded:: 1.10
+
+        Creates the final file name or path to be passed to the save method,
+        applying any defined upload_to of the model field and performing file
+        name validation.
+        By default uses the underlying os path operations, but should be overridden
+        to match any other file path manipulation requirement or custom code.
+
     .. method:: listdir(path)
 
         Lists the contents of the specified path, returning a 2-tuple of lists;

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -244,6 +244,10 @@ File Storage
   timezone-aware ``datetime`` if :setting:`USE_TZ` is ``True`` and a naive
   ``datetime`` in the local timezone otherwise.
 
+* The new  :meth:`Storage.generate_filename()
+  <django.core.files.storage.Storage.generate_filename>` method makes it easier
+  to implement custom storages that don't rely on the OS path behavior
+  previously handled by :class:`~django.db.models.FileField`.
 
 File Uploads
 ~~~~~~~~~~~~
@@ -733,6 +737,19 @@ Miscellaneous
 * If you override ``is_authenticated()`` or ``is_anonymous()`` in a custom user
   model, you must convert them to attributes or properties as described in
   :ref:`the deprecation note <user-is-auth-anon-deprecation>`.
+* :meth:`~django.core.files.storage.Storage.save` no longer replaces '\\' with
+  '/'. This behavior is moved to
+  :class:`~django.core.files.storage.FileSystemStorage` since this is a storage
+  specific implementation detail. Any Windows user with a custom storage
+  implementation that previously relied on this behavior will need to implement
+  it in the custom storage's ``save()`` method.
+
+* Private :class:`~django.db.models.FileField` methods ``get_directory_name()``
+  and ``get_filename()`` are no longer called (and are now deprecated) which is
+  a backwards incompatible change for users overriding those methods on custom
+  fields. To adopt same behavior, override ``FileField.generate_filename()`` or
+  :meth:`~django.core.files.storage.Storage.generate_filename` instead. It
+  might be enough to use :attr:`~django.db.models.FileField.upload_to` too.
 
 .. _deprecated-features-1.10:
 
@@ -928,6 +945,10 @@ Miscellaneous
   ``Field.contribute_to_class()`` and ``virtual`` in
   ``Model._meta.add_field()`` are deprecated in favor of ``private_only``
   and ``private``, respectively.
+* Private methods from :class:`~django.db.models.FileField` get_directory_name and
+  get_filename are now deprecated in favor to delegate this work to the underlying
+  storage class although they were never part of the public and
+  :meth:`~django.core.files.storage.Storage.generate_filename` is now recommended.
 
 .. _removed-features-1.10:
 


### PR DESCRIPTION
Related to #26382
First attempt at moving some logic performed by FileField which should
be actually performed by the Storage used. This changes makes it easier
to implement special kind of storages that do not rely on the operative
system (in particular os.path) which right now forces you to override
FileField.

All changes are backwards compatible for the exception of Storage.save
method, which was incorrectly replacing \ with / but was actually a
FileSystemStorage job. No tests were changed to make this change work
but anyone relying on this behaviour of Storage.save will start to get
unexpected results when running django on Windows.

The Storage class now has a new method 'generate_filename' which will
perform the old behaviour of FileField.generate_filename.

FileField.get_filename and FileField.get_directory_name are now
deprecated and should not be used since the job done by these two is now
done delegated to the Storage class. However FileField.generate_filename
will still exist (delegating the call to the Storage class) since it can
still be useful if other logic is required at the field level.

I have added tests for the deprecated methods and to the new
generate_filename at Storage, plus a custom Storage that simulates
(barely) an AWS S3 storage.

https://code.djangoproject.com/ticket/26058
https://code.djangoproject.com/ticket/26382
