### PR TITLE
Fixed #26390 -- Fixed order_by('?') breaking QuerySet aggregation.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -189,6 +189,9 @@ class BaseExpression(object):
 
     @cached_property
     def contributes_to_group_by(self):
+        for expr in self.get_source_expressions():
+            if expr and expr.contributes_to_group_by:
+                return True
         return self.contains_column_references
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -187,6 +187,10 @@ class BaseExpression(object):
                 return True
         return False
 
+    @cached_property
+    def contributes_to_group_by(self):
+        return self.contains_column_references
+
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
         """
         Provides the chance to do any preprocessing or validation before being
@@ -620,6 +624,8 @@ class DurationValue(Value):
 
 
 class RawSQL(Expression):
+    contributes_to_group_by = True
+
     def __init__(self, sql, params, output_field=None):
         if output_field is None:
             output_field = fields.Field()

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -109,7 +109,7 @@ class SQLCompiler(object):
             for col in cols:
                 expressions.append(col)
         for expr, (sql, params, is_ref) in order_by:
-            if expr.contains_aggregate:
+            if not expr.contributes_to_group_by:
                 continue
             # We can skip References to select clause, as all expressions in
             # the select clause are already part of the group by.

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -839,6 +839,37 @@ class AggregateTestCase(TestCase):
             max_books_per_rating,
             {'books_per_rating__max': 3})
 
+    def test_ticket26390(self):
+        """
+        Check that the random call does not break GROUP BY cluse when
+        used as ordering.
+        """
+        qs = Author.objects.annotate(contact_count=Count('book'))
+
+        self.assertQuerysetEqual(qs.order_by('contact_count'), [
+            ('Adrian Holovaty', 1),
+            ('Jacob Kaplan-Moss', 1),
+            ('Brad Dayley', 1),
+            ('James Bennett', 1),
+            ('Jeffrey Forcier', 1),
+            ('Paul Bissex', 1),
+            ('Wesley J. Chun', 1),
+            ('Stuart Russell', 1),
+            ('Peter Norvig', 2),
+        ], lambda o: (o.name, o.contact_count), ordered=False)
+
+        self.assertQuerysetEqual(qs.order_by('?'), [
+            ('Adrian Holovaty', 1),
+            ('Jacob Kaplan-Moss', 1),
+            ('Brad Dayley', 1),
+            ('James Bennett', 1),
+            ('Jeffrey Forcier', 1),
+            ('Paul Bissex', 1),
+            ('Wesley J. Chun', 1),
+            ('Stuart Russell', 1),
+            ('Peter Norvig', 2),
+        ], lambda o: (o.name, o.contact_count), ordered=False)
+
     def test_ticket17424(self):
         """
         Check that doing exclude() on a foreign model after annotate()

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -841,7 +841,7 @@ class AggregateTestCase(TestCase):
 
     def test_ticket26390(self):
         """
-        Check that the random call does not break GROUP BY cluse when
+        Check that the random call does not break GROUP BY clause when
         used as ordering.
         """
         qs = Author.objects.annotate(contact_count=Count('book'))


### PR DESCRIPTION
Adds a "contributes_to_group_by" attribute/property to expression that controls whether it should be included in the GROUP BY clause. The random expression sets this to False.

I am not very familiar with the ORM module, to be honest, and would love some advice on this.
