### PR TITLE
Fixed #25388 -- Added an option to allow disabling of migrations running during test database creation

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -48,8 +48,10 @@ class MigrationLoader(object):
         if load:
             self.build_graph()
 
-    @classmethod
-    def migrations_module(cls, app_label):
+    def migrations_module(self, app_label):
+        if (self.connection is not None and
+                not self.connection.settings_dict.get('TEST', {}).get('MIGRATE', True)):
+            return None
         if app_label in settings.MIGRATION_MODULES:
             return settings.MIGRATION_MODULES[app_label]
         else:

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -37,7 +37,7 @@ class MigrationQuestioner(object):
             app_config = apps.get_app_config(app_label)
         except LookupError:         # It's a fake app.
             return self.defaults.get("ask_initial", False)
-        migrations_import_path = MigrationLoader.migrations_module(app_config.label)
+        migrations_import_path = MigrationLoader(None, load=False).migrations_module(app_config.label)
         if migrations_import_path is None:
             # It's an application with migrations disabled.
             return self.defaults.get("ask_initial", False)

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -221,7 +221,7 @@ class MigrationWriter(object):
 
     @property
     def basedir(self):
-        migrations_package_name = MigrationLoader.migrations_module(self.migration.app_label)
+        migrations_package_name = MigrationLoader(None, load=False).migrations_module(self.migration.app_label)
 
         if migrations_package_name is None:
             raise ValueError(

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -710,6 +710,18 @@ The creation-order dependencies of the database. See the documentation
 on :ref:`controlling the creation order of test databases
 <topics-testing-creation-dependencies>` for details.
 
+.. setting:: TEST_MIGRATE
+
+``MIGRATE``
+^^^^^^^^^^^
+
+.. versionadded:: 1.10
+
+Default: ``True``
+
+If it is set to ``False``, Django won't use existing migrations to create a
+test database.
+
 .. setting:: TEST_MIRROR
 
 ``MIRROR``

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -394,6 +394,9 @@ Tests
   and run selectively with the new :option:`test --tag` and :option:`test
   --exclude-tag` options.
 
+* Added the :setting:`DATABASES['TEST']['MIGRATE'] <TEST_MIGRATE>` option to
+  allow disabling of migrations running during test database creation.
+
 URLs
 ~~~~
 

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from unittest import skipIf
 
-from django.db import connection, connections
+from django.db import ConnectionHandler, connection, connections
 from django.db.migrations.exceptions import AmbiguityError, NodeNotFoundError
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
@@ -199,6 +199,23 @@ class LoaderTests(TestCase):
         MIGRATION_MODULES allows disabling of migrations for a particular app.
         """
         migration_loader = MigrationLoader(connection)
+        self.assertEqual(migration_loader.migrated_apps, set())
+        self.assertEqual(migration_loader.unmigrated_apps, {'migrated_app'})
+
+    @override_settings(
+        INSTALLED_APPS=['migrations.migrations_test_apps.migrated_app'],
+    )
+    def test_disable_migrations(self):
+        connections = ConnectionHandler({
+            'default': {
+                'NAME': 'dummy',
+                'ENGINE': 'django.db.backends.sqlite3',
+                'TEST': {
+                    'MIGRATE': False,
+                },
+            },
+        })
+        migration_loader = MigrationLoader(connections['default'])
         self.assertEqual(migration_loader.migrated_apps, set())
         self.assertEqual(migration_loader.unmigrated_apps, {'migrated_app'})
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25388