### PR TITLE
Fixed #26387 -- Restored the functionality of the admin's raw_id_fields in list_editable.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -162,6 +162,14 @@
             }
         });
         $('.related-widget-wrapper select').trigger('change');
+        $('.related-lookup').click(function(e) {
+            e.preventDefault();
+            var event = $.Event('django:lookup-related');
+            $(this).trigger(event);
+            if (!event.isDefaultPrevented()) {
+                showRelatedObjectLookupPopup(this);
+            }
+        });
     });
 
 })(django.jQuery);

--- a/django/contrib/admin/static/admin/js/change_form.js
+++ b/django/contrib/admin/static/admin/js/change_form.js
@@ -12,14 +12,6 @@
                 showAddAnotherPopup(this);
             }
         });
-        $('.related-lookup').click(function(e) {
-            e.preventDefault();
-            var event = $.Event('django:lookup-related');
-            $(this).trigger(event);
-            if (!event.isDefaultPrevented()) {
-                showRelatedObjectLookupPopup(this);
-            }
-        });
 
         if (modelName) {
             $('form#' + modelName + '_form :input:visible:enabled:first').focus();

--- a/docs/releases/1.8.12.txt
+++ b/docs/releases/1.8.12.txt
@@ -15,3 +15,6 @@ Bugfixes
 
 * Fixed data loss on SQLite where ``DurationField`` values with fractional
   seconds could be saved as ``None`` (:ticket:`26324`).
+
+* Restored the functionality of the admin's ``raw_id_fields`` in
+  ``list_editable`` (:ticket:`26387`).

--- a/docs/releases/1.9.5.txt
+++ b/docs/releases/1.9.5.txt
@@ -37,3 +37,6 @@ Bugfixes
 
 * Fixed a regression in ``CommonMiddleware`` that caused spurious warnings in
   logs on requests missing a trailing slash (:ticket:`26293`).
+
+* Restored the functionality of the admin's ``raw_id_fields`` in
+  ``list_editable`` (:ticket:`26387`).

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -1007,5 +1007,13 @@ site.register(Group, GroupAdmin)
 site2 = admin.AdminSite(name="namespaced_admin")
 site2.register(User, UserAdmin)
 site2.register(Group, GroupAdmin)
+site2.register(ParentWithUUIDPK)
+site2.register(
+    RelatedWithUUIDPKModel,
+    list_display=['pk', 'parent'],
+    list_editable=['parent'],
+    raw_id_fields=['parent'],
+)
+
 site7 = admin.AdminSite(name="admin7")
 site7.register(Article, ArticleAdmin2)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26387