### PR TITLE
Fixed #11560 -- Allowed proxy model multiple-inheritance from the same concrete base model.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -177,10 +177,10 @@ class ModelBase(type):
                         )
                     else:
                         continue
-                if base is not None:
-                    raise TypeError("Proxy model '%s' has more than one non-abstract model base class." % name)
-                else:
+                if base is None:
                     base = parent
+                elif parent._meta.concrete_model is not base._meta.concrete_model:
+                    raise TypeError("Proxy model '%s' has more than one non-abstract model base class." % name)
             if base is None:
                 raise TypeError("Proxy model '%s' has no non-abstract model base class." % name)
             new_class._meta.setup_proxy(base)

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -359,6 +359,9 @@ Models
 
 * Added the :class:`~django.db.models.functions.Cast` database function.
 
+* A proxy model can now inherit multiple proxy model classes, if they all
+  share a common non-abstract parent class.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1232,6 +1232,15 @@ provide any connection between the rows in the different database tables. A
 proxy model can inherit from any number of abstract model classes, providing
 they do *not* define any model fields.
 
+A proxy model is allowed to inherit from any number of proxy model classes, as
+long as they all share a common non-abstract parent class.
+
+.. versionchanged:: 1.10
+
+In earlier versions, a proxy model was allowed to have only one concrete base
+model class. It can now have additional base classes if they all share the
+same concrete class.
+
 Proxy model managers
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/proxy_models/models.py
+++ b/tests/proxy_models/models.py
@@ -110,7 +110,17 @@ class UserProxy(User):
         proxy = True
 
 
+class AnotherUserProxy(User):
+    class Meta:
+        proxy = True
+
+
 class UserProxyProxy(UserProxy):
+    class Meta:
+        proxy = True
+
+
+class MultiUserProxy(UserProxy, AnotherUserProxy):
     class Meta:
         proxy = True
 


### PR DESCRIPTION
Fixed [#11560](https://code.djangoproject.com/ticket/11560/).