### PR TITLE
Fixed #21734 -- Handled ProtectedError on POST to admin's delete_selected action

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -38,7 +38,7 @@ def delete_selected(modeladmin, request, queryset):
 
     # The user has already confirmed the deletion.
     # Do the deletion and return a None to display the change list view again.
-    if request.POST.get('post'):
+    if request.POST.get('post') and not protected:
         if perms_needed:
             raise PermissionDenied
         n = queryset.count()

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3123,6 +3123,11 @@ class AdminActionsTest(TestCase):
             'action': 'delete_selected',
             'index': 0,
         }
+        delete_confirmation_data = {
+            ACTION_CHECKBOX_NAME: [q1.pk],
+            'action': 'delete_selected',
+            'post': 'yes',
+        }
 
         response = self.client.post(reverse('admin:admin_views_question_changelist'), action_data)
 
@@ -3137,6 +3142,12 @@ class AdminActionsTest(TestCase):
             '<li>Answer: <a href="%s">Yes.</a></li>' % reverse('admin:admin_views_answer_change', args=(a2.pk,)),
             html=True
         )
+
+        # A POST request to delete protected objects should display the page
+        # which says the deletion is prohibited.
+        response = self.client.post(reverse('admin:admin_views_question_changelist'), delete_confirmation_data)
+        self.assertEqual(Question.objects.count(), 2)
+        self.assertContains(response, "would require deleting the following protected related objects")
 
     def test_model_admin_default_delete_action_no_change_url(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/21734

Approach is similar to that used to solve [#26235](https://code.djangoproject.com/ticket/26235) in https://github.com/django/django/commit/49ac10b4de03279da9d67aeac5cb8561fc055085.