### PR TITLE
Fixed #26416 -- Fixed references to previous tutorial numbers in docs/intro/reusable-apps.txt.

### DIFF
--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -2,11 +2,11 @@
 Advanced tutorial: How to write reusable apps
 =============================================
 
-This advanced tutorial begins where :doc:`Tutorial 6 </intro/tutorial06>`
+This advanced tutorial begins where :doc:`Tutorial 7 </intro/tutorial07>`
 left off. We'll be turning our Web-poll into a standalone Python package
 you can reuse in new projects and share with other people.
 
-If you haven't recently completed Tutorials 1–6, we encourage you to review
+If you haven't recently completed Tutorials 1–7, we encourage you to review
 these so that your example project matches the one described below.
 
 Reusability matters


### PR DESCRIPTION
The "Advanced tutorial: How to write reusable apps" page references the previous tutorial, calling it number 6. However, it appears that it should reference tutorial 7.

 - Tutorial 6 does not point the user to this page; Tutorial 7 does.
 - Line 90 assumes the user has completed Tutorial 7.
 - Tutorial 7 is the last page in the basic tutorial.