### PR TITLE
Fixed #26421 -- Refactored ModelSignal to use Apps.lazy_model_operation()

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -372,29 +372,35 @@ class Apps(object):
         The function passed to this method must accept exactly n models as
         arguments, where n=len(model_keys).
         """
-        # If this function depends on more than one model, we recursively turn
-        # it into a chain of functions that accept a single model argument and
-        # pass each in turn to lazy_model_operation.
-        model_key, more_models = model_keys[0], model_keys[1:]
-        if more_models:
-            supplied_fn = function
-
-            def function(model):
-                next_function = partial(supplied_fn, model)
-                # Annotate the function with its field for retrieval in
-                # migrations.state.StateApps.
-                if getattr(supplied_fn, 'keywords', None):
-                    next_function.field = supplied_fn.keywords.get('field')
-                self.lazy_model_operation(next_function, *more_models)
-
-        # If the model is already loaded, pass it to the function immediately.
-        # Otherwise, delay execution until the class is prepared.
-        try:
-            model_class = self.get_registered_model(*model_key)
-        except LookupError:
-            self._pending_operations[model_key].append(function)
+        # Base case: no arguments, just execute the function.
+        if not model_keys:
+            function()
+        # Recursive case: take the head of model_keys, wait for the
+        # corresponding model class to be imported and registered, then apply
+        # that argument to the supplied function. Pass the resulting partial
+        # to lazy_model_operation() along with the remaining model args and
+        # repeat until all models are loaded and all arguments are applied.
         else:
-            function(model_class)
+            next_model, more_models = model_keys[0], model_keys[1:]
+
+            # This will be executed after the class corresponding to next_model
+            # has been imported and registered. The `func` attribute provides
+            # duck-type compatibility with partials.
+            def apply_next_model(model):
+                next_function = partial(apply_next_model.func, model)
+                self.lazy_model_operation(next_function, *more_models)
+            apply_next_model.func = function
+
+            # If the model has already been imported and registered, partially
+            # apply it to the function now. If not, add it to the list of
+            # pending operations for the model, where it will be executed with
+            # the model class as its sole argument once the model is ready.
+            try:
+                model_class = self.get_registered_model(*next_model)
+            except LookupError:
+                self._pending_operations[next_model].append(apply_next_model)
+            else:
+                apply_next_model(model_class)
 
     def do_pending_operations(self, model):
         """

--- a/django/core/checks/model_checks.py
+++ b/django/core/checks/model_checks.py
@@ -63,3 +63,99 @@ def check_model_signals(app_configs=None, **kwargs):
                         )
                     )
     return errors
+
+
+def _check_lazy_references(apps, ignore=None):
+    """
+    Ensure all lazy (i.e. string) model references have been resolved.
+
+    Lazy references are used in various places throughout Django, primarily in
+    related fields and model signals. Identify those common cases and provide
+    more helpful error messages for them.
+
+    The ignore parameter is used by StateApps to exclude swappable models from
+    this check.
+    """
+    pending_models = set(apps._pending_operations) - (ignore or set())
+
+    # Short circuit if there aren't any errors.
+    if not pending_models:
+        return []
+
+    def extract_operation(obj):
+        """
+        Take a callable found in Apps._pending_operations and identify the
+        original callable passed to Apps.lazy_model_operation(). If that
+        callable was a partial, return the inner, non-partial function and
+        any arguments and keyword arguments that were supplied with it.
+
+        obj is a callback defined locally in Apps.lazy_model_operation() and
+        annotated there with a `func` attribute so as to imitate a partial.
+        """
+        operation, args, keywords = obj, [], {}
+        while hasattr(operation, 'func'):
+            # The or clauses are redundant but work around a bug (#25945) in
+            # functools.partial in Python 3 <= 3.5.1 and Python 2 <= 2.7.11.
+            args.extend(getattr(operation, 'args', []) or [])
+            keywords.update(getattr(operation, 'keywords', {}) or {})
+            operation = operation.func
+        return operation, args, keywords
+
+    def app_model_error(model_key):
+        try:
+            apps.get_app_config(model_key[0])
+            model_error = "app '%s' doesn't provide model '%s'" % model_key
+        except LookupError:
+            model_error = "app '%s' isn't installed" % model_key[0]
+        return model_error
+
+    # Here are several functions which return CheckMessage instances for the
+    # most common usages of lazy operations throughout Django. These functions
+    # take the model that was being waited on as an (app_label, modelname)
+    # pair, the original lazy function, and its positional and keyword args as
+    # determined by extract_operation().
+
+    def field_error(model_key, func, args, keywords):
+        error_msg = (
+            "The field %(field)s was declared with a lazy reference "
+            "to '%(model)s', but %(model_error)s."
+        )
+        params = {
+            'model': '.'.join(model_key),
+            'field': keywords['field'],
+            'model_error': app_model_error(model_key),
+        }
+        return Error(error_msg % params, obj=keywords['field'], id='fields.E307')
+
+    def default_error(model_key, func, args, keywords):
+        error_msg = "%(op)s contains a lazy reference to %(model)s, but %(model_error)s."
+        params = {
+            'op': func,
+            'model': '.'.join(model_key),
+            'model_error': app_model_error(model_key),
+        }
+        return Error(error_msg % params, obj=func, id='models.E022')
+
+    # Maps common uses of lazy operations to corresponding error functions
+    # defined above. If a key maps to None, no error will be produced.
+    # default_error() will be used for usages that don't appear in this dict.
+    known_lazy = {
+        ('django.db.models.fields.related', 'resolve_related_class'): field_error,
+        ('django.db.models.fields.related', 'set_managed'): None,
+    }
+
+    def build_error(model_key, func, args, keywords):
+        key = (func.__module__, func.__name__)
+        error_fn = known_lazy.get(key, default_error)
+        return error_fn(model_key, func, args, keywords) if error_fn else None
+
+    return sorted(filter(None, (
+        build_error(model_key, *extract_operation(func))
+        for model_key in pending_models
+        for func in apps._pending_operations[model_key]
+    )), key=lambda error: error.msg)
+
+
+@register(Tags.models)
+def check_lazy_references(app_configs=None, **kwargs):
+    return _check_lazy_references(apps)

--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -7,12 +7,18 @@ def make_model_tuple(model):
     corresponding ("app_label", "modelname") tuple. If a tuple is passed in,
     it's assumed to be a valid model tuple already and returned unchanged.
     """
-    if isinstance(model, tuple):
-        model_tuple = model
-    elif isinstance(model, six.string_types):
-        app_label, model_name = model.split(".")
-        model_tuple = app_label, model_name.lower()
-    else:
-        model_tuple = model._meta.app_label, model._meta.model_name
-    assert len(model_tuple) == 2, "Invalid model representation: %s" % model
-    return model_tuple
+    try:
+        if isinstance(model, tuple):
+            model_tuple = model
+        elif isinstance(model, six.string_types):
+            app_label, model_name = model.split(".")
+            model_tuple = app_label, model_name.lower()
+        else:
+            model_tuple = model._meta.app_label, model._meta.model_name
+        assert len(model_tuple) == 2
+        return model_tuple
+    except (ValueError, AssertionError):
+        raise ValueError(
+            "Invalid model reference '%s'. String model references "
+            "must be of the form 'app_label.ModelName'." % model
+        )

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -248,7 +248,8 @@ Signals
 ~~~~~~~
 
 * **signals.E001**: ``<handler>`` was connected to the ``<signal>`` signal with
-  a lazy reference to the ``<model>`` sender, which has not been installed.
+  a lazy reference to the sender ``<app label>.<model>``, but app ``<app label>``
+  isn't installed or doesn't provide model ``<model>``.
 
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -138,6 +138,9 @@ Models
 * **models.E020**: The ``<model>.check()`` class method is currently overridden.
 * **models.E021**: ``ordering`` and ``order_with_respect_to`` cannot be used
   together.
+* **models.E022**: ``<function>`` contains a lazy reference to
+  ``<app label>>.<model>``, but app ``<app label>`` isn't installed or
+  doesn't provide model ``<model>``.
 
 Fields
 ~~~~~~
@@ -200,6 +203,9 @@ Related Fields
   for ``<field name>``.
 * **fields.E306**: Related name must be a valid Python identifier or end with
   a ``'+'``.
+* **fields.E307**: The field ``<app label>.<model>.<field name>`` was declared
+  with a lazy reference to ``<app label>.<model>``, but app ``<app label>``
+  isn't installed or doesn't provide model ``<model>``.
 * **fields.E310**: No subset of the fields ``<field1>``, ``<field2>``, ... on
   model ``<model>`` is unique. Add ``unique=True`` on any of those fields or
   add at least a subset of them to a unique_together constraint.

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -449,6 +449,12 @@ class MigrateTests(MigrationTestBase):
         """
         call_command("migrate", "migrated_unapplied_app", stdout=six.StringIO())
 
+        # unmigrated_app.SillyModel has a foreign key to 'migrations.Tribble',
+        # but that model is only defined in a migration, so the global app
+        # registry never sees it and the reference is left dangling. Remove it
+        # to avoid problems in subsequent tests.
+        del apps._pending_operations[('migrations', 'tribble')]
+
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
     def test_migrate_record_replaced(self):
         """

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -661,9 +661,10 @@ class StateTests(SimpleTestCase):
         project_state = ProjectState()
         project_state.add_model(ModelState.from_model(Book))
         msg = (
-            "Unhandled pending operations for models:\n"
-            "  migrations.author (referred to by fields: migrations.Book.author)\n"
-            "  migrations.publisher (referred to by fields: migrations.Book.publisher)"
+            "The field migrations.Book.author was declared with a lazy reference "
+            "to 'migrations.author', but app 'migrations' doesn't provide model 'author'.\n"
+            "The field migrations.Book.publisher was declared with a lazy reference "
+            "to 'migrations.publisher', but app 'migrations' doesn't provide model 'publisher'."
         )
         with self.assertRaisesMessage(ValueError, msg):
             project_state.apps
@@ -672,9 +673,10 @@ class StateTests(SimpleTestCase):
         project_state = ProjectState()
         project_state.add_model(ModelState.from_model(Magazine))
         msg = (
-            "Unhandled pending operations for models:\n"
-            "  migrations.author (referred to by fields: "
-            "migrations.Magazine.authors, migrations.Magazine_authors.author)"
+            "The field migrations.Magazine.authors was declared with a lazy reference "
+            "to 'migrations.author\', but app 'migrations' doesn't provide model 'author'.\n"
+            "The field migrations.Magazine_authors.author was declared with a lazy reference "
+            "to \'migrations.author\', but app 'migrations' doesn't provide model 'author'."
         )
         with self.assertRaisesMessage(ValueError, msg):
             project_state.apps
@@ -682,10 +684,14 @@ class StateTests(SimpleTestCase):
         # And now with multiple models and multiple fields.
         project_state.add_model(ModelState.from_model(Book))
         msg = (
-            "Unhandled pending operations for models:\n"
-            "  migrations.author (referred to by fields: migrations.Book.author, "
-            "migrations.Magazine.authors, migrations.Magazine_authors.author)\n"
-            "  migrations.publisher (referred to by fields: migrations.Book.publisher)"
+            "The field migrations.Book.author was declared with a lazy reference "
+            "to 'migrations.author', but app 'migrations' doesn't provide model 'author'.\n"
+            "The field migrations.Book.publisher was declared with a lazy reference "
+            "to 'migrations.publisher', but app 'migrations' doesn't provide model 'publisher'.\n"
+            "The field migrations.Magazine.authors was declared with a lazy reference "
+            "to 'migrations.author', but app 'migrations' doesn't provide model 'author'.\n"
+            "The field migrations.Magazine_authors.author was declared with a lazy reference "
+            "to 'migrations.author', but app 'migrations' doesn't provide model 'author'."
         )
         with self.assertRaisesMessage(ValueError, msg):
             project_state.apps

--- a/tests/model_validation/tests.py
+++ b/tests/model_validation/tests.py
@@ -1,24 +1,11 @@
 from django.core import management
-from django.core.checks import Error, run_checks
+from django.core.checks import Error
 from django.core.checks.model_checks import _check_lazy_references
 from django.db import models
 from django.db.models.signals import post_init
 from django.test import SimpleTestCase
 from django.test.utils import isolate_apps, override_settings
 from django.utils import six
-
-
-class OnPostInit(object):
-    def __call__(self, **kwargs):
-        pass
-
-
-def on_post_init(**kwargs):
-    pass
-
-
-def dummy_function(model):
-    pass
 
 
 @override_settings(
@@ -35,32 +22,6 @@ class ModelValidationTest(SimpleTestCase):
         #       See: https://code.djangoproject.com/ticket/21375
         management.call_command("check", stdout=six.StringIO())
 
-    def test_model_signal(self):
-        unresolved_references = post_init.unresolved_references.copy()
-        post_init.connect(on_post_init, sender='missing-app.Model')
-        post_init.connect(OnPostInit(), sender='missing-app.Model')
-
-        errors = run_checks()
-        expected = [
-            Error(
-                "The 'on_post_init' function was connected to the 'post_init' "
-                "signal with a lazy reference to the 'missing-app.Model' "
-                "sender, which has not been installed.",
-                obj='model_validation.tests',
-                id='signals.E001',
-            ),
-            Error(
-                "An instance of the 'OnPostInit' class was connected to "
-                "the 'post_init' signal with a lazy reference to the "
-                "'missing-app.Model' sender, which has not been installed.",
-                obj='model_validation.tests',
-                id='signals.E001',
-            )
-        ]
-        self.assertEqual(errors, expected)
-
-        post_init.unresolved_references = unresolved_references
-
     @isolate_apps('django.contrib.auth', kwarg_name='apps')
     def test_lazy_reference_checks(self, apps):
 
@@ -70,11 +31,24 @@ class ModelValidationTest(SimpleTestCase):
             class Meta:
                 app_label = "model_validation"
 
+        class DummyClass(object):
+            def __call__(self, **kwargs):
+                pass
+
+            def dummy_method(self):
+                pass
+
+        def dummy_function(*args, **kwargs):
+            pass
+
         apps.lazy_model_operation(dummy_function, ('auth', 'imaginarymodel'))
         apps.lazy_model_operation(dummy_function, ('fanciful_app', 'imaginarymodel'))
 
-        errors = _check_lazy_references(apps)
+        post_init.connect(dummy_function, sender='missing-app.Model', apps=apps)
+        post_init.connect(DummyClass(), sender='missing-app.Model', apps=apps)
+        post_init.connect(DummyClass().dummy_method, sender='missing-app.Model', apps=apps)
 
+        errors = _check_lazy_references(apps)
         expected = [
             Error(
                 "%r contains a lazy reference to auth.imaginarymodel, "
@@ -89,6 +63,22 @@ class ModelValidationTest(SimpleTestCase):
                 id='models.E022',
             ),
             Error(
+                "An instance of class 'DummyClass' was connected to "
+                "the 'post_init' signal with a lazy reference to the sender "
+                "'missing-app.model', but app 'missing-app' isn't installed.",
+                hint=None,
+                obj='model_validation.tests',
+                id='signals.E001',
+            ),
+            Error(
+                "Bound method 'DummyClass.dummy_method' was connected to the "
+                "'post_init' signal with a lazy reference to the sender "
+                "'missing-app.model', but app 'missing-app' isn't installed.",
+                hint=None,
+                obj='model_validation.tests',
+                id='signals.E001',
+            ),
+            Error(
                 "The field model_validation.DummyModel.author was declared "
                 "with a lazy reference to 'model_validation.author', but app "
                 "'model_validation' isn't installed.",
@@ -96,6 +86,13 @@ class ModelValidationTest(SimpleTestCase):
                 obj=DummyModel.author.field,
                 id='fields.E307',
             ),
+            Error(
+                "The function 'dummy_function' was connected to the 'post_init' "
+                "signal with a lazy reference to the sender "
+                "'missing-app.model', but app 'missing-app' isn't installed.",
+                hint=None,
+                obj='model_validation.tests',
+                id='signals.E001',
+            ),
         ]
-
         self.assertEqual(errors, expected)

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -267,7 +267,7 @@ class LazyModelRefTest(BaseSignalTest):
         self.received.append(kwargs)
 
     def test_invalid_sender_model_name(self):
-        msg = "Specified sender must either be a model or a model name of the 'app_label.ModelName' form."
+        msg = "Invalid model reference 'invalid'. String model references must be of the form 'app_label.ModelName'."
         with self.assertRaisesMessage(ValueError, msg):
             signals.post_init.connect(self.receiver, sender='invalid')
 
@@ -285,10 +285,10 @@ class LazyModelRefTest(BaseSignalTest):
         finally:
             signals.post_init.disconnect(self.receiver, sender=Book)
 
-    @isolate_apps('signals')
-    def test_not_loaded_model(self):
+    @isolate_apps('signals', kwarg_name='apps')
+    def test_not_loaded_model(self, apps):
         signals.post_init.connect(
-            self.receiver, sender='signals.Created', weak=False
+            self.receiver, sender='signals.Created', weak=False, apps=apps
         )
 
         try:


### PR DESCRIPTION
Currently `ModelSignal` has its own mechanism for resolving model strings for no good reason. This patch refactors it to use the mechanism in `Apps` instead.

There are two commits here.

The first is a slight refactor of `Apps.lazy_model_operation` and related code that
* expresses its workings in a clearer way
* improves the system's generality by allowing 0 or more models rather than 1 or more
* introduces a new check to detect unresolved reference and output nicer error messages, and removes similar code in `StateApps`

The second commit refactors `ModelSignal` to use `Apps.lazy_model_operation`.