### PR TITLE
Fixed #26440 -- Added system checks to verify urlpatterns contains valid objects.

### DIFF
--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -72,15 +72,16 @@ def check_pattern_startswith_slash(pattern):
     if hasattr(pattern, 'regex') and not hasattr(pattern.regex, 'pattern'):
         errors.append(Warning(
             "url objects should have a property regex.pattern",
-            id="urls.W004"))
-    regex_pattern = pattern.regex.pattern
-    if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
-        warning = Warning(
-            "Your URL pattern {} has a regex beginning with a '/'. "
-            "Remove this slash as it is unnecessary.".format(describe_pattern(pattern)),
-            id="urls.W002",
-        )
-        errors.append(warning)
+            id="urls.W005"))
+    if not errors:
+        regex_pattern = pattern.regex.pattern
+        if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
+            warning = Warning(
+                "Your URL pattern {} has a regex beginning with a '/'. "
+                "Remove this slash as it is unnecessary.".format(describe_pattern(pattern)),
+                id="urls.W002",
+            )
+            errors.append(warning)
 
     return errors
 

--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -67,12 +67,24 @@ def check_pattern_startswith_slash(pattern):
     errors = []
 
     if not hasattr(pattern, 'regex'):
-        errors.append(Warning("url objects should have a property regex",
-        id="urls.W004"))
+        warning = Warning(
+            "Your URL pattern {} is not an object returned from the 'url()'"
+            "method. If you are using a custom object, it should provide a `pattern`"
+            "attribute that represents a regular expression object. Hint: Did you forget"
+            "to add `url` to your pattern?".format(describe_pattern(pattern)),
+            id="urls.W004"
+        )
+        errors.append(warning)
     if hasattr(pattern, 'regex') and not hasattr(pattern.regex, 'pattern'):
-        errors.append(Warning(
-            "url objects should have a property regex.pattern",
-            id="urls.W005"))
+        warning = Warning(
+            "Your URL pattern {} is not an object returned from the 'url()'"
+            "method. If you are using a custom object, it should provide a regular "
+            "expression object at pattern.regex.pattern where pattern is a text like object"
+            "representing the pattern. If you are not using a custom object, you may have"
+            "forgotten to add 'url' to your pattern.".format(describe_pattern(pattern)),
+            id="urls.W005"
+        )
+        errors.append(warning)
     if not errors:
         regex_pattern = pattern.regex.pattern
         if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):

--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -64,6 +64,15 @@ def check_pattern_startswith_slash(pattern):
     """
     Check that the pattern does not begin with a forward slash.
     """
+    errors = []
+
+    if not hasattr(pattern, 'regex'):
+        errors.append(Warning("url objects should have a property regex",
+        id="urls.W004"))
+    if hasattr(pattern, 'regex') and not hasattr(pattern.regex, 'pattern'):
+        errors.append(Warning(
+            "url objects should have a property regex.pattern",
+            id="urls.W004"))
     regex_pattern = pattern.regex.pattern
     if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
         warning = Warning(
@@ -71,9 +80,9 @@ def check_pattern_startswith_slash(pattern):
             "Remove this slash as it is unnecessary.".format(describe_pattern(pattern)),
             id="urls.W002",
         )
-        return [warning]
-    else:
-        return []
+        errors.append(warning)
+
+    return errors
 
 
 def check_pattern_name(pattern):

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -611,9 +611,12 @@ The following checks are performed on your URL configuration:
 * **urls.W003**: Your URL pattern ``<pattern>`` has a ``name``
   including a ``:``. Remove the colon, to avoid ambiguous namespace
   references.
-* **urls.W004**: Your URL pattern is not an object returned from the `url()`
-  method. If you are using a custom object, it should provide a `pattern`
-  attribute that represents a regular expression object.
-* **urls.W005**: Your URL pattern is not an object returned from the `url()`
+* **urls.W004**: Your URL pattern ``<pattern>`` is not an object returned from the ``url()``
+  method. If you are using a custom object, it should provide a ``pattern``
+  attribute that represents a regular expression object. Hint: Did you forget
+  to add ``url`` to your pattern?
+* **urls.W005**: "Your URL pattern ``<pattern>`` is not an object returned from the ``url()``
   method. If you are using a custom object, it should provide a regular
-  expression object at `pattern.regex` that has a text property `pattern`.
+  expression object at ``pattern.regex.pattern`` where ``pattern`` is a text like object
+  representing the pattern. If you are not using a custom object, you may have
+  forgotten to add ``'url'`` to your pattern.

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -611,7 +611,9 @@ The following checks are performed on your URL configuration:
 * **urls.W003**: Your URL pattern ``<pattern>`` has a ``name``
   including a ``:``. Remove the colon, to avoid ambiguous namespace
   references.
-* **urls.W004**: Your URL pattern is not an object returned from  the `url()`
-  method. If you are using a custom object, it should provide a `pattern.regex`
-  attribute that represents a regular expression; or you may have forgotten
-  to add the characters `url` and are passing a tuple.
+* **urls.W004**: Your URL pattern is not an object returned from the `url()`
+  method. If you are using a custom object, it should provide a `pattern`
+  attribute that represents a regular expression object.
+* **urls.W005**: Your URL pattern is not an object returned from the `url()`
+  method. If you are using a custom object, it should provide a regular
+  expression object at `pattern.regex` that has a text property `pattern`.

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -611,3 +611,7 @@ The following checks are performed on your URL configuration:
 * **urls.W003**: Your URL pattern ``<pattern>`` has a ``name``
   including a ``:``. Remove the colon, to avoid ambiguous namespace
   references.
+* **urls.W004**: Your URL pattern is not an object returned from  the `url()`
+  method. If you are using a custom object, it should provide a `pattern.regex`
+  attribute that represents a regular expression; or you may have forgotten
+  to add the characters `url` and are passing a tuple.

--- a/tests/check_framework/test_urls.py
+++ b/tests/check_framework/test_urls.py
@@ -27,7 +27,23 @@ class CheckUrlsTest(SimpleTestCase):
         self.assertEqual(warning.id, 'urls.W002')
         expected_msg = "Your URL pattern '/starting-with-slash/$' has a regex beginning with a '/'"
         self.assertIn(expected_msg, warning.msg)
+        result = check_url_config(tuple())
+        warning = result[0]
+        self.assertEqual(warning.id, 'urls.W004')
+        expected_msg = "url objects should have a property regex"
+        self.assertEqual(warning.msg, expected_msg)
 
+        class Foo:
+            pass
+
+        obj = Foo()
+        obj.pattern = ''
+        result = check_url_config(obj)
+        warning = result[0]
+        self.assertEqual(warning.id, 'urls.W004')
+        expected_msg = 'url objects should have a property regex.pattern'
+        self.assertEqual(warning.msg, expected_msg)
+    
     @override_settings(ROOT_URLCONF='check_framework.urls.name_with_colon')
     def test_name_with_colon(self):
         result = check_url_config(None)

--- a/tests/check_framework/test_urls.py
+++ b/tests/check_framework/test_urls.py
@@ -19,6 +19,22 @@ class CheckUrlsTest(SimpleTestCase):
         expected_msg = "Your URL pattern '^include-with-dollar$' uses include with a regex ending with a '$'."
         self.assertIn(expected_msg, warning.msg)
 
+    @override_settings(ROOT_URLCONF='check_framework.urls.contains_tuple')
+    def test_contains_tuple_not_url_instance(self):
+        result = check_url_config(None)
+        warning = result[0]
+        self.assertEqual(warning.id, 'urls.W004')
+        expected_msg = "url objects should have a property regex"
+        self.assertEqual(warning.msg, expected_msg)
+
+    @override_settings(ROOT_URLCONF='check_framework.urls.contains_unknown_object')
+    def test_contains_object_not_url_instance(self):
+        result = check_url_config(None)
+        warning = result[0]
+        self.assertEqual(warning.id, 'urls.W005')
+        expected_msg = 'url objects should have a property regex.pattern'
+        self.assertEqual(warning.msg, expected_msg)
+
     @override_settings(ROOT_URLCONF='check_framework.urls.beginning_with_slash')
     def test_beginning_with_slash(self):
         result = check_url_config(None)
@@ -27,23 +43,7 @@ class CheckUrlsTest(SimpleTestCase):
         self.assertEqual(warning.id, 'urls.W002')
         expected_msg = "Your URL pattern '/starting-with-slash/$' has a regex beginning with a '/'"
         self.assertIn(expected_msg, warning.msg)
-        result = check_url_config(tuple())
-        warning = result[0]
-        self.assertEqual(warning.id, 'urls.W004')
-        expected_msg = "url objects should have a property regex"
-        self.assertEqual(warning.msg, expected_msg)
 
-        class Foo:
-            pass
-
-        obj = Foo()
-        obj.pattern = ''
-        result = check_url_config(obj)
-        warning = result[0]
-        self.assertEqual(warning.id, 'urls.W004')
-        expected_msg = 'url objects should have a property regex.pattern'
-        self.assertEqual(warning.msg, expected_msg)
-    
     @override_settings(ROOT_URLCONF='check_framework.urls.name_with_colon')
     def test_name_with_colon(self):
         result = check_url_config(None)

--- a/tests/check_framework/urls/contains_tuple.py
+++ b/tests/check_framework/urls/contains_tuple.py
@@ -1,0 +1,7 @@
+from django.conf.urls import include, url
+
+urlpatterns = [
+    url('^', include([
+        (r'/starting-with-slash/$', lambda x: x),
+    ])),
+]

--- a/tests/check_framework/urls/contains_unknown_object.py
+++ b/tests/check_framework/urls/contains_unknown_object.py
@@ -1,7 +1,9 @@
 from django.conf.urls import include, url
 
+
 class Foo:
     pass
+
 
 obj = Foo()
 obj.regex = ''

--- a/tests/check_framework/urls/contains_unknown_object.py
+++ b/tests/check_framework/urls/contains_unknown_object.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include, url
+
+class Foo:
+    pass
+
+obj = Foo()
+obj.regex = ''
+
+urlpatterns = [
+    url('^', include([
+        obj,
+    ])),
+]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26440

1. Adding new tests for "fake" objects in URLs
2. Adding new tests for case where user forgets to type `url`, and ends up with a tuple `(r'', foo, name=df)`
3. Added new warnings.