### PR TITLE
Fixed #14131 -- Docs note about Pagination and large Querysets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -174,6 +174,7 @@ answer newbie questions, and generally made Django that much better:
     Daniele Procida <daniele@vurt.org>
     Daniel Greenfeld
     dAniel hAhler
+    Daniel Jilg <daniel@breakthesystem.org>
     Daniel Lindsley <daniel@toastdriven.com>
     Daniel Poelzleithner <http://poelzi.org/>
     Daniel Pyrathon <pirosb3@gmail.com>

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -146,6 +146,11 @@ Required arguments
     clause or with a default :attr:`~django.db.models.Options.ordering` on the
     model.
 
+    .. note::
+
+        If you are using a ``QuerySet`` with a very large number of items,
+        requesting high page numbers might be slow on some database backends.
+
 ``per_page``
     The maximum number of items to include on a page, not including orphans
     (see the ``orphans`` optional argument below).


### PR DESCRIPTION
Added a small note to the Pagination documentation that informs about the dangers of using very large Querysets as described by mlissner.

I refrained from using the warning tag because I don't feel this is too critical. I also didn't specify a number for "unusually" high, since both "high" number and "slow" is very subjective.