### PR TITLE
Fixed the example how to use PEP 257 docstrings to be compatible with PEP 257.

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -40,8 +40,10 @@ Python style
 * In docstrings, follow :pep:`257`. For example::
 
       def foo():
-          """
-          Calculate something and return the result.
+          """Calculate something and return the result.
+
+          Execute a complex calculation using something as input and returning
+          something else as result.
           """
           ...
 


### PR DESCRIPTION
The example showed a single line docstring in three distinct lines instead of
one. This commit changed that, to be an actual multi-line docstring.