### PR TITLE
Fixed #25699 -- Allowed using the test client if 'django.contrib.sessions' isn't in INSTALLED_APPS.

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -417,6 +417,9 @@ Tests
 * Added the :setting:`DATABASES['TEST']['MIGRATE'] <TEST_MIGRATE>` option to
   allow disabling of migrations during test database creation.
 
+* You can now login and use sessions with the test client even if
+  :mod:`django.contrib.sessions` is not in :setting:`INSTALLED_APPS`.
+
 URLs
 ~~~~
 

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -348,6 +348,13 @@ class ClientTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['user'].username, 'testclient')
 
+    @override_settings(
+        INSTALLED_APPS=['django.contrib.auth'],
+        SESSION_ENGINE='django.contrib.sessions.backends.file',
+    )
+    def test_view_with_login_when_sessions_app_is_not_installed(self):
+        self.test_view_with_login()
+
     def test_view_with_force_login(self):
         "Request a page that is protected with @login_required"
         # Get the page without logging in. Should result in 302.
@@ -589,6 +596,21 @@ class ClientTest(TestCase):
 
         # Check that the session was modified
         self.assertEqual(self.client.session['tobacconist'], 'hovercraft')
+
+    @override_settings(
+        INSTALLED_APPS=[],
+        SESSION_ENGINE='django.contrib.sessions.backends.file',
+    )
+    def test_sessions_app_is_not_installed(self):
+        self.test_session_modifying_view()
+
+    @override_settings(
+        INSTALLED_APPS=[],
+        SESSION_ENGINE='django.contrib.sessions.backends.nonexistent',
+    )
+    def test_session_engine_is_invalid(self):
+        with self.assertRaisesMessage(ImportError, 'nonexistent'):
+            self.test_session_modifying_view()
 
     def test_view_with_exception(self):
         "Request a page that is known to throw an error"


### PR DESCRIPTION
Follows up https://github.com/django/django/pull/5586.

Now it is possible not only to use test client with custom session apps, but also to use it when `django.contrib.sessions` is not in `INSTALLED_APPS` (this covers an existing use-case for those wishing to avoid having an empty sessions table while using non-DB backends).

I've considered suggestion from @javins, and then discussed options with @apollo13 and @freakboy3742.

It seems that the `INSTALLED_APPS` check can be safely removed. Its origin has been narrowed down to commits https://github.com/django/django/commit/9ba27afce09cb5f19f429844bd699f5042eb2108 and https://github.com/django/django/commit/36b164d838c3de168defe9f1ebc02ea1abc790be.

Also, there's nothing that suggests that an empty dict had been anything but a convenient default value.