### PR TITLE
Fixed #24858 -- Added custom _get_FIELD_display to ArrayField

### DIFF
--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -97,6 +97,17 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
+            name='ChoiceIntegerArrayModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('field', ArrayField(models.IntegerField(), size=None)),
+            ],
+            options={
+                'required_db_vendor': 'postgresql',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
             name='CharFieldModel',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -5,6 +5,11 @@ from .fields import (
     FloatRangeField, HStoreField, IntegerRangeField, JSONField,
 )
 
+ARRAY_CHOICES = (
+    ([1, 2], 'Value 1'),
+    ([2, 3, 4], 'Value 2'),
+)
+
 
 class Tag(object):
     def __init__(self, tag_id):
@@ -44,6 +49,10 @@ class IntegerArrayModel(PostgreSQLModel):
 
 class NullableIntegerArrayModel(PostgreSQLModel):
     field = ArrayField(models.IntegerField(), blank=True, null=True)
+
+
+class ChoiceIntegerArrayModel(PostgreSQLModel):
+    field = ArrayField(base_field=models.IntegerField(), choices=ARRAY_CHOICES)
 
 
 class CharArrayModel(PostgreSQLModel):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -13,9 +13,9 @@ from django.utils import timezone
 
 from . import PostgreSQLTestCase
 from .models import (
-    ArrayFieldSubclass, CharArrayModel, DateTimeArrayModel, IntegerArrayModel,
-    NestedIntegerArrayModel, NullableIntegerArrayModel, OtherTypesArrayModel,
-    PostgreSQLModel, Tag,
+    ArrayFieldSubclass, CharArrayModel, ChoiceIntegerArrayModel,
+    DateTimeArrayModel, IntegerArrayModel, NestedIntegerArrayModel,
+    NullableIntegerArrayModel, OtherTypesArrayModel, PostgreSQLModel, Tag,
 )
 
 try:
@@ -116,6 +116,11 @@ class TestSaveLoad(PostgreSQLTestCase):
         field = instance._meta.get_field('field')
         self.assertEqual(field.model, IntegerArrayModel)
         self.assertEqual(field.base_field.model, IntegerArrayModel)
+
+    def test_choices(self):
+        instance = ChoiceIntegerArrayModel(field=[1, 2])
+        instance.save()
+        self.assertEqual(instance.get_field_display(), 'Value 1')
 
 
 class TestQuerying(PostgreSQLTestCase):

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -119,7 +119,6 @@ class TestSaveLoad(PostgreSQLTestCase):
 
     def test_choices(self):
         instance = ChoiceIntegerArrayModel(field=[1, 2])
-        instance.save()
         self.assertEqual(instance.get_field_display(), 'Value 1')
 
 


### PR DESCRIPTION
To support `choices` on the contrib.postgres ArrayField, added a custom `get_FIELD_display` through `contribute_to_class`.

https://code.djangoproject.com/ticket/24858