### PR TITLE
Fixed #14370 -- Added select2 widget for related object fields in admin.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -66,6 +66,7 @@ class BaseModelAdminChecks:
 
     def check(self, admin_obj, **kwargs):
         errors = []
+        errors.extend(self._check_autocomplete_fields(admin_obj))
         errors.extend(self._check_raw_id_fields(admin_obj))
         errors.extend(self._check_fields(admin_obj))
         errors.extend(self._check_fieldsets(admin_obj))
@@ -79,6 +80,61 @@ class BaseModelAdminChecks:
         errors.extend(self._check_ordering(admin_obj))
         errors.extend(self._check_readonly_fields(admin_obj))
         return errors
+
+    def _check_autocomplete_fields(self, obj):
+        """
+        Check that `autocomplete_fields` is a list or tuple of model fields.
+        """
+        if not isinstance(obj.autocomplete_fields, (list, tuple)):
+            return must_be('a list or tuple', option='autocomplete_fields', obj=obj, id='admin.E036')
+        else:
+            return list(chain.from_iterable([
+                self._check_autocomplete_fields_item(obj, obj.model, field_name, 'autocomplete_fields[%d]' % index)
+                for index, field_name in enumerate(obj.autocomplete_fields)
+            ]))
+
+    def _check_autocomplete_fields_item(self, obj, model, field_name, label):
+        """
+        Check that an item in `autocomplete_fields` is a ForeignKey or a
+        ManyToManyField and that the item has a related ModelAdmin with
+        search_fields defined.
+        """
+        try:
+            field = model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            return refer_to_missing_field(field=field_name, option=label, model=model, obj=obj, id='admin.E037')
+        else:
+            if not (field.many_to_many or field.many_to_one):
+                return must_be(
+                    'a foreign key or a many-to-many field',
+                    option=label, obj=obj, id='admin.E038'
+                )
+            related_admin = obj.admin_site._registry.get(field.remote_field.model)
+            if related_admin is None:
+                return [
+                    checks.Error(
+                        'An admin for model "%s" has to be registered '
+                        'to be referenced by %s.autocomplete_fields.' % (
+                            field.remote_field.model.__name__,
+                            type(obj).__name__,
+                        ),
+                        obj=obj.__class__,
+                        id='admin.E039',
+                    )
+                ]
+            elif not related_admin.search_fields:
+                return [
+                    checks.Error(
+                        '%s must define "search_fields", because it\'s '
+                        'referenced by %s.autocomplete_fields.' % (
+                            related_admin.__class__.__name__,
+                            type(obj).__name__,
+                        ),
+                        obj=obj.__class__,
+                        id='admin.E040',
+                    )
+                ]
+            return []
 
     def _check_raw_id_fields(self, obj):
         """ Check that `raw_id_fields` only contains field names that are listed

--- a/django/contrib/admin/static/admin/css/autocomplete.css
+++ b/django/contrib/admin/static/admin/css/autocomplete.css
@@ -1,0 +1,261 @@
+select.admin-autocomplete {
+    width: 20em;
+}
+
+.select2-container--admin-autocomplete.select2-container {
+    min-height: 30px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single,
+.select2-container--admin-autocomplete .select2-selection--multiple {
+    min-height: 30px;
+    padding: 0;
+}
+
+.select2-container--admin-autocomplete.select2-container--focus .select2-selection,
+.select2-container--admin-autocomplete.select2-container--open .select2-selection {
+    border-color: #999;
+    min-height: 30px;
+}
+
+.select2-container--admin-autocomplete.select2-container--focus .select2-selection.select2-selection--single,
+.select2-container--admin-autocomplete.select2-container--open .select2-selection.select2-selection--single {
+    padding: 0;
+}
+
+.select2-container--admin-autocomplete.select2-container--focus .select2-selection.select2-selection--multiple,
+.select2-container--admin-autocomplete.select2-container--open .select2-selection.select2-selection--multiple {
+    padding: 0;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single .select2-selection__rendered {
+    color: #444;
+    line-height: 30px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single .select2-selection__clear {
+    cursor: pointer;
+    float: right;
+    font-weight: bold;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single .select2-selection__placeholder {
+    color: #999;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single .select2-selection__arrow {
+    height: 26px;
+    position: absolute;
+    top: 1px;
+    right: 1px;
+    width: 20px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--single .select2-selection__arrow b {
+    border-color: #888 transparent transparent transparent;
+    border-style: solid;
+    border-width: 5px 4px 0 4px;
+    height: 0;
+    left: 50%;
+    margin-left: -4px;
+    margin-top: -2px;
+    position: absolute;
+    top: 50%;
+    width: 0;
+}
+
+.select2-container--admin-autocomplete[dir="rtl"] .select2-selection--single .select2-selection__clear {
+    float: left;
+}
+
+.select2-container--admin-autocomplete[dir="rtl"] .select2-selection--single .select2-selection__arrow {
+    left: 1px;
+    right: auto;
+}
+
+.select2-container--admin-autocomplete.select2-container--disabled .select2-selection--single {
+    background-color: #eee;
+    cursor: default;
+}
+
+.select2-container--admin-autocomplete.select2-container--disabled .select2-selection--single .select2-selection__clear {
+    display: none;
+}
+
+.select2-container--admin-autocomplete.select2-container--open .select2-selection--single .select2-selection__arrow b {
+    border-color: transparent transparent #888 transparent;
+    border-width: 0 4px 5px 4px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple {
+    background-color: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: text;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__rendered {
+    box-sizing: border-box;
+    list-style: none;
+    margin: 0;
+    padding: 0 5px;
+    width: 100%;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__rendered li {
+    list-style: none;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__placeholder {
+    color: #999;
+    margin-top: 5px;
+    float: left;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__clear {
+    cursor: pointer;
+    float: right;
+    font-weight: bold;
+    margin-top: 5px;
+    margin-right: 10px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__choice {
+    background-color: #e4e4e4;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: default;
+    float: left;
+    margin-right: 5px;
+    margin-top: 5px;
+    padding: 0 5px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__choice__remove {
+    color: #999;
+    cursor: pointer;
+    display: inline-block;
+    font-weight: bold;
+    margin-right: 2px;
+}
+
+.select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__choice__remove:hover {
+    color: #333;
+}
+
+.select2-container--admin-autocomplete[dir="rtl"] .select2-selection--multiple .select2-selection__choice, .select2-container--admin-autocomplete[dir="rtl"] .select2-selection--multiple .select2-selection__placeholder, .select2-container--admin-autocomplete[dir="rtl"] .select2-selection--multiple .select2-search--inline {
+    float: right;
+}
+
+.select2-container--admin-autocomplete[dir="rtl"] .select2-selection--multiple .select2-selection__choice {
+    margin-left: 5px;
+    margin-right: auto;
+}
+
+.select2-container--admin-autocomplete[dir="rtl"] .select2-selection--multiple .select2-selection__choice__remove {
+    margin-left: 2px;
+    margin-right: auto;
+}
+
+.select2-container--admin-autocomplete.select2-container--focus .select2-selection--multiple {
+    border: solid #999 1px;
+    outline: 0;
+}
+
+.select2-container--admin-autocomplete.select2-container--disabled .select2-selection--multiple {
+    background-color: #eee;
+    cursor: default;
+}
+
+.select2-container--admin-autocomplete.select2-container--disabled .select2-selection__choice__remove {
+    display: none;
+}
+
+.select2-container--admin-autocomplete.select2-container--open.select2-container--above .select2-selection--single, .select2-container--admin-autocomplete.select2-container--open.select2-container--above .select2-selection--multiple {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+.select2-container--admin-autocomplete.select2-container--open.select2-container--below .select2-selection--single, .select2-container--admin-autocomplete.select2-container--open.select2-container--below .select2-selection--multiple {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.select2-container--admin-autocomplete .select2-search--dropdown .select2-search__field {
+    border: 1px solid #ccc;
+}
+
+.select2-container--admin-autocomplete .select2-search--inline .select2-search__field {
+    background: transparent;
+    border: none;
+    outline: 0;
+    box-shadow: none;
+    -webkit-appearance: textfield;
+}
+
+.select2-container--admin-autocomplete .select2-results > .select2-results__options {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.select2-container--admin-autocomplete .select2-results__option[role=group] {
+    padding: 0;
+}
+
+.select2-container--admin-autocomplete .select2-results__option[aria-disabled=true] {
+    color: #999;
+}
+
+.select2-container--admin-autocomplete .select2-results__option[aria-selected=true] {
+    background-color: #ddd;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option {
+    padding-left: 1em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__group {
+    padding-left: 0;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__option {
+    margin-left: -1em;
+    padding-left: 2em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+    margin-left: -2em;
+    padding-left: 3em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+    margin-left: -3em;
+    padding-left: 4em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+    margin-left: -4em;
+    padding-left: 5em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option .select2-results__option {
+    margin-left: -5em;
+    padding-left: 6em;
+}
+
+.select2-container--admin-autocomplete .select2-results__option--highlighted[aria-selected] {
+    background-color: #79aec8;
+    color: white;
+}
+
+.select2-container--admin-autocomplete .select2-results__group {
+    cursor: default;
+    display: block;
+    padding: 6px;
+}

--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -108,6 +108,12 @@
                 this.value = newId;
             }
         });
+        selects.next().find('.select2-selection__rendered').each(function() {
+            // The element can have a clear button as a child.
+            // Use the lastChild to modify only the displayed value.
+            this.lastChild.textContent = newRepr;
+            this.title = newRepr;
+        });
         win.close();
     }
 

--- a/django/contrib/admin/static/admin/js/autocomplete.js
+++ b/django/contrib/admin/static/admin/js/autocomplete.js
@@ -1,0 +1,38 @@
+(function($) {
+    'use strict';
+    var init = function($element, options) {
+        var settings = $.extend({
+            ajax: {
+                data: function(params) {
+                    return {
+                        term: params.term,
+                        page: params.page
+                    };
+                }
+            }
+        }, options);
+        $element.select2(settings);
+    };
+
+    $.fn.djangoAdminSelect2 = function(options) {
+        var settings = $.extend({}, options);
+        $.each(this, function(i, element) {
+            var $element = $(element);
+            init($element, settings);
+        });
+        return this;
+    };
+
+    $(function() {
+        $('.admin-autocomplete').djangoAdminSelect2();
+    });
+
+    $(document).on('formset:added', (function() {
+        return function(event, $newFormset) {
+            var $widget = $newFormset.find('.admin-autocomplete');
+            // Exclude already initialized Select2 inputs.
+            $widget = $widget.not('.select2-hidden-accessible');
+            return init($widget);
+        };
+    })(this));
+}(django.jQuery));

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -1,0 +1,52 @@
+from django.http import Http404, JsonResponse
+from django.views.generic.list import BaseListView
+
+
+class AutocompleteJsonView(BaseListView):
+    """Handle AutocompleteWidget's AJAX requests for data."""
+    paginate_by = 20
+    model_admin = None
+
+    def get(self, request, *args, **kwargs):
+        """
+        Return a JsonResponse with search results of the form:
+        {
+            results: [{id: "123" text: "foo"}],
+            pagination: {more: true}
+        }
+        """
+        if not self.model_admin.get_search_fields(request):
+            raise Http404(
+                '%s must have search_fields for the autocomplete_view.' %
+                type(self.model_admin).__name__
+            )
+        if not self.has_perm(request):
+            return JsonResponse({'error': '403 Forbidden'}, status=403)
+
+        self.term = request.GET.get('term', '')
+        self.paginator_class = self.model_admin.paginator
+        self.object_list = self.get_queryset()
+        context = self.get_context_data()
+        return JsonResponse({
+            'results': [
+                {'id': str(obj.pk), 'text': str(obj)}
+                for obj in context['object_list']
+            ],
+            'pagination': {'more': context['page_obj'].has_next()},
+        })
+
+    def get_paginator(self, *args, **kwargs):
+        """Use the ModelAdmin's paginator."""
+        return self.model_admin.get_paginator(self.request, *args, **kwargs)
+
+    def get_queryset(self):
+        """Return queryset based on ModelAdmin.get_search_results()."""
+        qs = self.model_admin.get_queryset(self.request)
+        qs, search_use_distinct = self.model_admin.get_search_results(self.request, qs, self.term)
+        if search_use_distinct:
+            qs = qs.distinct()
+        return qs
+
+    def has_perm(self, request, obj=None):
+        """Check if user has permission to access the related model."""
+        return self.model_admin.has_change_permission(request, obj=obj)

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -527,6 +527,15 @@ with the admin site:
 * **admin.E034**: The value of ``readonly_fields`` must be a list or tuple.
 * **admin.E035**: The value of ``readonly_fields[n]`` is not a callable, an
   attribute of ``<ModelAdmin class>``, or an attribute of ``<model>``.
+* **admin.E036**: The value of ``autocomplete_fields`` must be a list or tuple.
+* **admin.E037**: The value of ``autocomplete_fields[n]`` refers to
+  ``<field name>``, which is not an attribute of ``<model>``.
+* **admin.E038**: The value of ``autocomplete_fields[n]`` must be a foreign
+  key or a many-to-many field.
+* **admin.E039**: An admin for model ``<model>`` has to be registered to be
+  referenced by ``<modeladmin>.autocomplete_fields``.
+* **admin.E040**: ``<modeladmin>`` must define ``search_fields``, because
+  it's referenced by ``<other_modeladmin>.autocomplete_fields``.
 
 ``ModelAdmin``
 ~~~~~~~~~~~~~~

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -519,11 +519,13 @@ subclass::
         If you want to use a custom widget with a relation field (i.e.
         :class:`~django.db.models.ForeignKey` or
         :class:`~django.db.models.ManyToManyField`), make sure you haven't
-        included that field's name in ``raw_id_fields`` or ``radio_fields``.
+        included that field's name in ``raw_id_fields``, ``radio_fields``, or
+        ``autocomplete_fields``.
 
         ``formfield_overrides`` won't let you change the widget on relation
-        fields that have ``raw_id_fields`` or ``radio_fields`` set. That's
-        because ``raw_id_fields`` and ``radio_fields`` imply custom widgets of
+        fields that have ``raw_id_fields``, ``radio_fields``, or
+        ``autocomplete_fields`` set. That's because ``raw_id_fields``,
+        ``radio_fields``, and ``autocomplete_fields`` imply custom widgets of
         their own.
 
 .. attribute:: ModelAdmin.inlines
@@ -1071,6 +1073,58 @@ subclass::
     Don't include a field in ``radio_fields`` unless it's a ``ForeignKey`` or has
     ``choices`` set.
 
+.. attribute:: ModelAdmin.autocomplete_fields
+
+    .. versionadded:: 2.0
+
+    ``autocomplete_fields`` is a list of ``ForeignKey`` and/or
+    ``ManyToManyField`` fields you would like to change to `Select2
+    <https://select2.org/>`_ autocomplete inputs.
+
+    By default, the admin uses a select-box interface (``<select>``) for fields
+    that are . Sometimes you don't want to incur the overhead of selecting all
+    the related instances to display in the dropdown.
+
+    The Select2 input looks similar to the default input but comes with a
+    search feature that loads the options asynchronously. This is faster and
+    more user-friendly if the related model has many instances.
+
+    You must define :attr:`~ModelAdmin.search_fields` on the related object's
+    ``ModelAdmin`` because the autocomplete search uses it.
+
+    Ordering and pagination of the results are controlled by the related
+    ``ModelAdmin``'s :meth:`~ModelAdmin.get_ordering` and
+    :meth:`~ModelAdmin.get_paginator` methods.
+
+    In the following example, ``ChoiceAdmin`` has an autocomplete field for the
+    ``ForeignKey`` to the ``Question``. The results are filtered by the
+    ``question_text`` field and ordered by the ``date_created`` field::
+
+        class QuestionAdmin(admin.ModelAdmin):
+            ordering = ['date_created']
+            search_fields = ['question_text']
+
+        class ChoiceAdmin(admin.ModelAdmin):
+            autocomplete_fields = ['question']
+
+    .. admonition:: Performance considerations for large datasets
+
+        Ordering using :attr:`ModelAdmin.ordering` may cause performance
+        problems as sorting on a large queryset will be slow.
+
+        Also, if your search fields include fields that aren't indexed by the
+        database, you might encounter poor performance on extremely large
+        tables.
+
+        For those cases, it's a good idea to write your own
+        :func:`ModelAdmin.get_search_results` implementation using a
+        full-text indexed search.
+
+        You may also want to change the ``Paginator`` on very large tables
+        as the default paginator always performs a ``count()`` query.
+        For example, you could override the default implementation of the
+        ``Paginator.count`` property.
+
 .. attribute:: ModelAdmin.raw_id_fields
 
     By default, Django's admin uses a select-box interface (<select>) for
@@ -1430,6 +1484,15 @@ templates used by the :class:`ModelAdmin` views:
     based on whether the parent is being added or changed. Here you can do any
     pre- or post-save operations for objects related to the parent. Note
     that at this point the parent object and its form have already been saved.
+
+.. method:: ModelAdmin.get_autocomplete_fields(request)
+
+    .. versionadded:: 2.0
+
+    The ``get_readonly_fields()`` method is given the ``HttpRequest`` and is
+    expected to return a ``list`` or ``tuple`` of field names that will be
+    displayed with an autocomplete widget as described above in the
+    :attr:`ModelAdmin.autocomplete_fields` section.
 
 .. method:: ModelAdmin.get_readonly_fields(request, obj=None)
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -66,7 +66,10 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.ModelAdmin.autocomplete_fields` attribute and
+  :meth:`.ModelAdmin.get_autocomplete_fields` method allow using an
+  `Select2 <https://select2.org>`_ search widget for ``ForeignKey`` and
+  ``ManyToManyField``.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -27,6 +27,7 @@ attr
 auth
 autoclobber
 autocommit
+autocomplete
 autocompletion
 autodetect
 autodetectable

--- a/tests/admin_views/customadmin.py
+++ b/tests/admin_views/customadmin.py
@@ -49,7 +49,7 @@ class CustomPwdTemplateUserAdmin(UserAdmin):
 site = Admin2(name="admin2")
 
 site.register(models.Article, base_admin.ArticleAdmin)
-site.register(models.Section, inlines=[base_admin.ArticleInline])
+site.register(models.Section, inlines=[base_admin.ArticleInline], search_fields=['name'])
 site.register(models.Thing, base_admin.ThingAdmin)
 site.register(models.Fabric, base_admin.FabricAdmin)
 site.register(models.ChapterXtra1, base_admin.ChapterXtra1Admin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -600,6 +600,10 @@ class Question(models.Model):
     question = models.CharField(max_length=20)
     posted = models.DateField(default=datetime.date.today)
     expires = models.DateTimeField(null=True, blank=True)
+    related_questions = models.ManyToManyField('self')
+
+    def __str__(self):
+        return self.question
 
 
 class Answer(models.Model):
@@ -746,6 +750,8 @@ class MainPrepopulated(models.Model):
 class RelatedPrepopulated(models.Model):
     parent = models.ForeignKey(MainPrepopulated, models.CASCADE)
     name = models.CharField(max_length=75)
+    fk = models.ForeignKey('self', models.CASCADE, blank=True, null=True)
+    m2m = models.ManyToManyField('self', blank=True)
     pubdate = models.DateField()
     status = models.CharField(
         max_length=20,
@@ -906,7 +912,6 @@ class InlineReference(models.Model):
     )
 
 
-# Models for #23604 and #23915
 class Recipe(models.Model):
     rname = models.CharField(max_length=20, unique=True)
 
@@ -957,3 +962,12 @@ class ParentWithUUIDPK(models.Model):
 
 class RelatedWithUUIDPKModel(models.Model):
     parent = models.ForeignKey(ParentWithUUIDPK, on_delete=models.SET_NULL, null=True, blank=True)
+
+
+class Author(models.Model):
+    pass
+
+
+class Authorship(models.Model):
+    book = models.ForeignKey(Book, models.CASCADE)
+    author = models.ForeignKey(Author, models.CASCADE)

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -1,0 +1,231 @@
+import json
+
+from django.contrib import admin
+from django.contrib.admin import site
+from django.contrib.admin.tests import AdminSeleniumTestCase
+from django.contrib.admin.views.autocomplete import AutocompleteJsonView
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
+from django.test import RequestFactory, override_settings
+from django.urls import reverse, reverse_lazy
+
+from .admin import AnswerAdmin, QuestionAdmin
+from .models import Answer, Author, Authorship, Book, Question
+from .tests import AdminViewBasicTestCase
+
+PAGINATOR_SIZE = AutocompleteJsonView.paginate_by
+
+
+class AuthorAdmin(admin.ModelAdmin):
+    search_fields = ['id']
+
+
+class AuthorshipInline(admin.TabularInline):
+    model = Authorship
+    autocomplete_fields = ['author']
+
+
+class BookAdmin(admin.ModelAdmin):
+    inlines = [AuthorshipInline]
+
+
+site.register(Question, QuestionAdmin)
+site.register(Answer, AnswerAdmin)
+site.register(Author, AuthorAdmin)
+site.register(Book, BookAdmin)
+
+
+class AutocompleteJsonViewTests(AdminViewBasicTestCase):
+    as_view_args = {'model_admin': QuestionAdmin(Question, site)}
+    factory = RequestFactory()
+    url = reverse_lazy('admin:admin_views_question_autocomplete')
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username='user', password='secret',
+            email='user@example.com', is_staff=True,
+        )
+        super().setUpTestData()
+
+    def test_success(self):
+        q = Question.objects.create(question='Is this a question?')
+        request = self.factory.get(self.url, {'term': 'is'})
+        request.user = self.superuser
+        response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data, {
+            'results': [{'id': str(q.pk), 'text': q.question}],
+            'pagination': {'more': False},
+        })
+
+    def test_must_be_logged_in(self):
+        response = self.client.get(self.url, {'term': ''})
+        self.assertEqual(response.status_code, 200)
+        self.client.logout()
+        response = self.client.get(self.url, {'term': ''})
+        self.assertEqual(response.status_code, 302)
+
+    def test_has_change_permission_required(self):
+        """
+        Users require the change permission for the related model to the
+        autocomplete view for it.
+        """
+        request = self.factory.get(self.url, {'term': 'is'})
+        self.user.is_staff = True
+        self.user.save()
+        request.user = self.user
+        response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
+        self.assertEqual(response.status_code, 403)
+        self.assertJSONEqual(response.content.decode('utf-8'), {'error': '403 Forbidden'})
+        # Add the change permission and retry.
+        p = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Question),
+            codename='change_question',
+        )
+        self.user.user_permissions.add(p)
+        request.user = User.objects.get(pk=self.user.pk)
+        response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_search_use_distinct(self):
+        """
+        Searching across model relations use QuerySet.distinct() to avoid
+        duplicates.
+        """
+        q1 = Question.objects.create(question='question 1')
+        q2 = Question.objects.create(question='question 2')
+        q2.related_questions.add(q1)
+        q3 = Question.objects.create(question='question 3')
+        q3.related_questions.add(q1)
+        request = self.factory.get(self.url, {'term': 'question'})
+        request.user = self.superuser
+
+        class DistinctQuestionAdmin(QuestionAdmin):
+            search_fields = ['related_questions__question', 'question']
+
+        model_admin = DistinctQuestionAdmin(Question, site)
+        response = AutocompleteJsonView.as_view(model_admin=model_admin)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(len(data['results']), 3)
+
+    def test_missing_search_fields(self):
+        class EmptySearchAdmin(QuestionAdmin):
+            search_fields = []
+
+        model_admin = EmptySearchAdmin(Question, site)
+        msg = 'EmptySearchAdmin must have search_fields for the autocomplete_view.'
+        with self.assertRaisesMessage(Http404, msg):
+            model_admin.autocomplete_view(self.factory.get(self.url))
+
+    def test_get_paginator(self):
+        """Search results are paginated."""
+        Question.objects.bulk_create(Question(question=str(i)) for i in range(PAGINATOR_SIZE + 10))
+        model_admin = QuestionAdmin(Question, site)
+        model_admin.ordering = ['pk']
+        # The first page of results.
+        request = self.factory.get(self.url, {'term': ''})
+        request.user = self.superuser
+        response = AutocompleteJsonView.as_view(model_admin=model_admin)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data, {
+            'results': [{'id': str(q.pk), 'text': q.question} for q in Question.objects.all()[:PAGINATOR_SIZE]],
+            'pagination': {'more': True},
+        })
+        # The second page of results.
+        request = self.factory.get(self.url, {'term': '', 'page': '2'})
+        request.user = self.superuser
+        response = AutocompleteJsonView.as_view(model_admin=model_admin)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data, {
+            'results': [{'id': str(q.pk), 'text': q.question} for q in Question.objects.all()[PAGINATOR_SIZE:]],
+            'pagination': {'more': False},
+        })
+
+
+@override_settings(ROOT_URLCONF='admin_views.urls')
+class SeleniumTests(AdminSeleniumTestCase):
+    available_apps = ['admin_views'] + AdminSeleniumTestCase.available_apps
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='super', password='secret', email='super@example.com',
+        )
+        self.admin_login(username='super', password='secret', login_url=reverse('admin:index'))
+
+    def test_select(self):
+        from selenium.webdriver.common.keys import Keys
+        from selenium.webdriver.support.ui import Select
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_answer_add'))
+        elem = self.selenium.find_element_by_css_selector('.select2-selection')
+        elem.click()  # Open the autocomplete dropdown.
+        results = self.selenium.find_element_by_css_selector('.select2-results')
+        self.assertTrue(results.is_displayed())
+        option = self.selenium.find_element_by_css_selector('.select2-results__option')
+        self.assertEqual(option.text, 'No results found')
+        elem.click()  # Close the autocomplete dropdown.
+        q1 = Question.objects.create(question='Who am I?')
+        Question.objects.bulk_create(Question(question=str(i)) for i in range(PAGINATOR_SIZE + 10))
+        elem.click()  # Reopen the dropdown now that some objects exist.
+        result_container = self.selenium.find_element_by_css_selector('.select2-results')
+        self.assertTrue(result_container.is_displayed())
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        # PAGINATOR_SIZE results and "Loading more results".
+        self.assertEqual(len(results), PAGINATOR_SIZE + 1)
+        search = self.selenium.find_element_by_css_selector('.select2-search__field')
+        # Load next page of results by scrolling to the bottom of the list.
+        for _ in range(len(results)):
+            search.send_keys(Keys.ARROW_DOWN)
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        # All objects and "Loading more results".
+        self.assertEqual(len(results), PAGINATOR_SIZE + 11)
+        # Limit the results with the search field.
+        search.send_keys('Who')
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), 1)
+        # Select the result.
+        search.send_keys(Keys.RETURN)
+        select = Select(self.selenium.find_element_by_id('id_question'))
+        self.assertEqual(select.first_selected_option.get_attribute('value'), str(q1.pk))
+
+    def test_select_multiple(self):
+        from selenium.webdriver.common.keys import Keys
+        from selenium.webdriver.support.ui import Select
+        self.selenium.get(self.live_server_url + reverse('admin:admin_views_question_add'))
+        elem = self.selenium.find_element_by_css_selector('.select2-selection')
+        elem.click()  # Open the autocomplete dropdown.
+        results = self.selenium.find_element_by_css_selector('.select2-results')
+        self.assertTrue(results.is_displayed())
+        option = self.selenium.find_element_by_css_selector('.select2-results__option')
+        self.assertEqual(option.text, 'No results found')
+        elem.click()  # Close the autocomplete dropdown.
+        Question.objects.create(question='Who am I?')
+        Question.objects.bulk_create(Question(question=str(i)) for i in range(PAGINATOR_SIZE + 10))
+        elem.click()  # Reopen the dropdown now that some objects exist.
+        result_container = self.selenium.find_element_by_css_selector('.select2-results')
+        self.assertTrue(result_container.is_displayed())
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), PAGINATOR_SIZE + 1)
+        search = self.selenium.find_element_by_css_selector('.select2-search__field')
+        # Load next page of results by scrolling to the bottom of the list.
+        for _ in range(len(results)):
+            search.send_keys(Keys.ARROW_DOWN)
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), 31)
+        # Limit the results with the search field.
+        search.send_keys('Who')
+        results = result_container.find_elements_by_css_selector('.select2-results__option')
+        self.assertEqual(len(results), 1)
+        # Select the result.
+        search.send_keys(Keys.RETURN)
+        # Reopen the dropdown and add the first result to the selection.
+        elem.click()
+        search.send_keys(Keys.ARROW_DOWN)
+        search.send_keys(Keys.RETURN)
+        select = Select(self.selenium.find_element_by_id('id_related_questions'))
+        self.assertEqual(len(select.all_selected_options), 2)

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -27,6 +27,7 @@ class Band(models.Model):
 
 class Album(models.Model):
     band = models.ForeignKey(Band, models.CASCADE)
+    featuring = models.ManyToManyField(Band, related_name='featured')
     name = models.CharField(max_length=100)
     cover_art = models.FileField(upload_to='albums')
     backside_art = MyFileField(upload_to='albums_back', null=True)

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -1,0 +1,133 @@
+from django import forms
+from django.contrib.admin.widgets import AutocompleteSelect
+from django.forms import ModelChoiceField
+from django.test import TestCase, override_settings
+from django.utils import translation
+
+from .models import Album, Band
+
+
+class AlbumForm(forms.ModelForm):
+    class Meta:
+        model = Album
+        fields = ['band', 'featuring']
+        widgets = {
+            'band': AutocompleteSelect(
+                Album._meta.get_field('band').remote_field,
+                attrs={'class': 'my-class'},
+            ),
+            'featuring': AutocompleteSelect(
+                Album._meta.get_field('featuring').remote_field,
+            )
+        }
+
+
+class NotRequiredBandForm(forms.Form):
+    band = ModelChoiceField(
+        queryset=Album.objects.all(),
+        widget=AutocompleteSelect(Album._meta.get_field('band').remote_field),
+        required=False,
+    )
+
+
+class RequiredBandForm(forms.Form):
+    band = ModelChoiceField(
+        queryset=Album.objects.all(),
+        widget=AutocompleteSelect(Album._meta.get_field('band').remote_field),
+        required=True,
+    )
+
+
+@override_settings(ROOT_URLCONF='admin_widgets.urls')
+class AutocompleteMixinTests(TestCase):
+    empty_option = '<option value=""></option>'
+    maxDiff = 1000
+
+    def test_build_attrs(self):
+        form = AlbumForm()
+        attrs = form['band'].field.widget.get_context(name='my_field', value=None, attrs={})['widget']['attrs']
+        self.assertEqual(attrs, {
+            'class': 'my-classadmin-autocomplete',
+            'data-ajax--cache': 'true',
+            'data-ajax--type': 'GET',
+            'data-ajax--url': '/admin_widgets/band/autocomplete/',
+            'data-theme': 'admin-autocomplete',
+            'data-allow-clear': 'false',
+            'data-placeholder': ''
+        })
+
+    def test_build_attrs_not_required_field(self):
+        form = NotRequiredBandForm()
+        attrs = form['band'].field.widget.build_attrs({})
+        self.assertJSONEqual(attrs['data-allow-clear'], True)
+
+    def test_build_attrs_required_field(self):
+        form = RequiredBandForm()
+        attrs = form['band'].field.widget.build_attrs({})
+        self.assertJSONEqual(attrs['data-allow-clear'], False)
+
+    def test_get_url(self):
+        rel = Album._meta.get_field('band').remote_field
+        w = AutocompleteSelect(rel)
+        url = w.get_url()
+        self.assertEqual(url, '/admin_widgets/band/autocomplete/')
+
+    def test_render_options(self):
+        beatles = Band.objects.create(name='The Beatles', style='rock')
+        who = Band.objects.create(name='The Who', style='rock')
+        # With 'band', a ForeignKey.
+        form = AlbumForm(initial={'band': beatles.pk})
+        output = form.as_table()
+        selected_option = '<option value="%s" selected>The Beatles</option>' % beatles.pk
+        option = '<option value="%s">The Who</option>' % who.pk
+        self.assertIn(selected_option, output)
+        self.assertNotIn(option, output)
+        # With 'featuring', a ManyToManyField.
+        form = AlbumForm(initial={'featuring': [beatles.pk, who.pk]})
+        output = form.as_table()
+        selected_option = '<option value="%s" selected>The Beatles</option>' % beatles.pk
+        option = '<option value="%s" selected>The Who</option>' % who.pk
+        self.assertIn(selected_option, output)
+        self.assertIn(option, output)
+
+    def test_render_options_required_field(self):
+        """Empty option is present if the field isn't required."""
+        form = NotRequiredBandForm()
+        output = form.as_table()
+        self.assertIn(self.empty_option, output)
+
+    def test_render_options_not_required_field(self):
+        """Empty option isn't present if the field isn't required."""
+        form = RequiredBandForm()
+        output = form.as_table()
+        self.assertNotIn(self.empty_option, output)
+
+    def test_media(self):
+        rel = Album._meta.get_field('band').remote_field
+        base_files = (
+            'admin/js/vendor/jquery/jquery.min.js',
+            'admin/js/vendor/select2/select2.full.min.js',
+            # Language file is inserted here.
+            'admin/js/jquery.init.js',
+            'admin/js/autocomplete.js',
+        )
+        languages = (
+            ('de', 'de'),
+            # Language with code 00 does not exist.
+            ('00', None),
+            # Language files are case sensitive.
+            ('sr-cyrl', 'sr-Cyrl'),
+            ('zh-cn', 'zh-CN'),
+        )
+        for lang, select_lang in languages:
+            with self.subTest(lang=lang):
+                if select_lang:
+                    expected_files = (
+                        base_files[:2] +
+                        (('admin/js/vendor/select2/i18n/%s.js' % select_lang),) +
+                        base_files[2:]
+                    )
+                else:
+                    expected_files = base_files
+                with translation.override(lang):
+                    self.assertEqual(AutocompleteSelect(rel).media._js, expected_files)

--- a/tests/modeladmin/models.py
+++ b/tests/modeladmin/models.py
@@ -14,6 +14,15 @@ class Band(models.Model):
         return self.name
 
 
+class Song(models.Model):
+    name = models.CharField(max_length=100)
+    band = models.ForeignKey(Band, models.CASCADE)
+    featuring = models.ManyToManyField(Band, related_name='featured')
+
+    def __str__(self):
+        return self.name
+
+
 class Concert(models.Model):
     main_band = models.ForeignKey(Band, models.CASCADE, related_name='main_concerts')
     opening_band = models.ForeignKey(Band, models.CASCADE, related_name='opening_concerts', blank=True)

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -7,14 +7,17 @@ from django.contrib.admin.options import (
     get_content_type_for_model,
 )
 from django.contrib.admin.sites import AdminSite
-from django.contrib.admin.widgets import AdminDateWidget, AdminRadioSelect
+from django.contrib.admin.widgets import (
+    AdminDateWidget, AdminRadioSelect, AutocompleteSelect,
+    AutocompleteSelectMultiple,
+)
 from django.contrib.auth.models import User
 from django.db import models
 from django.forms.widgets import Select
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import isolate_apps
 
-from .models import Band, Concert
+from .models import Band, Concert, Song
 
 
 class MockRequest:
@@ -637,6 +640,31 @@ class ModelAdminTests(TestCase):
                 else:
                     self.assertEqual(fetched.change_message, str(message))
                     self.assertEqual(fetched.object_repr, str(self.band))
+
+    def test_get_autocomplete_fields(self):
+        class NameAdmin(ModelAdmin):
+            search_fields = ['name']
+
+        class SongAdmin(ModelAdmin):
+            autocomplete_fields = ['featuring']
+            fields = ['featuring', 'band']
+
+        class OtherSongAdmin(SongAdmin):
+            def get_autocomplete_fields(self, request):
+                return ['band']
+
+        self.site.register(Band, NameAdmin)
+        try:
+            # Uses autocomplete_fields if not overridden.
+            model_admin = SongAdmin(Song, self.site)
+            form = model_admin.get_form(request)()
+            self.assertIsInstance(form.fields['featuring'].widget.widget, AutocompleteSelectMultiple)
+            # Uses overridden get_autocomplete_fields
+            model_admin = OtherSongAdmin(Song, self.site)
+            form = model_admin.get_form(request)()
+            self.assertIsInstance(form.fields['band'].widget.widget, AutocompleteSelect)
+        finally:
+            self.site.unregister(Band)
 
 
 class ModelAdminPermissionTests(SimpleTestCase):


### PR DESCRIPTION
Adds jQuery Select2 version 4 to support async select inputs
including a search feature.

**I split the PR in two commits, one is vendoring select2, one contains my code.**

### Links & Discussions
* [djangoproject#14370](https://code.djangoproject.com/ticket/14370)
* https://groups.google.com/forum/#!topic/django-developers/tCNWnLP8jzM
* https://groups.google.com/forum/#!topic/django-developers/Ip63Xqw01IA/discussion
* https://groups.google.com/forum/#!topic/django-developers/jGgZngTq3Gw/discussion

### Changes:
- ~~jQuery noConflict is set to false, jQuery itself does not get removed form global~~
- ~~the new select2 widget is automatically used if the related object
  has a registered admin and defines search fields~~
- only str representation is supported at this point
- the search feature uses the same field as the model admin
### Todo:
- [x] ~~Possible deprecation of raw_id field?~~
- [x] Release note. (Which release?)
- [x] Selenium integration tests
- [x] widget tests
- [x] pagingnator and page tests
- [x] view tests
- [x] admin_site integration tests
- [x] add `MODEL_change` permission to json view
- [x] [system checks](https://docs.djangoproject.com/en/1.9/ref/checks/#admin)
