### PR TITLE
Fixed #25420 -- Documented bash completion exit code behavior.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -276,7 +276,10 @@ class ManagementUtility(object):
                 if option[1]:
                     opt_label += '='
                 print(opt_label)
-        sys.exit(1)
+        # Exit code of the bash completion function is never passed back to
+        # the user, so it's safe to always exit with 0.
+        # For more details see #25420.
+        sys.exit(0)
 
     def execute(self):
         """


### PR DESCRIPTION
The code mentioned in [#25420](https://code.djangoproject.com/ticket/25420) is only called for bash completion. When
using bash completion the exit code isn't passed to the user, so the
value returned by Django doesn't really matter. Changed it from 1 to 0
to have it more clear that it's desired behavior and documented it.
If you're interesting in the background of this topic check [#25420](https://code.djangoproject.com/ticket/25420).