### PR TITLE
Fixed #10107 -- Allowed mark_safe() to be used as decorator

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -5,7 +5,7 @@ that the producer of the string has already turned characters that should not
 be interpreted by the HTML engine (e.g. '<') into the appropriate entities.
 """
 from django.utils import six
-from django.utils.functional import Promise, curry
+from django.utils.functional import Promise, curry, wraps
 
 
 class EscapeData(object):
@@ -114,13 +114,24 @@ else:
     SafeUnicode = SafeText
 
 
+def _safety_decorator(safety_marker, func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        return safety_marker(func(*args, **kwargs))
+    return wrapped
+
+
 def mark_safe(s):
     """
     Explicitly mark a string as safe for (HTML) output purposes. The returned
     object can be used everywhere a string or unicode object is appropriate.
 
+    If used on a method as a decorator, mark the returned data as safe.
+
     Can be called multiple times on a single string.
     """
+    if callable(s):
+        return _safety_decorator(mark_safe, s)
     if hasattr(s, '__html__'):
         return s
     if isinstance(s, bytes) or (isinstance(s, Promise) and s._delegate_bytes):
@@ -135,9 +146,13 @@ def mark_for_escaping(s):
     Explicitly mark a string as requiring HTML escaping upon output. Has no
     effect on SafeData subclasses.
 
+    If used on a method as a decorator, mark the returned data as requiring HTML escaping.
+
     Can be called multiple times on a single string (the resulting escaping is
     only applied once).
     """
+    if callable(s):
+        return _safety_decorator(mark_for_escaping, s)
     if hasattr(s, '__html__') or isinstance(s, EscapeData):
         return s
     if isinstance(s, bytes) or (isinstance(s, Promise) and s._delegate_bytes):

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -826,6 +826,8 @@ appropriate entities.
 
     Can be called multiple times on a single string.
 
+    Can also be used as a decorator.
+
     For building up fragments of HTML, you should normally be using
     :func:`django.utils.html.format_html` instead.
 
@@ -847,6 +849,8 @@ appropriate entities.
 
     Can be called multiple times on a single string (the resulting escaping is
     only applied once).
+
+    Can also be used as a decorator.
 
 ``django.utils.text``
 =====================


### PR DESCRIPTION
I cherry-picked old patch written by matehat 7 yrs ago. All unit tests pass.

Original ticket: https://code.djangoproject.com/ticket/10107

This is part of the djangocon europe 2016 sprints. :saxophone: As always, feedback is welcome and I usually respond within 24 hours.