### PR TITLE
Fixed #26355 -- Added API to register different expressions for operator/field combo.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -4,7 +4,8 @@ from django.contrib.postgres import lookups
 from django.contrib.postgres.forms import SimpleArrayField
 from django.contrib.postgres.validators import ArrayMaxLengthValidator
 from django.core import checks, exceptions
-from django.db.models import Field, IntegerField, Transform
+from django.db.models import Field, Func, IntegerField, Transform
+from django.db.models.expressions import CombinedExpression
 from django.db.models.lookups import Exact, In
 from django.utils.translation import gettext_lazy as _
 
@@ -294,3 +295,11 @@ class SliceTransformFactory:
 
     def __call__(self, *args, **kwargs):
         return SliceTransform(self.start, self.end, *args, **kwargs)
+
+
+@CombinedExpression.dispatch(CombinedExpression.ADD, ArrayField, ArrayField)
+class ArrayCatPair(Func):
+    function = 'ARRAY_CAT'
+
+    def __init__(self, lhs, connector, rhs, output_field):
+        super().__init__(lhs, rhs, output_field=output_field)

--- a/django/db/models/__init__.py
+++ b/django/db/models/__init__.py
@@ -27,6 +27,7 @@ from django.db.models.fields.related import (  # isort:skip
     ForeignKey, ForeignObject, OneToOneField, ManyToManyField,
     ManyToOneRel, ManyToManyRel, OneToOneRel,
 )
+from django.db.models.operators import *  # NOQA isort:skip
 
 
 def permalink(func):

--- a/django/db/models/operators.py
+++ b/django/db/models/operators.py
@@ -1,0 +1,57 @@
+from django.core.exceptions import FieldError
+from django.db.models.expressions import CombinedExpression, DurationValue
+from django.db.models.fields import (
+    CharField, DateField, DateTimeField, DurationField, TextField, TimeField,
+)
+from django.db.models.functions import ConcatPair
+
+# Don't export anything, the only purpose of this module is to register
+# dispatch expressions
+__all__ = ()
+
+
+@CombinedExpression.dispatch(CombinedExpression.SUB, DateField, DateField, commutative=False)
+@CombinedExpression.dispatch(CombinedExpression.SUB, DateTimeField, DateTimeField, commutative=False)
+@CombinedExpression.dispatch(CombinedExpression.SUB, TimeField, TimeField, commutative=False)
+class TemporalSubtraction(CombinedExpression):
+    def __init__(self, lhs, connector, rhs, output_field=None):
+        super().__init__(
+            lhs, self.SUB, rhs, output_field=output_field or DurationField()
+        )
+
+    def as_sql(self, compiler, connection):
+        connection.ops.check_expression_support(self)
+        lhs = compiler.compile(self.lhs, connection)
+        rhs = compiler.compile(self.rhs, connection)
+        return connection.ops.subtract_temporals(self.lhs.output_field.get_internal_type(), lhs, rhs)
+
+
+@CombinedExpression.dispatch(
+    CombinedExpression.ANY, (DurationField, DateTimeField, DateField, TimeField), DurationField)
+class DurationExpression(CombinedExpression):
+    def as_sql(self, compiler, connection):
+        def compile(side):
+            if not isinstance(side, DurationValue):
+                try:
+                    output = side.output_field
+                except FieldError:
+                    pass
+                else:
+                    if output.get_internal_type() == 'DurationField':
+                        sql, params = compiler.compile(side)
+                        return connection.ops.format_for_duration_arithmetic(sql), params
+            return compiler.compile(side)
+
+        if not connection.features.has_native_duration_field:
+            connection.ops.check_expression_support(self)
+            return self._as_sql(
+                compiler, connection, compile=compile,
+                combine_expression=connection.ops.combine_duration_expression)
+
+        return self._as_sql(compiler, connection)
+
+
+@CombinedExpression.dispatch(CombinedExpression.ADD, (CharField, TextField), (CharField, TextField))
+class TextAddition(ConcatPair):
+    def __init__(self, lhs, connector, rhs, output_field):
+        super().__init__(lhs, rhs, output_field=output_field)

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -893,3 +893,53 @@ file (or package) that is imported from the top level ``__init__.py``.
 
 For user projects wishing to patch the backend that they're using, this code
 should live in an :meth:`AppConfig.ready()<django.apps.AppConfig.ready>` method.
+
+Using operators to combine expressions
+--------------------------------------
+
+.. versionadded:: 2.0
+
+.. currentmodule:: django.db.models.expressions
+.. class:: CombinedExpression(lhs, connector, rhs, output_field=None)
+
+Query expressions can be combined using infix operators to produce complex
+queries. By default, this maps Python operators to their SQL equivalents,
+regardless of field types and configured database backend.
+
+While in most cases that's just fine, there are certain combinations of
+field types and operators that require special handling. A notable example of
+such combination is string concatenation, which should execute SQL operator
+``||`` or ``CONCAT`` function, instead of ``+``. For example::
+
+    >>> from django.db.models import F, Value, CharField
+    >>> qs = Author.objects.annotate(
+    ...    full_name=(
+    ...       F('first_name') +
+    ...       Value(' ', output_field=CharField()) +
+    ...       F('last_name')))
+    >>> qs.values_list('full_name')
+    <QuerySet [('Stephen Keats',)]>
+
+This works by registering such combinations using ``CombinedExpression.dispatch``
+decorator, allowing Django to generate correct SQL equivalent for Python
+operators for a given operator and left- and right-hand side operands.
+
+Therefore, string concatenation is registered as follows::
+
+    from django.db.models.expressions import CombinedExpression
+    from django.db.models.functions import ConcatPair
+
+    @CombinedExpression.dispatch(CombinedExpression.ADD, CharField, CharField)
+    class TextAddition(ConcatPair):
+        def __init__(self, lhs, connector, rhs, output_field):
+            super().__init__(lhs, rhs, output_field=output_field)
+
+Note that you need to be sure about database types used in such expressions,
+possibly using ``Cast`` or ``output_field`` to provide explicit typing, like
+in ``Value`` expression in the example above.
+
+.. note::
+
+    You must take extra care when registering such operators, since operator
+    overloads cannot be ambiguous. Django will issue a runtime warning when
+    such ambiguity is detected.

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -168,6 +168,12 @@ Migrations
 Models
 ~~~~~~
 
+* Added support for operator overloading to create
+  :class:`~django.db.models.expressions.CombinedExpression`. This means that ``F('text_field') +
+  Value('_suffix', output_field=CharField())`` now results in ``ConcatPair``
+  invocation instead of verbatim addition. Because of this, Django now
+  depends on ``multipledispatch``.
+
 * ...
 
 Requests and Responses

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     entry_points={'console_scripts': [
         'django-admin = django.core.management:execute_from_command_line',
     ]},
-    install_requires=['pytz'],
+    install_requires=['multipledispatch', 'pytz'],
     extras_require={
         "bcrypt": ["bcrypt"],
         "argon2": ["argon2-cffi >= 16.1.0"],

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 from django.core.exceptions import FieldError
 from django.db import DatabaseError, connection, models, transaction
-from django.db.models import TimeField, UUIDField
+from django.db.models import CharField, TimeField, UUIDField
 from django.db.models.aggregates import (
     Avg, Count, Max, Min, StdDev, Sum, Variance,
 )
@@ -1261,3 +1261,16 @@ class ReprTests(TestCase):
         self.assertEqual(repr(StdDev('a')), "StdDev(F(a), sample=False)")
         self.assertEqual(repr(Sum('a')), "Sum(F(a))")
         self.assertEqual(repr(Variance('a', sample=True)), "Variance(F(a), sample=True)")
+
+
+class OperatorTests(TestCase):
+
+    def test_add(self):
+        instance = Employee.objects.create(firstname='John', lastname='Doe')
+        Employee.objects.update(
+            firstname=F('firstname') + Value('_firstname', output_field=CharField()),
+            lastname=F('lastname') + Value('_lastname', output_field=CharField())
+        )
+        instance.refresh_from_db()
+        self.assertEqual(instance.firstname, 'John_firstname')
+        self.assertEqual(instance.lastname, 'Doe_lastname')

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -3,6 +3,7 @@ bcrypt
 docutils
 geoip2
 jinja2 >= 2.9.2
+multipledispatch
 numpy
 Pillow
 # pylibmc/libmemcached can't be built on Windows.


### PR DESCRIPTION
The idea is to register expression class in `CombinedExpression` lookup
dict so that it can construct i.e. a `Func` when combining two sides with
Python's `+` operator.
