### PR TITLE
Fixed #26450 -- Corrected "Save as new" button label in docs.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1143,8 +1143,8 @@ subclass::
     editing" and "Save and add another". If ``save_as`` is ``True``, "Save
     and add another" will be replaced by a "Save as new" button.
 
-    "Save as new" means the object will be saved as a new object (with a new ID),
-    rather than the old object.
+    "Save as new" means the object will be saved as a new object (with a new
+    ID), rather than the old object.
 
     By default, ``save_as`` is set to ``False``.
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1141,9 +1141,9 @@ subclass::
 
     Normally, objects have three save options: "Save", "Save and continue
     editing" and "Save and add another". If ``save_as`` is ``True``, "Save
-    and add another" will be replaced by a "Save as" button.
+    and add another" will be replaced by a "Save as new" button.
 
-    "Save as" means the object will be saved as a new object (with a new ID),
+    "Save as new" means the object will be saved as a new object (with a new ID),
     rather than the old object.
 
     By default, ``save_as`` is set to ``False``.


### PR DESCRIPTION
This fixes that the documentation for the `save_as` option on `ModelAdmin` says the button is labeled "Save as" while in fact it is labeled "Save as new".