### PR TITLE
Fixed #26101 -- Allowed introspection of base_field.model in RangeField

### DIFF
--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -17,6 +17,24 @@ __all__ = [
 class RangeField(models.Field):
     empty_strings_allowed = False
 
+    def __init__(self, *args, **kwargs):
+        # Initializing base_field here ensures that its model matches the model for self.
+        if hasattr(self, 'base_field'):
+            self.base_field = self.base_field()
+        super(RangeField, self).__init__(*args, **kwargs)
+
+    @property
+    def model(self):
+        try:
+            return self.__dict__['model']
+        except KeyError:
+            raise AttributeError("'%s' object has no attribute 'model'" % self.__class__.__name__)
+
+    @model.setter
+    def model(self, model):
+        self.__dict__['model'] = model
+        self.base_field.model = model
+
     def get_prep_value(self, value):
         if value is None:
             return None
@@ -65,7 +83,7 @@ class RangeField(models.Field):
 
 
 class IntegerRangeField(RangeField):
-    base_field = models.IntegerField()
+    base_field = models.IntegerField
     range_type = NumericRange
     form_field = forms.IntegerRangeField
 
@@ -74,7 +92,7 @@ class IntegerRangeField(RangeField):
 
 
 class BigIntegerRangeField(RangeField):
-    base_field = models.BigIntegerField()
+    base_field = models.BigIntegerField
     range_type = NumericRange
     form_field = forms.IntegerRangeField
 
@@ -83,7 +101,7 @@ class BigIntegerRangeField(RangeField):
 
 
 class FloatRangeField(RangeField):
-    base_field = models.FloatField()
+    base_field = models.FloatField
     range_type = NumericRange
     form_field = forms.FloatRangeField
 
@@ -92,7 +110,7 @@ class FloatRangeField(RangeField):
 
 
 class DateTimeRangeField(RangeField):
-    base_field = models.DateTimeField()
+    base_field = models.DateTimeField
     range_type = DateTimeTZRange
     form_field = forms.DateTimeRangeField
 
@@ -101,7 +119,7 @@ class DateTimeRangeField(RangeField):
 
 
 class DateRangeField(RangeField):
-    base_field = models.DateField()
+    base_field = models.DateField
     range_type = DateRange
     form_field = forms.DateRangeField
 

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -845,7 +845,7 @@ types.
 
     .. attribute:: base_field
 
-        The model field to use.
+        The model field class to use.
 
     .. attribute:: range_type
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -705,6 +705,13 @@ Miscellaneous
 * :func:`django.views.i18n.set_language` may now return a 204 status code for
   AJAX requests.
 
+* The ``base_field`` attribute of
+  :class:`~django.contrib.postgres.fields.RangeField`
+  is now a type of field, not an instance of a field.
+  If you have created a custom subclass of
+  :class:`~django.contrib.postgres.fields.RangeField`,
+  you should change the ``base_field`` attribute.
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -80,6 +80,12 @@ class TestSaveLoad(PostgreSQLTestCase):
         loaded = RangesModel.objects.get()
         self.assertIsNone(loaded.ints)
 
+    def test_model_set_on_base_field(self):
+        instance = RangesModel()
+        field = instance._meta.get_field('ints')
+        self.assertEqual(field.model, RangesModel)
+        self.assertEqual(field.base_field.model, RangesModel)
+
 
 class TestQuerying(PostgreSQLTestCase):
 


### PR DESCRIPTION
Used the same test and fix as in ticket #25867.
This required initializing base_field in `RangeField.__init__`,
instead of when setting the attribute on the model.