### PR TITLE
Fixed #25905 -- Prevented leading slashes in urljoin() calls

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -405,7 +405,10 @@ class FileSystemStorage(Storage):
     def url(self, name):
         if self.base_url is None:
             raise ValueError("This file is not accessible via a URL.")
-        return urljoin(self.base_url, filepath_to_uri(name))
+        url = filepath_to_uri(name)
+        if url is not None:
+            url = url.lstrip('/')
+        return urljoin(self.base_url, url)
 
     def accessed_time(self, name):
         warnings.warn(


### PR DESCRIPTION
Leading slashes in the second urljoin argument will return exactly that
argument, breaking FileSystemStorage.url behavior if called with a
parameter with leading slashes.
Also added test cases for null bytes and None. Thanks to Markus for
help and review.