### PR TITLE
Refs #26112 -- Made Distance GIS function always return a float.

### DIFF
--- a/django/contrib/gis/db/models/sql/conversion.py
+++ b/django/contrib/gis/db/models/sql/conversion.py
@@ -48,6 +48,10 @@ class DistanceField(BaseField):
         self.distance_att = distance_att
 
     def from_db_value(self, value, expression, connection, context):
+        # If the database returns a Decimal, convert it to a float as expected
+        # by the Python geometric objects.
+        if isinstance(value, Decimal):
+            value = float(value)
         if value is not None:
             value = Distance(**{self.distance_att: value})
         return value

--- a/django/contrib/gis/measure.py
+++ b/django/contrib/gis/measure.py
@@ -254,6 +254,7 @@ class Distance(MeasureBase):
         'survey_ft': 0.304800609601,
         'um': 0.000001,
         'yd': 0.9144,
+        'furlong': 201.168,
     }
 
     # Unit aliases for `UNIT` terms encountered in Spatial Reference WKT.


### PR DESCRIPTION
This complements a fix to failed Oracle tests about the Area function.
While at it, added a test for the Distance function, which wasn't tested.
While dealing with distances, added the Furlong unit, which is essential
to velocity calculations.

This was recommended in a comment by @claudep at #6041 