### PR TITLE
Fixed #25856 -- JS strftime shim could (sometimes) support %B

### DIFF
--- a/django/contrib/admin/static/admin/js/calendar.js
+++ b/django/contrib/admin/static/admin/js/calendar.js
@@ -204,4 +204,5 @@ depends on core.js for utility functions like removeChildren or quickElement
         }
     };
     window.Calendar = Calendar;
+    window.CalendarNamespace = CalendarNamespace;
 })();

--- a/django/contrib/admin/static/admin/js/core.js
+++ b/django/contrib/admin/static/admin/js/core.js
@@ -153,6 +153,12 @@ function findPosY(obj) {
         return this.getTwoDigitHour() + ':' + this.getTwoDigitMinute() + ':' + this.getTwoDigitSecond();
     };
 
+    Date.prototype.getFullMonthName = function() {
+        return typeof window.CalendarNamespace === "undefined"
+            ? this.getTwoDigitMonth()
+            : window.CalendarNamespace.monthsOfYear[this.getMonth()];
+    };
+
     Date.prototype.strftime = function(format) {
         var fields = {
             c: this.toString(),
@@ -168,6 +174,7 @@ function findPosY(obj) {
             X: this.toLocaleTimeString(),
             y: ('' + this.getFullYear()).substr(2, 4),
             Y: '' + this.getFullYear(),
+            B: this.getFullMonthName(),
             '%': '%'
         };
         var result = '', i = 0;

--- a/js_tests/admin/core.test.js
+++ b/js_tests/admin/core.test.js
@@ -54,6 +54,7 @@ test('Date.getHourMinuteSecond', function(assert) {
 test('Date.strftime', function(assert) {
     var date = new Date(2014, 6, 1, 11, 0, 5);
     assert.equal(date.strftime('%Y-%m-%d %H:%M:%S'), '2014-07-01 11:00:05');
+    assert.equal(date.strftime('%B %d, %Y'), 'July 01, 2014');
 });
 
 test('String.strptime', function(assert) {


### PR DESCRIPTION
Fixed [#25856](https://code.djangoproject.com/ticket/25856) -- JS strftime shim could (sometimes) support %B

Added `%B` support to `Date.strftime`. This way the django admin will display the correct localized month name if `%B` is used in the date format.