### PR TITLE
Fixed #26281 -- Added a helpful error message for an invalid format specifier to dateformat.format().

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -767,10 +767,10 @@ def time(value, arg=None):
         return ''
     try:
         return formats.time_format(value, arg)
-    except AttributeError:
+    except (AttributeError, TypeError):
         try:
             return time_format(value, arg)
-        except AttributeError:
+        except (AttributeError, TypeError):
             return ''
 
 

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -31,16 +31,14 @@ re_escaped = re.compile(r'\\(.)')
 
 class Formatter(object):
 
-    def format_piece(self, piece):
-        if type(self.data) is datetime.date and hasattr(TimeFormat, piece):
-            raise TypeError('The format for date objects may not contain time-related format specifiers')
-        return piece
-
     def format(self, formatstr):
         pieces = []
         for i, piece in enumerate(re_formatchars.split(force_text(formatstr))):
             if i % 2:
-                pieces.append(force_text(getattr(self, self.format_piece(piece))()))
+                if type(self.data) is datetime.date and hasattr(TimeFormat, piece):
+                    raise TypeError("The format for date objects may not contain time-related format specifiers "
+                                    "(found '%s')." % piece)
+                pieces.append(force_text(getattr(self, piece)()))
             elif piece:
                 pieces.append(re_escaped.sub(r'\1', piece))
         return ''.join(pieces)

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -30,11 +30,17 @@ re_escaped = re.compile(r'\\(.)')
 
 
 class Formatter(object):
+
+    def format_piece(self, piece):
+        if type(self.data) is datetime.date and hasattr(TimeFormat, piece):
+            raise TypeError('The format for date objects may not contain time-related format specifiers')
+        return piece
+
     def format(self, formatstr):
         pieces = []
         for i, piece in enumerate(re_formatchars.split(force_text(formatstr))):
             if i % 2:
-                pieces.append(force_text(getattr(self, piece)()))
+                pieces.append(force_text(getattr(self, self.format_piece(piece))()))
             elif piece:
                 pieces.append(re_escaped.sub(r'\1', piece))
         return ''.join(pieces)

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -158,8 +158,7 @@ class DateFormatTests(SimpleTestCase):
         my_birthday = date(1984, 8, 7)
 
         for specifier in ['a', 'A', 'f', 'g', 'G', 'h', 'H', 'i', 'P', 's', 'u']:
-            with self.assertRaises(TypeError):
+            msg = "The format for date objects may not contain time-related format specifiers " \
+                  "(found '%s')." % specifier
+            with self.assertRaisesMessage(TypeError, msg):
                 dateformat.format(my_birthday, specifier)
-
-
-

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -153,3 +153,13 @@ class DateFormatTests(SimpleTestCase):
 
         # Ticket #16924 -- We don't need timezone support to test this
         self.assertEqual(dateformat.format(aware_dt, 'O'), '-0330')
+
+    def test_format_specifiers(self):
+        my_birthday = date(1984, 8, 7)
+
+        for specifier in ['a', 'A', 'f', 'g', 'G', 'h', 'H', 'i', 'P', 's', 'u']:
+            with self.assertRaises(TypeError):
+                dateformat.format(my_birthday, specifier)
+
+
+


### PR DESCRIPTION
Added function for checking if time format specifiers are used with date object. If so function returns TypeError with a better error message. 