### PR TITLE
Refs #21608 -- Fixed wrong cache key in cache session backend.

### DIFF
--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -57,7 +57,7 @@ class SessionStore(SessionBase):
             return self.create()
         if must_create:
             func = self._cache.add
-        elif self._cache.get(self.session_key) is not None:
+        elif self._cache.get(self.cache_key) is not None:
             func = self._cache.set
         else:
             raise UpdateError

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -613,6 +613,12 @@ class CacheSessionTests(SessionTestsMixin, unittest.TestCase):
         self.assertEqual(caches['default'].get(self.session.cache_key), None)
         self.assertNotEqual(caches['sessions'].get(self.session.cache_key), None)
 
+    def test_create_and_save(self):
+        self.session = self.backend()
+        self.session.create()
+        self.session.save()
+        self.assertIsNotNone(caches['default'].get(self.session.cache_key))
+
 
 class SessionMiddlewareTests(TestCase):
 


### PR DESCRIPTION
Bug introduced in commit <https://github.com/django/django/commit/3389c5ea229884a1943873fe7e7ffc2800cefc22>