### PR TITLE
Fixed #26459 -- Modified DecimalField rounding to cast to str, then use ROUND_HALF_UP.

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -194,6 +194,7 @@ def format_number(value, max_digits, decimal_places):
         return None
     if isinstance(value, decimal.Decimal):
         context = decimal.getcontext().copy()
+        context.rounding = decimal.ROUND_HALF_UP
         if max_digits is not None:
             context.prec = max_digits
         if decimal_places is not None:

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1604,7 +1604,10 @@ class DecimalField(Field):
         if value is None:
             return value
         try:
-            return decimal.Decimal(value)
+            if isinstance(value, six.text_type):
+                return decimal.Decimal(value)
+            else:
+                return decimal.Decimal(str(value))
         except decimal.InvalidOperation:
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],

--- a/tests/model_fields/test_decimalfield.py
+++ b/tests/model_fields/test_decimalfield.py
@@ -25,6 +25,8 @@ class DecimalFieldTests(TestCase):
         f = models.DecimalField(max_digits=5, decimal_places=1)
         self.assertEqual(f._format(f.to_python(2)), '2.0')
         self.assertEqual(f._format(f.to_python('2.6')), '2.6')
+        self.assertEqual(f._format(f.to_python(2.15)), '2.2')
+        self.assertEqual(f._format(f.to_python(2.25)), '2.3')
         self.assertEqual(f._format(None), None)
 
     def test_get_db_prep_lookup(self):


### PR DESCRIPTION
DecimalField is often used for money, for instance, django-paypal.
I understand that this field normally must receive Decimal values, but here weird behavior in case of float values which tried to be handled anyway.
If decimal_places = 2
float 2.215 will be saved as 2.21 (!)
float 2.225 will be saved as 2.22 (!)
But if float value first convert to str:
float 2.215 will be saved as 2.22 (ok)
float 2.225 will be saved as 2.22 (!)
It's because of default decimal rounding ROUND_HALF_EVEN.
As I understand build-in round() use rounding similar to ROUND_HALF_UP.

I tried first cast float to str, then use ROUND_HALF_UP, so now:
float 2.215 will be saved as 2.22 (ok)
float 2.225 will be saved as 2.23 (ok)

```
class Invoice(models.Model):
    # same as django-paypal use
    mc_gross = models.DecimalField(max_digits=64, decimal_places=2, default=0)

invoice.mc_gross = 2.215 # float
invoice.save()
```
In DB will be value 2.21 (or if 2.225 -> 2.22)

https://code.djangoproject.com/ticket/26459