### PR TITLE
Fixed #26455 -- Allowed filtering and repairing invalid geometries.

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -64,6 +64,10 @@ class BaseSpatialFeatures(object):
     def supports_relate_lookup(self):
         return 'relate' in self.connection.ops.gis_operators
 
+    @property
+    def supports_isvalid_lookup(self):
+        return 'isvalid' in self.connection.ops.gis_operators
+
     # For each of those methods, the class will have a property named
     # `has_<name>_method` (defined in __init__) which accesses connection.ops
     # to determine GIS method availability.

--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -58,10 +58,10 @@ class BaseSpatialOperations(object):
     unsupported_functions = {
         'Area', 'AsGeoJSON', 'AsGML', 'AsKML', 'AsSVG',
         'BoundingCircle', 'Centroid', 'Difference', 'Distance', 'Envelope',
-        'ForceRHR', 'GeoHash', 'Intersection', 'Length', 'MemSize', 'NumGeometries',
-        'NumPoints', 'Perimeter', 'PointOnSurface', 'Reverse', 'Scale',
-        'SnapToGrid', 'SymDifference', 'Transform', 'Translate',
-        'Union',
+        'ForceRHR', 'GeoHash', 'Intersection', 'IsValid', 'Length', 'MakeValid',
+        'MemSize', 'NumGeometries', 'NumPoints', 'Perimeter', 'PointOnSurface',
+        'Reverse', 'Scale', 'SnapToGrid', 'SymDifference', 'Transform',
+        'Translate', 'Union',
     }
 
     # Serialization

--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -67,7 +67,7 @@ class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
     def unsupported_functions(self):
         unsupported = {
             'AsGeoJSON', 'AsGML', 'AsKML', 'AsSVG', 'BoundingCircle',
-            'ForceRHR', 'GeoHash', 'MemSize',
+            'ForceRHR', 'GeoHash', 'IsValid', 'MakeValid', 'MemSize',
             'Perimeter', 'PointOnSurface', 'Reverse', 'Scale', 'SnapToGrid',
             'Transform', 'Translate',
         }

--- a/django/contrib/gis/db/backends/oracle/operations.py
+++ b/django/contrib/gis/db/backends/oracle/operations.py
@@ -127,7 +127,7 @@ class OracleOperations(BaseSpatialOperations, DatabaseOperations):
     unsupported_functions = {
         'AsGeoJSON', 'AsGML', 'AsKML', 'AsSVG',
         'BoundingCircle', 'Envelope',
-        'ForceRHR', 'GeoHash', 'MemSize', 'Scale',
+        'ForceRHR', 'GeoHash', 'IsValid', 'MakeValid', 'MemSize', 'Scale',
         'SnapToGrid', 'Translate',
     }
 

--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -79,6 +79,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         'disjoint': PostGISOperator(func='ST_Disjoint'),
         'equals': PostGISOperator(func='ST_Equals'),
         'intersects': PostGISOperator(func='ST_Intersects', geography=True),
+        'isvalid': PostGISOperator(func='ST_IsValid'),
         'overlaps': PostGISOperator(func='ST_Overlaps'),
         'relate': PostGISOperator(func='ST_Relate'),
         'touches': PostGISOperator(func='ST_Touches'),
@@ -118,11 +119,13 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         self.geojson = prefix + 'AsGeoJson'
         self.gml = prefix + 'AsGML'
         self.intersection = prefix + 'Intersection'
+        self.isvalid = prefix + 'IsValid'
         self.kml = prefix + 'AsKML'
         self.length = prefix + 'Length'
         self.length3d = prefix + '3DLength'
         self.length_spheroid = prefix + 'length_spheroid'
         self.makeline = prefix + 'MakeLine'
+        self.makevalid = prefix + 'MakeValid'
         self.mem_size = prefix + 'mem_size'
         self.num_geom = prefix + 'NumGeometries'
         self.num_points = prefix + 'npoints'

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -96,7 +96,7 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
 
     @cached_property
     def unsupported_functions(self):
-        unsupported = {'BoundingCircle', 'ForceRHR', 'MemSize'}
+        unsupported = {'BoundingCircle', 'ForceRHR', 'IsValid', 'MakeValid', 'MemSize'}
         if self.spatial_version < (3, 1, 0):
             unsupported.add('SnapToGrid')
         if self.spatial_version < (4, 0, 0):

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -225,7 +225,7 @@ class GeometryField(GeoSelectFormatMixin, BaseSpatialField):
         returning to the caller.
         """
         value = super(GeometryField, self).get_prep_value(value)
-        if isinstance(value, Expression):
+        if isinstance(value, (Expression, bool)):
             return value
         elif isinstance(value, (tuple, list)):
             geom = value[0]

--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -6,7 +6,7 @@ from django.contrib.gis.measure import (
     Area as AreaMeasure, Distance as DistanceMeasure,
 )
 from django.core.exceptions import FieldError
-from django.db.models import FloatField, IntegerField, TextField
+from django.db.models import BooleanField, FloatField, IntegerField, TextField
 from django.db.models.expressions import Func, Value
 from django.utils import six
 
@@ -282,6 +282,10 @@ class Intersection(OracleToleranceMixin, GeoFuncWithGeoParam):
     arity = 2
 
 
+class IsValid(GeoFunc):
+    output_field_class = BooleanField
+
+
 class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     output_field_class = FloatField
 
@@ -317,6 +321,10 @@ class Length(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
             else:
                 self.function = 'GreatCircleLength'
         return super(Length, self).as_sql(compiler, connection)
+
+
+class MakeValid(GeoFunc):
+    pass
 
 
 class MemSize(GeoFunc):

--- a/docs/ref/contrib/gis/functions.txt
+++ b/docs/ref/contrib/gis/functions.txt
@@ -25,13 +25,12 @@ Function's summary:
 ==================  =======================   ======================  ===================  ==================  =====================
 Measurement         Relationships             Operations              Editors              Output format       Miscellaneous
 ==================  =======================   ======================  ===================  ==================  =====================
-:class:`Area`       :class:`BoundingCircle`   :class:`Difference`     :class:`ForceRHR`    :class:`AsGeoJSON`  :class:`MemSize`
-:class:`Distance`   :class:`Centroid`         :class:`Intersection`   :class:`Reverse`     :class:`AsGML`      :class:`NumGeometries`
-:class:`Length`     :class:`Envelope`         :class:`SymDifference`  :class:`Scale`       :class:`AsKML`      :class:`NumPoints`
-:class:`Perimeter`  :class:`PointOnSurface`   :class:`Union`          :class:`SnapToGrid`  :class:`AsSVG`
-
-                                                                      :class:`Transform`   :class:`GeoHash`
-
+:class:`Area`       :class:`BoundingCircle`   :class:`Difference`     :class:`ForceRHR`    :class:`AsGeoJSON`  :class:`IsValid`
+:class:`Distance`   :class:`Centroid`         :class:`Intersection`   :class:`MakeValid`   :class:`AsGML`      :class:`MemSize`
+:class:`Length`     :class:`Envelope`         :class:`SymDifference`  :class:`Reverse`     :class:`AsKML`      :class:`NumGeometries`
+:class:`Perimeter`  :class:`PointOnSurface`   :class:`Union`          :class:`Scale`       :class:`AsSVG`      :class:`NumPoints`
+                                                                      :class:`SnapToGrid`  :class:`GeoHash`
+                                                                      :class:`Transform`
                                                                       :class:`Translate`
 ==================  =======================   ======================  ===================  ==================  =====================
 
@@ -291,6 +290,18 @@ intersection between them.
 
     MySQL support was added.
 
+``IsValid``
+================
+
+.. class:: IsValid(expr)
+
+.. versionadded:: 1.10
+
+*Availability*: PostGIS
+
+Accepts a geographic field or expression and tests if the value is well formed.
+Returns ``True`` if its value is a valid geometry and ``False`` otherwise.
+
 ``Length``
 ==========
 
@@ -307,6 +318,20 @@ On PostGIS and SpatiaLite, when the coordinates are geodetic (angular), you can
 specify if the calculation should be based on a simple sphere (less
 accurate, less resource-intensive) or on a spheroid (more accurate, more
 resource-intensive) with the ``spheroid`` keyword argument.
+
+``MakeValid``
+================
+
+.. class:: MakeValid(expr)
+
+.. versionadded:: 1.10
+
+*Availability*: PostGIS
+
+Accepts a geographic field or expression and attempts to convert the value into
+a valid geometry without losing any of the input vertices. Geometries that are
+already valid are returned without changes. Simple polygons might become a
+multipolygon and the result might be of lower dimension than the input.
 
 ``MemSize``
 ===========

--- a/docs/ref/contrib/gis/geoquerysets.txt
+++ b/docs/ref/contrib/gis/geoquerysets.txt
@@ -247,6 +247,25 @@ MySQL       ``MBRIntersects(poly, geom)``
 SpatiaLite  ``Intersects(poly, geom)``
 ==========  =================================================
 
+.. fieldlookup:: isvalid
+
+``isvalid``
+--------------
+
+.. versionadded:: 1.10
+
+*Availability*: PostGIS
+
+Tests if the geometry is valid.
+
+Example::
+
+    Zipcode.objects.filter(poly__isvalid=True)
+
+PostGIS equivalent::
+
+    SELECT ... WHERE ST_IsValid(poly)
+
 .. fieldlookup:: overlaps
 
 ``overlaps``

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -147,6 +147,12 @@ Minor features
   <django.contrib.gis.gdal.GDALBand.data>` method was added. Band data can
   now be updated with repeated values efficiently.
 
+* Added database functions
+  :class:`~django.contrib.gis.db.models.functions.IsValid` and
+  :class:`~django.contrib.gis.db.models.functions.MakeValid`, as well as the
+  :lookup:`isvalid` lookup, all for PostGIS. This allows filtering and
+  repairing invalid geometries on the database side.
+
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -233,6 +233,17 @@ class GISFunctionsTests(TestCase):
                 expected = c.mpoly.intersection(geom)
             self.assertEqual(c.inter, expected)
 
+    @skipUnlessDBFeature("has_IsValid_function")
+    def test_isvalid(self):
+        valid_geom = fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))')
+        invalid_geom = fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 1 1, 1 0, 0 0))')
+        State.objects.create(name='valid', poly=valid_geom)
+        State.objects.create(name='invalid', poly=invalid_geom)
+        valid = State.objects.filter(name='valid').annotate(isvalid=functions.IsValid('poly')).first()
+        invalid = State.objects.filter(name='invalid').annotate(isvalid=functions.IsValid('poly')).first()
+        self.assertEqual(valid.isvalid, True)
+        self.assertEqual(invalid.isvalid, False)
+
     @skipUnlessDBFeature("has_Area_function")
     def test_area_with_regular_aggregate(self):
         # Create projected country objects, for this test to work on all backends.
@@ -248,6 +259,14 @@ class GISFunctionsTests(TestCase):
             if isinstance(result, Area):
                 result = result.sq_m
             self.assertAlmostEqual((result - c.mpoly.area) / c.mpoly.area, 0)
+
+    @skipUnlessDBFeature("has_MakeValid_function")
+    def test_make_valid(self):
+        invalid_geom = fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 1 1, 1 0, 0 0))')
+        State.objects.create(name='invalid', poly=invalid_geom)
+        invalid = State.objects.filter(name='invalid').annotate(repaired=functions.MakeValid('poly')).first()
+        self.assertEqual(invalid.repaired.valid, True)
+        self.assertEqual(invalid.repaired, fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))
 
     @skipUnlessDBFeature("has_MemSize_function")
     def test_memsize(self):

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -300,6 +300,13 @@ class GeoLookupTest(TestCase):
             0
         )
 
+    @skipUnlessDBFeature("supports_isvalid_lookup")
+    def test_isvalid_lookup(self):
+        invalid_geom = fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 1 1, 1 0, 0 0))')
+        State.objects.create(name='invalid', poly=invalid_geom)
+        self.assertEqual(State.objects.filter(poly__isvalid=False).count(), 1)
+        self.assertEqual(State.objects.filter(poly__isvalid=True).count(), State.objects.count() - 1)
+
     @skipUnlessDBFeature("supports_left_right_lookups")
     def test_left_right_lookups(self):
         "Testing the 'left' and 'right' lookup types."


### PR DESCRIPTION
The IsValid and MakeValid database functions were added to the GIS module, and a isvalid lookup was added to filter geometries by validity.