### PR TITLE
Fixed #26460 -- Issued a single warning for invalid cache key

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -242,6 +242,7 @@ class BaseCache(object):
                 warnings.warn('Cache key contains characters that will cause '
                         'errors if used with memcached: %r' % key,
                               CacheKeyWarning)
+                break
 
     def incr_version(self, key, delta=1, version=None):
         """Adds delta to the cache version for the supplied key. Returns the

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -586,7 +586,7 @@ class BaseCacheTests(object):
                 warnings.simplefilter("always")
                 # memcached does not allow whitespace or control characters in keys
                 cache.set('key with spaces', 'value')
-                self.assertEqual(len(w), 2)
+                self.assertEqual(len(w), 1)
                 self.assertIsInstance(w[0].message, CacheKeyWarning)
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")


### PR DESCRIPTION
In ``BaseCache.validate_key()`` if a ``key`` contains more than one
invalid character do not issue extra warnings.

Fixes [26460](https://code.djangoproject.com/ticket/26460)