### PR TITLE
Fixed #26462 -- Fixed Python 2 UnicodeEncodeError when warning about long cache keys.

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -235,7 +235,7 @@ class BaseCache(object):
         """
         if len(key) > MEMCACHE_MAX_KEY_LENGTH:
             warnings.warn('Cache key will cause errors if used with memcached: '
-                    '%s (longer than %s)' % (key, MEMCACHE_MAX_KEY_LENGTH),
+                    '%r (longer than %s)' % (key, MEMCACHE_MAX_KEY_LENGTH),
                     CacheKeyWarning)
         for char in key:
             if ord(char) < 33 or ord(char) == 127:


### PR DESCRIPTION
On Python 2 ``warnings.warn()`` expects a ``message`` that can be coerced to a ``str``.

Fixes [26462](https://code.djangoproject.com/ticket/26462)