### PR TITLE
New pre_handler() method for the View class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -565,6 +565,7 @@ answer newbie questions, and generally made Django that much better:
     Ossama M. Khayat <okhayat@yahoo.com>
     Owen Griffiths
     Pablo Martín <goinnn@gmail.com>
+    Pablo Recio <pablo@recio.me>
     Panos Laganakos <panos.laganakos@gmail.com>
     Pascal Hartig <phartig@rdrei.net>
     Pascal Varet

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -83,9 +83,16 @@ class View(object):
         # request method isn't on the approved list.
         if request.method.lower() in self.http_method_names:
             handler = getattr(self, request.method.lower(), self.http_method_not_allowed)
+            # Common code to get executed regardless the handler we'll use
+            self.pre_handler(request, *args, **kwargs)
         else:
             handler = self.http_method_not_allowed
         return handler(request, *args, **kwargs)
+
+    def pre_handler(self, request, *args, **kwargs):
+        # To be overriden in child classes to add common logic between
+        # different handlers without having to override the dispatch method
+        pass
 
     def http_method_not_allowed(self, request, *args, **kwargs):
         logger.warning('Method Not Allowed (%s): %s', request.method, request.path,

--- a/docs/ref/class-based-views/base.txt
+++ b/docs/ref/class-based-views/base.txt
@@ -29,8 +29,9 @@ MRO is an acronym for Method Resolution Order.
     **Method Flowchart**
 
     1. :meth:`dispatch()`
-    2. :meth:`http_method_not_allowed()`
-    3. :meth:`options()`
+    2. :meth:`pre_handler()``
+    3. :meth:`http_method_not_allowed()`
+    4. :meth:`options()`
 
     **Example views.py**::
 
@@ -82,12 +83,27 @@ MRO is an acronym for Method Resolution Order.
 
         The default implementation will inspect the HTTP method and attempt to
         delegate to a method that matches the HTTP method; a ``GET`` will be
-        delegated to ``get()``, a ``POST`` to ``post()``, and so on.
+        delegated to ``get()``, a ``POST`` to ``post()``, and so on. Before
+        calling the respective method, it will execute the method
+        ``pre_handler()``, for any common logic shared across different methods.
 
         By default, a ``HEAD`` request will be delegated to ``get()``.
         If you need to handle ``HEAD`` requests in a different way than ``GET``,
         you can override the ``head()`` method. See
         :ref:`supporting-other-http-methods` for an example.
+
+        .. versionadded:: 1.10
+
+        New ``pre_handler()`` method gets called before the HTTP method handler.
+
+    .. method:: pre_handler(request, *args, **kwargs)
+
+        Empty method that can be overridden to write logic shared across different
+        handlers without having to override the ``dispatch()`` method.
+
+        .. versionadded:: 1.10
+
+        Added method
 
     .. method:: http_method_not_allowed(request, *args, **kwargs)
 

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -5,7 +5,7 @@ import unittest
 
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.test import RequestFactory, SimpleTestCase, override_settings, mock
 from django.test.utils import require_jinja2
 from django.urls import resolve
 from django.views.generic import RedirectView, TemplateView, View
@@ -240,6 +240,21 @@ class ViewTest(unittest.TestCase):
         view = PostOnlyView()
         response = view.dispatch(self.rf.head('/'))
         self.assertEqual(response.status_code, 405)
+
+    def test_pre_handler_called_options(self):
+        view = SimpleView()
+        view.pre_handler = mock.Mock()
+        response = view.dispatch(self.rf.options('/'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(view.pre_handler.call_count, 1)
+
+    def test_pre_handler_called_get(self):
+        view = SimpleView()
+        view.pre_handler = mock.Mock()
+        response = view.dispatch(self.rf.get('/'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'This is a simple view')
+        self.assertEqual(view.pre_handler.call_count, 1)
 
 
 @override_settings(ROOT_URLCONF='generic_views.urls')


### PR DESCRIPTION
Sometimes we need to override the `dispatch()` method if we want to share some behaviour between different handler methods in a Class-Based View, being quite error-prone.

This patch adds a new method to achieve the same without having to override `dispatch()`.

[django-developers discussion](https://groups.google.com/d/topic/django-developers/4PW7o5ipi7k/discussion)