### PR TITLE
Fixed link in documentation/tutorial01.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -116,7 +116,7 @@ These files are:
 * :file:`mysite/wsgi.py`: An entry-point for WSGI-compatible web servers to
   serve your project. See :doc:`/howto/deployment/wsgi/index` for more details.
 
-.. _more about packages: https://docs.python.org/tutorial/modules.html#packages
+.. _more about packages: https://docs.python.org/3/tutorial/modules.html#packages
 
 The development server
 ======================


### PR DESCRIPTION
The tutorial was made for Python 3. The current link points to Python 2's documentation.