### PR TITLE
Fixed #14131 -- Extended info about Pagination and large QuerySets

### DIFF
--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -151,6 +151,11 @@ Required arguments
         If you are using a ``QuerySet`` with a very large number of items,
         requesting high page numbers might be slow on some database backends.
 
+        In Django's database layer, the ``QuerySet`` translates into a
+        ``LIMIT`` clause with an ``offset`` argument. While running on most
+        database  backends, this query needs to count off the first ``offset``
+        number of records, which takes longer as the page number gets higher.
+
 ``per_page``
     The maximum number of items to include on a page, not including orphans
     (see the ``orphans`` optional argument below).


### PR DESCRIPTION
Added some more background information about what database queries are run to the information about slow pagination. 

This extends what I added in https://github.com/django/django/pull/6378

Erik and I didn't see your comments before, @timgraham, thanks for the tip.