### PR TITLE
Fixed #26466 -- Added URL decoding to i18n set_language view

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -12,7 +12,7 @@ from django.utils import six
 from django.utils._os import upath
 from django.utils.encoding import smart_text
 from django.utils.formats import get_format, get_format_modules
-from django.utils.http import is_safe_url
+from django.utils.http import is_safe_url, urlunquote
 from django.utils.translation import (
     LANGUAGE_SESSION_KEY, check_for_language, get_language, to_locale,
 )
@@ -38,6 +38,10 @@ def set_language(request):
         next = request.META.get('HTTP_REFERER')
         if not is_safe_url(url=next, host=request.get_host()):
             next = '/'
+        # Decode the most probably urlencoded URL if we got it from
+        # HTTP_REFERER. Leaving it encoded could cause a redirect to an
+        # inexistent view after translate_url.
+        next = urlunquote(next)
     response = http.HttpResponseRedirect(next) if next else http.HttpResponse(status=204)
     if request.method == 'POST':
         lang_code = request.POST.get(LANGUAGE_QUERY_PARAMETER)

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -104,3 +104,7 @@ urlpatterns += [
     ),
     url(r'^render_no_template/$', views.render_no_template, name='render_no_template'),
 ]
+
+urlpatterns += [
+    url(r'^test-setlang/(?P<test_parameter>[^/]+)/$', views.dummy_ok, name='dummy_ok'),
+]

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -26,6 +26,10 @@ def index_page(request):
     return HttpResponse('<html><body>Dummy page</body></html>')
 
 
+def dummy_ok(request, test_parameter):
+    return HttpResponse('ok')
+
+
 def raises(request):
     # Make sure that a callable that raises an exception in the stack frame's
     # local vars won't hijack the technical 500 response. See:


### PR DESCRIPTION
Added decoding for URLs taken from HTTP_REFERER in set_language view,
by using the Python's urllib.parse.unquote (through Django's six). Added a regression test for (#26466).