### PR TITLE
Fixed #26085 -- Fixed contenttypes shortcut() view crash with a null fk to Site.

### DIFF
--- a/django/contrib/contenttypes/views.py
+++ b/django/contrib/contenttypes/views.py
@@ -62,10 +62,13 @@ def shortcut(request, content_type_id, object_id):
         if object_domain is None:
             for field in obj._meta.fields:
                 if field.remote_field and field.remote_field.model is Site:
+                    site = None
                     try:
-                        object_domain = getattr(obj, field.name).domain
+                        site = getattr(obj, field.name)
                     except Site.DoesNotExist:
                         pass
+                    if site is not None:
+                        object_domain = site.domain
                     if object_domain is not None:
                         break
 

--- a/tests/contenttypes_tests/models.py
+++ b/tests/contenttypes_tests/models.py
@@ -4,9 +4,19 @@ from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation,
 )
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import SiteManager
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.http import urlquote
+
+
+@python_2_unicode_compatible
+class Site(models.Model):
+    domain = models.CharField(max_length=100)
+    objects = SiteManager()
+
+    def __str__(self):
+        return self.domain
 
 
 @python_2_unicode_compatible
@@ -115,3 +125,16 @@ class Post(models.Model):
 
     def __str__(self):
         return self.title
+
+
+@python_2_unicode_compatible
+class ModelWithNullFKToSite(models.Model):
+    """A model with a nullable ForeignKey to Site"""
+    title = models.CharField(max_length=200)
+    site = models.ForeignKey(Site, null=True, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.title
+
+    def get_absolute_url(self):
+        return '/title/%s/' % urlquote(self.title)


### PR DESCRIPTION
fixed test as suggested in the comments of https://github.com/django/django/pull/5986