### PR TITLE
Remove comment about single '=' warning for template if-tag

### DIFF
--- a/django/template/smartif.py
+++ b/django/template/smartif.py
@@ -88,8 +88,6 @@ def prefix(bp, func):
 
 
 # Operator precedence follows Python.
-# NB - we can get slightly more accurate syntax error messages by not using the
-# same object for '==' and '='.
 # We defer variable evaluation to the lambda to ensure that terms are
 # lazily evaluated using Python's boolean parsing logic.
 OPERATORS = {


### PR DESCRIPTION
The functionality was removed in commit 2ccfac1a (Refs #23913 -- Removed
support for a single equals sign in {% if %} tag., 2015-09-05).