### PR TITLE
Corrected link to base_site.html

### DIFF
--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -335,7 +335,7 @@ when loading Django templates; it's a search path.
 Now create a directory called ``admin`` inside ``templates``, and copy the
 template ``admin/base_site.html`` from within the default Django admin
 template directory in the source code of Django itself
-(``django/contrib/admin/templates``) into that directory.
+(``django/contrib/admin/templates/admin``) into that directory.
 
 .. admonition:: Where are the Django source files?
 


### PR DESCRIPTION
Changed the stated position of the base_site.html from django/contrib/admin/templates to django/contrib/admin/templates/admin