### PR TITLE
Fixed #26487 -- Used EHLO after smtplib.SMTP_SSL too.

### DIFF
--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -56,11 +56,11 @@ class EmailBackend(BaseEmailBackend):
             })
         try:
             self.connection = connection_class(self.host, self.port, **connection_params)
+            self.connection.ehlo()
 
             # TLS/SSL are mutually exclusive, so only attempt TLS over
             # non-secure connections.
             if not self.use_ssl and self.use_tls:
-                self.connection.ehlo()
                 self.connection.starttls(keyfile=self.ssl_keyfile, certfile=self.ssl_certfile)
                 self.connection.ehlo()
             if self.username and self.password:


### PR DESCRIPTION
After smtplib.SMTP_SSL EHLO should be used.

Ticket: https://code.djangoproject.com/ticket/26487