### PR TITLE
Fixed #26492 -- Prevent "maximum recursion depth exceeded" error when

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
 
     def _run_checks(self, **kwargs):
         issues = run_checks(tags=[Tags.database])
-        issues.extend(super(Command, self).check(**kwargs))
+        issues.extend(super(Command, self)._run_checks(**kwargs))
         return issues
 
     def handle(self, *args, **options):

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -53,6 +53,16 @@ class MigrateTests(MigrationTestBase):
         self.assertTableNotExists("migrations_tribble")
         self.assertTableNotExists("migrations_book")
 
+    @override_settings(INSTALLED_APPS=[
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'migrations.migrations_test_apps.migrated_app',
+    ])
+    def test_migrate_do_not_skip_system_checks(self):
+        out = six.StringIO()
+        call_command("migrate", skip_checks=False, no_color=True, stdout=out)
+        self.assertIn('Apply all migrations: migrated_app', out.getvalue())
+
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_initial_false"})
     def test_migrate_initial_false(self):
         """


### PR DESCRIPTION
running migrate command with system checks enabled.

Current tests didn't catch this because call_command() defaults
to 'skip_checks = True'.

https://code.djangoproject.com/ticket/26492