### PR TITLE
Fixed #26493 Documented how Django sends built-in signals.

### DIFF
--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -4,6 +4,11 @@ Signals
 
 A list of all the signals that Django sends.
 
+.. note::
+
+    Built-in signals are sent using the :meth:`~django.dispatch.Signal.send` method
+    which does not catch any exceptions raised by receivers.
+
 .. seealso::
 
     See the documentation on the :doc:`signal dispatcher </topics/signals>` for


### PR DESCRIPTION
Improved documentation of built-in signals regarding the way they are sent.