### PR TITLE
Fixed #26504 -- Prevented warning logging for i18n redirect.

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -179,10 +179,6 @@ class BaseHandler(object):
                 response_is_rendered = True
 
         except http.Http404 as exc:
-            logger.warning(
-                'Not Found: %s', request.path,
-                extra={'status_code': 404, 'request': request},
-            )
             if settings.DEBUG:
                 response = debug.technical_404_response(request, exc)
             else:
@@ -245,6 +241,12 @@ class BaseHandler(object):
         # been rendered, force it to be rendered.
         if not response_is_rendered and callable(getattr(response, 'render', None)):
             response = response.render()
+
+        if response.status_code == 404:
+            logger.warning(
+                'Not Found: %s', request.path,
+                extra={'status_code': 404, 'request': request},
+            )
 
         return response
 

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -141,6 +141,12 @@ class I18NLoggingTest(LoggingCaptureMixin, SimpleTestCase):
         super(I18NLoggingTest, cls).tearDownClass()
         logging.config.dictConfig(cls._logging)
 
+    def test_i18n_page_found_no_warning(self):
+        with self.settings(DEBUG=True):
+            self.client.get('/exists/')
+            self.client.get('/en/exists/')
+            self.assertEqual(self.logger_output.getvalue(), '')
+
     def test_i18n_page_not_found_warning(self):
         with self.settings(DEBUG=True):
             self.client.get('/this_does_not/')

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -91,30 +91,30 @@ class DefaultLoggingTest(LoggingCaptureMixin, SimpleTestCase):
             self.logger.error("Hey, this is an error.")
             self.assertEqual(self.logger_output.getvalue(), 'Hey, this is an error.\n')
 
+    @override_settings(DEBUG=True)
     def test_django_logger_warning(self):
-        with self.settings(DEBUG=True):
-            self.logger.warning('warning')
-            self.assertEqual(self.logger_output.getvalue(), 'warning\n')
+        self.logger.warning('warning')
+        self.assertEqual(self.logger_output.getvalue(), 'warning\n')
 
+    @override_settings(DEBUG=True)
     def test_django_logger_info(self):
-        with self.settings(DEBUG=True):
-            self.logger.info('info')
-            self.assertEqual(self.logger_output.getvalue(), 'info\n')
+        self.logger.info('info')
+        self.assertEqual(self.logger_output.getvalue(), 'info\n')
 
+    @override_settings(DEBUG=True)
     def test_django_logger_debug(self):
-        with self.settings(DEBUG=True):
-            self.logger.debug('debug')
-            self.assertEqual(self.logger_output.getvalue(), '')
+        self.logger.debug('debug')
+        self.assertEqual(self.logger_output.getvalue(), '')
 
+    @override_settings(DEBUG=True)
     def test_page_found_no_warning(self):
-        with self.settings(DEBUG=True):
-            self.client.get('/innocent/')
-            self.assertEqual(self.logger_output.getvalue(), '')
+        self.client.get('/innocent/')
+        self.assertEqual(self.logger_output.getvalue(), '')
 
+    @override_settings(DEBUG=True)
     def test_page_not_found_warning(self):
-        with self.settings(DEBUG=True):
-            self.client.get('/does_not_exist/')
-            self.assertEqual(self.logger_output.getvalue(), 'Not Found: /does_not_exist/\n')
+        self.client.get('/does_not_exist/')
+        self.assertEqual(self.logger_output.getvalue(), 'Not Found: /does_not_exist/\n')
 
 
 @override_settings(
@@ -141,17 +141,17 @@ class I18NLoggingTest(LoggingCaptureMixin, SimpleTestCase):
         super(I18NLoggingTest, cls).tearDownClass()
         logging.config.dictConfig(cls._logging)
 
+    @override_settings(DEBUG=True)
     def test_i18n_page_found_no_warning(self):
-        with self.settings(DEBUG=True):
-            self.client.get('/exists/')
-            self.client.get('/en/exists/')
-            self.assertEqual(self.logger_output.getvalue(), '')
+        self.client.get('/exists/')
+        self.client.get('/en/exists/')
+        self.assertEqual(self.logger_output.getvalue(), '')
 
+    @override_settings(DEBUG=True)
     def test_i18n_page_not_found_warning(self):
-        with self.settings(DEBUG=True):
-            self.client.get('/this_does_not/')
-            self.client.get('/en/nor_this/')
-            self.assertEqual(self.logger_output.getvalue(), 'Not Found: /this_does_not/\nNot Found: /en/nor_this/\n')
+        self.client.get('/this_does_not/')
+        self.client.get('/en/nor_this/')
+        self.assertEqual(self.logger_output.getvalue(), 'Not Found: /this_does_not/\nNot Found: /en/nor_this/\n')
 
 
 class WarningLoggerTests(SimpleTestCase):

--- a/tests/logging_tests/urls.py
+++ b/tests/logging_tests/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url(r'^innocent/$', views.innocent),
     url(r'^suspicious/$', views.suspicious),
     url(r'^suspicious_spec/$', views.suspicious_spec),
 ]

--- a/tests/logging_tests/urls_i18n.py
+++ b/tests/logging_tests/urls_i18n.py
@@ -1,0 +1,9 @@
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+from django.conf.urls.i18n import i18n_patterns
+from django.http import HttpResponse
+
+urlpatterns = i18n_patterns(
+    url(r'^exists/$', lambda r: HttpResponse()),
+)

--- a/tests/logging_tests/views.py
+++ b/tests/logging_tests/views.py
@@ -1,6 +1,11 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import DisallowedHost, SuspiciousOperation
+from django.http import HttpResponse
+
+
+def innocent(request):
+    return HttpResponse('innocent')
 
 
 def suspicious(request):


### PR DESCRIPTION
I've noticed that I've been getting warnings logged for things like:

    Not Found: /

This results from accessing a path of "/" which is getting redirected by LocaleMiddleware to "/en/". So, in fact there is never any actual "page not found" happening here, but the code is logging based on a temporary 404 exception that the LocaleMiddleware will touch up into a redirect response.

I admit that I'm a little OCD when it comes to my log files, and I prefer them to be warning-free when nothing wrong is happening.

This commit series first adds 4 tests to verify correct logging (or lack of logging) for "page found"/"page not found" both with and without i18n_patterns. One of the 4 tests will fail currently, (demonstrating the bug).

The final commit in the series moves a call to logger.warning() so that all 4 tests pass.

https://code.djangoproject.com/ticket/26504