### PR TITLE
JsonpResponse subclass of HttpResponse helps easily create JSONP-encoded responses.

### DIFF
--- a/django/http/__init__.py
+++ b/django/http/__init__.py
@@ -7,7 +7,8 @@ from django.http.response import (
     HttpResponseBadRequest, HttpResponseForbidden, HttpResponseGone,
     HttpResponseNotAllowed, HttpResponseNotFound, HttpResponseNotModified,
     HttpResponsePermanentRedirect, HttpResponseRedirect,
-    HttpResponseServerError, JsonResponse, StreamingHttpResponse,
+    HttpResponseServerError, JsonpResponse, JsonResponse,
+    StreamingHttpResponse,
 )
 from django.http.utils import conditional_content_removal
 

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -519,3 +519,34 @@ class JsonResponse(HttpResponse):
         kwargs.setdefault('content_type', 'application/json')
         data = json.dumps(data, cls=encoder, **json_dumps_params)
         super(JsonResponse, self).__init__(content=data, **kwargs)
+
+
+class JsonpResponse(HttpResponse):
+    """
+    An HTTP response class that consumes data to be serialized to JSONP.
+
+    :param callback: Callback for JSONP. GET from request.GET.
+      ``callback = request.GET.get('callback', '')``
+    :param data: Data to be dumped into json. By default only ``dict`` objects
+      are allowed to be passed due to a security flaw before EcmaScript 5. See
+      the ``safe`` parameter for more information.
+    :param encoder: Should be an json encoder class. Defaults to
+      ``django.core.serializers.json.DjangoJSONEncoder``.
+    :param safe: Controls if only ``dict`` objects may be serialized. Defaults
+      to ``True``.
+    :param json_dumps_params: A dictionary of kwargs passed to json.dumps().
+    """
+
+    def __init__(self, callback, data, encoder=DjangoJSONEncoder, safe=True,
+                 json_dumps_params=None, **kwargs):
+        if safe and not isinstance(data, dict):
+            raise TypeError(
+                'In order to allow non-dict objects to be serialized set the '
+                'safe parameter to False.'
+            )
+        if json_dumps_params is None:
+            json_dumps_params = {}
+        kwargs.setdefault('content_type', 'application/javascript')
+        data = json.dumps(data, cls=encoder, **json_dumps_params)
+        data = '{}({})'.format(callback=callback, data=data)
+        super(JsonpResponse, self).__init__(content=data, **kwargs)


### PR DESCRIPTION
Django 1.7  realease JsonResponse subclass of HttpResponse helps easily create JSON-encoded responses.

As discussed in https://code.djangoproject.com/ticket/17942#comment:6
```
Trying to support JSONP callbacks would require to somehow allow Cross-origin resource sharing. I would say it's not needed for most use cases.
```

JsonpResponse isn't needed for most use cases. But is needed for some use cases.