### PR TITLE
Fixed problems with unicode

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -187,7 +187,7 @@ def get_path_info(environ):
     """
     path_info = get_bytes_from_wsgi(environ, 'PATH_INFO', '/')
 
-    return path_info.decode(UTF_8)
+    return path_info.decode(UTF_8) if six.PY3 else path_info
 
 
 def get_script_name(environ):
@@ -220,7 +220,7 @@ def get_script_name(environ):
     else:
         script_name = get_bytes_from_wsgi(environ, 'SCRIPT_NAME', '')
 
-    return script_name.decode(UTF_8)
+    return script_name.decode(UTF_8) if six.PY3 else script_name
 
 
 def get_bytes_from_wsgi(environ, key, default):


### PR DESCRIPTION
I was investigating exception we were getting after bumping Django to newest stable version.

And we found issue with unicode somewhere down in uwsgi.
After further investigation, we found that problem lies with environment variables created by Django.

Stacktrace of error:
```
Internal Server Error

Traceback (most recent call last):
  File "/Users/bim/Developer/Inventorum/site/eggs/waitress-0.9.0-py2.7.egg/waitress/channel.py", line 338, in service
    task.service()
  File "/Users/bim/Developer/Inventorum/site/eggs/waitress-0.9.0-py2.7.egg/waitress/task.py", line 169, in service
    self.execute()
  File "/Users/bim/Developer/Inventorum/site/eggs/waitress-0.9.0-py2.7.egg/waitress/task.py", line 399, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/Users/bim/Developer/Inventorum/site/eggs/Paste-2.0.3-py2.7.egg/paste/urlmap.py", line 216, in __call__
    return app(environ, start_response)
  File "/Users/bim/Developer/Inventorum/site/eggs/fanstatic-1.0a7-py2.7.egg/fanstatic/publisher.py", line 224, in __call__
    return self.app(environ, start_response)
  File "/Users/bim/Developer/Inventorum/site/eggs/fanstatic-1.0a7-py2.7.egg/fanstatic/injector.py", line 86, in __call__
    return response(environ, start_response)
  File "/Users/bim/Developer/Inventorum/site/eggs/WebOb-1.6.0-py2.7.egg/webob/response.py", line 1037, in __call__
    start_response(self.status, headerlist)
  File "/Users/bim/Developer/Inventorum/site/eggs/waitress-0.9.0-py2.7.egg/waitress/task.py", line 375, in start_response
    'Header value %r is not a string in %r' % (v, (k, v))
AssertionError: Header value u'http://127.0.0.1:5012/de/pay/select' is not a string in ('Location', u'http://127.0.0.1:5012/de/pay/select')

```

First fix was posted on https://github.com/Pylons/waitress/pull/125 but people maintaining project pointed out that headers should be `str` due to PEP rules. 

I hope this is proper way to fix it, if not please give me few hints. 