### PR TITLE
Refs #16508 -- Made Model.__init__ aware of virtual fields.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -452,11 +452,14 @@ class Model(six.with_metaclass(ModelBase)):
         if kwargs:
             for prop in list(kwargs):
                 try:
-                    if isinstance(getattr(self.__class__, prop), property):
+                    # Any remaining kwargs need to correspond either to
+                    # properties, or to virtual fields.
+                    if (isinstance(getattr(self.__class__, prop), property) or
+                            self._meta.get_field(prop)):
                         if kwargs[prop] is not DEFERRED:
                             setattr(self, prop, kwargs[prop])
                         del kwargs[prop]
-                except AttributeError:
+                except (AttributeError, FieldDoesNotExist):
                     pass
             if kwargs:
                 raise TypeError("'%s' is an invalid keyword argument for this function" % list(kwargs)[0])

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -400,6 +400,9 @@ Models
 * A proxy model may now inherit multiple proxy models that share a common
   non-abstract parent class.
 
+* ``Model.__init__`` now recognizes keyword arguments setting values of
+  virtual fields.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/generic_relations/tests.py
+++ b/tests/generic_relations/tests.py
@@ -555,6 +555,23 @@ id="id_generic_relations-taggeditem-content_type-object_id-1-id" /></p>""" % tag
         with self.assertRaises(IntegrityError):
             TaggedItem.objects.create(tag="shiny", content_object=quartz)
 
+    def test_cache_invalidation_for_content_type_id(self):
+        # Create a Vegetable and Mineral with the same id.
+        new_id = max(Vegetable.objects.order_by('-id')[0].id,
+                     Mineral.objects.order_by('-id')[0].id) + 1
+        broccoli = Vegetable.objects.create(id=new_id, name="Broccoli")
+        diamond = Mineral.objects.create(id=new_id, name="Diamond", hardness=7)
+        tag = TaggedItem.objects.create(content_object=broccoli, tag="yummy")
+        tag.content_type = ContentType.objects.get_for_model(diamond)
+        self.assertEqual(tag.content_object, diamond)
+
+    def test_cache_invalidation_for_object_id(self):
+        broccoli = Vegetable.objects.create(name="Broccoli")
+        cauliflower = Vegetable.objects.create(name="Cauliflower")
+        tag = TaggedItem.objects.create(content_object=broccoli, tag="yummy")
+        tag.object_id = cauliflower.id
+        self.assertEqual(tag.content_object, cauliflower)
+
 
 class CustomWidget(forms.TextInput):
     pass


### PR DESCRIPTION
Making Model.__init__ recognize keyword arguments for virtual fields means
it is no longer necessary for GenericForeignKey (and any other virtual
fields) to intercept them using the pre_init signal.

This makes two tests for `GenericRelatedObjectManager.add` fail, see [the ticket] for discussion.

[the ticket]: https://code.djangoproject.com/ticket/16508#comment:15