### PR TITLE
Fixed incorrect rendered widget in forms example.

### DIFF
--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -514,7 +514,7 @@ Here's the output of ``{{ form.as_p }}`` for our ``ContactForm`` instance:
     <p><label for="id_subject">Subject:</label>
         <input id="id_subject" type="text" name="subject" maxlength="100" /></p>
     <p><label for="id_message">Message:</label>
-        <input type="text" name="message" id="id_message" /></p>
+        <textarea name="message" id="id_message"></textarea></p>
     <p><label for="id_sender">Sender:</label>
         <input type="email" name="sender" id="id_sender" /></p>
     <p><label for="id_cc_myself">Cc myself:</label>


### PR DESCRIPTION
The form being rendered is defined here: 

<https://github.com/django/django/blob/b040ac06ebba2348cece7390b88f746d2c91d07b/docs/topics/forms/index.txt#L410-L414>