### PR TITLE
Fixed #26429 -- Placed a timestamp into generated merge migration names

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -76,7 +76,7 @@ def get_commands():
     return commands
 
 
-def call_command(name, *args, **options):
+def call_command(command_name, *args, **options):
     """
     Calls the given command, with the given options and args/kwargs.
 
@@ -95,25 +95,25 @@ def call_command(name, *args, **options):
         call_command(cmd, verbosity=0, interactive=False)
         # Do something with cmd ...
     """
-    if isinstance(name, BaseCommand):
+    if isinstance(command_name, BaseCommand):
         # Command object passed in.
-        command = name
-        name = command.__class__.__module__.split('.')[-1]
+        command = command_name
+        command_name = command.__class__.__module__.split('.')[-1]
     else:
         # Load the command object by name.
         try:
-            app_name = get_commands()[name]
+            app_name = get_commands()[command_name]
         except KeyError:
-            raise CommandError("Unknown command: %r" % name)
+            raise CommandError("Unknown command: %r" % command_name)
 
         if isinstance(app_name, BaseCommand):
             # If the command is already loaded, use it directly.
             command = app_name
         else:
-            command = load_command_class(app_name, name)
+            command = load_command_class(app_name, command_name)
 
     # Simulate argument parsing to get the option defaults (see #10080 for details).
-    parser = command.create_parser('', name)
+    parser = command.create_parser('', command_name)
     # Use the `dest` option name from the parser option
     opt_mapping = {
         sorted(s_opt.option_strings)[0].lstrip('-').replace('-', '_'): s_opt.dest

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -15,6 +15,7 @@ from django.db.migrations.questioner import (
 )
 from django.db.migrations.state import ProjectState
 from django.db.migrations.writer import MigrationWriter
+from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.six import iteritems
 from django.utils.six.moves import zip
@@ -283,7 +284,14 @@ class Command(BaseCommand):
                 subclass = type("Migration", (Migration, ), {
                     "dependencies": [(app_label, migration.name) for migration in merge_migrations],
                 })
-                new_migration = subclass("%04i_merge" % (biggest_number + 1), app_label)
+                if self.migration_name:
+                    migration_suffix = self.migration_name
+                else:
+                    migration_suffix = "merge_" + timezone.now().strftime("%Y%m%d_%H%M")
+
+                migration_name = "%04i_%s" % (biggest_number + 1, migration_suffix)
+
+                new_migration = subclass(migration_name, app_label)
                 writer = MigrationWriter(new_migration)
 
                 if not self.dry_run:

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -14,8 +14,8 @@ from django.db.migrations.questioner import (
     NonInteractiveMigrationQuestioner,
 )
 from django.db.migrations.state import ProjectState
+from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.migrations.writer import MigrationWriter
-from django.utils import timezone
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.six import iteritems
 from django.utils.six.moves import zip
@@ -284,13 +284,10 @@ class Command(BaseCommand):
                 subclass = type("Migration", (Migration, ), {
                     "dependencies": [(app_label, migration.name) for migration in merge_migrations],
                 })
-                if self.migration_name:
-                    migration_suffix = self.migration_name
-                else:
-                    migration_suffix = "merge_" + timezone.now().strftime("%Y%m%d_%H%M")
-
-                migration_name = "%04i_%s" % (biggest_number + 1, migration_suffix)
-
+                migration_name = "%04i_%s" % (
+                    biggest_number + 1,
+                    self.migration_name or ("merge_%s" % get_migration_name_timestamp())
+                )
                 new_migration = subclass(migration_name, app_label)
                 writer = MigrationWriter(new_migration)
 

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import datetime
 import functools
 import re
 from itertools import chain
@@ -12,7 +11,9 @@ from django.db.migrations.migration import Migration
 from django.db.migrations.operations.models import AlterModelOptions
 from django.db.migrations.optimizer import MigrationOptimizer
 from django.db.migrations.questioner import MigrationQuestioner
-from django.db.migrations.utils import COMPILED_REGEX_TYPE, RegexObject
+from django.db.migrations.utils import (
+    COMPILED_REGEX_TYPE, RegexObject, get_migration_name_timestamp,
+)
 from django.utils import six
 
 from .topological_sort import stable_topological_sort
@@ -1148,7 +1149,7 @@ class MigrationAutodetector(object):
         elif len(ops) > 1:
             if all(isinstance(o, operations.CreateModel) for o in ops):
                 return "_".join(sorted(o.name_lower for o in ops))
-        return "auto_%s" % datetime.datetime.now().strftime("%Y%m%d_%H%M")
+        return "auto_%s" % get_migration_name_timestamp()
 
     @classmethod
     def parse_number(cls, name):

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 COMPILED_REGEX_TYPE = type(re.compile(''))
@@ -10,3 +11,7 @@ class RegexObject(object):
 
     def __eq__(self, other):
         return self.pattern == other.pattern and self.flags == other.flags
+
+
+def get_migration_name_timestamp():
+    return datetime.datetime.now().strftime("%Y%m%d_%H%M")

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -723,17 +723,15 @@ class MakeMigrationsTests(MigrationTestBase):
                 self.assertTrue(os.path.exists(merge_file))
             self.assertIn("Created new merge migration", force_text(out.getvalue()))
 
-    def test_makemigrations_default_merge_name(self):
-        test_date = datetime.datetime(2016, 1, 2, 3, 4)
-        test_date_mock = mock.patch('django.utils.timezone.now', mock.Mock(return_value=test_date))
-        with mock.patch('django.db.migrations.questioner.input', mock.Mock(return_value='y')), test_date_mock:
+    @mock.patch('django.db.migrations.utils.datetime')
+    def test_makemigrations_default_merge_name(self, mock_datetime):
+        mock_datetime.datetime.now.return_value = datetime.datetime(2016, 1, 2, 3, 4)
+        with mock.patch('django.db.migrations.questioner.input', mock.Mock(return_value='y')):
             out = six.StringIO()
-
             with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
                 call_command("makemigrations", "migrations", merge=True, interactive=True, stdout=out)
                 merge_file = os.path.join(migration_dir, '0003_merge_20160102_0304.py')
                 self.assertTrue(os.path.exists(merge_file))
-
             self.assertIn("Created new merge migration", force_text(out.getvalue()))
 
     def test_makemigrations_non_interactive_not_null_addition(self):
@@ -824,8 +822,8 @@ class MakeMigrationsTests(MigrationTestBase):
         out = six.StringIO()
         with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
             call_command(
-                "makemigrations", "migrations", name="merge",
-                dry_run=True, merge=True, interactive=False, stdout=out
+                "makemigrations", "migrations", name="merge", dry_run=True,
+                merge=True, interactive=False, stdout=out,
             )
             merge_file = os.path.join(migration_dir, '0003_merge.py')
             self.assertFalse(os.path.exists(merge_file))
@@ -843,8 +841,8 @@ class MakeMigrationsTests(MigrationTestBase):
         out = six.StringIO()
         with self.temporary_migration_module(module="migrations.test_migrations_conflict") as migration_dir:
             call_command(
-                "makemigrations", "migrations", name="merge",
-                dry_run=True, merge=True, interactive=False, stdout=out, verbosity=3
+                "makemigrations", "migrations", name="merge", dry_run=True,
+                merge=True, interactive=False, stdout=out, verbosity=3,
             )
             merge_file = os.path.join(migration_dir, '0003_merge.py')
             self.assertFalse(os.path.exists(merge_file))


### PR DESCRIPTION
  This sets a timestamp to the generated merge migration names, much in the same fashion as other migrations. This is to help reduce the possibility of a naming conflict (especially after squashing migrations).

  This is to fix the issues mentioned in [#26469](https://code.djangoproject.com/ticket/26429#comment:3), where the combination of merge migration names and squashing can cause a migration to end up never running due to a name conflict.