### PR TITLE
Refs #26033 -- Added password hasher support for Argon2 v1.3.

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -142,7 +142,7 @@ Running all the tests
 If you want to run the full suite of tests, you'll need to install a number of
 dependencies:
 
-*  argon2-cffi_ 16.0.0+
+*  argon2-cffi_ 16.1.0+
 *  bcrypt_
 *  docutils_
 *  enum34_ (Python 2 only)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ]},
     extras_require={
         "bcrypt": ["bcrypt"],
-        "argon2": ["argon2-cffi >= 16.0.0"],
+        "argon2": ["argon2-cffi >= 16.1.0"],
     },
     zip_safe=False,
     classifiers=[

--- a/tests/auth_tests/test_hashers.py
+++ b/tests/auth_tests/test_hashers.py
@@ -457,11 +457,39 @@ class TestUtilsHashPassArgon2(SimpleTestCase):
         self.assertTrue(is_password_usable(blank_encoded))
         self.assertTrue(check_password('', blank_encoded))
         self.assertFalse(check_password(' ', blank_encoded))
+        # Old hashes without version attribute
+        encoded = ('argon2$argon2i$m=8,t=1,p=1$c29tZXNhbHQ$gwQOXSNhxiOxPOA0+'
+                   'PY10P9QFO4NAYysnqRt1GSQLE55m+2GYDt9FEjPMHhP2Cuf0nOEXXMoc'
+                   'VrsJAtNSsKyfg')
+        self.assertTrue(check_password('secret', encoded))
+        self.assertFalse(check_password('wrong', encoded))
 
     def test_argon2_upgrade(self):
         self._test_argon2_upgrade('time_cost', 'time cost', 1)
         self._test_argon2_upgrade('memory_cost', 'memory cost', 16)
         self._test_argon2_upgrade('parallelism', 'parallelism', 1)
+
+    def test_argon2_version_upgrade(self):
+        hasher = get_hasher('argon2')
+        state = {'upgraded': False}
+        encoded = ('argon2$argon2i$m=8,t=1,p=1$c29tZXNhbHQ$gwQOXSNhxiOxPOA0+'
+                   'PY10P9QFO4NAYysnqRt1GSQLE55m+2GYDt9FEjPMHhP2Cuf0nOEXXMoc'
+                   'VrsJAtNSsKyfg')
+        def setter(password):
+            state['upgraded'] = True
+        try:
+            old_m = hasher.memory_cost
+            old_t = hasher.time_cost
+            old_p = hasher.parallelism
+            hasher.memory_cost = 8
+            hasher.time_cost = 1
+            hasher.parallelism = 1
+            self.assertTrue(check_password('secret', encoded, setter, 'argon2'))
+            self.assertTrue(state['upgraded'])
+        finally:
+            hasher.memory_cost = old_m
+            hasher.time_cost = old_t
+            hasher.parallelism = old_p
 
     def _test_argon2_upgrade(self, attr, summary_key, new_value):
         hasher = get_hasher('argon2')

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,4 +1,4 @@
-argon2-cffi == 16.0.0
+argon2-cffi >= 16.1.0
 bcrypt
 docutils
 geoip2


### PR DESCRIPTION
The previous version of Argon2 uses encoded hashes of the form

    $argon2d$m=8,t=1,p=1$<salt>$<data>

Surprisingly the new version of Argon2 adds its version into the
encoded hash as follows

    $argon2d$v=19$m=8,t=1,p=1$<salt>$<data>

This commit lets Django handle both version properly.

https://code.djangoproject.com/ticket/26033