### PR TITLE
Fixed #26536 -- Preserved leading dashes of the cached template loader keys.

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -100,7 +100,7 @@ class Loader(BaseLoader):
         if template_dirs:
             dirs_prefix = self.generate_hash(template_dirs)
 
-        return ("%s-%s-%s" % (template_name, skip_prefix, dirs_prefix)).strip('-')
+        return '-'.join(filter(bool, [template_name, skip_prefix, dirs_prefix]))
 
     def generate_hash(self, values):
         return hashlib.sha1(force_bytes('|'.join(values))).hexdigest()

--- a/docs/releases/1.9.6.txt
+++ b/docs/releases/1.9.6.txt
@@ -21,3 +21,6 @@ Bugfixes
 
 * Fixed a regression where ``SessionBase.pop()`` returned ``None`` rather than
   raising a ``KeyError`` for nonexistent values (:ticket:`26520`).
+
+* Fixed a regression causing the cached template loader to crash when using
+  template names starting with a dash (:ticket:`26536`).

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -146,6 +146,13 @@ class CachedLoaderTests(SimpleTestCase):
         # The two templates should not have the same content
         self.assertNotEqual(t1.render(Context({})), t2.render(Context({})))
 
+    def test_template_name_leading_dash_caching(self):
+        """
+        #26536 -- A leading dash in a template name shouldn't be stripped
+        from its cache key.
+        """
+        self.assertEqual(self.engine.template_loaders[0].cache_key('-template.html', []), '-template.html')
+
 
 @unittest.skipUnless(pkg_resources, 'setuptools is not installed')
 class EggLoaderTests(SimpleTestCase):


### PR DESCRIPTION
Thanks Anders Roos for the report.