### PR TITLE
Fixed #19513, #18580 -- Cleared annotations on queryset before performing update

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -635,6 +635,9 @@ class QuerySet(object):
         self._for_write = True
         query = self.query.clone(sql.UpdateQuery)
         query.add_update_values(kwargs)
+        # Clear any annotations so that they won't be present in subqueries
+        query.set_annotation_mask(None)
+        query._annotations = None
         with transaction.atomic(using=self.db, savepoint=False):
             rows = query.get_compiler(self.db).execute_sql(CURSOR)
         self._result_cache = None
@@ -652,6 +655,9 @@ class QuerySet(object):
             "Cannot update a query once a slice has been taken."
         query = self.query.clone(sql.UpdateQuery)
         query.add_update_fields(values)
+        # Clear any annotations so that they won't be present in subqueries
+        query.set_annotation_mask(None)
+        query._annotations = None
         self._result_cache = None
         return query.get_compiler(self.db).execute_sql(CURSOR)
     _update.alters_data = True

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -142,7 +142,11 @@ class UpdateQuery(Query):
         that will be used to generate the UPDATE query. Might be more usefully
         called add_update_targets() to hint at the extra information here.
         """
-        self.values.extend(values_seq)
+        for field, model, val in values_seq:
+            if hasattr(val, 'resolve_expression'):
+                # Resolve expressions here so that annotations are no longer needed
+                val = val.resolve_expression(self, allow_joins=False, for_save=True)
+            self.values.append((field, model, val))
 
     def add_related_update(self, model, field, value):
         """

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from django.core.exceptions import FieldError
+from django.db.models import Count, F, Max
 from django.test import TestCase
 
 from .models import A, B, Bar, D, DataPoint, Foo, RelatedPoint
@@ -138,3 +140,49 @@ class AdvancedTests(TestCase):
         self.assertEqual(bar_qs[0].foo_id, a_foo.target)
         bar_qs.update(foo=b_foo)
         self.assertEqual(bar_qs[0].foo_id, b_foo.target)
+
+    def test_update_annotated_queryset(self):
+        """
+        Update of a queryset which has been annotated.
+        """
+        # Trivial annotated update first
+        qs = DataPoint.objects.annotate(alias=F('value'))
+        updated = qs.update(another_value='foo')
+        self.assertEqual(updated, 3)
+        # Update where annotation is used for filtering
+        qs = DataPoint.objects.annotate(alias=F('value'))
+        qs = qs.filter(alias='apple')
+        updated = qs.update(another_value='foo')
+        self.assertEqual(updated, 1)
+        # Update where annotation is used in update parameters
+        qs = DataPoint.objects.annotate(alias=F('value'))
+        updated = qs.update(another_value=F('alias'))
+        self.assertEqual(updated, 3)
+        # Update where aggregation annotation is used in update parameters
+        qs = DataPoint.objects.annotate(max=Max('value'))
+        with self.assertRaises(FieldError):
+            updated = qs.update(another_value=F('max'))
+
+    def test_update_annotated_multi_table_queryset(self):
+        """
+        Update of a queryset which has been annotated and involves
+        multiple tables. Regression test for #19513 and #18580
+        """
+        # Trivial annotated update first
+        qs = DataPoint.objects.annotate(related_count=Count('relatedpoint'))
+        updated = qs.update(value='Foo')
+        self.assertEqual(updated, 3)
+        # Update where annotation is used for filtering
+        qs = DataPoint.objects.annotate(related_count=Count('relatedpoint'))
+        qs = qs.filter(related_count=1)
+        updated = qs.update(value='Foo')
+        self.assertEqual(updated, 1)
+        # Update where annotation is used in update parameters
+        # #26539 - This isn't forbidden but also doesn't generate proper SQL
+        # qs = RelatedPoint.objects.annotate(data_name=F('data__name'))
+        # updated = qs.update(name=F('data_name'))
+        # self.assertEqual(updated, 1)
+        # Update where aggregation annotation is used in update parameters
+        qs = RelatedPoint.objects.annotate(max=Max('data__value'))
+        with self.assertRaises(FieldError):
+            updated = qs.update(name=F('max'))


### PR DESCRIPTION
More discussion about the fix is on [ticket 19513](https://code.djangoproject.com/ticket/19513#comment:5). The first added test case works fine on master as is but was added to provide some test coverage to `update` with an annotation. The second test case includes a commented out test that invokes [ticket 26539](https://code.djangoproject.com/ticket/26539) which I opened before this PR.