### PR TITLE
msgid errors

### DIFF
--- a/django/contrib/auth/locale/zh_CN/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/zh_CN/LC_MESSAGES/django.po
@@ -67,7 +67,7 @@ msgid "Password confirmation"
 msgstr "密码确认"
 
 msgid "Enter the same password as before, for verification."
-msgstr ""
+msgstr "为了校验，输入与上面相同的密码。"
 
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user's "

--- a/django/contrib/auth/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/zh_Hans/LC_MESSAGES/django.po
@@ -59,8 +59,8 @@ msgstr "密码"
 
 msgid "Password confirmation"
 msgstr "密码确认"
-
-msgid "Enter the same password as above, for verification."
+	   
+msgid "Enter the same password as before, for verification."
 msgstr "为了校验，输入与上面相同的密码。"
 
 msgid ""

--- a/django/contrib/auth/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/zh_Hant/LC_MESSAGES/django.po
@@ -59,7 +59,7 @@ msgstr "密碼"
 msgid "Password confirmation"
 msgstr "密碼確認"
 
-msgid "Enter the same password as above, for verification."
+msgid "Enter the same password as before, for verification."
 msgstr "為檢查用，請輸入與上面相同的密碼。"
 
 msgid ""

--- a/django/contrib/auth/locale/zh_TW/LC_MESSAGES/django.po
+++ b/django/contrib/auth/locale/zh_TW/LC_MESSAGES/django.po
@@ -67,7 +67,7 @@ msgid "Password confirmation"
 msgstr "密碼確認"
 
 msgid "Enter the same password as before, for verification."
-msgstr ""
+msgstr "為檢查用，請輸入與上面相同的密碼。"
 
 msgid ""
 "Raw passwords are not stored, so there is no way to see this user's "


### PR DESCRIPTION
UserCreationForm and  AdminPasswordChangeForm password2 field's help_text is `Enter the same password as before, for verification.` the msgid is 'Enter the same password as above, for verification.' They are different.