### PR TITLE
Fixed #24452 -- Fixed HashedFilesMixin correctness with nested paths.

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -293,6 +293,24 @@ content:
 
     @import url("../admin/css/base.27e20196a850.css");
 
+.. attribute:: storage.ManifestStaticFilesStorage.max_post_process_passes
+
+Since static files might reference other static files that need to have their
+paths replaced, multiple passes of replacing paths may be needed until the file
+hashes converge. To prevent an infinite loop due to hashes not converging (for
+example, if ``'foo.css'`` references ``'bar.css'`` which references
+``'foo.css'``) there is a maximum number of passes before post-processing is
+abandoned. In cases with a large number of references, a higher number of
+passes might be needed. Increase the maximum number of passes by subclassing
+``ManifestStaticFilesStorage`` and setting the ``max_post_process_passes``
+attribute. It defaults to 5.
+
+.. versionchanged:: 1.11
+
+    Previous versions didn't make multiple passes to ensure file hashes
+    converged, so often times file hashes weren't correct. The
+    ``max_post_process_passes`` attribute was added.
+
 To enable the ``ManifestStaticFilesStorage`` you have to make sure the
 following requirements are met:
 
@@ -314,6 +332,18 @@ during runtime, ``staticfiles`` will automatically store the mapping with
 hashed names for all processed files in a file called ``staticfiles.json``.
 This happens once when you run the :djadmin:`collectstatic` management
 command.
+
+.. attribute:: storage.ManifestStaticFilesStorage.manifest_strict
+
+If a file isn't found in the ``staticfiles.json`` manifest at runtime, a
+``ValueError`` is raised. This behavior can be disabled by subclassing
+``ManifestStaticFilesStorage`` and setting the ``manifest_strict`` attribute to
+``False`` -- nonexistent paths will remain unchanged.
+
+.. versionchanged:: 1.11
+
+    The ``manifest_strict`` attribute was added. In older versions, the
+    behavior is the same as ``manifest_strict=False``.
 
 Due to the requirement of running :djadmin:`collectstatic`, this storage
 typically shouldn't be used when running tests as ``collectstatic`` isn't run
@@ -349,6 +379,16 @@ have access to the file system.
 If you want to override certain options of the cache backend the storage uses,
 simply specify a custom entry in the :setting:`CACHES` setting named
 ``'staticfiles'``. It falls back to using the ``'default'`` cache backend.
+
+.. warning::
+
+    ``CachedStaticFilesStorage`` isn't recommended --  in almost all cases
+    ``ManifestStaticFilesStorage`` is a better choice. There are several
+    performance penalties when using ``CachedStaticFilesStorage`` since a cache
+    miss requires hashing files at runtime. Remote file storage require several
+    round-trips to hash a file on a cache miss, as several file accesses are
+    required to ensure that the file hash is correct in the case of nested file
+    paths.
 
 Finders Module
 ==============

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -481,6 +481,21 @@ Backwards incompatible changes in 1.11
   updated. Check your project if you subclass these widgets or extend the
   templates.
 
+:mod:`django.contrib.staticfiles`
+---------------------------------
+
+* ``collectstatic`` may now fail during post-processing when using a hashed
+  static files storage if a reference loop exists (e.g. ``'foo.css'``
+  references ``'bar.css'`` which itself references ``'foo.css'``) or if the
+  chain of files referencing other files is too deep to resolve in several
+  passes. In the latter case, increase the number of passes using
+  :attr:`.ManifestStaticFilesStorage.max_post_process_passes`.
+
+* When using ``ManifestStaticFilesStorage``, static files not found in the
+  manifest at runtime now raise a ``ValueError`` instead of returning an
+  unchanged path. You can revert to the old behavior by setting
+  :attr:`.ManifestStaticFilesStorage.manifest_strict` to ``False``.
+
 Database backend API
 --------------------
 

--- a/tests/staticfiles_tests/project/loop/bar.css
+++ b/tests/staticfiles_tests/project/loop/bar.css
@@ -1,0 +1,1 @@
+@import url("foo.css")

--- a/tests/staticfiles_tests/project/loop/foo.css
+++ b/tests/staticfiles_tests/project/loop/foo.css
@@ -1,0 +1,1 @@
+@import url("bar.css")

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -28,9 +28,21 @@ def hashed_file_path(test, path):
 class TestHashedFiles(object):
     hashed_file_path = hashed_file_path
 
+    def setUp(self):
+        self._max_post_process_passes = storage.staticfiles_storage.max_post_process_passes
+        super(TestHashedFiles, self).setUp()
+
     def tearDown(self):
         # Clear hashed files to avoid side effects among tests.
         storage.staticfiles_storage.hashed_files.clear()
+        storage.staticfiles_storage.max_post_process_passes = self._max_post_process_passes
+
+    def assertPostCondition(self):
+        """
+        Assert post conditions for a test are met. Must be manually called at
+        the end of each test.
+        """
+        pass
 
     def test_template_tag_return(self):
         """
@@ -39,17 +51,19 @@ class TestHashedFiles(object):
         self.assertStaticRaises(ValueError, "does/not/exist.png", "/static/does/not/exist.png")
         self.assertStaticRenders("test/file.txt", "/static/test/file.dad0999e4f8f.txt")
         self.assertStaticRenders("test/file.txt", "/static/test/file.dad0999e4f8f.txt", asvar=True)
-        self.assertStaticRenders("cached/styles.css", "/static/cached/styles.bb84a0240107.css")
+        self.assertStaticRenders("cached/styles.css", "/static/cached/styles.5e0040571e1a.css")
         self.assertStaticRenders("path/", "/static/path/")
         self.assertStaticRenders("path/?query", "/static/path/?query")
+        self.assertPostCondition()
 
     def test_template_tag_simple_content(self):
         relpath = self.hashed_file_path("cached/styles.css")
-        self.assertEqual(relpath, "cached/styles.bb84a0240107.css")
+        self.assertEqual(relpath, "cached/styles.5e0040571e1a.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"cached/other.css", content)
             self.assertIn(b"other.d41d8cd98f00.css", content)
+        self.assertPostCondition()
 
     def test_path_ignored_completely(self):
         relpath = self.hashed_file_path("cached/css/ignored.css")
@@ -62,28 +76,29 @@ class TestHashedFiles(object):
             self.assertIn(b'data:foobar', content)
             self.assertIn(b'chrome:foobar', content)
             self.assertIn(b'//foobar', content)
+        self.assertPostCondition()
 
     def test_path_with_querystring(self):
         relpath = self.hashed_file_path("cached/styles.css?spam=eggs")
-        self.assertEqual(relpath, "cached/styles.bb84a0240107.css?spam=eggs")
-        with storage.staticfiles_storage.open(
-                "cached/styles.bb84a0240107.css") as relfile:
+        self.assertEqual(relpath, "cached/styles.5e0040571e1a.css?spam=eggs")
+        with storage.staticfiles_storage.open("cached/styles.5e0040571e1a.css") as relfile:
             content = relfile.read()
             self.assertNotIn(b"cached/other.css", content)
             self.assertIn(b"other.d41d8cd98f00.css", content)
+        self.assertPostCondition()
 
     def test_path_with_fragment(self):
         relpath = self.hashed_file_path("cached/styles.css#eggs")
-        self.assertEqual(relpath, "cached/styles.bb84a0240107.css#eggs")
-        with storage.staticfiles_storage.open(
-                "cached/styles.bb84a0240107.css") as relfile:
+        self.assertEqual(relpath, "cached/styles.5e0040571e1a.css#eggs")
+        with storage.staticfiles_storage.open("cached/styles.5e0040571e1a.css") as relfile:
             content = relfile.read()
             self.assertNotIn(b"cached/other.css", content)
             self.assertIn(b"other.d41d8cd98f00.css", content)
+        self.assertPostCondition()
 
     def test_path_with_querystring_and_fragment(self):
         relpath = self.hashed_file_path("cached/css/fragments.css")
-        self.assertEqual(relpath, "cached/css/fragments.59dc2b188043.css")
+        self.assertEqual(relpath, "cached/css/fragments.c4e6753b52d3.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b'fonts/font.a4b0478549d0.eot?#iefix', content)
@@ -91,60 +106,79 @@ class TestHashedFiles(object):
             self.assertIn(b'fonts/font.b8d603e42714.svg#path/to/../../fonts/font.svg', content)
             self.assertIn(b'data:font/woff;charset=utf-8;base64,d09GRgABAAAAADJoAA0AAAAAR2QAAQAAAAAAAAAAAAA', content)
             self.assertIn(b'#default#VML', content)
+        self.assertPostCondition()
 
     def test_template_tag_absolute(self):
         relpath = self.hashed_file_path("cached/absolute.css")
-        self.assertEqual(relpath, "cached/absolute.df312c6326e1.css")
+        self.assertEqual(relpath, "cached/absolute.eb04def9f9a4.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"/static/cached/styles.css", content)
-            self.assertIn(b"/static/cached/styles.bb84a0240107.css", content)
+            self.assertIn(b"/static/cached/styles.5e0040571e1a.css", content)
             self.assertNotIn(b"/static/styles_root.css", content)
             self.assertIn(b"/static/styles_root.401f2509a628.css", content)
             self.assertIn(b'/static/cached/img/relative.acae32e4532b.png', content)
+        self.assertPostCondition()
 
     def test_template_tag_absolute_root(self):
         """
         Like test_template_tag_absolute, but for a file in STATIC_ROOT (#26249).
         """
         relpath = self.hashed_file_path("absolute_root.css")
-        self.assertEqual(relpath, "absolute_root.f864a4d7f083.css")
+        self.assertEqual(relpath, "absolute_root.f821df1b64f7.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"/static/styles_root.css", content)
             self.assertIn(b"/static/styles_root.401f2509a628.css", content)
+        self.assertPostCondition()
 
     def test_template_tag_relative(self):
         relpath = self.hashed_file_path("cached/relative.css")
-        self.assertEqual(relpath, "cached/relative.b0375bd89156.css")
+        self.assertEqual(relpath, "cached/relative.c3e9e1ea6f2e.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"../cached/styles.css", content)
             self.assertNotIn(b'@import "styles.css"', content)
             self.assertNotIn(b'url(img/relative.png)', content)
             self.assertIn(b'url("img/relative.acae32e4532b.png")', content)
-            self.assertIn(b"../cached/styles.bb84a0240107.css", content)
+            self.assertIn(b"../cached/styles.5e0040571e1a.css", content)
+        self.assertPostCondition()
 
     def test_import_replacement(self):
         "See #18050"
         relpath = self.hashed_file_path("cached/import.css")
-        self.assertEqual(relpath, "cached/import.2b1d40b0bbd4.css")
+        self.assertEqual(relpath, "cached/import.f53576679e5a.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
-            self.assertIn(b"""import url("styles.bb84a0240107.css")""", relfile.read())
+            self.assertIn(b"""import url("styles.5e0040571e1a.css")""", relfile.read())
+        self.assertPostCondition()
 
     def test_template_tag_deep_relative(self):
         relpath = self.hashed_file_path("cached/css/window.css")
-        self.assertEqual(relpath, "cached/css/window.3906afbb5a17.css")
+        self.assertEqual(relpath, "cached/css/window.5d5c10836967.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b'url(img/window.png)', content)
             self.assertIn(b'url("img/window.acae32e4532b.png")', content)
+        self.assertPostCondition()
 
     def test_template_tag_url(self):
         relpath = self.hashed_file_path("cached/url.css")
         self.assertEqual(relpath, "cached/url.902310b73412.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             self.assertIn(b"https://", relfile.read())
+        self.assertPostCondition()
+
+    @override_settings(
+        STATICFILES_DIRS=[os.path.join(TEST_ROOT, 'project', 'loop')],
+        STATICFILES_FINDERS=['django.contrib.staticfiles.finders.FileSystemFinder'],
+    )
+    def test_import_loop(self):
+        finders.get_finder.cache_clear()
+        err = six.StringIO()
+        with self.assertRaisesMessage(RuntimeError, 'Max post-process passes exceeded'):
+            call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
+        self.assertEqual("Post-processing 'All' failed!\n\n", err.getvalue())
+        self.assertPostCondition()
 
     def test_post_processing(self):
         """
@@ -173,14 +207,16 @@ class TestHashedFiles(object):
         self.assertIn(os.path.join('cached', 'css', 'window.css'), stats['post_processed'])
         self.assertIn(os.path.join('cached', 'css', 'img', 'window.png'), stats['unmodified'])
         self.assertIn(os.path.join('test', 'nonascii.css'), stats['post_processed'])
+        self.assertPostCondition()
 
     def test_css_import_case_insensitive(self):
         relpath = self.hashed_file_path("cached/styles_insensitive.css")
-        self.assertEqual(relpath, "cached/styles_insensitive.c609562b6d3c.css")
+        self.assertEqual(relpath, "cached/styles_insensitive.3fa427592a53.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertNotIn(b"cached/other.css", content)
             self.assertIn(b"other.d41d8cd98f00.css", content)
+        self.assertPostCondition()
 
     @override_settings(
         STATICFILES_DIRS=[os.path.join(TEST_ROOT, 'project', 'faulty')],
@@ -195,6 +231,7 @@ class TestHashedFiles(object):
         with self.assertRaises(Exception):
             call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
         self.assertEqual("Post-processing 'faulty.css' failed!\n\n", err.getvalue())
+        self.assertPostCondition()
 
 
 @override_settings(
@@ -206,13 +243,24 @@ class TestCollectionCachedStorage(TestHashedFiles, CollectionTestCase):
     """
     def test_cache_invalidation(self):
         name = "cached/styles.css"
-        hashed_name = "cached/styles.bb84a0240107.css"
+        hashed_name = "cached/styles.5e0040571e1a.css"
         # check if the cache is filled correctly as expected
         cache_key = storage.staticfiles_storage.hash_key(name)
         cached_name = storage.staticfiles_storage.hashed_files.get(cache_key)
         self.assertEqual(self.hashed_file_path(name), cached_name)
         # clearing the cache to make sure we re-set it correctly in the url method
         storage.staticfiles_storage.hashed_files.clear()
+        cached_name = storage.staticfiles_storage.hashed_files.get(cache_key)
+        self.assertIsNone(cached_name)
+        self.assertEqual(self.hashed_file_path(name), hashed_name)
+        cached_name = storage.staticfiles_storage.hashed_files.get(cache_key)
+        self.assertEqual(cached_name, hashed_name)
+
+        # Check files that had to be hashed multiple times since their content
+        # includes other files that were hashed.
+        name = 'cached/relative.css'
+        hashed_name = 'cached/relative.c3e9e1ea6f2e.css'
+        cache_key = storage.staticfiles_storage.hash_key(name)
         cached_name = storage.staticfiles_storage.hashed_files.get(cache_key)
         self.assertIsNone(cached_name)
         self.assertEqual(self.hashed_file_path(name), hashed_name)
@@ -236,6 +284,22 @@ class TestCollectionCachedStorage(TestHashedFiles, CollectionTestCase):
         cache_validator.validate_key(cache_key)
         self.assertEqual(cache_key, 'staticfiles:821ea71ef36f95b3922a77f7364670e7')
 
+    def test_corrupt_intermediate_files(self):
+        configured_storage = storage.staticfiles_storage
+        # Clear cache to force rehashing of the files
+        configured_storage.hashed_files.clear()
+        # Simulate a corrupt chain of intermediate files by ensuring they don't
+        # resolve before the max post-process count, which would normally be
+        # high enough.
+        configured_storage.max_post_process_passes = 1
+        # File without intermediates that can be rehashed without a problem.
+        self.hashed_file_path('cached/css/img/window.png')
+        # File with too many intermediates to rehash with the low max
+        # post-process passes.
+        err_msg = "The name 'cached/styles.css' could not be hashed with %r." % (configured_storage._wrapped,)
+        with self.assertRaisesMessage(ValueError, err_msg):
+            self.hashed_file_path('cached/styles.css')
+
 
 @override_settings(
     STATICFILES_STORAGE='staticfiles_tests.storage.ExtraPatternsCachedStaticFilesStorage',
@@ -258,15 +322,15 @@ class TestExtraPatternsCachedStorage(CollectionTestCase):
         """
         # CSS files shouldn't be touched by JS patterns.
         relpath = self.cached_file_path("cached/import.css")
-        self.assertEqual(relpath, "cached/import.2b1d40b0bbd4.css")
+        self.assertEqual(relpath, "cached/import.f53576679e5a.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
-            self.assertIn(b'import url("styles.bb84a0240107.css")', relfile.read())
+            self.assertIn(b'import url("styles.5e0040571e1a.css")', relfile.read())
 
         # Confirm JS patterns have been applied to JS files.
         relpath = self.cached_file_path("cached/test.js")
-        self.assertEqual(relpath, "cached/test.62789ffcd280.js")
+        self.assertEqual(relpath, "cached/test.388d7a790d46.js")
         with storage.staticfiles_storage.open(relpath) as relfile:
-            self.assertIn(b'JS_URL("import.2b1d40b0bbd4.css")', relfile.read())
+            self.assertIn(b'JS_URL("import.f53576679e5a.css")', relfile.read())
 
 
 @override_settings(
@@ -289,6 +353,7 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
             STATICFILES_DIRS=settings.STATICFILES_DIRS + [temp_dir])
         self.patched_settings.enable()
         self.addCleanup(shutil.rmtree, six.text_type(temp_dir))
+        self._manifest_strict = storage.staticfiles_storage.manifest_strict
 
     def tearDown(self):
         self.patched_settings.disable()
@@ -296,7 +361,16 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         if os.path.exists(self._clear_filename):
             os.unlink(self._clear_filename)
 
+        storage.staticfiles_storage.manifest_strict = self._manifest_strict
         super(TestCollectionManifestStorage, self).tearDown()
+
+    def assertPostCondition(self):
+        hashed_files = storage.staticfiles_storage.hashed_files
+        # The in-memory version of the manifest matches the one on disk
+        # since a properly created manifest should cover all filenames.
+        if hashed_files:
+            manifest = storage.staticfiles_storage.load_manifest()
+            self.assertEqual(hashed_files, manifest)
 
     def test_manifest_exists(self):
         filename = storage.staticfiles_storage.manifest_name
@@ -317,7 +391,7 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
         self.assertEqual(hashed_files, manifest)
 
     def test_clear_empties_manifest(self):
-        cleared_file_name = os.path.join('test', 'cleared.txt')
+        cleared_file_name = storage.staticfiles_storage.clean_name(os.path.join('test', 'cleared.txt'))
         # collect the additional file
         self.run_collectstatic()
 
@@ -341,6 +415,27 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
 
         manifest_content = storage.staticfiles_storage.load_manifest()
         self.assertNotIn(cleared_file_name, manifest_content)
+
+    def test_missing_entry(self):
+        missing_file_name = 'cached/missing.css'
+        configured_storage = storage.staticfiles_storage
+        self.assertNotIn(missing_file_name, configured_storage.hashed_files)
+
+        # File name not found in manifest
+        with self.assertRaisesMessage(ValueError, "Missing staticfiles manifest entry for '%s'" % missing_file_name):
+            self.hashed_file_path(missing_file_name)
+
+        configured_storage.manifest_strict = False
+        # File doesn't exist on disk
+        err_msg = "The file '%s' could not be found with %r." % (missing_file_name, configured_storage._wrapped)
+        with self.assertRaisesMessage(ValueError, err_msg):
+            self.hashed_file_path(missing_file_name)
+
+        content = six.StringIO()
+        content.write('Found')
+        configured_storage.save(missing_file_name, content)
+        # File exists on disk
+        self.hashed_file_path(missing_file_name)
 
 
 @override_settings(
@@ -446,3 +541,45 @@ class TestStaticFilePermissions(CollectionTestCase):
         dir_mode = os.stat(test_dir)[0] & 0o777
         self.assertEqual(file_mode, 0o640)
         self.assertEqual(dir_mode, 0o740)
+
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.CachedStaticFilesStorage',
+)
+class TestCollectionHashedFilesCache(CollectionTestCase):
+    """
+    Files referenced from CSS use the correct final hashed name regardless of
+    the order in which the files are post-processed.
+    """
+    hashed_file_path = hashed_file_path
+
+    def setUp(self):
+        self.testimage_path = os.path.join(
+            TEST_ROOT, 'project', 'documents', 'cached', 'css', 'img', 'window.png'
+        )
+        with open(self.testimage_path, 'r+b') as f:
+            self._orig_image_content = f.read()
+        super(TestCollectionHashedFilesCache, self).setUp()
+
+    def tearDown(self):
+        with open(self.testimage_path, 'w+b') as f:
+            f.write(self._orig_image_content)
+        super(TestCollectionHashedFilesCache, self).tearDown()
+
+    def test_file_change_after_collectstatic(self):
+        finders.get_finder.cache_clear()
+        err = six.StringIO()
+        call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
+        with open(self.testimage_path, 'w+b') as f:
+            f.write(b"new content of png file to change it's hash")
+
+        # Change modification time of self.testimage_path to make sure it gets
+        # collected again.
+        mtime = os.path.getmtime(self.testimage_path)
+        atime = os.path.getatime(self.testimage_path)
+        os.utime(self.testimage_path, (mtime + 1, atime + 1))
+
+        call_command('collectstatic', interactive=False, verbosity=0, stderr=err)
+        relpath = self.hashed_file_path('cached/css/window.css')
+        with storage.staticfiles_storage.open(relpath) as relfile:
+            self.assertIn(b'window.a836fe39729e.png', relfile.read())


### PR DESCRIPTION
There are several tickets open dealing with the problem of hashed filenames not propagating to all files that reference it: [ticket 26527](https://code.djangoproject.com/ticket/26527) is the newest, [ticket 22353](https://code.djangoproject.com/ticket/22353) is the oldest and [ticket 24452](https://code.djangoproject.com/ticket/24452) has the most relevant discussion on it.

This PR includes several new tests that cover special cases of nested filenames: infinite loop, cleared cache and referenced file changes between `collectstatic` runs. The last test is taken mostly verbatim from PR #2569 as I thought it was a useful test. I’ve also updated the tests to test the objectively correct hash values for the files. These have been painstakingly checked by getting the final content of the files and confirming the hash is correct. The current test has hashes that are not correct for the final content if nested filenames are correctly propagated. I’ve attached the tests patch by itself to [ticket 24452](https://code.djangoproject.com/ticket/24452) if anyone would like to run them against master unchanged to see the failures.

The meat of this PR is performing multiple passes of post-processing until no hashed filenames change on a pass. Since this may never converge if there are loops in the files referencing each other there is a max number of passes done before post-processing is aborted with a failure. Currently this is set on `HashedFilesMixin` and defaults to 5, but it can be overridden in a subclass for those with complex staticfiles trees which require many passes to finally converge. It may be useful to allow this max to be passed in from the `collectstatic` command so that it’s easier to use instead of requiring subclassing.

After these multiple passes to converge the hashed filenames, all the final filename hashes are accurate, and there are intermediate copies of the file for each pass where that file changed. That means that there may be multiple copies of the same file with different hashes. These extra copies are required to ensure `CachedStaticFilesStorage` works as expected. The output for `ManifestStaticFilesStorage` doesn’t use the intermediate files and lists the final correct hash name for a given filename.

When a cache miss occurs, the original filename is hashed as it currently is done today. However, since that may not be the final correct hash, the file pointed to by the hashed filename is requested and hashed. If the hash matches the name, then the final hash has been reached and things continue. If the hash does not match, then the process is repeated, requesting the file with the latest hash. This chain of intermediate files allows `CachedStaticFilesStorage` to avoid the issue mentioned by @pmclanahan in his [comment on ticket 24452](https://code.djangoproject.com/ticket/24452#comment:9) where a flushed cache would require a large amount of work to recalculate all of the hashes involved and the nested filenames. Instead on a cache miss or cache flush the intermediate files can simply be walked until the final file is found. All intermediate files are kept, from the very first hash of the file with no nested filenames changed to the final one, so nothing else is required for finding the final filename on a cache miss. A cache miss will only require N file hash computations, where N is the number of passes it took for that file to converge to the final filename. This is a better performance profile than doing the entire converge process again, but it does have the downside that it requires file hashes to be performed on all of the intermediate files, which may be stored off in S3. I have a TBD note on [line 378](https://github.com/django/django/pull/6507/files#diff-c7242dedd7c93b857a668acec1e310feR378) regarding if it makes sense to store the intermediate hashes in cache on the chance that only some of the keys in the chain were evicted. I opted to not do this in this PR as it would increase the complexity since each lookup could require a cache hit and then a media hit as well.

Due to the small performance penalty for `CachedStaticFilesStorage` if this PR is accepted I’d suggest a documentation update to go along with it which stresses only using `CachedStaticFilesStorage` if file system access is restricted since it offers worse performance than `ManifestStaticFilesStorage` across the board and for remote media lots of unnecessary accesses.

I’d very much like to see this issue fixed in 1.10, so I’m hoping this WIP can be made up to snuff in time for the code freeze. I’ve been dog fooding this change on 1.8 in production for 6 months now and it hasn’t given me any problems. I ported it to master in the last few days but there haven’t been any major changes there that would give me any pause.

While this WIP PR fixes the issue (in my testing) it is not necessarily the best solution to the problem. I tried to keep the changes as small as possible and make them fit into the existing codebase, but a reimagining of the whole implementation may be useful. It’s likely too late for that to happen for 1.10, but it could be on the roadmap for 1.11 and this PR would lay the groundwork by fixing the issue in 1.10 and providing a working set of regression tests for the refactoring. I think the bit that could benefit the most from a reimagining would be using recursion to make the filenames converge instead of the more brute force rehash all adjustable files approach. While it works, it ends up potentially hashing many more files than necessary and could be faster for large collections of staticfiles if these unnecessary hashes weren’t done.

Here’s a high-level summary of the PR:

The Good
- Hashed filenames are now fully correct and reflect the content in path-adjusted files (most important)
- Configured cache isn’t used during post-processing for filenames, so cache misses (or disabled cache) won’t cause unnecessary file hashes - final hashes are still updated in cache if `CachedStaticFilesStorage` used

The Bad
- Intermediate versions of path-adjusted files are stored, meaning there could be a half dozen copies of the same file with different contents/hashed name for complex staticfiles trees
- Cache misses will take longer due to walking intermediate files

The Ugly
- There are now at least 2 file accesses required on every cache miss to confirm the hash value is correct

NOTE: There is now a ValueError if an entry is missing from the staticfiles manifest, instead of silently succeeding like it did before. These cases should probably use ‘get_static_prefix’ anyway if it’s not for a real file.
