### PR TITLE
Fixed #26508 -- Clarified docs for various FieldFile methods

### DIFF
--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -16,6 +16,18 @@ The ``File`` class
     :py:term:`file object` with some Django-specific additions.
     Internally, Django uses this class when it needs to represent a file.
 
+    .. note::
+        Some subclasses of :class:`File`, including
+        :class:`django.core.files.base.ContentFile` and
+        :class:`django.db.models.fields.files.FieldFile`, may replace the
+        underlying :attr:`~django.core.files.File.file` attribute with an object
+        other than a Python :py:term:`file object`. In some cases, the
+        :attr:`~django.core.files.File.file` attribute of a
+        :class:`File` subclass may itself be a
+        :class:`File` subclass (and not necessarily the same subclass). Whenever
+        possible, please use the :class:`File` API defined here rather than
+        relying on the :attr:`~django.core.files.File.file` attribute.
+
     :class:`File` objects have the following attributes and methods:
 
     .. attribute:: name

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -764,9 +764,36 @@ can change the maximum length using the :attr:`~CharField.max_length` argument.
 
 When you access a :class:`~django.db.models.FileField` on a model, you are
 given an instance of :class:`FieldFile` as a proxy for accessing the underlying
-file. In addition to the functionality inherited from
-:class:`django.core.files.File`, this class has several attributes and methods
-that can be used to interact with file data:
+file. The API of :class:`FieldFile`  mirrors that of
+:class:`django.core.files.File`, with one key difference: *The object wrapped
+by the class is not necessarily a wrapper around Python's built-in file object.*
+Instead, it is a wrapper around the result of the underlying
+:attr:`django.core.files.storage.Storage.open` method, which may be a
+:class:`~django.core.files.File` object, or it may be a custom storage's
+implementation of the :class:`~django.core.files.File` API.
+
+To read from and write to a :class:`FieldFile`, please see the
+:class:`django.core.files.File` documentation for the
+:attr:`~django.core.files.File.read`, :attr:`~django.core.files.File.write`, and
+related methods. In addition to the API inherited from
+:class:`~django.core.files.File`, :class:`FieldFile` includes several methods
+that can be used to interact with the underlying file:
+
+.. warning::
+    Two methods of this class, ``save()`` and ``delete()``, default to saving
+    the model object of the associated :class:`FieldFile` in the database. See
+    below.
+
+.. attribute:: FieldFile.name
+
+The name of the file including the relative path from the root of the
+:class:`django.core.files.storage.Storage` in use by the associated
+:class:`~django.db.models.FileField`.
+
+.. attribute:: FieldFile.size
+
+The result of the underlying :attr:`django.core.files.storage.Storage.size`
+method.
 
 .. attribute:: FieldFile.url
 
@@ -776,8 +803,15 @@ A read-only property to access the file's relative URL by calling the
 
 .. method:: FieldFile.open(mode='rb')
 
-Behaves like the standard Python ``open()`` method and opens the file
-associated with this instance in the mode specified by ``mode``.
+Opens or reopens the file associated with this instance in the mode
+specified by ``mode``. Unlike the standard Python ``open()`` method, this
+method does *not* return a file descriptor.
+
+.. note::
+    The underlying ``file`` attribute (the object wrapped by this class) is
+    opened implicitly when accessed for the first time, so it may be
+    unnecessary to call this method except to reset the pointer to the
+    underlying file or change the ``mode``.
 
 .. method:: FieldFile.close()
 


### PR DESCRIPTION
* include a note in the `File` documentation about how subclasses may swap out the `file` attribute
* clarify in the `FieldFile` documentation what methods are custom to FieldFile vs. which method documentation in the `File` class can reasonably be relied upon
* clarify that FieldFile.open does not return a file descriptor like the standard Python `open()` method
* include a louder warning that the `save()` and `delete()` methods also save the associated model object
* add indentation to the `FieldFile` attribute documentation to make it easier to read/scan while editing

See: https://code.djangoproject.com/ticket/26508