### PR TITLE
Clarified explanation

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -641,7 +641,7 @@ subclass::
 
           admin.site.empty_value_display = '(None)'
 
-      You can also use :attr:`AdminSite.empty_value_display`::
+      You can also use :attr:`ModelAdmin.empty_value_display`::
 
           class PersonAdmin(admin.ModelAdmin):
               empty_value_display = 'unknown'


### PR DESCRIPTION
The example is for Model level annotation therefore it should be referring to `ModelAdmin.empty_value_display`