### PR TITLE
Update DjangoJSONEncoder to be aware of timedelta

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -108,6 +108,8 @@ class DjangoJSONEncoder(json.JSONEncoder):
             if o.microsecond:
                 r = r[:12]
             return r
+        elif isinstance(o, datetime.timedelta):
+            return o.total_seconds()
         elif isinstance(o, decimal.Decimal):
             return str(o)
         elif isinstance(o, uuid.UUID):


### PR DESCRIPTION
Current implementation is not datetime.timedelta aware.  This patch causes timedeltas to be returned as total_seconds()