### PR TITLE
Fixed #14415 -- Do not ignore DB test name setting

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -295,12 +295,10 @@ class BaseDatabaseCreation(object):
         accordingly to the RDBMS particularities.
         """
         settings_dict = self.connection.settings_dict
-        test_settings_dict = settings_dict.get('TEST', {})
-        test_db_name = test_settings_dict.get('NAME')
 
         return (
             settings_dict['HOST'],
             settings_dict['PORT'],
             settings_dict['ENGINE'],
-            test_db_name if test_db_name is not None else settings_dict['NAME']
+            self._get_test_db_name()
         )

--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -295,9 +295,12 @@ class BaseDatabaseCreation(object):
         accordingly to the RDBMS particularities.
         """
         settings_dict = self.connection.settings_dict
+        test_settings_dict = settings_dict.get('TEST', {})
+        test_db_name = test_settings_dict.get('NAME')
+
         return (
             settings_dict['HOST'],
             settings_dict['PORT'],
             settings_dict['ENGINE'],
-            settings_dict['NAME']
+            test_db_name if test_db_name is not None else settings_dict['NAME']
         )


### PR DESCRIPTION
Modified the code so it will take DATABASES['db-name']['TEST']['NAME'] into account while it decides which databases to create for tests. Using this setting is essential when testing with different tables in different databases