### PR TITLE
Refs #12690 -- Removed unneeded BaseSpatialOperations.truncate_params

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -4,7 +4,6 @@ class BaseSpatialOperations(object):
     instantiated by each spatial database backend with the features
     it has.
     """
-    truncate_params = {}
 
     # Quick booleans for the type of this spatial backend, and
     # an attribute for the spatial database version tuple (if applicable)

--- a/django/contrib/gis/db/backends/oracle/operations.py
+++ b/django/contrib/gis/db/backends/oracle/operations.py
@@ -122,8 +122,6 @@ class OracleOperations(BaseSpatialOperations, DatabaseOperations):
         'dwithin': SDODWithin(),
     }
 
-    truncate_params = {'relate': None}
-
     unsupported_functions = {
         'AsGeoJSON', 'AsGML', 'AsKML', 'AsSVG',
         'BoundingCircle', 'Envelope',

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -314,10 +314,6 @@ class GeometryField(GeoSelectFormatMixin, BaseSpatialField):
                 if self.class_lookups[lookup_type].distance:
                     # Getting the distance parameter in the units of the field.
                     params += self.get_distance(value[1:], lookup_type, connection)
-                elif lookup_type in connection.ops.truncate_params:
-                    # Lookup is one where SQL parameters aren't needed from the
-                    # given lookup value.
-                    pass
                 else:
                     params += value[1:]
             elif isinstance(value, Expression):


### PR DESCRIPTION
Unless a regression test is missing, things seem to now work on Oracle without this.
Original commit: 474ce51ffd9e7f0963d666bdb429f00b04cdaee3