### PR TITLE
Fixed support of ForeignKey subclasses which omit 'to'

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -100,7 +100,7 @@ class MigrationAutodetector(object):
         for name, field in sorted(fields):
             deconstruction = self.deep_deconstruct(field)
             if field.remote_field and field.remote_field.model:
-                del deconstruction[2]['to']
+                deconstruction[2].pop('to', None)
             fields_def.append(deconstruction)
         return fields_def
 


### PR DESCRIPTION
This allows subclasses of ForeignKey which omit the 'to' argument as it used to work in Django < 1.9.

```
class MyField(models.ForeignKey):
    def __init__(self, **kwargs):
        if 'to' in kwargs:
            raise TypeError("Invalid argument 'to'")
        super(MyField, self).__init__('app.model', **kwargs)

    def deconstruct(self):
        name, path, args, kwargs = super(MyField, self).deconstruct()
        kwargs.pop('to')
        return name, path, args, kwargs
```