### PR TITLE
Document requirement for uppercase setting names

### DIFF
--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -163,7 +163,7 @@ Creating your own settings
 There's nothing stopping you from creating your own settings, for your own
 Django apps. Just follow these conventions:
 
-* Setting names are in all uppercase.
+* Setting names are in all uppercase. This is a requirement.
 * Don't reinvent an already-existing setting.
 
 For settings that are sequences, Django itself uses lists, but this is only


### PR DESCRIPTION
Merely saying that it is a "convention" is not strong enough, as `django/conf/__init__.py` behaves differently depending on whether the name is all uppercase or not.

Here's an example of a user who tripped up on the fact that setting names must be uppercase. Merely documenting that it was a convention was not strong enough for this user:

http://stackoverflow.com/questions/11631194/unable-to-get-a-setting-from-settings-file-in-django#comment15404478_11631244

This pull request makes it clearly that it is a requirement.