### PR TITLE
Fixed #25966 -- Added Apps.import_model / Made get_user_model() work at import time.

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -155,13 +155,16 @@ class AppConfig(object):
         # Entry is a path to an app config class.
         return cls(app_name, app_module)
 
-    def get_model(self, model_name):
+    def get_model(self, model_name, require_ready=True):
         """
         Returns the model with the given case-insensitive model_name.
 
         Raises LookupError if no model exists with this name.
         """
-        self.apps.check_models_ready()
+        if require_ready:
+            self.apps.check_models_ready()
+        else:
+            self.apps.check_apps_ready()
         try:
             return self.models[model_name.lower()]
         except KeyError:

--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -190,12 +190,10 @@ class AppConfig(object):
                 continue
             yield model
 
-    def import_models(self, all_models):
+    def import_models(self):
         # Dictionary of models for this app, primarily maintained in the
         # 'all_models' attribute of the Apps this AppConfig is attached to.
-        # Injected as a parameter because it gets populated when models are
-        # imported, which might happen before populate() imports models.
-        self.models = all_models
+        self.models = self.apps.all_models[self.label]
 
         if module_has_submodule(self.module, MODELS_MODULE_NAME):
             models_module_name = '%s.%s' % (self.name, MODELS_MODULE_NAME)

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -77,7 +77,7 @@ class Apps(object):
             if self.app_configs:
                 raise RuntimeError("populate() isn't reentrant")
 
-            # Load app configs and app modules.
+            # Phase 1: initialize app configs and import app modules.
             for entry in installed_apps:
                 if isinstance(entry, AppConfig):
                     app_config = entry
@@ -103,15 +103,15 @@ class Apps(object):
 
             self.apps_ready = True
 
-            # Load models.
+            # Phase 2: import models modules.
             for app_config in self.app_configs.values():
-                all_models = self.all_models[app_config.label]
-                app_config.import_models(all_models)
+                app_config.import_models()
 
             self.clear_cache()
 
             self.models_ready = True
 
+            # Phase 3: run ready() methods of app configs.
             for app_config in self.get_app_configs():
                 app_config.ready()
 

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -89,6 +89,7 @@ class Apps(object):
                         "duplicates: %s" % app_config.label)
 
                 self.app_configs[app_config.label] = app_config
+                app_config.apps = self
 
             # Check for duplicate app names.
             counts = Counter(

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -172,7 +172,7 @@ def get_user_model():
     Returns the User model that is active in this project.
     """
     try:
-        return django_apps.get_model(settings.AUTH_USER_MODEL)
+        return django_apps.get_model(settings.AUTH_USER_MODEL, require_ready=False)
     except ValueError:
         raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form 'app_label.model_name'")
     except LookupError:

--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -4,13 +4,15 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 
 
+UserModel = get_user_model()
+
+
 class ModelBackend(object):
     """
     Authenticates against settings.AUTH_USER_MODEL.
     """
 
     def authenticate(self, request, username=None, password=None, **kwargs):
-        UserModel = get_user_model()
         if username is None:
             username = kwargs.get(UserModel.USERNAME_FIELD)
         try:
@@ -97,7 +99,6 @@ class ModelBackend(object):
         return False
 
     def get_user(self, user_id):
-        UserModel = get_user_model()
         try:
             user = UserModel._default_manager.get(pk=user_id)
         except UserModel.DoesNotExist:
@@ -138,8 +139,6 @@ class RemoteUserBackend(ModelBackend):
             return
         user = None
         username = self.clean_username(remote_user)
-
-        UserModel = get_user_model()
 
         # Note that this could be accomplished in one try-except clause, but
         # instead we use get_or_create when creating unknown users since it has

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -23,6 +23,9 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext, ugettext_lazy as _
 
 
+UserModel = get_user_model()
+
+
 class ReadOnlyPasswordHashWidget(forms.Widget):
     def render(self, name, value, attrs):
         encoded = value
@@ -179,7 +182,6 @@ class AuthenticationForm(forms.Form):
         super(AuthenticationForm, self).__init__(*args, **kwargs)
 
         # Set the label for the "username" field.
-        UserModel = get_user_model()
         self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)
         if self.fields['username'].label is None:
             self.fields['username'].label = capfirst(self.username_field.verbose_name)
@@ -254,7 +256,6 @@ class PasswordResetForm(forms.Form):
         that prevent inactive users and users with unusable passwords from
         resetting their password.
         """
-        UserModel = get_user_model()
         active_users = UserModel._default_manager.filter(**{
             '%s__iexact' % UserModel.get_email_field_name(): email,
             'is_active': True,

--- a/django/contrib/auth/handlers/modwsgi.py
+++ b/django/contrib/auth/handlers/modwsgi.py
@@ -3,6 +3,9 @@ from django.contrib import auth
 from django.utils.encoding import force_bytes
 
 
+UserModel = auth.get_user_model()
+
+
 def check_password(environ, username, password):
     """
     Authenticates against Django's auth database
@@ -11,7 +14,6 @@ def check_password(environ, username, password):
     on whether the user exists and authenticates.
     """
 
-    UserModel = auth.get_user_model()
     # db connection state is managed similarly to the wsgi handler
     # as mod_wsgi may call these functions outside of a request/response cycle
     db.reset_queries()
@@ -33,7 +35,6 @@ def groups_for_user(environ, username):
     Authorizes a user based on groups
     """
 
-    UserModel = auth.get_user_model()
     db.reset_queries()
 
     try:

--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -10,6 +10,9 @@ from django.db import DEFAULT_DB_ALIAS
 from django.utils.encoding import force_str
 
 
+UserModel = get_user_model()
+
+
 class Command(BaseCommand):
     help = "Change a user's password for django.contrib.auth."
     requires_migrations_checks = True
@@ -37,8 +40,6 @@ class Command(BaseCommand):
             username = options['username']
         else:
             username = getpass.getuser()
-
-        UserModel = get_user_model()
 
         try:
             u = UserModel._default_manager.using(options['database']).get(**{

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -32,6 +32,9 @@ from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
 
+UserModel = get_user_model()
+
+
 def deprecate_current_app(func):
     """
     Handle deprecation of the current_app parameter of the views.
@@ -320,7 +323,6 @@ def password_reset_confirm(request, uidb64=None, token=None,
     warnings.warn("The password_reset_confirm() view is superseded by the "
                   "class-based PasswordResetConfirmView().",
                   RemovedInDjango21Warning, stacklevel=2)
-    UserModel = get_user_model()
     assert uidb64 is not None and token is not None  # checked by URLconf
     if post_reset_redirect is None:
         post_reset_redirect = reverse('password_reset_complete')
@@ -444,7 +446,6 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
         return super(PasswordResetConfirmView, self).dispatch(*args, **kwargs)
 
     def get_user(self, uidb64):
-        UserModel = get_user_model()
         try:
             # urlsafe_base64_decode() decodes to bytestring on Python 3
             uid = force_text(urlsafe_base64_decode(uidb64))

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -214,8 +214,8 @@ class AppConfigStub(AppConfig):
         # the app name, but we need something unique, and the label works fine.
         super(AppConfigStub, self).__init__(label, None)
 
-    def import_models(self, all_models):
-        self.models = all_models
+    def import_models(self):
+        self.models = self.apps.all_models[self.label]
 
 
 class StateApps(Apps):

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -473,10 +473,6 @@ Here are some common problems that you may encounter during initialization:
   will also trigger this exception. The ORM cannot function properly until all
   models are available.
 
-  Another common culprit is :func:`django.contrib.auth.get_user_model()`. Use
-  the :setting:`AUTH_USER_MODEL` setting to reference the User model at import
-  time.
-
   This exception also happens if you forget to call :func:`django.setup()` in
   a standalone Python script.
 

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -229,14 +229,20 @@ Methods
 
     Requires the app registry to be fully populated.
 
-.. method:: AppConfig.get_model(model_name)
+.. method:: AppConfig.get_model(model_name, require_ready=True)
 
     Returns the :class:`~django.db.models.Model` with the given
     ``model_name``. ``model_name`` is case-insensitive.
 
     Raises :exc:`LookupError` if no such model exists in this application.
 
-    Requires the app registry to be fully populated.
+    Requires the app registry to be fully populated, unless the
+    ``require_ready`` argument is set to ``False``.  ``require_ready`` behaves
+    exactly as in :meth:`apps.get_model()`.
+
+    .. versionadded:: 1.11
+
+        The ``require_ready`` keyword argument was added.
 
 .. method:: AppConfig.ready()
 
@@ -341,7 +347,7 @@ Application registry
     Checks whether an application with the given name exists in the registry.
     ``app_name`` is the full name of the app, e.g. ``'django.contrib.admin'``.
 
-.. method:: apps.get_model(app_label, model_name)
+.. method:: apps.get_model(app_label, model_name, require_ready=True)
 
     Returns the :class:`~django.db.models.Model` with the given ``app_label``
     and ``model_name``. As a shortcut, this method also accepts a single
@@ -351,6 +357,26 @@ Application registry
     Raises :exc:`LookupError` if no such application or model exists. Raises
     :exc:`ValueError` when called with a single argument that doesn't contain
     exactly one dot.
+
+    Requires the app registry to be fully populated, unless the
+    ``require_ready`` argument is set to ``False``.
+
+    Setting ``require_ready`` to ``False`` allows looking up models
+    :ref:`while the app registry is being populated <app-loading-process>`,
+    specifically during the second phase, where it imports models. Then
+    ``get_model()`` has the same effect as importing the model. The main use
+    case is to configure model classes with settings, such as
+    :setting:`AUTH_USER_MODEL`.
+
+    When ``require_ready`` is ``False``, ``get_model()`` returns a model class
+    that may not be fully functional (reverse accessors may be missing, for
+    example) until the app registry is fully populated. For this reason, it's
+    best to leave ``require_ready`` to the default value of ``True`` whenever
+    possible.
+
+    .. versionadded:: 1.11
+
+        The ``require_ready`` keyword argument was added.
 
 .. _app-loading-process:
 

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -227,11 +227,16 @@ Methods
     Returns an iterable of :class:`~django.db.models.Model` classes for this
     application.
 
+    Requires the app registry to be fully populated.
+
 .. method:: AppConfig.get_model(model_name)
 
     Returns the :class:`~django.db.models.Model` with the given
-    ``model_name``. Raises :exc:`LookupError` if no such model exists in this
-    application. ``model_name`` is case-insensitive.
+    ``model_name``. ``model_name`` is case-insensitive.
+
+    Raises :exc:`LookupError` if no such model exists in this application.
+
+    Requires the app registry to be fully populated.
 
 .. method:: AppConfig.ready()
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -562,6 +562,14 @@ Miscellaneous
 * ``ConditionalGetMiddleware`` no longer sets the ``Date`` header as Web
   servers set that header.
 
+* :meth:`~django.apps.AppConfig.get_model` raises
+  :exc:`~django.core.exceptions.AppRegistryNotReady` if it's called before
+  models of all applications have been loaded. Previously it only required
+  the target application's models to be loaded and thus could return models
+  without all their relations set up.
+
+  :meth:`~django.apps.AppConfig.get_models` changed similarly.
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -98,6 +98,9 @@ Minor features
   ``password_reset_confirm()``, and ``password_reset_complete()`` function-based
   views.
 
+* :func:`~django.contrib.auth.get_user_model` can be called at import time,
+  even in modules that define models.
+
 * The new ``post_reset_login`` attribute for
   :class:`~django.contrib.auth.views.PasswordResetConfirmView` allows
   automatically logging in a user after a successful password reset.

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -566,9 +566,11 @@ Miscellaneous
   :exc:`~django.core.exceptions.AppRegistryNotReady` if it's called before
   models of all applications have been loaded. Previously it only required
   the target application's models to be loaded and thus could return models
-  without all their relations set up.
+  without all their relations set up. If you need the old behavior, you can
+  set the ``require_ready`` argument to ``False``.
 
-  :meth:`~django.apps.AppConfig.get_models` changed similarly.
+  :meth:`~django.apps.AppConfig.get_models` changed similarly, but
+  doesn't have a ``require_ready`` argument.
 
 .. _deprecated-features-1.11:
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -450,33 +450,10 @@ different User model.
     currently active User model -- the custom User model if one is specified, or
     :class:`~django.contrib.auth.models.User` otherwise.
 
-    When you define a foreign key or many-to-many relations to the User model,
-    you should specify the custom model using the :setting:`AUTH_USER_MODEL`
-    setting. For example::
+    .. versionchanged:: 1.11
 
-        from django.conf import settings
-        from django.db import models
-
-        class Article(models.Model):
-            author = models.ForeignKey(
-                settings.AUTH_USER_MODEL,
-                on_delete=models.CASCADE,
-            )
-
-    When connecting to signals sent by the ``User`` model, you should specify
-    the custom model using the :setting:`AUTH_USER_MODEL` setting. For example::
-
-        from django.conf import settings
-        from django.db.models.signals import post_save
-
-        def post_save_receiver(sender, instance, created, **kwargs):
-            pass
-
-        post_save.connect(post_save_receiver, sender=settings.AUTH_USER_MODEL)
-
-    Generally speaking, you should reference the User model with the
-    :setting:`AUTH_USER_MODEL` setting in code that is executed at import
-    time. ``get_user_model()`` only works once Django has imported all models.
+        It is now possible to call ``get_user_model()`` while Django is
+        importing models.
 
 .. _specifying-custom-user-model:
 


### PR DESCRIPTION
This function should make it possible to implement a get_user_model()
method that is less vulnerable to the order of apps in INSTALLED_APPS.

It breaks the invariant that models are registered in the app registry
in the order of INSTALLED_APPS at the second stage of the app loading
process. However there's no way for user code to hook at this point so
that shouldn't be an issue. If anything, it should bring the behavior
closer to what it was before Django 1.7.
