### PR TITLE
Fixed #26572 -- Stopped truncating AdminEmailHandler message subjects.

### DIFF
--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -128,12 +128,9 @@ class AdminEmailHandler(logging.Handler):
 
     def format_subject(self, subject):
         """
-        Escape CR and LF characters, and limit length.
-        RFC 2822's hard limit is 998 characters per line. So, minus "Subject: "
-        the actual subject must be no longer than 989 characters.
+        Escape CR and LF characters.
         """
-        formatted_subject = subject.replace('\n', '\\n').replace('\r', '\\r')
-        return formatted_subject[:989]
+        return subject.replace('\n', '\\n').replace('\r', '\\r')
 
 
 class CallbackFilter(logging.Filter):

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -836,6 +836,10 @@ Miscellaneous
   <django.core.files.storage.Storage.generate_filename>` instead. It
   might be possible to use :attr:`~django.db.models.FileField.upload_to` also.
 
+* The subject of mail sent by ``AdminEmailHandler`` is no longer truncated at
+  989 characters. If you were counting on a limited length, truncate the subject
+  yourself.
+
 .. _deprecated-features-1.10:
 
 Features deprecated in 1.10

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -300,28 +300,6 @@ class AdminEmailHandlerTest(SimpleTestCase):
         self.assertEqual(mail.outbox[0].subject, expected_subject)
 
     @override_settings(
-        ADMINS=(('admin', 'admin@example.com'),),
-        EMAIL_SUBJECT_PREFIX='',
-        DEBUG=False,
-    )
-    def test_truncate_subject(self):
-        """
-        RFC 2822's hard limit is 998 characters per line.
-        So, minus "Subject: ", the actual subject must be no longer than 989
-        characters.
-        Refs #17281.
-        """
-        message = 'a' * 1000
-        expected_subject = 'ERROR: aa' + 'a' * 980
-
-        self.assertEqual(len(mail.outbox), 0)
-
-        self.logger.error(message)
-
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, expected_subject)
-
-    @override_settings(
         ADMINS=[('admin', 'admin@example.com')],
         DEBUG=False,
     )


### PR DESCRIPTION
Refs #26572, #17281. The RFC doesn't limit total length, just the line length
which is already taken care of by Python itself.