### PR TITLE
Fixed #26449 -- Added one level deep merge to FORMFIELD_FOR_DBFIELD_D…

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -117,8 +117,11 @@ class BaseModelAdmin(six.with_metaclass(forms.MediaDefiningClass)):
         return self.checks_class().check(self, **kwargs)
 
     def __init__(self):
-        overrides = FORMFIELD_FOR_DBFIELD_DEFAULTS.copy()
-        overrides.update(self.formfield_overrides)
+        # we need a deep copy here as FORMFIELD_FOR_DBFIELD_DEFAULTS is nested;
+        # this merges the dict one level deep;
+        overrides = copy.deepcopy(FORMFIELD_FOR_DBFIELD_DEFAULTS)
+        for k, v in self.formfield_overrides.items():
+            overrides.setdefault(k, {}).update(v)
         self.formfield_overrides = overrides
 
     def formfield_for_dbfield(self, db_field, request, **kwargs):

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -15,7 +15,7 @@ from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import User
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db.models import CharField, DateField
+from django.db.models import CharField, DateField, DateTimeField
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import six, translation
@@ -149,6 +149,33 @@ class AdminFormfieldForDBFieldTests(SimpleTestCase):
         self.assertEqual(f1.widget.attrs['maxlength'], '100')
         self.assertEqual(f2.widget.attrs['maxlength'], '20')
         self.assertEqual(f2.widget.attrs['size'], '10')
+
+    def test_formfield_overrides_for_datetime_field(self):
+        """
+        Test that overriding widget for DateTimeField doesn't overrides
+        the default form_class for that field (#26449)
+        """
+        class MemberAdmin(admin.ModelAdmin):
+            formfield_overrides = {
+                DateTimeField: {'widget': widgets.AdminSplitDateTime}
+            }
+        ma = MemberAdmin(models.Member, admin.site)
+        f1 = ma.formfield_for_dbfield(models.Member._meta.get_field('birthdate'), request=None)
+        self.assertTrue(isinstance(f1.widget, widgets.AdminSplitDateTime))
+        self.assertTrue(isinstance(f1, forms.SplitDateTimeField))
+
+    def test_formfield_overrides_for_custom_field(self):
+        """
+        Test that formfield_overrides works also for custom field class
+        after fix (#26449)
+        """
+        class AlbumAdmin(admin.ModelAdmin):
+            formfield_overrides = {
+                models.MyFileField: {'widget': forms.TextInput()}
+            }
+        ma = AlbumAdmin(models.Member, admin.site)
+        f1 = ma.formfield_for_dbfield(models.Album._meta.get_field('backside_art'), request=None)
+        self.assertTrue(isinstance(f1.widget, forms.TextInput))
 
     def test_field_with_choices(self):
         self.assertFormfield(models.Member, 'gender', forms.Select)


### PR DESCRIPTION
…EFAULTS

Refactored merging FORMFIELD_FOR_DBFIELD_DEFAULTS with formfields_overrides,
so that formfields_overrides don't replace the value for a given field class
but get merged with the existing values.
Useful for overriding the DateTimeField widget.