### PR TITLE
Fixed #26580 -- Updated references to RFC 2822.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -44,7 +44,7 @@ class BadHeaderError(ValueError):
 # TODO: replace with email.utils.make_msgid(.., domain=DNS_NAME) when dropping
 # Python 2 (Python 2's version doesn't have domain parameter) (#23905).
 def make_msgid(idstring=None, domain=None):
-    """Returns a string suitable for RFC 2822 compliant Message-ID, e.g:
+    """Returns a string suitable for RFC 5322 compliant Message-ID, e.g:
 
     <20020201195627.33539.96671@nightshade.la.mastaler.com>
 

--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -293,7 +293,7 @@ class DateFormat(TimeFormat):
         return self.data.isocalendar()[0]
 
     def r(self):
-        "RFC 2822 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
+        "RFC 5322 formatted date; e.g. 'Thu, 21 Dec 2000 16:01:07 +0200'"
         return self.format('D, j M Y H:i:s O')
 
     def S(self):

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -129,7 +129,7 @@ class AdminEmailHandler(logging.Handler):
     def format_subject(self, subject):
         """
         Escape CR and LF characters, and limit length.
-        RFC 2822's hard limit is 998 characters per line. So, minus "Subject: "
+        RFC 5322's hard limit is 998 characters per line. So, minus "Subject: "
         the actual subject must be no longer than 989 characters.
         """
         formatted_subject = subject.replace('\n', '\\n').replace('\r', '\\r')

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1325,7 +1325,7 @@ P                 Time, in 12-hour hours, minutes and       ``'1 a.m.'``, ``'1:3
                   if they're zero and the special-case
                   strings 'midnight' and 'noon' if
                   appropriate. Proprietary extension.
-r                 :rfc:`2822` formatted date.               ``'Thu, 21 Dec 2000 16:01:07 +0200'``
+r                 :rfc:`5322` formatted date.               ``'Thu, 21 Dec 2000 16:01:07 +0200'``
 s                 Seconds, 2 digits with leading zeros.     ``'00'`` to ``'59'``
 S                 English ordinal suffix for day of the     ``'st'``, ``'nd'``, ``'rd'`` or ``'th'``
                   month, 2 characters.

--- a/tests/logging_tests/tests.py
+++ b/tests/logging_tests/tests.py
@@ -306,7 +306,7 @@ class AdminEmailHandlerTest(SimpleTestCase):
     )
     def test_truncate_subject(self):
         """
-        RFC 2822's hard limit is 998 characters per line.
+        RFC 5322's hard limit is 998 characters per line.
         So, minus "Subject: ", the actual subject must be no longer than 989
         characters.
         Refs #17281.


### PR DESCRIPTION
Did not rename django.utils.feedgenerator.rfc2822_date
as some external code may rely on it.