### PR TITLE
[Docs] Sitemap: Fix variable name

### DIFF
--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -56,7 +56,7 @@ To activate sitemap generation on your Django site, add this line to your
 
     from django.contrib.sitemaps.views import sitemap
 
-    url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
+    url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemap},
         name='django.contrib.sitemaps.views.sitemap')
 
 This tells Django to build a sitemap when a client accesses :file:`/sitemap.xml`.


### PR DESCRIPTION
Fix variable name in Sitemaps initialization code example.

Rename `sitemaps` to `sitemap`

Docs: https://docs.djangoproject.com/en/1.9/ref/contrib/sitemaps/#initialization
Ticket: https://code.djangoproject.com/ticket/26581