### PR TITLE
Fixed #26582 - prettier admin display for list values

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -402,7 +402,7 @@ def display_for_field(value, field, empty_value_display):
     elif isinstance(field, models.FileField) and value:
         return format_html('<a href="{}">{}</a>', value.url, value)
     else:
-        return smart_text(value)
+        return display_for_value(value, empty_value_display)
 
 
 def display_for_value(value, empty_value_display, boolean=False):
@@ -418,6 +418,8 @@ def display_for_value(value, empty_value_display, boolean=False):
         return formats.localize(value)
     elif isinstance(value, six.integer_types + (decimal.Decimal, float)):
         return formats.number_format(value)
+    elif isinstance(value, (list, tuple)):
+        return ', '.join(force_text(v) for v in value)
     else:
         return smart_text(value)
 

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -7,8 +7,8 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import (
-    NestedObjects, display_for_field, flatten, flatten_fieldsets,
-    label_for_field, lookup_field, quote,
+    NestedObjects, display_for_field, display_for_value, flatten,
+    flatten_fieldsets, label_for_field, lookup_field, quote,
 )
 from django.db import DEFAULT_DB_ALIAS, models
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -194,6 +194,13 @@ class UtilsTests(SimpleTestCase):
 
         display_value = display_for_field(12345, models.IntegerField(), self.empty_value)
         self.assertEqual(display_value, '12,345')
+
+    def test_list_display_for_value(self):
+        display_value = display_for_value([1, 2, 3], self.empty_value)
+        self.assertEqual(display_value, '1, 2, 3')
+
+        display_value = display_for_value([1, 2, 'buckle', 'my', 'shoe'], self.empty_value)
+        self.assertEqual(display_value, '1, 2, buckle, my, shoe')
 
     def test_label_for_field(self):
         """


### PR DESCRIPTION
Opting for the simple solution outlined in https://code.djangoproject.com/ticket/26582

Also has the nice side-effect of correctly rendering value types returned by fields Django doesn't know about - for instance, a custom field that returns `datetime.date` but is not a `DateField` subclass.