### PR TITLE
Fixed #26483 -- Change docs.python.org links to point to Python 3

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -264,4 +264,4 @@ drastically increase CPU usage by causing worst-case performance when
 creating ``dict`` instances. See `oCERT advisory #2011-003
 <http://www.ocert.org/advisories/ocert-2011-003.html>`_ for more information.
 
-.. _-r: https://docs.python.org/using/cmdline.html#cmdoption-R
+.. _-r: https://docs.python.org/3/using/cmdline.html#cmdoption-R

--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -70,7 +70,7 @@ mention:
 
     For more information, see the Python documentation of the :mod:`csv` module.
 
-    .. _`csv module's examples section`: https://docs.python.org/library/csv.html#examples
+    .. _`csv module's examples section`: https://docs.python.org/3/library/csv.html#examples
     .. _`python-unicodecsv module`: https://github.com/jdunck/python-unicodecsv
 
 .. _streaming-csv-files:

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -376,7 +376,7 @@ that passing a ``prefix`` parameter when creating an instance still works too.
       your teeth into, there's always the `Python unittest documentation`__.
 
 __ http://www.diveintopython.net/unit_testing/index.html
-__ https://docs.python.org/library/unittest.html
+__ https://docs.python.org/3/library/unittest.html
 
 Running your new test
 ---------------------

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -209,7 +209,7 @@ requested URL. (If none of them matches, Django calls a special-case 404 view.)
 This is blazingly fast, because the regular expressions are compiled at load
 time.
 
-.. _regular expressions: https://docs.python.org/howto/regex.html
+.. _regular expressions: https://docs.python.org/3/howto/regex.html
 
 Once one of the regexes matches, Django imports and calls the given view, which
 is a simple Python function. Each view gets passed a request object --

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -34,7 +34,7 @@ projects and ready to publish for others to install and use.
 
 .. admonition:: Package? App?
 
-    A Python `package <https://docs.python.org/tutorial/modules.html#packages>`_
+    A Python `package <https://docs.python.org/3/tutorial/modules.html#packages>`_
     provides a way of grouping related Python code for easy reuse. A package
     contains one or more files of Python code (also known as "modules").
 

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -116,7 +116,7 @@ These files are:
 * :file:`mysite/wsgi.py`: An entry-point for WSGI-compatible web servers to
   serve your project. See :doc:`/howto/deployment/wsgi/index` for more details.
 
-.. _more about packages: https://docs.python.org/tutorial/modules.html#packages
+.. _more about packages: https://docs.python.org/3/tutorial/modules.html#packages
 
 The development server
 ======================
@@ -236,7 +236,7 @@ That'll create a directory :file:`polls`, which is laid out like this::
 
 This directory structure will house the poll application.
 
-.. _`Python path`: https://docs.python.org/tutorial/modules.html#the-module-search-path
+.. _`Python path`: https://docs.python.org/3/tutorial/modules.html#the-module-search-path
 
 Write your first view
 =====================

--- a/docs/ref/contrib/index.txt
+++ b/docs/ref/contrib/index.txt
@@ -17,7 +17,7 @@ those packages have.
     ``'django.contrib.redirects'``) to your :setting:`INSTALLED_APPS` setting
     and re-run ``manage.py migrate``.
 
-.. _"batteries included" philosophy: https://docs.python.org/tutorial/stdlib.html#batteries-included
+.. _"batteries included" philosophy: https://docs.python.org/3/tutorial/stdlib.html#batteries-included
 
 .. toctree::
    :maxdepth: 1

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -667,7 +667,7 @@ method would return different values before and after the instance is
 saved, but changing the ``__hash__`` value of an instance `is forbidden
 in Python`_).
 
-.. _is forbidden in Python: https://docs.python.org/reference/datamodel.html#object.__hash__
+.. _is forbidden in Python: https://docs.python.org/3/reference/datamodel.html#object.__hash__
 
 ``get_absolute_url``
 --------------------

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1736,7 +1736,7 @@ configuration method by default.
 If you set :setting:`LOGGING_CONFIG` to ``None``, the logging
 configuration process will be skipped.
 
-.. _dictConfig: https://docs.python.org/library/logging.config.html#configuration-dictionary-schema
+.. _dictConfig: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
 
 .. setting:: MANAGERS
 
@@ -2376,7 +2376,7 @@ precedence and will be applied instead.
 
 See also :setting:`DATE_INPUT_FORMATS` and :setting:`DATETIME_INPUT_FORMATS`.
 
-.. _datetime: https://docs.python.org/library/datetime.html#strftime-strptime-behavior
+.. _datetime: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
 
 .. setting:: TIME_ZONE
 

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -154,7 +154,7 @@ Users of Python 2.5 and above may now use transaction management functions as
     with transaction.autocommit():
         # ...
 
-.. _context managers: https://docs.python.org/glossary.html#term-context-manager
+.. _context managers: https://docs.python.org/2/glossary.html#term-context-manager
 
 Configurable delete-cascade
 ---------------------------

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -1310,7 +1310,7 @@ This behavior was never documented. Since it is unpythonic and not obviously
 useful, it was removed in Django 1.4. If you relied on it, you must edit your
 settings file to list all your applications explicitly.
 
-.. _this can't be done reliably: https://docs.python.org/tutorial/modules.html#importing-from-a-package
+.. _this can't be done reliably: https://docs.python.org/2/tutorial/modules.html#importing-from-a-package
 
 ``HttpRequest.raw_post_data`` renamed to ``HttpRequest.body``
 -------------------------------------------------------------

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -435,7 +435,7 @@ If you wish to delay updates to your test suite, you can set your
 to fully restore the old test behavior. ``DjangoTestSuiteRunner`` is deprecated
 but will not be removed from Django until version 1.8.
 
-.. _recommendations in the Python documentation: https://docs.python.org/library/doctest.html#unittest-api
+.. _recommendations in the Python documentation: https://docs.python.org/2/library/doctest.html#unittest-api
 
 Removal of ``django.contrib.gis.tests.GeoDjangoTestSuiteRunner`` GeoDjango custom test runner
 ---------------------------------------------------------------------------------------------

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -1049,9 +1049,10 @@ Miscellaneous
 
 * ``django.http.responses.REASON_PHRASES`` and
   ``django.core.handlers.wsgi.STATUS_CODE_TEXT`` have been removed. Use
-  Python's stdlib instead: :data:`http.client.responses` for Python 3 and
+  Python's stdlib instead: `http.client.responses`_ for Python 3 and
   `httplib.responses`_ for Python 2.
 
+  .. _`http.client.responses`: https://docs.python.org/3/library/http.client.html#httpresponse-objects
   .. _`httplib.responses`: https://docs.python.org/2/library/httplib.html#httplib.responses
 
 * ``ValuesQuerySet`` and ``ValuesListQuerySet`` have been removed.

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -404,7 +404,7 @@ translates (roughly) into the following SQL:
    arguments whose names and values are evaluated at runtime. For more
    information, see `Keyword Arguments`_ in the official Python tutorial.
 
-   .. _`Keyword Arguments`: https://docs.python.org/tutorial/controlflow.html#keyword-arguments
+   .. _`Keyword Arguments`: https://docs.python.org/3/tutorial/controlflow.html#keyword-arguments
 
 The field specified in a lookup has to be the name of a model field. There's
 one exception though, in case of a :class:`~django.db.models.ForeignKey` you

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -231,7 +231,7 @@ Logging is configured as part of the general Django ``setup()`` function.
 Therefore, you can be certain that loggers are always ready for use in your
 project code.
 
-.. _dictConfig format: https://docs.python.org/library/logging.config.html#configuration-dictionary-schema
+.. _dictConfig format: https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
 
 Examples
 --------
@@ -408,7 +408,7 @@ This logging configuration does the following things:
     printed to the console; ``ERROR`` and ``CRITICAL``
     messages will also be output via email.
 
-.. _formatter documentation: https://docs.python.org/library/logging.html#formatter-objects
+.. _formatter documentation: https://docs.python.org/3/library/logging.html#formatter-objects
 
 Custom logging configuration
 ----------------------------

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -272,7 +272,7 @@ have to write a `special encoder`_ for it. Something like this will work::
 Also note that GeoDjango provides a :doc:`customized GeoJSON serializer
 </ref/contrib/gis/serializers>`.
 
-.. _special encoder: https://docs.python.org/library/json.html#encoders-and-decoders
+.. _special encoder: https://docs.python.org/3/library/json.html#encoders-and-decoders
 .. _ecma-262: http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
 
 YAML


### PR DESCRIPTION
Added version 3 on every docs.python.org links (`grep "docs.python.org" docs -R`)
Kept python 2 links in :
- docs/releases/{1.3, 1.4, 1.6}.txt (python 3 wasn't supported)
- docs/releases/1.9.txt (specific python 2 reference to httplib.responses L1056)
- refs/utils.txt (python2 reference specified)
- topics/python3.txt