### PR TITLE
Corrected dynamic lookup example.

### DIFF
--- a/docs/howto/custom-lookups.txt
+++ b/docs/howto/custom-lookups.txt
@@ -292,7 +292,7 @@ would override ``get_lookup`` with something like::
                     dimension = int(lookup_name[1:])
                 except ValueError:
                     pass
-                finally:
+                else:
                     return get_coordinate_lookup(dimension)
             return super(CoordinatesField, self).get_lookup(lookup_name)
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/howto/custom-lookups/#how-django-determines-the-lookups-and-transforms-which-are-used

In the example the `finally` block should be replaced with an `else` block to function as intended (that is, return the custom lookup if there were no exceptions.