### PR TITLE
Removed HTTP prefixed CONTENT_TYPE/LENGTH headers in MultiPartParser.

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -68,7 +68,7 @@ class MultiPartParser(object):
         # Content-Type should contain multipart and the boundary information.
         #
 
-        content_type = META.get('HTTP_CONTENT_TYPE', META.get('CONTENT_TYPE', ''))
+        content_type = META.get('CONTENT_TYPE', '')
         if not content_type.startswith('multipart/'):
             raise MultiPartParserError('Invalid Content-Type: %s' % content_type)
 
@@ -81,7 +81,7 @@ class MultiPartParser(object):
         # Content-Length should contain the length of the body we are about
         # to receive.
         try:
-            content_length = int(META.get('HTTP_CONTENT_LENGTH', META.get('CONTENT_LENGTH', 0)))
+            content_length = int(META.get('CONTENT_LENGTH', 0))
         except (ValueError, TypeError):
             content_length = 0
 


### PR DESCRIPTION
The docs say that these headers always appear without the HTTP_ prefix.
This may have been an oversight when they were added in
d725cc9734272f867d41f7236235c28b3931a1b2, the only commit that uses
these names.