### PR TITLE
Fixed #26734 - Made iterator class configurable on ModelChoiceField.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1142,6 +1142,7 @@ class ModelChoiceField(ChoiceField):
         'invalid_choice': _('Select a valid choice. That choice is not one of'
                             ' the available choices.'),
     }
+    iterator = ModelChoiceIterator
 
     def __init__(self, queryset, empty_label="---------",
                  required=True, widget=None, label=None, initial=None,
@@ -1209,7 +1210,7 @@ class ModelChoiceField(ChoiceField):
         # accessed) so that we can ensure the QuerySet has not been consumed. This
         # construct might look complicated but it allows for lazy evaluation of
         # the queryset.
-        return ModelChoiceIterator(self)
+        return self.iterator(self)
 
     choices = property(_get_choices, ChoiceField._set_choices)
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -14,8 +14,8 @@ from django.core.validators import ValidationError
 from django.db import connection, models
 from django.db.models.query import EmptyQuerySet
 from django.forms.models import (
-    ModelFormMetaclass, construct_instance, fields_for_model, model_to_dict,
-    modelform_factory,
+    ModelChoiceIterator, ModelFormMetaclass, construct_instance, fields_for_model,
+    model_to_dict, modelform_factory,
 )
 from django.template import Context, Template
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
@@ -1572,6 +1572,23 @@ class ModelChoiceFieldTests(TestCase):
         template = Template('{{ field.name }}{{ field }}{{ field.help_text }}')
         with self.assertNumQueries(1):
             template.render(Context({'field': field}))
+
+    def test_modelhoicefield_iterator(self):
+        """
+        Iterator defaults to ModelChoiceIterator but can be overridden with
+        the iterator attribute on a ModelChoiceField subclass
+        """
+        field = forms.ModelChoiceField(Category.objects.all())
+        self.assertTrue(isinstance(field.choices, ModelChoiceIterator))
+
+        class CustomModelChoiceIterator(ModelChoiceIterator):
+            pass
+
+        class CustomModelChoiceField(forms.ModelChoiceField):
+            iterator = CustomModelChoiceIterator
+
+        field = CustomModelChoiceField(Category.objects.all())
+        self.assertTrue(isinstance(field.choices, CustomModelChoiceIterator))
 
 
 class ModelMultipleChoiceFieldTests(TestCase):


### PR DESCRIPTION
This seemed too trivial to open a ticket regarding, so I just created a pull request without one. Currently isn't trivial to change the iterator class used for a subclass of `ModelChoiceField` since it is hardcoded in `_get_choices`, which is then used in a property. This means a subclass has to duplicate code and create the property again to change the iterator class.

Test coverage/documentation can be added if needed, but seemed like a trivial enough change to not need any.