### PR TITLE
Refs #26445 -- Used app config to lookup user model in _create_user

### DIFF
--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -6,6 +6,8 @@ from django.contrib.auth.models import (
 )
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
+from django.db import connection, migrations
+from django.db.migrations.state import ModelState, ProjectState
 from django.db.models.signals import post_save
 from django.test import TestCase, mock, override_settings
 
@@ -141,6 +143,23 @@ class UserManagerTestCase(TestCase):
                 username='test', email='test@test.com',
                 password='test', is_staff=False,
             )
+
+    def test_runpython_manager_model_methods(self):
+        def forwards(apps, schema_editor):
+            UserModel = apps.get_model('auth', 'User')
+            UserModel.objects.create_user('Ms X', password='secure')
+
+        operation = migrations.RunPython(forwards, migrations.RunPython.noop)
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(User))
+        project_state.add_model(ModelState.from_model(Group))
+        project_state.add_model(ModelState.from_model(Permission))
+        project_state.add_model(ModelState.from_model(ContentType))
+        new_state = project_state.clone()
+        with connection.schema_editor() as editor:
+            operation.state_forwards('migrations', new_state)
+            operation.database_forwards('migrations', editor, project_state, new_state)
+        self.assertEqual(User.objects.filter(username='Ms X').count(), 1)
 
 
 class AbstractUserTestCase(TestCase):


### PR DESCRIPTION
Ticket comment: https://code.djangoproject.com/ticket/26445#comment:3

Even though the UserManager is available to the user model in
migrations, one cannot use create_superuser() or create_user() due to
them using the attached model to set the password.

Since model managers used in migrations will _ALWAYS_ refer to their
current implementation and will have to work with the migration state
model and the "real" model, using the global app_registry to lookup the
user model is not a problem.
