### PR TITLE
Fixed #26603 -- Forced lazy template names to text when computing cache key.

### DIFF
--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -9,7 +9,7 @@ import warnings
 from django.template import Origin, Template, TemplateDoesNotExist
 from django.template.backends.django import copy_exception
 from django.utils.deprecation import RemovedInDjango20Warning
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, force_text
 from django.utils.inspect import func_supports_parameter
 
 from .base import Loader as BaseLoader
@@ -100,7 +100,7 @@ class Loader(BaseLoader):
         if template_dirs:
             dirs_prefix = self.generate_hash(template_dirs)
 
-        return '-'.join(filter(bool, [template_name, skip_prefix, dirs_prefix]))
+        return '-'.join(filter(bool, [force_text(template_name), skip_prefix, dirs_prefix]))
 
     def generate_hash(self, values):
         return hashlib.sha1(force_bytes('|'.join(values))).hexdigest()

--- a/docs/releases/1.9.7.txt
+++ b/docs/releases/1.9.7.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Fixed translation of password validators' ``help_text`` in forms
   (:ticket:`26544`).
+
+* Fixed a regression causing the cached template loader to crash when using
+  lazy template names (:ticket:`26603`).

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -13,6 +13,7 @@ from django.template.engine import Engine
 from django.test import SimpleTestCase, ignore_warnings, override_settings
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.functional import lazystr
 
 from .utils import TEMPLATE_DIR
 
@@ -152,6 +153,13 @@ class CachedLoaderTests(SimpleTestCase):
         from its cache key.
         """
         self.assertEqual(self.engine.template_loaders[0].cache_key('-template.html', []), '-template.html')
+
+    def test_template_name_lazy_string(self):
+        """
+        #26603 -- A template name specified as a lazy string should be forced
+        to text before computing its cache key.
+        """
+        self.assertEqual(self.engine.template_loaders[0].cache_key(lazystr('template.html'), []), 'template.html')
 
 
 @unittest.skipUnless(pkg_resources, 'setuptools is not installed')


### PR DESCRIPTION
Refs #26536.

Thanks Sylvain Fankhauser for the very detailed report.