### PR TITLE
Fix the ECMAScript edition

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -987,8 +987,8 @@ Without passing ``safe=False``, a :exc:`TypeError` will be raised.
 
 .. warning::
 
-    Before the `5th edition of EcmaScript
-    <http://www.ecma-international.org/publications/standards/Ecma-262.htm>`_
+    Before the `5th edition of ECMAScript
+    <http://www.ecma-international.org/ecma-262/5.1/index.html#sec-11.1.4>`_
     it was possible to poison the JavaScript ``Array`` constructor. For this
     reason, Django does not allow passing non-dict objects to the
     :class:`~django.http.JsonResponse` constructor by default.  However, most


### PR DESCRIPTION
The link goes to the ECMAScript 2015 spec, which is actually the 6th edition.