### PR TITLE
Prevented findstatic argument from appearing as multiple options.

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -149,7 +149,7 @@ that class path inside your :setting:`INSTALLED_APPS` setting:
 ``findstatic``
 --------------
 
-.. django-admin:: findstatic static file [static file ...]
+.. django-admin:: findstatic static-file [static-file ...]
 
 Searches for one or more relative paths with the enabled finders.
 


### PR DESCRIPTION
This is less confusing. The initial format appeared to present two separate options