### PR TITLE
Fixed #26615 -- Password reset token now depends on user's email.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -67,7 +67,7 @@ class PasswordResetTokenGenerator(object):
         # Ensure results are consistent across DB backends
         login_timestamp = '' if user.last_login is None else user.last_login.replace(microsecond=0, tzinfo=None)
         return (
-            six.text_type(user.pk) + user.password +
+            six.text_type(user.pk) + user.password + user.email +
             six.text_type(login_timestamp) + six.text_type(timestamp)
         )
 

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -32,6 +32,23 @@ class TokenGeneratorTest(TestCase):
         tk2 = p0.make_token(reload)
         self.assertEqual(tk1, tk2)
 
+    def test_26615(self):
+        """
+        Ensure that the token generated for a user will fail if that user
+        changes email addresses.
+        """
+        # See ticket #26615
+        username = 'changeemailuser'
+        user = User.objects.create_user(
+            username, 'test4@example.com', 'testpw')
+        p0 = PasswordResetTokenGenerator()
+        tk1 = p0.make_token(user)
+        user.email = 'test4newemail@example.com'
+        user.save()
+        user_new_email = User.objects.get(username=username)
+        tk2 = p0.make_token(user_new_email)
+        self.assertNotEqual(tk1, tk2)
+
     def test_timeout(self):
         """
         Ensure we can use the token after n days, but no greater.


### PR DESCRIPTION
Per [#26615](https://code.djangoproject.com/ticket/26615).

First submission to Django Project, please be nice.