### PR TITLE
Fix #26620 -- Made refresh_from_db() fail when passing unknown keyword args

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -585,7 +585,7 @@ class Model(six.with_metaclass(ModelBase)):
             if f.attname not in self.__dict__
         }
 
-    def refresh_from_db(self, using=None, fields=None, **kwargs):
+    def refresh_from_db(self, using=None, fields=None):
         """
         Reloads field values from the database.
 

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -128,7 +128,7 @@ in the ``from_db()`` method.
 Refreshing objects from database
 ================================
 
-.. method:: Model.refresh_from_db(using=None, fields=None, **kwargs)
+.. method:: Model.refresh_from_db(using=None, fields=None)
 
 If you need to reload a model's values from the database, you can use the
 ``refresh_from_db()`` method. When this method is called without arguments the

--- a/docs/releases/1.9.7.txt
+++ b/docs/releases/1.9.7.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Fixed a regression causing the cached template loader to crash when using
   lazy template names (:ticket:`26603`).
+
+* Made refresh_from_db() fail when passing unknown keyword arguments
+  (:ticket:`26620`).

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -692,6 +692,8 @@ class ModelRefreshTests(TestCase):
         with self.assertNumQueries(1):
             a.refresh_from_db()
             self.assertEqual(a.pub_date, new_pub_date)
+        with self.assertRaises(TypeError):
+            a.refresh_from_db(unknown_kwarg=10)
 
     def test_refresh_fk(self):
         s1 = SelfRef.objects.create()


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/26620
