### PR TITLE
Refs #26601 -- Fixed new-style SessionMiddleware to process the response if the view raises an exception.

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -3,14 +3,15 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
-from django.middleware.exception import ExceptionMiddleware
 from django.shortcuts import redirect
 from django.utils.cache import patch_vary_headers
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.http import cookie_date
 
 
-class SessionMiddleware(ExceptionMiddleware):
+class SessionMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
+        self.get_response = get_response
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore
         super(SessionMiddleware, self).__init__(get_response)
@@ -18,11 +19,6 @@ class SessionMiddleware(ExceptionMiddleware):
     def process_request(self, request):
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME)
         request.session = self.SessionStore(session_key)
-
-    def __call__(self, request):
-        self.process_request(request)
-        response = super(SessionMiddleware, self).__call__(request)
-        return self.process_response(request, response)
 
     def process_response(self, request, response):
         """

--- a/django/middleware/exception.py
+++ b/django/middleware/exception.py
@@ -3,15 +3,6 @@ from __future__ import unicode_literals
 import logging
 import sys
 
-from django.conf import settings
-from django.core import signals
-from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from django.http import Http404
-from django.http.multipartparser import MultiPartParserError
-from django.urls import get_resolver, get_urlconf
-from django.utils.encoding import force_text
-from django.views import debug
-
 logger = logging.getLogger('django.request')
 
 
@@ -31,6 +22,16 @@ class ExceptionMiddleware(object):
         self.handler = handler or BaseHandler()
 
     def __call__(self, request):
+        # Can move these inner imports when MiddlewareMixin is removed.
+        from django.conf import settings
+        from django.core import signals
+        from django.core.exceptions import PermissionDenied, SuspiciousOperation
+        from django.http import Http404
+        from django.http.multipartparser import MultiPartParserError
+        from django.urls import get_resolver, get_urlconf
+        from django.utils.encoding import force_text
+        from django.views import debug
+
         try:
             response = self.get_response(request)
         except Http404 as exc:

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -127,14 +127,19 @@ class MiddlewareMixin(ExceptionMiddleware):
             response = self.process_request(request)
         if not response:
             try:
-                response = super(MiddlewareMixin, self).__call__(request)
+                response = self.get_response(request)
             except Exception as e:
+                # Only the last middleware is likely to see this because other
+                # middleware will transform the exception into a response with
+                # the super() call below.
                 if hasattr(self, 'process_exception'):
                     response = self.process_exception(request, e)
                     if response:
                         return response
-                else:
-                    raise
+                # This rerenders the response but transforming any exceptions
+                # to a response. We could refactor it to avoid the second render.
+                if not response:
+                    response = super(MiddlewareMixin, self).__call__(request)
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response

--- a/tests/sessions_tests/urls.py
+++ b/tests/sessions_tests/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url('^404-with-session-modify/$', views.session_modify_and_http404, name='http404-with-session-modify'),
+]

--- a/tests/sessions_tests/views.py
+++ b/tests/sessions_tests/views.py
@@ -1,0 +1,6 @@
+from django.http import Http404
+
+
+def session_modify_and_http404(request):
+    request.session['foo'] = 'bar'
+    raise Http404


### PR DESCRIPTION
I guess any middleware that implements `process_response()` may suffer from the fact that it won't be unconditionally called under the new style anymore.

I'm wondering if the `MiddlewareMixin` should be adapted to account for this.