### PR TITLE
Fixed #26615 -- Password reset token now depends on user's email.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -9,6 +9,7 @@ from django.contrib.auth.hashers import (
     check_password, is_password_usable, make_password,
 )
 from django.db import models
+from django.utils import six
 from django.utils.crypto import get_random_string, salted_hmac
 from django.utils.deprecation import CallableFalse, CallableTrue
 from django.utils.encoding import python_2_unicode_compatible
@@ -121,6 +122,17 @@ class AbstractBaseUser(models.Model):
 
     def get_full_name(self):
         raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_full_name() method')
+
+    def get_hash_value(self, timestamp):
+        """Returns the timestamped hash value for purposes of generating
+        a password reset token.
+        """
+        # Ensure results are consistent across DB backends
+        login_timestamp = '' if self.last_login is None else self.last_login.replace(microsecond=0, tzinfo=None)
+        return (
+            six.text_type(self.pk) + self.password +
+            six.text_type(login_timestamp) + six.text_type(timestamp)
+        )
 
     def get_short_name(self):
         raise NotImplementedError('subclasses of AbstractBaseUser must provide a get_short_name() method.')

--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -125,7 +125,8 @@ class AbstractBaseUser(models.Model):
 
     def get_hash_value(self, timestamp):
         """Returns the timestamped hash value for purposes of generating
-        a password reset token.
+        a password reset token; uses primary key, password, and, if
+        available, email address.
         """
         # Ensure results are consistent across DB backends
         login_timestamp = '' if self.last_login is None else self.last_login.replace(microsecond=0, tzinfo=None)

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -358,9 +358,6 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         return self.first_name
 
     def get_hash_value(self, timestamp):
-        """Returns the timestamped hash value for purposes of generating
-        a password reset token.
-        """
         # Class now has email field and hash should depend on it
         hash_value = super(AbstractUser, self).get_hash_value(timestamp)
         return hash_value + self.email

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -361,12 +361,9 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         """Returns the timestamped hash value for purposes of generating
         a password reset token.
         """
-        # Ensure results are consistent across DB backends
-        login_timestamp = '' if self.last_login is None else self.last_login.replace(microsecond=0, tzinfo=None)
-        return (
-            six.text_type(self.pk) + self.password + self.email +
-            six.text_type(login_timestamp) + six.text_type(timestamp)
-        )
+        # Class now has email field and hash should depend on it
+        hash_value = super(AbstractUser, self).get_hash_value(timestamp)
+        return hash_value + self.email
 
     def email_user(self, subject, message, from_email=None, **kwargs):
         """

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -357,6 +357,17 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         "Returns the short name for the user."
         return self.first_name
 
+    def get_hash_value(self, timestamp):
+        """Returns the timestamped hash value for purposes of generating
+        a password reset token.
+        """
+        # Ensure results are consistent across DB backends
+        login_timestamp = '' if self.last_login is None else self.last_login.replace(microsecond=0, tzinfo=None)
+        return (
+            six.text_type(self.pk) + self.password + self.email +
+            six.text_type(login_timestamp) + six.text_type(timestamp)
+        )
+
     def email_user(self, subject, message, from_email=None, **kwargs):
         """
         Sends an email to this User.

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from django.conf import settings
-from django.utils import six
 from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.http import base36_to_int, int_to_base36
 
@@ -59,17 +58,9 @@ class PasswordResetTokenGenerator(object):
 
         hash = salted_hmac(
             self.key_salt,
-            self._make_hash_value(user, timestamp),
+            user.get_hash_value(timestamp),
         ).hexdigest()[::2]
         return "%s-%s" % (ts_b36, hash)
-
-    def _make_hash_value(self, user, timestamp):
-        # Ensure results are consistent across DB backends
-        login_timestamp = '' if user.last_login is None else user.last_login.replace(microsecond=0, tzinfo=None)
-        return (
-            six.text_type(user.pk) + user.password +
-            six.text_type(login_timestamp) + six.text_type(timestamp)
-        )
 
     def _num_days(self, dt):
         return (dt - date(2001, 1, 1)).days

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -32,7 +32,7 @@ class TokenGeneratorTest(TestCase):
         tk2 = p0.make_token(reload)
         self.assertEqual(tk1, tk2)
 
-    def test_26615(self):
+    def test_token_invalid_on_email_change(self):
         """
         Ensure that the token generated for a user will fail if that user
         changes email addresses.

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -39,8 +39,7 @@ class TokenGeneratorTest(TestCase):
         """
         # See ticket #26615
         username = 'changeemailuser'
-        user = User.objects.create_user(
-            username, 'test4@example.com', 'testpw')
+        user = User.objects.create_user(username, 'test4@example.com', 'testpw')
         p0 = PasswordResetTokenGenerator()
         tk1 = p0.make_token(user)
         user.email = 'test4newemail@example.com'

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -32,6 +32,23 @@ class TokenGeneratorTest(TestCase):
         tk2 = p0.make_token(reload)
         self.assertEqual(tk1, tk2)
 
+    def test_26615(self):
+        """
+        Ensure that the token generated for a user will fail if that user
+        changes email addresses.
+        """
+        # See ticket #26615
+        username = 'changeemailuser'
+        user = User.objects.create_user(
+            username, 'test4@example.com', 'testpw')
+        p0 = PasswordResetTokenGenerator()
+        tk1 = p0.make_token(user)
+        user.email = 'test4newemail@example.com'
+        user.save()
+        user_new_email = User.objects.get(username=username)
+        tk2 = p0.make_token(user_new_email)
+        self.assertNotEqual(tk1, tk2)
+
     def test_timeout(self):
         """
         Ensure we can use the token after n days, but no greater.


### PR DESCRIPTION
Per [26615](https://code.djangoproject.com/ticket/26615). Also refactored user's hash generation into methods on User and AbstractUser so that PasswordResetTokenGenerator doesn't need to know which fields are available.

Resubmit of #6608.