### PR TITLE
Fixed #26640 -- class_prepared is not a ModelSignal and differs from docs

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -308,6 +308,7 @@ class ModelBase(type):
 
         new_class._prepare()
         new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
+        signals.class_prepared.send(sender=new_class)
         return new_class
 
     def add_to_class(cls, name, value):
@@ -355,8 +356,6 @@ class ModelBase(type):
             manager = Manager()
             manager.auto_created = True
             cls.add_to_class('objects', manager)
-
-        signals.class_prepared.send(sender=cls)
 
     def _requires_legacy_default_manager(cls):  # RemovedInDjango20Warning
         opts = cls._meta

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -4,9 +4,6 @@ from django.db.models.utils import make_model_tuple
 from django.dispatch import Signal
 
 
-class_prepared = Signal(providing_args=["class"])
-
-
 class ModelSignal(Signal):
     """
     Signal subclass that allows the sender to be lazily specified as a string
@@ -21,6 +18,7 @@ class ModelSignal(Signal):
             apps = sender._meta.apps if hasattr(sender, '_meta') else Options.default_apps
         apps.lazy_model_operation(connect, *models)
 
+class_prepared = ModelSignal()
 
 pre_init = ModelSignal(providing_args=["instance", "args", "kwargs"], use_caching=True)
 post_init = ModelSignal(providing_args=["instance"], use_caching=True)

--- a/docs/ref/signals.txt
+++ b/docs/ref/signals.txt
@@ -37,7 +37,7 @@ model system.
 
 .. note::
 
-    Model signals ``sender`` model can be lazily referenced when connecting a
+    Model signals' ``sender`` model can be lazily referenced when connecting a
     receiver by specifying its full application label. For example, an
     ``Answer`` model defined in the ``polls`` application could be referenced
     as ``'polls.Answer'``. This sort of reference can be quite handy when


### PR DESCRIPTION
Fixes a couple of problems with `class_prepared`:
1. it's not a `ModelSignal` but it's documented as one
2. it's documented as being sent after the model is registered, but it's actually sent just before
3. it's instantiated with `providing_args=["class"]`, but it doesn't provide a class argument