### PR TITLE
Fixed #26642 -- Made ModelSignal.disconnect() work with lazy references.

### DIFF
--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -1,7 +1,9 @@
+import warnings
 from functools import partial
 
 from django.db.models.utils import make_model_tuple
 from django.dispatch import Signal
+from django.utils.deprecation import RemovedInDjango20Warning
 
 
 class_prepared = Signal(providing_args=["class"])
@@ -12,14 +14,26 @@ class ModelSignal(Signal):
     Signal subclass that allows the sender to be lazily specified as a string
     of the `app_label.ModelName` form.
     """
+    def _lazy_method(self, method, apps, receiver, sender, **kwargs):
+        # This partial takes a single optional argument named "sender".
+        partial_method = partial(method, receiver, **kwargs)
+        # import models here to avoid a circular import
+        from django.db import models
+        if isinstance(sender, models.Model) or sender is None:
+            # Skip lazy_model_operation to get a return value for disconnect()
+            return partial_method(sender)
+        apps = apps or models.base.Options.default_apps
+        apps.lazy_model_operation(partial_method, make_model_tuple(sender))
+
     def connect(self, receiver, sender=None, weak=True, dispatch_uid=None, apps=None):
-        # Takes a single optional argument named "sender"
-        connect = partial(super(ModelSignal, self).connect, receiver, weak=weak, dispatch_uid=dispatch_uid)
-        models = [make_model_tuple(sender)] if sender else []
-        if not apps:
-            from django.db.models.base import Options
-            apps = sender._meta.apps if hasattr(sender, '_meta') else Options.default_apps
-        apps.lazy_model_operation(connect, *models)
+        self._lazy_method(super(ModelSignal, self).connect, apps, receiver, sender, dispatch_uid=dispatch_uid)
+
+    def disconnect(self, receiver=None, sender=None, weak=None, dispatch_uid=None, apps=None):
+        if weak is not None:
+            warnings.warn("Passing `weak` to disconnect has no effect.", RemovedInDjango20Warning, stacklevel=2)
+        return self._lazy_method(
+            super(ModelSignal, self).disconnect, apps, receiver, sender, dispatch_uid=dispatch_uid
+        )
 
 
 pre_init = ModelSignal(providing_args=["instance", "args", "kwargs"], use_caching=True)

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -301,3 +301,21 @@ class LazyModelRefTest(BaseSignalTest):
             }])
         finally:
             signals.post_init.disconnect(self.receiver, sender=Created)
+
+    @isolate_apps('signals', kwarg_name='apps')
+    def test_disconnect(self, apps):
+
+        received = []
+
+        def receiver(**kwargs):
+            received.append(kwargs)
+
+        signals.post_init.connect(receiver, sender='signals.Created', apps=apps)
+        signals.post_init.disconnect(receiver, sender='signals.Created', apps=apps)
+
+        class Created(models.Model):
+            pass
+
+        Created()
+
+        self.assertEqual(received, [])


### PR DESCRIPTION
See [ticket #26642](https://code.djangoproject.com/ticket/26642).