### PR TITLE
fix #26643 - prevent migrations being added to the model state when

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -462,7 +462,6 @@ class ModelState(object):
                 default_manager.name = model._default_manager.name
                 managers.append((force_text(default_manager.name), default_manager))
 
-
         for manager in model._meta.managers:
             if manager.use_in_migrations and manager is not model._default_manager:
                 manager = copy.copy(manager)

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -451,15 +451,17 @@ class ModelState(object):
             if model._default_manager.use_in_migrations:
                 default_manager = copy.copy(model._default_manager)
                 default_manager._set_creation_counter()
+                managers.append((force_text(default_manager.name), default_manager))
 
             # If the default manager doesn't have `use_in_migrations = True`,
             # shim a default manager so another manager isn't promoted in its
             # place.
-            else:
+            elif model._default_manager.name != 'objects':
                 default_manager = models.Manager()
                 default_manager.model = model
                 default_manager.name = model._default_manager.name
-            managers.append((force_text(default_manager.name), default_manager))
+                managers.append((force_text(default_manager.name), default_manager))
+
 
         for manager in model._meta.managers:
             if manager.use_in_migrations and manager is not model._default_manager:

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -191,6 +191,26 @@ class StateTests(SimpleTestCase):
         author_state = project_state.models['migrations', 'author']
         self.assertEqual(author_state.managers, [('authors', custom_manager)])
 
+    def test_manager_not_for_migration_not_added_to_the_model_state_when_named_objects(self):
+        """
+        #26643 - When a manager is added with a name of 'objects', but it
+        does not have use_in_migrations = True, no migration should be
+        added to the model state.
+        """
+        new_apps = Apps(['migrations'])
+        custom_manager = models.Manager()
+
+        class Author(models.Model):
+            objects = custom_manager
+
+            class Meta:
+                app_label = 'migrations'
+                apps = new_apps
+
+        project_state = ProjectState.from_apps(new_apps)
+        author_state = project_state.models['migrations', 'author']
+        self.assertEqual(author_state.managers, [])
+
     def test_apps_bulk_update(self):
         """
         StateApps.bulk_update() should update apps.ready to False and reset


### PR DESCRIPTION
fix [#26643](https://code.djangoproject.com/ticket/26643) - prevent migrations being added to the model state when their name matches that of the auto created managers, and they have use_in_migrations=False