### PR TITLE
Refs #24067 -- Fixed contenttypes rename tests failures on Oracle.

### DIFF
--- a/tests/contenttypes_tests/operations_migrations/0001_initial.py
+++ b/tests/contenttypes_tests/operations_migrations/0001_initial.py
@@ -4,22 +4,6 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
-def assert_foo_contenttype_not_cached(apps, schema_editor):
-    ContentType = apps.get_model('contenttypes', 'ContentType')
-    try:
-        content_type = ContentType.objects.get_by_natural_key('contenttypes_tests', 'foo')
-    except ContentType.DoesNotExist:
-        pass
-    else:
-        if not ContentType.objects.filter(app_label='contenttypes_tests', model='foo').exists():
-            raise AssertionError('The contenttypes_tests.Foo ContentType should not be cached.')
-        elif content_type.model != 'foo':
-            raise AssertionError(
-                "The cached contenttypes_tests.Foo ContentType should have "
-                "its model set to 'foo'."
-            )
-
-
 class Migration(migrations.Migration):
 
     operations = [
@@ -29,6 +13,4 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True)),
             ],
         ),
-        migrations.RenameModel('Foo', 'RenamedFoo'),
-        migrations.RunPython(assert_foo_contenttype_not_cached, migrations.RunPython.noop)
     ]

--- a/tests/contenttypes_tests/operations_migrations/0002_rename_foo.py
+++ b/tests/contenttypes_tests/operations_migrations/0002_rename_foo.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def assert_foo_contenttype_not_cached(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    try:
+        content_type = ContentType.objects.get_by_natural_key('contenttypes_tests', 'foo')
+    except ContentType.DoesNotExist:
+        pass
+    else:
+        if not ContentType.objects.filter(app_label='contenttypes_tests', model='foo').exists():
+            raise AssertionError('The contenttypes_tests.Foo ContentType should not be cached.')
+        elif content_type.model != 'foo':
+            raise AssertionError(
+                "The cached contenttypes_tests.Foo ContentType should have "
+                "its model set to 'foo'."
+            )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes_tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RenameModel('Foo', 'RenamedFoo'),
+        migrations.RunPython(assert_foo_contenttype_not_cached, migrations.RunPython.noop)
+    ]

--- a/tests/contenttypes_tests/tests.py
+++ b/tests/contenttypes_tests/tests.py
@@ -454,7 +454,11 @@ class ContentTypesMultidbTestCase(TestCase):
     MIGRATION_MODULES=dict(settings.MIGRATION_MODULES, contenttypes_tests='contenttypes_tests.operations_migrations'),
 )
 class ContentTypeOperationsTests(TransactionTestCase):
-    available_apps = ['django.contrib.contenttypes', 'contenttypes_tests']
+    available_apps = [
+        'contenttypes_tests',
+        'django.contrib.contenttypes',
+        'django.contrib.auth',
+    ]
 
     def setUp(self):
         app_config = apps.get_app_config('contenttypes_tests')


### PR DESCRIPTION
Broke the initial migration in two to work around #25530 and added
'django.contrib.auth' to the available_apps to make sure its tables are also
flushed as Oracle doesn't implement cascade deletion in sql_flush().

Thanks Tim for the report.