### PR TITLE
Fixed #26656 -- Added duration (timedelta) support to DjangoJSONEncoder

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -16,6 +16,7 @@ from django.core.serializers.python import (
     Deserializer as PythonDeserializer, Serializer as PythonSerializer,
 )
 from django.utils import six
+from django.utils.duration import duration_iso_string
 from django.utils.functional import Promise
 from django.utils.timezone import is_aware
 
@@ -108,6 +109,8 @@ class DjangoJSONEncoder(json.JSONEncoder):
             if o.microsecond:
                 r = r[:12]
             return r
+        elif isinstance(o, datetime.timedelta):
+            return duration_iso_string(o)
         elif isinstance(o, decimal.Decimal):
             return str(o)
         elif isinstance(o, uuid.UUID):

--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -40,7 +40,8 @@ standard_duration_re = re.compile(
 # Support the sections of ISO 8601 date representation that are accepted by
 # timedelta
 iso8601_duration_re = re.compile(
-    r'^P'
+    r'^(?P<sign>[-+]?)'
+    r'P'
     r'(?:(?P<days>\d+(.\d+)?)D)?'
     r'(?:T'
     r'(?:(?P<hours>\d+(.\d+)?)H)?'
@@ -121,7 +122,8 @@ def parse_duration(value):
         match = iso8601_duration_re.match(value)
     if match:
         kw = match.groupdict()
+        sign = -1 if kw.pop('sign', '+') == '-' else 1
         if kw.get('microseconds'):
             kw['microseconds'] = kw['microseconds'].ljust(6, '0')
         kw = {k: float(v) for k, v in six.iteritems(kw) if v is not None}
-        return datetime.timedelta(**kw)
+        return sign * datetime.timedelta(**kw)

--- a/django/utils/duration.py
+++ b/django/utils/duration.py
@@ -1,7 +1,7 @@
-"""Version of str(timedelta) which is not English specific."""
+import datetime
 
 
-def duration_string(duration):
+def _get_duration_components(duration):
     days = duration.days
     seconds = duration.seconds
     microseconds = duration.microseconds
@@ -12,6 +12,13 @@ def duration_string(duration):
     hours = minutes // 60
     minutes = minutes % 60
 
+    return days, hours, minutes, seconds, microseconds
+
+
+def duration_string(duration):
+    """Version of str(timedelta) which is not English specific."""
+    days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
+
     string = '{:02d}:{:02d}:{:02d}'.format(hours, minutes, seconds)
     if days:
         string = '{} '.format(days) + string
@@ -19,3 +26,15 @@ def duration_string(duration):
         string += '.{:06d}'.format(microseconds)
 
     return string
+
+
+def duration_iso_string(duration):
+    if duration < datetime.timedelta(0):
+        sign = '-'
+        duration *= -1
+    else:
+        sign = ''
+
+    days, hours, minutes, seconds, microseconds = _get_duration_components(duration)
+    ms = '.{:06d}'.format(microseconds) if microseconds else ""
+    return '{}P{}DT{:02d}H{:02d}M{:02d}{}S'.format(sign, days, hours, minutes, seconds, ms)

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -195,6 +195,10 @@ Serialization
 * The new ``django.core.serializers.base.Serializer.stream_class`` attribute
   allows subclasses to customize the default stream.
 
+* The ``django.core.serializers.json.DjangoJSONEncoder`` now knows how to
+  serialize :class:`~datetime.timedelta` objects (used by
+  :class:`~django.db.models.DurationField`).
+
 Signals
 ~~~~~~~
 

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -286,12 +286,21 @@ The JSON serializer uses ``DjangoJSONEncoder`` for encoding. A subclass of
 :class:`~datetime.time`
    A string of the form ``HH:MM:ss.sss`` as defined in `ECMA-262`_.
 
+:class:`~datetime.timedelta`
+   A string representing a duration as defined in ISO-8601, e.g.
+   ``timedelta(days=1, hours=2, seconds=3.4)`` would be represented as
+   ``'P1DT02H00M03.400000S'``.
+
 :class:`~decimal.Decimal`, ``Promise`` (``django.utils.functional.lazy()`` objects), :class:`~uuid.UUID`
    A string representation of the object.
 
 .. versionchanged:: 1.10
 
     Support for ``Promise`` was added.
+
+.. versionchanged:: 1.11
+
+    Support for :class:`~datetime.timedelta` was added.
 
 .. _ecma-262: http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
 

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import datetime
 import json
 import re
 
@@ -286,3 +287,15 @@ class DjangoJSONEncoderTests(SimpleTestCase):
                 json.dumps({'lang': ugettext_lazy("French")}, cls=DjangoJSONEncoder),
                 '{"lang": "Fran\\u00e7ais"}'
             )
+
+    def test_timedelta(self):
+        duration = datetime.timedelta(days=1, hours=2, seconds=3)
+        self.assertEqual(
+            json.dumps({'duration': duration}, cls=DjangoJSONEncoder),
+            '{"duration": "P1DT02H00M03S"}'
+        )
+        duration = datetime.timedelta(0)
+        self.assertEqual(
+            json.dumps({'duration': duration}, cls=DjangoJSONEncoder),
+            '{"duration": "P0DT00H00M00S"}'
+        )

--- a/tests/utils_tests/test_duration.py
+++ b/tests/utils_tests/test_duration.py
@@ -2,7 +2,7 @@ import datetime
 import unittest
 
 from django.utils.dateparse import parse_duration
-from django.utils.duration import duration_string
+from django.utils.duration import duration_iso_string, duration_string
 
 
 class TestDurationString(unittest.TestCase):
@@ -41,3 +41,41 @@ class TestParseDurationRoundtrip(unittest.TestCase):
     def test_negative(self):
         duration = datetime.timedelta(days=-1, hours=1, minutes=3, seconds=5)
         self.assertEqual(parse_duration(duration_string(duration)), duration)
+
+
+class TestISODurationString(unittest.TestCase):
+
+    def test_simple(self):
+        duration = datetime.timedelta(hours=1, minutes=3, seconds=5)
+        self.assertEqual(duration_iso_string(duration), 'P0DT01H03M05S')
+
+    def test_days(self):
+        duration = datetime.timedelta(days=1, hours=1, minutes=3, seconds=5)
+        self.assertEqual(duration_iso_string(duration), 'P1DT01H03M05S')
+
+    def test_microseconds(self):
+        duration = datetime.timedelta(hours=1, minutes=3, seconds=5, microseconds=12345)
+        self.assertEqual(duration_iso_string(duration), 'P0DT01H03M05.012345S')
+
+    def test_negative(self):
+        duration = -1 * datetime.timedelta(days=1, hours=1, minutes=3, seconds=5)
+        self.assertEqual(duration_iso_string(duration), '-P1DT01H03M05S')
+
+
+class TestParseISODurationRoundtrip(unittest.TestCase):
+
+    def test_simple(self):
+        duration = datetime.timedelta(hours=1, minutes=3, seconds=5)
+        self.assertEqual(parse_duration(duration_iso_string(duration)), duration)
+
+    def test_days(self):
+        duration = datetime.timedelta(days=1, hours=1, minutes=3, seconds=5)
+        self.assertEqual(parse_duration(duration_iso_string(duration)), duration)
+
+    def test_microseconds(self):
+        duration = datetime.timedelta(hours=1, minutes=3, seconds=5, microseconds=12345)
+        self.assertEqual(parse_duration(duration_iso_string(duration)), duration)
+
+    def test_negative(self):
+        duration = datetime.timedelta(days=-1, hours=1, minutes=3, seconds=5)
+        self.assertEqual(parse_duration(duration_iso_string(duration)).total_seconds(), duration.total_seconds())


### PR DESCRIPTION
Currently `DjangoJSONEncoder` supports `datetime`, `date`, `time`, `Decimal` and `UUID` objects.

But when the `DurationField` was added recently, no support for `timedelta` was added to the JSON encoder.

## Implementation
For portability reasons, this fix uses the ISO 8601 formatting for duration, instead of Django's duration string (`duration_string` is closely tied to Python's `timedelta` and handles negative values in a slightly idiosyncratic manner). Django's builtin duration parser already supports ISO 8601 strings, but has been extended to handle negative values.

One downside to this approach is that the `DjangoJSONEncoder` will use a different format to Django's serialization framework.

## Links
* Ticket: https://code.djangoproject.com/ticket/26656
* Another PR (uses floats): https://github.com/django/django/pull/6535