### PR TITLE
Fixed #26691 -- Removed checking for a file's existence before deleting.

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -35,14 +35,13 @@ class FileBasedCache(BaseCache):
 
     def get(self, key, default=None, version=None):
         fname = self._key_to_file(key, version)
-        if os.path.exists(fname):
-            try:
-                with io.open(fname, 'rb') as f:
-                    if not self._is_expired(f):
-                        return pickle.loads(zlib.decompress(f.read()))
-            except IOError as e:
-                if e.errno == errno.ENOENT:
-                    pass  # Cache file was removed after the exists check
+        try:
+            with io.open(fname, 'rb') as f:
+                if not self._is_expired(f):
+                    return pickle.loads(zlib.decompress(f.read()))
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                pass  # Cache file does not exists
         return default
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -380,15 +380,13 @@ class FileSystemStorage(Storage):
         assert name, "The name argument is not allowed to be empty."
         name = self.path(name)
         # If the file exists, delete it from the filesystem.
-        # Note that there is a race between os.path.exists and os.remove:
-        # if os.remove fails with ENOENT, the file was removed
-        # concurrently, and we can continue normally.
-        if os.path.exists(name):
-            try:
-                os.remove(name)
-            except OSError as e:
-                if e.errno != errno.ENOENT:
-                    raise
+        # If os.remove fails with ENOENT, the file was removed concurrently,
+        # and we can continue normally.
+        try:
+            os.remove(name)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
     def exists(self, name):
         return os.path.exists(self.path(name))

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -48,12 +48,11 @@ class PathNotImplementedStorage(storage.Storage):
 
     def delete(self, name):
         name = self._path(name)
-        if os.path.exists(name):
-            try:
-                os.remove(name)
-            except OSError as e:
-                if e.errno != errno.ENOENT:
-                    raise
+        try:
+            os.remove(name)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
     def path(self, name):
         raise NotImplementedError


### PR DESCRIPTION
File operations will always raise a ENOENT error when a file does not
exist. Checking the file exists before the operation adds a race
condition where the file could be removed between operations. As the
operation already raises an error on a missing file, avoid this race and
avoid checking the file exists twice. Instead only check a file exists
by catching the ENOENT error.

Additionally, this follows the Python idiom "easier to ask for
forgiveness than permission".