### PR TITLE
Refs #25588 -- Fixed GDAL dependency in spatial lookups.

### DIFF
--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
+from unittest import skipUnless
+
 from django.contrib.gis.db.models import fields
+from django.contrib.gis.gdal import HAS_GDAL
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, migrations, models
 from django.db.migrations.migration import Migration
@@ -114,6 +117,7 @@ class OperationTests(TransactionTestCase):
             self.assertSpatialIndexExists('gis_neighborhood', 'heatmap')
 
     @skipIfDBFeature('supports_raster')
+    @skipUnless(HAS_GDAL, 'A different error is raised if GDAL is not installed.')
     def test_create_raster_model_on_db_without_raster_support(self):
         """
         Test creating a model with a raster field on a db without raster support.
@@ -123,6 +127,7 @@ class OperationTests(TransactionTestCase):
             self.set_up_test_model(True)
 
     @skipIfDBFeature('supports_raster')
+    @skipUnless(HAS_GDAL, 'A different error is raised if GDAL is not installed.')
     def test_add_raster_field_on_db_without_raster_support(self):
         """
         Test adding a raster field on a db without raster support.


### PR DESCRIPTION
I moved the attempt to convert to raster into a separate method that is only called if GDAL is installed. 

Is there a way to create a regression test for this? I don't know how to mock a system that does not have gdal installed.