### PR TITLE
Fixes #26635: clarify "memory_cost" of Argon2PasswordHasher differs from command line utility

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -232,6 +232,13 @@ follows:
    Pick a ``time_cost`` that takes an acceptable time for you.
    If ``time_cost`` set to 1 is unacceptably slow, lower ``memory_cost``.
 
+.. note::
+
+    The argon2 command-line utility and some other libraries
+    interpret the **memory_cost** parameter different.
+    The conversion is given by
+    :code:`memory_cost == 2 ** memory_cost_commandline`.
+
 .. _password-upgrades:
 
 Password upgrading


### PR DESCRIPTION
@timgraham 

https://code.djangoproject.com/ticket/26635