### PR TITLE
Fixes #26644 -- Allow saving NamedTemporaryFile

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -18,6 +18,8 @@ class File(FileProxyMixin):
         self.file = file
         if name is None:
             name = getattr(file, 'name', None)
+        if isinstance(name, six.string_types) and os.path.isabs(name):
+            name = os.path.basename(name)
         self.name = name
         if hasattr(file, 'mode'):
             self.mode = file.mode

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -10,6 +10,7 @@ import threading
 import time
 import unittest
 from datetime import datetime, timedelta
+from tempfile import NamedTemporaryFile
 
 from django.core.cache import cache
 from django.core.exceptions import SuspiciousFileOperation, SuspiciousOperation
@@ -451,6 +452,14 @@ class FileStorageTests(TestCase):
             self.storage.exists('..')
         with self.assertRaises(SuspiciousOperation):
             self.storage.exists('/etc/passwd')
+
+    def test_save_temporary_file(self):
+        """Saving a python tempfile should not fail"""
+        storage = Storage()
+        with NamedTemporaryFile(suffix='.pdf') as file_:
+            file_.write(b'Imagine some external lib wrote to this file')
+            storage.normal = File(file_)
+            storage.save()
 
     def test_file_storage_preserves_filename_case(self):
         """The storage backend should preserve case of filenames."""


### PR DESCRIPTION
914c72be2abb1c6dd860cb9279beaa66409ae1b2 introduced a regression that caused saving a NamedTemporaryFile in a FileField to raise a SuspiciousFileOperation.

To work around this scenario, and other possible similar scenarios, if a File object has an absolute path as a filename, only use the basename component as a filename.

There is no mention of this fix in the changelog, because the regression was introduced after 1.9, and this will hopefully, be merged before 1.10. No released django version has the issue this fixes.