### PR TITLE
Fixed #26673 -- Fixed a I18N test case error on Windows+Python 2.7.

### DIFF
--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -169,9 +169,10 @@ class CompilationErrorHandling(MessageCompilationTests):
         # po file contains invalid msgstr content (triggers non-ascii error content).
         mo_file = 'locale/ko/LC_MESSAGES/django.mo'
         self.addCleanup(self.rmfile, os.path.join(self.test_dir, mo_file))
-        # Make sure the output of msgfmt is unaffected by the current locale.
+        # Make sure the output of msgfmt is unaffected by the current locale. Use bytestring on var name and value as
+        # Python 2.7 on Windows needs that
         env = os.environ.copy()
-        env.update({'LANG': 'C'})
+        env.update({str('LANG'): str('C')})
         with mock.patch('django.core.management.utils.Popen', lambda *args, **kwargs: Popen(*args, env=env, **kwargs)):
             if six.PY2:
                 # Various assertRaises on PY2 don't support unicode error messages.


### PR DESCRIPTION
`subprocess.Popen` doesn't accept enviroment vars with Unicode var name
or value.