### PR TITLE
Refs #24227 -- Fixed crash of ManyToManyField.value_from_object() on unsaved model instances.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1565,6 +1565,8 @@ class ManyToManyField(RelatedField):
         """
         Return the value of this field in the given model instance.
         """
+        if obj.pk is None:
+            return []
         qs = getattr(obj, self.attname).all()
         if qs._result_cache is not None:
             return [item.pk for item in qs]

--- a/tests/model_fields/test_manytomanyfield.py
+++ b/tests/model_fields/test_manytomanyfield.py
@@ -6,6 +6,14 @@ from django.test.utils import isolate_apps
 
 class ManyToManyFieldTests(SimpleTestCase):
 
+    @isolate_apps('model_fields')
+    def test_value_from_object_instance_without_pk(self):
+        class ManyToManyModel(models.Model):
+            m2m = models.ManyToManyField('self', models.CASCADE)
+
+        instance = ManyToManyModel()
+        self.assertEqual(instance._meta.get_field('m2m').value_from_object(instance), [])
+
     def test_abstract_model_pending_operations(self):
         """
         Many-to-many fields declared on abstract models should not add lazy


### PR DESCRIPTION
This behavior was removed in 67d984413c9540074e4fe6aa033081a35cf192bc
but is needed to prevent a crash in formtools.