### PR TITLE
Fixed #26672 -- Raised ValidationError if non-dict-like JSON is passed to HStoreField.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -108,6 +108,7 @@ answer newbie questions, and generally made Django that much better:
     Bojan Mihelac <bmihelac@mihelac.org>
     Bouke Haarsma <bouke@haarsma.eu>
     Božidar Benko <bbenko@gmail.com>
+    Brad Melin <melinbrad@gmail.com>
     Brant Harris
     Brendan Hayward <brendanhayward85@gmail.com>
     Brenton Simpson <http://theillustratedlife.com>

--- a/django/contrib/postgres/forms/hstore.py
+++ b/django/contrib/postgres/forms/hstore.py
@@ -9,10 +9,13 @@ __all__ = ['HStoreField']
 
 
 class HStoreField(forms.CharField):
-    """A field for HStore data which accepts JSON input."""
+    """
+    A field for HStore data which accepts JSON input that resembles a dictionary.
+    """
     widget = forms.Textarea
     default_error_messages = {
         'invalid_json': _('Could not load JSON data.'),
+        'invalid_format': _('Input should resemble a dictionary.')
     }
 
     def prepare_value(self, value):
@@ -31,6 +34,13 @@ class HStoreField(forms.CharField):
                     self.error_messages['invalid_json'],
                     code='invalid_json',
                 )
+
+        if not isinstance(value, dict):
+            raise ValidationError(
+                self.error_messages['invalid_format'],
+                code='invalid_format',
+            )
+
         # Cast everything to strings for ease.
         for key, val in value.items():
             value[key] = six.text_type(val)

--- a/docs/releases/1.9.7.txt
+++ b/docs/releases/1.9.7.txt
@@ -20,3 +20,6 @@ Bugfixes
 
 * Fixed ``on_commit`` callbacks execution order when callbacks make
   transactions (:ticket:`26627`).
+
+* Raised ValidationError if non-dict-like JSON is passed to HStoreField
+  (:ticket: `26672`).

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -208,6 +208,14 @@ class TestFormField(PostgreSQLTestCase):
         self.assertEqual(cm.exception.messages[0], 'Could not load JSON data.')
         self.assertEqual(cm.exception.code, 'invalid_json')
 
+    def test_badly_formatted_json(self):
+        field = forms.HStoreField()
+
+        msg = 'Input should resemble a dictionary.'
+        with self.assertRaisesMessage(exceptions.ValidationError, msg) as cm:
+            field.clean('["a", "b", 1]')
+        self.assertEqual(cm.exception.code, 'invalid_format')
+
     def test_not_string_values(self):
         field = forms.HStoreField()
         value = field.clean('{"a": 1}')


### PR DESCRIPTION
Fixed validation logic in the field's to_python method to
prevent an AttributeError being raised when the values
are converted to strings.