### PR TITLE
Fixed #26677 -- Made some i18n tests use a disposable filesystem tree.

### DIFF
--- a/tests/i18n/test_percents.py
+++ b/tests/i18n/test_percents.py
@@ -9,7 +9,7 @@ from django.utils._os import upath
 from django.utils.encoding import force_text
 from django.utils.translation import activate, get_language, trans_real
 
-from .test_extraction import ExtractorTests
+from .test_extraction import POFileAssertionMixin
 
 SAMPLEPROJECT_DIR = os.path.join(os.path.dirname(os.path.abspath(upath(__file__))), 'sampleproject')
 SAMPLEPROJECT_LOCALE = os.path.join(SAMPLEPROJECT_DIR, 'locale')
@@ -31,7 +31,7 @@ class FrenchTestCase(SimpleTestCase):
         activate(self._language)
 
 
-class ExtractingStringsWithPercentSigns(FrenchTestCase, ExtractorTests):
+class ExtractingStringsWithPercentSigns(POFileAssertionMixin, FrenchTestCase):
     """
     Tests the extracted string found in the gettext catalog.
 


### PR DESCRIPTION
This allows makemessages/compilemessages tests in `test_extraction.py`
and `test_compilation.py` to actually run isolated from each other
(unaffected by stray FS objects left by cleanup actions failures, debug
sessions, etc.) and to take advantage of the parallel test execution
feature like most of the Django test suite.

`test_percents.py` gets slightly refactored to not inherit from the new
machinery which sets up every test case to copy and run under a
temporary tree.