### PR TITLE
Fixed #26678 -- Documented that ManyRelatedManager.add()/remove() accepts primary keys.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -1050,7 +1050,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
         def _remove_items(self, source_field_name, target_field_name, *objs):
             # source_field_name: the PK colname in join table for the source object
             # target_field_name: the PK colname in join table for the target object
-            # *objs - objects to remove
+            # *objs - objects to remove (model instances or primary keys)
             if not objs:
                 return
 

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -61,6 +61,9 @@ Related objects reference
         <django.db.models.query.QuerySet.bulk_create>`. If you need to execute
         some custom logic when a relationship is created, listen to the
         :data:`~django.db.models.signals.m2m_changed` signal.
+        
+        The ``add()`` method also accepts primary keys as arguments, so the
+        above example can be written directly as ``b.entry_set.add(234)``.
 
     .. method:: create(**kwargs)
 

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -128,6 +128,10 @@ Related objects reference
         :data:`~django.db.models.signals.post_save` signals and comes at the
         expense of performance.
 
+        Similary to :meth:`add()`, the ``remove()`` method also accepts primary
+        keys as arguments, so the above example can be rewritten as
+        ``b.entry_set.remove(234)``.
+
     .. method:: clear()
 
         Removes all objects from the related object set::

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -128,7 +128,7 @@ Related objects reference
         :data:`~django.db.models.signals.post_save` signals and comes at the
         expense of performance.
 
-        Similary to :meth:`add()`, the ``remove()`` method also accepts primary
+        Similarly to :meth:`add()`, the ``remove()`` method also accepts primary
         keys as arguments, so the above example can be rewritten as
         ``b.entry_set.remove(234)``.
 


### PR DESCRIPTION
Make it clear that it supports primary keys and not just model instances.
This is documented in the code but should also be written in the web documentation.
https://github.com/django/django/blob/master/django/db/models/fields/related_descriptors.py#L984

Trac ticket: https://code.djangoproject.com/ticket/26678