### PR TITLE
Fixed #26687 -- Made i18n test not use hardcoded path separator.

### DIFF
--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -534,27 +534,25 @@ class SymlinkExtractorTests(ExtractorTests):
         os.chdir(self._cwd)
 
     def test_symlink(self):
-        # On Python < 3.2 os.symlink() exists only on Unix
-        if hasattr(os, 'symlink'):
-            if os.path.exists(self.symlinked_dir):
-                self.assertTrue(os.path.islink(self.symlinked_dir))
-            else:
-                # On Python >= 3.2) os.symlink() exists always but then can
-                # fail at runtime when user hasn't the needed permissions on
-                # Windows versions that support symbolink links (>= 6/Vista).
-                # See Python issue 9333 (http://bugs.python.org/issue9333).
-                # Skip the test in that case
-                try:
-                    os.symlink(os.path.join(self.test_dir, 'templates'), self.symlinked_dir)
-                except (OSError, NotImplementedError):
-                    raise SkipTest("os.symlink() is available on this OS but can't be used by this user.")
-            os.chdir(self.test_dir)
-            management.call_command('makemessages', locale=[LOCALE], verbosity=0, symlinks=True)
-            self.assertTrue(os.path.exists(self.PO_FILE))
-            with open(self.PO_FILE, 'r') as fp:
-                po_contents = force_text(fp.read())
-                self.assertMsgId('This literal should be included.', po_contents)
-                self.assertIn('templates_symlinked/test.html', po_contents)
+        if os.path.exists(self.symlinked_dir):
+            self.assertTrue(os.path.islink(self.symlinked_dir))
+        else:
+            # On Python >= 3.2) os.symlink() exists always but then can
+            # fail at runtime when user hasn't the needed permissions on
+            # Windows versions that support symbolink links (>= 6/Vista).
+            # See Python issue 9333 (http://bugs.python.org/issue9333).
+            # Skip the test in that case
+            try:
+                os.symlink(os.path.join(self.test_dir, 'templates'), self.symlinked_dir)
+            except (OSError, NotImplementedError):
+                raise SkipTest("os.symlink() is available on this OS but can't be used by this user.")
+        os.chdir(self.test_dir)
+        management.call_command('makemessages', locale=[LOCALE], verbosity=0, symlinks=True)
+        self.assertTrue(os.path.exists(self.PO_FILE))
+        with open(self.PO_FILE, 'r') as fp:
+            po_contents = force_text(fp.read())
+            self.assertMsgId('This literal should be included.', po_contents)
+        self.assertLocationCommentPresent(self.PO_FILE, None, 'templates_symlinked', 'test.html')
 
 
 class CopyPluralFormsExtractorTests(ExtractorTests):

--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -534,25 +534,29 @@ class SymlinkExtractorTests(ExtractorTests):
         os.chdir(self._cwd)
 
     def test_symlink(self):
-        if os.path.exists(self.symlinked_dir):
-            self.assertTrue(os.path.islink(self.symlinked_dir))
+        # On Python < 3.2 os.symlink() exists only on Unix
+        if hasattr(os, 'symlink'):
+            if os.path.exists(self.symlinked_dir):
+                self.assertTrue(os.path.islink(self.symlinked_dir))
+            else:
+                # On Python >= 3.2) os.symlink() exists always but then can
+                # fail at runtime when user hasn't the needed permissions on
+                # Windows versions that support symbolink links (>= 6/Vista).
+                # See Python issue 9333 (http://bugs.python.org/issue9333).
+                # Skip the test in that case
+                try:
+                    os.symlink(os.path.join(self.test_dir, 'templates'), self.symlinked_dir)
+                except (OSError, NotImplementedError):
+                    raise SkipTest("os.symlink() is available on this OS but can't be used by this user.")
+            os.chdir(self.test_dir)
+            management.call_command('makemessages', locale=[LOCALE], verbosity=0, symlinks=True)
+            self.assertTrue(os.path.exists(self.PO_FILE))
+            with open(self.PO_FILE, 'r') as fp:
+                po_contents = force_text(fp.read())
+                self.assertMsgId('This literal should be included.', po_contents)
+            self.assertLocationCommentPresent(self.PO_FILE, None, 'templates_symlinked', 'test.html')
         else:
-            # On Python >= 3.2) os.symlink() exists always but then can
-            # fail at runtime when user hasn't the needed permissions on
-            # Windows versions that support symbolink links (>= 6/Vista).
-            # See Python issue 9333 (http://bugs.python.org/issue9333).
-            # Skip the test in that case
-            try:
-                os.symlink(os.path.join(self.test_dir, 'templates'), self.symlinked_dir)
-            except (OSError, NotImplementedError):
-                raise SkipTest("os.symlink() is available on this OS but can't be used by this user.")
-        os.chdir(self.test_dir)
-        management.call_command('makemessages', locale=[LOCALE], verbosity=0, symlinks=True)
-        self.assertTrue(os.path.exists(self.PO_FILE))
-        with open(self.PO_FILE, 'r') as fp:
-            po_contents = force_text(fp.read())
-            self.assertMsgId('This literal should be included.', po_contents)
-        self.assertLocationCommentPresent(self.PO_FILE, None, 'templates_symlinked', 'test.html')
+            raise SkipTest("os.symlink() not available on this OS + Python version combination.")
 
 
 class CopyPluralFormsExtractorTests(ExtractorTests):


### PR DESCRIPTION
This fails on Windows when the test run time conditions are such that
the assertion is really executed.