### PR TITLE
Fixed #26692 -- Relaxed a i18n compilemessages test.

### DIFF
--- a/tests/i18n/test_compilation.py
+++ b/tests/i18n/test_compilation.py
@@ -178,12 +178,12 @@ class CompilationErrorHandling(MessageCompilationTests):
                 try:
                     call_command('compilemessages', locale=['ko'], verbosity=0)
                 except CommandError as err:
-                    self.assertIn("'�' cannot start a field name", six.text_type(err))
+                    self.assertIn("' cannot start a field name", six.text_type(err))
             else:
                 cmd = MakeMessagesCommand()
                 if cmd.gettext_version < (0, 18, 3):
                     raise unittest.SkipTest("python-brace-format is a recent gettext addition.")
-                with self.assertRaisesMessage(CommandError, "'�' cannot start a field name"):
+                with self.assertRaisesMessage(CommandError, "' cannot start a field name"):
                     call_command('compilemessages', locale=['ko'], verbosity=0)
 
 


### PR DESCRIPTION
Combination of:

* Peculiarities of GNU gettext tools handling of error reporting (via
  sdterr)
* The fact that for this test we need to set the `LANG` env var to `"C"`
  to ensure such error messages are emitted in English
* Special characteristics of the Windows console regarding handling of
  encoding

Makes it hard to portably test for the actual content of the `msgfmt(1)`
error message that includes the culprit Unicode code point, as exercised
by the `i18n.test_compilation.CompilationErrorHandling.test_msgfmt_error_including_non_ascii`
test.

Proposed solution is to simply drop it but still check for other parts
of the expected error message.