### PR TITLE
[1.8.x] Reverted "Fixed #26687 -- Made an i18n test not use a hardcoded path separator.

### DIFF
--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -523,9 +523,7 @@ class SymlinkExtractorTests(ExtractorTests):
             with open(self.PO_FILE, 'r') as fp:
                 po_contents = force_text(fp.read())
                 self.assertMsgId('This literal should be included.', po_contents)
-            self.assertLocationCommentPresent(self.PO_FILE, None, 'templates_symlinked', 'test.html')
-        else:
-            raise SkipTest("os.symlink() not available on this OS + Python version combination.")
+                self.assertIn(os.path.join('templates_symlinked', 'test.html'), po_contents)
 
 
 class CopyPluralFormsExtractorTests(ExtractorTests):


### PR DESCRIPTION
This reverts commit c0a1e1984e0028022c5ac0722ff4933317bcdbc2 as it doesn't
work on the stable/1.8.x branch and instead uses os.path.join() to fix the
original failure on Windows.