### PR TITLE
Fixed 26359 -- Explain difference between GitHub and Issue Tracker.

### DIFF
--- a/docs/internals/contributing/bugs-and-features.txt
+++ b/docs/internals/contributing/bugs-and-features.txt
@@ -29,6 +29,11 @@ general points:
   likely to get lost. If a particular ticket is controversial, please move the
   discussion to |django-developers|.
 
+.. Note::
+
+    Django does not use GitHub for bug reports or feature requests.
+    All bug reports or feature requests should go through the `issue tracker`_.
+
 .. _reporting-bugs:
 
 Reporting bugs
@@ -171,4 +176,5 @@ Votes on technical matters should be announced and held in public on the
 
 .. _searching: https://code.djangoproject.com/search
 .. _custom queries: https://code.djangoproject.com/query
+.. _issue tracker: https://code.djangoproject.com/query
 .. _#django: irc://irc.freenode.net/django

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -29,7 +29,8 @@ it. We're passionate about helping Django users make the jump to contributing
 members of the community, so there are several ways you can help Django's
 development:
 
-* :doc:`Report bugs <bugs-and-features>` in our `ticket tracker`_.
+* :doc:`Report bugs <bugs-and-features>` in our `ticket tracker`_. We use
+  `GitHub`_ for source control and code review, not for tracking issues.
 
 * Join the |django-developers| mailing list and share your ideas for how
   to improve Django. We're always open to suggestions.
@@ -66,4 +67,5 @@ Browse the following sections to find out how:
 .. _community page: https://www.djangoproject.com/community/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/
 .. _ticket tracker: https://code.djangoproject.com/newticket
+.. _GitHub: https://github.com/django/django
 .. _easy pickings: https://code.djangoproject.com/query?status=!closed&easy=1


### PR DESCRIPTION
This commit is optimizing for making it clear to the reader as soon as possible
what the two systems are used for.