### PR TITLE
Fixed #26628 -- Documented CSRF failure logging

### DIFF
--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -211,6 +211,8 @@ The error page, however, is not very friendly, so you may want to provide your
 own view for handling this condition.  To do this, simply set the
 :setting:`CSRF_FAILURE_VIEW` setting.
 
+CSRF failures are logged to :ref:`django-request-logger` as warnings.
+
 .. _how-csrf-works:
 
 How it works


### PR DESCRIPTION
As noted in the ticket, logging already exists https://github.com/django/django/blob/f179113e6cbc8ba0a8d4e87e1d4410fb61d63e75/django/middleware/csrf.py#L100-L108