### PR TITLE
Fixed #26666 -- Added error message when assertRedirects encounters external URLs.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -303,6 +303,11 @@ class SimpleTestCase(unittest.TestCase):
                 path = urljoin(response.request['PATH_INFO'], path)
 
             if fetch_redirect_response:
+                if netloc:
+                    raise ValueError(
+                        "The Django test client is unable to fetch remote URLs (got %s). "
+                        "Use assertRedirects(..., fetch_redirect_response=False) instead." % url
+                    )
                 redirect_response = response.client.get(path, QueryDict(query), secure=(scheme == 'https'))
 
                 # Get the redirection page, using the same client that was used

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -595,6 +595,15 @@ class ClientTest(TestCase):
         response = self.client.get('/django_project_redirect/')
         self.assertRedirects(response, 'https://www.djangoproject.com/', fetch_redirect_response=False)
 
+    def test_external_redirect_with_fetch_error_msg(self):
+        """
+        Check that assertRedirects without fetch_redirect_response=False raises
+        a relevant ValueError rather than a non-descript AssertionError.
+        """
+        response = self.client.get('/django_project_redirect/')
+        with self.assertRaisesMessage(ValueError, 'unable to fetch'):
+            self.assertRedirects(response, 'https://www.djangoproject.com/')
+
     def test_session_modifying_view(self):
         "Request a page that modifies the session"
         # Session value isn't set initially


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/26666