### PR TITLE
Fixed #26698 -- Fixed a dbshell crashes on Postgres with an empty database name.

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -17,14 +17,14 @@ class DatabaseClient(BaseDatabaseClient):
     executable_name = 'psql'
 
     @classmethod
-    def runshell_db(cls, settings_dict):
+    def runshell_db(cls, conn_params):
         args = [cls.executable_name]
 
-        host = settings_dict.get('HOST', '')
-        port = settings_dict.get('PORT', '')
-        name = settings_dict.get('NAME', '')
-        user = settings_dict.get('USER', '')
-        passwd = settings_dict.get('PASSWORD', '')
+        host = conn_params.get('host', '')
+        port = conn_params.get('port', '')
+        dbname = conn_params.get('database', '')
+        user = conn_params.get('user', '')
+        passwd = conn_params.get('password', '')
 
         if user:
             args += ['-U', user]
@@ -32,7 +32,7 @@ class DatabaseClient(BaseDatabaseClient):
             args += ['-h', host]
         if port:
             args += ['-p', str(port)]
-        args += [name]
+        args += [dbname]
 
         temp_pgpass = None
         try:
@@ -43,7 +43,7 @@ class DatabaseClient(BaseDatabaseClient):
                     print_(
                         _escape_pgpass(host) or '*',
                         str(port) or '*',
-                        _escape_pgpass(name) or '*',
+                        _escape_pgpass(dbname) or '*',
                         _escape_pgpass(user) or '*',
                         _escape_pgpass(passwd),
                         file=temp_pgpass,
@@ -63,4 +63,4 @@ class DatabaseClient(BaseDatabaseClient):
                     del os.environ['PGPASSFILE']
 
     def runshell(self):
-        DatabaseClient.runshell_db(self.connection.settings_dict)
+        DatabaseClient.runshell_db(self.connection.get_connection_params())

--- a/docs/releases/1.9.7.txt
+++ b/docs/releases/1.9.7.txt
@@ -23,3 +23,6 @@ Bugfixes
 
 * Fixed ``HStoreField`` to raise a ``ValidationError`` instead of crashing on
   non-dictionary JSON input (:ticket:`26672`).
+
+* Fixed ``manage.py dbshell`` crash on PostgreSQL with an empty database name set.
+  (:ticket:`26698`)

--- a/tests/dbshell/test_postgresql_psycopg2.py
+++ b/tests/dbshell/test_postgresql_psycopg2.py
@@ -37,11 +37,11 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_basic(self):
         self.assertEqual(
             self._run_it({
-                'NAME': 'dbname',
-                'USER': 'someuser',
-                'PASSWORD': 'somepassword',
-                'HOST': 'somehost',
-                'PORT': 444,
+                'port': '444',
+                'host': 'somehost',
+                'password': 'somepassword',
+                'user': 'someuser',
+                'database': 'dbname'
             }), (
                 ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
                 b'somehost:444:dbname:someuser:somepassword',
@@ -51,10 +51,10 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_nopass(self):
         self.assertEqual(
             self._run_it({
-                'NAME': 'dbname',
-                'USER': 'someuser',
-                'HOST': 'somehost',
-                'PORT': 444,
+                'database': 'dbname',
+                'user': 'someuser',
+                'host': 'somehost',
+                'port': 444,
             }), (
                 ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
                 None,
@@ -64,11 +64,11 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_column(self):
         self.assertEqual(
             self._run_it({
-                'NAME': 'dbname',
-                'USER': 'some:user',
-                'PASSWORD': 'some:password',
-                'HOST': '::1',
-                'PORT': 444,
+                'database': 'dbname',
+                'user': 'some:user',
+                'password': 'some:password',
+                'host': '::1',
+                'port': 444,
             }), (
                 ['psql', '-U', 'some:user', '-h', '::1', '-p', '444', 'dbname'],
                 b'\\:\\:1:444:dbname:some\\:user:some\\:password',
@@ -78,11 +78,11 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_escape_characters(self):
         self.assertEqual(
             self._run_it({
-                'NAME': 'dbname',
-                'USER': 'some\\user',
-                'PASSWORD': 'some\\password',
-                'HOST': 'somehost',
-                'PORT': 444,
+                'database': 'dbname',
+                'user': 'some\\user',
+                'password': 'some\\password',
+                'host': 'somehost',
+                'port': 444,
             }), (
                 ['psql', '-U', 'some\\user', '-h', 'somehost', '-p', '444', 'dbname'],
                 b'somehost:444:dbname:some\\\\user:some\\\\password',
@@ -106,11 +106,11 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
                 self.skipTest("Your locale can't run this test.")
         self.assertEqual(
             self._run_it({
-                'NAME': 'dbname',
-                'USER': username_str,
-                'PASSWORD': password_str,
-                'HOST': 'somehost',
-                'PORT': 444,
+                'database': 'dbname',
+                'user': username_str,
+                'password': password_str,
+                'host': 'somehost',
+                'port': 444,
             }), (
                 ['psql', '-U', username_str, '-h', 'somehost', '-p', '444', 'dbname'],
                 pgpass_bytes,


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26698