### PR TITLE
Fixes #26700 -- Added how to upgrade to TEMPLATES link in 1.10 release notes.

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -1226,7 +1226,7 @@ removed in Django 1.10 (please see the :ref:`deprecation timeline
   * ``TEMPLATE_LOADERS``
   * ``TEMPLATE_STRING_IF_INVALID``
 
-* To migrate keeping similar functionality from Django 1.8-9: add a :setting:`TEMPLATES` setting. Fore more info 
+* To migrate keeping similar functionality from Django 1.8-9: add a :setting:`TEMPLATES` setting. For more info: 
   :doc:`/ref/templates/upgrading`
 
 * The backwards compatibility alias ``django.template.loader.BaseLoader`` is

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -467,6 +467,18 @@ Templates
 * Added relative path support for string arguments of the :ttag:`extends` and
   :ttag:`include` template tags.
 
+* To keep similar functionality from Django 1.8-9: add a :setting:`TEMPLATES` dict e.g.::
+
+      TEMPLATES = [
+          {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'OPTIONS': {'context_processors': 
+                        ['django.contrib.auth.context_processors.auth']},
+          },
+      ]
+
+
 Tests
 ~~~~~
 

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -467,18 +467,6 @@ Templates
 * Added relative path support for string arguments of the :ttag:`extends` and
   :ttag:`include` template tags.
 
-* To keep similar functionality from Django 1.8-9: add a :setting:`TEMPLATES` dict e.g.::
-
-      TEMPLATES = [
-          {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'APP_DIRS': True,
-            'OPTIONS': {'context_processors': 
-                        ['django.contrib.auth.context_processors.auth']},
-          },
-      ]
-
-
 Tests
 ~~~~~
 
@@ -1237,6 +1225,9 @@ removed in Django 1.10 (please see the :ref:`deprecation timeline
   * ``TEMPLATE_DIRS``
   * ``TEMPLATE_LOADERS``
   * ``TEMPLATE_STRING_IF_INVALID``
+
+* To migrate keeping similar functionality from Django 1.8-9: add a :setting:`TEMPLATES` setting. Fore more info 
+  :doc:`/ref/templates/upgrading`
 
 * The backwards compatibility alias ``django.template.loader.BaseLoader`` is
   removed.


### PR DESCRIPTION
The language is a little bad but it formatted correctly. Is this the right place to put it in the release notes? Since the users actually have to do something it seems important especially the auth bit (`?: (admin.E402) 'django.contrib.auth.context_processors.auth' must be in TEMPLATES in order to use the admin application.`)  which I only discovered after following the guide and hitting a check.