### PR TITLE
Fixed #26701 -- Replaced /newticket links to Trac with /.

### DIFF
--- a/docs/internals/contributing/committing-code.txt
+++ b/docs/internals/contributing/committing-code.txt
@@ -243,4 +243,4 @@ When a mistaken commit is discovered, please follow these guidelines:
   For instance, if you did: ``git push upstream feature_antigravity``,
   just do a reverse push: ``git push upstream :feature_antigravity``.
 
-.. _ticket tracker: https://code.djangoproject.com/newticket
+.. _ticket tracker: https://code.djangoproject.com/

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -65,5 +65,5 @@ Browse the following sections to find out how:
 .. _#django IRC channel: irc://irc.freenode.net/django
 .. _community page: https://www.djangoproject.com/community/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/
-.. _ticket tracker: https://code.djangoproject.com/query
+.. _ticket tracker: https://code.djangoproject.com/
 .. _easy pickings: https://code.djangoproject.com/query?status=!closed&easy=1

--- a/docs/internals/contributing/index.txt
+++ b/docs/internals/contributing/index.txt
@@ -65,5 +65,5 @@ Browse the following sections to find out how:
 .. _#django IRC channel: irc://irc.freenode.net/django
 .. _community page: https://www.djangoproject.com/community/
 .. _register it here: https://www.djangoproject.com/community/add/blogs/
-.. _ticket tracker: https://code.djangoproject.com/newticket
+.. _ticket tracker: https://code.djangoproject.com/query
 .. _easy pickings: https://code.djangoproject.com/query?status=!closed&easy=1

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -139,7 +139,7 @@ Regardless of the way you submit your work, follow these steps.
   checked. This makes the ticket appear in the "Patches needing review" queue
   on the `Development dashboard`_.
 
-.. _ticket tracker: https://code.djangoproject.com/newticket
+.. _ticket tracker: https://code.djangoproject.com/
 .. _Development dashboard: https://dashboard.djangoproject.com/
 
 Non-trivial patches

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -128,7 +128,7 @@ rather than asking broad tech-support questions. If you need help with your
 particular Django setup, try the |django-users| mailing list or the `#django
 IRC channel`_ instead.
 
-.. _ticket system: https://code.djangoproject.com/newticket?component=Documentation
+.. _ticket system: https://code.djangoproject.com/
 .. _#django IRC channel: irc://irc.freenode.net/django
 
 In plain text


### PR DESCRIPTION
Replaces forbidden link https://code.djangoproject.com/newticket with https://code.djangoproject.com/.  Commits can/should be combined into a single commit.