### PR TITLE
Fixed #12666 -- Added EMAIL_USE_LOCALTIME setting.

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -194,6 +194,9 @@ EMAIL_HOST = 'localhost'
 # Port for sending email.
 EMAIL_PORT = 25
 
+# Whether to send SMTP date headers in the local time zone or in UTC.
+EMAIL_USE_LOCALTIME = False
+
 # Optional SMTP authentication information for EMAIL_HOST.
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -316,7 +316,11 @@ class EmailMessage(object):
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if 'date' not in header_names:
-            msg['Date'] = formatdate()
+            # formatdate uses stdlib methods to format the date, which use
+            # the stdlib / os concept of a timezone. However, Django sets the
+            # TZ environment variable based on the TIME_ZONE setting, which
+            # will get picked up by formatdate.
+            msg['Date'] = formatdate(localtime=settings.EMAIL_USE_LOCALTIME)
         if 'message-id' not in header_names:
             # Use cached DNS_NAME for performance
             msg['Message-ID'] = make_msgid(domain=DNS_NAME)

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1251,6 +1251,20 @@ Subject-line prefix for email messages sent with ``django.core.mail.mail_admins`
 or ``django.core.mail.mail_managers``. You'll probably want to include the
 trailing space.
 
+.. setting:: EMAIL_USE_LOCALTIME
+
+``EMAIL_USE_LOCALTIME``
+-----------------------
+
+.. versionadded:: 1.11
+
+Default: ``False``
+
+Whether to send the SMTP date header in the local time zone (``True``) or in
+UTC (``False``). By default, email messages will have a date header in UTC no
+matter what timezone your server is using. Setting this value to ``True`` will
+send dates in the server's local time zone.
+
 .. setting:: EMAIL_USE_TLS
 
 ``EMAIL_USE_TLS``
@@ -3243,6 +3257,7 @@ Email
 * :setting:`EMAIL_SUBJECT_PREFIX`
 * :setting:`EMAIL_TIMEOUT`
 * :setting:`EMAIL_USE_TLS`
+* :setting:`EMAIL_USE_LOCALTIME`
 * :setting:`MANAGERS`
 * :setting:`SERVER_EMAIL`
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -133,7 +133,8 @@ Database backends
 Email
 ~~~~~
 
-* ...
+* Added the :setting:`EMAIL_USE_LOCALTIME` setting to allow sending SMTP date headers
+  in the local time zone.
 
 File Storage
 ~~~~~~~~~~~~

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -21,7 +21,8 @@ from django.core.mail import (
 )
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.message import BadHeaderError, sanitize_address
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.test.utils import requires_tz_support
 from django.utils._os import upath
 from django.utils.encoding import force_bytes, force_text
 from django.utils.six import PY3, StringIO, binary_type
@@ -603,6 +604,33 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             sanitize_address(('Tó Example', 'tó@example.com'), 'utf-8'),
             '=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>'
         )
+
+
+@requires_tz_support
+class MailTimeZoneTests(TestCase):
+
+    # setting the timezone requires a database query on PostgreSQL.
+    @override_settings(EMAIL_USE_LOCALTIME=False, USE_TZ=True, TIME_ZONE='Africa/Algiers')
+    def test_date_header_utc(self):
+        """
+        If settings.EMAIL_USE_LOCALTIME is False, return time in UTC
+        """
+        email = EmailMessage(
+            'Subject', 'Content', 'bounce@example.com', ['to@example.com']
+        )
+        message = email.message()
+        self.assertTrue(message['Date'].endswith('-0000'))
+
+    @override_settings(EMAIL_USE_LOCALTIME=True, USE_TZ=True, TIME_ZONE='Africa/Algiers')
+    def test_date_header_localtime(self):
+        """
+        If settings.EMAIL_USE_LOCALTIME is True, return time in local time zone
+        """
+        email = EmailMessage(
+            'Subject', 'Content', 'bounce@example.com', ['to@example.com'],
+        )
+        message = email.message()
+        self.assertTrue(message['Date'].endswith('+0100'))  # Africa/Algiers is UTC+1
 
 
 class PythonGlobalState(SimpleTestCase):


### PR DESCRIPTION
When EMAIL_USE_LOCALTIME setting is TRUE, send emails with a date header
in the local time zone.