### PR TITLE
Fixed #10107 -- Allowed mark_safe() to be used as decorator

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -8,7 +8,7 @@ import warnings
 
 from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
-from django.utils.functional import Promise, curry
+from django.utils.functional import Promise, curry, wraps
 
 
 class EscapeData(object):
@@ -117,10 +117,19 @@ else:
     SafeUnicode = SafeText
 
 
+def _safety_decorator(safety_marker, func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        return safety_marker(func(*args, **kwargs))
+    return wrapped
+
+
 def mark_safe(s):
     """
     Explicitly mark a string as safe for (HTML) output purposes. The returned
     object can be used everywhere a string or unicode object is appropriate.
+
+    If used on a method as a decorator, mark the returned data as safe.
 
     Can be called multiple times on a single string.
     """
@@ -130,6 +139,9 @@ def mark_safe(s):
         return SafeBytes(s)
     if isinstance(s, (six.text_type, Promise)):
         return SafeText(s)
+    if callable(s):
+        return _safety_decorator(mark_safe, s)
+
     return SafeString(str(s))
 
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -832,6 +832,12 @@ appropriate entities.
 
     Can be called multiple times on a single string.
 
+    Can also be used as a decorator.
+
+    .. versionchanged:: 1.11
+
+        Added support for decorator usage.
+
     For building up fragments of HTML, you should normally be using
     :func:`django.utils.html.format_html` instead.
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -195,7 +195,7 @@ Signals
 Templates
 ~~~~~~~~~
 
-* ...
+* ``mark_safe()`` can now be used as a decorator.
 
 Tests
 ~~~~~

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -13,6 +13,7 @@ from django.utils.decorators import method_decorator
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 from django.utils.functional import allow_lazy, keep_lazy, keep_lazy_text, lazy
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.cache import (
     cache_control, cache_page, never_cache,
@@ -74,6 +75,9 @@ full_decorator = compose(
     keep_lazy(HttpResponse),
     keep_lazy_text,
     lazy,
+
+    # django.utils.safestring
+    mark_safe,
 )
 
 fully_decorated = full_decorator(fully_decorated)

--- a/tests/utils_tests/test_safestring.py
+++ b/tests/utils_tests/test_safestring.py
@@ -109,3 +109,35 @@ class SafeStringTest(SimpleTestCase):
         s = text.slugify(lazystr('a'))
         s += mark_safe('&b')
         self.assertRenderEqual('{{ s }}', 'a&b', s=s)
+
+    def test_mark_safe_as_decorator(self):
+        """
+        mark_safe used as a decorator leaves the result of a function
+        unchanged.
+        """
+        def clean_string_provider():
+            return '<html><body>dummy</body></html>'
+
+        self.assertEqual(mark_safe(clean_string_provider)(), clean_string_provider())
+
+    def test_mark_safe_decorator_does_not_affect_dunder_html(self):
+        """
+        mark_safe does not affect a callable that contains a dunder html
+        method.
+        """
+        class SafeStringContainer:
+            def __html__(self):
+                return "<html></html>"
+
+        self.assertIs(mark_safe(SafeStringContainer), SafeStringContainer)
+
+    def test_mark_safe_decorator_does_not_affect_promises(self):
+        """
+        mark_safe does not affect lazy strings (Promise objects)
+        """
+        def html_str():
+            return "<html></html>"
+
+        lazy_str = lazy(html_str, str)()
+
+        self.assertEqual(mark_safe(lazy_str), html_str())


### PR DESCRIPTION
I pulled down the patch from @ArcTanSusan's PR (https://github.com/django/django/pull/6390) and incorporated the changes that @timgraham and @funkybob were looking for.

Please let me know if this needs to be squashed or if there's a better way to attribute the work to @ArcTanSusan.  Thanks!  (and good to meet you today, @MarkusH).