### PR TITLE
Fixed #26628 -- Changed CSRF logger to django.security.csrf

### DIFF
--- a/django/middleware/csrf.py
+++ b/django/middleware/csrf.py
@@ -20,7 +20,7 @@ from django.utils.http import is_same_domain
 from django.utils.six.moves import zip
 from django.utils.six.moves.urllib.parse import urlparse
 
-logger = logging.getLogger('django.request')
+logger = logging.getLogger('django.security.csrf')
 
 REASON_NO_REFERER = "Referer checking failed - no Referer."
 REASON_BAD_REFERER = "Referer checking failed - %s does not match any trusted origins."

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -211,8 +211,12 @@ The error page, however, is not very friendly, so you may want to provide your
 own view for handling this condition.  To do this, simply set the
 :setting:`CSRF_FAILURE_VIEW` setting.
 
-CSRF failures are logged as warnings to the :ref:`django-request-logger`
-logger.
+CSRF failures are logged as warnings to the :ref:`django.security.csrf
+<django-security-logger>` logger.
+
+.. versionchanged:: 1.11
+
+    CSRF failures log to ``django.security.csrf`` instead of ``django.request``.
 
 .. _how-csrf-works:
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -123,7 +123,7 @@ Cache
 CSRF
 ~~~~
 
-* ...
+* CSRF violations now log to :ref:`django.security.csrf <django-security-logger>` instead of :ref:`django-request-logger`
 
 Database backends
 ~~~~~~~~~~~~~~~~~

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -532,20 +532,27 @@ This logging does not include framework-level initialization (e.g.
 ``COMMIT``, and ``ROLLBACK``). Turn on query logging in your database if you
 wish to view all database queries.
 
+.. _django-security-logger:
+
 ``django.security.*``
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The security loggers will receive messages on any occurrence of
-:exc:`~django.core.exceptions.SuspiciousOperation`. There is a sub-logger for
-each sub-type of SuspiciousOperation. The level of the log event depends on
-where the exception is handled.  Most occurrences are logged as a warning, while
+:exc:`~django.core.exceptions.SuspiciousOperation` and other security-related 
+errors. There is a sub-logger for each sub-type of security error, including all 
+``SuspiciousOperation``s. The level of the log event depends on where the 
+exception is handled.  Most occurrences are logged as a warning, while
 any ``SuspiciousOperation`` that reaches the WSGI handler will be logged as an
 error. For example, when an HTTP ``Host`` header is included in a request from
 a client that does not match :setting:`ALLOWED_HOSTS`, Django will return a 400
 response, and an error message will be logged to the
 ``django.security.DisallowedHost`` logger.
 
-These log events will reach the 'django' logger by default, which mails error
+Other ``django.security`` loggers not based on SuspiciousOperations are:
+
+* ``django.security.csrf``: For  :mod:`~django.middleware.csrf` failures
+
+These log events will reach the ``django`` logger by default, which mails error
 events to admins when ``DEBUG=False``. Requests resulting in a 400 response due
 to a ``SuspiciousOperation`` will not be logged to the ``django.request``
 logger, but only to the ``django.security`` logger.


### PR DESCRIPTION
Reworded docs to include non-SuspiciousOperation security loggers. Updated CSRF tests to check logger output.

The docs looked like they are manually wrapped, and I wasn't sure if there was a way to make changes without noisy diffs.

Also, does this need to be added to patch notes, and if so which version?