### PR TITLE
Fixed #25127 -- Add docs on organizing models

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1426,6 +1426,12 @@ two files (besides an ``__init__.py``), ``person.py`` and ``robot.py``:
     from .person import Person
     from .robot import Robot
 
+.. note::
+
+    It is recommended to explicitly import each model class, rather than using
+    ``from .models import *``, which may clutter your namespace, make code less
+    readable, and limit the reliability of code analysis tools.
+
 .. seealso::
 
     :doc:`The Models Reference </ref/models/index>`

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1447,14 +1447,6 @@ to explicitly import each model class, rather than using
     from .person import Person
     from .robot import Robot
 
-You can then import classes directly from the ``models`` module as you normally
-would.
-
-``myapp/views.py``::
-
-    from .models import Person
-    from .models import Robot
-
 .. seealso::
 
     :doc:`The Models Reference </ref/models/index>`

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1418,13 +1418,13 @@ The :djadmin:`manage.py startapp <startapp>` script creates a package structure
 for an application that includes a file called ``models.py``, but you may
 also define a ``models`` package. For example, if you remove the ``models.py`` and
 create a ``myproject/myapp/models/`` with two files (besides an ``__init__.py``),
-``person.py`` and ``robot.py``:
+``organic.py`` and ``synthetic.py``:
 
 .. snippet::
     :filename: myapp/models/__init__.py
 
-    from .person import Person
-    from .robot import Robot
+    from .organic import Person
+    from .synthetic import Robot
 
 .. note::
 

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1420,29 +1420,8 @@ also define multiple files containing models, contained in a module. For example
 you can remove the ``models.py`` and create a ``myproject/myapp/models/`` with
 two files (besides an ``__init__.py``), ``person.py`` and ``robot.py``:
 
-``person.py``::
-
-    from django.db import models
-
-    class Person(models.Model):
-        first_name = models.CharField(max_length=30)
-        last_name = models.CharField(max_length=30)
-
-
-``robot.py``::
-
-    from django.db import models
-
-    class Robot(models.Model):
-        model_number = models.CharField(max_length=30)
-        unit_number = models.CharField(max_length=30)
-
-
-Then import your model classes into ``models/__init__.py``. It is recommended
-to explicitly import each model class, rather than using
-``from .models import *``.
-
-``myapp/models/__init__.py``::
+.. snippet::
+    :filename: myapp/models/__init__.py
 
     from .person import Person
     from .robot import Robot

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1410,11 +1410,6 @@ different database tables).
 Django will raise a :exc:`~django.core.exceptions.FieldError` if you override
 any model field in any ancestor model.
 
-.. seealso::
-
-    :doc:`The Models Reference </ref/models/index>`
-        Covers all the model related APIs including model fields, related
-        objects, and ``QuerySet``.
 
 Organizing models
 =================
@@ -1459,3 +1454,9 @@ would.
 
     from .models import Person
     from .models import Robot
+
+.. seealso::
+
+    :doc:`The Models Reference </ref/models/index>`
+        Covers all the model related APIs including model fields, related
+        objects, and ``QuerySet``.

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1418,9 +1418,9 @@ The :djadmin:`manage.py startapp <startapp>` script creates a package structure
 for an application that includes a file called ``models.py``, but you may
 also define multiple files containing models, contained in a module. For example,
 you can remove the ``models.py`` and create a ``myproject/myapp/models/`` with
-two files (besides an ``__init__.py``), ``person_models.py`` and ``robot_models.py``:
+two files (besides an ``__init__.py``), ``person.py`` and ``robot.py``:
 
-``person_models.py``::
+``person.py``::
 
     from django.db import models
 
@@ -1429,7 +1429,7 @@ two files (besides an ``__init__.py``), ``person_models.py`` and ``robot_models.
         last_name = models.CharField(max_length=30)
 
 
-``robot_models.py``::
+``robot.py``::
 
     from django.db import models
 
@@ -1444,8 +1444,8 @@ to explicitly import each model class, rather than using
 
 ``myapp/models/__init__.py``::
 
-    from .person_models import Person
-    from .robot_models import Robot
+    from .person import Person
+    from .robot import Robot
 
 You can then import classes directly from the ``models`` module as you normally
 would.

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1416,9 +1416,9 @@ Organizing models
 
 The :djadmin:`manage.py startapp <startapp>` script creates a package structure
 for an application that includes a file called ``models.py``, but you may
-also define multiple files containing models, contained in a module. For example,
-you can remove the ``models.py`` and create a ``myproject/myapp/models/`` with
-two files (besides an ``__init__.py``), ``person.py`` and ``robot.py``:
+also define a ``models`` package. For example, if you remove the ``models.py`` and
+create a ``myproject/myapp/models/`` with two files (besides an ``__init__.py``),
+``person.py`` and ``robot.py``:
 
 .. snippet::
     :filename: myapp/models/__init__.py

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1415,3 +1415,47 @@ any model field in any ancestor model.
     :doc:`The Models Reference </ref/models/index>`
         Covers all the model related APIs including model fields, related
         objects, and ``QuerySet``.
+
+Organizing models
+=================
+
+The :djadmin:`manage.py startapp <startapp>` script creates a package structure
+for an application that includes a file called ``models.py``, but you may
+also define multiple files containing models, contained in a module. For example,
+you can remove the ``models.py`` and create a ``myproject/myapp/models/`` with
+two files (besides an ``__init__.py``), ``person_models.py`` and ``robot_models.py``:
+
+``person_models.py``::
+
+    from django.db import models
+
+    class Person(models.Model):
+        first_name = models.CharField(max_length=30)
+        last_name = models.CharField(max_length=30)
+
+
+``robot_models.py``::
+
+    from django.db import models
+
+    class Robot(models.Model):
+        model_number = models.CharField(max_length=30)
+        unit_number = models.CharField(max_length=30)
+
+
+Then import your model classes into ``models/__init__.py``. It is recommended
+to explicitly import each model class, rather than using
+``from .models import *``.
+
+``myapp/models/__init__.py``::
+
+    from .person_models import Person
+    from .robot_models import Robot
+
+You can then import classes directly from the ``models`` module as you normally
+would.
+
+``myapp/views.py``::
+
+    from .models import Person
+    from .models import Robot


### PR DESCRIPTION
Added a section to the Models docs on organizing models across multiple files. Example recommends
explicit imports over 'import *'.