### PR TITLE
Fixed #24781 -- Added lazy objects __repr__

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -75,6 +75,10 @@ def lazy(func, *resultclasses):
                 (func, self.__args, self.__kw) + resultclasses
             )
 
+        def __repr__(self):
+            """ Make sure the lazy object's display is useful when debugging """
+            return self.__cast()
+
         @classmethod
         def __prepare_class__(cls):
             for resultclass in resultclasses:

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -76,8 +76,7 @@ def lazy(func, *resultclasses):
             )
 
         def __repr__(self):
-            """ Make sure the lazy object's display is useful when debugging """
-            return self.__cast()
+            return repr(self.__cast())
 
         @classmethod
         def __prepare_class__(cls):

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -5,6 +5,7 @@ import unittest
 
 from django.utils import six
 from django.utils.functional import cached_property, lazy, lazy_property
+from django.utils.translation import ugettext_lazy
 
 
 class FunctionalTestCase(unittest.TestCase):
@@ -130,3 +131,11 @@ class FunctionalTestCase(unittest.TestCase):
 
         self.assertEqual(lazy_a(), lazy_b())
         self.assertNotEqual(lazy_b(), lazy_c())
+
+    def test_lazy_repr(self):
+        """
+        Tests that a proxy of lazy object's repr equals to the object's value
+        """
+        original_object = 'Lazy translation text'
+        lazy_obj = ugettext_lazy(original_object)
+        self.assertEquals(original_object, repr(lazy_obj))

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -5,7 +5,6 @@ import unittest
 
 from django.utils import six
 from django.utils.functional import cached_property, lazy, lazy_property
-from django.utils.translation import ugettext_lazy
 
 
 class FunctionalTestCase(unittest.TestCase):
@@ -132,10 +131,17 @@ class FunctionalTestCase(unittest.TestCase):
         self.assertEqual(lazy_a(), lazy_b())
         self.assertNotEqual(lazy_b(), lazy_c())
 
-    def test_lazy_repr(self):
-        """
-        Tests that a proxy of lazy object's repr equals to the object's value
-        """
+    def test_lazy_repr_text(self):
         original_object = 'Lazy translation text'
-        lazy_obj = ugettext_lazy(original_object)
-        self.assertEquals(original_object, repr(lazy_obj))
+        lazy_obj = lazy(lambda: original_object, six.text_type)
+        self.assertEquals(repr(original_object), repr(lazy_obj()))
+
+    def test_lazy_repr_int(self):
+        original_object = 15
+        lazy_obj = lazy(lambda: original_object, int)
+        self.assertEquals(repr(original_object), repr(lazy_obj()))
+
+    def test_lazy_repr_bytes(self):
+        original_object = b'J\xc3\xbcst a str\xc3\xadng'
+        lazy_obj = lazy(lambda: original_object, bytes)
+        self.assertEquals(repr(original_object), repr(lazy_obj()))


### PR DESCRIPTION
Added `__repr__` method to lazy objects. Reproduced the issue with a test, which passes after fixing the issue. 

Related ticket: https://code.djangoproject.com/ticket/24781