### PR TITLE
Fixed #26707 -- Added QueryDict.fromkeys()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -771,6 +771,7 @@ answer newbie questions, and generally made Django that much better:
     William Schwartz <wkschwartz@gmail.com>
     Will Hardy <django@willhardy.com.au>
     Wilson Miner <wminer@gmail.com>
+    Wim Glenn <hey@wimglenn.com>
     wojtek
     Xia Kai <http://blog.xiaket.org/>
     Yann Fouillat <gagaro42@gmail.com>

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -402,6 +402,19 @@ class QueryDict(MultiValueDict):
                                 value)
         self._mutable = mutable
 
+    @classmethod
+    def fromkeys(cls, iterable, value='', mutable=False, encoding=None):
+        """
+        Return a new QueryDict with keys from iterable and values equal to value.
+        Note: repeated keys are allowed.
+        """
+        q = cls('', mutable=True, encoding=encoding)
+        for key in iterable:
+            q.appendlist(key, value)
+        if not mutable:
+            q._mutable = False
+        return q
+
     @property
     def encoding(self):
         if self._encoding is None:

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -422,6 +422,16 @@ a subclass of dictionary. Exceptions are outlined here:
     Strings for setting both keys and values will be converted from ``encoding``
     to unicode. If encoding is not set, it defaults to :setting:`DEFAULT_CHARSET`.
 
+.. classmethod:: QueryDict.fromkeys(iterable, value='', mutable=False, encoding=None)
+
+    .. versionadded:: 1.11
+
+    Factory method for instantiating a new ``QueryDict`` with keys from ``iterable``
+    and each value equal to ``value``.
+
+    >>> QueryDict.fromkeys(['a', 'a', 'b'], value='val')
+    <QueryDict: {'a': ['val', 'val'], 'b': ['val']}>
+
 .. method:: QueryDict.__getitem__(key)
 
     Returns the value for the given key. If the key has more than one value,

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -183,7 +183,7 @@ Models
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Added :meth:`QueryDict.fromkeys()<django.http.QueryDict.fromkeys>`.
 
 Serialization
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #26707  (Pycon2016 sprint, Friday June 3)

In `django.http.QueryDict`, we currently have the following weird behaviour and misleading error messages:

```
>>> QueryDict.fromkeys(['k1', 'k2'])
AttributeError: This QueryDict instance is immutable
```

It is not possible to pass the mutable kwarg to the initialise in this way, either:

```
>>> QueryDict.fromkeys(['k1', 'k2'], mutable=True)
TypeError: fromkeys() takes no keyword arguments
```

Django's `QueryDict` is-a `dict`, so the classmethod factory function `fromkeys` should either
  a) work, or
  b) be explicitly disabled in the subclass, and documented as such
 
The relevant section in the docs ( https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.QueryDict ) says that:

> QueryDict implements all the standard dictionary methods because it’s a subclass of dictionary. Exceptions are outlined here: ...

However, there is no mention about the `fromkeys` method.

This patch attempts to implement it in a usable way.  
