### PR TITLE
Allow user-specified reloaders

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -324,7 +324,9 @@ def main(main_func, args=None, kwargs=None):
         args = ()
     if kwargs is None:
         kwargs = {}
-    if sys.platform.startswith('java'):
+    if hasattr(settings, "RELOADER"):
+        reloader = settings.RELOADER.reloader
+    elif sys.platform.startswith('java'):
         reloader = jython_reloader
     else:
         reloader = python_reloader

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -325,7 +325,7 @@ def main(main_func, args=None, kwargs=None):
     if kwargs is None:
         kwargs = {}
     if hasattr(settings, "RELOADER"):
-        reloader = settings.RELOADER.reloader
+        reloader = settings.RELOADER['reloader']
     elif sys.platform.startswith('java'):
         reloader = jython_reloader
     else:

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3205,6 +3205,26 @@ setting.
 Static file finders are currently considered a private interface, and this
 interface is thus undocumented.
 
+.. setting:: RELOADER
+
+``RELOADER``
+-----------------------
+
+Default:: ``None``
+
+The function called by the Django process manager for the
+:djadmin:`runserver` management command.  If you want to provide your
+own reloader command, the format is a dictionary with a single key,
+`reloader`:
+
+    from my_reloader import my_reloader_function
+    RELOADER = {
+        "reloader": my_reloader_function 
+    }
+
+The dictionary can be used to pass additional arguments to the reloader,
+allowing for further customization.
+
 Core Settings Topical Index
 ===========================
 
@@ -3369,3 +3389,7 @@ URLs
 * :setting:`APPEND_SLASH`
 * :setting:`PREPEND_WWW`
 * :setting:`ROOT_URLCONF`
+
+Platform
+--------
+* :setting:`RELOADER`


### PR DESCRIPTION
The ability to provide a dynamic, optional reload function as an alternative to the Java or Python reloaders gives developers the ability to specify run functions that may not always be written in pure Python.  This patch supports future development in Django with alternative languages like Hy or Mochi.