### PR TITLE
Fixed #26706 -- Made RelatedManager modification methods clear prefetch_related() cache.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -979,6 +979,14 @@ database.
     performance, since you have done a database query that you haven't used. So
     use this feature with caution!
 
+    Also, if you call the database-altering methods
+    :meth:`~django.db.models.fields.related.RelatedManager.add`,
+    :meth:`~django.db.models.fields.related.RelatedManager.remove`,
+    :meth:`~django.db.models.fields.related.RelatedManager.clear` or
+    :meth:`~django.db.models.fields.related.RelatedManager.set` on
+    :class:`related managers<django.db.models.fields.related.RelatedManager>`,
+    any prefetched cache for the relation will be cleared.
+
 You can also use the normal join syntax to do related fields of related
 fields. Suppose we have an additional model to the example above::
 
@@ -1138,6 +1146,16 @@ where prefetching with a custom ``QuerySet`` is useful:
     advanced techniques may require that the lookups be performed in a
     specific order to avoid creating extra queries; therefore it's recommended
     to always carefully order ``prefetch_related`` arguments.
+
+.. versionchanged:: 1.11
+
+    If you call the database-altering methods
+    :meth:`~django.db.models.fields.related.RelatedManager.add`,
+    :meth:`~django.db.models.fields.related.RelatedManager.remove`,
+    :meth:`~django.db.models.fields.related.RelatedManager.clear` or
+    :meth:`~django.db.models.fields.related.RelatedManager.set` on
+    :class:`related managers<django.db.models.fields.related.RelatedManager>`,
+    any prefetched cache for the relation will be cleared.
 
 ``extra()``
 ~~~~~~~~~~~

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -170,6 +170,12 @@ Related objects reference
        ``add()``, ``create()``, ``remove()``, and ``set()`` methods are
        disabled.
 
+    .. versionchanged:: 1.11
+
+       If you use :meth:`~django.db.models.query.QuerySet.prefetch_related`,
+       note that the ``add()``, ``remove()``, ``clear()``, and ``set()`` will
+       clear the cache, so further queries will hit the database.
+
 Direct Assignment
 =================
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -300,6 +300,12 @@ Miscellaneous
   calls ``super()``. :meth:`.BaseUserManager.normalize_email` is called in a
   new :meth:`.AbstractUser.clean` method so that normalization is applied in
   cases like model form validation.
+* :meth:`RelatedManager.add()
+  <django.db.models.fields.related.RelatedManager.add>`,
+  :meth:`~django.db.models.fields.related.RelatedManager.remove`,
+  :meth:`~django.db.models.fields.related.RelatedManager.clear`, and
+  :meth:`~django.db.models.fields.related.RelatedManager.set` now
+  clear the ``prefetch_related()`` cache.
 
 .. _deprecated-features-1.11:
 

--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -509,6 +509,40 @@ class ManyToManyTests(TestCase):
         self.assertQuerysetEqual(self.a4.publications.all(), [])
         self.assertQuerysetEqual(self.p2.article_set.all(), ['<Article: NASA finds intelligent life on Earth>'])
 
+    def test_clear_after_prefetch(self):
+        a4 = Article.objects.prefetch_related('publications').get(id=self.a4.id)
+        self.assertQuerysetEqual(a4.publications.all(), ['<Publication: Science News>'])
+        a4.publications.clear()
+        self.assertQuerysetEqual(a4.publications.all(), [])
+
+    def test_remove_after_prefetch(self):
+        a4 = Article.objects.prefetch_related('publications').get(id=self.a4.id)
+        self.assertQuerysetEqual(a4.publications.all(), ['<Publication: Science News>'])
+        a4.publications.remove(self.p2)
+        self.assertQuerysetEqual(a4.publications.all(), [])
+
+    def test_add_after_prefetch(self):
+        a4 = Article.objects.prefetch_related('publications').get(id=self.a4.id)
+        self.assertEqual(a4.publications.count(), 1)
+        a4.publications.add(self.p1)
+        self.assertEqual(a4.publications.count(), 2)
+
+    def test_set_after_prefetch(self):
+        a4 = Article.objects.prefetch_related('publications').get(id=self.a4.id)
+        self.assertEqual(a4.publications.count(), 1)
+        a4.publications.set([self.p2, self.p1])
+        self.assertEqual(a4.publications.count(), 2)
+        a4.publications.set([self.p1])
+        self.assertEqual(a4.publications.count(), 1)
+
+    def test_add_then_remove_after_prefetch(self):
+        a4 = Article.objects.prefetch_related('publications').get(id=self.a4.id)
+        self.assertEqual(a4.publications.count(), 1)
+        a4.publications.add(self.p1)
+        self.assertEqual(a4.publications.count(), 2)
+        a4.publications.remove(self.p1)
+        self.assertQuerysetEqual(a4.publications.all(), ['<Publication: Science News>'])
+
     def test_inherited_models_selects(self):
         """
         #24156 - Objects from child models where the parent's m2m field uses

--- a/tests/many_to_one/models.py
+++ b/tests/many_to_one/models.py
@@ -43,7 +43,7 @@ class City(models.Model):
 
 @python_2_unicode_compatible
 class District(models.Model):
-    city = models.ForeignKey(City, models.CASCADE)
+    city = models.ForeignKey(City, models.CASCADE, related_name='districts', null=True)
     name = models.CharField(max_length=50)
 
     def __str__(self):


### PR DESCRIPTION
Doing a prefetch before clear() causes the cached value
to be returned after a query. Since they are cleared,
the cached values should no longer be needed, so this change
removed them from the cache inside clear().