### PR TITLE
Fix Python 2.7 flake8 error

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -213,7 +213,7 @@ class Command(BaseCommand):
                 model_keys.append(model_key)
                 post_migrate_apps.unregister_model(*model_key)
         post_migrate_apps.render_multiple([
-            ModelState.from_model(apps.get_model(*model_key)) for model_key in model_keys
+            ModelState.from_model(apps.get_model(*mk)) for mk in model_keys
         ])
 
         # Send the post_migrate signal, so individual apps can do whatever they need


### PR DESCRIPTION
There's a single error when running flake8 on Python 2.7 that would be nice to fix. Not sure why this doesn't show up with Python 3.5.

    ./django/core/management/commands/migrate.py:216:67: F812 list comprehension redefines 'model_key' from line 212