### PR TITLE
Fixed #26712 -- Avoided unnecessary SET TIMEZONE queries on PostgreSQL.

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -88,6 +88,13 @@ class BaseDatabaseWrapper(object):
         # is called?
         self.run_commit_hooks_on_set_autocommit_on = False
 
+    def ensure_timezone(self):
+        """
+        Ensure the connection's timezone is set to `self.timezone_name` and
+        return whether it changed or not.
+        """
+        return False
+
     @cached_property
     def timezone(self):
         """

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -69,10 +69,7 @@ def update_connections_time_zone(**kwargs):
                 del conn.timezone_name
             except AttributeError:
                 pass
-            tz_sql = conn.ops.set_time_zone_sql()
-            if tz_sql and conn.timezone_name:
-                with conn.cursor() as cursor:
-                    cursor.execute(tz_sql, [conn.timezone_name])
+            conn.ensure_timezone()
 
 
 @receiver(setting_changed)

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -94,9 +94,7 @@ class FileStorageDeconstructionTests(unittest.TestCase):
 requires_pytz = unittest.skipIf(pytz is None, "this test requires pytz")
 
 
-class FileStorageTests(TestCase):
-    # Changing TIME_ZONE may issue a query to set the database's timezone,
-    # hence TestCase.
+class FileStorageTests(SimpleTestCase):
     storage_class = FileSystemStorage
 
     def setUp(self):

--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -6,7 +6,7 @@ from unittest import skipIf
 
 from django.contrib.humanize.templatetags import humanize
 from django.template import Context, Template, defaultfilters
-from django.test import TestCase, modify_settings, override_settings
+from django.test import SimpleTestCase, modify_settings, override_settings
 from django.utils import translation
 from django.utils.html import escape
 from django.utils.timezone import get_fixed_timezone, utc
@@ -36,7 +36,7 @@ class MockDateTime(datetime.datetime):
 
 
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.humanize'})
-class HumanizeTests(TestCase):
+class HumanizeTests(SimpleTestCase):
 
     def humanize_tester(self, test_list, result_list, method, normalize_result_func=escape):
         for test_content, result in zip(test_list, result_list):

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -21,7 +21,7 @@ from django.core.mail import (
 )
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.message import BadHeaderError, sanitize_address
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils._os import upath
 from django.utils.encoding import force_bytes, force_text
@@ -607,9 +607,8 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
 
 
 @requires_tz_support
-class MailTimeZoneTests(TestCase):
+class MailTimeZoneTests(SimpleTestCase):
 
-    # setting the timezone requires a database query on PostgreSQL.
     @override_settings(EMAIL_USE_LOCALTIME=False, USE_TZ=True, TIME_ZONE='Africa/Algiers')
     def test_date_header_utc(self):
         """

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -840,7 +840,7 @@ class SerializationTests(SimpleTestCase):
 
 
 @override_settings(DATETIME_FORMAT='c', TIME_ZONE='Africa/Nairobi', USE_L10N=False, USE_TZ=True)
-class TemplateTests(TestCase):
+class TemplateTests(SimpleTestCase):
 
     @requires_tz_support
     def test_localtime_templatetag_and_filters(self):


### PR DESCRIPTION
A change of the USE_TZ or TIME_ZONE settings doesn't necessarly require a change to the active connections' timezones.