### PR TITLE
Copy data only when there are fields

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -140,12 +140,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         self.create_model(temp_model)
         # Copy data from the old table
         field_maps = list(mapping.items())
-        self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
-            self.quote_name(temp_model._meta.db_table),
-            ', '.join(self.quote_name(x) for x, y in field_maps),
-            ', '.join(y for x, y in field_maps),
-            self.quote_name(model._meta.db_table),
-        ))
+        if field_maps:
+            self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
+                self.quote_name(temp_model._meta.db_table),
+                ', '.join(self.quote_name(x) for x, y in field_maps),
+                ', '.join(y for x, y in field_maps),
+                self.quote_name(model._meta.db_table),
+            ))
         # Delete the old table
         self.delete_model(model, handle_autom2m=False)
         # Rename the new to the old


### PR DESCRIPTION
In case the migration has removed all fields but before dropping the
table (in case some other one-to-one relationship is still referencing
it).

An example is a migration that removes the last foreign key field of a model that is referenced by the model whose foreign key is being removed (e.g. one-to-one relationship).

After removing the last field, doing the copy generates an invalid INSERT such as this:

```sql
INSERT INTO "app_model__new" () SELECT  FROM "app_model" 
```