### PR TITLE
Fixed #24424 -- Fixed SQLite migrations crash when removing the last column of a table.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -192,12 +192,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
             # Copy data from the old table into the new table
             field_maps = list(mapping.items())
-            self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
-                self.quote_name(temp_model._meta.db_table),
-                ', '.join(self.quote_name(x) for x, y in field_maps),
-                ', '.join(y for x, y in field_maps),
-                self.quote_name(model._meta.db_table),
-            ))
+            if field_maps:
+                self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
+                    self.quote_name(temp_model._meta.db_table),
+                    ', '.join(self.quote_name(x) for x, y in field_maps),
+                    ', '.join(y for x, y in field_maps),
+                    self.quote_name(model._meta.db_table),
+                ))
 
             # Delete the old table
             self.delete_model(model, handle_autom2m=False)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -654,6 +654,28 @@ class SchemaTests(TransactionTestCase):
         columns = self.column_classes(AuthorWithDefaultHeight)
         self.assertFalse(columns['height'][1][6])
 
+    def test_alter_pk(self):
+        """
+        Tests altering of PK - renaming the field in this case
+        """
+        class TestModel(Model):
+            field = IntegerField(primary_key=True)
+
+            class Meta:
+                app_label = 'schema'
+                apps = new_apps
+
+        self.local_models = [TestModel]
+
+        with connection.schema_editor() as editor:
+            editor.create_model(TestModel)
+
+        new_field = IntegerField(TestModel, primary_key=True)
+        new_field.set_attributes_from_name("new_field")
+        with connection.schema_editor() as editor:
+            editor.remove_field(TestModel, TestModel._meta.get_field('field'))
+            editor.add_field(TestModel, new_field)
+
     @skipUnlessDBFeature('supports_foreign_keys')
     def test_alter_fk(self):
         """


### PR DESCRIPTION
In case the migration has removed all fields but before dropping the
table (in case some other one-to-one relationship is still referencing
it).

An example is a migration that removes the last foreign key field of a model that is referenced by the model whose foreign key is being removed (e.g. one-to-one relationship).

After removing the last field, doing the copy generates an invalid INSERT such as this:

```sql
INSERT INTO "app_model__new" () SELECT  FROM "app_model" 
```

Another example is simply renaming a custom PK which the regression test in this PR covers.