### PR TITLE
Fixed #4548 -- Added a username hint for password managers to admin's change_password form.

### DIFF
--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -20,7 +20,7 @@
 {% endif %}
 {% block content %}<div id="content-main">
 <form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
-<input type="text" name="username" value="{{ original.username }}" style="display: none" />
+<input type="text" name="username" value="{{ original.get_username }}" style="display: none" />
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if form.errors %}

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -20,6 +20,7 @@
 {% endif %}
 {% block content %}<div id="content-main">
 <form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
+<input type="text" name="username" value="{{ original.username }}" style="display: none" />
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if form.errors %}

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -818,6 +818,17 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             msg_prefix='The "change password" link should not be displayed if a user does not have a usable password.'
         )
 
+    def test_template_change_password(self):
+        """
+        Ensure that the auth/user/change_password.html template has
+        username input field which is not displayed.
+
+        Refs: #4548
+        """
+        user = User.objects.get(username='super')
+        response = self.client.get(reverse('admin:auth_user_password_change', args=(user.id,)))
+        self.assertContains(response, '<input type="text" name="username" value="super" style="display: none" />')
+
     def test_change_view_with_show_delete_extra_context(self):
         """
         Ensured that the 'show_delete' context variable in the admin's change

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -820,10 +820,9 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
 
     def test_template_change_password(self):
         """
-        Ensure that the auth/user/change_password.html template has
-        username input field which is not displayed.
-
-        Refs: #4548
+        When more than one password is stored in the password manager of browser
+        of one single site, a confirm password dialog pops up when changing password.
+        To prevent this username needs to be part of the change password submit form.
         """
         user = User.objects.get(username='super')
         response = self.client.get(reverse('admin:auth_user_password_change', args=(user.id,)))


### PR DESCRIPTION
When more than one password is stored in the browser of a single site, a confirm password dialog pops up when changing password as browser doesn't know which user actually changed password.

This can be avoided by simply adding a username input field which is not displayed.

See also http://stackoverflow.com/a/2700066/535679

Successfully tested with Chromium and Firefox.