### PR TITLE
Made AutoField consistent between postgresql and mysql

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -152,8 +152,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     # be interpolated against the values of Field.__dict__ before being output.
     # If a column type is set to None, it won't be included in the output.
     _data_types = {
-        'AutoField': 'integer AUTO_INCREMENT',
-        'BigAutoField': 'bigint AUTO_INCREMENT',
+        'AutoField': 'serial',
+        'BigAutoField': 'serial',
         'BinaryField': 'longblob',
         'BooleanField': 'bool',
         'CharField': 'varchar(%(max_length)s)',


### PR DESCRIPTION
**The problem**
Currently, (Big)*AutoField becomes an `integer AUTO_INCREMENT` field in MySQL whereas it becomes a `serial` in PostgreSQL (which is a positive integer).

**The resolution**
This patch updates the MySQL version to use the `serial` datatype (which is just a macro for `bigint unsigned not null auto_increment unique`).

**Caveats**
The MySQL `serial` datatype might introduce too many unwanted restrictions. If the community thinks this might break too much code, I would suggest to at least make the MySQL version unsigned too, to increase the consistency between the DB adapters.

Cheers