### PR TITLE
Fixed #16281 -- Made ContentType.get_object_for_this_type() fetch models from the correct database.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -240,7 +240,7 @@ class GenericForeignKey(object):
         if ct_id is not None:
             ct = self.get_content_type(id=ct_id, using=instance._state.db)
             try:
-                rel_obj = ct.get_object_for_this_type(pk=pk_val)
+                rel_obj = ct.get_db_manager_for_this_type().get(pk=pk_val)
             except ObjectDoesNotExist:
                 pass
         setattr(instance, self.cache_attr, rel_obj)

--- a/django/contrib/contenttypes/models.py
+++ b/django/contrib/contenttypes/models.py
@@ -163,6 +163,12 @@ class ContentType(models.Model):
         except LookupError:
             return None
 
+    def get_db_manager_for_this_type(self):
+        """
+        Returns the manager of this type using the same db as this contenttype.
+        """
+        return self.model_class()._base_manager.using(self._state.db)
+
     def get_object_for_this_type(self, **kwargs):
         """
         Returns an object of this type for the keyword arguments given.
@@ -170,13 +176,13 @@ class ContentType(models.Model):
         method. The ObjectNotExist exception, if thrown, will not be caught,
         so code that calls this method should catch it.
         """
-        return self.model_class()._base_manager.using(self._state.db).get(**kwargs)
+        return self.model_class()._base_manager.get(**kwargs)
 
     def get_all_objects_for_this_type(self, **kwargs):
         """
         Returns all objects of this type for the keyword arguments given.
         """
-        return self.model_class()._base_manager.using(self._state.db).filter(**kwargs)
+        return self.model_class()._base_manager.filter(**kwargs)
 
     def natural_key(self):
         return (self.app_label, self.model)

--- a/tests/contenttypes_tests/tests.py
+++ b/tests/contenttypes_tests/tests.py
@@ -450,6 +450,47 @@ class ContentTypesMultidbTestCase(TestCase):
             ContentType.objects.get_for_model(Author)
 
 
+class TestDifferentRouter(object):
+    def db_for_read(self, model, **hints):
+        if model._meta.app_label == 'contenttypes':
+            return 'default'
+        return 'other'
+
+    def db_for_write(self, model, **hints):
+        if model._meta.app_label == 'contenttypes':
+            return 'default'
+        return 'other'
+
+
+@override_settings(DATABASE_ROUTERS=[TestDifferentRouter()])
+class ContentTypesCrossMultidbTestCase(TestCase):
+
+    def setUp(self):
+        # Whenever a test starts executing, only the "default" database is
+        # connected. We explicitly connect to the "other" database here. If we
+        # don't do it, then it will be implicitly connected later when we query
+        # it, but in that case some database backends may automatically perform
+        # extra queries upon connecting (notably mysql executes
+        # "SET SQL_AUTO_IS_NULL = 0"), which will affect assertNumQueries().
+        connections['other'].ensure_connection()
+
+    def test_multidb(self):
+        """
+        Test that, when having contenttypes in one database and a model in
+        another, ContentType uses correct database to retrieve the model
+        """
+        ContentType.objects.clear_cache()
+
+        author1 = Author.objects.create(name='Boris')
+        ct = ContentType.objects.get_for_model(Author)
+
+        author_count = ct.get_all_objects_for_this_type().count()
+        self.assertEqual(author_count, 1)
+
+        author2 = ct.get_object_for_this_type(pk=author1.pk)
+        self.assertEqual(author1, author2)
+
+
 @override_settings(
     MIGRATION_MODULES=dict(settings.MIGRATION_MODULES, contenttypes_tests='contenttypes_tests.operations_migrations'),
 )


### PR DESCRIPTION
Removes the using clause to let db router decide which db to use.
https://code.djangoproject.com/ticket/16281