### PR TITLE
Fix "TypeError: can't compare datetime.datetime to datetime.time"

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2177,7 +2177,7 @@ class TimeField(DateTimeCheckMixin, Field):
             upper = now + second_offset
             value = datetime.datetime.combine(now.date(), value)
             if timezone.is_aware(value):
-                value = timezone.make_naive(value, timezone.utc).time()
+                value = timezone.make_naive(value, timezone.utc)
         else:
             # No explicit time / datetime value -- no checks necessary
             return []


### PR DESCRIPTION
In TimeField if provided default is TZ aware it is being converted to `datetime.time` instance while in any other case it is already `datetime.datetime`. This leads to "TypeError: can't compare datetime.datetime to datetime.time".

Affects 1.9.x, 1.8.x, 1.7.x.