### PR TITLE
Fixed #26742 -- Fixed action select color in admin changelist.

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -304,6 +304,7 @@
     vertical-align: top;
     height: 24px;
     background: none;
+    color: #000;
     border: 1px solid #ccc;
     border-radius: 4px;
     font-size: 14px;


### PR DESCRIPTION
The CSS defines the `background: none` for this particular select box
which makes it use white background, like the container behind it.
But it does not set any `color` property. So it uses the system default
for form controls.

Thus, when using light-on-dark system theme (GTK in my case), it renders
white text on white background, making the text in the select box
invisible or unreadable at best.

In this change we use `color: inherit` which makes the select box use
the color property from its parent, making the text in select use the
same color as the text around it.