### PR TITLE
Fixed an error in 1.11 release notes.

### DIFF
--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -255,8 +255,8 @@ Miscellaneous
   ``django.request``.
 
 * Using a foreign key's id (e.g. ``'field_id'``) in ``ModelAdmin.list_display``
-  displays the related object's ID instead of ``repr(object)``. Remove the
-  ``_id`` suffix if you want the ``repr()``.
+  displays the related object's ID. Remove the ``_id`` suffix if you want the
+  string representation of the object.
 
 .. _deprecated-features-1.11:
 


### PR DESCRIPTION
The release notes for [#26524](https://code.djangoproject.com/ticket/26524) are misleading: the admin uses `smart_text` for displaying FKs in `list_display`, not `repr`.