### PR TITLE
Bug fix for postgres array indices

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -474,7 +474,7 @@ class Func(Expression):
     An SQL function call.
     """
     function = None
-    template = '%(function)s(%(expressions)s)'
+    template = '(%(function)s(%(expressions)s))'
     arg_joiner = ', '
     arity = None  # The number of arguments the function accepts.
 

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -7,6 +7,7 @@ from django import forms
 from django.core import exceptions, serializers, validators
 from django.core.management import call_command
 from django.db import IntegrityError, connection, models
+from django.db.models import Max
 from django.test import TransactionTestCase, override_settings
 from django.test.utils import isolate_apps
 from django.utils import timezone
@@ -220,6 +221,13 @@ class TestQuerying(PostgreSQLTestCase):
         instance = NestedIntegerArrayModel.objects.create(field=[[1, 2], [3, 4]])
         self.assertSequenceEqual(
             NestedIntegerArrayModel.objects.filter(field__0__0=1),
+            [instance]
+        )
+
+    def test_index_on_annotated_function(self):
+        instance = NestedIntegerArrayModel.objects.create(field=[[1], [2]])
+        self.assertSequenceEqual(
+            NestedIntegerArrayModel.objects.annotate(annotation=Max('field')).filter(annotation__0=1),
             [instance]
         )
 


### PR DESCRIPTION
Hey guys, this is my first attempt at contribution, hopefully I'll get it right.

I've encountered a bug when trying to filter on an annotated function call (the function is my own, written in plpgpsql).
The test case I've provided, which fails without my fix, is somewhat odd, but I could not find a general example of an annotation function that returns an array.

I think my fix might be too over-reaching, it can be maybe fixed by surrounding the SQL before the array index in parenthesis.

Thanks!