### PR TITLE
Fixed #26746 -- Fixed handling of zero priority in Accept-Language header parsing.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -791,7 +791,7 @@ def parse_accept_lang_header(lang_string):
             return []
         if priority:
             priority = float(priority)
-        if not priority:        # if priority is 0.0 at this point make it 1.0
+        else:
             priority = 1.0
         result.append((lang, priority))
     result.sort(key=lambda k: k[1], reverse=True)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1315,7 +1315,7 @@ class MiscTests(SimpleTestCase):
             p('de,en-au;q=0.75,en-us;q=0.5,en;q=0.25,es;q=0.125,fa;q=0.125')
         )
         self.assertEqual([('*', 1.0)], p('*'))
-        self.assertEqual([('de', 1.0)], p('de;q=0.'))
+        self.assertEqual([('de', 0.0)], p('de;q=0.'))
         self.assertEqual([('en', 1.0), ('*', 0.5)], p('en; q=1.0, * ; q=0.5'))
         self.assertEqual([('en', 1.0)], p('en; q=1,'))
         self.assertEqual([], p(''))


### PR DESCRIPTION
[#26746](https://code.djangoproject.com/ticket/26746)