### PR TITLE
Fixed #26748 -- Allowed JSONField's widget to be overridden as an attribute

### DIFF
--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -15,10 +15,7 @@ class JSONField(forms.CharField):
     default_error_messages = {
         'invalid': _("'%(value)s' value must be valid JSON."),
     }
-
-    def __init__(self, **kwargs):
-        kwargs.setdefault('widget', forms.Textarea)
-        super(JSONField, self).__init__(**kwargs)
+    widget = forms.Textarea
 
     def to_python(self, value):
         if value in self.empty_values:

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -3,7 +3,7 @@ import unittest
 
 from django.core import exceptions, serializers
 from django.db import connection
-from django.forms import CharField, Form
+from django.forms import CharField, Form, widgets
 from django.test import TestCase
 from django.utils.html import escape
 
@@ -291,3 +291,21 @@ class TestFormField(PostgreSQLTestCase):
         form = JsonForm({'name': 'xy', 'jfield': '{"foo"}'})
         # Appears once in the textarea and once in the error message
         self.assertEqual(form.as_p().count(escape('{"foo"}')), 2)
+
+    def test_widget(self):
+        """The default widget of a JSONField is a Textarea."""
+        field = forms.JSONField()
+        self.assertIsInstance(field.widget, widgets.Textarea)
+
+    def test_custom_widget_kwarg(self):
+        """The widget can be overridden with a kwarg."""
+        field = forms.JSONField(widget=widgets.Input)
+        self.assertIsInstance(field.widget, widgets.Input)
+
+    def test_custom_widget_attribute(self):
+        """The widget can be overridden with an attribute."""
+        class CustomJSONField(forms.JSONField):
+            widget = widgets.Input
+
+        field = CustomJSONField()
+        self.assertIsInstance(field.widget, widgets.Input)


### PR DESCRIPTION
ref https://code.djangoproject.com/ticket/26748