### PR TITLE
Not masking psql exit code

### DIFF
--- a/django/db/backends/postgresql_psycopg2/client.py
+++ b/django/db/backends/postgresql_psycopg2/client.py
@@ -1,4 +1,4 @@
-import subprocess
+import os
 
 from django.db.backends.base.client import BaseDatabaseClient
 
@@ -16,4 +16,4 @@ class DatabaseClient(BaseDatabaseClient):
         if settings_dict['PORT']:
             args.extend(["-p", str(settings_dict['PORT'])])
         args += [settings_dict['NAME']]
-        subprocess.call(args)
+        os.execvp(self.executable_name, args)


### PR DESCRIPTION
Hi,

I'm trying to use dbshell to execute a SQL script in bash script, but using django SQL settings. Since the latest changes around password management in dbshell, i thought dbshell was the right tool for this use case. And it executes SQL in the right connection successfully, but I hit a bug: dbshell always success with exit code `0`. Even the following script succeed:

```sql
\set ON_ERROR_STOP on
auiestn;
```

Here is a simple diff to let psql manage exit code of dbshell command.

What is your opinion on the issue ? What about this diff ? I'm also seeking for a testcase around this feature.

Regards,
Étienne