### PR TITLE
Fixed #26751 -- Made dbshell exit with the shell's error code.

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -39,4 +39,4 @@ class DatabaseClient(BaseDatabaseClient):
 
     def runshell(self):
         args = DatabaseClient.settings_to_cmd_args(self.connection.settings_dict)
-        subprocess.call(args)
+        subprocess.check_call(args)

--- a/django/db/backends/oracle/client.py
+++ b/django/db/backends/oracle/client.py
@@ -9,4 +9,4 @@ class DatabaseClient(BaseDatabaseClient):
     def runshell(self):
         conn_string = self.connection._connect_string()
         args = [self.executable_name, "-L", conn_string]
-        subprocess.call(args)
+        subprocess.check_call(args)

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -55,7 +55,7 @@ class DatabaseClient(BaseDatabaseClient):
                     # If the current locale can't encode the data, we let
                     # the user input the password manually.
                     pass
-            subprocess.call(args)
+            subprocess.check_call(args)
         finally:
             if temp_pgpass:
                 temp_pgpass.close()

--- a/django/db/backends/sqlite3/client.py
+++ b/django/db/backends/sqlite3/client.py
@@ -9,4 +9,4 @@ class DatabaseClient(BaseDatabaseClient):
     def runshell(self):
         args = [self.executable_name,
                 self.connection.settings_dict['NAME']]
-        subprocess.call(args)
+        subprocess.check_call(args)


### PR DESCRIPTION
Hi,

I'm trying to use dbshell to execute a SQL script in bash script, but using django SQL settings. Since the latest changes around password management in dbshell, i thought dbshell was the right tool for this use case. And it executes SQL in the right connection successfully, but I hit a bug: dbshell always success with exit code `0`. Even the following script succeed:

```sql
\set ON_ERROR_STOP on
auiestn;
```

Here is a simple diff to let psql manage exit code of dbshell command.

What is your opinion on the issue ? What about this diff ? I'm also seeking for a testcase around this feature.

Regards,
Étienne

This PR is a rebase of #6767 