### PR TITLE
Fixed #26644 -- Allowed wrapping NamedTemporaryFile with File.

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -18,6 +18,10 @@ class File(FileProxyMixin):
         self.file = file
         if name is None:
             name = getattr(file, 'name', None)
+        # Use only the basename from a file's name if it's an absolute path,
+        # e.g. from NamedTemporaryFile.
+        if isinstance(name, six.string_types) and os.path.isabs(name):
+            name = os.path.basename(name)
         self.name = name
         if hasattr(file, 'mode'):
             self.mode = file.mode

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -10,6 +10,7 @@ import threading
 import time
 import unittest
 from datetime import datetime, timedelta
+from tempfile import NamedTemporaryFile
 
 from django.core.cache import cache
 from django.core.exceptions import SuspiciousFileOperation, SuspiciousOperation
@@ -868,6 +869,13 @@ class FileFieldStorageTests(TestCase):
         self.assertTrue(temp_storage.exists('tests/stringio'))
         with temp_storage.open('tests/stringio') as f:
             self.assertEqual(f.read(), b'content')
+
+    def test_save_temporary_file(self):
+        storage = Storage()
+        with NamedTemporaryFile() as f:
+            f.write(b'content')
+            storage.normal = File(f)
+            storage.save()  # no crash
 
 
 # Tests for a race condition on file saving (#4948).

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -26,6 +26,12 @@ else:
 
 
 class FileTests(unittest.TestCase):
+
+    def test_file_truncates_namedtemporaryfile_name(self):
+        named_file = NamedTemporaryFile()
+        f = File(named_file)
+        self.assertEqual(f.name, os.path.basename(named_file.name))
+
     def test_unicode_uploadedfile_name(self):
         uf = UploadedFile(name='¿Cómo?', content_type='text')
         self.assertIs(type(repr(uf)), str)


### PR DESCRIPTION
914c72be2abb1c6dd860cb9279beaa66409ae1b2 introduced a regression that
caused saving a NamedTemporaryFile in a FileField to raise a
SuspiciousFileOperation. To remedy this, if a File has an absolute
path as a filename, only use the basename as the filename.

(updated from https://github.com/django/django/pull/6658)