### PR TITLE
Add DEFAULT_EXTRA_HEADERS setting

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -215,6 +215,10 @@ TEMPLATES = []
 # the site managers.
 DEFAULT_FROM_EMAIL = 'webmaster@localhost'
 
+# Default extra headers to use for various automated correspondence from the
+# site managers.
+DEFAULT_EXTRA_HEADERS = {}
+
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.
 EMAIL_SUBJECT_PREFIX = '[Django] '

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -291,7 +291,7 @@ class EmailMessage(object):
         self.subject = subject
         self.body = body
         self.attachments = attachments or []
-        self.extra_headers = headers or {}
+        self.extra_headers = headers or settings.DEFAULT_EXTRA_HEADERS
         self.connection = connection
 
     def get_connection(self, fail_silently=False):

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1122,6 +1122,16 @@ Default exception reporter filter class to be used if none has been assigned to
 the :class:`~django.http.HttpRequest` instance yet.
 See :ref:`Filtering error reports<filtering-error-reports>`.
 
+.. setting:: DEFAULT_EXTRA_HEADERS
+
+``DEFAULT_EXTRA_HEADERS``
+-------------------------
+
+Default: ``{}``
+
+Default extra headers to use for various automated email correspondence from the
+site manager(s).
+
 .. setting:: DEFAULT_FILE_STORAGE
 
 ``DEFAULT_FILE_STORAGE``
@@ -3243,6 +3253,7 @@ Email
 -----
 * :setting:`ADMINS`
 * :setting:`DEFAULT_CHARSET`
+* :setting:`DEFAULT_EXTRA_HEADERS`
 * :setting:`DEFAULT_FROM_EMAIL`
 * :setting:`EMAIL_BACKEND`
 * :setting:`EMAIL_FILE_PATH`

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -278,7 +278,8 @@ All parameters are optional and can be set at any time prior to calling the
 * ``headers``: A dictionary of extra headers to put on the message. The
   keys are the header name, values are the header values. It's up to the
   caller to ensure header names and values are in the correct format for
-  an email message. The corresponding attribute is ``extra_headers``.
+  an email message. The corresponding attribute is ``extra_headers``. If
+  omitted, the :setting:`DEFAULT_EXTRA_HEADERS` setting is used.
 
 * ``cc``: A list or tuple of recipient addresses used in the "Cc" header
   when sending the email.

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -191,6 +191,17 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             ('date', 'Fri, 09 Nov 2001 01:08:47 -0000'),
         })
 
+    def test_default_extra_headers(self):
+        """
+        Default extra headers from settings.
+        """
+        with self.settings(DEFAULT_EXTRA_HEADERS={'X-Test-Extra-Header': 'Example'}):
+            email = EmailMessage('subject', 'content', 'from@example.com', ['to@example.com'])
+
+        self.assertMessageHasHeaders(email.message(), {
+            ('X-Test-Extra-Header', 'Example')
+        })
+
     def test_from_header(self):
         """
         Make sure we can manually set the From header (#9214)


### PR DESCRIPTION
Allow `EmailMessage` to use `DEFAULT_EXTRA_HEADERS` setting if the parameter `headers` is omitted.

Test and docs included.