### PR TITLE
Fixed #26401 -- Allow auth machinery to be used without installing auth app

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -151,7 +151,7 @@ def logout(request):
         request.session[LANGUAGE_SESSION_KEY] = language
 
     if hasattr(request, 'user'):
-        from django.contrib.auth.models import AnonymousUser
+        from django.contrib.auth.base_user import AnonymousUser
         request.user = AnonymousUser()
 
 
@@ -174,7 +174,7 @@ def get_user(request):
     Returns the user model instance associated with the given request session.
     If no user is retrieved an instance of `AnonymousUser` is returned.
     """
-    from .models import AnonymousUser
+    from .base_user import AnonymousUser
     user = None
     try:
         user_id = _get_user_session_key(request)

--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
 
 
 class ModelBackend(object):
@@ -35,6 +34,7 @@ class ModelBackend(object):
         return user_obj.user_permissions.all()
 
     def _get_group_permissions(self, user_obj):
+        from django.contrib.auth.models import Permission
         user_groups_field = get_user_model()._meta.get_field('groups')
         user_groups_query = 'group__%s' % user_groups_field.related_query_name()
         return Permission.objects.filter(**{user_groups_query: user_obj})
@@ -45,6 +45,7 @@ class ModelBackend(object):
         be either "group" or "user" to return permissions from
         `_get_group_permissions` or `_get_user_permissions` respectively.
         """
+        from django.contrib.auth.models import Permission
         if not user_obj.is_active or user_obj.is_anonymous or obj is not None:
             return set()
 

--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -148,8 +148,6 @@ class AnonymousUser(object):
     is_staff = False
     is_active = False
     is_superuser = False
-    _groups = EmptyManager(Group)
-    _user_permissions = EmptyManager(Permission)
 
     def __init__(self):
         pass
@@ -179,20 +177,24 @@ class AnonymousUser(object):
         raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
 
     def _get_groups(self):
-        return self._groups
+        from .models import Group
+        return EmptyManager(Group)
     groups = property(_get_groups)
 
     def _get_user_permissions(self):
-        return self._user_permissions
+        from .models import Permission
+        return EmptyManager(Permission)
     user_permissions = property(_get_user_permissions)
 
     def get_group_permissions(self, obj=None):
         return set()
 
     def get_all_permissions(self, obj=None):
+        from .models import _user_get_all_permissions
         return _user_get_all_permissions(self, obj=obj)
 
     def has_perm(self, perm, obj=None):
+        from .models import _user_has_perm
         return _user_has_perm(self, perm, obj=obj)
 
     def has_perms(self, perm_list, obj=None):
@@ -202,6 +204,7 @@ class AnonymousUser(object):
         return True
 
     def has_module_perms(self, module):
+        from .models import _user_has_module_perms
         return _user_has_module_perms(self, module)
 
     @property

--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -11,6 +11,7 @@ from django.contrib.auth.hashers import (
     check_password, is_password_usable, make_password,
 )
 from django.db import models
+from django.db.models.manager import EmptyManager
 from django.utils.crypto import get_random_string, salted_hmac
 from django.utils.deprecation import CallableFalse, CallableTrue
 from django.utils.encoding import force_text, python_2_unicode_compatible
@@ -137,3 +138,79 @@ class AbstractBaseUser(models.Model):
         """
         key_salt = "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash"
         return salted_hmac(key_salt, self.password).hexdigest()
+
+
+@python_2_unicode_compatible
+class AnonymousUser(object):
+    id = None
+    pk = None
+    username = ''
+    is_staff = False
+    is_active = False
+    is_superuser = False
+    _groups = EmptyManager(Group)
+    _user_permissions = EmptyManager(Permission)
+
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return 'AnonymousUser'
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return 1  # instances always return the same hash value
+
+    def save(self):
+        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
+
+    def delete(self):
+        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
+
+    def set_password(self, raw_password):
+        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
+
+    def check_password(self, raw_password):
+        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
+
+    def _get_groups(self):
+        return self._groups
+    groups = property(_get_groups)
+
+    def _get_user_permissions(self):
+        return self._user_permissions
+    user_permissions = property(_get_user_permissions)
+
+    def get_group_permissions(self, obj=None):
+        return set()
+
+    def get_all_permissions(self, obj=None):
+        return _user_get_all_permissions(self, obj=obj)
+
+    def has_perm(self, perm, obj=None):
+        return _user_has_perm(self, perm, obj=obj)
+
+    def has_perms(self, perm_list, obj=None):
+        for perm in perm_list:
+            if not self.has_perm(perm, obj):
+                return False
+        return True
+
+    def has_module_perms(self, module):
+        return _user_has_module_perms(self, module)
+
+    @property
+    def is_anonymous(self):
+        return CallableTrue
+
+    @property
+    def is_authenticated(self):
+        return CallableFalse
+
+    def get_username(self):
+        return self.username

--- a/django/contrib/auth/context_processors.py
+++ b/django/contrib/auth/context_processors.py
@@ -57,7 +57,7 @@ def auth(request):
     if hasattr(request, 'user'):
         user = request.user
     else:
-        from django.contrib.auth.models import AnonymousUser
+        from django.contrib.auth.base_user import AnonymousUser
         user = AnonymousUser()
 
     return {

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals
 
 from django.contrib import auth
+from django.contrib.auth.base_user import AnonymousUser  # NOQA
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.signals import user_logged_in
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.db import models
-from django.db.models.manager import EmptyManager
 from django.utils import six, timezone
-from django.utils.deprecation import CallableFalse, CallableTrue
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -371,79 +370,3 @@ class User(AbstractUser):
     """
     class Meta(AbstractUser.Meta):
         swappable = 'AUTH_USER_MODEL'
-
-
-@python_2_unicode_compatible
-class AnonymousUser(object):
-    id = None
-    pk = None
-    username = ''
-    is_staff = False
-    is_active = False
-    is_superuser = False
-    _groups = EmptyManager(Group)
-    _user_permissions = EmptyManager(Permission)
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        return 'AnonymousUser'
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __hash__(self):
-        return 1  # instances always return the same hash value
-
-    def save(self):
-        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
-
-    def delete(self):
-        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
-
-    def set_password(self, raw_password):
-        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
-
-    def check_password(self, raw_password):
-        raise NotImplementedError("Django doesn't provide a DB representation for AnonymousUser.")
-
-    def _get_groups(self):
-        return self._groups
-    groups = property(_get_groups)
-
-    def _get_user_permissions(self):
-        return self._user_permissions
-    user_permissions = property(_get_user_permissions)
-
-    def get_group_permissions(self, obj=None):
-        return set()
-
-    def get_all_permissions(self, obj=None):
-        return _user_get_all_permissions(self, obj=obj)
-
-    def has_perm(self, perm, obj=None):
-        return _user_has_perm(self, perm, obj=obj)
-
-    def has_perms(self, perm_list, obj=None):
-        for perm in perm_list:
-            if not self.has_perm(perm, obj):
-                return False
-        return True
-
-    def has_module_perms(self, module):
-        return _user_has_module_perms(self, module)
-
-    @property
-    def is_anonymous(self):
-        return CallableTrue
-
-    @property
-    def is_authenticated(self):
-        return CallableFalse
-
-    def get_username(self):
-        return self.username


### PR DESCRIPTION
Fix for https://code.djangoproject.com/ticket/26401

I still can't figure out a good way to regression test this.