### PR TITLE
Add information about choice_value attribute.

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -649,7 +649,8 @@ Selector and checkbox widgets
         </div>
 
     That included the ``<label>`` tags. To get more granular, you can use each
-    radio button's ``tag``, ``choice_label`` and ``id_for_label`` attributes.
+    radio button's ``tag``, ``choice_label`` and ``id_for_label`` attributes. Additionally, there is a ``choice_value``
+    attribute for accesing values of radio buttons (which are the first elements of ``choices`` tuples). 
     For example, this template...
 
     .. code-block:: html+django


### PR DESCRIPTION
Small addition to `docs/ref/forms/widgets.txt` documentation, showing how to get access radio button's values while using `RadioSelect`.
Maybe it wasn't obvious just for me, but I spent a plenty of time trying to figure out how to get values. 
I suppose, it can be useful to show this in docs. 