### PR TITLE
Add information about choice_values to widgets doc

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -650,6 +650,7 @@ Selector and checkbox widgets
 
     That included the ``<label>`` tags. To get more granular, you can use each
     radio button's ``tag``, ``choice_label`` and ``id_for_label`` attributes.
+    There is also ``choice_value`` attribute for button's values.
     For example, this template...
 
     .. code-block:: html+django


### PR DESCRIPTION
Small addition to `docs/ref/forms/widgets.txt` documentation, showing how to access radio button's values while using `RadioSelect`.
Maybe it wasn't obvious just for me, but I spent a plenty of time trying to figure out how to get values. 
I suppose, it can be useful to show this in docs. 