### PR TITLE
Oracle: cast value to str before checking for '.'

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -570,7 +570,7 @@ def _rowfactory(row, cursor):
                     # NUMBER column: decimal-precision floating point
                     # This will normally be an integer from a sequence,
                     # but it could be a decimal value.
-                    if '.' in value:
+                    if '.' in str(value):
                         value = decimal.Decimal(value)
                     else:
                         value = int(value)
@@ -585,7 +585,7 @@ def _rowfactory(row, cursor):
                     value = int(value)
                 else:
                     value = decimal.Decimal(value)
-            elif '.' in value:
+            elif '.' in str(value):
                 # No type information. This normally comes from a
                 # mathematical expression in the SELECT list. Guess int
                 # or Decimal based on whether it has a decimal point.


### PR DESCRIPTION
Found a breaking case within the oracle backend at work.

Where `desc` is `('_RN', <type 'cx_Oracle.NUMBER'>, 127, 22, 0, -127, 1)` and `value` is `1`, the exception `argument of type 'int' is not iterable` will be thrown as the code checks for a `'.'` in the value.

Adds an explicit cast before treating the value as an iterable.

