### PR TITLE
Fixed #26774 — changed default_zoom value in GeoModelAdmin doc

### DIFF
--- a/docs/ref/contrib/gis/admin.txt
+++ b/docs/ref/contrib/gis/admin.txt
@@ -20,7 +20,7 @@ GeoDjango's admin site
 
     .. attribute:: default_zoom
 
-    The default zoom level to use.  Defaults to 18.
+    The default zoom level to use.  Defaults to 4.
 
     .. attribute:: extra_js
 


### PR DESCRIPTION
A fix to the ticket “[GeoModelAdmin documentation states incorrect default value of default_zoom](https://code.djangoproject.com/ticket/26774)”.