### PR TITLE
Fixed #26729 -- Allowed overriding the label of a tabular inline form field

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -279,7 +279,7 @@ class InlineAdminFormSet(object):
                     'help_text': help_text_for_field(field_name, self.opts.model),
                 }
             else:
-                form_field = self.formset.form.base_fields[field_name]
+                form_field = self.formset.empty_form.fields[field_name]
                 label = form_field.label
                 if label is None:
                     label = label_for_field(field_name, self.opts.model, self.opts)

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -182,7 +182,7 @@ class SightingInline(admin.TabularInline):
     model = Sighting
 
 
-# admin and form for #18263
+# admin and form for #18263 & #26729
 class SomeChildModelForm(forms.ModelForm):
 
     class Meta:
@@ -191,6 +191,10 @@ class SomeChildModelForm(forms.ModelForm):
         widgets = {
             'position': forms.HiddenInput,
         }
+
+    def __init__(self, *args, **kwargs):
+        super(SomeChildModelForm, self).__init__(*args, **kwargs)
+        self.fields['name'].label = 'new label'
 
 
 class SomeChildModelInline(admin.TabularInline):

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -95,6 +95,16 @@ class TestInline(TestDataMixin, TestCase):
         response = self.client.get(reverse('admin:admin_inlines_titlecollection_add'))
         self.assertContains(response, '<th class="required">Title1</th>', html=True)
 
+    def test_custom_form_tabular_inline_overridden_label(self):
+        """
+        A model form that overrides the label of a form field should display
+        the overridden label in the tabular inline. Refs #26729.
+        """
+        response = self.client.get(reverse('admin:admin_inlines_someparentmodel_add'))
+        field = list(response.context['inline_admin_formset'].fields())[0]
+        self.assertEqual(field['label'], 'new label')
+        self.assertContains(response, '<th class="required">New label</th>', html=True)
+
     def test_tabular_non_field_errors(self):
         """
         Ensure that non_field_errors are displayed correctly, including the


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26729