### PR TITLE
Fixed #22446 -- Added basic tox.ini to automate all checks expected of new patches and pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.egg-info
 *.pot
 *.py[co]
+.tox/
 __pycache__
 MANIFEST
 dist/

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -4,6 +4,8 @@ Coding style
 
 Please follow these coding standards when writing code for inclusion in Django.
 
+.. _coding-style-python:
+
 Python style
 ============
 
@@ -50,6 +52,8 @@ Python style
   message. Use :meth:`~unittest.TestCase.assertRaisesRegex`
   (``six.assertRaisesRegex()`` as long as we support Python 2) only if you need
   to use regular expression matching.
+
+.. _coding-style-imports:
 
 Imports
 =======

--- a/docs/internals/contributing/writing-code/javascript.txt
+++ b/docs/internals/contributing/writing-code/javascript.txt
@@ -60,6 +60,8 @@ Closure Compiler library requires `Java`_ 7 or higher.
 Please don't forget to run ``compress.py`` and include the ``diff`` of the
 minified scripts when submitting patches for Django's JavaScript.
 
+.. _javascript-tests:
+
 JavaScript tests
 ================
 

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -45,6 +45,72 @@ See :ref:`installing-development-version`.
 
 Having problems? See :ref:`troubleshooting-unit-tests` for some common issues.
 
+Running tests using ``tox``
+---------------------------
+
+`Tox <http://tox.testrun.org/>`_ is a tool for running tests in different
+virtual environments. Django includes a basic ``tox.ini`` that automates the
+checks expected of patches and pull requests. To run the unit tests and other
+checks (such as :ref:`import sorting <coding-style-imports>`, the
+:ref:`documentation spelling checker <documentation-spelling-check>`, and
+:ref:`code formatting <coding-style-python>`), install and run the ``tox``
+command from any place in the Django source tree::
+
+    $ pip install tox
+    $ tox
+
+By default, ``tox`` runs the test suite with the bundled test settings file for
+SQLite, ``flake8``, ``isort``, and the documentation spelling checker. In
+addition to the system dependencies noted elsewhere in this documentation,
+the commands ``python2`` and ``python3`` must be on your path and linked to
+the appropriate versions of Python. A list of default environments can be seen
+as follows::
+
+    $ tox -l
+    py3
+    flake8
+    docs
+    isort
+
+Testing other Python versions and database backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the default environments, ``tox`` supports running unit tests
+for other versions of Python and other database backends. Since Django's test
+suite doesn't bundle a settings file for database backends other than SQLite,
+however, you must :ref:`create and provide your own test settings
+<running-unit-tests-settings>`. For example, to run the tests on Python 3.5
+using PostgreSQL::
+
+    $ tox -e py35-postgres -- --settings=my_postgres_settings
+
+This command sets up a Python 3.5 virtual environment, installs Django's
+test suite dependencies (including those for PostgreSQL), and calls
+``runtests.py`` with the supplied arguments (in this case,
+``--settings=my_postgres_settings``).
+
+The remainder of this documentation shows commands for running tests without
+``tox``, however, any option passed to ``runtests.py`` can also be passed to
+``tox`` by prefixing the argument list with ``--``, as above.
+
+Tox also respects the ``DJANGO_SETTINGS_MODULE`` environment variable, if set.
+For example, the following is equivalent to the command above::
+
+    $ DJANGO_SETTINGS_MODULE=my_postgres_settings tox -e py35-postgres
+
+Running the JavaScript tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Django includes a set of :ref:`JavaScript unit tests <javascript-tests>` for
+functions in certain contrib apps. The JavaScript tests aren't run by default
+using ``tox`` because they require `Node.js` to be installed. To run the
+JavaScript tests using ``tox``::
+
+    $ tox -e javascript
+
+This command will run ``npm install`` to ensure test requirements are up to
+date and then run ``npm test``.
+
 .. _running-unit-tests-settings:
 
 Using another ``settings`` module

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -841,6 +841,7 @@ Tomek
 toolbar
 toolkits
 toolset
+Tox
 trac
 tracebacks
 transactional

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,69 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests in multiple
+# virtualenvs. This configuration file helps to run the test suite on all
+# supported Python versions. To use it, "pip install tox" and then run "tox"
+# from this directory.
+
+[tox]
+skipsdist = true
+envlist =
+    py3
+    flake8
+    docs
+    isort
+
+# Add environments to use default python2 and python3 installations
+[testenv:py2]
+basepython = python2
+
+[testenv:py3]
+basepython = python3
+
+[testenv]
+usedevelop = true
+passenv = DJANGO_SETTINGS_MODULE
+deps =
+    py{2,27}: -rtests/requirements/py2.txt
+    py{3,34,35}: -rtests/requirements/py3.txt
+    postgres: -rtests/requirements/postgres.txt
+    mysql: -rtests/requirements/mysql.txt
+    oracle: -rtests/requirements/oracle.txt
+changedir = tests
+commands =
+    {envpython} runtests.py {posargs}
+
+[testenv:flake8]
+basepython = python3
+usedevelop = false
+deps = flake8
+changedir = {toxinidir}
+commands = flake8 .
+
+[testenv:docs]
+# On OS X, as of pyenchant 1.6.6, the docs build only works under Python 2.
+basepython = python2
+usedevelop = false
+whitelist_externals =
+    make
+deps =
+    Sphinx
+    pyenchant
+    sphinxcontrib-spelling
+changedir = docs
+commands =
+    make spelling
+
+[testenv:isort]
+basepython = python3
+usedevelop = false
+deps = isort
+changedir = {toxinidir}
+commands = isort --recursive --check-only --diff django tests scripts
+
+[testenv:javascript]
+usedevelop = false
+deps =
+changedir = {toxinidir}
+whitelist_externals = npm
+commands =
+    npm install
+    npm test


### PR DESCRIPTION
This patch fixes https://code.djangoproject.com/ticket/22446 ("Add tox support"). A few notes about the approach:

- The goal of this patch is to automate the simple checks expected of patches/PRs, not to replace Jenkins' scripts (there is, however, no reason that Jenkins couldn't call tox for _some_ of the checks, which might help keep everything in sync and be an integration test for the ``tox.ini`` itself).
- When Django bundles dependencies for other test environments, the ``tox.ini`` supports them, however, it still requires creating and passing a custom settings file for other Database backends.
- The file assumes both Python 2 and 3 are available on the developer's machine. Python 2 seems still to be needed for the docs spell checker on Mac OS X, a requirement that will go away once pyenchant 1.6.7 is released (see https://github.com/rfk/pyenchant/issues/45). The SQLite tests default to Python 3.5, however, other versions can be specified on the command line if desired.

Open questions:

- ~~Do we expect people to look for flake8 errors in Python 2, Python 3, both, or only whatever version they happen to be developing with? A PR to fix a flake8 error in Python 2.7 was previously rejected (https://github.com/django/django/pull/6730) although I see it was then subsequently fixed along with some Python 2.6 errors (https://github.com/django/django/pull/6790)~~ (Answer: Python 3 only)
- ~~How to make tox usage easy for Windows users. The ``python2`` and ``python3`` commands don't exist by default, and there doesn't seem to be much consensus on how to get them: http://stackoverflow.com/questions/3809314/how-to-install-both-python-2-x-and-python-3-x-in-windows-7~~ (Answer: referencing the need for these variables on one's path is sufficient)
- ~~Whether or not to use ``skipsdist`` (https://testrun.org/tox/latest/example/general.html#avoiding-expensive-sdist). Note that ``python setup.py sdist`` does not work on Windows currently, so unless that's fixed it's probably easier (and faster for tests) to leave this as-is (with ``skipsdist = true``).~~ (Answer: use it.)

Other thoughts/questions/comments/concerns?