### PR TITLE
Fixed #26776 - Proper url() documentation.

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -30,6 +30,14 @@ Helper function to return a URL pattern for serving files in debug mode::
         ...
     ]
 
+The ``view`` parameter can be:
+
+* view function name.
+
+* list or tuple containing 3 arguments: ``urlconf_module``, ``app_name`` and ``namespace``.
+
+* ``include(...)`` which is returning such tuple.
+
 The ``kwargs`` parameter allows you to pass additional arguments to the view
 function or method. See :ref:`views-extra-options` for an example.
 


### PR DESCRIPTION
Fixed documentation for `url()` view parameter.
See https://code.djangoproject.com/ticket/26776 for details. 