### PR TITLE
Refs #22384 -- Readded RegexURLResolver.reverse().

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -323,6 +323,9 @@ class RegexURLResolver(LocaleRegexProvider):
             callback = getattr(urls, 'handler%s' % view_type)
         return get_callable(callback), {}
 
+    def reverse(self, lookup_view, *args, **kwargs):
+        return self._reverse_with_prefix(lookup_view, '', *args, **kwargs)
+
     def _reverse_with_prefix(self, lookup_view, _prefix, *args, **kwargs):
         if args and kwargs:
             raise ValueError("Don't mix *args and **kwargs in call to reverse()!")

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -364,6 +364,12 @@ class ResolverTests(unittest.TestCase):
         except TypeError:
             self.fail('Failed to coerce lazy object to text')
 
+    def test_resolver_reverse(self):
+        resolver = get_resolver('urlpatterns_reverse.named_urls')
+        self.assertEqual(resolver.reverse('named-url1'), '')
+        self.assertEqual(resolver.reverse('named-url2', 'arg'), 'extra/arg/')
+        self.assertEqual(resolver.reverse('named-url2', extra='arg'), 'extra/arg/')
+
     def test_non_regex(self):
         """
         Verifies that we raise a Resolver404 if what we are resolving doesn't


### PR DESCRIPTION
It was removed in 785cc71d5b3300e2702b0b2fc7316e58ca70b563 only because
it was untested and unused in Django itself, however, some third-party
apps use it.