### PR TITLE
Fixed #26765 - Removed ETag when Cache-Control: no-store

### DIFF
--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -5,7 +5,9 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.mail import mail_managers
 from django.urls import is_valid_path
-from django.utils.cache import get_conditional_response, set_response_etag
+from django.utils.cache import (
+    cc_delim_re, get_conditional_response, set_response_etag,
+)
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_text
 from django.utils.http import unquote_etag
@@ -113,7 +115,7 @@ class CommonMiddleware(MiddlewareMixin):
             if self.should_redirect_with_slash(request):
                 return self.response_redirect_class(self.get_full_path_with_slash(request))
 
-        if settings.USE_ETAGS:
+        if settings.USE_ETAGS and self.need_etag(response):
             if not response.has_header('ETag'):
                 set_response_etag(response)
 
@@ -125,6 +127,13 @@ class CommonMiddleware(MiddlewareMixin):
                 )
 
         return response
+
+    def need_etag(self, response):
+        """
+        Returns True if ETag header should be added to response.
+        """
+        cache_control_headers = cc_delim_re.split(response.get('Cache-Control', ''))
+        return 'no-store' not in (header.lower() for header in cache_control_headers)
 
 
 class BrokenLinkEmailsMiddleware(MiddlewareMixin):

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -276,6 +276,20 @@ class CommonMiddlewareTest(SimpleTestCase):
         self.assertFalse(CommonMiddleware().process_response(req, res).has_header('ETag'))
 
     @override_settings(USE_ETAGS=True)
+    def test_no_etag_no_store_cache(self):
+        req = HttpRequest()
+        res = HttpResponse('content')
+        res['Cache-Control'] = 'No-Cache, No-Store, Max-age=0'
+        self.assertFalse(CommonMiddleware().process_response(req, res).has_header('ETag'))
+
+    @override_settings(USE_ETAGS=True)
+    def test_etag_extended_cache_control(self):
+        req = HttpRequest()
+        res = HttpResponse('content')
+        res['Cache-Control'] = 'my-directive="my-no-store"'
+        self.assertTrue(CommonMiddleware().process_response(req, res).has_header('ETag'))
+
+    @override_settings(USE_ETAGS=True)
     def test_if_none_match(self):
         first_req = HttpRequest()
         first_res = CommonMiddleware().process_response(first_req, HttpResponse('content'))


### PR DESCRIPTION
Removed `ETag` when `Cache-Control` contains `no-store`.
See https://code.djangoproject.com/ticket/26765 for details.