### PR TITLE
Fixed #26784 -- Made ForeignKey.validate() pass `model` to router if model_instance=None.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -926,7 +926,7 @@ class ForeignKey(ForeignObject):
         if value is None:
             return
 
-        using = router.db_for_read(model_instance.__class__, instance=model_instance)
+        using = router.db_for_read(self.remote_field.model, instance=model_instance)
         qs = self.remote_field.model._default_manager.using(using).filter(
             **{self.remote_field.field_name: value}
         )


### PR DESCRIPTION
The model_instance argument to model fields' clean() and validate() methods is allowed to be None, and when this was the case, ForeignKey.validate() was passing NoneType as the first argument to router.db_for_read(). But that argument is expected to be a model class, not NoneType, so any routers that tried to access model._meta would throw an AttributeError.

Really, it makes more sense to pass in the remote model class because that's the model that's being looked up, and, conveniently, is never None.