### PR TITLE
Fixed #26785 -- Set BaseSpatialField.empty_strings_allowed to False.

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -78,6 +78,7 @@ class BaseSpatialField(Field):
     of the spatial reference system of the field.
     """
     description = _("The base GIS field.")
+    empty_strings_allowed = False
     # Geodetic units.
     geodetic_units = ('decimal degree', 'degree')
 

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -223,12 +223,9 @@ class GISFunctionsTests(TestCase):
         geom = Point(5, 23, srid=4326)
         qs = Country.objects.annotate(inter=functions.Intersection('mpoly', geom))
         for c in qs:
-            if spatialite or mysql:
-                # When the intersection is empty, Spatialite and MySQL return None
+            if spatialite or mysql or oracle:
+                # When the intersection is empty, Spatialite, MySQL and Oracle return None
                 expected = None
-            elif oracle:
-                # When the intersection is empty, Oracle returns an empty string
-                expected = ''
             else:
                 expected = c.mpoly.intersection(geom)
             self.assertEqual(c.inter, expected)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26785