### PR TITLE
fix change password in admin

### DIFF
--- a/django/contrib/auth/admin.py
+++ b/django/contrib/auth/admin.py
@@ -84,7 +84,7 @@ class UserAdmin(admin.ModelAdmin):
     def get_urls(self):
         return [
             url(
-                r'^(.+)/password/$',
+                r'^(.+)/change/password/$',
                 self.admin_site.admin_view(self.user_change_password),
                 name='auth_user_password_change',
             ),


### PR DESCRIPTION
I found this bug when I change password for an account, so I just fix it by changing r'^(.+)/password/$' to r'^(.+)/change/password/$'.