### PR TITLE
Fixed #15665 -- Fixed inlines on a ModelAdmin with an inline to a child related model.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -10,7 +10,7 @@ from django.contrib.admin.utils import (
     lookup_field,
 )
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models.fields.related import ManyToManyRel
+from django.db.models.fields.related import ManyToManyRel, OneToOneField
 from django.forms.utils import flatatt
 from django.template.defaultfilters import capfirst, linebreaksbr
 from django.utils import six
@@ -334,6 +334,9 @@ class InlineAdminForm(AdminForm):
     def needs_explicit_pk_field(self):
         # Auto fields are editable (oddly), so need to check for auto or non-editable pk
         if self.form._meta.model._meta.has_auto_field or not self.form._meta.model._meta.pk.editable:
+            return True
+        # If the PK is a One-to-One field, it will be considered as editable, while it's not
+        if isinstance(self.form._meta.model._meta.pk, OneToOneField):
             return True
         # Also search any parents for an auto field. (The pk info is propagated to child
         # models so that does not need to be checked in parents.)

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -4,10 +4,10 @@ from django.contrib import admin
 from .models import (
     Author, BinaryTree, CapoFamiglia, Chapter, ChildModel1, ChildModel2,
     Consigliere, EditablePKBook, ExtraTerrestrial, Fashionista, Holder,
-    Holder2, Holder3, Holder4, Inner, Inner2, Inner3, Inner4Stacked,
+    Holder2, Holder3, Holder4, Holder15665, Inner, Inner2, Inner3, Inner4Stacked,
     Inner4Tabular, NonAutoPKBook, Novel, ParentModelWithCustomPk, Poll,
     Profile, ProfileCollection, Question, ReadOnlyInline, ShoppingWeakness,
-    Sighting, SomeChildModel, SomeParentModel, SottoCapo, Title,
+    Sighting, SomeChildModel, SomeParentModel, SottoCapo, SubInner15665, Title,
     TitleCollection,
 )
 
@@ -150,6 +150,9 @@ class ProfileInline(admin.TabularInline):
     model = Profile
     extra = 1
 
+# admin for #15665
+class SubInner15665Inline(admin.StackedInline):
+    model = SubInner15665
 
 # admin for #18433
 class ChildModel1Inline(admin.TabularInline):
@@ -219,3 +222,4 @@ site.register(BinaryTree, inlines=[BinaryTreeAdmin])
 site.register(ExtraTerrestrial, inlines=[SightingInline])
 site.register(SomeParentModel, inlines=[SomeChildModelInline])
 site.register([Question, Inner4Stacked, Inner4Tabular])
+site.register(Holder15665,inlines=[SubInner15665Inline])

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -5,6 +5,7 @@ Testing of admin inline formsets.
 from __future__ import unicode_literals
 
 import random
+import uuid
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -174,6 +175,25 @@ class FootNote(models.Model):
     chapter = models.ForeignKey(Chapter, models.PROTECT)
     note = models.CharField(max_length=40)
 
+
+# Models for #15665
+
+class Holder15665(models.Model):
+    class Meta:
+        verbose_name = 'Holder'
+    dummy = models.IntegerField()
+
+class Inner15665(models.Model):
+    class Meta:
+        verbose_name = 'Inner'
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    dummy = models.IntegerField()
+    holder = models.ForeignKey(Holder15665, models.CASCADE)
+
+class SubInner15665(Inner15665):
+    pass
+
+
 # Models for #16838
 
 
@@ -251,6 +271,8 @@ class SomeChildModel(models.Model):
     name = models.CharField(max_length=1)
     position = models.PositiveIntegerField()
     parent = models.ForeignKey(SomeParentModel, models.CASCADE)
+
+
 
 # Other models
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -11,10 +11,10 @@ from django.urls import reverse
 from .admin import InnerInline, site as admin_site
 from .models import (
     Author, BinaryTree, Book, Chapter, Child, ChildModel1, ChildModel2,
-    Fashionista, FootNote, Holder, Holder2, Holder3, Holder4, Inner, Inner2,
+    Fashionista, FootNote, Holder, Holder15665, Holder2, Holder3, Holder4, Inner, Inner2,
     Inner3, Inner4Stacked, Inner4Tabular, Novel, OutfitItem, Parent,
     ParentModelWithCustomPk, Person, Poll, Profile, ProfileCollection,
-    Question, Sighting, SomeChildModel, SomeParentModel, Teacher,
+    Question, Sighting, SomeChildModel, SomeParentModel, SubInner15665, Teacher,
 )
 
 INLINE_CHANGELINK_HTML = 'class="inlinechangelink">Change</a>'
@@ -378,6 +378,19 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<div class="inline-related" id="inner_set-1">',
+            count=1
+        )
+
+    def test_stacked_inline_edit_form_contains_has_original_class(self):
+        holder = Holder15665.objects.create(dummy=1)
+        inner = SubInner15665.objects.create(dummy=1, holder=holder)
+        
+        response = self.client.get(reverse('admin:admin_inlines_holder15665_change', args=(holder.pk,)))
+        expected = '<input id="id_subinner15665_set-0-inner15665_ptr" name="subinner15665_set-0-inner15665_ptr" type="hidden" value="{}" />'.format(inner.id)
+        
+        self.assertContains(
+            response,
+            expected,
             count=1
         )
 
@@ -896,3 +909,34 @@ class SeleniumTests(AdminSeleniumTestCase):
             self.wait_until_visible(field_name)
             hide_links[hide_index].click()
             self.wait_until_invisible(field_name)
+
+    def test_non_autofield_primary_key(self):
+        """
+        Test for #15665 where inline wouldn't work if using non-AutoField ids and inherinting the model
+        """
+        self.admin_login(username='super', password='secret')
+        self.selenium.get(self.live_server_url + reverse('admin:admin_holder15665_add'))
+
+        # Enter some data and click 'Save'
+        self.selenium.find_element_by_name('inner15665_set-0-dummy').send_keys('111')
+        self.selenium.find_element_by_name('inner15665_set-1-dummy').send_keys('222')
+        self.selenium.find_element_by_name('inner15665_set-2-dummy').send_keys('333')
+
+        self.selenium.find_element_by_xpath('//input[@value="Save"]').click()
+        self.wait_page_loaded()
+
+        # Check that the objects have been created in the database
+        self.assertEqual(Holder15665.objects.all().count(), 1)
+        self.assertEqual(Inner15665.objects.all().count(), 3)
+
+        # Enter some more data and click 'Save'
+        self.selenium.find_element_by_name('inner15665_set-3-dummy').send_keys('444')
+        self.selenium.find_element_by_name('inner15665_set-4-dummy').send_keys('555')
+        self.selenium.find_element_by_name('inner15665_set-5-dummy').send_keys('666')
+
+        self.selenium.find_element_by_xpath('//input[@value="Save"]').click()
+        self.wait_page_loaded()
+
+        # Check that the objects have been created in the database
+        self.assertEqual(Holder15665.objects.all().count(), 1)
+        self.assertEqual(Inner15665.objects.all().count(), 6)


### PR DESCRIPTION
Hi,

This is a fix for https://code.djangoproject.com/ticket/15665#trac-add-comment

As explained in the ticket, I see two places where this can be fixed.

A. in django/db/models/base.py (see commit https://github.com/olivierdalang/django/commit/a4ea0a021b784c5fbbecebed01f86c3987f1a8e9 )

Model inheritance is created using OneToOneField but doesn't set the field to editable=False.
This seems wrong, but at the same time, it seem to be consistent with regular primary keys, that for some reason don't set editable=False neither.
The fix consists of settings editable=False on those fields.
I'm not sure of the consequences of this, but this breaks potentially a lot of things, so unless someone with deep knowledge of django supports it, I propose to go for B.

​
B. in django/contrib/admin/helpers.py (this PR)

There's a needs_explicit_pk_field() method which is exactly for that.
The fix B consists of returning True if the primary key is a OneToOneField.
I guess this has much less consequences and is much safer.

Also, what I can I do to get this backported to 1.9 ? The patch should apply without conflict.
