### PR TITLE
Fixed #26792 -- Allowed None for the value of cache.get_or_set().

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -147,7 +147,7 @@ class BaseCache(object):
                 d[k] = val
         return d
 
-    def get_or_set(self, key, default=None, timeout=DEFAULT_TIMEOUT, version=None):
+    def get_or_set(self, key, default, timeout=DEFAULT_TIMEOUT, version=None):
         """
         Fetch a given key from the cache. If the key does not exist,
         the key is added and set to the default value. The default value can
@@ -156,8 +156,6 @@ class BaseCache(object):
 
         Return the value of the key stored or retrieved.
         """
-        if default is None:
-            raise ValueError('You need to specify a value.')
         val = self.get(key, version=version)
         if val is None:
             if callable(default):

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -212,6 +212,7 @@ class DummyCacheTests(SimpleTestCase):
 
     def test_get_or_set(self):
         self.assertEqual(cache.get_or_set('mykey', 'default'), 'default')
+        self.assertEqual(cache.get_or_set('mykey', None), None)
 
     def test_get_or_set_callable(self):
         def my_callable():
@@ -918,12 +919,14 @@ class BaseCacheTests(object):
         self.assertIsNone(cache.get('projector'))
         self.assertEqual(cache.get_or_set('projector', 42), 42)
         self.assertEqual(cache.get('projector'), 42)
+        self.assertEqual(cache.get_or_set('null', None), None)
 
     def test_get_or_set_callable(self):
         def my_callable():
             return 'value'
 
         self.assertEqual(cache.get_or_set('mykey', my_callable), 'value')
+        self.assertEqual(cache.get_or_set('mykey', my_callable()), 'value')
 
     def test_get_or_set_version(self):
         cache.get_or_set('brian', 1979, version=2)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -42,7 +42,6 @@ from django.utils.cache import (
 )
 from django.utils.encoding import force_text
 from django.views.decorators.cache import cache_page
-
 from .models import Poll, expensive_calculation
 
 try:    # Use the same idiom as in cache backends
@@ -219,6 +218,7 @@ class DummyCacheTests(SimpleTestCase):
             return 'default'
 
         self.assertEqual(cache.get_or_set('mykey', my_callable), 'default')
+        self.assertEqual(cache.get_or_set('mykey', my_callable()), 'default')
 
 
 def custom_key_func(key, key_prefix, version):
@@ -927,9 +927,15 @@ class BaseCacheTests(object):
 
     def test_get_or_set_version(self):
         cache.get_or_set('brian', 1979, version=2)
-        with self.assertRaisesMessage(ValueError, 'You need to specify a value.'):
+        with self.assertRaisesMessage(TypeError,
+                                      "get_or_set() missing 1 required positional argument: 'default'"
+                                      if six.PY3
+                                      else 'get_or_set() takes at least 3 arguments (2 given)'):
             cache.get_or_set('brian')
-        with self.assertRaisesMessage(ValueError, 'You need to specify a value.'):
+        with self.assertRaisesMessage(TypeError,
+                                      "get_or_set() missing 1 required positional argument: 'default'"
+                                      if six.PY3
+                                      else 'get_or_set() takes at least 3 arguments (3 given)'):
             cache.get_or_set('brian', version=1)
         self.assertIsNone(cache.get('brian', version=1))
         self.assertEqual(cache.get_or_set('brian', 42, version=1), 42)


### PR DESCRIPTION
The check "if default is None" was causing an unconditional calculation of default value.

Behaviour before patch:

```python
def heavy_routine_whose_result_to_be_cached():
    return todays_weather_forecast_calculated

...
cache.set('todays_weather_forecast', heavy_routine_which_result_to_be_cached())
...
val = cache.get_or_set('todays_weather_forecast', heavy_routine_which_result_to_be_cached())  ## calculates 2nd time, which is unwanted behaviour
```
Trac ticket created -> https://code.djangoproject.com/ticket/26792#ticket