### PR TITLE
Removed a test workaround for some old GDAL 1.7.x versions.

### DIFF
--- a/tests/gis_tests/gdal_tests/test_ds.py
+++ b/tests/gis_tests/gdal_tests/test_ds.py
@@ -108,17 +108,11 @@ class DataSourceTest(unittest.TestCase):
                 self.assertEqual(source.nfld, len(layer.fields))
 
                 # Testing the layer's extent (an Envelope), and its properties
-                if source.driver == 'VRT' and (GDAL_VERSION >= (1, 7, 0) and GDAL_VERSION < (1, 7, 3)):
-                    # There's a known GDAL regression with retrieving the extent
-                    # of a VRT layer in versions 1.7.0-1.7.2:
-                    #  http://trac.osgeo.org/gdal/ticket/3783
-                    pass
-                else:
-                    self.assertIsInstance(layer.extent, Envelope)
-                    self.assertAlmostEqual(source.extent[0], layer.extent.min_x, 5)
-                    self.assertAlmostEqual(source.extent[1], layer.extent.min_y, 5)
-                    self.assertAlmostEqual(source.extent[2], layer.extent.max_x, 5)
-                    self.assertAlmostEqual(source.extent[3], layer.extent.max_y, 5)
+                self.assertIsInstance(layer.extent, Envelope)
+                self.assertAlmostEqual(source.extent[0], layer.extent.min_x, 5)
+                self.assertAlmostEqual(source.extent[1], layer.extent.min_y, 5)
+                self.assertAlmostEqual(source.extent[2], layer.extent.max_x, 5)
+                self.assertAlmostEqual(source.extent[3], layer.extent.max_y, 5)
 
                 # Now checking the field names.
                 flds = layer.fields


### PR DESCRIPTION
@sir-sigurd  @claudep, I spotted this and figured it's not needed anymore. It's assuming we want to keep support for GDAL 1.7 at all and not do a more thorough cleanup. GDAL 1.7.3 was released November 2010.