### PR TITLE
Fixed #26804 -- Added select_for_update() in update_or_create

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -347,6 +347,7 @@ answer newbie questions, and generally made Django that much better:
     Jeff Triplett <jeff.triplett@gmail.com>
     Jens Diemer <django@htfx.de>
     Jens Page
+    Jensen Cochran <jensen.cochran@gmail.com>
     Jeong-Min Lee <falsetru@gmail.com>
     Jérémie Blaser <blaserje@gmail.com>
     Jeremy Carbaugh <jcarbaugh@gmail.com>

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -1,10 +1,14 @@
 from __future__ import unicode_literals
 
+import time
 import traceback
-from datetime import date
+from datetime import date, datetime, timedelta
+from threading import Thread
 
 from django.db import DatabaseError, IntegrityError
-from django.test import TestCase, TransactionTestCase, ignore_warnings
+from django.test import (
+    TestCase, TransactionTestCase, ignore_warnings, skipUnlessDBFeature,
+)
 from django.utils.encoding import DjangoUnicodeDecodeError
 
 from .models import (
@@ -422,3 +426,53 @@ class UpdateOrCreateTests(TestCase):
         )
         self.assertIs(created, False)
         self.assertEqual(obj.last_name, 'NotHarrison')
+
+
+class UpdateOrCreateTransactionTests(TransactionTestCase):
+
+    available_apps = ['get_or_create']
+
+    @skipUnlessDBFeature('has_select_for_update')
+    @skipUnlessDBFeature('supports_transactions')
+    def test_updates_in_transaction(self):
+        """
+        Should select and update objects in a transaction to avoid race
+        conditions. This test basically forces update_or_create to hold the lock
+        in another thread for a relatively long time so that we can update
+        while it holds the lock.  The field we update is not a field in
+        'defaults', so update_or_create should have no effect on it.
+        """
+
+        def birthday_sleep():
+            time.sleep(0.3)
+            return date(1940, 10, 10)
+
+        def update_birthday_slowly():
+            Person.objects.update_or_create(
+                first_name='John', defaults={
+                    'birthday': birthday_sleep
+                }
+            )
+
+        # Create the person so that an update occurs instead of an insert
+        Person.objects.create(first_name='John', last_name='Lennon', birthday=date(1940, 10, 9))
+
+        # Perform the update_or_create in a separate thread
+        t = Thread(target=update_birthday_slowly)
+        before_start = datetime.now()
+        t.start()
+
+        # Wait for lock to begin
+        time.sleep(0.05)
+
+        # Update during lock
+        Person.objects.filter(first_name='John').update(last_name='NotLennon')
+        after_update = datetime.now()
+
+        # Wait for thread to finish
+        t.join()
+
+        # Make sure our update remains and our update blocked
+        updated_person = Person.objects.get(first_name='John')
+        self.assertGreater(after_update - before_start, timedelta(seconds=0.3))
+        self.assertEqual(updated_person.last_name, 'NotLennon')


### PR DESCRIPTION
Added a select_for_update() when retrieving the object in update_or_create
to avoid race conditions between when the object is retrieved and when
it is saved.