### PR TITLE
Fix #2131: support nginx X-Accel-Redirect feature with a simple view

### DIFF
--- a/django/views/static.py
+++ b/django/views/static.py
@@ -42,13 +42,11 @@ def serve(request, path, document_root=None, show_indexes=False):
     if newpath and path != newpath:
         return HttpResponseRedirect(newpath)
     fullpath = os.path.join(document_root, newpath)
-    if os.path.isdir(fullpath):
-        if show_indexes:
-            return directory_index(newpath, fullpath)
-        raise Http404(_("Directory indexes are not allowed here."))
-    if not os.path.exists(fullpath):
-        raise Http404(_('"%(path)s" does not exist') % {'path': fullpath})
-    return _make_response(request, fullpath)
+    is_dir = _check_path(fullpath, show_indexes)
+    if is_dir and show_indexes:
+        return directory_index(newpath, fullpath)
+    else:
+        return _make_response(request, fullpath)
 
 
 def _normalize_path(path):
@@ -67,6 +65,18 @@ def _normalize_path(path):
         newpath = os.path.join(newpath, part).replace('\\', '/')
 
     return newpath
+
+
+def _check_path(fullpath, show_indexes):
+    is_dir = os.path.isdir(fullpath)
+
+    if is_dir and not show_indexes:
+        raise Http404(_("Directory indexes are not allowed here."))
+
+    if not os.path.exists(fullpath):
+        raise Http404(_('"%(path)s" does not exist') % {'path': fullpath})
+
+    return is_dir
 
 
 def _make_response(request, fullpath):

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -38,17 +38,7 @@ def serve(request, path, document_root=None, show_indexes=False):
     """
     path = posixpath.normpath(unquote(path))
     path = path.lstrip('/')
-    newpath = ''
-    for part in path.split('/'):
-        if not part:
-            # Strip empty path components.
-            continue
-        drive, part = os.path.splitdrive(part)
-        head, part = os.path.split(part)
-        if part in (os.curdir, os.pardir):
-            # Strip '.' and '..' in path.
-            continue
-        newpath = os.path.join(newpath, part).replace('\\', '/')
+    newpath = _normalize_path(path)
     if newpath and path != newpath:
         return HttpResponseRedirect(newpath)
     fullpath = os.path.join(document_root, newpath)
@@ -72,6 +62,24 @@ def serve(request, path, document_root=None, show_indexes=False):
     if encoding:
         response["Content-Encoding"] = encoding
     return response
+
+
+def _normalize_path(path):
+    """Clean the path from unnecessary constructs like '.', '..', '//'."""
+    newpath = ''
+
+    for part in path.split('/'):
+        if not part:
+            # Strip empty path components.
+            continue
+        drive, part = os.path.splitdrive(part)
+        head, part = os.path.split(part)
+        if part in (os.curdir, os.pardir):
+            # Strip '.' and '..' in path.
+            continue
+        newpath = os.path.join(newpath, part).replace('\\', '/')
+
+    return newpath
 
 
 DEFAULT_DIRECTORY_INDEX_TEMPLATE = """

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -36,10 +36,8 @@ def serve(request, path, document_root=None, show_indexes=False):
     but if you'd like to override it, you can create a template called
     ``static/directory_index.html``.
     """
-    path = posixpath.normpath(unquote(path))
-    path = path.lstrip('/')
-    newpath = _normalize_path(path)
-    if newpath and path != newpath:
+    normpath, newpath = _normalize_path(path)
+    if newpath and normpath != newpath:
         return HttpResponseRedirect(newpath)
     fullpath = os.path.join(document_root, newpath)
     is_dir = _check_path(fullpath, show_indexes)
@@ -71,10 +69,8 @@ def nginx_serve(request, path, location=None, alias=None, show_indexes=False):
     For more details, see the xsendfile feature in nginx documentation:
     https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/
     """
-    path = posixpath.normpath(unquote(path))
-    path = path.lstrip('/')
-    newpath = _normalize_path(path)
-    if newpath and path != newpath:
+    normpath, newpath = _normalize_path(path)
+    if newpath and normpath != newpath:
         return HttpResponseRedirect(newpath)
     fullpath = os.path.join(alias, newpath)
     is_dir = _check_path(fullpath, show_indexes)
@@ -88,9 +84,11 @@ def nginx_serve(request, path, location=None, alias=None, show_indexes=False):
 
 def _normalize_path(path):
     """Clean the path from unnecessary constructs like '.', '..', '//'."""
+    normpath = posixpath.normpath(unquote(path))
+    normpath = normpath.lstrip('/')
     newpath = ''
 
-    for part in path.split('/'):
+    for part in normpath.split('/'):
         if not part:
             # Strip empty path components.
             continue
@@ -101,7 +99,7 @@ def _normalize_path(path):
             continue
         newpath = os.path.join(newpath, part).replace('\\', '/')
 
-    return newpath
+    return normpath, newpath
 
 
 def _check_path(fullpath, show_indexes):

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -11,7 +11,8 @@ import re
 import stat
 
 from django.http import (
-    FileResponse, Http404, HttpResponse, HttpResponseNotModified, HttpResponseRedirect
+    FileResponse, Http404, HttpResponse, HttpResponseNotModified,
+    HttpResponseRedirect,
 )
 from django.template import Context, Engine, TemplateDoesNotExist, loader
 from django.utils.http import http_date, parse_http_date

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -46,7 +46,7 @@ def serve(request, path, document_root=None, show_indexes=False):
     if is_dir and show_indexes:
         return directory_index(newpath, fullpath)
     else:
-        return _make_response(request, fullpath)
+        return _make_response(request, fullpath, FileResponse, open(fullpath, 'rb'))
 
 
 def _normalize_path(path):
@@ -79,7 +79,7 @@ def _check_path(fullpath, show_indexes):
     return is_dir
 
 
-def _make_response(request, fullpath):
+def _make_response(request, fullpath, response_class, content):
     statobj = os.stat(fullpath)
     # Respect the If-Modified-Since header.
     if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
@@ -87,7 +87,7 @@ def _make_response(request, fullpath):
         return HttpResponseNotModified()
     content_type, encoding = mimetypes.guess_type(fullpath)
     content_type = content_type or 'application/octet-stream'
-    response = FileResponse(open(fullpath, 'rb'), content_type=content_type)
+    response = response_class(content, content_type=content_type)
     response["Last-Modified"] = http_date(statobj.st_mtime)
     if stat.S_ISREG(statobj.st_mode):
         response["Content-Length"] = statobj.st_size

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -11,8 +11,7 @@ import re
 import stat
 
 from django.http import (
-    FileResponse, Http404, HttpResponse, HttpResponseNotModified,
-    HttpResponseRedirect,
+    FileResponse, Http404, HttpResponse, HttpResponseNotModified, HttpResponseRedirect
 )
 from django.template import Context, Engine, TemplateDoesNotExist, loader
 from django.utils.http import http_date, parse_http_date
@@ -51,7 +50,8 @@ def nginx_serve(request, path, location=None, alias=None, show_indexes=False):
     """
     Serve files with nginx "X-Accel-Redirect" header (you might know it as "X-Sendfile").
 
-    It works similarly as django.views.static.serve view. You have to specify 'location' and 'alias' keyword arguments
+    It works similarly as django.views.static.serve view.
+    You have to specify 'location' and 'alias' keyword arguments
     in the urlconf (which are corresponging to the appropriate nginx configuration directives)::
 
         from django.views.static import nginx_serve

--- a/docs/howto/deployment/webservers.txt
+++ b/docs/howto/deployment/webservers.txt
@@ -1,0 +1,41 @@
+==============================
+Serving files with a webserver
+==============================
+
+When you need to serve protected static files (e.g. user generated content, protected PDF files or other content) which
+requires Django's permission system to control who can download what, you still can efficiently serve them with your
+webserver. In this case Django would decide if the user can download the file (e.g. based on the user's permission,
+subscription or other means) and just tell the webserver at the end of the view or just simply forbid it. This feature
+is called more commonly as ``X-Sendfile`` feature.
+
+
+Configuring nginx for serving MEDIA files
+=========================================
+
+You can configure nginx to serve ``MEDIA`` files for only authenticated users. First you need a Django view which
+instructs nginx which file to send or just forbid if the user is not authenticated:
+
+.. code-block:: python
+
+    # urls.py
+    from django.conf.urls import url
+    from django.views.static import nginx_serve
+    from django.contrib.auth.decorators import login_required
+
+    urlpatterns = [
+        url(r'^admin/', admin.site.urls),
+        url(r'^protected-media/(?P<path>.*)$', login_required(nginx_serve),
+            {'location': '/protected/', alias': '/path/to/my/files/'})
+    ]
+
+
+Next, you need to configure nginx to serve the files Django tells it to::
+
+    location /protected/ {
+        internal;
+        alias   /path/to/my/files/;  # note the trailing slash
+    }
+
+The ``nginx_serve`` view does the same as ``django.views.static.serve`` expcept it sets the ``X-Accel-Redirect``
+header. For more explanation of this nginx feature, see it's documentation:
+https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -228,6 +228,7 @@ testing of Django applications:
   :doc:`Overview <howto/deployment/index>` |
   :doc:`WSGI servers <howto/deployment/wsgi/index>` |
   :doc:`Deploying static files <howto/static-files/deployment>` |
+  :doc:`Serving files with a webserver <howto/deployment/webservers>` |
   :doc:`Tracking code errors by email <howto/error-reporting>`
 
 The admin


### PR DESCRIPTION
Add support for nginx X-Accel-Redirect (known as X-Sendfile) feature by introducing a simple view which does everything the same way as `django.views.static.serve`.

First, I refactored the original `serve` view so I can reuse functionality and make it DRY.