### PR TITLE
Fix #25694: Fix incorrect _uniq suffix on indexes during migrations.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -692,7 +692,7 @@ class BaseDatabaseSchemaEditor(object):
         if (not old_field.db_index and new_field.db_index and
                 not new_field.unique and not
                 (not old_field.unique and new_field.unique)):
-            self.execute(self._create_index_sql(model, [new_field], suffix="_uniq"))
+            self.execute(self._create_index_sql(model, [new_field]))
         # Type alteration on primary key? Then we need to alter the column
         # referring to us.
         rels_to_update = []

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -12,6 +12,7 @@ new_apps = Apps()
 class Author(models.Model):
     name = models.CharField(max_length=255)
     height = models.PositiveIntegerField(null=True, blank=True)
+    weight = models.IntegerField(null=True, blank=True)
 
     class Meta:
         apps = new_apps

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1773,7 +1773,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Author, old_field, new_field, strict=True)
         self.assertEqual(
             self.get_constraints_for_column(Author, 'name'),
-            ['schema_author_name_1fbc5617_like', 'schema_author_name_1fbc5617_uniq']
+            ['schema_author_b068931c', 'schema_author_name_1fbc5617_like']
         )
         # Remove db_index=True to drop both indexes.
         with connection.schema_editor() as editor:
@@ -1794,7 +1794,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Note, old_field, new_field, strict=True)
         self.assertEqual(
             self.get_constraints_for_column(Note, 'info'),
-            ['schema_note_info_4b0ea695_like', 'schema_note_info_4b0ea695_uniq']
+            ['schema_note_caf9b6b9', 'schema_note_info_4b0ea695_like']
         )
         # Remove db_index=True to drop both indexes.
         with connection.schema_editor() as editor:
@@ -1858,6 +1858,29 @@ class SchemaTests(TransactionTestCase):
             self.get_constraints_for_column(Tag, 'slug'),
             ['schema_tag_slug_2c418ba3_like', 'schema_tag_slug_key']
         )
+
+    def test_alter_field_add_index_to_integerfield(self):
+        # Create the table and verify no initial indexes.
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        self.assertEqual(self.get_constraints_for_column(Author, 'weight'), [])
+
+        # Alter to add db_index=True and create index.
+        old_field = Author._meta.get_field('weight')
+        new_field = IntegerField(null=True, db_index=True)
+        new_field.set_attributes_from_name('weight')
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, old_field, new_field, strict=True)
+
+        expected = ['schema_author_7edabf99']
+        if connection.features.uppercases_column_names:
+            expected = [name.upper() for name in expected]
+        self.assertEqual(self.get_constraints_for_column(Author, 'weight'), expected)
+
+        # Remove db_index=True to drop index.
+        with connection.schema_editor() as editor:
+            editor.alter_field(Author, new_field, old_field, strict=True)
+        self.assertEqual(self.get_constraints_for_column(Author, 'weight'), [])
 
     def test_alter_pk_with_self_referential_field(self):
         """


### PR DESCRIPTION
<https://code.djangoproject.com/ticket/25694>