### PR TITLE
Fixed #25292 - str object has no attribute '_meta' crash in ManyToManyField.through_fields check

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1689,6 +1689,11 @@ class Model(six.with_metaclass(ModelBase)):
         for f in cls._meta.local_many_to_many:
             # Check if auto-generated name for the M2M field is too long
             # for the database.
+
+            # Skip nonexistent models.
+            if isinstance(f.remote_field.through, six.string_types):
+                continue
+
             for m2m in f.remote_field.through._meta.local_fields:
                 _, rel_name = m2m.get_attname_column()
                 if m2m.db_column is None and rel_name is not None and len(rel_name) > allowed_len:

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -307,6 +307,25 @@ class RelativeFieldTests(SimpleTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_missing_relationship_model_on_model_check(self):
+        class Person(models.Model):
+            pass
+
+        class Group(models.Model):
+            members = models.ManyToManyField('Person', through="MissingM2MModel")
+
+        model = Group
+        errors = model.check()
+        expected = [
+            Error(
+                "Field specifies a many-to-many relation through model "
+                "'MissingM2MModel', which has not been installed.",
+                obj=Group._meta.get_field('members'),
+                id='fields.E331',
+            ),
+        ]
+        self.assertEqual(errors, expected)
+
     @isolate_apps('invalid_models_tests')
     def test_many_to_many_through_isolate_apps_model(self):
         """


### PR DESCRIPTION
If we have string representing non-existing model in `through` parameter when defining many-to-many relationship, we have crash caused by `_check_long_column_names` method.

Tests are not failed because when we have sqltile configured as db there is no action taken about checking long names. But issue can be reproducible on different databases, such as MySQL for example.

That's why test are not included in this PR.
As @timgraham suggests I took solution similar to this https://github.com/django/django/commit/21130ce1a9c4fcbfce4c614be9e5408b43092bf0#diff-3010fc5a498b7171c342520f34507968R472

See https://code.djangoproject.com/ticket/25292 for details