### PR TITLE
Fixed #26671 -- Made HashedFilesMixin ignore the 'chrome' scheme.

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -162,8 +162,8 @@ class HashedFilesMixin(object):
             """
             matched, url = matchobj.groups()
 
-            # Ignore absolute/protocol-relative, fragments and data-uri URLs.
-            if url.startswith(('http:', 'https:', '//', '#', 'data:')):
+            # Ignore absolute/protocol-relative and data-uri URLs.
+            if re.match(r'^[a-z]+:', url):
                 return matched
 
             # Ignore absolute URLs that don't point to a static file (dynamic

--- a/tests/staticfiles_tests/project/documents/cached/css/ignored.css
+++ b/tests/staticfiles_tests/project/documents/cached/css/ignored.css
@@ -3,6 +3,7 @@ body {
     background: url("http:foobar");
     background: url("https:foobar");
     background: url("data:foobar");
+    background: url("chrome:foobar");
     background: url("//foobar");
 }
 

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -53,13 +53,14 @@ class TestHashedFiles(object):
 
     def test_path_ignored_completely(self):
         relpath = self.hashed_file_path("cached/css/ignored.css")
-        self.assertEqual(relpath, "cached/css/ignored.6c77f2643390.css")
+        self.assertEqual(relpath, "cached/css/ignored.554da52152af.css")
         with storage.staticfiles_storage.open(relpath) as relfile:
             content = relfile.read()
             self.assertIn(b'#foobar', content)
             self.assertIn(b'http:foobar', content)
             self.assertIn(b'https:foobar', content)
             self.assertIn(b'data:foobar', content)
+            self.assertIn(b'chrome:foobar', content)
             self.assertIn(b'//foobar', content)
 
     def test_path_with_querystring(self):


### PR DESCRIPTION
Fixed using schemes like `chrome://` and etc in static files.
Test provided.

See https://code.djangoproject.com/ticket/26671 for details