### PR TITLE
Fixed #10686 -- Added interpolation of 'class'/'verbose_name' in Meta.permissions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -248,6 +248,7 @@ answer newbie questions, and generally made Django that much better:
     Finn Gruwier Larsen <finn@gruwier.dk>
     flavio.curella@gmail.com
     Florian Apolloner <florian@apolloner.eu>
+    Forrest Aldridge <forrest.aldridge@gmail.com>
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
     Frank Tegtmeyer <fte@fte.to>
     Frank Wierzbicki

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -193,6 +193,16 @@ class Options(object):
             self.unique_together = normalize_together(self.unique_together)
             self.index_together = normalize_together(self.index_together)
 
+            # Replace any %(model_name)s / %(verbose_name)s placeholders.
+            perms = meta_attrs.pop('permissions', self.permissions)
+            interpolated_perms = []
+            if perms:
+                for codename, name in perms:
+                    codename %= {'class': self.model_name}
+                    name = name % {'verbose_name': self.verbose_name}
+                    interpolated_perms.append((codename, name))
+            self.permissions = interpolated_perms
+
             # verbose_name_plural is a special case because it uses a 's'
             # by default.
             if self.verbose_name_plural is None:

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -329,6 +329,30 @@ Django quotes column and table names behind the scenes.
     This is a list or tuple of 2-tuples in the format ``(permission_code,
     human_readable_permission_name)``.
 
+    The permission code and name on an (abstract) model may contain
+    ``%(class)s`` and ``%(verbose_name)s``. The models inheriting from the base
+    model will then have those permissions specific to the inheriting model,
+    e.g.::
+
+        class Base(models.Model):
+            ...
+
+            class Meta:
+                permissions = (
+                    ("can_deliver_%(class)s", "Can deliver %(verbose_name)"),
+                )
+
+
+        class Pizza(Base):
+            pass
+
+    The model ``Pizza`` now has the permissions ``can_deliver_pizza`` with the
+    label "Can deliver pizza".
+
+    .. versionadded:: 1.11
+
+        The ability to use ``%(class)s`` interpolation was added.
+
 ``default_permissions``
 ------------------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -216,6 +216,9 @@ Models
   to truncate :class:`~django.db.models.DateTimeField` to its time component
   and exposed it through the :lookup:`time` lookup.
 
+* :attr:`~django.db.models.Options.permissions` now supports class interpolation
+  using the ``'%(class)s'`` and ``'%(verbose_name)s'`` string.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -299,6 +299,34 @@ example, the following checks if a user may view tasks::
 
     user.has_perm('app.view_task')
 
+Custom permissions may contain the ``%(class)s`` and ``%(verbose_name)s``
+placeholders. Child models will then inherit the specific permission::
+
+    class BaseTask(models.Model):
+        ...
+        class Meta:
+            abstract = True
+            permissions = (
+                ("view_%(class)s", "Can view %(verbose_name)s"),
+            )
+
+
+    class Task(BaseTask):
+        ...
+        class Meta(BaseTask.Meta):
+            permissions = BaseTask.Meta.permissions + (
+                ("close_task", "Can remove a task by setting its status as closed"),
+            )
+
+
+The ``Task`` model will have two custom permissions: ``app.view_task`` and
+``app.close_task``.
+
+.. versionadded:: 1.11
+
+    Added ``%(class)s`` and ``%(verbose_name)s`` interpolation for custom
+    permissions.
+
 .. _extending-user:
 
 Extending the existing ``User`` model

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -155,6 +155,36 @@ class ModelInheritanceTests(TestCase):
 
         self.assertIs(C._meta.parents[A], C._meta.get_field('a'))
 
+    @isolate_apps('model_inheritance')
+    def test_permission_inheritance_abstract(self):
+        """
+        Abstract permissions with %class interpolation should become concrete
+        """
+        class A(models.Model):
+            class Meta:
+                app_label = 'model_inheritance'
+                abstract = True
+                permissions = [
+                    ('view_%(class)s', 'View %(verbose_name)s'),
+                ]
+
+        class B(A):
+            pass
+
+        class C(A):
+            class Meta(A.Meta):
+                app_label = 'model_inheritance'
+                permissions = A.Meta.permissions + [
+                    ('concrete_c_permission', 'Concrete C permission'),
+                ]
+
+        self.assertEqual(A._meta.permissions, [('view_a', 'View a')])
+        self.assertEqual(B._meta.permissions, [('view_b', 'View b')])
+        self.assertEqual(
+            C._meta.permissions,
+            [('view_c', 'View c'), ('concrete_c_permission', 'Concrete C permission')]
+        )
+
 
 class ModelInheritanceDataTests(TestCase):
     @classmethod


### PR DESCRIPTION
Allowed (base) models to specify generic permissions that become
specific for the children.

Thanks to faldridge for the report and initial patch, Soby for the
improved patch and derega for adding a test case.

---

This is the improved patch after processing the remarks on #6071, trac and the mailing list (https://groups.google.com/forum/#!topic/django-developers/imjaHrfk6Eo/discussion)
