### PR TITLE
Fixed #26827 -- Removed raisings of exceptions for modelstate.fields …

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -342,17 +342,6 @@ class ModelState(object):
                 raise ValueError(
                     'ModelState.fields cannot be bound to a model - "%s" is.' % name
                 )
-            # Sanity-check that relation fields are NOT referring to a model class.
-            if field.is_relation and hasattr(field.related_model, '_meta'):
-                raise ValueError(
-                    'ModelState.fields cannot refer to a model class - "%s.to" does. '
-                    'Use a string reference instead.' % name
-                )
-            if field.many_to_many and hasattr(field.remote_field.through, '_meta'):
-                raise ValueError(
-                    'ModelState.fields cannot refer to a model class - "%s.through" does. '
-                    'Use a string reference instead.' % name
-                )
 
     @cached_property
     def name_lower(self):

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -897,25 +897,6 @@ class ModelStateTests(SimpleTestCase):
         with self.assertRaisesMessage(ValueError, 'ModelState.fields cannot be bound to a model - "field" is.'):
             ModelState('app', 'Model', [('field', field)])
 
-    def test_sanity_check_to(self):
-        field = models.ForeignKey(UnicodeModel, models.CASCADE)
-        with self.assertRaisesMessage(
-            ValueError,
-            'ModelState.fields cannot refer to a model class - "field.to" does. '
-            'Use a string reference instead.'
-        ):
-            ModelState('app', 'Model', [('field', field)])
-
-    def test_sanity_check_through(self):
-        field = models.ManyToManyField('UnicodeModel')
-        field.remote_field.through = UnicodeModel
-        with self.assertRaisesMessage(
-            ValueError,
-            'ModelState.fields cannot refer to a model class - "field.through" does. '
-            'Use a string reference instead.'
-        ):
-            ModelState('app', 'Model', [('field', field)])
-
     def test_fields_immutability(self):
         """
         Tests that rendering a model state doesn't alter its internal fields.


### PR DESCRIPTION
Done during the Django sprint in Amsterdam (July 2 2016)