### PR TITLE
Refs #26709 -- Restructuring Index class and it's internals

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -316,17 +316,17 @@ class BaseDatabaseSchemaEditor(object):
             "table": self.quote_name(model._meta.db_table),
         })
 
-    def add_index(self, index):
+    def add_index(self, model, index):
         """
         Add an index on a model.
         """
-        self.execute(index.create_sql(self))
+        self.execute(index.create_sql(model, self))
 
-    def remove_index(self, index):
+    def remove_index(self, model, index):
         """
         Remove an index from a model.
         """
-        self.execute(index.remove_sql(self))
+        self.execute(index.remove_sql(model, self))
 
     def alter_unique_together(self, model, old_unique_together, new_unique_together):
         """

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -768,18 +768,17 @@ class AddIndex(IndexOperation):
 
     def state_forwards(self, app_label, state):
         model_state = state.models[app_label, self.model_name_lower]
-        self.index.model = state.apps.get_model(app_label, self.model_name)
         model_state.options[self.option_name].append(self.index)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
-            schema_editor.add_index(self.index)
+            schema_editor.add_index(model, self.index)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = from_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
-            schema_editor.remove_index(self.index)
+            schema_editor.remove_index(model, self.index)
 
     def deconstruct(self):
         kwargs = {
@@ -818,14 +817,14 @@ class RemoveIndex(IndexOperation):
         if self.allow_migrate_model(schema_editor.connection.alias, model):
             from_model_state = from_state.models[app_label, self.model_name_lower]
             index = from_model_state.get_index_by_name(self.name)
-            schema_editor.remove_index(index)
+            schema_editor.remove_index(model, index)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
             to_model_state = to_state.models[app_label, self.model_name_lower]
             index = to_model_state.get_index_by_name(self.name)
-            schema_editor.add_index(index)
+            schema_editor.add_index(model, index)
 
     def deconstruct(self):
         kwargs = {

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -772,10 +772,14 @@ class AddIndex(IndexOperation):
         model_state.options[self.option_name].append(self.index)
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        schema_editor.add_index(self.index)
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.add_index(self.index)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        schema_editor.remove_index(self.index)
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.remove_index(self.index)
 
     def deconstruct(self):
         kwargs = {
@@ -810,14 +814,18 @@ class RemoveIndex(IndexOperation):
         model_state.options[self.option_name] = [idx for idx in indexes if idx.name != self.name]
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        from_model_state = from_state.models[app_label, self.model_name_lower]
-        index = from_model_state.get_index_by_name(self.name)
-        schema_editor.remove_index(index)
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            from_model_state = from_state.models[app_label, self.model_name_lower]
+            index = from_model_state.get_index_by_name(self.name)
+            schema_editor.remove_index(index)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        to_model_state = to_state.models[app_label, self.model_name_lower]
-        index = to_model_state.get_index_by_name(self.name)
-        schema_editor.add_index(index)
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            to_model_state = to_state.models[app_label, self.model_name_lower]
+            index = to_model_state.get_index_by_name(self.name)
+            schema_editor.add_index(index)
 
     def deconstruct(self):
         kwargs = {

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -45,23 +45,23 @@ class Index(object):
             self._name = 'D%s' % self._name[1:]
         return errors
 
-    def create_sql(self, schema_editor):
-        fields = [self.model._meta.get_field(field) for field in self.fields]
-        tablespace_sql = schema_editor._get_index_tablespace_sql(self.model, fields)
+    def create_sql(self, model, schema_editor):
+        fields = [model._meta.get_field(field) for field in self.fields]
+        tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields)
         columns = [field.column for field in fields]
 
         quote_name = schema_editor.quote_name
         return schema_editor.sql_create_index % {
-            'table': quote_name(self.model._meta.db_table),
+            'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
             'columns': ', '.join(quote_name(column) for column in columns),
             'extra': tablespace_sql,
         }
 
-    def remove_sql(self, schema_editor):
+    def remove_sql(self, model, schema_editor):
         quote_name = schema_editor.quote_name
         return schema_editor.sql_delete_index % {
-            'table': quote_name(self.model._meta.db_table),
+            'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
         }
 

--- a/docs/ref/schema-editor.txt
+++ b/docs/ref/schema-editor.txt
@@ -67,6 +67,24 @@ unique constraints or indexes it requires.
 Drops the model's table in the database along with any unique constraints
 or indexes it has.
 
+``add_index()``
+---------------
+
+.. method:: BaseDatabaseSchemaEditor.add_index(model, index)
+
+.. versionadded:: 1.11
+
+Adds the index defined by the ``index`` argument to the table defined by ``model``.
+
+``remove_index()``
+------------------
+
+.. method:: BaseDatabaseSchemaEditor.remove_index(model, index)
+
+.. versionadded:: 1.11
+
+Removes the index defined by the ``index`` argument from the table defined by ``model``.
+
 ``alter_unique_together()``
 ---------------------------
 

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2347,3 +2347,23 @@ class SwappableOperationTests(OperationTestBase):
         with connection.schema_editor() as editor:
             operation.database_backwards("test_adfligsw", editor, new_state, project_state)
         self.assertTableNotExists("test_adfligsw_pony")
+
+    @override_settings(TEST_SWAP_MODEL="migrations.SomeFakeModel")
+    def test_indexes_ignore_swapped(self):
+        """
+        Test Add/RemoveIndex operations ignore swapped models.
+        """
+        # Test for AddIndex
+        operation = migrations.AddIndex("Pony", models.Index(fields=["pink"], name='my_name_idx'))
+        project_state, new_state = self.make_test_state("test_adinigsw", operation)
+        with connection.schema_editor() as editor:
+            # No database queries should be run for swapped models
+            operation.database_forwards("test_adinigsw", editor, project_state, new_state)
+            operation.database_backwards("test_adinigsw", editor, new_state, project_state)
+        # Test for RemoveIndex
+        operation = migrations.RemoveIndex("Pony", models.Index(fields=["pink"], name='my_name_idx'))
+        project_state, new_state = self.make_test_state("test_rminigsw", operation)
+        with connection.schema_editor() as editor:
+            # No queries should be run on database for swapped models
+            operation.database_forwards("test_rminigsw", editor, project_state, new_state)
+            operation.database_backwards("test_rminigsw", editor, new_state, project_state)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1455,13 +1455,12 @@ class SchemaTests(TransactionTestCase):
         self.assertNotIn('title', self.get_indexes(Author._meta.db_table))
         # Add the index
         index = Index(fields=['name'], name='author_title_idx')
-        index.model = Author
         with connection.schema_editor() as editor:
-            editor.add_index(index)
+            editor.add_index(Author, index)
         self.assertIn('name', self.get_indexes(Author._meta.db_table))
         # Drop the index
         with connection.schema_editor() as editor:
-            editor.remove_index(index)
+            editor.remove_index(Author, index)
         self.assertNotIn('name', self.get_indexes(Author._meta.db_table))
 
     def test_indexes(self):


### PR DESCRIPTION
This commit
 * removes the dependency of the `Index` class on it's `model` attribute when a `name` is explicitly passed to it. The signatures of `SchemaEditor` methods `add_index` and `remove_index` have been changed for that.
 * makes it necessary for the index name to be passed to the `AddIndex` migration as it is supposed to be a part of the deconstructed form of the migration.
 * adds docs for the `SchemaEditor`'s `add_index` and `remove_index` methods.

This PR aims to stabilise the newly added `Index` API and it's migrations. @markush - as per our earlier discussions.