### PR TITLE
Fixed #26615 -- Password reset token now depends on user's email.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -359,6 +359,11 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         "Returns the short name for the user."
         return self.first_name
 
+    def get_hash_value(self, timestamp):
+        # Class now has email field and hash should depend on it
+        hash_value = super(AbstractUser, self).get_hash_value(timestamp)
+        return hash_value + self.email
+
     def email_user(self, subject, message, from_email=None, **kwargs):
         """
         Sends an email to this User.

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from django.conf import settings
-from django.utils import six
 from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.http import base36_to_int, int_to_base36
 
@@ -59,17 +58,9 @@ class PasswordResetTokenGenerator(object):
 
         hash = salted_hmac(
             self.key_salt,
-            self._make_hash_value(user, timestamp),
+            user.get_hash_value(timestamp),
         ).hexdigest()[::2]
         return "%s-%s" % (ts_b36, hash)
-
-    def _make_hash_value(self, user, timestamp):
-        # Ensure results are consistent across DB backends
-        login_timestamp = '' if user.last_login is None else user.last_login.replace(microsecond=0, tzinfo=None)
-        return (
-            six.text_type(user.pk) + user.password +
-            six.text_type(login_timestamp) + six.text_type(timestamp)
-        )
 
     def _num_days(self, dt):
         return (dt - date(2001, 1, 1)).days

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1577,6 +1577,11 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
         same variables that :func:`~django.contrib.auth.views.password_reset`
         passes to its email context.
 
+        .. note::
+            The password reset link includes the user's email address when generating the link. If
+            the user's email is changed after the link has been generated then the link will no longer work.
+            You can change this behaviour when using AbstractUser by overriding the .get_hash_value() method.
+
 .. class:: SetPasswordForm
 
     A form that lets a user change their password without entering the old

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -32,6 +32,22 @@ class TokenGeneratorTest(TestCase):
         tk2 = p0.make_token(reload)
         self.assertEqual(tk1, tk2)
 
+    def test_token_invalid_on_email_change(self):
+        """
+        Ensure that the token generated for a user will fail if that user
+        changes email addresses.
+        """
+        # See ticket #26615
+        username = 'changeemailuser'
+        user = User.objects.create_user(username, 'test4@example.com', 'testpw')
+        p0 = PasswordResetTokenGenerator()
+        tk1 = p0.make_token(user)
+        user.email = 'test4newemail@example.com'
+        user.save()
+        user_new_email = User.objects.get(username=username)
+        tk2 = p0.make_token(user_new_email)
+        self.assertNotEqual(tk1, tk2)
+
     def test_timeout(self):
         """
         Ensure we can use the token after n days, but no greater.


### PR DESCRIPTION
Also refactored user's hash generation into methods on User and
AbstractUser so that PasswordResetTokenGenerator doesn't need to
know which fields are available.

Added documentation to auth/default to highlight user email being
used in password reset hash

Based on work of @SilasX in pull request https://github.com/django/django/pull/6621.  This provides the missing documentation and squashes his commits.