### PR TITLE
Fixed #26739 -- Made reverse RemoveField handle non-nullable columns

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -178,8 +178,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         def altered_table_name(model, temporary_table_name):
             original_table_name = model._meta.db_table
             model._meta.db_table = temporary_table_name
-            yield
-            model._meta.db_table = original_table_name
+            try:
+                yield
+            finally:
+                model._meta.db_table = original_table_name
 
         with altered_table_name(model, model._meta.db_table + "__old"):
             # Rename the old table to make way for the new

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1126,10 +1126,14 @@ class OperationTests(OperationTestBase):
             operation.database_forwards("test_rmflnn", editor, project_state, new_state)
 
         # And test reversal
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                with connection.schema_editor() as editor:
-                    operation.database_backwards("test_rmflnn", editor, new_state, project_state)
+
+        # MySQL populates NOT NULL cols with implicit defaults instead of raising an error.
+        if connection.vendor != 'mysql':
+            with self.assertRaises(IntegrityError):
+                with transaction.atomic():
+                    with connection.schema_editor() as editor:
+                        operation.database_backwards("test_rmflnn", editor, new_state, project_state)
+
         operation.default = 42
         with connection.schema_editor() as editor:
             operation.database_backwards("test_rmflnn", editor, new_state, project_state)


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/26739

Thanks @Gagaro for the report and @apollo13 for the initial patch
and pair programming.
