### PR TITLE
Refs #25251: update settings.SERIALIZE description related to --keepdb issue.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -747,7 +747,9 @@ Boolean value to control whether or not the default test runner serializes the
 database into an in-memory JSON string before running tests (used to restore
 the database state between tests if you don't have transactions). You can set
 this to ``False`` to speed up creation time if you don't have any test classes
-with :ref:`serialized_rollback=True <test-case-serialized-rollback>`.
+with :ref:`serialized_rollback=True <test-case-serialized-rollback>` and don't
+want to keep the pre-test database state at the end of the tests (
+:option:`--keepdb <test --keepdb>` option).
 
 .. setting:: TEST_CREATE
 


### PR DESCRIPTION
Using `SERIALIZE = False` prevents tests with `serialize_rollback = True` to work as expected, and is described in the documentation.
But it will also prevent the `--keepdb` option to properly keep the serialized initia data at the end of the test suite.
This PR is updating the documentation according to this, and is related to some discussions with @timgraham in #6297.
