### PR TITLE
Added clipboard support to tutorial's code snippets

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -110,7 +110,7 @@ def visit_snippet(self, node):
                                                    linenos=linenos,
                                                    **highlight_args)
     starttag = self.starttag(node, 'div', suffix='',
-                             CLASS='highlight-%s' % lang)
+                             CLASS='highlight-%s snippet' % lang)
     self.body.append(starttag)
     self.body.append('<div class="snippet-filename">%s</div>\n''' % (fname,))
     self.body.append(highlighted)


### PR DESCRIPTION
This works in tandem with django/djangoproject.com#678 to add a "copy to clipboard" icon on the tutorial's code snippets (only those with a filename for now).