### PR TITLE
Fixed #26761 Added tooltip for custom field in admin changelist view

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -857,6 +857,16 @@ class ModelAdmin(BaseModelAdmin):
             # Use only the first item in list_display as link
             return list(list_display)[:1]
 
+    def get_field_help_text(self, field_name):
+        """
+        Return the help text property of a custom field defined in the
+        list_display parameter.
+        """
+        if field_name in self.list_display:
+            method = getattr(self, field_name, None)
+            if method:
+                return getattr(method, 'help_text', None)
+
     def get_list_filter(self, request):
         """
         Returns a sequence containing the fields to be displayed as filters in

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -10,7 +10,7 @@
 <thead>
 <tr>
 {% for header in result_headers %}
-<th scope="col" {{ header.class_attrib }}>
+<th scope="col" {{ header.class_attrib }}{% if header.help_text %} title="{{ header.help_text }}"{% endif %}>
    {% if header.sortable %}
      {% if header.sort_priority > 0 %}
        <div class="sortoptions">

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -122,6 +122,7 @@ def result_headers(cl):
                 # Not sortable
                 yield {
                     "text": text,
+                    "help_text": cl.model_admin.get_field_help_text(field_name),
                     "class_attrib": format_html(' class="column-{}"', field_name),
                     "sortable": False,
                 }
@@ -168,6 +169,7 @@ def result_headers(cl):
 
         yield {
             "text": text,
+            "help_text": cl.model_admin.get_field_help_text(field_name),
             "sortable": True,
             "sorted": sorted,
             "ascending": order_type == "asc",

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -591,6 +591,17 @@ subclass::
           class PersonAdmin(admin.ModelAdmin):
               list_display = ('name', 'decade_born_in')
 
+    .. note::
+
+        You can set a ``help_text`` property to any callable used in
+        ``list_display``. This property will be shown as a tooltip in
+        the changelist view. For example::
+
+            def decade_born_in(self):
+                return self.birthday.strftime('%Y')[:3] + "0's"
+            decade_born_in.short_description = 'Birth decade'
+            decade_born_in.help_text = 'This is a tooltip.'
+
     A few special cases to note about ``list_display``:
 
     * If the field is a ``ForeignKey``, Django will display the

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -55,6 +55,9 @@ Minor features
 
 * :attr:`.ModelAdmin.date_hierarchy` can now reference fields across relations.
 
+* A ``help_text`` property set to a callable used in :attr:`.ModelAdmin.list_display`
+  is now displayed as a tooltip in the changelist view.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -841,6 +841,7 @@ Tomek
 toolbar
 toolkits
 toolset
+tooltip
 trac
 tracebacks
 transactional


### PR DESCRIPTION
Fixed ticket #26761 (Cf. https://code.djangoproject.com/ticket/26761)

A help_text property can be set for a custom field defined
in ModelAdmin.list_display. This property is displayed as a
tooltip on hover in the change list page of the admin.
