### PR TITLE
Fixed AcmeBookList publisher name case to match note

### DIFF
--- a/docs/topics/class-based-views/generic-display.txt
+++ b/docs/topics/class-based-views/generic-display.txt
@@ -290,7 +290,7 @@ technique::
     class AcmeBookList(ListView):
 
         context_object_name = 'book_list'
-        queryset = Book.objects.filter(publisher__name='Acme Publishing')
+        queryset = Book.objects.filter(publisher__name='ACME Publishing')
         template_name = 'books/acme_list.html'
 
 Notice that along with a filtered ``queryset``, we're also using a custom


### PR DESCRIPTION
The name field on Publisher is a case-sensitive CharField.  The example code filtered against 'Acme Publishing', but the note below it said to create 'ACME Publishing'.