### PR TITLE
Fixed #26822 -- Recreate database clones when using keepdb option

### DIFF
--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -26,8 +26,6 @@ class DatabaseCreation(BaseDatabaseCreation):
             try:
                 cursor.execute("CREATE DATABASE %s" % qn(target_database_name))
             except Exception as e:
-                if keepdb:
-                    return
                 try:
                     if verbosity >= 1:
                         print("Destroying old test database for alias %s..." % (

--- a/django/db/backends/postgresql/creation.py
+++ b/django/db/backends/postgresql/creation.py
@@ -28,8 +28,6 @@ class DatabaseCreation(BaseDatabaseCreation):
                 cursor.execute("CREATE DATABASE %s WITH TEMPLATE %s" % (
                     qn(target_database_name), qn(source_database_name)))
             except Exception as e:
-                if keepdb:
-                    return
                 try:
                     if verbosity >= 1:
                         print("Destroying old test database for alias %s..." % (

--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -70,8 +70,6 @@ class DatabaseCreation(BaseDatabaseCreation):
         if not self.connection.is_in_memory_db(source_database_name):
             # Erase the old test database
             if os.access(target_database_name, os.F_OK):
-                if keepdb:
-                    return
                 if verbosity >= 1:
                     print("Destroying old test database for alias %s..." % (
                         self._get_database_display_str(verbosity, target_database_name),


### PR DESCRIPTION
This PR is related to this ticket https://code.djangoproject.com/ticket/26822 and proposes a solution to handle new migrations when options `--keepdb` and `--parallel` are used at the same time.

I wanted to see if we could apply migrations with `migrate` on cloned databases, but it seems that Django is not initialising the clones on the standard way, but with specific features (file copy for sqlite, database template for PostgreSQL, sqldump for MySQL).
Using a more "conventional" way to initialise these clones databases would imply:
- A quite massive refactoring,
- A longer cloned database time creation.
And it would make sense only when both options (`keepdb` and `parallel`) are used at the same time.

At the meantime, I propose to recreate the clones, even with `keepdb` option, so that adding new migrations and running the tests still works.
If we stay with this solution, we probably have to add some documentation around `keepdb` option and/or `parallel` one to explain this behaviour.
