### PR TITLE
Fixed #26067 -- Allowed ordering with StringAgg and ArrayAgg.

### DIFF
--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -5,7 +5,43 @@ __all__ = [
 ]
 
 
-class ArrayAgg(Aggregate):
+class OrderableAgg(Aggregate):
+    template = "%(function)s(%(expressions)s %(ordering)s)"
+
+    def __init__(self, expression, ordering=None, **extra):
+        super(OrderableAgg, self).__init__(
+            expression,
+            ordering=ordering,
+            **extra
+        )
+
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False,
+                           for_save=False):
+        # resolve the ordering if it's there
+        ordering = self.extra.pop('ordering', None)
+        if ordering is not None:
+            parsed_ordering = self._parse_expressions(ordering)[0]
+            resolved_ordering = parsed_ordering.resolve_expression(query, allow_joins, reuse,
+                                                                   summarize)
+
+            self.extra['ordering'] = resolved_ordering
+
+        return super(OrderableAgg, self).resolve_expression(query, allow_joins, reuse, summarize,
+                                                            for_save)
+
+    def as_sql(self, compiler, connection):
+        # turn ordering parameter to ORDER BY sql clause
+        if 'ordering' in self.extra:
+            sqled_ordering, _ = self.extra['ordering'].as_sql(compiler, connection)
+            self.extra['ordering'] = 'ORDER BY ' + sqled_ordering
+        else:
+            self.extra['ordering'] = ''
+
+        (formatted, params) = super(OrderableAgg, self).as_sql(compiler, connection)
+        return (formatted, params)
+
+
+class ArrayAgg(OrderableAgg):
     function = 'ARRAY_AGG'
 
     def convert_value(self, value, expression, connection, context):
@@ -30,9 +66,9 @@ class BoolOr(Aggregate):
     function = 'BOOL_OR'
 
 
-class StringAgg(Aggregate):
+class StringAgg(OrderableAgg):
     function = 'STRING_AGG'
-    template = "%(function)s(%(distinct)s%(expressions)s, '%(delimiter)s')"
+    template = "%(function)s(%(distinct)s%(expressions)s, '%(delimiter)s'%(ordering)s)"
 
     def __init__(self, expression, delimiter, distinct=False, **extra):
         distinct = 'DISTINCT ' if distinct else ''

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -18,13 +18,40 @@ These functions are described in more detail in the `PostgreSQL docs
 
 General-purpose aggregation functions
 =====================================
+``OrderableAgg``
+----------------
+
+.. class: OrderableAgg(expression, ordering=None, **extra)
+
+    .. versionadded:: 1.11
+
+    Base class for aggregates that are orderable. Some aggregates, such as
+    ``ArrayAgg``, return all elements in aggregation. When the ``ordering``
+    parameter is specified, the elements are returned after ordering.
+
+    .. attribute:: ordering
+
+        When an ``ordering`` expression, e.g. ``F('some_field').desc()``, is
+        specified, the elements composing the aggregation are ordered before
+        composition.
 
 ``ArrayAgg``
 ------------
 
-.. class:: ArrayAgg(expression, **extra)
+.. class:: ArrayAgg(expression, ordering=None, **extra)
 
     Returns a list of values, including nulls, concatenated into an array.
+    Ordering within the array is unspecified by default. Has one optional
+    parameter:
+
+    .. attribute:: ordering
+
+        .. versionadded:: 1.11
+
+        By default the ordering of elements within the returned list is
+        unspecified.  When an ``ordering`` expression
+        (``F('some_field).asc()``) is provided, the elements in the returned
+        list are ordered by expression.
 
 ``BitAnd``
 ----------
@@ -61,10 +88,12 @@ General-purpose aggregation functions
 ``StringAgg``
 -------------
 
-.. class:: StringAgg(expression, delimiter, distinct=False)
+.. class:: StringAgg(expression, delimiter, distinct=False, ordering=None)
 
-    Returns the input values concatenated into a string, separated by
-    the ``delimiter`` string.
+    Returns the input values concatenated into a string, separated by the
+    ``delimiter`` string. Ordering of the elements in the aggregation is
+    unspecified by default:
+
 
     .. attribute:: delimiter
 
@@ -76,6 +105,16 @@ General-purpose aggregation functions
 
         An optional boolean argument that determines if concatenated values
         will be distinct. Defaults to ``False``.
+
+    .. attribute:: ordering
+
+        .. versionadded:: 1.11
+
+        By default the ordering of the elements that form the string is
+        unspecified. When an ``ordering`` expression (e.g.
+        ``F('some_field').desc()``) is provided, these elements are
+        concatenated in the specified order.
+
 
 Aggregate functions for statistics
 ==================================


### PR DESCRIPTION
Added OrderableAgg base class for aggregates that allow for ordering input before aggregation,
such as Postgres' string_agg() and array_agg().

An 'ordering' element is added to the 'extra' parameter. It is parsed and resolved in
OrderableAggs 'resolve_expression'.

The actual 'ORDER BY' clause is formed in OrderableAggs 'as_sql' to ensure this parameter contains
well-formed SQL.

Add ordering to StringAgg and ArrayAgg

By inheriting from the novel OrderableAgg, these aggregations now allow ordering inputs prior to
aggregation.