### PR TITLE
Fixed #25461: Handling class inheritance for meta API backward code examples

### DIFF
--- a/docs/ref/models/meta.txt
+++ b/docs/ref/models/meta.txt
@@ -215,7 +215,8 @@ can be made to convert your code to the new API:
 
       [
           f for f in MyModel._meta.get_fields()
-          if (f.one_to_many or f.one_to_one) and f.auto_created
+          if (f.one_to_many or f.one_to_one)
+          and f.auto_created and not f.concrete
       ]
 
 * ``MyModel._meta.get_all_related_objects_with_model()`` becomes::
@@ -223,7 +224,8 @@ can be made to convert your code to the new API:
       [
           (f, f.model if f.model != MyModel else None)
           for f in MyModel._meta.get_fields()
-          if (f.one_to_many or f.one_to_one) and f.auto_created
+          if (f.one_to_many or f.one_to_one)
+          and f.auto_created and not f.concrete
       ]
 
 * ``MyModel._meta.get_all_related_many_to_many_objects()`` becomes::


### PR DESCRIPTION
In case of inherited classes, `get_all_related_objects` and `get_all_related_objects_with_model`
were, in the old internal API, not returning the `OneToOneField` auto-created by Django to handle this inheritance.
But the examples given to help people to go through this transition smoothly are not
equivalent for these 2 functions.

The idea is now to also check that the returned fields are not concrete to avoid this difference
(original idea from ad-65 in related [ticket](https://code.djangoproject.com/ticket/25461)).