### PR TITLE
Fixed #26749 -- Preserved behavior of use_for_related_field during deprecation.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -106,8 +106,7 @@ class ForwardManyToOneDescriptor(object):
     def get_queryset(self, **hints):
         related_model = self.field.remote_field.model
 
-        if (not related_model._meta.base_manager_name and
-                getattr(related_model._default_manager, 'use_for_related_fields', False)):
+        if (getattr(related_model._default_manager, 'use_for_related_fields', False)):
             if not getattr(related_model._default_manager, 'silence_use_for_related_fields_deprecation', False):
                 warnings.warn(
                     "use_for_related_fields is deprecated, instead "
@@ -292,8 +291,7 @@ class ReverseOneToOneDescriptor(object):
     def get_queryset(self, **hints):
         related_model = self.related.related_model
 
-        if (not related_model._meta.base_manager_name and
-                getattr(related_model._default_manager, 'use_for_related_fields', False)):
+        if (getattr(related_model._default_manager, 'use_for_related_fields', False)):
             if not getattr(related_model._default_manager, 'silence_use_for_related_fields_deprecation', False):
                 warnings.warn(
                     "use_for_related_fields is deprecated, instead "

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -1091,6 +1091,12 @@ class to override the manager from the concrete model, or you'll set the
 model's ``Meta.manager_inheritance_from_future=True`` option to opt-in to the
 new inheritance behavior.
 
+During the deprecation period, ``use_for_related_fields`` will be
+honored and raise a warning, even if a ``base_manager_name`` is set. This
+allows third-party code to preserve legacy behavior while transitioning
+to the new API. The warning can be silenced by setting
+``silence_use_for_related_fields_deprecation = True`` on the manager.
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
Follow-up of #6825.

* Updates test cases
* Adjusts deprecation warning texts
* Adds corner case addressed by #6825, providing a workaround for [ticket 26749](https://code.djangoproject.com/ticket/26749)

As it's intended to be a temporary workaround for v1.10, I based the change on top of `stable.1.10.x`, but I can move it back to `master` if needed. I can also merge the two commits.