### PR TITLE
Fixed #26837 -- Updated ModelMultipleChoiceField docs

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1207,13 +1207,19 @@ method::
     Allows the selection of one or more model objects, suitable for
     representing a many-to-many relation. As with :class:`ModelChoiceField`,
     you can use ``label_from_instance`` to customize the object
-    representations, and ``queryset`` is a required parameter:
+    representations.
+
+    A single argument is required:
 
     .. attribute:: queryset
 
-        A ``QuerySet`` of model objects from which the choices for the
-        field will be derived, and which will be used to validate the
-        user's selection.
+        See :class:`ModelChoiceField.queryset` for more information.
+
+    Also has one optional argument:
+
+    .. attribute:: to_field_name
+
+        See :class:`ModelChoiceField.to_field_name` for more information.
 
 Creating custom fields
 ======================


### PR DESCRIPTION
Added a note in the ModelMultipleChoiceField docs that
mentions support for the to_field_name parameter.

- Documented support for to_field_name parameter
- Linked to_field_name docs from ModelChoiceField

Changes:

- ref/forms/fields.txt

Notes:
The to_field_name parameter is tested for both ModelChoiceField and ModelMultipleChoiceField in the [OtherModelFormTests class](https://github.com/django/django/blob/c9ae09addffb839403312131d4251e9d8b454508/tests/model_forms/tests.py#L2404). I don't think it requires any new tests.