### PR TITLE
Fixed #26868 -- Change MySQL version detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -463,6 +463,7 @@ answer newbie questions, and generally made Django that much better:
     Marcin Wróbel
     Marc Remolt <m.remolt@webmasters.de>
     Marc Tamlyn <marc.tamlyn@gmail.com>
+    Marc-Aurèle Brothier <ma.brothier@gmail.com>
     Marian Andre <django@andre.sk>
     Marijn Vriens <marijn@metronomo.cl>
     Mario Gonzalez <gonzalemario@gmail.com>

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -369,8 +369,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     @cached_property
     def mysql_version(self):
-        with self.temporary_connection():
-            server_info = self.connection.get_server_info()
+        with self.temporary_connection() as cur:
+            cur.execute("SELECT VERSION()")
+            server_info = cur.fetchone()[0]
         match = server_version_re.match(server_info)
         if not match:
             raise Exception('Unable to determine MySQL version from version string %r' % server_info)


### PR DESCRIPTION
Change how the server version is retrieved to handle a bug with mariadb and mysql native client not stripping the `5.5.5-` prefix.