### PR TITLE
Fixed #26891 -- Fixed lookup registration for ForeignObject

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import inspect
 import warnings
 from functools import partial
 
@@ -17,6 +18,7 @@ from django.utils import six
 from django.utils.deprecation import RemovedInDjango20Warning
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property, curry
+from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 from django.utils.version import get_docs_version
 
@@ -731,26 +733,13 @@ class ForeignObject(RelatedField):
         pathinfos = [PathInfo(from_opts, opts, (opts.pk,), self.remote_field, not self.unique, False)]
         return pathinfos
 
-    def get_lookup(self, lookup_name):
-        if lookup_name == 'in':
-            return RelatedIn
-        elif lookup_name == 'exact':
-            return RelatedExact
-        elif lookup_name == 'gt':
-            return RelatedGreaterThan
-        elif lookup_name == 'gte':
-            return RelatedGreaterThanOrEqual
-        elif lookup_name == 'lt':
-            return RelatedLessThan
-        elif lookup_name == 'lte':
-            return RelatedLessThanOrEqual
-        elif lookup_name == 'isnull':
-            return RelatedIsNull
-        else:
-            raise TypeError('Related Field got invalid lookup: %s' % lookup_name)
-
-    def get_transform(self, *args, **kwargs):
-        raise NotImplementedError('Relational fields do not support transforms.')
+    @classmethod
+    @lru_cache(maxsize=None)
+    def get_lookups(cls):
+        bases = inspect.getmro(cls)
+        bases = bases[:bases.index(ForeignObject) + 1]
+        class_lookups = [parent.__dict__.get('class_lookups', {}) for parent in bases]
+        return cls.merge_dicts(class_lookups)
 
     def contribute_to_class(self, cls, name, private_only=False, **kwargs):
         super(ForeignObject, self).contribute_to_class(cls, name, private_only=private_only, **kwargs)
@@ -766,6 +755,14 @@ class ForeignObject(RelatedField):
             # model load time.
             if self.remote_field.limit_choices_to:
                 cls._meta.related_fkey_lookups.append(self.remote_field.limit_choices_to)
+
+ForeignObject.register_lookup(RelatedIn)
+ForeignObject.register_lookup(RelatedExact)
+ForeignObject.register_lookup(RelatedLessThan)
+ForeignObject.register_lookup(RelatedGreaterThan)
+ForeignObject.register_lookup(RelatedGreaterThanOrEqual)
+ForeignObject.register_lookup(RelatedLessThanOrEqual)
+ForeignObject.register_lookup(RelatedIsNull)
 
 
 class ForeignKey(ForeignObject):

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models.constants import LOOKUP_SEP
 from django.utils import tree
+from django.utils.lru_cache import lru_cache
 
 # PathInfo is used when converting lookups (fk__somecol). The contents
 # describe the relation in Model terms (model Options and Fields for both
@@ -25,6 +26,15 @@ class InvalidQuery(Exception):
     The query passed to raw isn't a safe query to use with raw.
     """
     pass
+
+
+def subclasses(cls):
+    yield cls
+    # Python 2 lacks 'yield from', which could replace the inner loop
+    for subclass in cls.__subclasses__():
+        # yield from subclasses(subclass)
+        for item in subclasses(subclass):
+            yield item
 
 
 class QueryWrapper(object):
@@ -132,20 +142,16 @@ class DeferredAttribute(object):
 
 
 class RegisterLookupMixin(object):
-    def _get_lookup(self, lookup_name):
-        try:
-            return self.class_lookups[lookup_name]
-        except KeyError:
-            # To allow for inheritance, check parent class' class_lookups.
-            for parent in inspect.getmro(self.__class__):
-                if 'class_lookups' not in parent.__dict__:
-                    continue
-                if lookup_name in parent.class_lookups:
-                    return parent.class_lookups[lookup_name]
-        except AttributeError:
-            # This class didn't have any class_lookups
-            pass
-        return None
+
+    @classmethod
+    def _get_lookup(cls, lookup_name):
+        return cls.get_lookups().get(lookup_name, None)
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def get_lookups(cls):
+        class_lookups = [parent.__dict__.get('class_lookups', {}) for parent in inspect.getmro(cls)]
+        return cls.merge_dicts(class_lookups)
 
     def get_lookup(self, lookup_name):
         from django.db.models.lookups import Lookup
@@ -165,6 +171,22 @@ class RegisterLookupMixin(object):
             return None
         return found
 
+    @staticmethod
+    def merge_dicts(dicts):
+        """
+        Merge dicts in reverse to preference the order of the original list. e.g.,
+        merge_dicts([a, b]) will preference the keys in 'a' over those in 'b'.
+        """
+        merged = {}
+        for d in reversed(dicts):
+            merged.update(d)
+        return merged
+
+    @classmethod
+    def _clear_cached_lookups(cls):
+        for subclass in subclasses(cls):
+            subclass.get_lookups.cache_clear()
+
     @classmethod
     def register_lookup(cls, lookup, lookup_name=None):
         if lookup_name is None:
@@ -172,6 +194,7 @@ class RegisterLookupMixin(object):
         if 'class_lookups' not in cls.__dict__:
             cls.class_lookups = {}
         cls.class_lookups[lookup_name] = lookup
+        cls._clear_cached_lookups()
         return lookup
 
     @classmethod

--- a/tests/custom_lookups/models.py
+++ b/tests/custom_lookups/models.py
@@ -13,6 +13,10 @@ class Author(models.Model):
         return self.name
 
 
+class Article(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+
+
 @python_2_unicode_compatible
 class MySQLUnixTimestamp(models.Model):
     timestamp = models.PositiveIntegerField()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26891

Update - just recapping the current state of the PR:

### Implementation:
The scope has expanded a bit. In fixing the original lookup registration issue, it was necessary to add `get_lookups()` to the registration API.

- `get_lookups()` simply returns the merged set of `class_lookups` in a field's class hierarchy. 
- For performance reasons, the lookups are cached on the field as `cached_lookups`. 
- Similar to registering lookups, `cached_lookups` are checked on the `cls.__dict__`. This prevents DateTimeField from accidentally using `Field.cached_lookups`, which wouldn't include the date transforms.
- `register_lookup()` will bust the cached lookups on a field and any of its subclasses. e.g., `ForeignObject.register_lookup()` would bust the cache of ForeignObject, ForeignKey, OneToOneField, etc...
- `ForeignObject.get_lookups()` only caches `class_lookups` up to it's position in the class hierarchy, excluding the lookups registered to Field.

### Performance tests:
Used timeit to time `field.get_lookup('in')` for different fields, comparing the current master to the PR. 100,000 iterations per run, 5 runs per field.

**master branch:**
```
CharField       average: 0.2338s [0.2377979755401611, 0.2334151268005371, 0.2305140495300293, 0.2334628105163574, 0.2340850830078125]
DateTimeField   average: 0.4872s [0.4839980602264404, 0.4864580631256103, 0.4956321716308594, 0.4867660999298095, 0.4834890365600586]
ForeignKey      average: 0.0266s [0.0261549949645996, 0.0266189575195312, 0.0267159938812255, 0.0269579887390136, 0.0267570018768310]
```

- Getting lookups on ForeignKey is fast because the lookups are hardcoded (which causes lookup registration to have no effect).
- DateTimeField is slower than CharField since it needs to test multiple `class_lookups` dicts.

**pr:**
```
CharField       average: 0.2818s [0.2849998474121094, 0.2799849510192871, 0.2836630344390869, 0.2778408527374267, 0.2827849388122558]
DateTimeField   average: 0.2833s [0.2864518165588379, 0.2799329757690429, 0.2777631282806396, 0.2892100811004638, 0.2832741737365722]
ForeignKey      average: 0.2851s [0.2807130813598633, 0.2836570739746094, 0.2891471385955810, 0.2907619476318359, 0.2814109325408935]
```