### PR TITLE
Fixed #26884 -- Evaluated callables in QuerySet.update_or_create()'s defaults when updating.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -489,7 +489,7 @@ class QuerySet(object):
             if created:
                 return obj, created
         for k, v in six.iteritems(defaults):
-            setattr(obj, k, v)
+            setattr(obj, k, v()) if callable(v) else setattr(obj, k, v)
         obj.save(using=self.db)
         return obj, False
 

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -404,9 +404,18 @@ class UpdateOrCreateTests(TestCase):
         self.assertFalse(created)
         self.assertEqual(obj.defaults, 'another testing')
 
-    def test_update_callable_default(self):
+    def test_create_callable_default(self):
         obj, created = Person.objects.update_or_create(
             first_name='George', last_name='Harrison',
             defaults={'birthday': lambda: date(1943, 2, 25)},
         )
         self.assertEqual(obj.birthday, date(1943, 2, 25))
+
+    def test_update_callable_default(self):
+        Person.objects.update_or_create(first_name='George', last_name='Harrison', birthday=date(1942, 2, 25))
+        obj, created = Person.objects.update_or_create(
+            first_name='George',
+            defaults={'last_name': lambda: 'NotHarrison'},
+        )
+        self.assertEqual(obj.last_name, 'NotHarrison')
+

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -418,4 +418,3 @@ class UpdateOrCreateTests(TestCase):
             defaults={'last_name': lambda: 'NotHarrison'},
         )
         self.assertEqual(obj.last_name, 'NotHarrison')
-


### PR DESCRIPTION
Fixed the case where update_or_create is updating, the callables are not evaluated.