### PR TITLE
Fixed #26890 -- Fixed IntegerField crash on Unicode numbers.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -276,7 +276,7 @@ class IntegerField(Field):
             value = formats.sanitize_separators(value)
         # Strip trailing decimal and zeros.
         try:
-            value = int(self.re_decimal.sub('', str(value)))
+            value = int(self.re_decimal.sub('', force_text(value)))
         except (ValueError, TypeError):
             raise ValidationError(self.error_messages['invalid'], code='invalid')
         return value

--- a/tests/forms_tests/field_tests/test_integerfield.py
+++ b/tests/forms_tests/field_tests/test_integerfield.py
@@ -123,6 +123,10 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertEqual(9223372036854775808, f.clean('9223372036854775808'))
         self.assertEqual(9223372036854775808, f.clean('9223372036854775808.0'))
 
+    def test_integerfield_unicode_number(self):
+        f = IntegerField()
+        self.assertEqual(50, f.clean('５０'))
+
     def test_integerfield_subclass(self):
         """
         Class-defined widget is not overwritten by __init__() (#22245).


### PR DESCRIPTION
<https://code.djangoproject.com/ticket/26890>