### PR TITLE
Fixed #26902 -- Added require_https argument to is_safe_url()

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -84,7 +84,12 @@ class LoginView(FormView):
             self.redirect_field_name,
             self.request.GET.get(self.redirect_field_name, '')
         )
-        if not is_safe_url(url=redirect_to, host=self.request.get_host()):
+        url_is_safe = is_safe_url(
+            url=redirect_to,
+            host=self.request.get_host(),
+            require_https=self.request.is_secure(),
+        )
+        if not url_is_safe:
             return resolve_url(settings.LOGIN_REDIRECT_URL)
         return redirect_to
 
@@ -150,8 +155,13 @@ class LogoutView(TemplateView):
                 self.redirect_field_name,
                 self.request.GET.get(self.redirect_field_name)
             )
+            url_is_safe = is_safe_url(
+                url=next_page,
+                host=self.request.get_host(),
+                require_https=self.request.is_secure(),
+            )
             # Security check -- don't allow redirection to a different host.
-            if not is_safe_url(url=next_page, host=self.request.get_host()):
+            if not url_is_safe:
                 next_page = self.request.path
         return next_page
 

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -37,11 +37,12 @@ def set_language(request):
     any state.
     """
     next = request.POST.get('next', request.GET.get('next'))
-    if (next or not request.is_ajax()) and not is_safe_url(url=next, host=request.get_host()):
+    if ((next or not request.is_ajax()) and
+            not is_safe_url(url=next, host=request.get_host(), require_https=request.is_secure())):
         next = request.META.get('HTTP_REFERER')
         if next:
             next = urlunquote(next)  # HTTP_REFERER may be encoded.
-        if not is_safe_url(url=next, host=request.get_host()):
+        if not is_safe_url(url=next, host=request.get_host(), require_https=request.is_secure()):
             next = '/'
     response = http.HttpResponseRedirect(next) if next else http.HttpResponse(status=204)
     if request.method == 'POST':

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -288,6 +288,13 @@ Validators
   :data:`~django.core.validators.validate_image_file_extension` to validate
   image files.
 
+Miscellaneous
+~~~~~~~~~~~~~
+
+* ``utils.http.is_safe_url()`` accepts a new ``require_https`` argument. If
+  ``require_https`` is ``True``, only HTTPS will be considered as a valid
+  scheme as opposed to both HTTP and HTTPS with the default ``False``.
+
 .. _backwards-incompatible-1.11:
 
 Backwards incompatible changes in 1.11

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -300,6 +300,13 @@ Miscellaneous
 Backwards incompatible changes in 1.11
 ======================================
 
+:mod:`django.contrib.auth`
+--------------------------
+
+* ``LoginView`` and ``LogoutView`` protect users against being redirected to non
+  HTTPS ``next`` URLs when the app is running behind HTTPS. This is done by
+  using the ``require_https`` argument to ``is_safe_url()``.
+
 :mod:`django.contrib.gis`
 -------------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -347,6 +347,14 @@ Django 1.11 sets PostgreSQL 9.3 as the minimum version it officially supports.
 Support for PostGIS 2.0 is also removed as PostgreSQL 9.2 is the last version
 to support it.
 
+Internationalization
+--------------------
+
+* The :func:`django.views.i18n.set_language` view now protects users against
+  being redirected to non HTTPS ``next`` URLs when the app is running behind
+  HTTPS. This is done by using the ``require_https`` argument to
+  ``is_safe_url()``.
+
 ``LiveServerTestCase`` binds to port zero
 -----------------------------------------
 

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -140,6 +140,24 @@ class TestUtilsHttp(unittest.TestCase):
         # Basic auth without host is not allowed.
         self.assertFalse(http.is_safe_url(r'http://testserver\@example.com'))
 
+    def test_is_safe_url_secure_param_https_urls(self):
+        secure_urls = (
+            'https://example.com/p',
+            'HTTPS://example.com/p',
+            '/view/?param=http://example.com',
+        )
+        for url in secure_urls:
+            self.assertTrue(http.is_safe_url(url, 'example.com', require_https=True))
+
+    def test_is_safe_url_secure_param_non_https_urls(self):
+        not_secure_urls = (
+            'http://example.com/p',
+            'ftp://example.com/p',
+            '//example.com/p',
+        )
+        for url in not_secure_urls:
+            self.assertFalse(http.is_safe_url(url, 'example.com', require_https=True))
+
     def test_urlsafe_base64_roundtrip(self):
         bytestring = b'foo'
         encoded = http.urlsafe_base64_encode(bytestring)

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -54,6 +54,18 @@ class I18NTests(TestCase):
         self.assertEqual(response.url, '/')
         self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], lang_code)
 
+    def test_setlang_not_secured_next(self):
+        """
+        The set_language view only redirects to the 'next' argument if it is
+        "safe" and its scheme is https if the request was sent over https.
+        """
+        lang_code = self._get_inactive_language_code()
+        non_https_next_url = 'http://testserver/redirection/'
+        post_data = dict(language=lang_code, next=non_https_next_url)
+        response = self.client.post('/i18n/setlang/', data=post_data, secure=True)
+        self.assertEqual(response.url, '/')
+        self.assertEqual(self.client.session[LANGUAGE_SESSION_KEY], lang_code)
+
     def test_setlang_redirect_to_referer(self):
         """
         The set_language view redirects to the URL in the referer header when


### PR DESCRIPTION
And use the argument in Django's views where it makes sense, i.e.
`django.contrib.auth` and `django.views.i18n`

Fixes https://code.djangoproject.com/ticket/26902