### PR TITLE
Fixed #26114 -- Removing Meta.db_table generates migration with wrong…

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -314,7 +314,10 @@ class AlterModelTable(Operation):
         return name.lower() == self.name_lower
 
     def describe(self):
-        return "Rename table for %s to %s" % (self.name, self.table)
+        if self.table is None:
+            return "Rename table for %s to (default)" % (self.name)
+        else:
+            return "Rename table for %s to %s" % (self.name, self.table)
 
 
 class AlterUniqueTogether(Operation):


### PR DESCRIPTION
Removing Meta.db_table generates migration with wrong rename in comment (None).

