### PR TITLE
Fixed #26180 -- AlterUniqueTogether should stay before RemoveField operation after optimization

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -972,6 +972,7 @@ class MigrationAutodetector(object):
                     app_label,
                     operation(
                         name=model_name,
+                        old_value=old_value,
                         **{option_name: new_value}
                     ),
                     dependencies=dependencies,

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -496,15 +496,18 @@ class AlterUniqueTogether(FieldRelatedOptionOperation):
     """
     option_name = "unique_together"
 
-    def __init__(self, name, unique_together):
+    def __init__(self, name, unique_together, old_value=[]):
         unique_together = normalize_together(unique_together)
+        old_value = normalize_together(old_value)
         self.unique_together = set(tuple(cons) for cons in unique_together)
+        self.old_value = set(tuple(cons) for cons in old_value)
         super(AlterUniqueTogether, self).__init__(name)
 
     def deconstruct(self):
         kwargs = {
             'name': self.name,
             'unique_together': self.unique_together,
+            'old_value': self.old_value,
         }
         return (
             self.__class__.__name__,
@@ -535,7 +538,8 @@ class AlterUniqueTogether(FieldRelatedOptionOperation):
             self.references_model(model_name, app_label) and
             (
                 not self.unique_together or
-                any((name in together) for together in self.unique_together)
+                any((name in together) for together in self.unique_together) or
+                any((name in together) for together in self.old_value)
             )
         )
 
@@ -550,15 +554,18 @@ class AlterIndexTogether(FieldRelatedOptionOperation):
     """
     option_name = "index_together"
 
-    def __init__(self, name, index_together):
+    def __init__(self, name, index_together, old_value=[]):
         index_together = normalize_together(index_together)
+        old_value = normalize_together(old_value)
         self.index_together = set(tuple(cons) for cons in index_together)
+        self.old_value = set(tuple(cons) for cons in old_value)
         super(AlterIndexTogether, self).__init__(name)
 
     def deconstruct(self):
         kwargs = {
             'name': self.name,
             'index_together': self.index_together,
+            'old_value': self.old_value,
         }
         return (
             self.__class__.__name__,
@@ -589,7 +596,8 @@ class AlterIndexTogether(FieldRelatedOptionOperation):
             self.references_model(model_name, app_label) and
             (
                 not self.index_together or
-                any((name in together) for together in self.index_together)
+                any((name in together) for together in self.index_together) or
+                any((name in together) for together in self.old_value)
             )
         )
 

--- a/docs/ref/migration-operations.txt
+++ b/docs/ref/migration-operations.txt
@@ -91,20 +91,30 @@ option on the ``Meta`` subclass).
 ``AlterUniqueTogether``
 -----------------------
 
-.. class:: AlterUniqueTogether(name, unique_together)
+.. class:: AlterUniqueTogether(name, unique_together, old_value=[])
 
 Changes the model's set of unique constraints (the
 :attr:`~django.db.models.Options.unique_together` option on the ``Meta``
 subclass).
 
+.. versionadded:: 1.11
+
+The optional ``old_value`` argument was added which stores the earlier value of
+unique_together.
+
 ``AlterIndexTogether``
 ----------------------
 
-.. class:: AlterIndexTogether(name, index_together)
+.. class:: AlterIndexTogether(name, index_together, old_value=[])
 
 Changes the model's set of custom indexes (the
 :attr:`~django.db.models.Options.index_together` option on the ``Meta``
 subclass).
+
+.. versionadded:: 1.11
+
+The optional ``old_value`` argument was added which stores the earlier value of
+index_together.
 
 ``AlterOrderWithRespectTo``
 ---------------------------

--- a/docs/releases/1.9.8.txt
+++ b/docs/releases/1.9.8.txt
@@ -15,3 +15,6 @@ Bugfixes
 
 * Fixed ``makemessages`` crash on Python 2 with non-ASCII file names
   (:ticket:`26897`).
+
+* Fixed a crash when a field with unique/index_together constraint was
+  removed (:ticket:`26180`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1238,10 +1238,16 @@ class AutodetectorTests(TestCase):
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["RemoveField", "AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, model_name="book", name="newfield")
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={("author", "title")})
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("author", "title")})
+        self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether", "RemoveField"])
+        self.assertOperationAttributes(
+            changes, "otherapp", 0, 0,
+            name="book", unique_together={("author", "title")}, old_value={("title", "newfield")},
+        )
+        self.assertOperationAttributes(
+            changes, "otherapp", 0, 1,
+            name="book", index_together={("author", "title")}, old_value={("title", "newfield")},
+        )
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, model_name="book", name="newfield")
 
     def test_rename_field_and_foo_together(self):
         """

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1374,7 +1374,7 @@ class OperationTests(OperationTestBase):
         definition = operation.deconstruct()
         self.assertEqual(definition[0], "AlterUniqueTogether")
         self.assertEqual(definition[1], [])
-        self.assertEqual(definition[2], {'name': "Pony", 'unique_together': {("pink", "weight")}})
+        self.assertEqual(definition[2], {'name': "Pony", 'unique_together': {("pink", "weight")}, 'old_value': set()})
 
     def test_alter_unique_together_remove(self):
         operation = migrations.AlterUniqueTogether("Pony", None)
@@ -1466,7 +1466,7 @@ class OperationTests(OperationTestBase):
         definition = operation.deconstruct()
         self.assertEqual(definition[0], "AlterIndexTogether")
         self.assertEqual(definition[1], [])
-        self.assertEqual(definition[2], {'name': "Pony", 'index_together': {("pink", "weight")}})
+        self.assertEqual(definition[2], {'name': "Pony", 'index_together': {("pink", "weight")}, 'old_value': set()})
 
     def test_alter_index_together_remove(self):
         operation = migrations.AlterIndexTogether("Pony", None)

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -653,13 +653,6 @@ class OptimizerTests(SimpleTestCase):
     def test_create_alter_owrt_field(self):
         self._test_create_alter_foo_field(migrations.AlterOrderWithRespectTo("Foo", "b"))
 
-    def test_alter_unique_remove_field(self):
-        # self.assertEqual(1, 2)
-        self.assertDoesNotOptimize([
-            migrations.AlterUniqueTogether("Foo", [["a", "b"]], [["a", "b"], ["b", "c"]]),
-            migrations.RemoveField("Foo", "c"),
-        ])
-
     def test_optimize_through_fields(self):
         """
         Checks that field-level through checking is working.

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -653,6 +653,13 @@ class OptimizerTests(SimpleTestCase):
     def test_create_alter_owrt_field(self):
         self._test_create_alter_foo_field(migrations.AlterOrderWithRespectTo("Foo", "b"))
 
+    def test_alter_unique_remove_field(self):
+        # self.assertEqual(1, 2)
+        self.assertDoesNotOptimize([
+            migrations.AlterUniqueTogether("Foo", [["a", "b"]], [["a", "b"], ["b", "c"]]),
+            migrations.RemoveField("Foo", "c"),
+        ])
+
     def test_optimize_through_fields(self):
         """
         Checks that field-level through checking is working.


### PR DESCRIPTION
Ticket [#26180](https://code.djangoproject.com/ticket/26180).
AlterFooTogether operations now take into account their older value while deciding field_reference.