### PR TITLE
Fixed #26908 -- Fixed crash with jsonfield__key__isnull lookup on PostgreSQL 9.4.

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -106,7 +106,7 @@ class KeyTransform(Transform):
             lookup = "'%s'" % self.key_name
         else:
             lookup = "%s" % self.key_name
-        return "%s -> %s" % (lhs, lookup), params
+        return "(%s -> %s)" % (lhs, lookup), params
 
 
 class KeyTransformFactory(object):

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -156,6 +156,17 @@ class TestQuerying(TestCase):
             [self.objs[0]]
         )
 
+    def test_isnull_key(self):
+        # key__isnull works the same as has_key='key'.
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__a__isnull=True),
+            self.objs[:7] + self.objs[9:]
+        )
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__a__isnull=False),
+            [self.objs[7], self.objs[8]]
+        )
+
     def test_contains(self):
         self.assertSequenceEqual(
             JSONModel.objects.filter(field__contains={'a': 'b'}),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26908