### PR TITLE
#26789 Save empty GIS geometries to the database

### DIFF
--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -177,10 +177,10 @@ class BaseSpatialField(Field):
         """
         Prepare the value for saving in the database.
         """
-        if not value:
-            return None
-        else:
+        if value or isinstance(value, Geometry):
             return connection.ops.Adapter(self.get_prep_value(value))
+        else:
+            return None
 
     def get_raster_prep_value(self, value, is_candidate):
         """


### PR DESCRIPTION
Previously Falsey geometry objects didn't get saved, which is a random mix depending on their types & content. Every geometry object is now explicitly saved regardless of Truthiness.

EMPTY handling isn't that great with the supporting libraries/DBs, but this at least always ensures the geometry is passed to the database to decide.

* Skips issue with GEOS 3.5.0 for 'POINT EMPTY'
* Skips issue with PostGIS 2.2.2 for 'POLYGON EMPTY'

This is still a WIP for ticket discussion