### PR TITLE
Fixed #13809 -- Modified FieldFile to allow opening in modes other than 'rb'

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -79,7 +79,10 @@ class FieldFile(File):
 
     def open(self, mode='rb'):
         self._require_file()
-        self.file.open(mode)
+        if hasattr(self, '_file') and self._file is not None:
+            self.file.open(mode)
+        else:
+            self.file = self.storage.open(self.name, mode)
     # open() doesn't alter the file's contents, but it does reset the pointer
     open.alters_data = True
 

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -733,6 +733,16 @@ class FileFieldStorageTests(TestCase):
         self.assertEqual(list(obj.normal.chunks(chunk_size=2)), [b"co", b"nt", b"en", b"t"])
         obj.normal.close()
 
+    def test_filefield_read_text_mode(self):
+        obj = Storage.objects.create(
+            normal=SimpleUploadedFile("assignment.txt", b"content"))
+        obj.normal.open(mode='r')
+        self.assertEqual(obj.normal.file.mode, 'r')
+        self.assertEqual(obj.normal.read(3), "con")
+        self.assertEqual(obj.normal.read(), "tent")
+        self.assertEqual(list(obj.normal.chunks(chunk_size=2)), ["co", "nt", "en", "t"])
+        obj.normal.close()
+
     def test_filefield_reopen(self):
         obj = Storage.objects.create(normal=SimpleUploadedFile('reopen.txt', b'content'))
         with obj.normal as normal:


### PR DESCRIPTION
I've been running into this recently, and so I took a stab at a (hopefully) trivial fix for this issue.

The root problem here (as discussed in the [ticket](https://code.djangoproject.com/ticket/13809)) is that the `FieldFile.file` property opens all files in mode 'rb', regardless of what mode you request.

To work around this, people seem to be closing and re-opening the file, or else just opening the file straight from the storage. An attempted patch for this issue did that exact thing, but was rejected.

As an alternative, I just made `FileField.open()` check for the `_file` property. If it's missing, we open the file from the storage using the given mode. Otherwise, we fall back to the previous behavior of calling `FileField.file.open()`.