### PR TITLE
 Fixed #24928 -- Added introspection support for PostgreSQL-specific fields

### DIFF
--- a/django/contrib/postgres/signals.py
+++ b/django/contrib/postgres/signals.py
@@ -9,6 +9,12 @@ def register_type_handlers(connection, **kwargs):
 
     try:
         register_hstore(connection.connection, globally=True)
+        if ('django.contrib.postgresql.fields.HStoreField' not in
+                connection.introspection.data_types_reverse.values()):
+            with connection.cursor() as cursor:
+                cursor.execute("""SELECT oid from pg_type WHERE typname = 'hstore'""")
+                oid = cursor.fetchone()[0]
+                connection.introspection.data_types_reverse[oid] = 'django.contrib.postgresql.fields.HStoreField'
     except ProgrammingError:
         # Hstore is not available on the database.
         #

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -153,9 +153,11 @@ class Command(BaseCommand):
                     if extra_params:
                         if not field_desc.endswith('('):
                             field_desc += ', '
-                        field_desc += ', '.join(
+                        field_args = ', '.join(extra_params.get('__args__', []))
+                        field_kwargs = ', '.join(
                             '%s=%s' % (k, strip_prefix(repr(v)))
-                            for k, v in extra_params.items())
+                            for k, v in extra_params.items() if k != '__args__')
+                        field_desc += ', '.join([arg for arg in [field_args, field_kwargs] if arg])
                     field_desc += ')'
                     if comment_notes:
                         field_desc += '  # ' + ' '.join(comment_notes)

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -1,3 +1,4 @@
+import copy
 from collections import namedtuple
 
 # Structure returned by DatabaseIntrospection.get_table_list()
@@ -22,7 +23,7 @@ class BaseDatabaseIntrospection:
         For Oracle, the column data_type on its own is insufficient to
         distinguish between a FloatField and IntegerField, for example.
         """
-        return self.data_types_reverse[data_type]
+        return copy.deepcopy(self.data_types_reverse[data_type])
 
     def table_name_converter(self, name):
         """

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -71,7 +71,8 @@ def update_connections_time_zone(**kwargs):
                 del conn.timezone_name
             except AttributeError:
                 pass
-            conn.ensure_timezone()
+            if conn.connection is not None:
+                conn.ensure_timezone()
 
 
 @receiver(setting_changed)

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -56,6 +56,8 @@ class Migration(migrations.Migration):
             name='OtherTypesArrayModel',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('bools', ArrayField(models.BooleanField(), size=None)),
+                ('texts', ArrayField(models.TextField(), size=None)),
                 ('ips', ArrayField(models.GenericIPAddressField(), size=None)),
                 ('uuids', ArrayField(models.UUIDField(), size=None)),
                 ('decimals', ArrayField(models.DecimalField(max_digits=5, decimal_places=2), size=None)),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -63,6 +63,8 @@ class NestedIntegerArrayModel(PostgreSQLModel):
 
 
 class OtherTypesArrayModel(PostgreSQLModel):
+    bools = ArrayField(models.BooleanField())
+    texts = ArrayField(models.TextField())
     ips = ArrayField(models.GenericIPAddressField())
     uuids = ArrayField(models.UUIDField())
     decimals = ArrayField(models.DecimalField(max_digits=5, decimal_places=2))

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -92,6 +92,8 @@ class TestSaveLoad(PostgreSQLTestCase):
 
     def test_other_array_types(self):
         instance = OtherTypesArrayModel(
+            bools=[False, True],
+            texts=['aa', 'bb'],
             ips=['192.168.0.1', '::1'],
             uuids=[uuid.uuid4()],
             decimals=[decimal.Decimal(1.25), 1.75],
@@ -99,6 +101,8 @@ class TestSaveLoad(PostgreSQLTestCase):
         )
         instance.save()
         loaded = OtherTypesArrayModel.objects.get()
+        self.assertEqual(instance.bools, loaded.bools)
+        self.assertEqual(instance.texts, loaded.texts)
         self.assertEqual(instance.ips, loaded.ips)
         self.assertEqual(instance.uuids, loaded.uuids)
         self.assertEqual(instance.decimals, loaded.decimals)
@@ -106,6 +110,8 @@ class TestSaveLoad(PostgreSQLTestCase):
 
     def test_null_from_db_value_handling(self):
         instance = OtherTypesArrayModel.objects.create(
+            bools=[False, True],
+            texts=['aa', 'bb'],
             ips=['192.168.0.1', '::1'],
             uuids=[uuid.uuid4()],
             decimals=[decimal.Decimal(1.25), 1.75],
@@ -363,12 +369,16 @@ class TestDateTimeExactQuerying(PostgreSQLTestCase):
 class TestOtherTypesExactQuerying(PostgreSQLTestCase):
 
     def setUp(self):
+        self.bools = [False, True]
+        self.texts = ['aa', 'bb']
         self.ips = ['192.168.0.1', '::1']
         self.uuids = [uuid.uuid4()]
         self.decimals = [decimal.Decimal(1.25), 1.75]
         self.tags = [Tag(1), Tag(2), Tag(3)]
         self.objs = [
             OtherTypesArrayModel.objects.create(
+                bools=self.bools,
+                texts=self.texts,
                 ips=self.ips,
                 uuids=self.uuids,
                 decimals=self.decimals,

--- a/tests/postgres_tests/test_introspection.py
+++ b/tests/postgres_tests/test_introspection.py
@@ -25,6 +25,50 @@ class InspectDBTests(PostgreSQLTestCase):
             ['field = django.contrib.postgresql.fields.JSONField(blank=True, null=True)'],
         )
 
+    def test_hstore_introspection(self):
+        self.assertFieldsInModel(
+            'postgres_tests_hstoremodel',
+            ['field = django.contrib.postgresql.fields.HStoreField(blank=True, null=True)'],
+        )
+
+    def test_array_introspection(self):
+        """
+        Note that nested arrays do not seem to be introspectable.
+        """
+        self.assertFieldsInModel(
+            'postgres_tests_integerarraymodel',
+            ['field = django.contrib.postgresql.fields.ArrayField(models.IntegerField())'],
+        )
+        self.assertFieldsInModel(
+            'postgres_tests_nullableintegerarraymodel',
+            ['field = django.contrib.postgresql.fields.ArrayField(models.IntegerField(), blank=True, null=True)'],
+        )
+        self.assertFieldsInModel(
+            'postgres_tests_chararraymodel',
+            ['field = django.contrib.postgresql.fields.ArrayField(models.CharField(max_length=10))'],
+        )
+        self.assertFieldsInModel(
+            'postgres_tests_datetimearraymodel',
+            [
+                'datetimes = django.contrib.postgresql.fields.ArrayField(models.DateTimeField())',
+                'dates = django.contrib.postgresql.fields.ArrayField(models.DateField())',
+                'times = django.contrib.postgresql.fields.ArrayField(models.TimeField())',
+            ],
+        )
+        self.assertFieldsInModel(
+            'postgres_tests_othertypesarraymodel',
+            [
+                'bools = django.contrib.postgresql.fields.ArrayField(models.BooleanField())',
+                'texts = django.contrib.postgresql.fields.ArrayField(models.TextField())',
+                'ips = django.contrib.postgresql.fields.ArrayField(models.GenericIPAddressField())',
+                'uuids = django.contrib.postgresql.fields.ArrayField(models.UUIDField())',
+                'decimals = django.contrib.postgresql.fields.ArrayField'
+                '(models.DecimalField(max_digits=5, decimal_places=2))',
+                'tags = django.contrib.postgresql.fields.ArrayField'
+                '(models.SmallIntegerField(), blank=True, null=True)',
+            ],
+        )
+
     def test_range_fields(self):
         self.assertFieldsInModel(
             'postgres_tests_rangesmodel',


### PR DESCRIPTION
The first two commits are supposed to be committed separately. I'll rebase after that.
