### PR TITLE
Fixed #26922 -- Fixed SimpleTestCase.assertHTMLEqual() crash on Python 3.5.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -66,7 +66,7 @@ def assert_and_parse_html(self, html, user_msg, msg):
     try:
         dom = parse_html(html)
     except HTMLParseError as e:
-        standardMsg = '%s\n%s' % (msg, e.msg)
+        standardMsg = '%s\n%s' % (msg, e)
         self.fail(self._formatMessage(user_msg, standardMsg))
     return dom
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -627,6 +627,19 @@ class HTMLEqualTests(SimpleTestCase):
             self.assertHTMLEqual('<p>', '')
         with self.assertRaises(AssertionError):
             self.assertHTMLEqual('', '<p>')
+        if six.PY2:
+            error_msg = (
+                "First argument is not valid HTML:\n"
+                "Unexpected end tag `div` (Line 1, Column 6), "
+                "at line 1, column 7"
+            )
+        else:
+            error_msg = (
+                "First argument is not valid HTML:\n"
+                "('Unexpected end tag `div` (Line 1, Column 6)', (1, 6))"
+            )
+        with self.assertRaisesMessage(AssertionError, error_msg):
+            self.assertHTMLEqual('< div></ div>', '<div></div>')
         with self.assertRaises(HTMLParseError):
             parse_html('</p>')
 


### PR DESCRIPTION
I got this on Django 1.9 with Python 3.5:

```
    def assert_and_parse_html(self, html, user_msg, msg):
        try:
            dom = parse_html(html)
        except HTMLParseError as e:
>           standardMsg = '%s\n%s' % (msg, e.msg)
E           AttributeError: 'HTMLParseError' object has no attribute 'msg'
```

As I see it happens when input HTML is not valid (I tried with "< div></ div>")