### PR TITLE
Fixed #26882 -- Added tests for auth.views.logout_then_login().

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -176,12 +176,19 @@ def logout(request, *args, **kwargs):
     )
     return LogoutView.as_view(**kwargs)(request, *args, **kwargs)
 
+_sentinel = object()
 
 @deprecate_current_app
-def logout_then_login(request, login_url=None):
+def logout_then_login(request, login_url=None, extra_context=_sentinel):
     """
     Logs out the user if they are logged in. Then redirects to the log-in page.
     """
+    if extra_context is not _sentinel:
+        warnings.warn(
+            "Passing `extra_context` as a keyword argument is deprecated.",
+            RemovedInDjango21Warning
+        )
+
     if not login_url:
         login_url = settings.LOGIN_URL
     login_url = resolve_url(login_url)

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -178,7 +178,7 @@ def logout(request, *args, **kwargs):
 
 
 @deprecate_current_app
-def logout_then_login(request, login_url=None, extra_context=None):
+def logout_then_login(request, login_url=None):
     """
     Logs out the user if they are logged in. Then redirects to the log-in page.
     """

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -20,6 +20,9 @@ details on these changes.
   ``password_reset_confirm()``, and ``password_reset_complete()`` will be
   removed.
 
+* ``contrib.auth.views.logout_then_login()``’s ``extra_context``
+  parameter will be removed.
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -366,6 +366,10 @@ Miscellaneous
   :class:`~django.contrib.auth.views.LoginView` and
   :class:`~django.contrib.auth.views.LogoutView`.
 
+* ``contrib.auth.views.logout_then_login``’s ``extra_context`` parameter is deprecated
+  because ``logout_then_login`` returns ``HttpRedirectResponse`` that does not use
+  context.
+
 * ``contrib.auth``’s ``password_change()``, ``password_change_done()``,
   ``password_reset()``, ``password_reset_done()``, ``password_reset_confirm()``,
   and ``password_reset_complete()`` function-based views are deprecated in favor

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1475,7 +1475,7 @@ implementation details see :ref:`using-the-views`.
       will default to ``default_token_generator``, it's an instance of
       ``django.contrib.auth.tokens.PasswordResetTokenGenerator``.
 
-    * ``form_class``: Form that will be used to set the password. Defaults to 
+    * ``form_class``: Form that will be used to set the password. Defaults to
       :class:`~django.contrib.auth.forms.SetPasswordForm`.
 
     * ``success_url``: URL to redirect after the password reset done. Defaults

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1405,6 +1405,12 @@ implementation details see :ref:`using-the-views`.
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
+    .. deprecated:: 1.11
+
+        The ``extra_context`` parameter is deprecated and will be removed in
+        Django 2.1 because ``logout_then_login`` returns ``HttpRedirectResponse``
+        that does not use context.
+
 .. class:: PasswordResetDoneView
 
     .. versionadded:: 1.11


### PR DESCRIPTION
Added couple of tests for `logout_then_login`
`extra_content` parameter marked as deprecated because it's redundant in `logout_then_login` function.

See https://code.djangoproject.com/ticket/26882 for details

See https://code.djangoproject.com/ticket/26929 for details about `extra_context` parameter depreaction