### PR TITLE
Fixed #26923 -- Fixed tests with older releases of numpy

### DIFF
--- a/tests/template_tests/syntax_tests/test_numpy.py
+++ b/tests/template_tests/syntax_tests/test_numpy.py
@@ -10,6 +10,8 @@ try:
     VisibleDeprecationWarning = numpy.VisibleDeprecationWarning
 except ImportError:
     numpy = False
+except AttributeError:  # numpy < 1.9.0, e.g. 1.8.2 in Debian 8
+    VisibleDeprecationWarning = DeprecationWarning
 
 
 @skipIf(numpy is False, "Numpy must be installed to run these tests.")
@@ -20,7 +22,7 @@ class NumpyTests(SimpleTestCase):
             "ignore",
             "Using a non-integer number instead of an "
             "integer will result in an error in the future",
-            numpy.VisibleDeprecationWarning
+            VisibleDeprecationWarning
         )
 
     @setup({'numpy-array-index01': '{{ var.1 }}'})


### PR DESCRIPTION
numpy.VisibleDeprecationWarning does not exist in older releases
of numpy that are still widely used (like 1.8.2 in Debian 8)
and we must deal properly with its non-existence.