### PR TITLE
Refs #26796 -- Fixed ManyToManyField's limit_choices_to warning without a through model.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1228,7 +1228,8 @@ class ManyToManyField(RelatedField):
                     id='fields.W341',
                 )
             )
-        if self.remote_field.limit_choices_to and self.remote_field.through:
+        if (self.remote_field.limit_choices_to and self.remote_field.through and
+                not self.remote_field.through._meta.auto_created):
             warnings.append(
                 checks.Warning(
                     'limit_choices_to has no effect on ManyToManyField '

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -176,6 +176,19 @@ class RelativeFieldTests(SimpleTestCase):
         field = Model._meta.get_field('m2m')
         self.assertEqual(field.check(from_model=Model), [])
 
+    def test_many_to_many_with_limit_choices_auto_created_no_warning(self):
+        class Model(models.Model):
+            name = models.CharField(max_length=20)
+
+        class ModelM2M(models.Model):
+            m2m = models.ManyToManyField(
+                Model,
+                limit_choices_to={'name': 'test_name'},
+            )
+
+        errors = ModelM2M.check()
+        self.assertEqual(errors, [])
+
     def test_many_to_many_with_useless_options(self):
         class Model(models.Model):
             name = models.CharField(max_length=20)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26796

per discussion https://github.com/django/django/commit/ba53da894fc713629ae4d3fbdd14eff98c808389#commitcomment-18263905