### PR TITLE
Fixed #25788 -- Enabled the cached template loader if debug=False.

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -27,6 +27,9 @@ class Engine(object):
             loaders = ['django.template.loaders.filesystem.Loader']
             if app_dirs:
                 loaders += ['django.template.loaders.app_directories.Loader']
+            if not debug:
+                # If debug is False, wrap default loaders in the cached loader
+                loaders = [('django.template.loaders.cached.Loader', loaders)]
         else:
             if app_dirs:
                 raise ImproperlyConfigured(

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -97,13 +97,21 @@ what's passed by :class:`~django.template.backends.django.DjangoTemplates`.
       item in the tuple should be the ``Loader`` class name, subsequent items
       are passed to the ``Loader`` during initialization.
 
-      It defaults to a list containing:
+      If ``debug`` is ``True`` it defaults to a list containing:
 
       * ``'django.template.loaders.filesystem.Loader'``
       * ``'django.template.loaders.app_directories.Loader'`` if and only if
         ``app_dirs`` is ``True``.
 
+      If ``debug`` is ``False``, it defaults to the same list, but wrapped in
+      ``django.template.loaders.cached.Loader``.
+
       See :ref:`template-loaders` for details.
+
+      .. versionchanged:: 1.11
+
+          Default loaders are now wrapped in
+          ``django.template.loaders.cached.Loader`` if ``debug`` is ``False``.
 
     * ``string_if_invalid`` is the output, as a string, that the template
       system should use for invalid (e.g. misspelled) variables.

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -353,6 +353,21 @@ Miscellaneous
   argument. Remove it because it doesn't have an effect in older versions of
   Django as these fields alway strip whitespace.
 
+* :class:`.template.Engine` now wraps default template loaders in
+  :class:`.template.loaders.cached.Loader` if ``loaders`` is
+  ``None`` and ``debug`` is ``False``. This means that if :setting:`DEBUG` is
+  ``False`` and no loaders are specified in
+  :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>`,
+  the default loaders will be::
+
+      [('django.template.loaders.cached.Loader', [
+          'django.template.loaders.filesystem.Loader',
+          // If APP_DIRS is True:
+          'django.template.loaders.app_directories.Loader',
+      ])]
+
+
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -130,3 +130,31 @@ class DjangoTemplatesTests(TemplateStringsTests):
             engines['django'].from_string('Hello, {{ name }}').render({'name': 'Bob & Jim'}),
             'Hello, Bob &amp; Jim'
         )
+
+    @override_settings(DEBUG=False)
+    def test_non_debug_default_template_loaders(self):
+        engine = DjangoTemplates({
+            'DIRS': [],
+            'APP_DIRS': True,
+            'NAME': 'django',
+            'OPTIONS': {},
+        })
+        expected_loaders = [('django.template.loaders.cached.Loader', [
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader'
+        ])]
+        self.assertEqual(engine.engine.loaders, expected_loaders)
+
+    @override_settings(DEBUG=True)
+    def test_debug_default_template_loaders(self):
+        engine = DjangoTemplates({
+            'DIRS': [],
+            'APP_DIRS': True,
+            'NAME': 'django',
+            'OPTIONS': {},
+        })
+        expected_loaders = [
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader'
+        ]
+        self.assertEqual(engine.engine.loaders, expected_loaders)


### PR DESCRIPTION
Changed `Engine` to wrap default loaders in the cached template
loader if no loaders are specified and debug is False. Updated the
documentation and release notes accordingly and added tests to
ensure that the default loaders are as expected.