### PR TITLE
Fixed #25937 -- Fixed null value crashes when annotating with Trunc functions.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -394,6 +394,7 @@ def _sqlite_datetime_parse(dt, tzname):
         return None
     try:
         dt = backend_utils.typecast_timestamp(dt)
+        # Typecast_timestamp is returning time rather than datetime
     except (ValueError, TypeError):
         return None
     if tzname is not None:

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -360,21 +360,18 @@ def _sqlite_date_extract(lookup_type, dt):
 
 
 def _sqlite_date_trunc(lookup_type, dt):
-    try: 
-        try:
-            dt = backend_utils.typecast_timestamp(dt)
-        except (ValueError, TypeError):
-            return None
-        if dt is None: 
-            return None
-        if lookup_type == 'year':
-            return "%i-01-01" % dt.year
-        elif lookup_type == 'month':
-            return "%i-%02i-01" % (dt.year, dt.month)
-        elif lookup_type == 'day':
-            return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
-    except Exception as e: 
-        print e
+    try:
+        dt = backend_utils.typecast_timestamp(dt)
+    except (ValueError, TypeError):
+        return None
+    if dt is None:
+        return None
+    if lookup_type == 'year':
+        return "%i-01-01" % dt.year
+    elif lookup_type == 'month':
+        return "%i-%02i-01" % (dt.year, dt.month)
+    elif lookup_type == 'day':
+        return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
 
 
 def _sqlite_time_trunc(lookup_type, dt):

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -375,11 +375,11 @@ def _sqlite_date_trunc(lookup_type, dt):
 
 
 def _sqlite_time_trunc(lookup_type, dt):
-    if dt is None:
-        return None
     try:
         dt = backend_utils.typecast_time(dt)
     except (ValueError, TypeError):
+        return None
+    if dt is None:
         return None
     if lookup_type == 'hour':
         return "%02i:00:00" % dt.hour

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -375,10 +375,10 @@ def _sqlite_date_trunc(lookup_type, dt):
 
 
 def _sqlite_time_trunc(lookup_type, dt):
+    if dt is None:
+        return None
     try:
         dt = backend_utils.typecast_time(dt)
-        if dt is None:
-            return None
     except (ValueError, TypeError):
         return None
     if lookup_type == 'hour':

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -377,6 +377,8 @@ def _sqlite_date_trunc(lookup_type, dt):
 def _sqlite_time_trunc(lookup_type, dt):
     try:
         dt = backend_utils.typecast_time(dt)
+        if dt is None:
+            return None
     except (ValueError, TypeError):
         return None
     if lookup_type == 'hour':
@@ -401,6 +403,8 @@ def _sqlite_datetime_parse(dt, tzname):
 
 def _sqlite_datetime_cast_date(dt, tzname):
     dt = _sqlite_datetime_parse(dt, tzname)
+    if type(dt) is datetime.date:
+        return dt.isoformat()
     if dt is None:
         return None
     return dt.date().isoformat()
@@ -408,6 +412,8 @@ def _sqlite_datetime_cast_date(dt, tzname):
 
 def _sqlite_datetime_cast_time(dt, tzname):
     dt = _sqlite_datetime_parse(dt, tzname)
+    if isinstance(dt, datetime.time):
+        return dt.isoformat()
     if dt is None:
         return None
     return dt.time().isoformat()

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -360,16 +360,21 @@ def _sqlite_date_extract(lookup_type, dt):
 
 
 def _sqlite_date_trunc(lookup_type, dt):
-    try:
-        dt = backend_utils.typecast_timestamp(dt)
-    except (ValueError, TypeError):
-        return None
-    if lookup_type == 'year':
-        return "%i-01-01" % dt.year
-    elif lookup_type == 'month':
-        return "%i-%02i-01" % (dt.year, dt.month)
-    elif lookup_type == 'day':
-        return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
+    try: 
+        try:
+            dt = backend_utils.typecast_timestamp(dt)
+        except (ValueError, TypeError):
+            return None
+        if dt is None: 
+            return None
+        if lookup_type == 'year':
+            return "%i-01-01" % dt.year
+        elif lookup_type == 'month':
+            return "%i-%02i-01" % (dt.year, dt.month)
+        elif lookup_type == 'day':
+            return "%i-%02i-%02i" % (dt.year, dt.month, dt.day)
+    except Exception as e: 
+        print e
 
 
 def _sqlite_time_trunc(lookup_type, dt):

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -135,8 +135,10 @@ def typecast_timestamp(s):  # does NOT store time zone information
     # "2005-07-29 09:56:00-05"
     if not s:
         return None
-    if ' ' not in s:
+    if ':' not in s:
         return typecast_date(s)
+    if '-' not in s:
+        return typecast_time(s)
     d, t = s.split()
     # Extract timezone information, if it exists. Currently we just throw
     # it away, but in the future we may make use of it.

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -233,10 +233,12 @@ class TruncDate(TruncBase):
     def as_sql(self, compiler, connection):
         # Cast to date rather than truncate to date.
         lhs, lhs_params = compiler.compile(self.lhs)
-        tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
-        sql, tz_params = connection.ops.datetime_cast_date_sql(lhs, tzname)
-        lhs_params.extend(tz_params)
-        return sql, lhs_params
+        if isinstance(self.lhs.output_field, DateTimeField):
+            tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
+            sql, tz_params = connection.ops.datetime_cast_date_sql(lhs, tzname)
+            lhs_params.extend(tz_params)
+            return sql, lhs_params
+        return lhs, lhs_params
 
 
 class TruncTime(TruncBase):
@@ -248,12 +250,15 @@ class TruncTime(TruncBase):
         return TimeField()
 
     def as_sql(self, compiler, connection):
+
         # Cast to time rather than truncate to time.
         lhs, lhs_params = compiler.compile(self.lhs)
-        tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
-        sql, tz_params = connection.ops.datetime_cast_time_sql(lhs, tzname)
-        lhs_params.extend(tz_params)
-        return sql, lhs_params
+        if isinstance(self.lhs.output_field, DateTimeField):
+            tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
+            sql, tz_params = connection.ops.datetime_cast_time_sql(lhs, tzname)
+            lhs_params.extend(tz_params)
+            return sql, lhs_params
+        return lhs, lhs_params
 
 
 class TruncHour(TruncBase):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -250,7 +250,6 @@ class TruncTime(TruncBase):
         return TimeField()
 
     def as_sql(self, compiler, connection):
-
         # Cast to time rather than truncate to time.
         lhs, lhs_params = compiler.compile(self.lhs)
         if isinstance(self.lhs.output_field, DateTimeField):

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -248,7 +248,7 @@ class TruncTime(TruncBase):
         return TimeField()
 
     def as_sql(self, compiler, connection):
-        # Cast to date rather than truncate to date.
+        # Cast to time rather than truncate to time.
         lhs, lhs_params = compiler.compile(self.lhs)
         tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
         sql, tz_params = connection.ops.datetime_cast_time_sql(lhs, tzname)

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -481,8 +481,6 @@ class DateFunctionTests(TestCase):
             extracted=TruncYear('start_date', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
-        print "QUERY: {}".format(with_null_fields.query)
-
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
             extracted=TruncYear('start_date', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
@@ -559,15 +557,11 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime__date=TruncDate('start_datetime')).count(), 2)
 
-        # TestFlag
-
         self.create_model(None, None)
 
         with_null_fields = DTModel.objects.annotate(
             extracted=TruncDate('start_date', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
-
-        print with_null_fields.query
 
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
             extracted=TruncDate('start_date', tzinfo=timezone.UTC())
@@ -603,15 +597,15 @@ class DateFunctionTests(TestCase):
         self.create_model(None, None)
 
         with_null_fields = DTModel.objects.annotate(
-            extracted=TruncTime('start_date', tzinfo=timezone.UTC())
+            extracted=TruncTime('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncTime('start_date', tzinfo=timezone.UTC())
+            extracted=TruncTime('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values('start_time')),
+                         list(without_null_fields.values('start_time')))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to TimeField"):
             list(DTModel.objects.annotate(truncated=TruncTime('start_date')))
@@ -685,11 +679,11 @@ class DateFunctionTests(TestCase):
         self.create_model(None, None)
 
         with_null_fields = DTModel.objects.annotate(
-            extracted=TruncHour('start_date', tzinfo=timezone.UTC())
+            extracted=TruncHour('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncHour('start_date', tzinfo=timezone.UTC())
+            extracted=TruncHour('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
@@ -730,11 +724,11 @@ class DateFunctionTests(TestCase):
         self.create_model(None, None)
 
         with_null_fields = DTModel.objects.annotate(
-            extracted=TruncMinute('start_date', tzinfo=timezone.UTC())
+            extracted=TruncMinute('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncMinute('start_date', tzinfo=timezone.UTC())
+            extracted=TruncMinute('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
@@ -777,11 +771,11 @@ class DateFunctionTests(TestCase):
         self.create_model(None, None)
 
         with_null_fields = DTModel.objects.annotate(
-            extracted=TruncSecond('start_date', tzinfo=timezone.UTC())
+            extracted=TruncSecond('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncSecond('start_date', tzinfo=timezone.UTC())
+            extracted=TruncSecond('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
         self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -481,6 +481,8 @@ class DateFunctionTests(TestCase):
             extracted=TruncYear('start_date', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
+        print "QUERY: {}".format(with_null_fields.query)
+
         without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
             extracted=TruncYear('start_date', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
@@ -520,6 +522,19 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncMonth('start_datetime')).count(), 1)
 
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncMonth('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncMonth('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
+
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMonth('start_time')))
 
@@ -543,6 +558,23 @@ class DateFunctionTests(TestCase):
             lambda m: (m.start_datetime, m.extracted)
         )
         self.assertEqual(DTModel.objects.filter(start_datetime__date=TruncDate('start_datetime')).count(), 2)
+
+        # TestFlag
+
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncDate('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        print with_null_fields.query
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncDate('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateField"):
             list(DTModel.objects.annotate(truncated=TruncDate('start_time')))
@@ -568,6 +600,19 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime__time=TruncTime('start_datetime')).count(), 2)
 
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncTime('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncTime('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
+
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to TimeField"):
             list(DTModel.objects.annotate(truncated=TruncTime('start_date')))
 
@@ -591,6 +636,19 @@ class DateFunctionTests(TestCase):
             lambda m: (m.start_datetime, m.extracted)
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncDay('start_datetime')).count(), 1)
+
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncDay('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncDay('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncDay('start_time')))
@@ -624,6 +682,19 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncHour('start_datetime')).count(), 1)
 
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncHour('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncHour('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
+
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncHour('start_date')))
 
@@ -655,6 +726,19 @@ class DateFunctionTests(TestCase):
             lambda m: (m.start_datetime, m.extracted)
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncMinute('start_datetime')).count(), 1)
+
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncMinute('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncMinute('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMinute('start_date')))
@@ -689,6 +773,19 @@ class DateFunctionTests(TestCase):
 
         result = 1 if connection.features.supports_microsecond_precision else 2
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncSecond('start_datetime')).count(), result)
+
+        self.create_model(None, None)
+
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncSecond('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncSecond('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncSecond('start_date')))

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -600,7 +600,7 @@ class DateFunctionTests(TestCase):
             extracted=TruncTime('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+        without_null_fields = DTModel.objects.filter(start_time__isnull=False).annotate(
             extracted=TruncTime('start_time', tzinfo=timezone.UTC())
         ).values('extracted').annotate(c=Count('pk'))
 

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -449,6 +449,12 @@ class DateFunctionTests(TestCase):
         self.assertEqual(qs.count(), 2)
 
     def test_trunc_year_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncYear('start_date')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'year')
         if settings.USE_TZ:
@@ -475,19 +481,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncYear('start_datetime')).count(), 1)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncYear('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncYear('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncYear('start_time')))
 
@@ -495,6 +488,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncYear('start_time', output_field=TimeField())))
 
     def test_trunc_month_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncMonth('start_date')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'month')
         if settings.USE_TZ:
@@ -520,19 +519,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncMonth('start_datetime')).count(), 1)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncMonth('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncMonth('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMonth('start_time')))
 
@@ -540,6 +526,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncMonth('start_time', output_field=TimeField())))
 
     def test_trunc_date_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncDate('start_date')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123))
         if settings.USE_TZ:
@@ -557,19 +549,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime__date=TruncDate('start_datetime')).count(), 2)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncDate('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncDate('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateField"):
             list(DTModel.objects.annotate(truncated=TruncDate('start_time')))
 
@@ -577,6 +556,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncDate('start_time', output_field=TimeField())))
 
     def test_trunc_time_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncTime('start_time')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123))
         if settings.USE_TZ:
@@ -594,19 +579,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime__time=TruncTime('start_datetime')).count(), 2)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncTime('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_time__isnull=False).annotate(
-            extracted=TruncTime('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values('start_time')),
-                         list(without_null_fields.values('start_time')))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to TimeField"):
             list(DTModel.objects.annotate(truncated=TruncTime('start_date')))
 
@@ -614,6 +586,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncTime('start_date', output_field=DateField())))
 
     def test_trunc_day_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncDay('start_date')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'day')
         if settings.USE_TZ:
@@ -631,19 +609,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncDay('start_datetime')).count(), 1)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncDay('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncDay('start_date', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncDay('start_time')))
 
@@ -651,6 +616,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncDay('start_time', output_field=TimeField())))
 
     def test_trunc_hour_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncHour('start_time')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'hour')
         if settings.USE_TZ:
@@ -676,19 +647,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncHour('start_datetime')).count(), 1)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncHour('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncHour('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncHour('start_date')))
 
@@ -696,6 +654,13 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncHour('start_date', output_field=DateField())))
 
     def test_trunc_minute_func(self):
+
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncMinute('start_time')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'minute')
         if settings.USE_TZ:
@@ -721,19 +686,6 @@ class DateFunctionTests(TestCase):
         )
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncMinute('start_datetime')).count(), 1)
 
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncMinute('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncMinute('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
-
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMinute('start_date')))
 
@@ -741,6 +693,12 @@ class DateFunctionTests(TestCase):
             list(DTModel.objects.annotate(truncated=TruncMinute('start_date', output_field=DateField())))
 
     def test_trunc_second_func(self):
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.annotate(extracted=TruncSecond('start_time')).values_list('extracted', flat=True).get()
+        )
+        DTModel.objects.get(start_time=None).delete()
+
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'second')
         if settings.USE_TZ:
@@ -767,19 +725,6 @@ class DateFunctionTests(TestCase):
 
         result = 1 if connection.features.supports_microsecond_precision else 2
         self.assertEqual(DTModel.objects.filter(start_datetime=TruncSecond('start_datetime')).count(), result)
-
-        self.create_model(None, None)
-
-        with_null_fields = DTModel.objects.annotate(
-            extracted=TruncSecond('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
-            extracted=TruncSecond('start_time', tzinfo=timezone.UTC())
-        ).values('extracted').annotate(c=Count('pk'))
-
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
-                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncSecond('start_date')))

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -5,7 +5,9 @@ from unittest import skipIf
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import DateField, DateTimeField, IntegerField, TimeField, Count
+from django.db.models import (
+    Count, DateField, DateTimeField, IntegerField, TimeField,
+)
 from django.db.models.functions import (
     Extract, ExtractDay, ExtractHour, ExtractMinute, ExtractMonth,
     ExtractSecond, ExtractWeekDay, ExtractYear, Trunc, TruncDate, TruncDay,
@@ -70,26 +72,26 @@ class DateFunctionTests(TestCase):
         end_time = None
         duration = timedelta(0)
 
-        if start_datetime: 
+        if start_datetime:
             name = start_datetime.isoformat()
             start_date = start_datetime.date()
             start_time = start_datetime.time()
 
-        if end_datetime: 
+        if end_datetime:
             end_date = end_datetime.date()
             end_time = end_datetime.time()
 
-        if start_datetime != end_datetime: 
+        if start_datetime != end_datetime:
             duration = end_datetime - start_datetime
 
         return DTModel.objects.create(
-            name=name, 
+            name=name,
             start_datetime=start_datetime, end_datetime=end_datetime,
-            start_date=start_date, 
-            end_date=end_date, 
-            start_time=start_time, 
-            end_time=end_time, 
-            duration=duration, 
+            start_date=start_date,
+            end_date=end_date,
+            start_time=start_time,
+            end_time=end_time,
+            duration=duration,
         )
 
     def test_extract_year_exact_lookup(self):
@@ -475,10 +477,16 @@ class DateFunctionTests(TestCase):
 
         self.create_model(None, None)
 
-        with_null_fields = DTModel.objects.annotate(extracted=TruncYear('start_date', tzinfo=timezone.UTC())).values('extracted').annotate(c=Count('pk'))
-        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(extracted=TruncYear('start_date', tzinfo=timezone.UTC())).values('extracted').annotate(c=Count('pk'))
+        with_null_fields = DTModel.objects.annotate(
+            extracted=TruncYear('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
 
-        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()), list(without_null_fields.values()))
+        without_null_fields = DTModel.objects.filter(start_date__isnull=False).annotate(
+            extracted=TruncYear('start_date', tzinfo=timezone.UTC())
+        ).values('extracted').annotate(c=Count('pk'))
+
+        self.assertEqual(list(with_null_fields.filter(extracted__isnull=False).values()),
+                         list(without_null_fields.values()))
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncYear('start_time')))

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -5,9 +5,7 @@ from unittest import skipIf
 
 from django.conf import settings
 from django.db import connection
-from django.db.models import (
-    DateField, DateTimeField, IntegerField, TimeField,
-)
+from django.db.models import DateField, DateTimeField, IntegerField, TimeField
 from django.db.models.functions import (
     Extract, ExtractDay, ExtractHour, ExtractMinute, ExtractMonth,
     ExtractSecond, ExtractWeekDay, ExtractYear, Trunc, TruncDate, TruncDay,
@@ -449,12 +447,6 @@ class DateFunctionTests(TestCase):
         self.assertEqual(qs.count(), 2)
 
     def test_trunc_year_func(self):
-        self.create_model(None, None)
-        self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncYear('start_date')).values_list('extracted', flat=True).get()
-        )
-        DTModel.objects.get(start_time=None).delete()
-
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'year')
         if settings.USE_TZ:
@@ -487,13 +479,15 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncYear('start_time', output_field=TimeField())))
 
-    def test_trunc_month_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncMonth('start_date')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncYear('start_date')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+
+    def test_trunc_month_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'month')
         if settings.USE_TZ:
@@ -525,13 +519,14 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMonth('start_time', output_field=TimeField())))
 
-    def test_trunc_date_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncDate('start_date')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncMonth('start_date')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+    def test_trunc_date_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123))
         if settings.USE_TZ:
@@ -555,13 +550,15 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateField"):
             list(DTModel.objects.annotate(truncated=TruncDate('start_time', output_field=TimeField())))
 
-    def test_trunc_time_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncTime('start_time')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncDate('start_date')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+
+    def test_trunc_time_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123))
         if settings.USE_TZ:
@@ -585,13 +582,14 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to TimeField"):
             list(DTModel.objects.annotate(truncated=TruncTime('start_date', output_field=DateField())))
 
-    def test_trunc_day_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncDay('start_date')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncTime('start_time')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+    def test_trunc_day_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'day')
         if settings.USE_TZ:
@@ -615,13 +613,14 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate TimeField 'start_time' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncDay('start_time', output_field=TimeField())))
 
-    def test_trunc_hour_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncHour('start_time')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncDay('start_date')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+    def test_trunc_hour_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'hour')
         if settings.USE_TZ:
@@ -653,14 +652,14 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncHour('start_date', output_field=DateField())))
 
-    def test_trunc_minute_func(self):
-
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncMinute('start_time')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncHour('start_time')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+    def test_trunc_minute_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'minute')
         if settings.USE_TZ:
@@ -692,13 +691,14 @@ class DateFunctionTests(TestCase):
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncMinute('start_date', output_field=DateField())))
 
-    def test_trunc_second_func(self):
         self.create_model(None, None)
         self.assertIsNone(
-            DTModel.objects.annotate(extracted=TruncSecond('start_time')).values_list('extracted', flat=True).get()
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncMinute('start_time')
+            ).values_list('extracted', flat=True).get()
         )
-        DTModel.objects.get(start_time=None).delete()
 
+    def test_trunc_second_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'second')
         if settings.USE_TZ:
@@ -731,6 +731,13 @@ class DateFunctionTests(TestCase):
 
         with self.assertRaisesMessage(ValueError, "Cannot truncate DateField 'start_date' to DateTimeField"):
             list(DTModel.objects.annotate(truncated=TruncSecond('start_date', output_field=DateField())))
+
+        self.create_model(None, None)
+        self.assertIsNone(
+            DTModel.objects.filter(start_datetime=None).annotate(
+                extracted=TruncSecond('start_time')
+            ).values_list('extracted', flat=True).get()
+        )
 
 
 @skipIf(pytz is None, "this test requires pytz")

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -486,7 +486,6 @@ class DateFunctionTests(TestCase):
             ).values_list('extracted', flat=True).get()
         )
 
-
     def test_trunc_month_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))
         end_datetime = truncate_to(microsecond_support(datetime(2016, 6, 15, 14, 10, 50, 123)), 'month')
@@ -556,7 +555,6 @@ class DateFunctionTests(TestCase):
                 extracted=TruncDate('start_date')
             ).values_list('extracted', flat=True).get()
         )
-
 
     def test_trunc_time_func(self):
         start_datetime = microsecond_support(datetime(2015, 6, 15, 14, 30, 50, 321))

--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -6,7 +6,7 @@ from unittest import skipIf
 from django.conf import settings
 from django.db import connection
 from django.db.models import (
-    Count, DateField, DateTimeField, IntegerField, TimeField,
+    DateField, DateTimeField, IntegerField, TimeField,
 )
 from django.db.models.functions import (
     Extract, ExtractDay, ExtractHour, ExtractMinute, ExtractMonth,


### PR DESCRIPTION
Summary of changes: 
- Rewrote `create_model` helper in tests file to account for null fields. 
- Added test case to `test_trunc_year_func` for querying items with null fields.
- Added graceful handling of null values to user-defined sqlite function `_sqlite_date_trunc`, so that the test passes.

**WIP**. Need to add tests to all other `Trunc` functions and add fixes to a couple other user-defined sqlite functions (as none are checking for `None` at the moment). 
