### PR TITLE
Fixed #26834 -- Made IntegerField forward min/max validators to form …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -653,6 +653,7 @@ answer newbie questions, and generally made Django that much better:
     Ryan Kelly <ryan@rfk.id.au>
     Ryan Niemeyer <https://profiles.google.com/ryan.niemeyer/about>
     Ryno Mathee <rmathee@gmail.com>
+    Sagar Nilesh Shah <shah.sagar.nilesh@gmail.com>
     Sam Newman <http://www.magpiebrain.com/>
     Sander Dijkhuis <sander.dijkhuis@gmail.com>
     Sarthak Mehrish <sarthakmeh03@gmail.com>

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1852,6 +1852,11 @@ class IntegerField(Field):
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.IntegerField}
+        for validator in self.validators:
+            if isinstance(validator, validators.MinValueValidator):
+                kwargs['min_value'] = validator.limit_value
+            if isinstance(validator, validators.MaxValueValidator):
+                kwargs['max_value'] = validator.limit_value
         defaults.update(kwargs)
         return super(IntegerField, self).formfield(**defaults)
 

--- a/tests/model_fields/test_integerfield.py
+++ b/tests/model_fields/test_integerfield.py
@@ -132,6 +132,20 @@ class IntegerFieldTests(TestCase):
         instance = self.model.objects.get(value='10')
         self.assertEqual(instance.value, 10)
 
+    def test_min_max_validator_limit_value_passed_to_formfield(self):
+        """
+        IntegerField passes the limit value set in MinValueValidator and
+        MaxValueValidator to the form fields using formfield() method.
+        """
+        if1 = models.IntegerField()
+        if2 = models.IntegerField(validators=[validators.MinValueValidator(10),
+                                              validators.MaxValueValidator(100)
+                                              ])
+        self.assertIsNone(if1.formfield().min_value)
+        self.assertIsNone(if1.formfield().max_value)
+        self.assertEqual(10, if2.formfield().min_value)
+        self.assertEqual(100, if2.formfield().max_value)
+
 
 class SmallIntegerFieldTests(IntegerFieldTests):
     model = SmallIntegerModel


### PR DESCRIPTION
…field

The change forwards the user set limit values of MinValueValidator/MaxValueValidator
defined in the model IntegerField to the form field using the formfield() method.

Thanks Markus Holtermann for help with the patch.