### PR TITLE
Fixed #26930 -- Fixed makemigrations crash with an empty DATABASES value.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -95,7 +95,8 @@ class Command(BaseCommand):
 
         # Raise an error if any migrations are applied before their dependencies.
         for db in connections:
-            loader.check_consistent_history(connections[db])
+            if connections[db].is_usable():
+                loader.check_consistent_history(connections[db])
 
         # Before anything else, see if there's conflicting apps and drop out
         # hard if there are any and they don't want to merge

--- a/django/db/backends/dummy/base.py
+++ b/django/db/backends/dummy/base.py
@@ -83,4 +83,4 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.validation = BaseDatabaseValidation(self)
 
     def is_usable(self):
-        return True
+        return False

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -9,7 +9,9 @@ import sys
 
 from django.apps import apps
 from django.core.management import CommandError, call_command
-from django.db import DatabaseError, connection, connections, models
+from django.db import (
+    ConnectionHandler, DatabaseError, connection, connections, models,
+)
 from django.db.migrations.exceptions import InconsistentMigrationHistory
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import ignore_warnings, mock, override_settings
@@ -579,6 +581,21 @@ class MakeMigrationsTests(MigrationTestBase):
                 importlib.invalidate_caches()
             call_command('makemigrations', 'migrations', '--empty', '-n', 'a', '-v', '0')
             self.assertTrue(os.path.exists(os.path.join(migration_dir, '0002_a.py')))
+
+    def test_makemigrations_empty_connections(self):
+        empty_connections = ConnectionHandler({
+            'default': {},
+        })
+        with mock.patch('django.core.management.commands.makemigrations.connections', new=empty_connections):
+            # check with no apps
+            out = six.StringIO()
+            call_command("makemigrations", stdout=out)
+            self.assertIn("No changes detected", out.getvalue())
+            # check with app
+            with self.temporary_migration_module() as migration_dir:
+                call_command('makemigrations', 'migrations', verbosity=0)
+                init_file = os.path.join(migration_dir, "__init__.py")
+                self.assertTrue(os.path.exists(init_file))
 
     def test_failing_migration(self):
         # If a migration fails to serialize, it shouldn't generate an empty file. #21280


### PR DESCRIPTION
Set is_usable on the dummy db to False and checked this setting in
makemigrations when iterating through the connections.