### PR TITLE
Fixed #26945 -- Ensured that i18n_patterns returns a list

### DIFF
--- a/django/conf/urls/i18n.py
+++ b/django/conf/urls/i18n.py
@@ -12,7 +12,7 @@ def i18n_patterns(*urls, **kwargs):
     URLconf.
     """
     if not settings.USE_I18N:
-        return urls
+        return list(urls)
     prefix_default_language = kwargs.pop('prefix_default_language', True)
     assert not kwargs, 'Unexpected kwargs for i18n_patterns(): %s' % kwargs
     return [LocaleRegexURLResolver(list(urls), prefix_default_language=prefix_default_language)]

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1525,6 +1525,12 @@ class MiscTests(SimpleTestCase):
         with self.settings(LANGUAGES=[('en', 'English')]):
             self.assertNotEqual('pt-br', g(r))
 
+    def test_i18n_patterns_returns_list(self):
+        with override_settings(USE_I18N=False):
+            self.assertIsInstance(i18n_patterns([]), list)
+        with override_settings(USE_I18N=True):
+            self.assertIsInstance(i18n_patterns([]), list)
+
 
 class ResolutionOrderI18NTests(SimpleTestCase):
 


### PR DESCRIPTION
`i18n_patterns()` can return a tuple, but should return a list: [#26945](https://code.djangoproject.com/ticket/26945)