### PR TITLE
Fixed #26917 -- Fixed crash in disabled ModelChoiceFields.

### DIFF
--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -18,6 +18,8 @@ class JSONField(forms.CharField):
     widget = forms.Textarea
 
     def to_python(self, value):
+        if self.disabled:
+            return value
         if value in self.empty_values:
             return None
         try:

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -373,14 +373,13 @@ class BaseForm(object):
 
     def _clean_fields(self):
         for name, field in self.fields.items():
-            if field.disabled:
-                # Initial values are supposed to be clean
-                self.cleaned_data[name] = self.initial.get(name, field.initial)
-                continue
             # value_from_datadict() gets the data from the data dictionaries.
             # Each widget type knows how to retrieve its own data, because some
             # widgets split data over several HTML fields.
-            value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
+            if field.disabled:
+                value = self.initial.get(name, field.initial)
+            else:
+                value = field.widget.value_from_datadict(self.data, self.files, self.add_prefix(name))
             try:
                 if isinstance(field, FileField):
                     initial = self.initial.get(name, field.initial)

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1519,6 +1519,21 @@ class ModelChoiceFieldTests(TestCase):
             '<label><input name="foo" type="radio" value="" /> ---------</label>'
         )
 
+    def test_disabled_modelchoicefield(self):
+        class ModelChoiceForm(forms.ModelForm):
+            author = forms.ModelChoiceField(Author.objects.all(), disabled=True)
+
+            class Meta:
+                model = Book
+                fields = ['author']
+
+        book = Book.objects.create(author=Writer.objects.create(name='Test writer'))
+        form = ModelChoiceForm({}, instance=book)
+        self.assertEqual(
+            form.errors['author'],
+            ['Select a valid choice. That choice is not one of the available choices.']
+        )
+
     def test_modelchoicefield_iterator(self):
         """
         Iterator defaults to ModelChoiceIterator and can be overridden with

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -260,14 +260,6 @@ class TestFormField(PostgreSQLTestCase):
         form_field = model_field.formfield()
         self.assertIsInstance(form_field, forms.JSONField)
 
-    def test_formfield_disabled(self):
-        class JsonForm(Form):
-            name = CharField()
-            jfield = forms.JSONField(disabled=True)
-
-        form = JsonForm({'name': 'xyz', 'jfield': '["bar"]'}, initial={'jfield': ['foo']})
-        self.assertIn('[&quot;foo&quot;]</textarea>', form.as_p())
-
     def test_prepare_value(self):
         field = forms.JSONField()
         self.assertEqual(field.prepare_value({'a': 'b'}), '{"a": "b"}')

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -260,6 +260,14 @@ class TestFormField(PostgreSQLTestCase):
         form_field = model_field.formfield()
         self.assertIsInstance(form_field, forms.JSONField)
 
+    def test_formfield_disabled(self):
+        class JsonForm(Form):
+            name = CharField()
+            jfield = forms.JSONField(disabled=True)
+
+        form = JsonForm({'name': 'xyz', 'jfield': '["bar"]'}, initial={'jfield': ['foo']})
+        self.assertIn('[&quot;foo&quot;]</textarea>', form.as_p())
+
     def test_prepare_value(self):
         field = forms.JSONField()
         self.assertEqual(field.prepare_value({'a': 'b'}), '{"a": "b"}')


### PR DESCRIPTION
Partially reverted refs #25532 to fix a regression in Django 1.10.
This reintroduces a crash for disabled forms.JSONField (refs #26949),
however, that issue is also present on Django 1.9.

https://code.djangoproject.com/ticket/26917