### PR TITLE
Don't set path_info to '/'

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -79,13 +79,7 @@ class LimitedStream(object):
 class WSGIRequest(http.HttpRequest):
     def __init__(self, environ):
         script_name = get_script_name(environ)
-        path_info = get_path_info(environ)
-        if not path_info:
-            # Sometimes PATH_INFO exists, but is empty (e.g. accessing
-            # the SCRIPT_NAME URL without a trailing slash). We really need to
-            # operate as if they'd requested '/'. Not amazingly nice to force
-            # the path like this, but should be harmless.
-            path_info = '/'
+        path_info = get_path_info(environ) or ''
         self.environ = environ
         self.path_info = path_info
         # be careful to only replace the first slash in the path because of


### PR DESCRIPTION
This addresses the root cause of the following problem:

`APPEND_SLASH` does not work on a project's root URL. Sample project url conf:
```
project/urls.py:

urlpatterns = [
    url('', include(project.main.urls, namespace='project'))
]

project/main/urls.py:

urlpatterns = [
    url('^$', IndexPage.as_view(), name='index'),
    url('^about/$', AboutPage.as_view(), name='about'),
    url('^faq/$', FAQPage.as_view(), name='faq'),
    ...
]
```

Django's `RegexURLResolver` class is instantiated with `^/` as its root URL (https://github.com/django/django/blob/1.9.8/django/core/urlresolvers.py#L152), and it is against this pattern that the request path is first matched before being checked against each URL pattern. For example, if the request path is `/about/`, the RegexURLResolver instance matches the leading `/` and runs the remainder of the string (`about/`) through each pattern. Essentially, this means that leading slashes in the request path are thrown away in matching patterns.

The request path is calculated from the `PATH_INFO` environment variable—except that the Django `WSGIRequest` class forces an empty string to a `/` (https://github.com/django/django/blob/1.9.8/django/core/handlers/wsgi.py#L86). That is, if `PATH_INFO` is an empty string, the URL resolver is still matching against `/`. Because of this behavior of the `WSGIRequest` class, Django's URL resolving mechanism cannot tell the difference between navigating to `http://example.com/my-project` and `http://example.com/my-project/`, since both result in the request path being `/`.

Before the URL resolution happens, Django's `CommonMiddleware` decides (https://github.com/django/django/blob/1.9.8/django/middleware/common.py#L76) whether it should force a redirect and append a slash to the current request path. It makes this decision in part by checking whether the current URL ends with `/`. If it does end with `/`, then no redirect happens. If the path is `/about`, the redirect still happens. If, however, the path is `/`, it already ends with `/` as far as Django is concerned. Therefore, no redirect is issued.

This bug is only noticeable when Django lives in a sub-path of the root of the domain. Therefore, even though the Django tests passed after I made this change, I am not confident that it really solves the problem. I am hoping someone can recommend the best way to test this problem, and to verify that it does not cause other problems.