### PR TITLE
Fixed #20888 -- Allowed specifying index ordering in class-based indexes.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -160,6 +160,9 @@ class BaseDatabaseFeatures(object):
     # Can the backend introspect a TimeField, instead of a DateTimeField?
     can_introspect_time_field = True
 
+    # Can the backend introspect the column order (ASC/DESC) for indexes
+    supports_index_column_ordering = True
+
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -24,6 +24,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_autofield = True
     can_introspect_binary_field = False
     can_introspect_small_integer_field = True
+    supports_index_column_ordering = False
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
     allows_auto_pk_0 = False

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -259,7 +259,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         cursor.execute("""
             SELECT
                 index_name,
-                LOWER(column_name)
+                LOWER(column_name), descend
             FROM
                 user_ind_columns cols
             WHERE
@@ -271,11 +271,12 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 )
             ORDER BY cols.column_position
         """, [table_name])
-        for constraint, column in cursor.fetchall():
+        for constraint, column, order in cursor.fetchall():
             # If we're the first column, make the record
             if constraint not in constraints:
                 constraints[constraint] = {
                     "columns": [],
+                    "orders": [],
                     "primary_key": False,
                     "unique": False,
                     "foreign_key": None,
@@ -284,4 +285,5 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 }
             # Record the details
             constraints[constraint]['columns'].append(column)
+            constraints[constraint]['orders'].append(order)
         return constraints

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -46,6 +46,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return Database.sqlite_version_info >= (3, 6, 8)
 
     @cached_property
+    def supports_index_column_ordering(self):
+        return Database.sqlite_version_info >= (3, 3, 0)
+
+    @cached_property
     def can_release_savepoints(self):
         return self.uses_savepoints
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -17,6 +17,8 @@ class Index(object):
         if not fields:
             raise ValueError('At least one field is required to define an index.')
         self.fields = fields
+        # A list of 2-tuple with the name and ordering (DESC for reverse) of the field
+        self.fields_orders = [(f[1:], 'DESC') if f.startswith('-') else (f, '') for f in self.fields]
         self.name = name or ''
         if self.name:
             errors = self.check_name()
@@ -38,15 +40,15 @@ class Index(object):
         return errors
 
     def create_sql(self, model, schema_editor):
-        fields = [model._meta.get_field(field) for field in self.fields]
+        fields = [model._meta.get_field(fo[0]) for fo in self.fields_orders]
         tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields)
-        columns = [field.column for field in fields]
 
         quote_name = schema_editor.quote_name
+        columns = [('%s %s' % (quote_name(f.column), fo[1])).strip() for f, fo in zip(fields, self.fields_orders)]
         return schema_editor.sql_create_index % {
             'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
-            'columns': ', '.join(quote_name(column) for column in columns),
+            'columns': ', '.join(columns),
             'extra': tablespace_sql,
         }
 
@@ -82,8 +84,11 @@ class Index(object):
         fit its size by truncating the excess length.
         """
         table_name = model._meta.db_table
-        column_names = [model._meta.get_field(field).column for field in self.fields]
-        hash_data = [table_name] + column_names + [self.suffix]
+        column_names = [model._meta.get_field(fo[0]).column for fo in self.fields_orders]
+        column_names_with_order = [
+            (('-%s' if fo[1] else '%s') % cn) for cn, fo in zip(column_names, self.fields_orders)
+        ]
+        hash_data = [table_name] + column_names_with_order + [self.suffix]
         self.name = '%s_%s_%s' % (
             table_name[:11],
             column_names[0][:7],

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -34,6 +34,25 @@ options`_.
 
 A list of the name of the fields on which the index is desired.
 
+By default the indexes are created with an ascending order for all the columns.
+To define an index with a descending order for a particular column, a hyphen
+(-) can be added before the field's name while defining the index.
+
+For example::
+
+    Index(fields=['headline', '-pub_date'], name='headline_pub_date_reverse_idx')
+
+The above index would issue an SQL with ``(headline, pub_date DESC)``. This is
+supported only for PostgreSQL, Oracle and SQLite. Databases that don't
+support defining ordering on index columns simply ignore the ``ASC/DESC``
+keywords in the executed SQL.
+
+  .. admonition:: Support for column ordering on SQLite
+
+    Column ordering is supported by SQLite only for versions>=3.3.0 and some
+    database file formats. Please refer the `official docs
+    <https://www.sqlite.org/lang_createindex.html>`_ of SQLite for specifics.
+
 ``name``
 --------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -305,6 +305,10 @@ Database backend API
 * To enable ``FOR UPDATE SKIP LOCKED`` support, set
   ``DatabaseFeatures.has_select_for_update_skip_locked = True``.
 
+* The ``DatabaseFeatures.supports_index_column_ordering`` flag was added
+  for backends that allow defining ordering for columns (ASC/DESC) in indexes.
+  The default value is ``True``.
+
 Dropped support for PostgreSQL 9.2 and PostGIS 2.0
 --------------------------------------------------
 

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -182,6 +182,18 @@ class IntrospectionTests(TransactionTestCase):
         self.assertNotIn('first_name', indexes)
         self.assertIn('id', indexes)
 
+    @skipUnlessDBFeature('supports_index_column_ordering')
+    def test_get_constraints_indexes_orders(self):
+        """
+        Indexes should have the "orders" key.
+        """
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(cursor, Article._meta.db_table)
+        for key, val in constraints.items():
+            if val['index'] and not (val['primary_key'] or val['unique']):
+                self.assertIn('orders', val)
+                self.assertEqual(len(val['columns']), len(val['orders']))
+
 
 def datatype(dbtype, description):
     """Helper to convert a data type into a string."""

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -46,6 +46,11 @@ class IndexesTests(TestCase):
         index.set_name_with_model(Book)
         self.assertEqual(index.name, 'model_index_author_0f5565_idx')
 
+        # '-' for DESC set columns should be accounted in index name
+        index = models.Index(fields=['-author'])
+        index.set_name_with_model(Book)
+        self.assertEqual(index.name, 'model_index_author_708765_idx')
+
         # fields may be truncated in the name. db_column is used for naming.
         long_field_index = models.Index(fields=['pages'])
         long_field_index.set_name_with_model(Book)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -156,6 +156,12 @@ class SchemaTests(TransactionTestCase):
                     counts['indexes'] += 1
         return counts
 
+    def assertIndexOrder(self, table, index, order):
+        constraints = self.get_constraints(table)
+        self.assertIn(index, constraints)
+        index_orders = constraints[index]['orders']
+        self.assertTrue(all([(val == expected) for val, expected in zip(index_orders, order)]))
+
     # Tests
     def test_creation_deletion(self):
         """
@@ -1596,6 +1602,25 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.remove_index(Author, index)
         self.assertNotIn('name', self.get_indexes(Author._meta.db_table))
+
+    def test_order_index(self):
+        """
+        Indexes defined with ordering (ASC/DESC) defined on column
+        """
+        # Create the table
+        with connection.schema_editor() as editor:
+            editor.create_model(Author)
+        # Ensure the table is there and has no index
+        self.assertNotIn('title', self.get_indexes(Author._meta.db_table))
+        index_name = 'author_name_idx'
+        # Add the index
+        index = Index(fields=['name', '-weight'], name=index_name)
+        with connection.schema_editor() as editor:
+            editor.add_index(Author, index)
+        if connection.features.supports_index_column_ordering:
+            if connection.features.uppercases_column_names:
+                index_name = index_name.upper()
+            self.assertIndexOrder(Author._meta.db_table, index_name, ['ASC', 'DESC'])
 
     def test_indexes(self):
         """


### PR DESCRIPTION
Ticket [#20888](https://code.djangoproject.com/ticket/20888/).

MySQL doesn't support this feature.

This PR is divided into 2 commits
* Modifying the introspections of all databases to take index order (ASC/DESC) into account.
* The feature itself.

I am using "refs" instead of "fixed" because the reporter had requested for the feature in `unique_together` as well but I couldn't understand what that means.