### PR TITLE
(Docs) Minor consistency fix in index.txt

### DIFF
--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -78,7 +78,7 @@ details on how ``staticfiles`` finds your files.
 .. _serving-static-files-in-development:
 
 Serving static files during development
-========================================
+=======================================
 
 If you use :mod:`django.contrib.staticfiles` as explained above,
 :djadmin:`runserver` will do this automatically when :setting:`DEBUG` is set
@@ -112,7 +112,7 @@ this by adding the following snippet to your urls.py::
 .. _serving-uploaded-files-in-development:
 
 Serving files uploaded by a user during development
-====================================================
+===================================================
 
 During development, you can serve user-uploaded media files from
 :setting:`MEDIA_ROOT` using the :func:`django.contrib.staticfiles.views.serve`

--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -77,7 +77,7 @@ details on how ``staticfiles`` finds your files.
 
 .. _serving-static-files-in-development:
 
-Serving static files during development.
+Serving static files during development
 ========================================
 
 If you use :mod:`django.contrib.staticfiles` as explained above,
@@ -111,7 +111,7 @@ this by adding the following snippet to your urls.py::
 
 .. _serving-uploaded-files-in-development:
 
-Serving files uploaded by a user during development.
+Serving files uploaded by a user during development
 ====================================================
 
 During development, you can serve user-uploaded media files from


### PR DESCRIPTION
Hello,
I noticed a small consistency issue in index.txt
I removed periods in two section headers