### PR TITLE
Omit 'just' from docs when explaining context processors

### DIFF
--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -758,7 +758,7 @@ variables:
 Writing your own context processors
 -----------------------------------
 
-A context processor has a very simple interface: It's just a Python function
+A context processor has a very simple interface: It's a Python function
 that takes one argument, an :class:`~django.http.HttpRequest` object, and
 returns a dictionary that gets added to the template context. Each context
 processor *must* return a dictionary.


### PR DESCRIPTION
This is a trivial documentation improvement.