### PR TITLE
Fixed #26960 -- Added PasswordResetConfirmView option to automatically log in after a reset.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -381,6 +381,7 @@ answer newbie questions, and generally made Django that much better:
     Jonathan Feignberg <jdf@pobox.com>
     Jonathan Slenders
     Jordan Dimov <s3x3y1@gmail.com>
+    Jordi J. Tablada <jordi.joan@gmail.com>
     Jorge Bastida <me@jorgebastida.com>
     Jorge Gajon <gajon@gajon.org>
     José Tomás Tocino García <josetomas.tocino@gmail.com>

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -415,6 +415,7 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
     template_name = 'registration/password_reset_confirm.html'
     title = _('Enter new password')
     token_generator = default_token_generator
+    post_reset_login = False
 
     @method_decorator(sensitive_post_parameters())
     @method_decorator(never_cache)
@@ -438,7 +439,9 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
         return kwargs
 
     def form_valid(self, form):
-        form.save()
+        user = form.save()
+        if self.post_reset_login:
+            auth_login(self.request, user)
         return super(PasswordResetConfirmView, self).form_valid(form)
 
     def get_context_data(self, **kwargs):

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -81,6 +81,10 @@ Minor features
   ``password_reset_confirm()``, and ``password_reset_complete()`` function-based
   views.
 
+* The :class:`~django.contrib.auth.views.PasswordResetConfirmView` accepts a new
+  ``post_reset_login`` argument to decide whether a user gets automatically logged in
+  after a successful password reset or not.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1480,6 +1480,10 @@ implementation details see :ref:`using-the-views`.
       will default to ``default_token_generator``, it's an instance of
       ``django.contrib.auth.tokens.PasswordResetTokenGenerator``.
 
+    * ``post_reset_login``: Boolean, if set to True the user is going to be
+      automatically authenticated after the password has been successfully reset.
+      Set to False by default.
+
     * ``form_class``: Form that will be used to set the password. Defaults to
       :class:`~django.contrib.auth.forms.SetPasswordForm`.
 

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -307,6 +307,14 @@ class PasswordResetTest(AuthViewsTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertURLEqual(response.url, '/password_reset/')
 
+    def test_confirm_login_post_reset(self):
+        url, path = self._test_confirm_start()
+        path = path.replace('/reset/', '/reset/post_reset_login/')
+        response = self.client.post(path, {'new_password1': 'anewpassword', 'new_password2': 'anewpassword'})
+        self.assertEqual(response.status_code, 302)
+        self.assertURLEqual(response.url, '/reset/done/')
+        self.assertIn(SESSION_KEY, self.client.session)
+
     def test_confirm_display_user_from_form(self):
         url, path = self._test_confirm_start()
         response = self.client.get(path)

--- a/tests/auth_tests/urls.py
+++ b/tests/auth_tests/urls.py
@@ -85,6 +85,8 @@ urlpatterns = auth_urlpatterns + [
         views.PasswordResetConfirmView.as_view(success_url='/custom/')),
     url(r'^reset/custom/named/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         views.PasswordResetConfirmView.as_view(success_url=reverse_lazy('password_reset'))),
+    url(r'^reset/post_reset_login/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        views.PasswordResetConfirmView.as_view(post_reset_login=True)),
     url(r'^password_change/custom/$',
         views.PasswordChangeView.as_view(success_url='/custom/')),
     url(r'^password_change/custom/named/$',


### PR DESCRIPTION
Sometimes it's useful to log in users right after they have successfully reset their passwords. This patch adds a new attribute to the `PasswordResetConfirmView` to activate this behaviour.