### PR TITLE
Improve misleading comment

### DIFF
--- a/django/contrib/admin/static/admin/js/jquery.init.js
+++ b/django/contrib/admin/static/admin/js/jquery.init.js
@@ -1,7 +1,8 @@
 /*global django:true, jQuery:false*/
 /* Puts the included jQuery into our own namespace using noConflict and passing
  * it 'true'. This ensures that the included jQuery doesn't pollute the global
- * namespace.
+ * namespace (i.e. this preserves pre-existing values for window.$ if window.$
+ * is not a jQuery object, but removes jQuery from the global namespace).
  */
 var django = django || {};
 django.jQuery = jQuery.noConflict(true);

--- a/django/contrib/admin/static/admin/js/jquery.init.js
+++ b/django/contrib/admin/static/admin/js/jquery.init.js
@@ -1,8 +1,7 @@
 /*global django:true, jQuery:false*/
 /* Puts the included jQuery into our own namespace using noConflict and passing
  * it 'true'. This ensures that the included jQuery doesn't pollute the global
- * namespace (i.e. this preserves pre-existing values for both window.$ and
- * window.jQuery).
+ * namespace.
  */
 var django = django || {};
 django.jQuery = jQuery.noConflict(true);


### PR DESCRIPTION
The comment `i.e. this preserves pre-existing values for both window.$ and	window.jQuery` is demonstrably untrue:

from https://api.jquery.com/jquery.noconflict/

**removeAll**
Type: `Boolean`
A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).

This can be verified by logging the value of `$` before and after `jQuery.noConflict(true)` is called.