### PR TITLE
Fixed #26896 - Fix lazy init() of FileSystemStorage

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -254,8 +254,6 @@ class FileSystemStorage(Storage):
     def __init__(self, location=None, base_url=None, file_permissions_mode=None,
                  directory_permissions_mode=None):
         self._location = location
-        if base_url is not None and not base_url.endswith('/'):
-            base_url += '/'
         self._base_url = base_url
         self._file_permissions_mode = file_permissions_mode
         self._directory_permissions_mode = directory_permissions_mode
@@ -286,6 +284,8 @@ class FileSystemStorage(Storage):
 
     @cached_property
     def base_url(self):
+        if self._base_url is not None and not self._base_url.endswith('/'):
+            self._base_url += '/'
         return self._value_or_setting(self._base_url, settings.MEDIA_URL)
 
     @cached_property

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -24,6 +24,7 @@ from django.test import (
     override_settings,
 )
 from django.test.utils import requires_tz_support
+from django.urls import NoReverseMatch, reverse_lazy
 from django.utils import six, timezone
 from django.utils._os import upath
 from django.utils.deprecation import RemovedInDjango20Warning
@@ -115,6 +116,19 @@ class FileStorageTests(SimpleTestCase):
         storage = self.storage_class(location='')
         self.assertEqual(storage.base_location, '')
         self.assertEqual(storage.location, upath(os.getcwd()))
+
+    def test_lazy_init(self):
+        """
+        Makes sure that init is lazy.
+        """
+        storage = self.storage_class(location=self.temp_dir,
+                                     base_url=reverse_lazy('app:url'))
+        f = ContentFile('custom contents')
+        f.name = 'test.file'
+        storage.save(None, f)
+
+        with self.assertRaises(NoReverseMatch):
+            storage.url(f.name)
 
     def test_file_access_options(self):
         """


### PR DESCRIPTION
The check for trailing slash is omitted if the `base_url` is not of `string_types`.