### PR TITLE
Fixed #26974 -- Added Hash index class for postgres

### DIFF
--- a/django/contrib/gis/db/backends/postgis/introspection.py
+++ b/django/contrib/gis/db/backends/postgis/introspection.py
@@ -24,14 +24,15 @@ class PostGISIntrospection(DatabaseIntrospection):
     # expression over the raster column through the ST_ConvexHull function.
     # So the default query has to be adapted to include raster indices.
     _get_indexes_query = """
-        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary
-        FROM pg_catalog.pg_class c, pg_catalog.pg_class c2,
-            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr
-        LEFT JOIN pg_catalog.pg_type t ON t.oid = attr.atttypid
+        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary,
+            am.amname
+        FROM pg_catalog.pg_class c, pg_catalog.pg_class c2, pg_catalog.pg_index idx,
+            pg_catalog.pg_attribute attr, pg_catalog.pg_type t, pg_catalog.pg_am am
         WHERE
             c.oid = idx.indrelid
             AND idx.indexrelid = c2.oid
             AND attr.attrelid = c.oid
+            AND t.oid = attr.atttypid
             AND (
                 attr.attnum = idx.indkey[0] OR
                 (t.typname LIKE 'raster' AND idx.indkey = '0')

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -883,6 +883,7 @@ class BaseDatabaseSchemaEditor(object):
         return sql_create_index % {
             "table": self.quote_name(model._meta.db_table),
             "name": self.quote_name(self._create_index_name(model, columns, suffix=suffix)),
+            "using": "",
             "columns": ", ".join(self.quote_name(column) for column in columns),
             "extra": tablespace_sql,
         }

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -36,13 +36,15 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     ignored_tables = []
 
     _get_indexes_query = """
-        SELECT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary
+        SELECT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary,
+            am.amname
         FROM pg_catalog.pg_class c, pg_catalog.pg_class c2,
-            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr
+            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr, pg_catalog.pg_am am
         WHERE c.oid = idx.indrelid
             AND idx.indexrelid = c2.oid
             AND attr.attrelid = c.oid
             AND attr.attnum = idx.indkey[0]
+            AND c2.relam = am.oid
             AND c.relname = %s"""
 
     def get_field_type(self, data_type, description):
@@ -132,6 +134,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             # row[1] (idx.indkey) is stored in the DB as an array. It comes out as
             # a string of space-separated integers. This designates the field
             # indexes (1-based) of the fields that have indexes on the table.
+            # row[4] is the type of index, eg. btree, hash, etc.
             # Here, we skip any indexes across multiple fields.
             if ' ' in row[1]:
                 continue
@@ -142,6 +145,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 indexes[row[0]]['primary_key'] = True
             if row[2]:
                 indexes[row[0]]['unique'] = True
+            indexes[row[0]]['type'] = row[4]
         return indexes
 
     def get_constraints(self, cursor, table_name):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -11,6 +11,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_sequence = "DROP SEQUENCE IF EXISTS %(sequence)s CASCADE"
     sql_set_sequence_max = "SELECT setval('%(sequence)s', MAX(%(column)s)) FROM %(table)s"
 
+    sql_create_index = "CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s"
     sql_create_varchar_index = "CREATE INDEX %(name)s ON %(table)s (%(columns)s varchar_pattern_ops)%(extra)s"
     sql_create_text_index = "CREATE INDEX %(name)s ON %(table)s (%(columns)s text_pattern_ops)%(extra)s"
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -5,7 +5,7 @@ import hashlib
 from django.utils.encoding import force_bytes
 from django.utils.functional import cached_property
 
-__all__ = ['Index']
+__all__ = ['Index', 'Hash']
 
 # The max length of the names of the indexes (restricted to 30 due to Oracle)
 MAX_NAME_LENGTH = 30
@@ -45,15 +45,15 @@ class Index(object):
             self._name = 'D%s' % self._name[1:]
         return errors
 
-    def create_sql(self, model, schema_editor):
+    def create_sql(self, model, schema_editor, using=''):
         fields = [model._meta.get_field(field) for field in self.fields]
         tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields)
         columns = [field.column for field in fields]
-
         quote_name = schema_editor.quote_name
         return schema_editor.sql_create_index % {
             'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
+            'using': using,
             'columns': ', '.join(quote_name(column) for column in columns),
             'extra': tablespace_sql,
         }
@@ -111,3 +111,14 @@ class Index(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+
+class Hash(Index):
+    suffix = 'hsh'
+    supported_backends = ['postgresql']
+
+    def create_sql(self, model, schema_editor):
+        using = ''
+        if schema_editor.connection.vendor in self.supported_backends:
+            using = 'USING hash'
+        return super(Hash, self).create_sql(model, schema_editor, using)

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -9,7 +9,8 @@ Model index reference
 .. versionadded:: 1.11
 
 Index classes ease creating database indexes. This document explains the API
-references of :class:`Index` which includes the `index options`_.
+references of :class:`Index` which includes the `index options`_ and
+`built-in indexes`_.
 
 .. admonition:: Referencing built-in indexes
 
@@ -22,8 +23,6 @@ references of :class:`Index` which includes the `index options`_.
 =================
 
 .. class:: Index(fields=[], name=None)
-
-    Creates an index (B-Tree) in the database.
 
 ``fields``
 -----------
@@ -46,3 +45,15 @@ than 30 characters and shouldn't start with a number (0-9) or underscore (_).
     Use the :class:`~django.db.migrations.operations.AddIndex` and
     :class:`~django.db.migrations.operations.RemoveIndex` operations to add
     and remove indexes.
+
+Built-in indexes
+================
+
+.. class:: Index(fields=[], name=None)
+
+    Creates the default index (B-Tree) in the database.
+
+.. class:: Hash(Index)
+
+    Creates a hash index in the database. This index is supported only by
+    postgresql.

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -170,7 +170,11 @@ class IntrospectionTests(TransactionTestCase):
     def test_get_indexes(self):
         with connection.cursor() as cursor:
             indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
-        self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
+        if connection.vendor == 'postgresql':
+            self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False, 'type': 'btree'})
+        else:
+
+            self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
 
     def test_get_indexes_multicol(self):
         """


### PR DESCRIPTION
Ticket [#26974](https://code.djangoproject.com/ticket/26974#ticket).

PR divided into two commits
1. Add introspection for index types in postgres
2. Add Hash index

I need some advice on one thing - Databases other than `postgresql` (which do not support hash indexes) silently fall back to creating a btree index according to my current implementation. Is this the right way ?