### PR TITLE
Fix #26975: clarify use of paths with loaddata and how to namespace fixture files

### DIFF
--- a/docs/howto/initial-data.txt
+++ b/docs/howto/initial-data.txt
@@ -72,12 +72,25 @@ Where Django finds fixture files
 --------------------------------
 
 By default, Django looks in the ``fixtures`` directory inside each app for
-fixtures. You can set the :setting:`FIXTURE_DIRS` setting to a list of
-additional directories where Django should look.
+fixtures, so the command ``loaddata sample`` would find the file
+``my_app/fixtures/sample.json``.  This works with relative paths as
+well, so ``loaddata my_app/sample`` will find the file
+``my_app/fixtures/my_app/sample.json``.  If you want to suppress the
+usual search, use an absolute path to specify the location of
+your fixture file, as in ``loaddata /path/to/sample``.
 
-When running :djadmin:`manage.py loaddata <loaddata>`, you can also
-specify a path to a fixture file, which overrides searching the usual
-directories.
+You can set the :setting:`FIXTURE_DIRS` setting to a list of
+additional directories where Django should look for fixtures.
+
+.. admonition:: Fixture file namespacing
+
+    Django will use the first fixture file it finds whose name matches,
+    so if you have fixture files with the same name in
+    different applications, you will be unable to
+    distinguish between them in your loaddata commands.
+    The easiest way to avoid this problem is by *namespacing* your
+    fixture files; that is, by putting them inside a directory named
+    for their application, as in the relative path example above.
 
 .. seealso::
 


### PR DESCRIPTION
- Explain the different effects of relative and absolute paths on loaddata.
- Suggest that fixture files be namespaced, which makes the documentation for fixtures consistent with that for templates and static files.