### PR TITLE
Fixed #26976 -- Added LiveServerTestCase.server_thread_class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -144,6 +144,7 @@ answer newbie questions, and generally made Django that much better:
     Chris Bennett <chrisrbennett@yahoo.com>
     Chris Cahoon <chris.cahoon@gmail.com>
     Chris Chamberlin <dja@cdc.msbx.net>
+    Chris Jerdonek
     Chris Jones <chris@brack3t.com>
     Chris Lamb <chris@chris-lamb.co.uk>
     Chris Streeter <chris@chrisstreeter.com>

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1285,6 +1285,7 @@ class LiveServerTestCase(TransactionTestCase):
     other thread can see the changes.
     """
     host = 'localhost'
+    server_thread_class = LiveServerThread
     static_handler = _StaticFilesHandler
 
     @classproperty
@@ -1321,7 +1322,7 @@ class LiveServerTestCase(TransactionTestCase):
 
     @classmethod
     def _create_server_thread(cls, connections_override):
-        return LiveServerThread(
+        return cls.server_thread_class(
             cls.host,
             cls.static_handler,
             connections_override=connections_override,


### PR DESCRIPTION
This makes it easier for one to change the class used by the TestCase
class to create server threads.  This follows the pattern used in other
test-related classes, like with SimpleTestCase.client_class and
DiscoverRunner.test_suite.