### PR TITLE
Fixed #26954 -- Fixed has_module_permission on ModelAdmin

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.admin import ModelAdmin, actions
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -399,8 +399,6 @@ class AdminSite(object):
 
             has_module_perms = model_admin.has_module_permission(request)
             if not has_module_perms:
-                if label:
-                    raise PermissionDenied
                 continue
 
             perms = model_admin.get_model_perms(request)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1926,7 +1926,7 @@ class AdminViewPermissionsTest(TestCase):
         # the user has no module permissions, because this module doesn't exist
         change_user.user_permissions.remove(permission)
         response = self.client.get(reverse('admin:app_list', args=('admin_views',)))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
         # the user now has module permissions
         change_user.user_permissions.add(permission)


### PR DESCRIPTION
When has_module_permission method set to False on ModelAdmin,
app page was raising 403 Forbidden error. Now, it is fixed.