### PR TITLE
Fixed #25598 -- Support for SCRIPT_NAME in STATIC_URL and MEDIA_URL

### DIFF
--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals
 
 import logging
 
-from django.conf import settings
 from django.contrib.gis import gdal
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 from django.forms.widgets import Widget
 from django.template import loader
+from django.urls import get_prefixed_static_url
 from django.utils import six, translation
 
 logger = logging.getLogger('django.contrib.gis')
@@ -68,7 +68,7 @@ class BaseGeometryWidget(Widget):
             module='geodjango_%s' % name.replace('-', '_'),  # JS-safe
             serialized=self.serialize(value),
             geom_type=gdal.OGRGeomType(self.attrs['geom_type']),
-            STATIC_URL=settings.STATIC_URL,
+            STATIC_URL=get_prefixed_static_url(),
             LANGUAGE_BIDI=translation.get_language_bidi(),
         )
         return loader.render_to_string(self.template_name, context)

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -8,7 +8,9 @@ import re
 from collections import OrderedDict
 
 from django.conf import settings
-from django.contrib.staticfiles.utils import check_settings, check_base_url, matches_patterns
+from django.contrib.staticfiles.utils import (
+    check_base_url, check_settings, matches_patterns,
+)
 from django.core.cache import (
     InvalidCacheBackendError, cache as default_cache, caches,
 )

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -8,13 +8,14 @@ import re
 from collections import OrderedDict
 
 from django.conf import settings
-from django.contrib.staticfiles.utils import check_settings, matches_patterns
+from django.contrib.staticfiles.utils import check_settings, check_base_url, matches_patterns
 from django.core.cache import (
     InvalidCacheBackendError, cache as default_cache, caches,
 )
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage, get_storage_class
+from django.urls import get_prefixed_static_url
 from django.utils.encoding import force_bytes, force_text
 from django.utils.functional import LazyObject
 from django.utils.six import iteritems
@@ -34,10 +35,10 @@ class StaticFilesStorage(FileSystemStorage):
         if location is None:
             location = settings.STATIC_ROOT
         if base_url is None:
-            base_url = settings.STATIC_URL
-        check_settings(base_url)
-        super(StaticFilesStorage, self).__init__(location, base_url,
-                                                 *args, **kwargs)
+            base_url = get_prefixed_static_url()
+        check_settings()
+        check_base_url(base_url)
+        super(StaticFilesStorage, self).__init__(location, base_url, *args, **kwargs)
         # FileSystemStorage fallbacks to MEDIA_ROOT when location
         # is empty, so we restore the empty value.
         if not location:
@@ -161,6 +162,7 @@ class HashedFilesMixin(object):
             to and calling the url() method of the storage.
             """
             matched, url = matchobj.groups()
+            static_url = get_prefixed_static_url()
 
             # Ignore absolute/protocol-relative and data-uri URLs.
             if re.match(r'^[a-z]+:', url):
@@ -168,7 +170,7 @@ class HashedFilesMixin(object):
 
             # Ignore absolute URLs that don't point to a static file (dynamic
             # CSS / JS?). Note that STATIC_URL cannot be empty.
-            if url.startswith('/') and not url.startswith(settings.STATIC_URL):
+            if url.startswith('/') and not url.startswith(static_url):
                 return matched
 
             # Strip off the fragment so a path-like fragment won't interfere.
@@ -176,8 +178,8 @@ class HashedFilesMixin(object):
 
             if url_path.startswith('/'):
                 # Otherwise the condition above would have returned prematurely.
-                assert url_path.startswith(settings.STATIC_URL)
-                target_name = url_path[len(settings.STATIC_URL):]
+                assert url_path.startswith(static_url)
+                target_name = url_path[len(static_url):]
             else:
                 # We're using the posixpath module to mix paths and URLs conveniently.
                 source_name = name if os.sep == '/' else name.replace(os.sep, '/')

--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -3,6 +3,7 @@ import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.urls import get_prefixed_static_url, get_prefixed_media_url
 
 
 def matches_patterns(path, patterns=None):
@@ -41,20 +42,28 @@ def get_files(storage, ignore_patterns=None, location=''):
             yield fn
 
 
-def check_settings(base_url=None):
+def check_settings():
     """
     Checks if the staticfiles settings have sane values.
     """
-    if base_url is None:
-        base_url = settings.STATIC_URL
-    if not base_url:
+    if not settings.STATIC_URL:
         raise ImproperlyConfigured(
             "You're using the staticfiles app "
             "without having set the required STATIC_URL setting.")
-    if settings.MEDIA_URL == base_url:
+    if settings.MEDIA_URL == settings.STATIC_URL:
         raise ImproperlyConfigured("The MEDIA_URL and STATIC_URL "
                                    "settings must have different values")
     if ((settings.MEDIA_ROOT and settings.STATIC_ROOT) and
             (settings.MEDIA_ROOT == settings.STATIC_ROOT)):
         raise ImproperlyConfigured("The MEDIA_ROOT and STATIC_ROOT "
                                    "settings must have different values")
+
+
+def check_base_url(base_url=None):
+    """
+    Checks if the base static URL differs from media URL.
+    """
+    if base_url is None:
+        base_url = get_prefixed_static_url()
+    if get_prefixed_media_url() == base_url:
+        raise ImproperlyConfigured("The media and static URLs must have different values")

--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -3,7 +3,7 @@ import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import get_prefixed_static_url, get_prefixed_media_url
+from django.urls import get_prefixed_media_url, get_prefixed_static_url
 
 
 def matches_patterns(path, patterns=None):

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -254,6 +254,8 @@ class FileSystemStorage(Storage):
     def __init__(self, location=None, base_url=None, file_permissions_mode=None,
                  directory_permissions_mode=None):
         self._location = location
+        if base_url is not None and not base_url.endswith('/'):
+            base_url += '/'
         self._base_url = base_url
         self._file_permissions_mode = file_permissions_mode
         self._directory_permissions_mode = directory_permissions_mode
@@ -284,9 +286,8 @@ class FileSystemStorage(Storage):
 
     @cached_property
     def base_url(self):
-        if self._base_url is not None and not self._base_url.endswith('/'):
-            self._base_url += '/'
-        return self._value_or_setting(self._base_url, settings.MEDIA_URL)
+        from django.urls import get_prefixed_media_url
+        return self._value_or_setting(self._base_url, get_prefixed_media_url())
 
     @cached_property
     def file_permissions_mode(self):

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -254,8 +254,6 @@ class FileSystemStorage(Storage):
     def __init__(self, location=None, base_url=None, file_permissions_mode=None,
                  directory_permissions_mode=None):
         self._location = location
-        if base_url is not None and not base_url.endswith('/'):
-            base_url += '/'
         self._base_url = base_url
         self._file_permissions_mode = file_permissions_mode
         self._directory_permissions_mode = directory_permissions_mode
@@ -287,6 +285,8 @@ class FileSystemStorage(Storage):
     @cached_property
     def base_url(self):
         from django.urls import get_prefixed_media_url
+        if self._base_url is not None and not self._base_url.endswith('/'):
+            self._base_url += '/'
         return self._value_or_setting(self._base_url, get_prefixed_media_url())
 
     @cached_property

--- a/django/template/context_processors.py
+++ b/django/template/context_processors.py
@@ -13,7 +13,7 @@ import itertools
 
 from django.conf import settings
 from django.middleware.csrf import get_token
-from django.urls import get_prefixed_static_url, get_prefixed_media_url
+from django.urls import get_prefixed_media_url, get_prefixed_static_url
 from django.utils.encoding import smart_text
 from django.utils.functional import SimpleLazyObject, lazy
 

--- a/django/template/context_processors.py
+++ b/django/template/context_processors.py
@@ -13,6 +13,7 @@ import itertools
 
 from django.conf import settings
 from django.middleware.csrf import get_token
+from django.urls import get_prefixed_static_url, get_prefixed_media_url
 from django.utils.encoding import smart_text
 from django.utils.functional import SimpleLazyObject, lazy
 
@@ -70,14 +71,14 @@ def static(request):
     """
     Adds static-related context variables to the context.
     """
-    return {'STATIC_URL': settings.STATIC_URL}
+    return {'STATIC_URL': get_prefixed_static_url()}
 
 
 def media(request):
     """
     Adds media-related context variables to the context.
     """
-    return {'MEDIA_URL': settings.MEDIA_URL}
+    return {'MEDIA_URL': get_prefixed_media_url()}
 
 
 def request(request):

--- a/django/templatetags/static.py
+++ b/django/templatetags/static.py
@@ -1,6 +1,5 @@
 from django import template
 from django.apps import apps
-from django.utils.encoding import iri_to_uri
 from django.utils.six.moves.urllib.parse import urljoin
 
 register = template.Library()
@@ -15,6 +14,9 @@ class PrefixNode(template.Node):
         if name is None:
             raise template.TemplateSyntaxError(
                 "Prefix nodes must be given a name to return.")
+        if name not in ('STATIC_URL', 'MEDIA_URL'):
+            raise template.TemplateSyntaxError(
+                "Prefix node name must be STATIC_URL or MEDIA_URL.")
         self.varname = varname
         self.name = name
 
@@ -36,12 +38,15 @@ class PrefixNode(template.Node):
 
     @classmethod
     def handle_simple(cls, name):
+        prefix = ''
         try:
-            from django.conf import settings
-        except ImportError:
-            prefix = ''
-        else:
-            prefix = iri_to_uri(getattr(settings, name, ''))
+            from django.urls.base import get_prefixed_static_url, get_prefixed_media_url
+            if name == 'STATIC_URL':
+                prefix = get_prefixed_static_url()
+            elif name == 'MEDIA_URL':
+                prefix = get_prefixed_media_url()
+        except (ImportError, TypeError):
+            pass
         return prefix
 
     def render(self, context):
@@ -55,8 +60,8 @@ class PrefixNode(template.Node):
 @register.tag
 def get_static_prefix(parser, token):
     """
-    Populates a template variable with the static prefix,
-    ``settings.STATIC_URL``.
+    Populates a template variable with the static prefix:
+    ``settings.STATIC_URL`` prefixed with ``SCRIPT_NAME`` WSGI parameter.
 
     Usage::
 
@@ -74,7 +79,7 @@ def get_static_prefix(parser, token):
 def get_media_prefix(parser, token):
     """
     Populates a template variable with the media prefix,
-    ``settings.MEDIA_URL``.
+    ``settings.MEDIA_URL`` prefixed with ``SCRIPT_NAME`` WSGI parameter.
 
     Usage::
 
@@ -139,7 +144,8 @@ class StaticNode(template.Node):
 @register.tag('static')
 def do_static(parser, token):
     """
-    Joins the given path with the STATIC_URL setting.
+    Joins the given path with the ``STATIC_URL`` setting,
+    prefixed with ``SCRIPT_NAME`` WSGI parameter.
 
     Usage::
 

--- a/django/urls/__init__.py
+++ b/django/urls/__init__.py
@@ -1,7 +1,7 @@
 from .base import (
     clear_script_prefix, clear_url_caches, get_script_prefix, get_urlconf,
     is_valid_path, resolve, reverse, reverse_lazy, set_script_prefix,
-    set_urlconf, translate_url,
+    set_urlconf, translate_url, get_prefixed_static_url, get_prefixed_media_url
 )
 from .exceptions import NoReverseMatch, Resolver404
 from .resolvers import (
@@ -16,5 +16,5 @@ __all__ = [
     'clear_script_prefix', 'clear_url_caches', 'get_callable', 'get_mod_func',
     'get_ns_resolver', 'get_resolver', 'get_script_prefix', 'get_urlconf',
     'is_valid_path', 'resolve', 'reverse', 'reverse_lazy', 'set_script_prefix',
-    'set_urlconf', 'translate_url',
+    'set_urlconf', 'translate_url', 'get_prefixed_static_url', 'get_prefixed_media_url'
 ]

--- a/django/urls/__init__.py
+++ b/django/urls/__init__.py
@@ -1,7 +1,8 @@
 from .base import (
-    clear_script_prefix, clear_url_caches, get_script_prefix, get_urlconf,
-    is_valid_path, resolve, reverse, reverse_lazy, set_script_prefix,
-    set_urlconf, translate_url, get_prefixed_static_url, get_prefixed_media_url
+    clear_script_prefix, clear_url_caches, get_prefixed_media_url,
+    get_prefixed_static_url, get_script_prefix, get_urlconf, is_valid_path,
+    resolve, reverse, reverse_lazy, set_script_prefix, set_urlconf,
+    translate_url,
 )
 from .exceptions import NoReverseMatch, Resolver404
 from .resolvers import (

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.utils import six
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.functional import lazy
-from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit, urljoin
+from django.utils.six.moves.urllib.parse import urljoin, urlsplit, urlunsplit
 from django.utils.translation import override
 
 from .exceptions import NoReverseMatch, Resolver404

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -2,10 +2,11 @@ from __future__ import unicode_literals
 
 from threading import local
 
+from django.conf import settings
 from django.utils import six
 from django.utils.encoding import force_text, iri_to_uri
 from django.utils.functional import lazy
-from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
+from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit, urljoin
 from django.utils.translation import override
 
 from .exceptions import NoReverseMatch, Resolver404
@@ -181,3 +182,19 @@ def translate_url(url, lang_code):
             else:
                 url = urlunsplit((parsed.scheme, parsed.netloc, url, parsed.query, parsed.fragment))
     return url
+
+
+def get_prefixed_static_url():
+    """
+    Helper function that returns concatenated
+    ``SCRIPT_NAME`` prefix and ``settings.STATIC_URL``.
+    """
+    return urljoin(get_script_prefix(), settings.STATIC_URL.lstrip('/'))
+
+
+def get_prefixed_media_url():
+    """
+    Helper function that returns concatenated
+    ``SCRIPT_NAME`` prefix and ``settings.MEDIA_URL``.
+    """
+    return urljoin(get_script_prefix(), settings.MEDIA_URL.lstrip('/'))

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -567,7 +567,7 @@ class FileStorageTests(SimpleTestCase):
 
     @override_settings(
         MEDIA_ROOT='media_root',
-        MEDIA_URL='media_url/',
+        MEDIA_URL='/media_url/',
         FILE_UPLOAD_PERMISSIONS=0o777,
         FILE_UPLOAD_DIRECTORY_PERMISSIONS=0o777,
     )
@@ -578,21 +578,21 @@ class FileStorageTests(SimpleTestCase):
         """
         storage = self.storage_class(
             location='explicit_location',
-            base_url='explicit_base_url/',
+            base_url='/explicit_base_url/',
             file_permissions_mode=0o666,
             directory_permissions_mode=0o666,
         )
         defaults_storage = self.storage_class()
         settings = {
             'MEDIA_ROOT': 'overriden_media_root',
-            'MEDIA_URL': 'overriden_media_url/',
+            'MEDIA_URL': '/overriden_media_url/',
             'FILE_UPLOAD_PERMISSIONS': 0o333,
             'FILE_UPLOAD_DIRECTORY_PERMISSIONS': 0o333,
         }
         with self.settings(**settings):
             self.assertEqual(storage.base_location, 'explicit_location')
             self.assertIn('explicit_location', storage.location)
-            self.assertEqual(storage.base_url, 'explicit_base_url/')
+            self.assertEqual(storage.base_url, '/explicit_base_url/')
             self.assertEqual(storage.file_permissions_mode, 0o666)
             self.assertEqual(storage.directory_permissions_mode, 0o666)
             self.assertEqual(defaults_storage.base_location, settings['MEDIA_ROOT'])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25598

Build static and media URLs using SCRIPT_NAME prefix.
The prefix should be added when displaying the URL
and omitted when serving the URL.
