### PR TITLE
Fixed #27000 -- Removed BaseCommand.usage() per deprecation timeline (refs #19973).

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -225,17 +225,6 @@ class BaseCommand(object):
         """
         return django.get_version()
 
-    def usage(self, subcommand):
-        """
-        Return a brief description of how to use this command, by
-        default from the attribute ``self.help``.
-        """
-        usage = '%%prog %s [options] %s' % (subcommand, self.args)
-        if self.help:
-            return '%s\n\n%s' % (usage, self.help)
-        else:
-            return usage
-
     def create_parser(self, prog_name, subcommand):
         """
         Create and return the ``ArgumentParser`` which will be used to

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Allowed ``User.is_authenticated`` and ``User.is_anonymous`` properties to be
   compared using ``==`` and ``!=`` (:ticket:`26988`).
+
+* Removed the broken ``BaseCommand.usage()`` method which was for
+  ``optparse`` support (:ticket:`27000`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27000