### PR TITLE
Fixed #27001 -- Added __iter__ to ChoiceFieldRenderer

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -693,8 +693,11 @@ class ChoiceFieldRenderer(object):
         self.choices = choices
 
     def __getitem__(self, idx):
-        choice = list(self.choices)[idx]  # Let the IndexError propagate
-        return self.choice_input_class(self.name, self.value, self.attrs.copy(), choice, idx)
+        return list(self)[idx]
+
+    def __iter__(self):
+        for idx, choice in enumerate(self.choices):
+            yield self.choice_input_class(self.name, self.value, self.attrs.copy(), choice, idx)
 
     def __str__(self):
         return self.render()

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1576,6 +1576,18 @@ class ModelChoiceFieldTests(TestCase):
         field = CustomModelChoiceField(Category.objects.all())
         self.assertIsInstance(field.choices, CustomModelChoiceIterator)
 
+    def test_radioselect_num_queries(self):
+        class CategoriesForm(forms.Form):
+            categories = forms.ModelChoiceField(
+                queryset=Category.objects.all(),
+                widget=forms.RadioSelect
+            )
+
+        template = Template('{% for widget in form.categories %}{{ widget }}{% endfor %}')
+
+        with self.assertNumQueries(2):
+            template.render(Context({'form': CategoriesForm()}))
+
 
 class ModelMultipleChoiceFieldTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
`ChoiceFieldRenderer` doesn't have `__iter__` defined, so Python iterates over it by calling `__getitem__` with an increasing index until an exception is raised. `ChoiceFieldRenderer.__getitem__` calls `list` on itself, which turns iteration into an n^2 operation. When the choices are backed by a queryset as in ModelChoiceField, that means lots of redundant database queries.

Fixed by adding an `__iter__` method to `ChoiceFieldRenderer` and changing `__getitem__` to use it, so that indexing still works.