### PR TITLE
Fixed #27003: ArrayField and JSONField form fields check for already-converted values

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,6 +109,7 @@ answer newbie questions, and generally made Django that much better:
     Bouke Haarsma <bouke@haarsma.eu>
     Božidar Benko <bbenko@gmail.com>
     Brad Melin <melinbrad@gmail.com>
+    Brandon Chinn <http://brandonchinn178.github.io>
     Brant Harris
     Brendan Hayward <brendanhayward85@gmail.com>
     Brenton Simpson <http://theillustratedlife.com>

--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -35,7 +35,9 @@ class SimpleArrayField(forms.CharField):
         return value
 
     def to_python(self, value):
-        if value:
+        if isinstance(value, list):
+            items = value
+        elif value:
             items = value.split(self.delimiter)
         else:
             items = []

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -633,6 +633,11 @@ class TestSimpleFormField(PostgreSQLTestCase):
         self.assertIsInstance(form_field, SimpleArrayField)
         self.assertEqual(form_field.max_length, 4)
 
+    def test_already_converted_value(self):
+        field = SimpleArrayField(forms.CharField())
+        vals = ['a', 'b', 'c']
+        self.assertEqual(field.clean(vals), vals)
+
 
 class TestSplitFormField(PostgreSQLTestCase):
 

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -309,3 +309,18 @@ class TestFormField(PostgreSQLTestCase):
 
         field = CustomJSONField()
         self.assertIsInstance(field.widget, widgets.Input)
+
+    def test_already_converted_value(self):
+        field = forms.JSONField(required=False)
+        tests = [
+            '["a", "b", "c"]',
+            '{"a": 1, "b": 2}',
+            '1',
+            '1.5',
+            'true',
+            'null',
+            '"foo"',
+        ]
+        for json_string in tests:
+            val = field.clean(json_string)
+            self.assertEqual(field.clean(val), val)


### PR DESCRIPTION
`ArrayField`'s and `JSONField`'s `to_python` method goes straight to parsing the value, instead of checking if the value has already been converted to its type.
