### PR TITLE
Fixed #27004 -- Made migrations consistency check ignore unapplied squashed migrations.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -280,6 +280,10 @@ class MigrationLoader(object):
                 continue
             for parent in self.graph.node_map[migration].parents:
                 if parent not in applied:
+                    # Skip unapplied squashed migrations that have all of their `replaces` applied.
+                    if parent in self.replacements:
+                        if all(m in applied for m in self.replacements[parent].replaces):
+                            continue
                     raise InconsistentMigrationHistory(
                         "Migration {}.{} is applied before its dependency {}.{}".format(
                             migration[0], migration[1], parent[0], parent[1],

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -29,3 +29,6 @@ Bugfixes
 
 * Fixed the ``isnull`` lookup on a ``ForeignKey`` with its ``to_field``
   pointing to a ``CharField`` (:ticket:`26983`).
+
+* Prevented the ``migrate`` command from raising ``InconsistentMigrationHistory``
+  in the presence of unapplied squashed migrations (:ticket:`27004`).

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -381,6 +381,22 @@ class LoaderTests(TestCase):
         with self.assertRaisesMessage(InconsistentMigrationHistory, msg):
             loader.check_consistent_history(connection)
 
+    @override_settings(
+        MIGRATION_MODULES={'migrations': 'migrations.test_migrations_squashed_extra'},
+        INSTALLED_APPS=['migrations'],
+    )
+    def test_check_consistent_history_squashed(self):
+        """
+        MigrationLoader.check_consistent_history() should ignore unapplied squashed migrations that
+        have all of their `replaces` applied.
+        """
+        loader = MigrationLoader(connection=None)
+        recorder = MigrationRecorder(connection)
+        recorder.record_applied('migrations', '0001_initial')
+        recorder.record_applied('migrations', '0002_second')
+        recorder.record_applied('migrations', '0003_third')
+        loader.check_consistent_history(connection)
+
     @override_settings(MIGRATION_MODULES={
         "app1": "migrations.test_migrations_squashed_ref_squashed.app1",
         "app2": "migrations.test_migrations_squashed_ref_squashed.app2",

--- a/tests/migrations/test_migrations_squashed_extra/0001_initial.py
+++ b/tests/migrations/test_migrations_squashed_extra/0001_initial.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    pass

--- a/tests/migrations/test_migrations_squashed_extra/0001_squashed_0002.py
+++ b/tests/migrations/test_migrations_squashed_extra/0001_squashed_0002.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    replaces = [
+        ("migrations", "0001_initial"),
+        ("migrations", "0002_second"),
+    ]

--- a/tests/migrations/test_migrations_squashed_extra/0002_second.py
+++ b/tests/migrations/test_migrations_squashed_extra/0002_second.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("migrations", "0001_initial")]

--- a/tests/migrations/test_migrations_squashed_extra/0003_third.py
+++ b/tests/migrations/test_migrations_squashed_extra/0003_third.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("migrations", "0002_second")]


### PR DESCRIPTION
Would recommend this goes into the next 1.10 release, as it makes using squashed migrations nigh impossible. Please advise if I'm supposed to make the PR against a different base branch for this.

I'll add a failing test + documentation in a couple of hours.
Might also change the exception message for squashmigration cases.