### PR TITLE
Fixed #27007 -- Handled non-UTF-8 bytes objects for text/* attachments.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -518,6 +518,7 @@ answer newbie questions, and generally made Django that much better:
     michael.mcewan@gmail.com
     Michael Placentra II <someone@michaelplacentra2.net>
     Michael Radziej <mir@noris.de>
+    Michael Schwarz <michi.schwarz@gmail.com>
     Michael Thornhill <michael.thornhill@gmail.com>
     Michal Chruszcz <troll@pld-linux.org>
     michal@plovarna.cz

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -158,6 +158,10 @@ Email
 * Added the :setting:`EMAIL_USE_LOCALTIME` setting to allow sending SMTP date
   headers in the local time zone rather than in UTC.
 
+* ``attach()`` and ``attach_file()`` now fall back to MIME type
+  ``application/octet-stream`` when binary content which cannot be decoded as
+  UTF-8 is specified for a ``text/*`` attachment.
+
 File Storage
 ~~~~~~~~~~~~
 

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -345,6 +345,11 @@ The class has the following methods:
     If you specify a ``mimetype`` of ``message/rfc822``, it will also accept
     :class:`django.core.mail.EmailMessage` and :py:class:`email.message.Message`.
 
+    For a ``mimetype`` starting with ``text/``, content is expect to be a string.
+    If binary data is passed, decoding it using `UTF-8` is tried. If that fails,
+    the MIME type will be changed to ``application/octet-stream`` and the data
+    will be attached unchanged.
+
     In addition, ``message/rfc822`` attachments will no longer be
     base64-encoded in violation of :rfc:`2046#section-5.2.1`, which can cause
     issues with displaying the attachments in `Evolution`__ and `Thunderbird`__.
@@ -358,6 +363,15 @@ The class has the following methods:
   will be guessed from the filename. The simplest use would be::
 
     message.attach_file('/images/weather_map.png')
+
+  For MIME types starting with ``text/``, binary data is handled identically
+  ``attach()``.
+
+.. versionchanged:: 1.11
+
+    Added Fallback to MIME type ``application/octet-stream`` when binary data
+    for ``text/*`` attachment cannot be decoded.
+
 
 Sending alternative content types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/27007