### PR TITLE
Fixed #27005 -- Fixed crash if request.META[''CONTENT_LENGTH']=''.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -264,7 +264,7 @@ class HttpRequest(object):
 
             # Limit the maximum request data size that will be handled in-memory.
             if (settings.DATA_UPLOAD_MAX_MEMORY_SIZE is not None and
-                    int(self.META.get('CONTENT_LENGTH', 0)) > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
+                    int(self.META.get('CONTENT_LENGTH') or 0) > settings.DATA_UPLOAD_MAX_MEMORY_SIZE):
                 raise RequestDataTooBig('Request body exceeded settings.DATA_UPLOAD_MAX_MEMORY_SIZE.')
 
             try:

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -23,3 +23,6 @@ Bugfixes
 
 * Fixed a regression in the number of queries when using ``RadioSelect`` with a
   ``ModelChoiceField`` form field (:ticket:`27001`).
+
+* Fixed a crash if ``request.META['CONTENT_LENGTH']`` is an empty string
+  (:ticket:`27005`).

--- a/tests/requests/test_data_upload_settings.py
+++ b/tests/requests/test_data_upload_settings.py
@@ -104,6 +104,10 @@ class DataUploadMaxMemorySizeGetTests(SimpleTestCase):
         with self.settings(DATA_UPLOAD_MAX_MEMORY_SIZE=None):
             self.request.body
 
+    def test_empty_content_length(self):
+        self.request.environ['CONTENT_LENGTH'] = ''
+        self.request.body
+
 
 class DataUploadMaxNumberOfFieldsGet(SimpleTestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27005