### PR TITLE
changed length of last name from 30 to 255 as discussed in the issue description

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -317,7 +317,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         },
     )
     first_name = models.CharField(_('first name'), max_length=30, blank=True)
-    last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    last_name = models.CharField(_('last name'), max_length=255, blank=True)
     email = models.EmailField(_('email address'), blank=True)
     is_staff = models.BooleanField(
         _('staff status'),


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/26993
Issue: Increase the length of the User model's last_name field to allow more of the world to use it
reference:
https://groups.google.com/forum/#!topic/django-developers/h98-oEi7z7g