### PR TITLE
Fixed #27010 -- Made Argon2PasswordHasher decode with ASCII.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -323,7 +323,7 @@ class Argon2PasswordHasher(BasePasswordHasher):
             hash_len=argon2.DEFAULT_HASH_LENGTH,
             type=argon2.low_level.Type.I,
         )
-        return self.algorithm + data.decode('utf-8')
+        return self.algorithm + data.decode('ascii')
 
     def verify(self, password, encoded):
         argon2 = self._load_library()


### PR DESCRIPTION
The underlying hasher only generates strings containing ASCII
characters so this is merely a clarifying change.

https://code.djangoproject.com/ticket/27010