### PR TITLE
Refs #27025 -- Fixed servers test for Python 3.6.

### DIFF
--- a/tests/servers/test_basehttp.py
+++ b/tests/servers/test_basehttp.py
@@ -12,6 +12,9 @@ class Stub(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+    def sendall(self, data):
+        self.makefile('wb').write(data)
+
 
 class WSGIRequestHandlerTestCase(SimpleTestCase):
 


### PR DESCRIPTION
After https://hg.python.org/cpython/rev/4ea79767ff75/, `test_strips_underscore_headers` fails with `'Stub' object has no attribute 'sendall'`. I added that stub and now it fails like this:
```
Traceback (most recent call last):
  File "/home/tim/code/django/tests/servers/test_basehttp.py", line 117, in test_strips_underscore_headers
    body = list(wfile.readlines())[-1]
IndexError: list index out of range
```