### PR TITLE
Fixed #27026 -- Fixed state initialization of bulk_create() objects if can_return_ids_from_bulk_insert.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -452,8 +452,10 @@ class QuerySet(object):
                     ids = self._batched_insert(objs_without_pk, fields, batch_size)
                     if connection.features.can_return_ids_from_bulk_insert:
                         assert len(ids) == len(objs_without_pk)
-                    for i in range(len(ids)):
-                        objs_without_pk[i].pk = ids[i]
+                    for obj_without_pk, pk in zip(objs_without_pk, ids):
+                        obj_without_pk.pk = pk
+                        obj_without_pk._state.adding = False
+                        obj_without_pk._state.db = self.db
 
         return objs
 

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -29,3 +29,8 @@ Bugfixes
 
 * Fixed the ``isnull`` lookup on a ``ForeignKey`` with its ``to_field``
   pointing to a ``CharField`` (:ticket:`26983`).
+
+* Made `bulk_create()` properly initialize model instances on backends such as
+  PostgreSQL that support returning the IDs of the newly created records so
+  that many-to-many relationships can be used on the new objects
+  (:ticket:`27026`).

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -217,3 +217,16 @@ class BulkCreateTests(TestCase):
         self.assertEqual(Country.objects.get(pk=countries[1].pk), countries[1])
         self.assertEqual(Country.objects.get(pk=countries[2].pk), countries[2])
         self.assertEqual(Country.objects.get(pk=countries[3].pk), countries[3])
+
+    @skipUnlessDBFeature('can_return_ids_from_bulk_insert')
+    def test_set_state(self):
+        country_nl = Country(name='Netherlands', iso_two_letter='NL')
+        country_be = Country(name='Belgium', iso_two_letter='BE')
+
+        # Save `country_nl` using `bulk_create`, but `country_be` using `save`.
+        Country.objects.bulk_create([country_nl])
+        country_be.save()
+
+        # Check that both countries have equal state.
+        self.assertEqual(country_nl._state.adding, country_be._state.adding)
+        self.assertEqual(country_nl._state.db, country_be._state.db)


### PR DESCRIPTION
The `bulk_create` now also updates the `_state` field of a model
instance. This makes it possible to use it in `ManyToMany` relations.