### PR TITLE
[WIP] Fixed #26180 -- Add [Add|Remove]UniqueTogether migration operations

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -328,6 +328,19 @@ class BaseDatabaseSchemaEditor(object):
         """
         self.execute(index.remove_sql(model, self))
 
+    def add_unique_together(self, model, fields):
+        """
+        Add a unique together constraint
+        """
+        columns = [model._meta.get_field(field).column for field in fields]
+        self.execute(self._create_unique_sql(model, columns))
+
+    def remove_unique_together(self, model, fields):
+        """
+        Remove a unique together constraint
+        """
+        self._delete_composed_index(model, fields, {'unique': True}, self.sql_delete_unique)
+
     def alter_unique_together(self, model, old_unique_together, new_unique_together):
         """
         Deals with a model changing its unique_together.

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -127,6 +127,7 @@ class MigrationAutodetector(object):
         # into migrations to resolve dependencies caused by M2Ms and FKs.
         self.generated_operations = {}
         self.altered_indexes = {}
+        self.altered_unique_togethers = {}
 
         # Prepare some old/new state and model lists, separating
         # proxy models and ignoring unmigrated apps.
@@ -180,14 +181,19 @@ class MigrationAutodetector(object):
         # This avoids the same computation in generate_removed_indexes()
         # and generate_added_indexes().
         self.create_altered_indexes()
-        # Generate index removal operations before field is removed
+        # Similarly for unique_togethers
+        self.create_altered_unique_togethers()
+
+        # Generate index/constraints removal operations before field is removed
         self.generate_removed_indexes()
+        self.generate_removed_unique_togethers()
         # Generate field operations
         self.generate_renamed_fields()
         self.generate_removed_fields()
         self.generate_added_fields()
         self.generate_altered_fields()
-        self.generate_altered_unique_together()
+        self.generate_added_unique_togethers()
+        # self.generate_altered_unique_together()
         self.generate_altered_index_together()
         self.generate_added_indexes()
         self.generate_altered_db_table()
@@ -998,6 +1004,50 @@ class MigrationAutodetector(object):
             ))
         return dependencies
 
+    def create_altered_unique_togethers(self):
+        # option_name = operations.AddUniqueTogether.option_name
+        option_name = 'unique_together'
+        for app_label, model_name in sorted(self.kept_model_keys):
+            old_model_name = self.renamed_models.get((app_label, model_name), model_name)
+            old_model_state = self.from_state.models[app_label, old_model_name]
+            new_model_state = self.to_state.models[app_label, model_name]
+
+            old_value = set(old_model_state.options.get(option_name) or ())
+            new_value = set(new_model_state.options.get(option_name) or ())
+
+            added = new_value.difference(old_value)
+            removed = old_value.difference(new_value)
+
+            self.altered_unique_togethers[(app_label, model_name)] = {'added': added, 'removed': removed}
+
+    def generate_added_unique_togethers(self):
+        for (app_label, model_name), alt_ut in self.altered_unique_togethers.items():
+            for fields in alt_ut['added']:
+                dependencies = []
+                for field_name in fields:
+                    field = self.new_apps.get_model(app_label, model_name)._meta.get_field(field_name)
+                    if field.remote_field and field.remote_field.model:
+                        dependencies.extend(self._get_dependencies_for_foreign_key(field))
+                self.add_operation(
+                    app_label,
+                    operations.AddUniqueTogether(
+                        name=model_name,
+                        fields=fields,
+                    ),
+                    dependencies=dependencies,
+                )
+
+    def generate_removed_unique_togethers(self):
+        for (app_label, model_name), alt_ut in self.altered_unique_togethers.items():
+            for fields in alt_ut['removed']:
+                self.add_operation(
+                    app_label,
+                    operations.RemoveUniqueTogether(
+                        name=model_name,
+                        fields=fields,
+                    )
+                )
+
     def _generate_altered_foo_together(self, operation):
         option_name = operation.option_name
         for app_label, model_name in sorted(self.kept_model_keys):
@@ -1038,6 +1088,7 @@ class MigrationAutodetector(object):
                 )
 
     def generate_altered_unique_together(self):
+        # TODO: Add deprecation warnings here.
         self._generate_altered_foo_together(operations.AlterUniqueTogether)
 
     def generate_altered_index_together(self):

--- a/django/db/migrations/operations/__init__.py
+++ b/django/db/migrations/operations/__init__.py
@@ -1,8 +1,8 @@
 from .fields import AddField, AlterField, RemoveField, RenameField
 from .models import (
-    AddIndex, AlterIndexTogether, AlterModelManagers, AlterModelOptions,
+    AddIndex, AddUniqueTogether, AlterIndexTogether, AlterModelManagers, AlterModelOptions,
     AlterModelTable, AlterOrderWithRespectTo, AlterUniqueTogether, CreateModel,
-    DeleteModel, RemoveIndex, RenameModel,
+    DeleteModel, RemoveIndex, RemoveUniqueTogether, RenameModel,
 )
 from .special import RunPython, RunSQL, SeparateDatabaseAndState
 
@@ -10,6 +10,6 @@ __all__ = [
     'CreateModel', 'DeleteModel', 'AlterModelTable', 'AlterUniqueTogether',
     'RenameModel', 'AlterIndexTogether', 'AlterModelOptions', 'AddIndex',
     'RemoveIndex', 'AddField', 'RemoveField', 'AlterField', 'RenameField',
-    'SeparateDatabaseAndState', 'RunSQL', 'RunPython',
-    'AlterOrderWithRespectTo', 'AlterModelManagers',
+    'SeparateDatabaseAndState', 'RunSQL', 'RunPython', 'AddUniqueTogether',
+    'RemoveUniqueTogether', 'AlterOrderWithRespectTo', 'AlterModelManagers',
 ]

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -492,6 +492,75 @@ class FieldRelatedOptionOperation(ModelOptionOperation):
         return super(FieldRelatedOptionOperation, self).reduce(operation, in_between, app_label=app_label)
 
 
+class AddUniqueTogether(FieldRelatedOptionOperation):
+    """
+    Add new unique_together constraint
+    """
+    option_name = 'unique_together'
+
+    def __init__(self, name, fields):
+        self.fields = fields
+        super(AddUniqueTogether, self).__init__(name)
+
+    def state_forwards(self, app_label, state):
+        model_state = state.models[app_label, self.name_lower]
+        model_state.options[self.option_name].add(self.fields)
+        state.reload_model(app_label, self.name_lower)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        new_model = to_state.apps.get_model(app_label, self.name)
+        if self.allow_migrate_model(schema_editor.connection.alias, new_model):
+            schema_editor.add_unique_together(
+                new_model,
+                self.fields,
+            )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        return self.database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def references_field(self, model_name, name, app_label=None):
+        return (
+            self.references_model(model_name, app_label) and
+            name in self.fields
+        )
+
+    def deconstruct(self):
+        kwargs = {
+            'name': self.name,
+            'fields': self.fields,
+        }
+        return (
+            self.__class__.__name__,
+            [],
+            kwargs
+        )
+
+    def describe(self):
+        return "Add unique together constraint on %s for %s" % (self.fields, self.name)
+
+
+class RemoveUniqueTogether(AddUniqueTogether):
+    """
+    Remove a unique_together constraint
+    """
+
+    def state_forwards(self, app_label, state):
+        model_state = state.models[app_label, self.name_lower]
+        model_state.options[self.option_name].remove(self.fields)
+        state.reload_model(app_label, self.name_lower)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        new_model = to_state.apps.get_model(app_label, self.name)
+        if self.allow_migrate_model(schema_editor.connection.alias, new_model):
+            schema_editor.remove_unique_together(
+                new_model,
+                self.fields,
+            )
+
+    def describe(self):
+        return "Remove unique together constraint on %s for %s" % (self.fields, self.name)
+
+
 class AlterUniqueTogether(FieldRelatedOptionOperation):
     """
     Changes the value of unique_together to the target one.

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -331,6 +331,7 @@ class ModelState(object):
         self.fields = fields
         self.options = options or {}
         self.options.setdefault('indexes', [])
+        self.options.setdefault('unique_together', set())
         self.bases = bases or (models.Model, )
         self.managers = managers or []
         # Sanity-check that fields is NOT a dict. It must be ordered.

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1204,8 +1204,8 @@ class AutodetectorTests(TestCase):
         changes = self.get_changes([self.author_empty, self.book], [self.author_empty, self.book_foo_together])
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together={("author", "title")})
+        self.assertOperationTypes(changes, "otherapp", 0, ["AddUniqueTogether", "AlterIndexTogether"])
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("author", "title"))
         self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together={("author", "title")})
 
     def test_remove_foo_together(self):
@@ -1213,8 +1213,8 @@ class AutodetectorTests(TestCase):
         changes = self.get_changes([self.author_empty, self.book_foo_together], [self.author_empty, self.book])
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together=set())
+        self.assertOperationTypes(changes, "otherapp", 0, ["RemoveUniqueTogether", "AlterIndexTogether"])
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("author", "title"))
         self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together=set())
 
     def test_foo_together_remove_fk(self):
@@ -1225,9 +1225,9 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
         self.assertOperationTypes(changes, "otherapp", 0, [
-            "AlterUniqueTogether", "AlterIndexTogether", "RemoveField"
+            "RemoveUniqueTogether", "AlterIndexTogether", "RemoveField"
         ])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together=set())
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("author", "title"))
         self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together=set())
         self.assertOperationAttributes(changes, "otherapp", 0, 2, model_name="book", name="author")
 
@@ -1251,9 +1251,12 @@ class AutodetectorTests(TestCase):
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together={("title", "author")})
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together={("title", "author")})
+        self.assertOperationTypes(
+            changes, "otherapp", 0, ["RemoveUniqueTogether", "AddUniqueTogether", "AlterIndexTogether"]
+        )
+        # self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("author", "title"))
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", fields=("title", "author"))
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("title", "author")})
 
     def test_add_field_and_foo_together(self):
         """
@@ -1263,8 +1266,8 @@ class AutodetectorTests(TestCase):
         changes = self.get_changes([self.author_empty, self.book], [self.author_empty, self.book_foo_together_3])
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["AddField", "AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={("title", "newfield")})
+        self.assertOperationTypes(changes, "otherapp", 0, ["AddField", "AddUniqueTogether", "AlterIndexTogether"])
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", fields=("title", "newfield"))
         self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("title", "newfield")})
 
     def test_create_model_and_unique_together(self):
@@ -1289,7 +1292,7 @@ class AutodetectorTests(TestCase):
         # Right actions order?
         self.assertOperationTypes(
             changes, 'otherapp', 0,
-            ['CreateModel', 'AddField', 'AlterUniqueTogether', 'AlterIndexTogether']
+            ['CreateModel', 'AddField', 'AddUniqueTogether', 'AlterIndexTogether']
         )
 
     def test_remove_field_and_foo_together(self):
@@ -1302,10 +1305,13 @@ class AutodetectorTests(TestCase):
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["RemoveField", "AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, model_name="book", name="newfield")
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={("author", "title")})
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("author", "title")})
+        self.assertOperationTypes(
+            changes, "otherapp", 0, ["RemoveUniqueTogether", "RemoveField", "AddUniqueTogether", "AlterIndexTogether"]
+        )
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("title", "newfield"))
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, model_name="book", name="newfield")
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", fields=("author", "title"))
+        self.assertOperationAttributes(changes, "otherapp", 0, 3, name="book", index_together={("author", "title")})
 
     def test_rename_field_and_foo_together(self):
         """
@@ -1319,11 +1325,13 @@ class AutodetectorTests(TestCase):
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["RenameField", "AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={
-            ("title", "newfield2")
-        })
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("title", "newfield2")})
+        self.assertOperationTypes(
+            changes, "otherapp", 0, ["RemoveUniqueTogether", "RenameField", "AddUniqueTogether", "AlterIndexTogether"]
+        )
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", fields=("title", "newfield"))
+        # self.assertOperationAttributes(changes, "otherapp", 0, 1)
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", fields=("title", "newfield2"))
+        self.assertOperationAttributes(changes, "otherapp", 0, 3, name="book", index_together={("title", "newfield2")})
 
     def test_proxy(self):
         """Tests that the autodetector correctly deals with proxy models."""

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1333,7 +1333,8 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(changes, "testapp", 0, ["CreateModel"])
         self.assertOperationAttributes(
-            changes, "testapp", 0, 0, name="AuthorProxy", options={"proxy": True, "indexes": []}
+            changes, "testapp", 0, 0,
+            name="AuthorProxy", options={"proxy": True, "indexes": [], "unique_together": set()}
         )
         # Now, we test turning a proxy model into a non-proxy model
         # It should delete the proxy then make the real one

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -140,14 +140,17 @@ class StateTests(SimpleTestCase):
         self.assertEqual(book_state.fields[3][1].__class__.__name__, "ManyToManyField")
         self.assertEqual(
             book_state.options,
-            {"verbose_name": "tome", "db_table": "test_tome", "indexes": [book_index]},
+            {"verbose_name": "tome", "db_table": "test_tome", "indexes": [book_index], "unique_together": set()},
         )
         self.assertEqual(book_state.bases, (models.Model, ))
 
         self.assertEqual(author_proxy_state.app_label, "migrations")
         self.assertEqual(author_proxy_state.name, "AuthorProxy")
         self.assertEqual(author_proxy_state.fields, [])
-        self.assertEqual(author_proxy_state.options, {"proxy": True, "ordering": ["name"], "indexes": []})
+        self.assertEqual(
+            author_proxy_state.options,
+            {"proxy": True, "ordering": ["name"], "indexes": [], "unique_together": set()}
+        )
         self.assertEqual(author_proxy_state.bases, ("migrations.author", ))
 
         self.assertEqual(sub_author_state.app_label, "migrations")
@@ -1004,7 +1007,10 @@ class ModelStateTests(SimpleTestCase):
         self.assertEqual(author_state.fields[1][1].max_length, 255)
         self.assertIs(author_state.fields[2][1].null, False)
         self.assertIs(author_state.fields[3][1].null, True)
-        self.assertEqual(author_state.options, {'swappable': 'TEST_SWAPPABLE_MODEL', 'indexes': []})
+        self.assertEqual(
+            author_state.options,
+            {'swappable': 'TEST_SWAPPABLE_MODEL', 'indexes': [], 'unique_together': set()}
+        )
         self.assertEqual(author_state.bases, (models.Model, ))
         self.assertEqual(author_state.managers, [])
 


### PR DESCRIPTION
Ticket [#26180](https://code.djangoproject.com/ticket/26180).

@MarkusH This time I have tried to solve this by introducing `[Add|Remove]UniqueTogether` as per your [earlier suggestion](https://github.com/django/django/pull/6926#issuecomment-233632828). There's quite some work remaining before this gets fully complete but the basic implementation is complete so I wanted to show it to make sure this is going in the right direction.