### PR TITLE
Fixed #27029 -- Fixed EmailValidator to allow non-ASCII characters in local part of the address.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -171,9 +171,10 @@ class EmailValidator(object):
     message = _('Enter a valid email address.')
     code = 'invalid'
     user_regex = _lazy_re_compile(
-        r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"  # dot-atom
+        r"(^[-!#$%&'*+/=?^`{}|~\w]+(\.[-!#$%&'*+/=?^`{}|~\w]+)*\Z"  # dot-atom
         r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
-        re.IGNORECASE)
+        re.IGNORECASE + (re.UNICODE if six.PY2 else 0)
+    )
     domain_regex = _lazy_re_compile(
         # max length for domain name labels is 63 characters per RFC 1034
         r'((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+)(?:[A-Z0-9-]{2,63}(?<!-))\Z',

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -125,6 +125,10 @@ to, or in lieu of custom ``field.clean()`` methods.
     :param code: If not ``None``, overrides :attr:`code`.
     :param whitelist: If not ``None``, overrides :attr:`whitelist`.
 
+    .. versionchanged:: 1.11
+
+        Non-ASCII characters are now allowed in the local part of the address.
+
     .. attribute:: message
 
         The error message used by

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -282,6 +282,9 @@ Validators
   :data:`~django.core.validators.validate_image_file_extension` to validate
   image files.
 
+* :class:`~django.core.validators.EmailValidator` now allows non-ASCII
+  characters in the local part of the email address (as per :rfc:`6530`).
+
 .. _backwards-incompatible-1.11:
 
 Backwards incompatible changes in 1.11

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -54,6 +54,7 @@ TEST_DATA = [
     (validate_email, 'example@valid-----hyphens.com', None),
     (validate_email, 'example@valid-with-hyphens.com', None),
     (validate_email, 'test@domain.with.idn.tld.उदाहरण.परीक्षा', None),
+    (validate_email, 'うえあいお@email.com', None),
     (validate_email, 'email@localhost', None),
     (EmailValidator(whitelist=['localdomain']), 'email@localdomain', None),
     (validate_email, '"test@test"@example.com', None),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27029