### PR TITLE
Fixed #26940 -- Removed makemessages from no_settings_commands whitelist

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -308,8 +308,7 @@ class ManagementUtility(object):
 
         no_settings_commands = [
             'help', 'version', '--help', '--version', '-h',
-            'compilemessages', 'makemessages',
-            'startapp', 'startproject',
+            'startapp', 'startproject', 'compilemessages',
         ]
 
         try:

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -364,6 +364,9 @@ Miscellaneous
   :meth:`~django.db.models.fields.related.RelatedManager.set` now
   clear the ``prefetch_related()`` cache.
 
+* The :djadmin:`makemessages` command now requires configured settings, like
+  most other commands.
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11


### PR DESCRIPTION
As makemessages uses several settings for proper run (FILE_CHARSET,
LOCALE_PATHS, MEDIA_ROOT, and STATIC_ROOT), we should require settings
configuration for this command.