### PR TITLE
Fixed #26973 -- Fixed views.static.serve() crash with show_indexes enabled.

### DIFF
--- a/django/views/static.py
+++ b/django/views/static.py
@@ -107,7 +107,7 @@ def directory_index(path, fullpath):
             'static/directory_index',
         ])
     except TemplateDoesNotExist:
-        t = Engine().from_string(DEFAULT_DIRECTORY_INDEX_TEMPLATE)
+        t = Engine(libraries={'i18n': 'django.templatetags.i18n'}).from_string(DEFAULT_DIRECTORY_INDEX_TEMPLATE)
     files = []
     for f in os.listdir(fullpath):
         if not f.startswith('.'):

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -42,3 +42,6 @@ Bugfixes
   backends, such as PostgreSQL, that support returning the IDs of the created
   records so that many-to-many relationships can be used on the new objects
   (:ticket:`27026`).
+
+* Fixed crash of ``django.views.static.serve()`` with ``show_indexes`` enabled
+  (:ticket:`26973`).

--- a/tests/view_tests/tests/test_static.py
+++ b/tests/view_tests/tests/test_static.py
@@ -108,6 +108,10 @@ class StaticTests(SimpleTestCase):
         response = self.client.get('/%s/non_existing_resource' % self.prefix)
         self.assertEqual(404, response.status_code)
 
+    def test_index(self):
+        response = self.client.get('/%s/' % self.prefix)
+        self.assertContains(response, 'Index of /')
+
 
 class StaticHelperTest(StaticTests):
     """

--- a/tests/view_tests/urls.py
+++ b/tests/view_tests/urls.py
@@ -103,7 +103,7 @@ urlpatterns = [
     url(r'^jsoni18n/$', i18n.JSONCatalog.as_view(packages=['view_tests'])),
 
     # Static views
-    url(r'^site_media/(?P<path>.*)$', static.serve, {'document_root': media_dir}),
+    url(r'^site_media/(?P<path>.*)$', static.serve, {'document_root': media_dir, 'show_indexes': True}),
 ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26973