### PR TITLE
Fixed #27030 -- Added contrib.postgres.indexes.GinIndex

### DIFF
--- a/django/contrib/gis/db/backends/postgis/introspection.py
+++ b/django/contrib/gis/db/backends/postgis/introspection.py
@@ -24,14 +24,16 @@ class PostGISIntrospection(DatabaseIntrospection):
     # expression over the raster column through the ST_ConvexHull function.
     # So the default query has to be adapted to include raster indices.
     _get_indexes_query = """
-        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary
-        FROM pg_catalog.pg_class c, pg_catalog.pg_class c2,
-            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr
-        LEFT JOIN pg_catalog.pg_type t ON t.oid = attr.atttypid
+        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary,
+            am.amname
+        FROM pg_catalog.pg_class c, pg_catalog.pg_class c2, pg_catalog.pg_index idx,
+            pg_catalog.pg_attribute attr, pg_catalog.pg_type t, pg_catalog.pg_am am
         WHERE
             c.oid = idx.indrelid
             AND idx.indexrelid = c2.oid
             AND attr.attrelid = c.oid
+            AND t.oid = attr.atttypid
+            AND c2.relam = am.oid
             AND (
                 attr.attnum = idx.indkey[0] OR
                 (t.typname LIKE 'raster' AND idx.indkey = '0')

--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+
+from django.db.models import Index
+
+__all__ = ['GinIndex']
+
+
+class GinIndex(Index):
+    suffix = 'gin'
+
+    def create_sql(self, model, schema_editor):
+        if schema_editor.connection.vendor == 'postgresql':
+            using = ' USING gin'
+            return super(GinIndex, self).create_sql(model, schema_editor, using)
+        # Raise error for other databases?

--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -46,3 +46,9 @@ class TrigramExtension(CreateExtension):
 
     def __init__(self):
         self.name = 'pg_trgm'
+
+
+class BtreeGinExtension(CreateExtension):
+
+    def __init__(self):
+        self.name = 'btree_gin'

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -160,6 +160,9 @@ class BaseDatabaseFeatures(object):
     # Can the backend introspect a TimeField, instead of a DateTimeField?
     can_introspect_time_field = True
 
+    # Can the backend introspect the type of index created e.g. btree, gin, etc.
+    can_introspect_index_type = False
+
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -883,6 +883,7 @@ class BaseDatabaseSchemaEditor(object):
         return sql_create_index % {
             "table": self.quote_name(model._meta.db_table),
             "name": self.quote_name(self._create_index_name(model, columns, suffix=suffix)),
+            "using": "",
             "columns": ", ".join(self.quote_name(column) for column in columns),
             "extra": tablespace_sql,
         }

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -22,6 +22,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_autofield = True
     can_introspect_ip_address_field = True
     can_introspect_small_integer_field = True
+    can_introspect_index_type = True
     can_distinct_on_fields = True
     can_rollback_ddl = True
     supports_combined_alters = True

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -134,7 +134,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             # row[1] (idx.indkey) is stored in the DB as an array. It comes out as
             # a string of space-separated integers. This designates the field
             # indexes (1-based) of the fields that have indexes on the table.
-            # row[4] is the type of index, eg. btree, hash, etc.
+            # row[4] is the type of index, e.g. btree, hash, etc.
             # Here, we skip any indexes across multiple fields.
             if ' ' in row[1]:
                 continue

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -36,13 +36,15 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     ignored_tables = []
 
     _get_indexes_query = """
-        SELECT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary
+        SELECT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary,
+            am.amname
         FROM pg_catalog.pg_class c, pg_catalog.pg_class c2,
-            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr
+            pg_catalog.pg_index idx, pg_catalog.pg_attribute attr, pg_catalog.pg_am am
         WHERE c.oid = idx.indrelid
             AND idx.indexrelid = c2.oid
             AND attr.attrelid = c.oid
             AND attr.attnum = idx.indkey[0]
+            AND c2.relam = am.oid
             AND c.relname = %s"""
 
     def get_field_type(self, data_type, description):
@@ -132,6 +134,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             # row[1] (idx.indkey) is stored in the DB as an array. It comes out as
             # a string of space-separated integers. This designates the field
             # indexes (1-based) of the fields that have indexes on the table.
+            # row[4] is the type of index, eg. btree, hash, etc.
             # Here, we skip any indexes across multiple fields.
             if ' ' in row[1]:
                 continue
@@ -142,6 +145,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 indexes[row[0]]['primary_key'] = True
             if row[2]:
                 indexes[row[0]]['unique'] = True
+            indexes[row[0]]['type'] = row[4]
         return indexes
 
     def get_constraints(self, cursor, table_name):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -11,6 +11,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_sequence = "DROP SEQUENCE IF EXISTS %(sequence)s CASCADE"
     sql_set_sequence_max = "SELECT setval('%(sequence)s', MAX(%(column)s)) FROM %(table)s"
 
+    sql_create_index = "CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s"
     sql_create_varchar_index = "CREATE INDEX %(name)s ON %(table)s (%(columns)s varchar_pattern_ops)%(extra)s"
     sql_create_text_index = "CREATE INDEX %(name)s ON %(table)s (%(columns)s text_pattern_ops)%(extra)s"
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -37,7 +37,7 @@ class Index(object):
             self.name = 'D%s' % self.name[1:]
         return errors
 
-    def create_sql(self, model, schema_editor):
+    def create_sql(self, model, schema_editor, using=''):
         fields = [model._meta.get_field(field) for field in self.fields]
         tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields)
         columns = [field.column for field in fields]
@@ -46,7 +46,7 @@ class Index(object):
         return schema_editor.sql_create_index % {
             'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
-            'using': '',
+            'using': using,
             'columns': ', '.join(quote_name(column) for column in columns),
             'extra': tablespace_sql,
         }

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -46,6 +46,7 @@ class Index(object):
         return schema_editor.sql_create_index % {
             'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
+            'using': '',
             'columns': ', '.join(quote_name(column) for column in columns),
             'extra': tablespace_sql,
         }

--- a/docs/ref/contrib/postgres/index.txt
+++ b/docs/ref/contrib/postgres/index.txt
@@ -35,6 +35,7 @@ release. Some fields require higher versions.
     fields
     forms
     functions
+    indexes
     lookups
     operations
     search

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -1,0 +1,25 @@
+=================================
+PostgreSQL specific model indexes
+=================================
+
+.. module:: django.contrib.postgres.indexes
+
+.. versionadded:: 1.11
+
+The following are the PostgreSQL specific :doc:`indexes </ref/models/indexes>`
+supported by Django and are available from the
+``django.contrib.postgres.indexes`` module.
+
+``GinIndex``
+============
+
+.. class:: GinIndex()
+
+    A subclass of :class:`~django.db.models.Index` which will install the
+    `gin index <https://www.postgresql.org/docs/current/static/gin.html>`_.
+
+    To use this index, you might need to activate the `btree_gin extension
+    <https://www.postgresql.org/docs/current/static/btree-gin.html>`_ on
+    PostgreSQL. You can install it using the
+    :class:`~django.contrib.postgres.operations.BtreeGinExtension` migration
+    operation.

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -44,3 +44,13 @@ the ``django.contrib.postgres.operations`` module.
 
     A subclass of :class:`~django.contrib.postgres.operations.CreateExtension`
     which will install the ``unaccent`` extension.
+
+``BtreeGinExtension``
+=====================
+
+.. class:: BtreeGinExtension()
+
+    .. versionadded:: 1.11
+
+    A subclass of :class:`~django.contrib.postgres.operations.CreateExtension`
+    which will install the ``btree_gin`` extension.

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -42,3 +42,8 @@ A list of the name of the fields on which the index is desired.
 The name of the index. If ``name`` isn't provided Django will auto-generate a
 name. For compatibility with different databases, index names cannot be longer
 than 30 characters and shouldn't start with a number (0-9) or underscore (_).
+
+.. admonition:: See also
+
+    For a list of built-in indexes supported only by PostgreSQL see
+    :mod:`django.contrib.postgres.indexes`.

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -305,6 +305,10 @@ Database backend API
 * To enable ``FOR UPDATE SKIP LOCKED`` support, set
   ``DatabaseFeatures.has_select_for_update_skip_locked = True``.
 
+* The  ``DatabaseFeatures.can_introspect_index_type`` flag was added. Set it to
+  ``True`` if the backend can introspect the type (``btree``, ``gin``) of an
+  index.
+
 Dropped support for PostgreSQL 9.2 and PostGIS 2.0
 --------------------------------------------------
 

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -170,6 +170,9 @@ class IntrospectionTests(TransactionTestCase):
     def test_get_indexes(self):
         with connection.cursor() as cursor:
             indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
+        if connection.features.can_introspect_index_type:
+            self.assertIn('type', indexes['reporter_id'])
+            indexes['reporter_id'].pop('type')
         self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
 
     def test_get_indexes_multicol(self):

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -171,8 +171,8 @@ class IntrospectionTests(TransactionTestCase):
         with connection.cursor() as cursor:
             indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
         if connection.features.can_introspect_index_type:
-            self.assertIn('type', indexes['reporter_id'])
-            indexes['reporter_id'].pop('type')
+            index_type = indexes['reporter_id'].pop('type', None)
+            self.assertEqual(index_type, 'btree')
         self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
 
     def test_get_indexes_multicol(self):

--- a/tests/postgres_tests/migrations/0001_setup_extensions.py
+++ b/tests/postgres_tests/migrations/0001_setup_extensions.py
@@ -5,10 +5,12 @@ from django.db import migrations
 
 try:
     from django.contrib.postgres.operations import (
-        CreateExtension, HStoreExtension, TrigramExtension, UnaccentExtension,
+        BtreeGinExtension, CreateExtension, HStoreExtension, TrigramExtension,
+        UnaccentExtension,
     )
 except ImportError:
     from django.test import mock
+    BtreeGinExtension = mock.Mock()
     CreateExtension = mock.Mock()
     HStoreExtension = mock.Mock()
     TrigramExtension = mock.Mock()
@@ -18,6 +20,7 @@ except ImportError:
 class Migration(migrations.Migration):
 
     operations = [
+        BtreeGinExtension(),
         # Ensure CreateExtension quotes extension names by creating one with a
         # dash in its name.
         CreateExtension('uuid-ossp'),

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -1,0 +1,62 @@
+from django.contrib.postgres.indexes import GinIndex
+from django.db import connection
+
+from . import PostgreSQLTestCase
+from .models import IntegerArrayModel
+
+
+class IndexesTests(PostgreSQLTestCase):
+
+    def test_repr(self):
+        # GinIndex
+        index = GinIndex(fields=['title'])
+        self.assertEqual(repr(index), "<GinIndex: fields='title'>")
+
+    def test_eq(self):
+        # GinIndex
+        index = GinIndex(fields=['title'])
+        same_index = GinIndex(fields=['title'])
+        another_index = GinIndex(fields=['author'])
+        self.assertEqual(index, same_index)
+        self.assertNotEqual(index, another_index)
+
+    def test_name_auto_generation(self):
+        # GinIndex
+        index = GinIndex(fields=['field'])
+        index.set_name_with_model(IntegerArrayModel)
+        self.assertEqual(index.name, 'postgres_te_field_def2f8_gin')
+
+    def test_deconstruction(self):
+        # GinIndex
+        index = GinIndex(fields=['title'], name='test_title_gin')
+        path, args, kwargs = index.deconstruct()
+        self.assertEqual(path, 'django.contrib.postgres.indexes.GinIndex')
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_gin'})
+
+
+class SchemaTests(PostgreSQLTestCase):
+
+    def get_indexes(self, table):
+        """
+        Get the indexes on the table using a new cursor.
+        """
+        with connection.cursor() as cursor:
+            return connection.introspection.get_indexes(cursor, table)
+
+    def test_gin_index(self):
+        """
+        gin index addition and removal
+        """
+        # Ensure the table is there and has no index
+        self.assertNotIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))
+        # Add the index
+        index = GinIndex(fields=['field'], name='integer_array_model_field_gin')
+        with connection.schema_editor() as editor:
+            editor.add_index(IntegerArrayModel, index)
+        self.assertIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))
+        self.assertEqual(self.get_indexes(IntegerArrayModel._meta.db_table)['field']['type'], 'gin')
+        # Drop the index
+        with connection.schema_editor() as editor:
+            editor.remove_index(IntegerArrayModel, index)
+        self.assertNotIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1779,6 +1779,7 @@ class SchemaTests(TransactionTestCase):
                 editor.sql_create_index % {
                     "table": editor.quote_name(table),
                     "name": editor.quote_name(constraint_name),
+                    "using": "",
                     "columns": editor.quote_name(column),
                     "extra": "",
                 }


### PR DESCRIPTION
Ticket [#27030](https://code.djangoproject.com/ticket/27030#ticket).

Adds
1. introspection for index types in postgres
2. `BtreeGinExtension` operation in contrib.postgres
3. `GinIndex` index