### PR TITLE
Refs #27025 -- Fixed a couple timezone tests for Python 3.6.

### DIFF
--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -1,9 +1,10 @@
 import copy
 import datetime
 import pickle
+import sys
 import unittest
 
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
 try:
@@ -18,8 +19,10 @@ if pytz is not None:
 EAT = timezone.get_fixed_timezone(180)      # Africa/Nairobi
 ICT = timezone.get_fixed_timezone(420)      # Asia/Bangkok
 
+PY36 = sys.version_info >= (3, 6)
 
-class TimezoneTests(unittest.TestCase):
+
+class TimezoneTests(SimpleTestCase):
 
     def test_localtime(self):
         now = datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
@@ -28,8 +31,12 @@ class TimezoneTests(unittest.TestCase):
         self.assertEqual(local_now.tzinfo, local_tz)
 
     def test_localtime_naive(self):
-        with self.assertRaises(ValueError):
-            timezone.localtime(datetime.datetime.now())
+        now = datetime.datetime.now()
+        if PY36:
+            self.assertEqual(timezone.localtime(now), now.replace(tzinfo=timezone.LocalTimezone()))
+        else:
+            with self.assertRaisesMessage(ValueError, 'astimezone() cannot be applied to a naive datetime'):
+                timezone.localtime(now)
 
     def test_localtime_out_of_range(self):
         local_tz = timezone.LocalTimezone()
@@ -136,8 +143,13 @@ class TimezoneTests(unittest.TestCase):
         self.assertEqual(
             timezone.make_naive(datetime.datetime(2011, 9, 1, 17, 20, 30, tzinfo=ICT), EAT),
             datetime.datetime(2011, 9, 1, 13, 20, 30))
-        with self.assertRaises(ValueError):
-            timezone.make_naive(datetime.datetime(2011, 9, 1, 13, 20, 30), EAT)
+
+        args = (datetime.datetime(2011, 9, 1, 13, 20, 30), EAT)
+        if PY36:
+            self.assertEqual(timezone.make_naive(*args), datetime.datetime(2011, 9, 1, 21, 20, 30))
+        else:
+            with self.assertRaisesMessage(ValueError, 'astimezone() cannot be applied to a naive datetime'):
+                timezone.make_naive(*args)
 
     @requires_pytz
     def test_make_aware2(self):


### PR DESCRIPTION
Reflects behavior changes in [PEP 495](https://www.python.org/dev/peps/pep-0495/) (Local Time Disambiguation).
