### PR TITLE
[1.10.x] Fixed #26957 -- Corrected inconsistency between code and docs

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -122,20 +122,19 @@ Authenticating users
     form of keyword arguments, for the default configuration this is
     ``username`` and ``password``, and it returns
     a :class:`~django.contrib.auth.models.User` object if the password is valid
-    for the given username. If the password is invalid,
+    for the given username **and** if the ``user.is_active==True``. 
+    If the password is invalid or ``user.is_active==False``,
     :func:`~django.contrib.auth.authenticate()` returns ``None``. Example::
 
         from django.contrib.auth import authenticate
         user = authenticate(username='john', password='secret')
         if user is not None:
             # the password verified for the user
-            if user.is_active:
-                print("User is valid, active and authenticated")
-            else:
-                print("The password is valid, but the account has been disabled!")
+            print("User is valid, active and authenticated")
         else:
-            # the authentication system was unable to verify the username and password
-            print("The username and password were incorrect.")
+            # the authentication system was unable to verify 
+            # the username and password or user is not active
+            print("The username and password were incorrect, or user is inactive.")
 
     .. note::
 
@@ -348,11 +347,8 @@ If you have an authenticated user you want to attach to the current session
             password = request.POST['password']
             user = authenticate(username=username, password=password)
             if user is not None:
-                if user.is_active:
-                    login(request, user)
+                login(request, user)
                     # Redirect to a success page.
-                else:
-                    # Return a 'disabled account' error message
                     ...
             else:
                 # Return an 'invalid login' error message.
@@ -503,7 +499,7 @@ The ``login_required`` decorator
 
         from django.contrib.auth import views as auth_views
 
-        url(r'^accounts/login/$', auth_views.Login.as_view()),
+        url(r'^accounts/login/$', auth_views.login),
 
     The :setting:`settings.LOGIN_URL <LOGIN_URL>` also accepts view function
     names and :ref:`named URL patterns <naming-url-patterns>`. This allows you
@@ -533,6 +529,8 @@ achieve the same behavior as with ``login_required`` by using the
 inheritance list.
 
 .. class:: LoginRequiredMixin
+
+    .. versionadded:: 1.9
 
     If a view is using this mixin, all requests by non-authenticated users will
     be redirected to the login page or shown an HTTP 403 Forbidden error,
@@ -620,6 +618,8 @@ redirects to the login page::
 .. currentmodule:: django.contrib.auth.mixins
 
 .. class:: UserPassesTestMixin
+
+    .. versionadded:: 1.9
 
     When using :doc:`class-based views </topics/class-based-views/index>`, you
     can use the ``UserPassesTestMixin`` to do this.
@@ -716,6 +716,11 @@ The ``permission_required`` decorator
         def my_view(request):
             ...
 
+    .. versionchanged:: 1.9
+
+        In older versions, the ``permission`` parameter only worked with
+        strings, lists, and tuples instead of strings and any iterable.
+
 .. currentmodule:: django.contrib.auth.mixins
 
 The ``PermissionRequiredMixin`` mixin
@@ -725,6 +730,8 @@ To apply permission checks to :doc:`class-based views
 </ref/class-based-views/index>`, you can use the ``PermissionRequiredMixin``:
 
 .. class:: PermissionRequiredMixin
+
+    .. versionadded:: 1.9
 
     This mixin, just like the ``permission_required``
     decorator, checks whether the user accessing a view has all given
@@ -765,6 +772,8 @@ To ease the handling of access restrictions in :doc:`class-based views
 user to the login page or issue an HTTP 403 Forbidden response.
 
 .. class:: AccessMixin
+
+    .. versionadded:: 1.9
 
     .. attribute:: login_url
 
@@ -839,7 +848,7 @@ request matches the one that's computed server-side. This allows a user to log
 out all of their sessions by changing their password.
 
 The default password change views included with Django,
-:class:`django.contrib.auth.views.PasswordChangeView` and the
+:func:`django.contrib.auth.views.password_change` and the
 ``user_change_password`` view in the :mod:`django.contrib.auth` admin, update
 the session with the new password hash so that a user changing their own
 password won't log themselves out. If you have a custom password change view
@@ -917,7 +926,7 @@ your URLconf::
     from django.contrib.auth import views as auth_views
 
     urlpatterns = [
-        url('^change-password/$', auth_views.PasswordChangeView.as_view()),
+        url('^change-password/$', auth_views.password_change),
     ]
 
 The views have optional arguments you can use to alter the behavior of the
@@ -928,12 +937,24 @@ arguments in the URLconf, these will be passed on to the view. For example::
     urlpatterns = [
         url(
             '^change-password/$',
-            auth_views.PasswordChangeView.as_view(template_name='change-password.html'),
+            auth_views.password_change,
+            {'template_name': 'change-password.html'}
         ),
     ]
 
-All views are :doc:`class-based </topics/class-based-views/index>`, which allows
-you to easily customize them by subclassing.
+All views return a :class:`~django.template.response.TemplateResponse`
+instance, which allows you to easily customize the response data before
+rendering. A way to do this is to wrap a view in your own view::
+
+    from django.contrib.auth import views
+
+    def change_password(request):
+        template_response = views.password_change(request)
+        # Do something with `template_response`
+        return template_response
+
+For more details, see the :doc:`TemplateResponse documentation
+</ref/template-response>`.
 
 .. _all-authentication-views:
 
@@ -945,37 +966,12 @@ implementation details see :ref:`using-the-views`.
 
 .. function:: login(request, template_name=`registration/login.html`, redirect_field_name='next', authentication_form=AuthenticationForm, current_app=None, extra_context=None, redirect_authenticated_user=False)
 
-    .. deprecated:: 1.11
-
-        The ``login`` function-based view should be replaced by the class-based
-        :class:`LoginView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``LoginView`` attributes. In addition, it has:
-
-    * ``current_app``: A hint indicating which application contains the
-      current view. See the :ref:`namespaced URL resolution strategy
-      <topics-http-reversing-url-namespaces>` for more information.
-
-    .. deprecated:: 1.9
-
-        The ``current_app`` attribute is deprecated and will be removed in
-        Django 2.0. Callers should set ``request.current_app`` instead.
-
-    .. versionadded:: 1.10
-
-        The ``redirect_authenticated_user`` parameter was added.
-
-.. class:: LoginView
-
-    .. versionadded:: 1.11
-
     **URL name:** ``login``
 
     See :doc:`the URL documentation </topics/http/urls>` for details on using
     named URL patterns.
 
-    **Attributes:**
+    **Optional arguments:**
 
     * ``template_name``: The name of a template to display for the view used to
       log the user in. Defaults to :file:`registration/login.html`.
@@ -987,6 +983,10 @@ implementation details see :ref:`using-the-views`.
       use for authentication. Defaults to
       :class:`~django.contrib.auth.forms.AuthenticationForm`.
 
+    * ``current_app``: A hint indicating which application contains the current
+      view. See the :ref:`namespaced URL resolution strategy
+      <topics-http-reversing-url-namespaces>` for more information.
+
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
 
@@ -994,7 +994,16 @@ implementation details see :ref:`using-the-views`.
       authenticated users accessing the login page will be redirected as if
       they had just successfully logged in. Defaults to ``False``.
 
-    Here's what ``LoginView`` does:
+    .. deprecated:: 1.9
+
+        The ``current_app`` parameter is deprecated and will be removed in
+        Django 2.0. Callers should set ``request.current_app`` instead.
+
+    .. versionadded:: 1.10
+
+        The ``redirect_authenticated_user`` parameter was added.
+
+    Here's what ``django.contrib.auth.views.login`` does:
 
     * If called via ``GET``, it displays a login form that POSTs to the
       same URL. More on this in a bit.
@@ -1030,14 +1039,14 @@ implementation details see :ref:`using-the-views`.
 
     If you'd prefer not to call the template :file:`registration/login.html`,
     you can pass the ``template_name`` parameter via the extra arguments to
-    the ``as_view`` method in your URLconf. For example, this URLconf line would
-    use :file:`myapp/login.html` instead::
+    the view in your URLconf. For example, this URLconf line would use
+    :file:`myapp/login.html` instead::
 
-        url(r'^accounts/login/$', auth_views.LoginView.as_view(template_name='myapp/login.html')),
+        url(r'^accounts/login/$', auth_views.login, {'template_name': 'myapp/login.html'}),
 
     You can also specify the name of the ``GET`` field which contains the URL
-    to redirect to after login using ``redirect_field_name``. By default, the
-    field is called ``next``.
+    to redirect to after login by passing ``redirect_field_name`` to the view.
+    By default, the field is called ``next``.
 
     Here's a sample :file:`registration/login.html` template you can use as a
     starting point. It assumes you have a :file:`base.html` template that
@@ -1084,54 +1093,48 @@ implementation details see :ref:`using-the-views`.
 
         {% endblock %}
 
-    If you have customized authentication (see :doc:`Customizing Authentication
-    </topics/auth/customizing>`) you can use a custom authentication form by
-    setting the ``authentication_form`` attribute. This form must accept a
-    ``request`` keyword argument in its ``__init__()`` method and provide a
-    ``get_user()`` method which returns the authenticated user object (this
-    method is only ever called after successful form validation).
+    If you have customized authentication (see
+    :doc:`Customizing Authentication </topics/auth/customizing>`) you can pass
+    a custom authentication form to the login view via the
+    ``authentication_form`` parameter. This form must accept a ``request``
+    keyword argument in its ``__init__`` method, and provide a ``get_user()``
+    method which returns the authenticated user object (this method is only
+    ever called after successful form validation).
+
+    .. _forms documentation: ../forms/
+    .. _site framework docs: ../sites/
 
 .. function:: logout(request, next_page=None, template_name='registration/logged_out.html', redirect_field_name='next', current_app=None, extra_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``logout`` function-based view should be replaced by the
-        class-based :class:`LogoutView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``LogoutView`` attributes. In addition, it has:
-
-    * ``current_app``: A hint indicating which application contains the
-      current view. See the :ref:`namespaced URL resolution strategy
-      <topics-http-reversing-url-namespaces>` for more information.
-
-    .. deprecated:: 1.9
-
-        The ``current_app`` attribute is deprecated and will be removed in
-        Django 2.0. Callers should set ``request.current_app`` instead.
-
-.. class:: LogoutView
-
-    .. versionadded:: 1.11
 
     Logs a user out.
 
     **URL name:** ``logout``
 
-    **Attributes:**
+    **Optional arguments:**
 
     * ``next_page``: The URL to redirect to after logout. Defaults to
-      :setting:`settings.LOGOUT_REDIRECT_URL <LOGOUT_REDIRECT_URL>`.
+      :setting:`settings.LOGOUT_REDIRECT_URL <LOGOUT_REDIRECT_URL>` if not
+      supplied.
 
     * ``template_name``: The full name of a template to display after
-      logging the user out. Defaults to :file:`registration/logged_out.html`.
+      logging the user out. Defaults to
+      :file:`registration/logged_out.html` if no argument is supplied.
 
     * ``redirect_field_name``: The name of a ``GET`` field containing the
       URL to redirect to after log out. Defaults to ``next``. Overrides the
       ``next_page`` URL if the given ``GET`` parameter is passed.
 
+    * ``current_app``: A hint indicating which application contains the current
+      view. See the :ref:`namespaced URL resolution strategy
+      <topics-http-reversing-url-namespaces>` for more information.
+
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
+
+    .. deprecated:: 1.9
+
+        The ``current_app`` parameter is deprecated and will be removed in
+        Django 2.0. Callers should set ``request.current_app`` instead.
 
     **Template context:**
 
@@ -1179,123 +1182,67 @@ implementation details see :ref:`using-the-views`.
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
-    .. deprecated:: 1.11
-
-        The unused ``extra_context`` parameter is deprecated and will be
-        removed in Django 2.1.
-
 .. function:: password_change(request, template_name='registration/password_change_form.html', post_change_redirect=None, password_change_form=PasswordChangeForm, current_app=None, extra_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``password_change`` function-based view should be replaced by the
-        class-based :class:`PasswordChangeView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordChangeView`` attributes, except the ``post_change_redirect`` and
-    ``password_change_form`` arguments which map to the ``success_url`` and
-    ``form_class`` attributes of the class-based view. In addition, it has:
-
-    * ``current_app``: A hint indicating which application contains the current
-      view. See the :ref:`namespaced URL resolution strategy
-      <topics-http-reversing-url-namespaces>` for more information.
-
-    .. deprecated:: 1.9
-
-        The ``current_app`` parameter is deprecated and will be removed in
-        Django 2.0. Callers should set ``request.current_app`` instead.
-
-.. class:: PasswordChangeView
-
-    .. versionadded:: 1.11
-
-    **URL name:** ``password_change``
 
     Allows a user to change their password.
 
-    **Attributes:**
+    **URL name:** ``password_change``
+
+    **Optional arguments:**
 
     * ``template_name``: The full name of a template to use for
       displaying the password change form. Defaults to
       :file:`registration/password_change_form.html` if not supplied.
 
-    * ``success_url``: The URL to redirect to after a successful password
-      change.
+    * ``post_change_redirect``: The URL to redirect to after a successful
+      password change.
 
-    * ``form_class``: A custom "change password" form which must accept a
-      ``user`` keyword argument. The form is responsible for actually changing
-      the user's password. Defaults to
+    * ``password_change_form``: A custom "change password" form which must
+      accept a ``user`` keyword argument. The form is responsible for
+      actually changing the user's password. Defaults to
       :class:`~django.contrib.auth.forms.PasswordChangeForm`.
-
-    * ``extra_context``: A dictionary of context data that will be added to the
-      default context data passed to the template.
-
-    **Template context:**
-
-    * ``form``: The password change form (see ``form_class`` above).
-
-.. function:: password_change_done(request, template_name='registration/password_change_done.html', current_app=None, extra_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``password_change_done`` function-based view should be replaced by
-        the class-based :class:`PasswordChangeDoneView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordChangeDoneView`` attributes. In addition, it has:
 
     * ``current_app``: A hint indicating which application contains the current
       view. See the :ref:`namespaced URL resolution strategy
       <topics-http-reversing-url-namespaces>` for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the
+      default context data passed to the template.
 
     .. deprecated:: 1.9
 
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
-.. class:: PasswordChangeDoneView
+    **Template context:**
 
-    .. versionadded:: 1.11
+    * ``form``: The password change form (see ``password_change_form`` above).
 
-    **URL name:** ``password_change_done``
+.. function:: password_change_done(request, template_name='registration/password_change_done.html', current_app=None, extra_context=None)
 
     The page shown after a user has changed their password.
 
-    **Attributes:**
+    **URL name:** ``password_change_done``
+
+    **Optional arguments:**
 
     * ``template_name``: The full name of a template to use.
       Defaults to :file:`registration/password_change_done.html` if not
       supplied.
 
-    * ``extra_context``: A dictionary of context data that will be added to the
-      default context data passed to the template.
-
-.. function:: password_reset(request, template_name='registration/password_reset_form.html', email_template_name='registration/password_reset_email.html', subject_template_name='registration/password_reset_subject.txt', password_reset_form=PasswordResetForm, token_generator=default_token_generator, post_reset_redirect=None, from_email=None, current_app=None, extra_context=None, html_email_template_name=None, extra_email_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``password_reset`` function-based view should be replaced by the
-        class-based :class:`PasswordResetView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordResetView`` attributes, except the ``post_reset_redirect`` and
-    ``password_reset_form`` arguments which map to the ``success_url`` and
-    ``form_class`` attributes of the class-based view. In addition, it has:
-
     * ``current_app``: A hint indicating which application contains the current
       view. See the :ref:`namespaced URL resolution strategy
       <topics-http-reversing-url-namespaces>` for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the
+      default context data passed to the template.
 
     .. deprecated:: 1.9
 
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
-.. class:: PasswordResetView
-
-    .. versionadded:: 1.11
-
-    **URL name:** ``password_reset``
+.. function:: password_reset(request, template_name='registration/password_reset_form.html', email_template_name='registration/password_reset_email.html', subject_template_name='registration/password_reset_subject.txt', password_reset_form=PasswordResetForm, token_generator=default_token_generator, post_reset_redirect=None, from_email=None, current_app=None, extra_context=None, html_email_template_name=None, extra_email_context=None)
 
     Allows a user to reset their password by generating a one-time use link
     that can be used to reset the password, and sending that link to the
@@ -1306,7 +1253,7 @@ implementation details see :ref:`using-the-views`.
     This prevents information leaking to potential attackers. If you want to
     provide an error message in this case, you can subclass
     :class:`~django.contrib.auth.forms.PasswordResetForm` and use the
-    ``form_class`` attribute.
+    ``password_reset_form`` argument.
 
     Users flagged with an unusable password (see
     :meth:`~django.contrib.auth.models.User.set_unusable_password()` aren't
@@ -1315,15 +1262,13 @@ implementation details see :ref:`using-the-views`.
     error message since this would expose their account's existence but no
     mail will be sent either.
 
-    **Attributes:**
+    **URL name:** ``password_reset``
+
+    **Optional arguments:**
 
     * ``template_name``: The full name of a template to use for
       displaying the password reset form. Defaults to
       :file:`registration/password_reset_form.html` if not supplied.
-
-    * ``form_class``: Form that will be used to get the email of
-      the user to reset the password for. Defaults to
-      :class:`~django.contrib.auth.forms.PasswordResetForm`.
 
     * ``email_template_name``: The full name of a template to use for
       generating the email with the reset password link. Defaults to
@@ -1333,15 +1278,23 @@ implementation details see :ref:`using-the-views`.
       the subject of the email with the reset password link. Defaults
       to :file:`registration/password_reset_subject.txt` if not supplied.
 
+    * ``password_reset_form``: Form that will be used to get the email of
+      the user to reset the password for. Defaults to
+      :class:`~django.contrib.auth.forms.PasswordResetForm`.
+
     * ``token_generator``: Instance of the class to check the one time link.
       This will default to ``default_token_generator``, it's an instance of
       ``django.contrib.auth.tokens.PasswordResetTokenGenerator``.
 
-    * ``success_url``: The URL to redirect to after a successful password reset
-      request.
+    * ``post_reset_redirect``: The URL to redirect to after a successful
+      password reset request.
 
     * ``from_email``: A valid email address. By default Django uses
       the :setting:`DEFAULT_FROM_EMAIL`.
+
+    * ``current_app``: A hint indicating which application contains the current
+      view. See the :ref:`namespaced URL resolution strategy
+      <topics-http-reversing-url-namespaces>` for more information.
 
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
@@ -1353,10 +1306,19 @@ implementation details see :ref:`using-the-views`.
     * ``extra_email_context``: A dictionary of context data that will available
       in the email template.
 
+    .. deprecated:: 1.9
+
+        The ``current_app`` parameter is deprecated and will be removed in
+        Django 2.0. Callers should set ``request.current_app`` instead.
+
+    .. versionadded:: 1.9
+
+        The ``extra_email_context`` parameter was added.
+
     **Template context:**
 
-    * ``form``: The form (see ``form_class`` above) for resetting the user's
-      password.
+    * ``form``: The form (see ``password_reset_form`` above) for resetting
+      the user's password.
 
     **Email template context:**
 
@@ -1393,32 +1355,11 @@ implementation details see :ref:`using-the-views`.
 
 .. function:: password_reset_done(request, template_name='registration/password_reset_done.html', current_app=None, extra_context=None)
 
-    .. deprecated:: 1.11
-
-        The ``password_reset_done`` function-based view should be replaced by
-        the  class-based :class:`PasswordResetDoneView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordResetDoneView`` attributes. In addition, it has:
-
-    * ``current_app``: A hint indicating which application contains the current
-      view. See the :ref:`namespaced URL resolution strategy
-      <topics-http-reversing-url-namespaces>` for more information.
-
-    .. deprecated:: 1.9
-
-        The ``current_app`` parameter is deprecated and will be removed in
-        Django 2.0. Callers should set ``request.current_app`` instead.
-
-.. class:: PasswordResetDoneView
-
-    .. versionadded:: 1.11
+    The page shown after a user has been emailed a link to reset their
+    password. This view is called by default if the :func:`password_reset` view
+    doesn't have an explicit ``post_reset_redirect`` URL set.
 
     **URL name:** ``password_reset_done``
-
-    The page shown after a user has been emailed a link to reset their
-    password. This view is called by default if the :class:`PasswordResetView`
-    doesn't have an explicit ``success_url`` URL set.
 
     .. note::
 
@@ -1426,69 +1367,53 @@ implementation details see :ref:`using-the-views`.
         inactive, or has an unusable password, the user will still be
         redirected to this view but no email will be sent.
 
-    **Attributes:**
+    **Optional arguments:**
 
     * ``template_name``: The full name of a template to use.
       Defaults to :file:`registration/password_reset_done.html` if not
       supplied.
 
-    * ``extra_context``: A dictionary of context data that will be added to the
-      default context data passed to the template.
-
-.. function:: password_reset_confirm(request, uidb64=None, token=None, template_name='registration/password_reset_confirm.html', token_generator=default_token_generator, set_password_form=SetPasswordForm, post_reset_redirect=None, current_app=None, extra_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``password_reset_confirm`` function-based view should be replaced by
-        the class-based :class:`PasswordResetConfirmView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordResetConfirmView`` attributes, except the ``post_reset_redirect``
-    and ``set_password_form`` arguments which map to the ``success_url`` and
-    ``form_class`` attributes of the class-based view. In addition, it has:
-
     * ``current_app``: A hint indicating which application contains the current
       view. See the :ref:`namespaced URL resolution strategy
       <topics-http-reversing-url-namespaces>` for more information.
+
+    * ``extra_context``: A dictionary of context data that will be added to the
+      default context data passed to the template.
 
     .. deprecated:: 1.9
 
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
-.. class:: PasswordResetConfirmView
-
-    .. versionadded:: 1.11
-
-    **URL name:** ``password_reset_confirm``
+.. function:: password_reset_confirm(request, uidb64=None, token=None, template_name='registration/password_reset_confirm.html', token_generator=default_token_generator, set_password_form=SetPasswordForm, post_reset_redirect=None, current_app=None, extra_context=None)
 
     Presents a form for entering a new password.
 
-    **Keyword arguments from the URL:**
+    **URL name:** ``password_reset_confirm``
 
-    * ``uidb64``: The user's id encoded in base 64.
+    **Optional arguments:**
 
-    * ``token``: Token to check that the password is valid.
+    * ``uidb64``: The user's id encoded in base 64. Defaults to ``None``.
 
-    **Attributes:**
+    * ``token``: Token to check that the password is valid. Defaults to
+      ``None``.
 
     * ``template_name``: The full name of a template to display the confirm
-      password view. Default value is
-      :file:`registration/password_reset_confirm.html`.
+      password view. Default value is :file:`registration/password_reset_confirm.html`.
 
     * ``token_generator``: Instance of the class to check the password. This
       will default to ``default_token_generator``, it's an instance of
       ``django.contrib.auth.tokens.PasswordResetTokenGenerator``.
 
-    * ``post_reset_login``: A boolean indicating if the user should be
-      automatically authenticated after a successful password reset. Defaults
-      to ``False``.
+    * ``set_password_form``: Form that will be used to set the password.
+      Defaults to :class:`~django.contrib.auth.forms.SetPasswordForm`
 
-    * ``form_class``: Form that will be used to set the password. Defaults to
-      :class:`~django.contrib.auth.forms.SetPasswordForm`.
+    * ``post_reset_redirect``: URL to redirect after the password reset
+      done. Defaults to ``None``.
 
-    * ``success_url``: URL to redirect after the password reset done. Defaults
-      to ``'password_reset_complete'``.
+    * ``current_app``: A hint indicating which application contains the current
+      view. See the :ref:`namespaced URL resolution strategy
+      <topics-http-reversing-url-namespaces>` for more information.
 
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
@@ -1501,41 +1426,34 @@ implementation details see :ref:`using-the-views`.
     * ``validlink``: Boolean, True if the link (combination of ``uidb64`` and
       ``token``) is valid or unused yet.
 
-.. function:: password_reset_complete(request, template_name='registration/password_reset_complete.html', current_app=None, extra_context=None)
-
-    .. deprecated:: 1.11
-
-        The ``password_reset_complete`` function-based view should be replaced
-        by the class-based :class:`PasswordResetCompleteView`.
-
-    The optional arguments of this view are similar to the class-based
-    ``PasswordResetCompleteView`` attributes. In addition, it has:
-
-    * ``current_app``: A hint indicating which application contains the current
-      view. See the :ref:`namespaced URL resolution strategy
-      <topics-http-reversing-url-namespaces>` for more information.
-
     .. deprecated:: 1.9
 
         The ``current_app`` parameter is deprecated and will be removed in
         Django 2.0. Callers should set ``request.current_app`` instead.
 
-.. class:: PasswordResetCompleteView
-
-    .. versionadded:: 1.11
-
-    **URL name:** ``password_reset_complete``
+.. function:: password_reset_complete(request, template_name='registration/password_reset_complete.html', current_app=None, extra_context=None)
 
     Presents a view which informs the user that the password has been
     successfully changed.
 
-    **Attributes:**
+    **URL name:** ``password_reset_complete``
+
+    **Optional arguments:**
 
     * ``template_name``: The full name of a template to display the view.
       Defaults to :file:`registration/password_reset_complete.html`.
 
+    * ``current_app``: A hint indicating which application contains the current
+      view. See the :ref:`namespaced URL resolution strategy
+      <topics-http-reversing-url-namespaces>` for more information.
+
     * ``extra_context``: A dictionary of context data that will be added to the
       default context data passed to the template.
+
+    .. deprecated:: 1.9
+
+        The ``current_app`` parameter is deprecated and will be removed in
+        Django 2.0. Callers should set ``request.current_app`` instead.
 
 Helper functions
 ----------------
@@ -1651,9 +1569,8 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
             defaults to ``None``, in which case a plain text email is sent.
 
         By default, ``save()`` populates the ``context`` with the
-        same variables that
-        :class:`~django.contrib.auth.views.PasswordResetView` passes to its
-        email context.
+        same variables that :func:`~django.contrib.auth.views.password_reset`
+        passes to its email context.
 
 .. class:: SetPasswordForm
 


### PR DESCRIPTION
Updated description and code example for default authenticate() method
in 'Authenticating users' section.
Updated code example for 'How to log a user in' section.