### PR TITLE
Fixed #27046 -- Supported IPv6-formatted IPv4 addresses in host validation.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -24,7 +24,7 @@ from django.utils.six.moves.urllib.parse import (
 )
 
 RAISE_ERROR = object()
-host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9:]+\])(:\d+)?$")
+host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:\d+)?$")
 
 
 class UnreadablePostError(IOError):

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -589,7 +589,7 @@ class HostValidationTests(SimpleTestCase):
         ALLOWED_HOSTS=[
             'forward.com', 'example.com', 'internal.com', '12.34.56.78',
             '[2001:19f0:feee::dead:beef:cafe]', 'xn--4ca9at.com',
-            '.multitenant.com', 'INSENSITIVE.com',
+            '.multitenant.com', 'INSENSITIVE.com', '[::ffff:169.254.169.254]',
         ])
     def test_http_get_host(self):
         # Check if X_FORWARDED_HOST is provided.
@@ -641,6 +641,7 @@ class HostValidationTests(SimpleTestCase):
             'insensitive.com',
             'example.com.',
             'example.com.:80',
+            '[::ffff:169.254.169.254]',
         ]
 
         for host in legit_hosts:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27046