### PR TITLE
Fixed #27054 -- makemigrations fails with external databases

### DIFF
--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -62,7 +62,11 @@ class MigrationRecorder(object):
         """
         Returns a set of (app, name) of applied migrations.
         """
-        self.ensure_schema()
+        try:
+            self.ensure_schema()
+        except MigrationSchemaMissing:
+            # If the migration schema is missing, then there are no migrations applied.
+            return set()
         return set(tuple(x) for x in self.migration_qs.values_list("app", "name"))
 
     def record_applied(self, app, name):


### PR DESCRIPTION
Change applied_migrations in MigrationRecorder to return an empty set
if the django_migrations table is missing and it cannot be created.

This is necessary when there are multiple database connections and at
least one of the connections is a read-only connection to an external
database that will never have migrations applied to it. All models for
the read-only database will have managed = False.