### PR TITLE
Fixed #26993 -- User model's last_name length increased to 100 chars.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -317,7 +317,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         },
     )
     first_name = models.CharField(_('first name'), max_length=30, blank=True)
-    last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    last_name = models.CharField(_('last name'), max_length=100, blank=True)
     email = models.EmailField(_('email address'), blank=True)
     is_staff = models.BooleanField(
         _('staff status'),


### PR DESCRIPTION
The max_length attribute of User model's last_name field was
increased to 100 characters as a result of the mailing list's
discussion.