### PR TITLE
Add get method to CacheHandler

### DIFF
--- a/django/core/cache/__init__.py
+++ b/django/core/cache/__init__.py
@@ -84,6 +84,12 @@ class CacheHandler(object):
     def all(self):
         return getattr(self._caches, 'caches', {}).values()
 
+    def get(self, alias, default=DEFAULT_CACHE_ALIAS):
+        try:
+            return self[alias]
+        except InvalidCacheBackendError:
+            return self[default]
+
 caches = CacheHandler()
 
 

--- a/django/templatetags/cache.py
+++ b/django/templatetags/cache.py
@@ -36,10 +36,7 @@ class CacheNode(Node):
             except InvalidCacheBackendError:
                 raise TemplateSyntaxError('Invalid cache name specified for cache tag: %r' % cache_name)
         else:
-            try:
-                fragment_cache = caches['template_fragments']
-            except InvalidCacheBackendError:
-                fragment_cache = caches['default']
+            fragment_cache = caches.get('template_fragments')
 
         vary_on = [var.resolve(context) for var in self.vary_on]
         cache_key = make_template_fragment_key(self.fragment_name, vary_on)


### PR DESCRIPTION
Since CacheHandler is already dict-like, add get so things like the template cache tag can fall-back to default.