### PR TITLE
Fixed #24112 -- Fixed counting of elements if needle has no root element

### DIFF
--- a/django/test/html.py
+++ b/django/test/html.py
@@ -94,6 +94,9 @@ class Element(object):
         if not isinstance(element, six.string_types):
             if self == element:
                 return 1
+        if isinstance(element, RootElement):
+            if self.children == element.children:
+                return 1
         i = 0
         for child in self.children:
             # child is text content and element is also text content, then

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -591,6 +591,8 @@ class HTMLEqualTests(SimpleTestCase):
         self.assertIn(dom1, dom2)
         dom1 = parse_html('<p>bar</p>')
         self.assertIn(dom1, dom2)
+        dom1 = parse_html('<div><p>foo</p><p>bar</p></div>')
+        self.assertIn(dom2, dom1)
 
     def test_count(self):
         # equal html contains each other one time
@@ -625,6 +627,11 @@ class HTMLEqualTests(SimpleTestCase):
 
         dom2 = parse_html('<p>foo<p>bar</p></p>')
         self.assertEqual(dom2.count(dom1), 0)
+
+        # html with a root element contains the same html with no root element
+        dom1 = parse_html('<p>foo</p><p>bar</p>')
+        dom2 = parse_html('<div><p>foo</p><p>bar</p></div>')
+        self.assertEqual(dom2.count(dom1), 1)
 
     def test_parsing_errors(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
This PR has the fixes suggested by @timgraham in #4041:

- Use `assertRaisesMessage` instead of `assertRaises`
- Print the element with the exception message to give context for debugging