### PR TITLE
Don't necessitate installing btree_gin extension to use GinIndex in contrib.postgres.indexes docs

### DIFF
--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -17,7 +17,10 @@ available from the ``django.contrib.postgres.indexes`` module.
     Creates a `gin index
     <https://www.postgresql.org/docs/current/static/gin.html>`_.
 
-    To use this index, you need to activate the `btree_gin extension
+    To use this index on data types not supported by the `built-in operator
+    classes
+    <https://www.postgresql.org/docs/current/static/gin-builtin-opclasses.html>`_
+    you need to activate the `btree_gin extension
     <https://www.postgresql.org/docs/current/static/btree-gin.html>`_ on
     PostgreSQL. You can install it using the
     :class:`~django.contrib.postgres.operations.BtreeGinExtension` migration


### PR DESCRIPTION
We should not make it a compulsion to use `BtreeGinExtension` operation and create the `btree_gin` extension on the db, to use `gin` indexes. I think so because PostgreSQL allows creating gin index for some fields (tsvector type) without installing the btree_gin extension.

For example, I have used the `ArrayField(models.IntegerField())` in the [test for GinIndex](https://github.com/django/django/blob/master/tests/postgres_tests/test_indexes.py#L45) because this doesn't require the btree_gin extension to be installed. I had used that field deliberately to keep the tests for `GinIndex` and `BtreeGinExtension` independent (i.e. the tests for `GinIndex` won't fail even if `BtreeGinExtension` is removed from the [migrations](https://github.com/django/django/blob/master/tests/postgres_tests/migrations/0001_setup_extensions.py#L23).