### PR TITLE
Improvements for models.Index class and it's operations

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -795,7 +795,8 @@ class AddIndex(IndexOperation):
         )
 
     def describe(self):
-        return 'Create index on field(s) %s of model %s' % (
+        return 'Create index %s on field(s) %s of model %s' % (
+            self.index.name,
             ', '.join(self.index.fields),
             self.model_name,
         )

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -14,9 +14,11 @@ class Index(object):
     suffix = 'idx'
 
     def __init__(self, fields=[], name=None):
+        if not isinstance(fields, (list, tuple)):
+            raise ValueError('Index.fields must be a list or tuple.')
         if not fields:
             raise ValueError('At least one field is required to define an index.')
-        self.fields = fields
+        self.fields = list(fields)
         # A list of 2-tuple with the field name and ordering ('' or 'DESC').
         self.fields_orders = [
             (field_name[1:], 'DESC') if field_name.startswith('-') else (field_name, '')

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -32,7 +32,7 @@ options`_.
 
 .. attribute:: Index.fields
 
-A list of the name of the fields on which the index is desired.
+A list or tuple of the name of the fields on which the index is desired.
 
 By default, indexes are created with an ascending order for each column. To
 define an index with a descending order for a column, add a hyphen before the

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1405,7 +1405,7 @@ class OperationTests(OperationTestBase):
             migrations.AddIndex("Pony", models.Index(fields=["pink"]))
         index = models.Index(fields=["pink"], name="test_adin_pony_pink_idx")
         operation = migrations.AddIndex("Pony", index)
-        self.assertEqual(operation.describe(), "Create index on field(s) pink of model Pony")
+        self.assertEqual(operation.describe(), "Create index test_adin_pony_pink_idx on field(s) pink of model Pony")
         new_state = project_state.clone()
         operation.state_forwards("test_adin", new_state)
         # Test the database alteration

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -22,6 +22,13 @@ class IndexesTests(TestCase):
         self.assertEqual(index, same_index)
         self.assertNotEqual(index, another_index)
 
+    def test_index_fields_type(self):
+        index = models.Index(fields=('title', ))
+        self.assertEqual(index.fields, ['title'])
+        msg = 'Index.fields must be a list or tuple.'
+        with self.assertRaisesMessage(ValueError, msg):
+            models.Index(fields='title')
+
     def test_raises_error_without_field(self):
         msg = 'At least one field is required to define an index.'
         with self.assertRaisesMessage(ValueError, msg):


### PR DESCRIPTION
PR has 2 commits:

* Added sanity type check for Index.fields argument being a `list`.
Else if we forget to define Index(fields=...) as a list, we get something like `Create index on field(s) a, n, s, w, e, r, _, t, e, x, t of model question`. It would be nice to have an error message to prevent that.

* Now that [it is necessary for index passed `AddIndex` operation to have name](https://github.com/django/django/commit/b1e7d19d4c7015efe0c65361bb7f00a2f1c7047c), it would be better to have that name in the `describe` method of the operation as well. Markus had also [suggested this earlier](https://github.com/django/django/pull/6726#discussion-diff-66308920).