### PR TITLE
Fixed #26866 -- Added format_lazy function

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -7,7 +7,7 @@ from io import BytesIO
 
 from django.utils import six
 from django.utils.encoding import force_text
-from django.utils.functional import SimpleLazyObject, keep_lazy, keep_lazy_text
+from django.utils.functional import SimpleLazyObject, keep_lazy, keep_lazy_text, lazy
 from django.utils.safestring import SafeText, mark_safe
 from django.utils.six.moves import html_entities
 from django.utils.translation import pgettext, ugettext as _, ugettext_lazy
@@ -434,3 +434,17 @@ def camel_case_to_spaces(value):
     trailing whitespace.
     """
     return re_camel_case.sub(r' \1', value).strip().lower()
+
+
+def _format_lazy(string, *args, **kwargs):
+    """
+    Lazy variant of string format, useful when formatting strings with
+    1 or more lazy variables in args and/or kwargs
+    """
+    return force_text(
+        string.format(
+            *args,
+            **kwargs
+        )
+    )
+format_lazy = lazy(_format_lazy, six.text_type)

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -888,6 +888,32 @@ appropriate entities.
 
     If ``value`` is ``"你好 World"``, the output will be ``"你好-world"``.
 
+.. function:: format_lazy(format, *args, **kwargs)
+
+    .. versionadded:: 1.11
+
+    Lazy version of string format, useful when args and/or kwargs contains
+    lazy objects. First argument should be the string to be formatted.
+    For example::
+
+        from django.utils.text import format_lazy
+        from django.utils.translation import pgettext_lazy
+        ...
+        t = {
+            'auction': pgettext_lazy('Url', 'auction'),
+            'star': pgettext_lazy('Url', 'star')
+        }
+
+        urlpatterns = [
+            url(format_lazy(r'{auction}/(?P<pk>\d+)/{star}/$', **t),
+                StarAuction.as_view()
+            )
+        ]
+
+    Syntax is similar to the standard Python str.format() method
+    (see https://docs.python.org/3/library/string.html#formatstrings for
+    documentation and examples).
+
 .. _time-zone-selection-functions:
 
 ``django.utils.timezone``

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -6,6 +6,7 @@ import json
 from django.test import SimpleTestCase
 from django.utils import six, text
 from django.utils.functional import lazystr
+from django.utils.text import format_lazy
 from django.utils.translation import override
 
 IS_WIDE_BUILD = (len('\U0001F4A9') == 1)
@@ -225,3 +226,17 @@ class TestUtilsText(SimpleTestCase):
         out = text.compress_sequence(seq)
         compressed_length = len(b''.join(out))
         self.assertTrue(compressed_length < actual_length)
+
+    def test_format_lazy(self):
+        """
+        Test the format_lazy function
+        """
+        self.assertEqual('django/test', six.text_type(format_lazy('{}/{}', 'django', 'test')))
+        self.assertEqual('django/test', six.text_type(format_lazy('{0}/{1}', *('django', 'test'))))
+        self.assertEqual('django/test', six.text_type(format_lazy('{a}/{b}', **{'a': 'django', 'b': 'test'})))
+        self.assertEqual('django/test', six.text_type(format_lazy('{a[0]}/{a[1]}', a=('django', 'test'))))
+
+        t = {}
+        s = format_lazy('{0[a]}-{p[a]}', t, p=t)
+        t['a'] = 'django'
+        self.assertEqual('django-django', six.text_type(s))


### PR DESCRIPTION
Added format_lazy function to django.utils.text module.
Useful when dealing with relative complex lazy string concatenations
(e.g. in urls.py when translating urls in regular expressions).