### PR TITLE
Fixed #22414 -- Ensured that LiveServerTestCase closes connections.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -1262,6 +1262,8 @@ class LiveServerThread(threading.Thread):
         except Exception as e:
             self.error = e
             self.is_ready.set()
+        finally:
+            connections.close_all()
 
     def _create_server(self, port):
         return WSGIServer((self.host, port), QuietWSGIRequestHandler, allow_reuse_address=False)
@@ -1271,6 +1273,7 @@ class LiveServerThread(threading.Thread):
             # Stop the WSGI server
             self.httpd.shutdown()
             self.httpd.server_close()
+        self.join()
 
 
 class LiveServerTestCase(TransactionTestCase):
@@ -1335,7 +1338,6 @@ class LiveServerTestCase(TransactionTestCase):
         if hasattr(cls, 'server_thread'):
             # Terminate the live server's thread
             cls.server_thread.terminate()
-            cls.server_thread.join()
 
         # Restore sqlite in-memory database connections' non-shareability
         for conn in connections.all():

--- a/tests/servers/test_liveserverthread.py
+++ b/tests/servers/test_liveserverthread.py
@@ -1,0 +1,28 @@
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.test import LiveServerTestCase, TestCase
+
+
+class LiveServerThreadTest(TestCase):
+
+    def run_live_server_thread(self, connections_override=None):
+        thread = LiveServerTestCase._create_server_thread(connections_override)
+        thread.daemon = True
+        thread.start()
+        thread.is_ready.wait()
+        thread.terminate()
+
+    def test_closes_connections(self):
+        conn = connections[DEFAULT_DB_ALIAS]
+        if conn.vendor == 'sqlite' and conn.is_in_memory_db():
+            self.skipTest("the sqlite backend's close() method is a no-op when using an in-memory database")
+        # Pass a connection to the thread to check they are being closed.
+        connections_override = {DEFAULT_DB_ALIAS: conn}
+
+        saved_sharing = conn.allow_thread_sharing
+        try:
+            conn.allow_thread_sharing = True
+            self.assertTrue(conn.is_usable())
+            self.run_live_server_thread(connections_override)
+            self.assertFalse(conn.is_usable())
+        finally:
+            conn.allow_thread_sharing = saved_sharing

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -153,4 +153,5 @@ class LiveServerPort(LiveServerBase):
                 "Acquired duplicate server addresses for server threads: %s" % self.live_server_url
             )
         finally:
-            TestCase.tearDownClass()
+            if hasattr(TestCase, 'server_thread'):
+                TestCase.server_thread.terminate()


### PR DESCRIPTION
I confirmed on the CI servers that the test fails without the fix (on the mysql, postgres, and postgis configurations).