### PR TITLE
Fixed incorrect doc reference to Field.initial.

### DIFF
--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -231,8 +231,8 @@ it's not necessary to include every field in your form. For example::
 These values are only displayed for unbound forms, and they're not used as
 fallback values if a particular value isn't provided.
 
-Note that if a :class:`~django.forms.Field` defines :attr:`~Form.initial` *and*
-you include ``initial`` when instantiating the ``Form``, then the latter
+If a :class:`~django.forms.Field` defines :attr:`~Field.initial` *and* you
+include :attr:`~Form.initial` when instantiating the ``Form``, then the latter
 ``initial`` will have precedence. In this example, ``initial`` is provided both
 at the field level and at the form instance level, and the latter gets
 precedence::


### PR DESCRIPTION
Based on the context, I believe this is intended to be `Field.initial` not `Form.initial`.