### PR TITLE
Fixes #27080 -- making Manager instances created from QuerySet correctly serialise in migrations

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -180,6 +180,7 @@ class QuerySet(object):
         from django.db.models.manager import Manager
         manager = Manager.from_queryset(cls)()
         manager._built_with_as_manager = True
+        manager.use_in_migrations = getattr(cls, 'use_in_migrations', Manager.use_in_migrations)
         return manager
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)


### PR DESCRIPTION
Passes down `use_in_migrations` attribute if found on `QuerySet` to the
resulting `Manager` when calling `QuerySet.as_manager`, so that
`Manager` instances that are created from `QuerySet`s will be correctly
serialised into migrations.