### PR TITLE
Add correct text from the installer for Windows.

### DIFF
--- a/docs/howto/windows.txt
+++ b/docs/howto/windows.txt
@@ -22,7 +22,7 @@ machine. At the time of writing, Python 3.5 is the latest version.
 To install Python on your machine go to https://python.org/downloads/. The
 website should offer you a download button for the latest Python version.
 Download the executable installer and run it. Check the box next to ``Add
-Python to to environment variables`` and then click ``Install Now``.
+Python 3.5 to PATH`` and then click ``Install Now``.
 
 After installation, open the command prompt and check that the Python version
 matches the version you installed by executing::


### PR DESCRIPTION
The word "to" was repeated, and the descriptive text was wrong for the Windows installer.