### PR TITLE
Fixed #27089 -- Added database alias to InconsistentMigrationHistory message.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -292,8 +292,10 @@ class MigrationLoader(object):
                         if all(m in applied for m in self.replacements[parent].replaces):
                             continue
                     raise InconsistentMigrationHistory(
-                        "Migration {}.{} is applied before its dependency {}.{}".format(
+                        "Migration {}.{} is applied before its dependency "
+                        "{}.{} on database '{}'.".format(
                             migration[0], migration[1], parent[0], parent[1],
+                            connection.alias,
                         )
                     )
 

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -65,3 +65,6 @@ Bugfixes
 * Reverted a few admin checks that checked ``field.many_to_many`` back to
   ``isinstance(field, models.ManyToManyField)`` since it turned out the checks
   weren't suitable to be generalized like that (:ticket:`26998`).
+
+* Added the database alias to the ``InconsistentMigrationHistory`` message
+  raised by ``makemigrations`` and ``migrate`` (:ticket:`27089`).

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -378,7 +378,10 @@ class LoaderTests(TestCase):
         loader.check_consistent_history(connection)
         recorder = MigrationRecorder(connection)
         recorder.record_applied('migrations', '0002_second')
-        msg = "Migration migrations.0002_second is applied before its dependency migrations.0001_initial"
+        msg = (
+            "Migration migrations.0002_second is applied before its dependency "
+            "migrations.0001_initial on database 'default'."
+        )
         with self.assertRaisesMessage(InconsistentMigrationHistory, msg):
             loader.check_consistent_history(connection)
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27089