### PR TITLE
Fixed #27018 -- Fixed AttributeError in admindocs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -290,6 +290,7 @@ answer newbie questions, and generally made Django that much better:
     hambaloney
     Hannes Struß <x@hannesstruss.de>
     Hawkeye
+    Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
     Henrique Romano <onaiort@gmail.com>
     hipertracker@gmail.com
     Hiroki Kiyohara <hirokiky@gmail.com>

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -13,6 +13,7 @@ from django.db import models
 from django.http import Http404
 from django.template.engine import Engine
 from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
+from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.inspect import (
     func_accepts_kwargs, func_accepts_var_args, func_has_no_args,
@@ -126,13 +127,23 @@ class TemplateFilterIndexView(BaseAdminDocsView):
 class ViewIndexView(BaseAdminDocsView):
     template_name = 'admin_doc/view_index.html'
 
+    @staticmethod
+    def _get_full_name(func):
+        mod_name = func.__module__
+        if six.PY3:
+            return '%s.%s' % (mod_name, func.__qualname__)
+        else:
+            # PY2 does not support __qualname__ (#27018)
+            func_name = getattr(func, '__name__', func.__class__.__name__)
+            return '%s.%s' % (mod_name, func_name)
+
     def get_context_data(self, **kwargs):
         views = []
         urlconf = import_module(settings.ROOT_URLCONF)
         view_functions = extract_views_from_urlpatterns(urlconf.urlpatterns)
         for (func, regex, namespace, name) in view_functions:
             views.append({
-                'full_name': '%s.%s' % (func.__module__, getattr(func, '__name__', func.__class__.__name__)),
+                'full_name': self._get_full_name(func),
                 'url': simplify_regex(regex),
                 'url_name': ':'.join((namespace or []) + (name and [name] or [])),
                 'namespace': ':'.join((namespace or [])),
@@ -145,13 +156,29 @@ class ViewIndexView(BaseAdminDocsView):
 class ViewDetailView(BaseAdminDocsView):
     template_name = 'admin_doc/view_detail.html'
 
-    def get_context_data(self, **kwargs):
-        view = self.kwargs['view']
+    @staticmethod
+    def _get_view_func(view):
         urlconf = get_urlconf()
         if get_resolver(urlconf)._is_callback(view):
             mod, func = get_mod_func(view)
-            view_func = getattr(import_module(mod), func)
-        else:
+            try:
+                return getattr(import_module(mod), func)
+            except ImportError:
+                # Unable to import the module - try processing it again to get the class.
+                mod, klass = get_mod_func(mod)
+                return getattr(getattr(import_module(mod), klass), func)
+
+    def get_context_data(self, **kwargs):
+        view = self.kwargs['view']
+        try:
+            view_func = self._get_view_func(view)
+        except AttributeError:
+            # PY2 generates incorrect paths for views that are methods
+            # (e.g. django.contrib.admin.sites.index)
+            # because it cannot detect the class name.
+            # This will cause an AttributeError in _get_view_func (see #27018).
+            raise Http404
+        if view_func is None:
             raise Http404
         title, body, metadata = utils.parse_docstring(view_func.__doc__)
         if title:

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -146,7 +146,7 @@ class RegexURLPattern(LocaleRegexProvider):
         elif six.PY3:
             return callback.__module__ + "." + callback.__qualname__
         else:
-            # PY2 does not support __qualname__ (#27018)
+            # PY2 does not support __qualname__
             return callback.__module__ + "." + callback.__name__
 
 

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -143,7 +143,10 @@ class RegexURLPattern(LocaleRegexProvider):
             callback = callback.func
         if not hasattr(callback, '__name__'):
             return callback.__module__ + "." + callback.__class__.__name__
+        elif six.PY3:
+            return callback.__module__ + "." + callback.__qualname__
         else:
+            # PY2 does not support __qualname__ (#27018)
             return callback.__module__ + "." + callback.__name__
 
 

--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -108,19 +108,6 @@ For example::
         context = {'mymodel': MyModel.objects.get(slug=slug)}
         return render(request, 'myapp/my_template.html', context)
 
-Due to the fact ``__qualname__`` was only introduced in Python 3, Django cannot
-correctly generate admindocs URLS for views that are methods on a class in Python 2.
-
-This includes some of the views belonging to the admin and any view in the
-following format::
-
-    class MyViewContainer(object):
-        def my_view(self, request):
-            pass
-
-If you are using admindocs with Python 2, we recommend you define views as
-module level functions or use :doc:`/topics/class-based-views/index`.
-
 
 Template tags and filters reference
 ===================================

--- a/docs/ref/contrib/admin/admindocs.txt
+++ b/docs/ref/contrib/admin/admindocs.txt
@@ -108,6 +108,20 @@ For example::
         context = {'mymodel': MyModel.objects.get(slug=slug)}
         return render(request, 'myapp/my_template.html', context)
 
+Due to the fact ``__qualname__`` was only introduced in Python 3, Django cannot
+correctly generate admindocs URLS for views that are methods on a class in Python 2.
+
+This includes some of the views belonging to the admin and any view in the
+following format::
+
+    class MyViewContainer(object):
+        def my_view(self, request):
+            pass
+
+If you are using admindocs with Python 2, we recommend you define views as
+module level functions or use :doc:`/topics/class-based-views/index`.
+
+
 Template tags and filters reference
 ===================================
 

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -58,3 +58,6 @@ Bugfixes
 * Fixed ``makemigrations`` crash if a database is read-only (:ticket:`27054`).
 
 * Removed duplicated managers in ``Model._meta.managers`` (:ticket:`27073`).
+
+* Fixed crash of admindocs with ``AttributeError`` when view is in a class
+  (:ticket:`27018`).

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -9,6 +9,7 @@ from django.contrib.sites.models import Site
 from django.test import TestCase, modify_settings, override_settings
 from django.test.utils import captured_stderr
 from django.urls import reverse
+from django.utils import six
 
 from .models import Company, Person
 
@@ -82,6 +83,18 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         self.assertContains(response, 'Views by namespace test')
         self.assertContains(response, 'Name: <code>test:func</code>.')
 
+    @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
+    def test_view_index_with_method(self):
+        """
+        #27018 - Ensure views that are methods are listed correctly.
+        """
+        response = self.client.get(reverse('django-admindocs-views-index'))
+        self.assertContains(
+            response,
+            '<h3><a href="/admindocs/views/django.contrib.admin.sites.AdminSite.index/">/admin/</a></h3>',
+            html=True
+        )
+
     def test_view_detail(self):
         url = reverse('django-admindocs-views-detail', args=['django.contrib.admindocs.views.BaseAdminDocsView'])
         response = self.client.get(url)
@@ -102,6 +115,31 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
         self.assertNotIn("urlpatterns_reverse.nonimported_module", sys.modules)
+
+    @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
+    def test_view_detail_as_method(self):
+        """
+        #27018 - Ensure views that are methods can be displayed
+        """
+        url = reverse(
+            'django-admindocs-views-detail',
+            args=['django.contrib.admin.sites.AdminSite.index'],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    @unittest.skipUnless(six.PY2, "Python 2 doesn't support __qualname__.")
+    def test_view_detail_incorrect_method_path(self):
+        """
+        #27018 - Views that are methods can't be made to work on python 2
+        but should raise a 404
+        """
+        url = reverse(
+            'django-admindocs-views-detail',
+            args=['django.contrib.admin.sites.index'],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
 
     def test_model_index(self):
         response = self.client.get(reverse('django-admindocs-models-index'))

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -86,7 +86,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
     @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
     def test_view_index_with_method(self):
         """
-        #27018 - Ensure views that are methods are listed correctly.
+        Ensure views that are methods are listed correctly.
         """
         response = self.client.get(reverse('django-admindocs-views-index'))
         self.assertContains(
@@ -116,30 +116,13 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         self.assertEqual(response.status_code, 404)
         self.assertNotIn("urlpatterns_reverse.nonimported_module", sys.modules)
 
-    @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
     def test_view_detail_as_method(self):
         """
-        #27018 - Ensure views that are methods can be displayed
+        Ensure views that are methods can be displayed
         """
-        url = reverse(
-            'django-admindocs-views-detail',
-            args=['django.contrib.admin.sites.AdminSite.index'],
-        )
+        url = reverse('django-admindocs-views-detail', args=['django.contrib.admin.sites.AdminSite.index'])
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-    @unittest.skipUnless(six.PY2, "Python 2 doesn't support __qualname__.")
-    def test_view_detail_incorrect_method_path(self):
-        """
-        #27018 - Views that are methods can't be made to work on python 2
-        but should raise a 404
-        """
-        url = reverse(
-            'django-admindocs-views-detail',
-            args=['django.contrib.admin.sites.index'],
-        )
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200 if six.PY3 else 404)
 
     def test_model_index(self):
         response = self.client.get(reverse('django-admindocs-models-index'))

--- a/tests/urlpatterns_reverse/method_view_urls.py
+++ b/tests/urlpatterns_reverse/method_view_urls.py
@@ -1,0 +1,19 @@
+from django.conf.urls import url
+from django.http import HttpResponse
+
+
+class ViewContainer(object):
+    def method_view(self, request):
+        return HttpResponse('')
+
+    @classmethod
+    def classmethod_view(cls, request):
+        return HttpResponse('')
+
+view_container = ViewContainer()
+
+
+urlpatterns = [
+    url(r'^$', view_container.method_view, name='instance-method-url'),
+    url(r'^$', ViewContainer.classmethod_view, name='instance-method-url'),
+]

--- a/tests/urlpatterns_reverse/method_view_urls.py
+++ b/tests/urlpatterns_reverse/method_view_urls.py
@@ -1,14 +1,13 @@
 from django.conf.urls import url
-from django.http import HttpResponse
 
 
 class ViewContainer(object):
     def method_view(self, request):
-        return HttpResponse('')
+        pass
 
     @classmethod
     def classmethod_view(cls, request):
-        return HttpResponse('')
+        pass
 
 view_container = ViewContainer()
 

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -434,7 +434,7 @@ class ResolverTests(SimpleTestCase):
     @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
     def test_view_detail_as_method(self):
         """
-        #27018 - with class name as part of the view path
+        View which has a class name as part of its path
         """
         resolver = get_resolver('urlpatterns_reverse.method_view_urls')
         self.assertTrue(resolver._is_callback('urlpatterns_reverse.method_view_urls.ViewContainer.method_view'))

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import sys
 import threading
+import unittest
 
 from admin_scripts.tests import AdminScriptTestCase
 
@@ -429,6 +430,15 @@ class ResolverTests(SimpleTestCase):
         self.assertTrue(resolver._is_callback('urlpatterns_reverse.nested_urls.view2'))
         self.assertTrue(resolver._is_callback('urlpatterns_reverse.nested_urls.View3'))
         self.assertFalse(resolver._is_callback('urlpatterns_reverse.nested_urls.blub'))
+
+    @unittest.skipIf(six.PY2, "Python 2 doesn't support __qualname__.")
+    def test_view_detail_as_method(self):
+        """
+        #27018 - with class name as part of the view path
+        """
+        resolver = get_resolver('urlpatterns_reverse.method_view_urls')
+        self.assertTrue(resolver._is_callback('urlpatterns_reverse.method_view_urls.ViewContainer.method_view'))
+        self.assertTrue(resolver._is_callback('urlpatterns_reverse.method_view_urls.ViewContainer.classmethod_view'))
 
     def test_populate_concurrency(self):
         """


### PR DESCRIPTION
Generated correct admindocs URLs for views that are methods on classes
in Python 3. For Python 2, URLs remain broken but fixed to generate
404s rather than errors.