### PR TITLE
Fixed #25181 -- Added localdate() function to get date in a different time zone.

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -299,13 +299,18 @@ def template_localtime(value, use_tz=None):
 
 # Utilities
 
-def localtime(value, timezone=None):
+def localtime(value=None, timezone=None):
     """
     Converts an aware datetime.datetime to local time.
+
+    Only aware datetimes are allowed. When value is omitted, it defaults to
+    now().
 
     Local time is defined by the current time zone, unless another time zone
     is specified.
     """
+    if value is None:
+        value = now()
     if timezone is None:
         timezone = get_current_timezone()
     # If `value` is naive, astimezone() will raise a ValueError,
@@ -315,6 +320,19 @@ def localtime(value, timezone=None):
         # This method is available for pytz time zones.
         value = timezone.normalize(value)
     return value
+
+
+def localdate(value=None, timezone=None):
+    """
+    Convert an aware datetime to local time and return the value's date.
+
+    Only aware datetimes are allowed. When value is omitted, it defaults to
+    now().
+
+    Local time is defined by the current time zone, unless another time zone is
+    specified.
+    """
+    return localtime(value, timezone).date()
 
 
 def now():

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -792,6 +792,6 @@ def timezone_today():
     Return the current date in the current time zone.
     """
     if settings.USE_TZ:
-        return timezone.localtime(timezone.now()).date()
+        return timezone.localdate()
     else:
         return datetime.date.today()

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -974,13 +974,31 @@ appropriate entities.
 
     ``override`` is also usable as a function decorator.
 
-.. function:: localtime(value, timezone=None)
+.. function:: localtime(value=None, timezone=None)
 
     Converts an aware :class:`~datetime.datetime` to a different time zone,
     by default the :ref:`current time zone <default-current-time-zone>`.
 
+    When ``value`` is omitted, it defaults to :func:`now`.
+
     This function doesn't work on naive datetimes; use :func:`make_aware`
     instead.
+
+    .. versionchanged:: 1.11
+
+        In older versions, ``value`` is a required argument.
+
+.. function:: localdate(value=None, timezone=None)
+
+    .. versionadded:: 1.11
+
+    Uses :func:`localtime` to convert an aware :class:`~datetime.datetime` to a
+    :meth:`~datetime.datetime.date` in a different time zone, by default the
+    :ref:`current time zone <default-current-time-zone>`.
+
+    When ``value`` is omitted, it defaults to :func:`now`.
+
+    This function doesn't work on naive datetimes.
 
 .. function:: now()
 


### PR DESCRIPTION
Thanks @kswiat for the original [PR](https://github.com/django/django/pull/5055).

<https://code.djangoproject.com/ticket/25181>

Some response to other tickets and PRs:

From @aaugustin 

> It may be useful to make these functions fallback reasonably when `USE_TZ` is `False` for the benefit of pluggable applications. In that case, `localtime()` should return:
> 
> ...
> 3. (probably) an exception if `value` is provided and it is aware

Adding the following guard to `localtime()` produces a [few test failures](http://dpaste.com/2S6RD55). It looks like there is an existing assumption that `localtime()` works on aware datetimes regardless of the value `USE_TZ`. I'm open towards moving in the suggested direction, but it may be more invasive than originally thought and have backwards compatibility concerns. What are you thoughts?

Guard: 

```python
if not settings.USE_TZ and is_aware(value):
    raise ValueError("Cannot call localtime() with an aware datetime when USE_TZ is False")
```

---

If agreeable, I would also like to add an analogous function to return `datetime.time()` in the current time zone. (Obviously, the name `localtime()` won't work.) I think it would be just as useful as `localdate()` for the same reasons. IME, just the current TZ's time is frequently  important to display to the user or compare to other values. Having an official, documented convenience function that gets this right and is reusable across applications seems beneficial to me. However, @aaugustin didn't give it the same "+0" as `localdate()` in ticket [#27082](https://code.djangoproject.com/ticket/27082). So I'm looking for feedback.

Thanks!