### PR TITLE
Fixed #27102 -- Fixed simplify_regex in admindocs

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -442,7 +442,8 @@ def simplify_regex(pattern):
     pattern = non_named_group_matcher.sub("<var>", pattern)
 
     # clean up any outstanding regex-y characters.
-    pattern = pattern.replace('^', '').replace('$', '').replace('?', '').replace('//', '/').replace('\\', '')
+    pattern = pattern.replace('^', '').replace('$', '').replace('?', '').replace('//', '/') \
+                                                                        .replace('\\', '').replace(')', '')
     if not pattern.startswith('/'):
         pattern = '/' + pattern
     return pattern

--- a/tests/admin_docs/tests.py
+++ b/tests/admin_docs/tests.py
@@ -155,6 +155,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
             ('^a', '/a'),
             ('^(?P<a>\w+)/b/(?P<c>\w+)/$', '/<a>/b/<c>/'),
             ('^(?P<a>\w+)/b/(?P<c>\w+)$', '/<a>/b/<c>'),
+            ('^(?P<a>(\w+))/b/(?P<c>(\w+))$', '/<a>/b/<c>')
         )
         for pattern, output in tests:
             self.assertEqual(simplify_regex(pattern), output)


### PR DESCRIPTION
Fixes #27102: https://code.djangoproject.com/ticket/27102

Fixes an issue where simplify_regex would not notice a trailing
bracket when cleaning up regex patterns involving groups.

Steps to reproduce:
run this in your shell: 
`django.contrib.admindocs.views.simplify_regex('^orgs/(?P<org_id>([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))$')`
output:
`'/orgs/<org_id>)'`

expected output:
`'/orgs/<org_id>'`
