### PR TITLE
Fixed #27103 -- Registered vcapi/rcapi GDAL prototypes based on their own drivers.

### DIFF
--- a/django/contrib/gis/gdal/driver.py
+++ b/django/contrib/gis/gdal/driver.py
@@ -76,10 +76,11 @@ class Driver(GDALBase):
         """
         Attempts to register all the data source drivers.
         """
-        # Only register all if the driver count is 0 (or else all drivers
+        # Only register all if the driver counts are 0 (or else all drivers
         # will be registered over and over again)
-        if not cls.driver_count():
+        if not vcapi.get_driver_count():
             vcapi.register_all()
+        if not rcapi.get_driver_count():
             rcapi.register_all()
 
     @classmethod

--- a/tests/gis_tests/gdal_tests/test_driver.py
+++ b/tests/gis_tests/gdal_tests/test_driver.py
@@ -1,6 +1,7 @@
 import unittest
 
 from django.contrib.gis.gdal import HAS_GDAL
+from django.test import mock
 
 if HAS_GDAL:
     from django.contrib.gis.gdal import Driver, GDALException
@@ -48,3 +49,13 @@ class DriverTest(unittest.TestCase):
         for alias, full_name in aliases.items():
             dr = Driver(alias)
             self.assertEqual(full_name, str(dr))
+
+    @mock.patch('django.contrib.gis.gdal.driver.vcapi.get_driver_count')
+    @mock.patch('django.contrib.gis.gdal.driver.rcapi.get_driver_count')
+    @mock.patch('django.contrib.gis.gdal.driver.vcapi.register_all')
+    def test04_registered(self, vreg, rcount, vcount):
+        "Testing driver registration"
+        rcount.return_value = 120
+        vcount.return_value = 0
+        Driver.ensure_registered()
+        vreg.assert_called_with()

--- a/tests/gis_tests/gdal_tests/test_driver.py
+++ b/tests/gis_tests/gdal_tests/test_driver.py
@@ -63,11 +63,11 @@ class DriverTest(unittest.TestCase):
             vcount.return_value = v
             Driver.ensure_registered()
             if r:
-                rreg.assert_not_called()
+                self.assertFalse(rreg.called)
             else:
                 rreg.assert_called_once_with()
             if v:
-                vreg.assert_not_called()
+                self.assertFalse(vreg.called)
             else:
                 vreg.assert_called_once_with()
 


### PR DESCRIPTION
It is possible for one set to be registered, and then ensure_registered
would think they had all been registered.

Hopefully fixes https://code.djangoproject.com/ticket/27103