### PR TITLE
Remove uses of assert_not_called().

### DIFF
--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -710,8 +710,8 @@ class NonExistentFixtureTests(TestCase):
         """
         with self.assertRaisesMessage(CommandError, "No fixture named 'this_fixture_doesnt_exist' found."):
             management.call_command('loaddata', 'this_fixture_doesnt_exist', verbosity=0)
-        disable_constraint_checking.assert_not_called()
-        enable_constraint_checking.assert_not_called()
+        self.assertFalse(disable_constraint_checking.called)
+        self.assertFalse(enable_constraint_checking.called)
 
 
 class FixtureTransactionTests(DumpDataAssertMixin, TransactionTestCase):

--- a/tests/signals/tests.py
+++ b/tests/signals/tests.py
@@ -269,7 +269,7 @@ class SignalTests(BaseSignalTest):
 
         signals.pre_init.connect(callback, weak=False)
         signals.pre_init.disconnect(callback)
-        ref.assert_not_called()
+        self.assertFalse(ref.called)
 
 
 class LazyModelRefTest(BaseSignalTest):


### PR DESCRIPTION
assert_not_called was added to core mock in Python 3.5, so these tests are actually mock noops in Python 3.3 and 3.4.