### PR TITLE
Whitelisted environment vars in tox for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ basepython = python3
 
 [testenv]
 usedevelop = true
-passenv = DJANGO_SETTINGS_MODULE
+passenv = DJANGO_SETTINGS_MODULE PYTHONPATH HOME DISPLAY
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
 deps =
     py{2,27}: -rtests/requirements/py2.txt
     py{3,34,35}: -rtests/requirements/py3.txt


### PR DESCRIPTION
PYTHONPATH is required for passing through test modules that don't
already exist within the Django tests/ directory.

DISPLAY is required for testing selenium on systems that use Xvfb.

HOME is where the Vagrant djangobox stores geoip data, but it could be
useful for other tox commands that require access to data outside of
Django.