### PR TITLE
Fixed #26170 -- Made ModelAdmin views run transactions on the correct database.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1405,9 +1405,11 @@ class ModelAdmin(BaseModelAdmin):
         return initial
 
     @csrf_protect_m
-    @transaction.atomic
     def changeform_view(self, request, object_id=None, form_url='', extra_context=None):
+        with transaction.atomic(using=router.db_for_write(self.model)):
+            return self._changeform_view(request, object_id, form_url, extra_context)
 
+    def _changeform_view(self, request, object_id, form_url, extra_context):
         to_field = request.POST.get(TO_FIELD_VAR, request.GET.get(TO_FIELD_VAR))
         if to_field and not self.to_field_allowed(request, to_field):
             raise DisallowedModelAdminToField("The field %s cannot be referenced." % to_field)
@@ -1681,8 +1683,11 @@ class ModelAdmin(BaseModelAdmin):
         ], context)
 
     @csrf_protect_m
-    @transaction.atomic
     def delete_view(self, request, object_id, extra_context=None):
+        with transaction.atomic(using=router.db_for_write(self.model)):
+            return self._delete_view(request, object_id, extra_context)
+
+    def _delete_view(self, request, object_id, extra_context):
         "The 'delete' admin view for this model."
         opts = self.model._meta
         app_label = opts.app_label

--- a/tests/admin_views/test_multidb.py
+++ b/tests/admin_views/test_multidb.py
@@ -1,0 +1,75 @@
+from django.conf.urls import url
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.db import connections
+from django.test import TestCase, mock, override_settings
+from django.urls import reverse
+
+from .models import Book
+
+
+class Router(object):
+    target_db = None
+
+    def db_for_read(self, model, **hints):
+        return self.target_db
+
+    db_for_write = db_for_read
+
+site = admin.AdminSite(name='test_adminsite')
+site.register(Book)
+
+urlpatterns = [
+    url(r'^admin/', site.urls),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__, DATABASE_ROUTERS=['%s.Router' % __name__])
+class MultiDatabaseTests(TestCase):
+    multi_db = True
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superusers = {}
+        cls.test_book_ids = {}
+        for db in connections:
+            Router.target_db = db
+            cls.superusers[db] = User.objects.create_superuser(
+                username='admin', password='something', email='test@test.org',
+            )
+            b = Book(name='Test Book')
+            b.save(using=db)
+            cls.test_book_ids[db] = b.id
+
+    @mock.patch('django.contrib.admin.options.transaction')
+    def test_add_view(self, mock):
+        for db in connections:
+            Router.target_db = db
+            self.client.force_login(self.superusers[db])
+            self.client.post(
+                reverse('test_adminsite:admin_views_book_add'),
+                {'name': 'Foobar: 5th edition'},
+            )
+            mock.atomic.assert_called_with(using=db)
+
+    @mock.patch('django.contrib.admin.options.transaction')
+    def test_change_view(self, mock):
+        for db in connections:
+            Router.target_db = db
+            self.client.force_login(self.superusers[db])
+            self.client.post(
+                reverse('test_adminsite:admin_views_book_change', args=[self.test_book_ids[db]]),
+                {'name': 'Test Book 2: Test more'},
+            )
+            mock.atomic.assert_called_with(using=db)
+
+    @mock.patch('django.contrib.admin.options.transaction')
+    def test_delete_view(self, mock):
+        for db in connections:
+            Router.target_db = db
+            self.client.force_login(self.superusers[db])
+            self.client.post(
+                reverse('test_adminsite:admin_views_book_delete', args=[self.test_book_ids[db]]),
+                {'post': 'yes'},
+            )
+            mock.atomic.assert_called_with(using=db)

--- a/tests/auth_tests/test_admin_multidb.py
+++ b/tests/auth_tests/test_admin_multidb.py
@@ -1,0 +1,49 @@
+from django.conf.urls import url
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.db import connections
+from django.test import TestCase, mock, override_settings
+from django.urls import reverse
+
+
+class Router(object):
+    target_db = None
+
+    def db_for_read(self, model, **hints):
+        return self.target_db
+
+    db_for_write = db_for_read
+
+site = admin.AdminSite(name='test_adminsite')
+site.register(User, admin_class=UserAdmin)
+
+urlpatterns = [
+    url(r'^admin/', site.urls),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__, DATABASE_ROUTERS=['%s.Router' % __name__])
+class MultiDatabaseTests(TestCase):
+    multi_db = True
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superusers = {}
+        for db in connections:
+            Router.target_db = db
+            cls.superusers[db] = User.objects.create_superuser(
+                username='admin', password='something', email='test@test.org',
+            )
+
+    @mock.patch('django.contrib.auth.admin.transaction')
+    def test_add_view(self, mock):
+        for db in connections:
+            Router.target_db = db
+            self.client.force_login(self.superusers[db])
+            self.client.post(reverse('test_adminsite:auth_user_add'), {
+                'username': 'some_user',
+                'password1': 'helloworld',
+                'password2': 'helloworld',
+            })
+            mock.atomic.assert_called_with(using=db)


### PR DESCRIPTION
(Previous pull request: #6076)

Now with tests!

These tests can be found in `tests/admin_views/test_multidb.py` and they require that the `tests/test_dummy_default_db.py` file is used as the settings file, in order to set the default database to be a dummy. So to run the tests:

    python runtests.py --settings test_dummy_default_db admin_views.test_multidb

(the tests will be skipped if the default database is not a dummy)

In order for testing with a dummy database to work, I've had to [put a check](https://github.com/django/django/commit/003bcb0cdee3cbd0400cd7b6f5fea368c8404c4a) during teardown to skip dummies (which naturally, do not actually need tearing down).