### PR TITLE
Fixed #27111 -- Prevented KeyError when USERNAME_FIELD is not in UserCreationForm.fields

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -94,7 +94,8 @@ class UserCreationForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(UserCreationForm, self).__init__(*args, **kwargs)
-        self.fields[self._meta.model.USERNAME_FIELD].widget.attrs.update({'autofocus': ''})
+        if self._meta.model.USERNAME_FIELD in self.fields:
+            self.fields[self._meta.model.USERNAME_FIELD].widget.attrs.update({'autofocus': ''})
 
     def clean_password2(self):
         password1 = self.cleaned_data.get("password1")

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -76,3 +76,6 @@ Bugfixes
 * Included the already applied migration state changes in the ``Apps`` instance
   provided to the ``pre_migrate`` signal receivers to allow ``ContentType``
   renaming to be performed on model rename (:ticket:`27100`).
+
+* Reallowed subclassing ``UserCreationForm`` without ``USERNAME_FIELD`` in
+  ``Meta.fields`` (:ticket:`27111`).

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -22,7 +22,9 @@ from django.utils.encoding import force_text
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
-from .models.custom_user import CustomUser, ExtensionUser
+from .models.custom_user import (
+    CustomUser, CustomUserWithoutIsActiveField, ExtensionUser,
+)
 from .models.with_integer_username import IntegerUsernameUser
 from .settings import AUTH_TEMPLATES
 
@@ -205,6 +207,20 @@ class UserCreationFormTest(TestDataMixin, TestCase):
             'password1': 'testclient',
             'password2': 'testclient',
             'date_of_birth': '1988-02-24',
+        }
+        form = CustomUserCreationForm(data)
+        self.assertTrue(form.is_valid())
+
+    def test_custom_form_hidden_username_field(self):
+        class CustomUserCreationForm(UserCreationForm):
+            class Meta(UserCreationForm.Meta):
+                model = CustomUserWithoutIsActiveField
+                fields = ('email',)  # without USERNAME_FIELD
+
+        data = {
+            'email': 'testclient@example.com',
+            'password1': 'testclient',
+            'password2': 'testclient',
         }
         form = CustomUserCreationForm(data)
         self.assertTrue(form.is_valid())


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27111