### PR TITLE
Fixed #27097 -- Added introspection for index type

### DIFF
--- a/django/contrib/gis/db/backends/postgis/introspection.py
+++ b/django/contrib/gis/db/backends/postgis/introspection.py
@@ -24,16 +24,14 @@ class PostGISIntrospection(DatabaseIntrospection):
     # expression over the raster column through the ST_ConvexHull function.
     # So the default query has to be adapted to include raster indices.
     _get_indexes_query = """
-        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary,
-            am.amname
+        SELECT DISTINCT attr.attname, idx.indkey, idx.indisunique, idx.indisprimary
         FROM pg_catalog.pg_class c, pg_catalog.pg_class c2, pg_catalog.pg_index idx,
-            pg_catalog.pg_attribute attr, pg_catalog.pg_type t, pg_catalog.pg_am am
+            pg_catalog.pg_attribute attr, pg_catalog.pg_type t
         WHERE
             c.oid = idx.indrelid
             AND idx.indexrelid = c2.oid
             AND attr.attrelid = c.oid
             AND t.oid = attr.atttypid
-            AND c2.relam = am.oid
             AND (
                 attr.attnum = idx.indkey[0] OR
                 (t.typname LIKE 'raster' AND idx.indkey = '0')

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -163,9 +163,6 @@ class BaseDatabaseFeatures(object):
     # Can the backend introspect the column order (ASC/DESC) for indexes?
     supports_index_column_ordering = True
 
-    # Can the backend introspect the type of index created?
-    can_introspect_index_type = False
-
     # Support for the DISTINCT ON clause
     can_distinct_on_fields = False
 

--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -172,6 +172,8 @@ class BaseDatabaseIntrospection(object):
          * foreign_key: (table, column) of target, or None
          * check: True if check constraint, False otherwise
          * index: True if index, False otherwise.
+         * orders: The order (ASC/DESC) defined for the columns of indexes
+         * type: The type of the index (btree, hash, etc.)
 
         Some backends may return special constraint names that don't exist
         if they don't name constraints of a certain type (e.g. SQLite)

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -201,17 +201,17 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 constraints[constraint]['unique'] = True
         # Now add in the indexes
         cursor.execute("SHOW INDEX FROM %s" % self.connection.ops.quote_name(table_name))
-        for table, non_unique, index, colseq, column in [x[:5] for x in cursor.fetchall()]:
+        for table, non_unique, index, colseq, column, type_ in [x[:5] + (x[10],) for x in cursor.fetchall()]:
             if index not in constraints:
                 constraints[index] = {
                     'columns': OrderedSet(),
                     'primary_key': False,
                     'unique': False,
-                    'index': True,
                     'check': False,
                     'foreign_key': None,
                 }
             constraints[index]['index'] = True
+            constraints[index]['type'] = type_.lower()
             constraints[index]['columns'].add(column)
         # Convert the sorted sets to lists
         for constraint in constraints.values():

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -258,20 +258,21 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Now get indexes
         cursor.execute("""
             SELECT
-                index_name,
-                LOWER(column_name), descend
+                cols.index_name, LOWER(cols.column_name), cols.descend,
+                LOWER(ind.index_type)
             FROM
-                user_ind_columns cols
+                user_ind_columns cols, user_indexes ind
             WHERE
-                table_name = UPPER(%s) AND
+                cols.table_name = UPPER(%s) AND
                 NOT EXISTS (
                     SELECT 1
                     FROM user_constraints cons
                     WHERE cols.index_name = cons.index_name
-                )
+                ) AND
+                cols.index_name = ind.index_name
             ORDER BY cols.column_position
         """, [table_name])
-        for constraint, column, order in cursor.fetchall():
+        for constraint, column, order, type_ in cursor.fetchall():
             # If we're the first column, make the record
             if constraint not in constraints:
                 constraints[constraint] = {
@@ -282,6 +283,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     "foreign_key": None,
                     "check": False,
                     "index": True,
+                    "type": 'btree' if type_ == 'normal' else type_,
                 }
             # Record the details
             constraints[constraint]['columns'].append(column)

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -22,7 +22,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     can_introspect_autofield = True
     can_introspect_ip_address_field = True
     can_introspect_small_integer_field = True
-    can_introspect_index_type = True
     can_distinct_on_fields = True
     can_rollback_ddl = True
     supports_combined_alters = True

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -255,8 +255,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                         "index": True,
                     }
                 constraints[index]['columns'].append(column)
-            # Add column orders for indexes
+            # Add type and column orders for indexes
             if constraints[index]['index'] and not constraints[index]['unique']:
+                # SQLite doesn't support any index type other than b-tree
+                constraints[index]['type'] = 'btree'
                 cursor.execute(
                     "SELECT sql FROM sqlite_master "
                     "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -184,14 +184,15 @@ class IntrospectionTests(TransactionTestCase):
         self.assertNotIn('first_name', indexes)
         self.assertIn('id', indexes)
 
-    @skipUnlessDBFeature('can_introspect_index_type')
     def test_get_constraints_indexes_types(self):
         with connection.cursor() as cursor:
             constraints = connection.introspection.get_constraints(cursor, Article._meta.db_table)
-        for key, val in constraints.items():
-            if val['index'] and not (val['primary_key'] or val['unique']):
-                self.assertIn('type', val)
-                self.assertEqual('btree', val['type'])
+        constraint = 'introspection_article_headline_pub_date_c749bad3_idx'
+        if connection.vendor == 'oracle':
+            constraint = 'introspec_headline__c749bad3_i'
+        if connection.features.uppercases_column_names:
+            constraint = constraint.upper()
+        self.assertEqual(constraints[constraint]['type'], 'btree')
 
     @skipUnlessDBFeature('supports_index_column_ordering')
     def test_get_constraints_indexes_orders(self):

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -172,11 +172,6 @@ class IntrospectionTests(TransactionTestCase):
     def test_get_indexes(self):
         with connection.cursor() as cursor:
             indexes = connection.introspection.get_indexes(cursor, Article._meta.db_table)
-        if connection.features.can_introspect_index_type:
-            index_type = indexes['reporter_id'].pop('type', None)
-            self.assertIsNotNone(index_type)
-            if connection.vendor == 'postgresql':
-                self.assertEqual(index_type, 'btree')
         self.assertEqual(indexes['reporter_id'], {'unique': False, 'primary_key': False})
 
     def test_get_indexes_multicol(self):
@@ -188,6 +183,15 @@ class IntrospectionTests(TransactionTestCase):
             indexes = connection.introspection.get_indexes(cursor, Reporter._meta.db_table)
         self.assertNotIn('first_name', indexes)
         self.assertIn('id', indexes)
+
+    @skipUnlessDBFeature('can_introspect_index_type')
+    def test_get_constraints_indexes_types(self):
+        with connection.cursor() as cursor:
+            constraints = connection.introspection.get_constraints(cursor, Article._meta.db_table)
+        for key, val in constraints.items():
+            if val['index'] and not (val['primary_key'] or val['unique']):
+                self.assertIn('type', val)
+                self.assertEqual('btree', val['type'])
 
     @skipUnlessDBFeature('supports_index_column_ordering')
     def test_get_constraints_indexes_orders(self):

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -44,15 +44,14 @@ class SchemaTests(PostgreSQLTestCase):
         # Ensure the table is there and doesn't have an index.
         self.assertNotIn('field', self.get_constraints(IntegerArrayModel._meta.db_table))
         # Add the index
-        index = GinIndex(fields=['field'], name='integer_array_model_field_gin')
+        index_name = 'integer_array_model_field_gin'
+        index = GinIndex(fields=['field'], name=index_name)
         with connection.schema_editor() as editor:
             editor.add_index(IntegerArrayModel, index)
-        self.assertIn('integer_array_model_field_gin', self.get_constraints(IntegerArrayModel._meta.db_table))
-        self.assertEqual(
-            self.get_constraints(IntegerArrayModel._meta.db_table)['integer_array_model_field_gin']['type'],
-            'gin'
-        )
+        constraints = self.get_constraints(IntegerArrayModel._meta.db_table)
+        # Check gin index was added
+        self.assertEqual(constraints[index_name]['type'], 'gin')
         # Drop the index
         with connection.schema_editor() as editor:
             editor.remove_index(IntegerArrayModel, index)
-        self.assertNotIn('integer_array_model_field_gin', self.get_constraints(IntegerArrayModel._meta.db_table))
+        self.assertNotIn(index_name, self.get_constraints(IntegerArrayModel._meta.db_table))

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -33,23 +33,26 @@ class GinIndexTests(PostgreSQLTestCase):
 
 class SchemaTests(PostgreSQLTestCase):
 
-    def get_indexes(self, table):
+    def get_constraints(self, table):
         """
         Get the indexes on the table using a new cursor.
         """
         with connection.cursor() as cursor:
-            return connection.introspection.get_indexes(cursor, table)
+            return connection.introspection.get_constraints(cursor, table)
 
     def test_gin_index(self):
         # Ensure the table is there and doesn't have an index.
-        self.assertNotIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))
+        self.assertNotIn('field', self.get_constraints(IntegerArrayModel._meta.db_table))
         # Add the index
         index = GinIndex(fields=['field'], name='integer_array_model_field_gin')
         with connection.schema_editor() as editor:
             editor.add_index(IntegerArrayModel, index)
-        self.assertIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))
-        self.assertEqual(self.get_indexes(IntegerArrayModel._meta.db_table)['field']['type'], 'gin')
+        self.assertIn('integer_array_model_field_gin', self.get_constraints(IntegerArrayModel._meta.db_table))
+        self.assertEqual(
+            self.get_constraints(IntegerArrayModel._meta.db_table)['integer_array_model_field_gin']['type'],
+            'gin'
+        )
         # Drop the index
         with connection.schema_editor() as editor:
             editor.remove_index(IntegerArrayModel, index)
-        self.assertNotIn('field', self.get_indexes(IntegerArrayModel._meta.db_table))
+        self.assertNotIn('integer_array_model_field_gin', self.get_constraints(IntegerArrayModel._meta.db_table))


### PR DESCRIPTION
Ticket [#27097](https://code.djangoproject.com/ticket/27097#ticket).

I am introspecting this in the `get_constraints` method and moved the earlier implementation for PostgreSQL from `get_indexes` to `get_constraints` as well, since there are efforts to  [deprecate `get_indexes`](https://code.djangoproject.com/ticket/27098#ticket).