### PR TITLE
cannot use django template backend in standalone mode

### DIFF
--- a/django/template/backends/django.py
+++ b/django/template/backends/django.py
@@ -27,7 +27,8 @@ class DjangoTemplates(BaseEngine):
         options.setdefault('debug', settings.DEBUG)
         options.setdefault('file_charset', settings.FILE_CHARSET)
         libraries = options.get('libraries', {})
-        options['libraries'] = self.get_templatetag_libraries(libraries)
+        if libraries:
+            options['libraries'] = self.get_templatetag_libraries(libraries)
         super(DjangoTemplates, self).__init__(params)
         self.engine = Engine(self.dirs, self.app_dirs, **options)
 


### PR DESCRIPTION
I can't use the django template backend in standalone mode because it tries to look for installed apps: `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.`.

This is how I'm using it:

```python
from django.template import Template, Context
from django.conf import settings
settings.configure(
    TEMPLATES=[{'NAME': 'django', 'BACKEND': 'django.template.backends.django.DjangoTemplates'}]
)

c = Context(make_context_data(race))
t = Template("blah {{ hello }}")
print(t.render(c))
```

Full Traceback
```
Traceback (most recent call last):
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/utils.py", line 65, in __getitem__
    return self._engines[alias]
KeyError: 'django'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./scripts/make_context_data.py", line 145, in <module>
    """)
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/base.py", line 184, in __init__
    engine = Engine.get_default()
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/engine.py", line 74, in get_default
    django_engines = [engine for engine in engines.all()
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/utils.py", line 89, in all
    return [self[alias] for alias in self]
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/utils.py", line 89, in <listcomp>
    return [self[alias] for alias in self]
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/utils.py", line 80, in __getitem__
    engine = engine_cls(params)
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/backends/django.py", line 31, in __init__
    options['libraries'] = self.get_templatetag_libraries(libraries)
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/backends/django.py", line 49, in get_templatetag_libraries
    libraries = get_installed_libraries()
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/template/backends/django.py", line 104, in get_installed_libraries
    for app_config in apps.get_app_configs())
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/apps/registry.py", line 137, in get_app_configs
    self.check_apps_ready()
  File "/Users/johria/anaconda3/lib/python3.5/site-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```