### PR TITLE
Fixed #27063 -- Prevented i18n_patterns() from using too much of the URL as the language.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -45,7 +45,7 @@ language_code_re = re.compile(
     re.IGNORECASE
 )
 
-language_code_prefix_re = re.compile(r'^/([\w@-]+)(/|$)')
+language_code_prefix_re = re.compile(r'^/(\w+([@-]\w+)?)(/|$)')
 
 
 @receiver(setting_changed)

--- a/docs/releases/1.10.3.txt
+++ b/docs/releases/1.10.3.txt
@@ -23,3 +23,6 @@ Bugfixes
 
 * Fixed ``QuerySet.bulk_create()`` on PostgreSQL when the number of objects is
   a multiple plus one of ``batch_size`` (:ticket:`27385`).
+
+* Fixed issue where pages starting with /<language_code>-* are matched to language_code.
+    (:ticket:`27063`)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1472,11 +1472,26 @@ class MiscTests(SimpleTestCase):
         r.META = {'HTTP_ACCEPT_LANGUAGE': 'de'}
         self.assertEqual(g(r), 'zh-hans')
 
+    @override_settings(
+        LANGUAGES=[
+            ('en', 'English'),
+            ('de', 'German'),
+            ('de-at', 'Austrian German'),
+            ('pl', 'Polish'),
+        ]
+    )
     def test_get_language_from_path_real(self):
         g = trans_real.get_language_from_path
         self.assertEqual(g('/pl/'), 'pl')
         self.assertEqual(g('/pl'), 'pl')
         self.assertIsNone(g('/xyz/'))
+
+        self.assertEqual(g('/en/'), 'en')
+        self.assertEqual(g('/en-gb/'), 'en')
+
+        self.assertEqual(g('/de/'), 'de')
+        self.assertEqual(g('/de-at/'), 'de-at')
+        self.assertEqual(g('/de-ch/'), 'de')
 
     def test_get_language_from_path_null(self):
         from django.utils.translation.trans_null import get_language_from_path as g

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1493,6 +1493,9 @@ class MiscTests(SimpleTestCase):
         self.assertEqual(g('/de-at/'), 'de-at')
         self.assertEqual(g('/de-ch/'), 'de')
 
+        # Regresion #27063: Make sure that pages starting with /de* dont change language to german
+        self.assertIsNone(g('/de-simple-page/'))
+
     def test_get_language_from_path_null(self):
         from django.utils.translation.trans_null import get_language_from_path as g
         self.assertIsNone(g('/pl/'))
@@ -1824,6 +1827,7 @@ class LocaleMiddlewareTests(TestCase):
     USE_I18N=True,
     LANGUAGES=[
         ('en', 'English'),
+        ('de', 'German'),
         ('fr', 'French'),
     ],
     MIDDLEWARE=[
@@ -1853,6 +1857,11 @@ class UnprefixedDefaultLanguageTests(SimpleTestCase):
     def test_unexpected_kwarg_to_i18n_patterns(self):
         with self.assertRaisesMessage(AssertionError, "Unexpected kwargs for i18n_patterns(): {'foo':"):
             i18n_patterns(object(), foo='bar')
+
+    # Regresion #27063: Make sure that pages starting with /de* dont change language to german
+    def test_page_with_dash(self):
+        response = self.client.get('/de-simple-page/')
+        self.assertEqual(response.content, b'Yes')
 
 
 @override_settings(

--- a/tests/i18n/urls_default_unprefixed.py
+++ b/tests/i18n/urls_default_unprefixed.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 
 urlpatterns = i18n_patterns(
+    url(r'^(?P<arg>[\w-]+)-page', lambda request, **arg: HttpResponse(_("Yes"))),
     url(r'^simple/$', lambda r: HttpResponse(_("Yes"))),
     prefix_default_language=False,
 )


### PR DESCRIPTION
Fixing the issue described here https://code.djangoproject.com/ticket/27063.

That commit makes `get_language_from_path` returning only valid (defined in LANGUAGES setting) languages, so things like `/de-moines-parking/` is not a valid laguage anymore.

Before it assumes it's `de` language with `moines-parking` variant and returned `de`, just silently ignoring the invalid `monies-parking` part.

We should not assume that anything starting with a valid language code followed by a dash and any random string is a language with some random variant. That's changed only while looking up languages from path, the `Accept-Language` header parsing remains unchanged.

As looked at the code  I think we can also modify the regex to match only languages with one dash or at sign, AFAIK there's no case where language code contains two `@` or `-`.

Here's the proposed change to regex, not committed yet, cause I'm not 100% sure about it.

I'm waiting for feedback.

```
-language_code_prefix_re = re.compile(r'^/([\w@-]+)(/|$)')
+language_code_prefix_re = re.compile(r'^/(\w+([@-]\w+))(/|$)')
```
