### PR TITLE
Fixed #27153 -- Added validation for HttpResponse status.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -50,7 +50,13 @@ class HttpResponseBase(six.Iterator):
         self.cookies = SimpleCookie()
         self.closed = False
         if status is not None:
-            self.status_code = status
+            try:
+                self.status_code = int(status)
+            except (ValueError, TypeError):
+                raise TypeError('HTTP status code must be an integer.')
+
+            if not 100 <= self.status_code <= 599:
+                raise ValueError('HTTP status code must be an integer from 100 to 599.')
         self._reason_phrase = reason
         self._charset = charset
         if content_type is None:

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -63,10 +63,32 @@ class HttpResponseTests(SimpleTestCase):
         self.assertEqual(resp.status_code, 503)
         self.assertEqual(resp.reason_phrase, "Service Unavailable")
 
+    def test_valid_status_code_string(self):
+        resp = HttpResponse(status='100')
+        self.assertEqual(resp.status_code, 100)
+        resp = HttpResponse(status='404')
+        self.assertEqual(resp.status_code, 404)
+        resp = HttpResponse(status='599')
+        self.assertEqual(resp.status_code, 599)
+
+    def test_invalid_status_code(self):
+        with self.assertRaisesMessage(TypeError, 'HTTP status code must be an integer.'):
+            HttpResponse(status=object())
+        with self.assertRaisesMessage(TypeError, 'HTTP status code must be an integer.'):
+            HttpResponse(status="J'attendrai")
+        with self.assertRaisesMessage(ValueError, 'HTTP status code must be an integer from 100 to 599.'):
+            HttpResponse(status='99')
+        with self.assertRaisesMessage(ValueError, 'HTTP status code must be an integer from 100 to 599.'):
+            HttpResponse(status='600')
+        with self.assertRaisesMessage(ValueError, 'HTTP status code must be an integer from 100 to 599.'):
+            HttpResponse(status=99)
+        with self.assertRaisesMessage(ValueError, 'HTTP status code must be an integer from 100 to 599.'):
+            HttpResponse(status=600)
+
     def test_reason_phrase(self):
         reason = "I'm an anarchist coffee pot on crack."
-        resp = HttpResponse(status=814, reason=reason)
-        self.assertEqual(resp.status_code, 814)
+        resp = HttpResponse(status=419, reason=reason)
+        self.assertEqual(resp.status_code, 419)
         self.assertEqual(resp.reason_phrase, reason)
 
     def test_charset_detection(self):


### PR DESCRIPTION
I was accidentally passing a string for the status to DRF's `Response` class ([it inherits from Django's SimpleTemplateResponse](https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/response.py#L16)) and getting:

```
  File "[...]/django/http/utils.py", line 17, in conditional_content_removal
    if 100 <= response.status_code < 200 or response.status_code in (204, 304):
TypeError: unorderable types: int() <= str()
```

Thinking the bad value shouldn't get that far so this PR checks the value in the `HttpResponseBase` class.

https://code.djangoproject.com/ticket/27153