### PR TITLE
Refs #27132 -- Added pylibmc to tests/requirements/base.txt

### DIFF
--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -6,6 +6,8 @@ jinja2 >= 2.7
 numpy
 Pillow
 PyYAML
+# pylibmc/libmemcached can't be built on Windows.
+pylibmc; sys.platform != 'win32'
 pytz > dev
 selenium
 sqlparse


### PR DESCRIPTION
pylibmc needs to be installed in advance of #7168, so that when the global Jenkins test configuration (used for all branches) is updated, the tests don't fail with "no module named pylibmc".

This will need to be backported to all supported branches.

See:
https://github.com/django/django/pull/7168#issuecomment-242986039