### PR TITLE
Fixed #27141 -- Fixed makemigrations crash on readonly database with django_migrations table.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -14,7 +14,7 @@ from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style, no_style
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.migrations.exceptions import MigrationSchemaMissing
+from django.db.migrations.exceptions import MigrationInformationMissing
 from django.utils.encoding import force_str
 
 
@@ -438,7 +438,7 @@ class BaseCommand(object):
         except ImproperlyConfigured:
             # No databases are configured (or the dummy one)
             return
-        except MigrationSchemaMissing:
+        except MigrationInformationMissing:
             self.stdout.write(self.style.NOTICE(
                 "\nNot checking migrations as it is not possible to access/create the django_migrations table."
             ))

--- a/django/db/migrations/exceptions.py
+++ b/django/db/migrations/exceptions.py
@@ -64,7 +64,7 @@ class NodeNotFoundError(LookupError):
         return "NodeNotFoundError(%r)" % (self.node, )
 
 
-class MigrationSchemaMissing(DatabaseError):
+class MigrationInformationMissing(DatabaseError):
     pass
 
 

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,7 +6,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
-from django.db.migrations.exceptions import MigrationSchemaMissing
+from django.db.migrations.exceptions import MigrationInformationMissing
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six
@@ -276,7 +276,7 @@ class MigrationLoader(object):
         recorder = MigrationRecorder(connection)
         try:
             applied = recorder.applied_migrations()
-        except MigrationSchemaMissing:
+        except MigrationInformationMissing:
             # Skip check if the django_migrations table is missing and can't be
             # created.
             return

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -23,7 +23,7 @@ from django.core.management import (
     BaseCommand, CommandError, call_command, color,
 )
 from django.db import ConnectionHandler
-from django.db.migrations.exceptions import MigrationSchemaMissing
+from django.db.migrations.exceptions import MigrationInformationMissing
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import (
     LiveServerTestCase, SimpleTestCase, TestCase, mock, override_settings,
@@ -1349,7 +1349,7 @@ class ManageRunserver(AdminScriptTestCase):
         """
         with mock.patch.object(
                 MigrationRecorder, 'ensure_schema',
-                side_effect=MigrationSchemaMissing()):
+                side_effect=MigrationInformationMissing()):
             self.cmd.check_migrations()
         # Check a warning is emitted
         self.assertIn("Not checking migrations", self.output.getvalue())

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -4,7 +4,7 @@ from unittest import skipIf
 
 from django.db import connection, connections
 from django.db.migrations.exceptions import (
-    AmbiguityError, InconsistentMigrationHistory, MigrationSchemaMissing,
+    AmbiguityError, InconsistentMigrationHistory, MigrationInformationMissing,
     NodeNotFoundError,
 )
 from django.db.migrations.loader import MigrationLoader
@@ -474,6 +474,6 @@ class LoaderTests(TestCase):
         check_consistent_history() ignores read-only databases, possibly
         without a django_migrations table.
         """
-        with mock.patch.object(MigrationRecorder, 'ensure_schema', side_effect=MigrationSchemaMissing()):
+        with mock.patch.object(MigrationRecorder, 'applied_migrations', side_effect=MigrationInformationMissing()):
             loader = MigrationLoader(connection=None)
             loader.check_consistent_history(connection)


### PR DESCRIPTION
Follow-up on 76ab8851181675a59425f9637bdbf3f2de95f6f1.