### PR TITLE
Added failing test for ModelMultipleChoiceField with UUIDField.

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 import datetime
-import os
 from decimal import Decimal
+import os
 from unittest import skipUnless
 
 from django import forms
@@ -23,13 +23,14 @@ from django.utils import six
 from django.utils._os import upath
 
 from .models import (
-    Article, ArticleStatus, Author, Author1, Award, BetterWriter, BigInt, Book,
-    Category, Character, Colour, ColourfulItem, CommaSeparatedInteger,
-    CustomErrorMessage, CustomFF, CustomFieldForExclusionModel, DateTimePost,
-    DerivedBook, DerivedPost, Document, ExplicitPK, FilePathModel,
-    FlexibleDatePost, Homepage, ImprovedArticle, ImprovedArticleWithParentLink,
-    Inventory, NullableUniqueCharFieldModel, Person, Photo, Post, Price,
-    Product, Publication, PublicationDefaults, StrictAssignmentAll,
+    UUIDPK, Article, ArticleStatus, Author, Author1, Award, BetterWriter,
+    BigInt, Book, Category, Character, Colour, ColourfulItem,
+    CommaSeparatedInteger, CustomErrorMessage, CustomFF,
+    CustomFieldForExclusionModel, DateTimePost, DerivedBook, DerivedPost,
+    Document, ExplicitPK, FilePathModel, FlexibleDatePost, Homepage,
+    ImprovedArticle, ImprovedArticleWithParentLink, Inventory,
+    NullableUniqueCharFieldModel, Person, Photo, Post, Price, Product,
+    Publication, PublicationDefaults, StrictAssignmentAll,
     StrictAssignmentFieldSpecific, Student, StumpJoke, TextFile, Triple,
     Writer, WriterProfile, test_images,
 )
@@ -1697,6 +1698,11 @@ class ModelMultipleChoiceFieldTests(TestCase):
         Category.objects.get(url='6th').delete()
         with self.assertRaises(ValidationError):
             f.clean([c6.id])
+
+    def test_model_multiple_choice_field_uuid_pk(self):
+        f = forms.ModelMultipleChoiceField(UUIDPK.objects.all())
+        with self.assertRaises(ValidationError):
+            f.clean(['invalid_uuid'])
 
     def test_model_multiple_choice_required_false(self):
         f = forms.ModelMultipleChoiceField(Category.objects.all(), required=False)


### PR DESCRIPTION
This test shows that an invalid value for a UUIDField will bubble up as
`ValueError`.  The problem here seems to be that `get_prep_value` just
passes through the (invalid) string.

Only when the queryset is evaluated just below via the following code,
the ValueError from `UUIDField.get_db_prep_value` is raised and bubbles
up:

    self.queryset.filter(**{'%s__in' % key: value})
    pks = set(force_text(getattr(o, key)) for o in qs)

Explicitly evaluating the queryset above already would fix it, but that
would get done for every selected value then.

Needs `UUIDField` to be fixed for this, e.g. raising the `ValueError`
from `get_prep_value` already?
In this case other fields would need the same fix probably (from what I
have seen while skimming the code).

Django issue: https://code.djangoproject.com/ticket/27148