### PR TITLE
Fixed #28458 --  Added ModelMultipleChoiceField.validate_choices() 

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1317,8 +1317,11 @@ class ModelMultipleChoiceField(ModelChoiceField):
                     params={'pk': pk},
                 )
         qs = self.queryset.filter(**{'%s__in' % key: value})
-        pks = {str(getattr(o, key)) for o in qs}
-        for val in value:
+        return self.validate_choices(qs, key, value)
+
+    def validate_choices(self, qs, field_name, values):
+        pks = {str(getattr(o, field_name)) for o in qs}
+        for val in values:
             if str(val) not in pks:
                 raise ValidationError(
                     self.error_messages['invalid_choice'],

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -1228,6 +1228,16 @@ method::
 
         Same as :class:`ModelChoiceField.to_field_name`.
 
+.. method:: ModelMultipleChoiceField.validate_choices(qs, key, values)
+
+``validate_choices`` gets called with the filtered queryset (``qs``), the name
+of the field, and the list of selected values.  It should return the queryset.
+
+The default implementation raises a ``ValidationError`` in case any of the
+``values`` is not in the list of attribute lookups of ``field_name`` in ``qs``
+(using the string representations for comparison).
+
+
 Creating custom fields
 ======================
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1875,6 +1875,17 @@ class ModelMultipleChoiceFieldTests(TestCase):
         with self.assertRaises(ValidationError):
             f.clean([c6.id])
 
+    def test_model_multiple_choice_field_validate_choices(self):
+        class CustomModelMultipleChoiceField(forms.ModelMultipleChoiceField):
+            def validate_choices(self, qs, field_name, values):
+                raise ValidationError('custom_error')
+
+        with self.assertNumQueries(0):
+            field = CustomModelMultipleChoiceField(Category.objects.all())
+            with self.assertRaises(ValidationError) as exc:
+                field.clean([self.c1.id])
+        self.assertEqual(exc.exception.message, 'custom_error')
+
     def test_model_multiple_choice_required_false(self):
         f = forms.ModelMultipleChoiceField(Category.objects.all(), required=False)
         self.assertIsInstance(f.clean([]), EmptyQuerySet)


### PR DESCRIPTION
This allows to easily override it, e.g. when using django-filter and you
do not want the evaluation of the queryset, and/but instead validate the
input manually.

Ref: https://code.djangoproject.com/ticket/27148

TODO:
- [x] documentation
