### PR TITLE
Added documentation about detecting threaded runserver.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -69,7 +69,10 @@ this database small.
 
 The development server creates a new thread for each request it handles,
 negating the effect of persistent connections. Don't enable them during
-development.
+development. You can use the following code to check if the runserver command
+is being used with threading::
+
+    sys.argv[1] == 'runserver' and '--nothreading' not in sys.argv[2:]
 
 When Django establishes a connection to the database, it sets up appropriate
 parameters, depending on the backend being used. If you enable persistent


### PR DESCRIPTION
This helps with configuring the database according to what is mentioned
above.

    # Do not use connection pooling with threaded "runserver".
    import sys
    is_runserver_with_threading = (
        sys.argv[1] == 'runserver' and '--nothreading' not in sys.argv[2:]
    )
    conn_max_age = 0 if is_runserver_with_threading else 1800

TODO:
 - [ ] handle `IndexError`, or use `sys.argv[1:2] == ['runserver']`