### PR TITLE
Fixed #27163 -- Allowed a colon separated pythonpath in django-admin.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -73,7 +73,8 @@ def handle_default_options(options):
     if options.settings:
         os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
     if options.pythonpath:
-        sys.path.insert(0, options.pythonpath)
+        for path in options.pythonpath.split(":"):
+            sys.path.insert(0, path)
 
 
 class OutputWrapper(object):


### PR DESCRIPTION
I have my `INSTALLED_APPS` in separate directories (packages) and would like to supply multiple paths to `django-admin` via the `pythonpath` parameter.

For example:

```
django-admin dbshell --settings=myapp.settings --pythonpath "admin:lib"
```

I do not want to use pip as described here: https://docs.djangoproject.com/en/1.10/intro/reusable-apps/#using-your-own-package