### PR TITLE
Fixed #27152 -- Supported comma delimiter in memcached LOCATION string.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -1,6 +1,7 @@
 "Memcached cache backend"
 
 import pickle
+import re
 import time
 import warnings
 
@@ -15,7 +16,7 @@ class BaseMemcachedCache(BaseCache):
     def __init__(self, server, params, library, value_not_found_exception):
         super(BaseMemcachedCache, self).__init__(params)
         if isinstance(server, six.string_types):
-            self._servers = server.split(';')
+            self._servers = re.split('[;,]', server)
         else:
             self._servers = server
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -173,6 +173,10 @@ Cache
   control of client behavior. See the :ref:`cache arguments <cache_arguments>`
   documentation for examples.
 
+* For memcached backends, the :setting:`LOCATION <CACHES-LOCATION>` setting now
+  supports defining multiple servers as a comma-delimited string, for convenience
+  with third-party services that use such strings in environment variables.
+
 CSRF
 ~~~~
 

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -128,8 +128,8 @@ multiple servers. This means you can run Memcached daemons on multiple
 machines, and the program will treat the group of machines as a *single*
 cache, without the need to duplicate cache values on each machine. To take
 advantage of this feature, include all server addresses in
-:setting:`LOCATION <CACHES-LOCATION>`, either separated by semicolons or as
-a list.
+:setting:`LOCATION <CACHES-LOCATION>`, either as a semicolon or comma
+delimited string, or as a list.
 
 In this example, the cache is shared over Memcached instances running on IP
 address 172.19.26.240 and 172.19.26.242, both on port 11211::
@@ -167,6 +167,11 @@ Without a doubt, *none* of the Django caching backends should be used for
 permanent storage -- they're all intended to be solutions for caching, not
 storage -- but we point this out here because memory-based caching is
 particularly temporary.
+
+.. versionchanged:: 1.11
+
+    The :setting:`LOCATION <CACHES-LOCATION>` setting now supports defining
+    multiple servers as a comma-delimited string.
 
 .. _database-caching:
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1160,6 +1160,7 @@ class BaseMemcachedTests(BaseCacheTests):
         locations = [
             ['server1.tld', 'server2:11211'],
             'server1.tld;server2:11211',
+            'server1.tld,server2:11211',
         ]
         for location in locations:
             params = {'BACKEND': self.base_params['BACKEND'], 'LOCATION': location}

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1156,6 +1156,16 @@ memcached_excluded_caches = {'cull', 'zero_cull'}
 
 class BaseMemcachedTests(BaseCacheTests):
 
+    def test_location_multiple_servers(self):
+        locations = [
+            ['server1.tld', 'server2:11211'],
+            'server1.tld;server2:11211',
+        ]
+        for location in locations:
+            params = {'BACKEND': self.base_params['BACKEND'], 'LOCATION': location}
+            with self.settings(CACHES={'default': params}):
+                self.assertEqual(cache._servers, ['server1.tld', 'server2:11211'])
+
     def test_invalid_key_characters(self):
         """
         On memcached, we don't introduce a duplicate key validation


### PR DESCRIPTION
The alternative was a `server.replace(',', ';').split(';')`, however I think the `re.split()` is cleaner.

https://code.djangoproject.com/ticket/27152