### PR TITLE
Fixed #27142, #27110 -- Made makemigrations consistency checks respect database routers.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -6,7 +6,6 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
-from django.db.migrations.exceptions import MigrationSchemaMissing
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.utils import six
@@ -280,12 +279,7 @@ class MigrationLoader(object):
         unapplied dependencies.
         """
         recorder = MigrationRecorder(connection)
-        try:
-            applied = recorder.applied_migrations()
-        except MigrationSchemaMissing:
-            # Skip check if the django_migrations table is missing and can't be
-            # created.
-            return
+        applied = recorder.applied_migrations()
         for migration in applied:
             # If the migration is unknown, skip it.
             if migration not in self.graph.nodes:

--- a/docs/releases/1.10.1.txt
+++ b/docs/releases/1.10.1.txt
@@ -55,7 +55,9 @@ Bugfixes
 
 * Reallowed the ``{% for %}`` tag to unpack any iterable (:ticket:`27058`).
 
-* Fixed ``makemigrations`` crash if a database is read-only (:ticket:`27054`).
+* Made ``makemigrations`` skip inconsistent history checks on non-default
+  databases if database routers aren't in use or if no apps can be migrated
+  to the database (:ticket:`27054`, :ticket:`27110`, :ticket:`27142`).
 
 * Removed duplicated managers in ``Model._meta.managers`` (:ticket:`27073`).
 

--- a/tests/migrations/routers.py
+++ b/tests/migrations/routers.py
@@ -1,3 +1,7 @@
+class EmptyRouter(object):
+    pass
+
+
 class TestRouter(object):
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         """

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -4,12 +4,11 @@ from unittest import skipIf
 
 from django.db import connection, connections
 from django.db.migrations.exceptions import (
-    AmbiguityError, InconsistentMigrationHistory, MigrationSchemaMissing,
-    NodeNotFoundError,
+    AmbiguityError, InconsistentMigrationHistory, NodeNotFoundError,
 )
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
-from django.test import TestCase, mock, modify_settings, override_settings
+from django.test import TestCase, modify_settings, override_settings
 from django.utils import six
 
 
@@ -484,12 +483,3 @@ class LoaderTests(TestCase):
             ('app1', '4_auto'),
         }
         self.assertEqual(plan, expected_plan)
-
-    def test_readonly_database(self):
-        """
-        check_consistent_history() ignores read-only databases, possibly
-        without a django_migrations table.
-        """
-        with mock.patch.object(MigrationRecorder, 'ensure_schema', side_effect=MigrationSchemaMissing()):
-            loader = MigrationLoader(connection=None)
-            loader.check_consistent_history(connection)


### PR DESCRIPTION
Partially reverted refs #27054 except for one of the tests as this solution supersedes that one.

https://code.djangoproject.com/ticket/27142
https://code.djangoproject.com/ticket/27110
https://code.djangoproject.com/ticket/27054