### PR TITLE
Fixed #27099 added note to ModelAdmin.list_filter doc

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -969,6 +969,11 @@ subclass::
         The ``FieldListFilter`` API is considered internal and might be
         changed.
 
+      .. note::
+
+        If there is only one possible option for a list filter, then the filter
+        will not be displayed in the admin site.
+
     It is possible to specify a custom template for rendering a list filter::
 
         class FilterWithCustomTemplate(admin.SimpleListFilter):


### PR DESCRIPTION
- Documented that ModelAdmin.list_filter does not display in the admin site if there is only one choice for the filter

- Fixed a typo in the fix for #27099