### PR TITLE
Fixed #11331 -- Stopped closing pylibmc connections after each request.

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -103,6 +103,7 @@ class BaseMemcachedCache(BaseCache):
         return ret
 
     def close(self, **kwargs):
+        # Many clients don't clean up connections properly themselves.
         self._cache.disconnect_all()
 
     def incr(self, key, delta=1, version=None):

--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -203,3 +203,9 @@ class PyLibMCCache(BaseMemcachedCache):
     @cached_property
     def _cache(self):
         return self._lib.Client(self._servers, **self._options)
+
+    def close(self, **kwargs):
+        # Override base behavior since libmemcached manages its own connections,
+        # and calling disconnect_all() resets the failover state and creates an
+        # unnecessary amount of reconnects.
+        pass

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1280,6 +1280,8 @@ class MemcachedCacheTests(BaseMemcachedTests, TestCase):
 ))
 class PyLibMCCacheTests(BaseMemcachedTests, TestCase):
     base_params = PyLibMCCache_params
+    # libmemcached manages its own connections.
+    should_disconnect_on_close = False
 
     # By default, pylibmc/libmemcached don't verify keys client-side and so
     # this test triggers a server-side bug that causes later tests to fail


### PR DESCRIPTION
Since this resets the failover state, and creates an unnecessary amount of reconnects. libmemcached manages its own connections, so isn't affected by [ticket 5133](https://code.djangoproject.com/ticket/5133).

Fixes:
https://code.djangoproject.com/ticket/11331

Supersedes PR #4866.