### PR TITLE
Fixed #25788 -- Enabled the cached template loader if debug is False.

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -27,6 +27,8 @@ class Engine(object):
             loaders = ['django.template.loaders.filesystem.Loader']
             if app_dirs:
                 loaders += ['django.template.loaders.app_directories.Loader']
+            if not debug:
+                loaders = [('django.template.loaders.cached.Loader', loaders)]
         else:
             if app_dirs:
                 raise ImproperlyConfigured(

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -103,7 +103,15 @@ what's passed by :class:`~django.template.backends.django.DjangoTemplates`.
       * ``'django.template.loaders.app_directories.Loader'`` if and only if
         ``app_dirs`` is ``True``.
 
+      If ``debug`` is ``False``, these loaders are wrapped in
+      :class:`django.template.loaders.cached.Loader`.
+
       See :ref:`template-loaders` for details.
+
+      .. versionchanged:: 1.11
+
+          Enabling of the cached template loader when ``debug`` is ``False``
+          was added.
 
     * ``string_if_invalid`` is the output, as a string, that the template
       system should use for invalid (e.g. misspelled) variables.
@@ -899,18 +907,22 @@ loaders that come with Django:
 
 .. class:: cached.Loader
 
-    By default, the templating system will read and compile your templates every
-    time they need to be rendered. While the Django templating system is quite
-    fast, the overhead from reading and compiling templates can add up.
+    By default (when :setting:`DEBUG` is ``True``), the template system reads
+    and compiles your templates every time they're rendered. While the Django
+    template system is quite fast, the overhead from reading and compiling
+    templates can add up.
 
-    The cached template loader is a class-based loader that you configure with
-    a list of other loaders that it should wrap. The wrapped loaders are used to
-    locate unknown templates when they are first encountered. The cached loader
-    then stores the compiled ``Template`` in memory. The cached ``Template``
-    instance is returned for subsequent requests to load the same template.
+    You configure the cached template loader with a list of other loaders that
+    it should wrap. The wrapped loaders are used to locate unknown templates
+    when they're first encountered. The cached loader then stores the compiled
+    ``Template`` in memory. The cached ``Template`` instance is returned for
+    subsequent requests to load the same template.
 
-    For example, to enable template caching with the ``filesystem`` and
-    ``app_directories`` template loaders you might use the following settings::
+    This loader is automatically enabled if :setting:`DEBUG` is ``False`` and
+    :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified.
+
+    You can also enable template caching with some custom template loaders
+    using settings like this::
 
         TEMPLATES = [{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -920,6 +932,7 @@ loaders that come with Django:
                     ('django.template.loaders.cached.Loader', [
                         'django.template.loaders.filesystem.Loader',
                         'django.template.loaders.app_directories.Loader',
+                        'path.to.custom.Loader',
                     ]),
                 ],
             },
@@ -934,7 +947,10 @@ loaders that come with Django:
         information, see :ref:`template tag thread safety considerations
         <template_tag_thread_safety>`.
 
-    This loader is disabled by default.
+    .. versionchanged:: 1.11
+
+        The automatic enabling of the cached template loader when ``debug`` is
+        ``False`` was added.
 
 ``django.template.loaders.locmem.Loader``
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -467,6 +467,12 @@ Miscellaneous
   :class:`~django.core.serializers.json.DjangoJSONEncoder` (renamed in Django
   1.0) is removed.
 
+* The :class:`cached template loader <django.template.loaders.cached.Loader>`
+  is now enabled if :setting:`DEBUG` is ``False`` and
+  :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified. This could
+  be backwards-incompatible if you have some :ref:`template tags that aren't
+  thread safe <template_tag_thread_safety>`.
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -130,3 +130,18 @@ class DjangoTemplatesTests(TemplateStringsTests):
             engines['django'].from_string('Hello, {{ name }}').render({'name': 'Bob & Jim'}),
             'Hello, Bob &amp; Jim'
         )
+
+    default_loaders = [
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    ]
+
+    @override_settings(DEBUG=False)
+    def test_non_debug_default_template_loaders(self):
+        engine = DjangoTemplates({'DIRS': [], 'APP_DIRS': True, 'NAME': 'django', 'OPTIONS': {}})
+        self.assertEqual(engine.engine.loaders, [('django.template.loaders.cached.Loader', self.default_loaders)])
+
+    @override_settings(DEBUG=True)
+    def test_debug_default_template_loaders(self):
+        engine = DjangoTemplates({'DIRS': [], 'APP_DIRS': True, 'NAME': 'django', 'OPTIONS': {}})
+        self.assertEqual(engine.engine.loaders, self.default_loaders)

--- a/tests/template_loader/tests.py
+++ b/tests/template_loader/tests.py
@@ -11,11 +11,14 @@ from django.test.client import RequestFactory
     'APP_DIRS': True,
 }, {
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'APP_DIRS': True,
     'OPTIONS': {
         'context_processors': [
             'django.template.context_processors.request',
         ],
+        'loaders': [
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        ]
     },
 }])
 class TemplateLoaderTests(SimpleTestCase):

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -279,7 +279,7 @@ class FileSystemLoaderTests(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = Engine(dirs=[TEMPLATE_DIR])
+        cls.engine = Engine(dirs=[TEMPLATE_DIR], loaders=['django.template.loaders.filesystem.Loader'])
         super(FileSystemLoaderTests, cls).setUpClass()
 
     @contextmanager


### PR DESCRIPTION
https://code.djangoproject.com/ticket/25788

Updated from https://github.com/django/django/pull/6954 to fix tests. A few tests relied on the default loaders and needed to have them specified so the cached loader isn't used instead.