### PR TITLE
Fixed #27175 -- Deprecated silencing exceptions from the {% include %} template tag.

### DIFF
--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -1,8 +1,10 @@
 import logging
 import posixpath
+import warnings
 from collections import defaultdict
 
 from django.utils import six
+from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.safestring import mark_safe
 
 from .base import (
@@ -208,10 +210,17 @@ class IncludeNode(Node):
                 return template.render(context.new(values))
             with context.push(**values):
                 return template.render(context)
-        except Exception:
+        except Exception as e:
             if context.template.engine.debug:
                 raise
             template_name = getattr(context, 'template_name', None) or 'unknown'
+            warnings.warn(
+                "Rendering {%% include '%s' %%} raised %s. In Django 2.1, "
+                "this exception will be raised rather than silenced and "
+                "rendered as an empty string." %
+                (template_name, e.__class__.__name__),
+                RemovedInDjango21Warning,
+            )
             logger.warning(
                 "Exception raised while rendering {%% include %%} for "
                 "template '%s'. Empty string rendered instead.",

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -33,6 +33,9 @@ details on these changes.
 * The ``host`` parameter of ``django.utils.http.is_safe_url()`` will be
   removed.
 
+* Silencing of exceptions raised while rendering the ``{% include %}`` template
+  tag will be removed.
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -731,6 +731,11 @@ is turned off, ``{% include %}`` logs a warning to the ``django.template``
 logger with the exception that happens while rendering the included template
 and returns an empty string.
 
+.. deprecated:: 1.11
+
+    Silencing exceptions raised while rendering the ``{% include %}`` template
+    tag is deprecated. In Django 2.1, the exception will be raised.
+
 .. note::
     The :ttag:`include` tag should be considered as an implementation of
     "render this subtemplate and include the HTML", not as "parse this

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -528,3 +528,8 @@ Miscellaneous
 
 * The ``host`` parameter of ``django.utils.http.is_safe_url()`` is deprecated
   in favor of the new ``allowed_hosts`` parameter.
+
+* Silencing exceptions raised while rendering the
+  :ttag:`{% include %} <include>` template tag is deprecated as the behavior is
+  often more confusing than helpful. In Django 2.1, the exception will be
+  raised.

--- a/tests/template_tests/test_logging.py
+++ b/tests/template_tests/test_logging.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 import logging
 
 from django.template import Context, Engine, Variable, VariableDoesNotExist
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango21Warning
 
 
 class TestHandler(logging.Handler):
@@ -104,7 +105,8 @@ class IncludeNodeLoggingTests(BaseTemplateLoggingTestCase):
     def test_logs_exceptions_during_rendering_with_debug_disabled(self):
         template = self.engine.from_string('{% include "child" %}')
         template.name = 'template_name'
-        self.assertEqual(template.render(self.ctx), '')
+        with ignore_warnings(category=RemovedInDjango21Warning):
+            self.assertEqual(template.render(self.ctx), '')
         self.assertEqual(
             self.test_handler.log_record.getMessage(),
             "Exception raised while rendering {% include %} for template "
@@ -115,7 +117,8 @@ class IncludeNodeLoggingTests(BaseTemplateLoggingTestCase):
 
     def test_logs_exceptions_during_rendering_with_no_template_name(self):
         template = self.engine.from_string('{% include "child" %}')
-        self.assertEqual(template.render(self.ctx), '')
+        with ignore_warnings(category=RemovedInDjango21Warning):
+            self.assertEqual(template.render(self.ctx), '')
         self.assertEqual(
             self.test_handler.log_record.getMessage(),
             "Exception raised while rendering {% include %} for template "


### PR DESCRIPTION
<https://code.djangoproject.com/ticket/27175>

<https://groups.google.com/forum/#!topic/django-developers/hscW1VboJxY>