### PR TITLE
Fixed #27179 -- Added parenthesis to KeyTransform for postgres JSONField

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -106,7 +106,7 @@ class KeyTransform(Transform):
             lookup = "'%s'" % self.key_name
         else:
             lookup = "%s" % self.key_name
-        return "%s -> %s" % (lhs, lookup), params
+        return "(%s -> %s)" % (lhs, lookup), params
 
 
 class KeyTransformFactory(object):

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -136,6 +136,14 @@ class TestQuerying(TestCase):
                 'k': True,
                 'l': False,
             }),
+            JSONModel.objects.create(field='z'),
+            JSONModel.objects.create(field='Z'),
+            JSONModel.objects.create(field={
+                'x': 'y'
+            }),
+            JSONModel.objects.create(field={
+                'x': 'Y'
+            })
         ]
 
     def test_exact(self):
@@ -236,6 +244,30 @@ class TestQuerying(TestCase):
         self.assertSequenceEqual(
             JSONModel.objects.filter(id__in=JSONModel.objects.filter(field__c=1)),
             self.objs[7:9]
+        )
+
+    def test_regex(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__regex=r'z'),
+            [self.objs[11]]
+        )
+
+    def test_iregex(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__iregex=r'z'),
+            [self.objs[11], self.objs[12]]
+        )
+
+    def test_regex_subkey(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__x__regex=r'y'),
+            [self.objs[13]]
+        )
+
+    def test_iregex_subkey(self):
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__x__iregex=r'y'),
+            [self.objs[13], self.objs[14]]
         )
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27179