### PR TITLE
correct isinstance call

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -72,7 +72,7 @@ def Deserializer(stream_or_string, **options):
     """
     Deserialize a stream or string of JSON data.
     """
-    if not isinstance(stream_or_string, (bytes, six.string_types)):
+    if not isinstance(stream_or_string, (bytes,) + six.string_types):
         stream_or_string = stream_or_string.read()
     if isinstance(stream_or_string, bytes):
         stream_or_string = stream_or_string.decode('utf-8')


### PR DESCRIPTION
Since six.string_types is a tuple, it should be concatenated with (bytes,) to form the set of types.