### PR TITLE
Fixed #27195 -- Stopped DROPing DEFAULT on NULLable column addition.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -420,7 +420,7 @@ class BaseDatabaseSchemaEditor(object):
         self.execute(sql, params)
         # Drop the default if we need to
         # (Django usually does not use in-database defaults)
-        if not self.skip_default(field) and field.default is not None:
+        if not self.skip_default(field) and self.effective_default(field) is not None:
             sql = self.sql_alter_column % {
                 "table": self.quote_name(model._meta.db_table),
                 "changes": self.sql_alter_column_no_default % {


### PR DESCRIPTION
Thanks Rob Golding from Zapier for the report.