### PR TITLE
Fixed #27159 -- Prevented pickling a query with an __in=inner_qs lookup from evaluating inner_qs.

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -83,6 +83,22 @@ class RelatedIn(In):
         else:
             return super(RelatedIn, self).as_sql(compiler, connection)
 
+    def __getstate__(self):
+        # Avoid circular imports
+        from django.db.models.query import QuerySet
+        state = self.__dict__.copy()
+        if isinstance(self.rhs, QuerySet):
+            state['rhs'] = (self.rhs.__class__, self.rhs.query)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if isinstance(self.rhs, tuple):
+            queryset_class, query = self.rhs
+            queryset = queryset_class()
+            queryset.query = query
+            self.rhs = queryset
+
 
 class RelatedLookupMixin(object):
     def get_prep_lookup(self):


### PR DESCRIPTION
Fixing the issue that RelatedIn right hand side was always pickled as is, thus resulting pickling the whole queryset. Now only query is pickled from RHS.

https://code.djangoproject.com/ticket/27159