### PR TITLE
Fixed #27204 -- Made clashing m2m intermediary table checks ignore unmanaged models.

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1438,12 +1438,12 @@ class ManyToManyField(RelatedField):
         return errors
 
     def _check_table_uniqueness(self, **kwargs):
-        if isinstance(self.remote_field.through, six.string_types):
+        if isinstance(self.remote_field.through, six.string_types) or not self.remote_field.through._meta.managed:
             return []
         registered_tables = {
             model._meta.db_table: model
             for model in self.opts.apps.get_models(include_auto_created=True)
-            if model != self.remote_field.through
+            if model != self.remote_field.through and model._meta.managed
         }
         m2m_db_table = self.m2m_db_table()
         if m2m_db_table in registered_tables:

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -830,6 +830,36 @@ class OtherModelTests(SimpleTestCase):
             )
         ])
 
+    def test_m2m_unmanaged_shadow_models_not_checked(self):
+        class A1(models.Model):
+            pass
+
+        class C1(models.Model):
+            mm_a = models.ManyToManyField(A1, db_table='d1')
+
+        # Unmanaged models that shadow the above models. Reused table names
+        # shouldn't be flagged by any checks.
+        class A2(models.Model):
+            class Meta:
+                managed = False
+
+        class C2(models.Model):
+            mm_a = models.ManyToManyField(A2, through='Intermediate')
+
+            class Meta:
+                managed = False
+
+        class Intermediate(models.Model):
+            a2 = models.ForeignKey(A2, models.CASCADE, db_column='a1_id')
+            c2 = models.ForeignKey(C2, models.CASCADE, db_column='c1_id')
+
+            class Meta:
+                db_table = 'd1'
+                managed = False
+
+        self.assertEqual(C1.check(), [])
+        self.assertEqual(C2.check(), [])
+
     @isolate_apps('django.contrib.auth', kwarg_name='apps')
     def test_lazy_reference_checks(self, apps):
         class DummyModel(models.Model):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27204