### PR TITLE
Fixed #26524 -- Fixed crash in admin change view when displaying many to many forward refs.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -317,7 +317,7 @@ def _get_non_gfk_field(opts, name):
         raise FieldDoesNotExist()
 
     # Avoid coercing <FK>_id fields to FK
-    if field.is_relation and hasattr(field, 'attname') and field.attname == name:
+    if field.is_relation and not field.many_to_many and hasattr(field, 'attname') and field.attname == name:
         raise FieldIsAForeignKeyColumnName()
 
     return field

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -596,8 +596,12 @@ class CyclicTwo(models.Model):
         return self.name
 
 
+@python_2_unicode_compatible
 class Topping(models.Model):
     name = models.CharField(max_length=20)
+
+    def __str__(self):
+        return self.name
 
 
 class Pizza(models.Model):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -4696,6 +4696,14 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         response = self.client.get(reverse('admin:admin_views_topping_add'))
         self.assertEqual(response.status_code, 200)
 
+    def test_readonly_manytomany_forwards_ref(self):
+        topping = Topping.objects.create(name='Salami')
+        pizza = Pizza.objects.create(name='Americano')
+        pizza.toppings.add(topping)
+        response = self.client.get(reverse('admin:admin_views_pizza_change', args=(pizza.pk,)))
+        self.assertContains(response, '<label>Toppings:</label>', html=True)
+        self.assertContains(response, '<p>Salami</p>', html=True)
+
     def test_readonly_onetoone_backwards_ref(self):
         """
         Can reference a reverse OneToOneField in ModelAdmin.readonly_fields.

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -52,9 +52,9 @@ from .models import (
     CyclicOne, CyclicTwo, DooHickey, Employee, EmptyModel, ExternalSubscriber,
     Fabric, FancyDoodad, FieldOverridePost, FilteredManager, FooAccount,
     FoodDelivery, FunkyTag, Gallery, Grommet, Inquisition, Language, Link,
-    MainPrepopulated, ModelWithStringPrimaryKey, OtherStory, Paper, Parent,
-    ParentWithDependentChildren, ParentWithUUIDPK, Person, Persona, Picture,
-    Pizza, Plot, PlotDetails, PluggableSearchPerson, Podcast, Post,
+    MainPrepopulated, Media, ModelWithStringPrimaryKey, OtherStory, Paper,
+    Parent, ParentWithDependentChildren, ParentWithUUIDPK, Person, Persona,
+    Picture, Pizza, Plot, PlotDetails, PluggableSearchPerson, Podcast, Post,
     PrePopulatedPost, Promo, Question, Recommendation, Recommender,
     RelatedPrepopulated, RelatedWithUUIDPKModel, Report, Restaurant,
     RowLevelChangePermissionModel, SecretHideout, Section, ShortMessage,
@@ -539,7 +539,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
             self.assertContentBefore(response, 'The First Item', 'The Middle Item')
             self.assertContentBefore(response, 'The Middle Item', 'The Last Item')
 
-    def test_has_related_field_in_list_display(self):
+    def test_has_related_field_in_list_display_fk(self):
         """Joins shouldn't be performed for <FK>_id fields in list display."""
         state = State.objects.create(name='Karnataka')
         City.objects.create(state=state, name='Bangalore')
@@ -549,6 +549,18 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertIs(response.context['cl'].has_related_field_in_list_display(), True)
 
         response.context['cl'].list_display = ['id', 'name', 'state_id']
+        self.assertIs(response.context['cl'].has_related_field_in_list_display(), False)
+
+    def test_has_related_field_in_list_display_o2o(self):
+        """Joins shouldn't be performed for <O2O>_id fields in list display."""
+        media = Media.objects.create(name='Foo')
+        Vodcast.objects.create(media=media)
+        response = self.client.get(reverse('admin:admin_views_vodcast_changelist'), {})
+
+        response.context['cl'].list_display = ['media']
+        self.assertIs(response.context['cl'].has_related_field_in_list_display(), True)
+
+        response.context['cl'].list_display = ['media_id']
         self.assertIs(response.context['cl'].has_related_field_in_list_display(), False)
 
     def test_limited_filter(self):


### PR DESCRIPTION
Thanks Tim Graham for the regression test.

<https://code.djangoproject.com/ticket/26524>