### PR TITLE
Fixed #27219 -- Changed cx_Oracle client encoding to AL32UTF8.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -41,7 +41,7 @@ def _setup_environment(environ):
 
 _setup_environment([
     # Oracle takes client-side character set encoding from the environment.
-    ('NLS_LANG', '.UTF8'),
+    ('NLS_LANG', '.AL32UTF8'),
     # This prevents unicode from getting mangled by getting encoded into the
     # potentially non-unicode database character set.
     ('ORA_NCHAR_LITERAL_REPLACE', 'TRUE'),

--- a/tests/model_fields/test_charfield.py
+++ b/tests/model_fields/test_charfield.py
@@ -1,5 +1,10 @@
+# encoding: utf-8
+from __future__ import unicode_literals
+
+from unittest import skipIf
+
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import connection, models
 from django.test import SimpleTestCase, TestCase
 from django.utils.functional import lazy
 
@@ -20,6 +25,13 @@ class TestCharField(TestCase):
 
     def test_lookup_integer_in_charfield(self):
         self.assertEqual(Post.objects.filter(title=9).count(), 0)
+
+    @skipIf(connection.vendor == 'mysql', 'See https://code.djangoproject.com/ticket/18392')
+    def test_emoji(self):
+        p = Post.objects.create(title='Parrot programs in Python 😀',
+                                body='Catchy title is catchy.')
+        p.refresh_from_db()
+        self.assertEqual(p.title, 'Parrot programs in Python 😀')
 
 
 class ValidationTests(SimpleTestCase):

--- a/tests/model_fields/test_textfield.py
+++ b/tests/model_fields/test_textfield.py
@@ -1,4 +1,9 @@
-from django.db import models
+# encoding: utf-8
+from __future__ import unicode_literals
+
+from unittest import skipIf
+
+from django.db import connection, models
 from django.test import TestCase
 
 from .models import Post
@@ -23,3 +28,10 @@ class TextFieldTests(TestCase):
 
     def test_lookup_integer_in_textfield(self):
         self.assertEqual(Post.objects.filter(body=24).count(), 0)
+
+    @skipIf(connection.vendor == 'mysql', 'See https://code.djangoproject.com/ticket/18392')
+    def test_emoji(self):
+        p = Post.objects.create(title='The way the parrot programs',
+                                body='Parrot programs in Python 😀.')
+        p.refresh_from_db()
+        self.assertEqual(p.body, 'Parrot programs in Python 😀.')


### PR DESCRIPTION
As per documentation at

https://docs.oracle.com/database/121/NLSPG/ch6unicode.htm#NLSPG-GUID-EB57AB68-A390-4814-81DD-6B78D33310CC

Developers are recommended to switch to AL32UTF8 that supports the most
recent Unicode standard and is able to encode 4-byte supplementary
characters properly, unlike UTF8 encoding, that supports only Unicode
version 3 and is unable to properly encode 4-byte characters.

Currently with latest Django I can't store emojis in TextFields using Oracle.
With this change, however, it seems to work for me.

I understand that this needs some tests, so I ask for someone with better knowledge to assist me and direct me to where should I put the tests.

https://code.djangoproject.com/ticket/27219