### PR TITLE
Fixed #27222 -- Refreshed fields that are expressions after Model.save().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -804,6 +804,20 @@ class Model(six.with_metaclass(ModelBase)):
                        force_update=force_update, update_fields=update_fields)
     save.alters_data = True
 
+    def _refresh_expressions(self, update_fields):
+        """
+        Refresh fields that are expressions with the value from the database.
+        """
+        to_refresh = set()
+        for field in self._meta.concrete_fields:
+            if update_fields and field.attname not in update_fields:
+                continue
+            val = getattr(self, field.attname, None)
+            if hasattr(val, 'as_sql'):
+                to_refresh.add(field.attname)
+        if to_refresh:
+            self.refresh_from_db(fields=to_refresh)
+
     def save_base(self, raw=False, force_insert=False,
                   force_update=False, using=None, update_fields=None):
         """
@@ -835,6 +849,7 @@ class Model(six.with_metaclass(ModelBase)):
         # Once saved, this is no longer a to-be-added instance.
         self._state.adding = False
 
+        self._refresh_expressions(update_fields)
         # Signal that the save is complete
         if not meta.auto_created:
             signals.post_save.send(sender=origin, instance=self, created=(not updated),

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -163,21 +163,24 @@ robust: it will only ever update the field based on the value of the field in
 the database when the :meth:`~Model.save()` or ``update()`` is executed, rather
 than based on its value when the instance was retrieved.
 
-``F()`` assignments persist after ``Model.save()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``F()`` assignments are refreshed after ``Model.save()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``F()`` objects assigned to model fields persist after saving the model
-instance and will be applied on each :meth:`~Model.save()`. For example::
+Any expressions, including ``F()`` objects, assigned to model fields are
+refreshed after saving the model instance. For example::
 
-    reporter = Reporters.objects.get(name='Tintin')
-    reporter.stories_filed = F('stories_filed') + 1
-    reporter.save()
+    >>> reporter = Reporters.objects.get(name='Tintin')
+    >>> reporter.stories_filed
+    3
+    >>> reporter.stories_filed = F('stories_filed') + 1
+    >>> reporter.save()
+    >>> reporter.stories_filed
+    4
 
-    reporter.name = 'Tintin Jr.'
-    reporter.save()
+.. versionchanged:: 1.11
 
-``stories_filed`` will be updated twice in this case. If it's initially ``1``,
-the final value will be ``3``.
+    In older versions, expressions assigned to model fields persisted after
+    saving the model instance.
 
 Using ``F()`` in filters
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -446,10 +446,18 @@ When you save an object, Django performs the following steps:
    data is then composed into an SQL statement for insertion into the
    database.
 
-5. **Emit a post-save signal.** The signal
+5. **Refresh any expressions.** Any fields that are assigned to expressions
+   such as ``F('field') + 1`` or ``Lower('field')`` are refreshed with the
+   value from the database.
+
+6. **Emit a post-save signal.** The signal
    :attr:`django.db.models.signals.post_save` is sent, allowing
    any functions listening for that signal to take some customized
    action.
+
+.. versionchanged:: 1.11
+
+    The refresh expressions step was added.
 
 How Django knows to UPDATE vs. INSERT
 -------------------------------------

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -152,7 +152,7 @@ Minor features
   creating :class:`~django.contrib.gis.gdal.GDALRaster` objects.
 
 * Added SpatiaLite support for the
-  :class:`~django.contrib.gis.db.models.functions.IsValid` function,
+  :class:`~django.contrib.gis.db.models.functions.IsValid` function,expressions
   :class:`~django.contrib.gis.db.models.functions.MakeValid` function, and
   :lookup:`isvalid` lookup.
 
@@ -328,6 +328,9 @@ Models
 
 * You can now use the ``unique=True`` option with
   :class:`~django.db.models.FileField`.
+
+* ``Model.save()`` now refreshes the value of any model fields that are
+  assigned to expressions.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/expressions/test_model_save_refresh.py
+++ b/tests/expressions/test_model_save_refresh.py
@@ -1,0 +1,35 @@
+from django.db.models.expressions import F, Value
+from django.db.models.functions import Lower
+from django.test import TestCase
+
+from .models import Employee
+
+
+class ModelSaveFieldRefreshTests(TestCase):
+    def test_insert(self):
+        employee = Employee.objects.create(firstname=Lower(Value('David')), lastname='Smith')
+        refreshed = Employee.objects.get(pk=employee.pk)
+        self.assertEqual(refreshed.firstname, 'david')
+        self.assertEqual(employee.firstname, 'david')
+
+    def test_update(self):
+        employee = Employee.objects.create(firstname='David', lastname='Smith')
+        employee.firstname = Lower('firstname')
+        employee.save()
+        refreshed = Employee.objects.get(pk=employee.pk)
+        self.assertEqual(refreshed.firstname, 'david')
+        self.assertEqual(employee.firstname, 'david')
+
+    def test_update_fields(self):
+        employee = Employee.objects.create(firstname='David', lastname='Smith')
+        employee.firstname = Lower('firstname')
+        employee.save(update_fields=['lastname'])
+        self.assertNotEqual(employee.firstname, 'david')  # Lower(F(firstname))
+        employee.save(update_fields=['firstname'])
+        self.assertEqual(employee.firstname, 'david')
+
+    def test_f_refreshed(self):
+        employee = Employee.objects.create(firstname='David', lastname='Smith', salary=0)
+        employee.salary = F('salary') + 1
+        employee.save()
+        self.assertEqual(employee.salary, 1)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27222
