### PR TITLE
Fixed #27225 -- Made FetchFromCacheMiddleware set Age header for cached responses.

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -72,8 +72,10 @@ def patch_cache_control(response, **kwargs):
     # If there's already a max-age header but we're being asked to set a new
     # max-age, use the minimum of the two ages. In practice this happens when
     # a decorator and a piece of middleware both operate on a given view.
-    if 'max-age' in cc and 'max_age' in kwargs:
-        kwargs['max_age'] = min(int(cc['max-age']), kwargs['max_age'])
+    if 'max_age' in kwargs:
+        kwargs['max_age'] = max_age = int(kwargs['max_age'])
+        if 'max-age' in cc:
+            kwargs['max_age'] = min(int(cc['max-age']), max_age)
 
     # Allow overriding private caching and vice versa
     if 'private' in cc and 'public' in kwargs:

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2171,21 +2171,21 @@ class CacheMiddlewareTest(SimpleTestCase):
             response = view(request)
             response.close()
             self.assertIn('Expires', response)
-            self.assertEqual('Sun, 17 Jul 2016 10:00:02 GMT', response['Expires'])
+            self.assertEqual(response['Expires'], 'Sun, 17 Jul 2016 10:00:02 GMT')
             self.assertIn('Cache-Control', response)
-            self.assertEqual('max-age=2', response['Cache-Control'])
+            self.assertEqual(response['Cache-Control'], 'max-age=2')
             self.assertNotIn('Age', response)
 
-        # Response for second request made later must have Age header
+        # Response for second request made 1 second later must have 'Age: 1' header
         with mock.patch.object(time, 'time', return_value=1468749601):  # Sun, 17 Jul 2016 10:00:01 GMT
             response = view(request)
             response.close()
             self.assertIn('Expires', response)
-            self.assertEqual('Sun, 17 Jul 2016 10:00:02 GMT', response['Expires'])
+            self.assertEqual(response['Expires'], 'Sun, 17 Jul 2016 10:00:02 GMT')
             self.assertIn('Cache-Control', response)
-            self.assertEqual('max-age=2', response['Cache-Control'])
+            self.assertEqual(response['Cache-Control'], 'max-age=2')
             self.assertIn('Age', response)
-            self.assertEqual('1', response['Age'])
+            self.assertEqual(response['Age'], '1')
 
 
 @override_settings(

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2174,6 +2174,7 @@ class CacheMiddlewareTest(SimpleTestCase):
             self.assertEqual('Sun, 17 Jul 2016 10:00:02 GMT', response['Expires'])
             self.assertIn('Cache-Control', response)
             self.assertEqual('max-age=2', response['Cache-Control'])
+            self.assertNotIn('Age', response)
 
         # Second request made later should have different Cache-Control's max-age
         with mock.patch.object(time, 'time', return_value=1468749601):  # Sun, 17 Jul 2016 10:00:01 GMT
@@ -2182,7 +2183,9 @@ class CacheMiddlewareTest(SimpleTestCase):
             self.assertIn('Expires', response)
             self.assertEqual('Sun, 17 Jul 2016 10:00:02 GMT', response['Expires'])
             self.assertIn('Cache-Control', response)
-            self.assertEqual('max-age=1', response['Cache-Control'])
+            self.assertEqual('max-age=2', response['Cache-Control'])
+            self.assertIn('Age', response)
+            self.assertEqual('1', response['Age'])
 
 
 @override_settings(

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -2176,7 +2176,7 @@ class CacheMiddlewareTest(SimpleTestCase):
             self.assertEqual('max-age=2', response['Cache-Control'])
             self.assertNotIn('Age', response)
 
-        # Second request made later should have different Cache-Control's max-age
+        # Response for second request made later must have Age header
         with mock.patch.object(time, 'time', return_value=1468749601):  # Sun, 17 Jul 2016 10:00:01 GMT
             response = view(request)
             response.close()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27225
