### PR TITLE
Fixed #27229 -- Aggregates in admin change lists

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -482,6 +482,7 @@ class ModelAdmin(BaseModelAdmin):
 
     list_display = ('__str__',)
     list_display_links = ()
+    list_aggregates = ()
     list_filter = ()
     list_select_related = False
     list_per_page = 100

--- a/django/contrib/admin/templates/admin/change_list_results.html
+++ b/django/contrib/admin/templates/admin/change_list_results.html
@@ -33,6 +33,11 @@
 <tr class="{% cycle 'row1' 'row2' %}">{% for item in result %}{{ item }}{% endfor %}</tr>
 {% endfor %}
 </tbody>
+{% if result_footers %}
+<tfoot>
+<tr>{% for aggregate in result_footers %}<th title="{{ aggregate.fn_name }}">{{ aggregate.text }}</th>{% endfor %}</tr>
+</tfoot>
+{% endif %}
 </table>
 </div>
 {% endif %}

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -179,6 +179,17 @@ def result_headers(cl):
         }
 
 
+def result_footers(cl):
+    """
+    Generates the list footer aggregates.
+    """
+    for i, field_name in enumerate(cl.list_display):
+        fn_name, val = '', ''
+        if field_name in cl.result_list_aggregates:
+            fn_name, val = cl.result_list_aggregates[field_name]
+        yield {'text': val, 'fn_name': fn_name}
+
+
 def _boolean_icon(field_val):
     icon_url = static('admin/img/icon-%s.svg' %
                       {True: 'yes', False: 'no', None: 'unknown'}[field_val])
@@ -336,6 +347,7 @@ def result_list(cl):
     return {'cl': cl,
             'result_hidden_fields': list(result_hidden_fields(cl)),
             'result_headers': headers,
+            'result_footers': list(result_footers(cl)),
             'num_sorted_fields': num_sorted_fields,
             'results': list(results(cl))}
 

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -9,7 +9,8 @@ from django.contrib.admin.options import (
     IS_POPUP_VAR, TO_FIELD_VAR, IncorrectLookupParameters,
 )
 from django.contrib.admin.utils import (
-    get_fields_from_path, lookup_needs_distinct, prepare_lookup_value, quote, label_for_field,
+    get_fields_from_path, label_for_field, lookup_needs_distinct,
+    prepare_lookup_value, quote,
 )
 from django.core.exceptions import (
     FieldDoesNotExist, ImproperlyConfigured, SuspiciousOperation,

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -9,7 +9,7 @@ from django.contrib.admin.options import (
     IS_POPUP_VAR, TO_FIELD_VAR, IncorrectLookupParameters,
 )
 from django.contrib.admin.utils import (
-    get_fields_from_path, lookup_needs_distinct, prepare_lookup_value, quote,
+    get_fields_from_path, lookup_needs_distinct, prepare_lookup_value, quote, label_for_field,
 )
 from django.core.exceptions import (
     FieldDoesNotExist, ImproperlyConfigured, SuspiciousOperation,
@@ -195,9 +195,37 @@ class ChangeList(object):
         self.show_admin_actions = not self.show_full_result_count or bool(full_result_count)
         self.full_result_count = full_result_count
         self.result_list = result_list
+        self.result_list_aggregates = self.get_result_aggregates(result_list)
         self.can_show_all = can_show_all
         self.multi_page = multi_page
         self.paginator = paginator
+
+    def get_result_aggregates(self, result_queryset):
+        fields = {}
+        aggregate_funcs = {}
+
+        # Build the arguments for the QuerySet.aggregate() method.
+        for field_name, aggregate_class in self.model_admin.list_aggregates:
+            _, field_attr = label_for_field(field_name, self.model, self.model_admin, True)
+            model_field_name = getattr(field_attr, 'admin_aggregate_field', field_name) if field_attr else field_name
+
+            fields[model_field_name] = (field_name, field_attr)
+            aggregate_funcs[model_field_name] = aggregate_class(model_field_name)
+        
+        result_aggregates = {}
+
+        # Call QuerySet.aggregate() and process the results.
+        if aggregate_funcs:
+            for model_field_name, result in result_queryset.aggregate(**aggregate_funcs).items():
+                if result:
+                    field_name, field_attr = fields[model_field_name]
+                    result_aggregates[field_name] = (
+                        aggregate_funcs[model_field_name].name,
+                        field_attr(result) if callable(field_attr) else result
+                    )
+        
+        return result_aggregates
+
 
     def _get_default_ordering(self):
         ordering = []

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -211,7 +211,7 @@ class ChangeList(object):
 
             fields[model_field_name] = (field_name, field_attr)
             aggregate_funcs[model_field_name] = aggregate_class(model_field_name)
-        
+
         result_aggregates = {}
 
         # Call QuerySet.aggregate() and process the results.
@@ -223,9 +223,8 @@ class ChangeList(object):
                         aggregate_funcs[model_field_name].name,
                         field_attr(result) if callable(field_attr) else result
                     )
-        
-        return result_aggregates
 
+        return result_aggregates
 
     def _get_default_ordering(self):
         ordering = []

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -245,7 +245,7 @@ subclass::
             empty_value_display = '-empty-'
 
     You can also override ``empty_value_display`` for all admin pages with
-    :attr:`AdminSite.empty_value_display`, or for specific fields like this::
+    :attr:`AdminSite.empty_value_display`, or for specific fields like this:::
 
         from django.contrib import admin
 
@@ -813,6 +813,54 @@ subclass::
         class AuditEntryAdmin(admin.ModelAdmin):
             list_display = ('timestamp', 'message')
             list_display_links = None
+
+.. attribute:: ModelAdmin.list_aggregates
+
+    .. versionadded:: 1.11
+
+    Set ``list_aggregates`` to control which aggregations are displayed on the change
+    list page of the admin.
+    The aggregations will be performed on the displayed results (i.e. not on the full queryset).
+
+    For example, let’s consider the following model::
+
+        from django.db import models
+
+        class Employee(models.Model):
+            name = models.CharField(max_length=64)
+            age = models.PositiveIntegerField()
+            monthly_salary = models.DecimalField(decimal_places=2, max_digits=7)
+
+    If you want to display the average age of your employees along with the sum of their
+    salaries, you would specify ``list_aggregates`` like this::
+
+        from django.contrib import admin
+        from django.db.models import Avg, Sum
+
+        class EmployeeAdmin(admin.ModelAdmin):
+            list_display = ('name', 'age', 'monthly_salary')
+            list_aggregates = (('age', Avg), ('monthly_salary', Sum))
+
+    You can use the same four possible value types as in ``list_display``.
+    However, if you do not specify a field of the model, you must set ``admin_aggregate_field``
+    to the actual name of the model field to aggregate::
+
+        class EmployeeAdmin(admin.ModelAdmin):
+            list_display = ('name', 'age', 'formatted_monthly_salary')
+            list_aggregates = (('age', Avg), ('formatted_monthly_salary', Sum))
+
+            def formatted_monthly_salary(self, employee_or_salary):
+                salary = getattr(employee_or_salary, 'monthly_salary', employee_or_salary)
+                return '${0:,.2f}'.format(salary)
+
+            formatted_monthly_salary.admin_aggregate_field = 'monthly_salary'
+
+    .. note::
+
+        * Only one aggregate result can be displayed for a field.
+
+        * Any field in ``list_aggregates`` must also be in ``list_display``.
+          You can't display an aggregate result for a field that's not displayed!
 
 .. _admin-list-editable:
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -245,7 +245,7 @@ subclass::
             empty_value_display = '-empty-'
 
     You can also override ``empty_value_display`` for all admin pages with
-    :attr:`AdminSite.empty_value_display`, or for specific fields like this:::
+    :attr:`AdminSite.empty_value_display`, or for specific fields like this::
 
         from django.contrib import admin
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -67,6 +67,7 @@ Minor features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :attr:`.ModelAdmin.date_hierarchy` can now reference fields across relations.
+* Added :attr:`.ModelAdmin.list_aggregates` to display aggregation results in change lists.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
-from django.db.models import Avg
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator
+from django.db.models import Avg
 
 from .models import Child, Event, Parent, Swallow
 

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Avg
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator
@@ -39,6 +40,11 @@ class ChildAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         return super(ChildAdmin, self).get_queryset(request).select_related("parent")
+
+
+class ChildAggregateAdmin(admin.ModelAdmin):
+    list_display = ['name', 'age']
+    list_aggregates = [('age', Avg)]
 
 
 class CustomPaginationAdmin(ChildAdmin):

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -18,7 +18,7 @@ from django.utils import formats, six
 from django.utils.deprecation import RemovedInDjango20Warning
 
 from .admin import (
-    BandAdmin, ChildAdmin, ChordsBandAdmin, ConcertAdmin,
+    BandAdmin, ChildAdmin, ChildAggregateAdmin, ChordsBandAdmin, ConcertAdmin,
     CustomPaginationAdmin, CustomPaginator, DynamicListDisplayChildAdmin,
     DynamicListDisplayLinksChildAdmin, DynamicListFilterChildAdmin,
     DynamicSearchFieldsChildAdmin, EmptyValueChildAdmin, EventAdmin,
@@ -111,6 +111,24 @@ class ChangeListTests(TestCase):
             *get_changelist_args(ia, list_select_related=ia.get_list_select_related(request))
         )
         self.assertEqual(cl.queryset.query.select_related, {'player': {}, 'band': {}})
+
+    def test_result_list_aggregate_html(self):
+        """
+        Test for #27229: a cell with an aggregate result should be present
+        in the output HTML.
+        """
+        child1 = Child.objects.create(name='name', age=10)
+        child2 = Child.objects.create(name='name', age=20)
+        children_age_avg = (child1.age + child2.age) / 2
+        m = ChildAggregateAdmin(Child, custom_site)
+        request = self.factory.get('/child/')
+        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl.formset = None
+        template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
+        context = Context({'cl': cl})
+        table_output = template.render(context)
+        avg_th_html = '<th title="Avg">{}</th>'.format(children_age_avg)
+        self.assertInHTML(avg_th_html, table_output, msg_prefix='Failed to find aggregate cell')
 
     def test_result_list_empty_changelist_value(self):
         """


### PR DESCRIPTION
Example:

![django-admin](https://cloud.githubusercontent.com/assets/1499307/18555738/964622e0-7b71-11e6-9a53-3a525ba25b4b.png)
