### PR TITLE
Fixed #27118 -- Made get_or_create()/update_or_create() error for a non-field in defaults.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -527,6 +527,18 @@ class QuerySet(object):
                 lookup[f.name] = lookup.pop(f.attname)
         params = {k: v for k, v in kwargs.items() if LOOKUP_SEP not in k}
         params.update(defaults)
+        invalid_params = []
+        for param in params:
+            try:
+                self.model._meta.get_field(param)
+            except exceptions.FieldDoesNotExist:
+                invalid_params.append(param)
+        if invalid_params:
+            raise exceptions.FieldError(
+                "Invalid field name(s) for model %s: '%s'." % (
+                    self.model._meta.object_name,
+                    "', '".join(sorted(invalid_params)),
+                ))
         return lookup, params
 
     def _earliest_or_latest(self, field_name=None, direction="-"):

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -446,6 +446,14 @@ Protection against insecure redirects in :mod:`django.contrib.auth` and ``i18n``
 and :func:`~django.views.i18n.set_language` protect users from being redirected
 to non-HTTPS ``next`` URLs when the app is running over HTTPS.
 
+``QuerySet.get_or_create()`` and ``update_or_create()`` check ``defaults``
+--------------------------------------------------------------------------
+
+To prevent typos from passing silently,
+:meth:`~django.db.models.query.QuerySet.get_or_create` and
+:meth:`~django.db.models.query.QuerySet.update_or_create` ensure that defaults
+are model fields.
+
 Miscellaneous
 -------------
 

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -5,9 +5,10 @@ import traceback
 from datetime import date, datetime, timedelta
 from threading import Thread
 
+from django.core.exceptions import FieldError
 from django.db import DatabaseError, IntegrityError, connection
 from django.test import (
-    TestCase, TransactionTestCase, ignore_warnings, skipUnlessDBFeature,
+    SimpleTestCase, TestCase, TransactionTestCase, ignore_warnings, skipUnlessDBFeature,
 )
 from django.utils.encoding import DjangoUnicodeDecodeError
 
@@ -484,3 +485,27 @@ class UpdateOrCreateTransactionTests(TransactionTestCase):
         updated_person = Person.objects.get(first_name='John')
         self.assertGreater(after_update - before_start, timedelta(seconds=0.5))
         self.assertEqual(updated_person.last_name, 'NotLennon')
+
+
+class InvalidCreateArgumentsTests(SimpleTestCase):
+    msg = "Invalid field name(s) for model Thing: 'nonexistent'."
+
+    def test_get_or_create_with_invalid_defaults(self):
+        with self.assertRaisesMessage(FieldError, self.msg):
+            Thing.objects.get_or_create(name='a', defaults={'nonexistent': 'b'})
+
+    def test_get_or_create_with_invalid_kwargs(self):
+        with self.assertRaisesMessage(FieldError, self.msg):
+            Thing.objects.get_or_create(name='a', nonexistent='b')
+
+    def test_update_or_create_with_invalid_defaults(self):
+        with self.assertRaisesMessage(FieldError, self.msg):
+            Thing.objects.update_or_create(name='a', defaults={'nonexistent': 'b'})
+
+    def test_update_or_create_with_invalid_kwargs(self):
+        with self.assertRaisesMessage(FieldError, self.msg):
+            Thing.objects.update_or_create(name='a', nonexistent='b')
+
+    def test_multiple_invalid_fields(self):
+        with self.assertRaisesMessage(FieldError, "Invalid field name(s) for model Thing: 'invalid', 'nonexistent'"):
+            Thing.objects.update_or_create(name='a', nonexistent='b', defaults={'invalid': 'c'})


### PR DESCRIPTION
Specifying an incorrect field in the `get_or_create` / `update_or_create` should not fail silently because it is likely a programming error.

For more details, see https://code.djangoproject.com/ticket/27118.

As Tim noted, this is a backward-incompatible change. If a smoother landing of this feature seems like a better option, we could first raise a warning then turn it into an error in a next version.

This solution covers for incorrect defaults and incorrect exact keyword arguments (without `LOOKUP_SEP`) that would be used for the model creation. It does not cover invalid non-exact lookups such as `does_not_exist__icontains`.

I would not document this change outside of the changelog as I would have expected Django to tell me if my defaults / fields lookups were incorrect, but it could help some users if an error pops out during a version upgrade. What do you think?