### PR TITLE
Refs #27118 -- Made FieldDoesNotExist messages uniform across Python versions

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -223,7 +223,7 @@ class Options(object):
                     if f.name == query or f.attname == query
                 )
             except StopIteration:
-                raise FieldDoesNotExist('%s has no field named %r' % (self.object_name, query))
+                raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, query))
 
             self.ordering = ('_order',)
             if not any(isinstance(field, OrderWrt) for field in model._meta.local_fields):
@@ -605,7 +605,7 @@ class Options(object):
             # unavailable, therefore we throw a FieldDoesNotExist exception.
             if not self.apps.models_ready:
                 raise FieldDoesNotExist(
-                    "%s has no field named %r. The app cache isn't ready yet, "
+                    "%s has no field named '%s'. The app cache isn't ready yet, "
                     "so if this is an auto-created related field, it won't "
                     "be available yet." % (self.object_name, field_name)
                 )
@@ -615,7 +615,7 @@ class Options(object):
             # field map.
             return self.fields_map[field_name]
         except KeyError:
-            raise FieldDoesNotExist('%s has no field named %r' % (self.object_name, field_name))
+            raise FieldDoesNotExist("%s has no field named '%s'" % (self.object_name, field_name))
 
     def get_base_chain(self, model):
         """

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1339,7 +1339,7 @@ class Query(object):
                 if pos == -1 or fail_on_missing:
                     field_names = list(get_field_names_from_opts(opts))
                     available = sorted(field_names + list(self.annotation_select))
-                    raise FieldError("Cannot resolve keyword %r into field. "
+                    raise FieldError("Cannot resolve keyword '%s' into field. "
                                      "Choices are: %s" % (name, ", ".join(available)))
                 break
             # Check if we need any joins for concrete inheritance cases (the

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -237,7 +237,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             self.assertEqual(book.sum_rating, book.rating)
 
     def test_filter_wrong_annotation(self):
-        with six.assertRaisesRegex(self, FieldError, "Cannot resolve keyword .*"):
+        with self.assertRaisesMessage(FieldError, "Cannot resolve keyword 'nope' into field."):
             list(Book.objects.annotate(
                 sum_rating=Sum('rating')
             ).filter(sum_rating=F('nope')))

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -307,7 +307,7 @@ class NonAggregateAnnotationTestCase(TestCase):
             self.assertEqual(book.rating, 5)
             self.assertEqual(book.other_rating, 4)
 
-        with six.assertRaisesRegex(self, FieldDoesNotExist, "\w has no field named u?'other_rating'"):
+        with self.assertRaisesMessage(FieldDoesNotExist, "Book has no field named 'other_rating'"):
             book = qs.defer('other_rating').get(other_rating=4)
 
     def test_mti_annotations(self):

--- a/tests/dates/tests.py
+++ b/tests/dates/tests.py
@@ -6,7 +6,6 @@ from unittest import skipUnless
 from django.core.exceptions import FieldError
 from django.db import connection
 from django.test import TestCase, override_settings
-from django.utils import six
 
 from .models import Article, Category, Comment
 
@@ -86,10 +85,9 @@ class DatesTests(TestCase):
             Article.objects.dates()
 
     def test_dates_fails_when_given_invalid_field_argument(self):
-        six.assertRaisesRegex(
-            self,
+        self.assertRaisesMessage(
             FieldError,
-            "Cannot resolve keyword u?'invalid_field' into field. Choices are: "
+            "Cannot resolve keyword 'invalid_field' into field. Choices are: "
             "categories, comments, id, pub_date, pub_datetime, title",
             Article.objects.dates,
             "invalid_field",

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -688,7 +688,7 @@ class ExpressionsNumericTests(TestCase):
         self.assertEqual(Number.objects.get(pk=n.pk).float, Approximate(256.900, places=3))
 
     def test_incorrect_field_expression(self):
-        with six.assertRaisesRegex(self, FieldError, "Cannot resolve keyword u?'nope' into field.*"):
+        with self.assertRaisesMessage(FieldError, "Cannot resolve keyword 'nope' into field."):
             list(Employee.objects.filter(firstname=F('nope')))
 
 


### PR DESCRIPTION
This PR relates to #7255.

The exception message used `repr` to format the field name. The field name is unicode and its `repr` changes depending on the version of Python:

- Python 2: `u'field_name'`
- Python 3: `'field_name'`

This is not handy to test and lead to the use of `six.assertRaisesRegex()` to tolerate the presence of the leading `u` character. A more consistent approach is to use `'%s'` in the exception message instead of `%r`, to make sure the message is the same on both versions.