### PR TITLE
Update fields.txt

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1897,8 +1897,8 @@ Field API reference
         :class:`~django.forms.ModelForm`.
 
         By default, if both ``form_class`` and ``choices_form_class`` are
-        ``None``, it uses :class:`~django.forms.CharField`; if
-        ``choices_form_class`` is given, it returns
+        ``None``, it uses :class:`~django.forms.CharField`; if attribute `choices`
+        is given while ``choices_form_class`` not, it returns 
         :class:`~django.forms.TypedChoiceField`.
 
         See :ref:`specifying-form-field-for-model-field` for usage.


### PR DESCRIPTION
According to the lines from 857 to 860 of [this file](https://github.com/django/django/blob/master/django/db/models/fields/__init__.py), `~django.forms.TypedChoiceField` is only returned when ``choices_form_class`` is ``None``.