### PR TITLE
[az] locale format fix

### DIFF
--- a/django/conf/locale/az/formats.py
+++ b/django/conf/locale/az/formats.py
@@ -5,10 +5,10 @@ from __future__ import unicode_literals
 
 # The *_FORMAT strings use the Django date format syntax,
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
-DATE_FORMAT = 'j E Y г.'
+DATE_FORMAT = 'j E Y'
 TIME_FORMAT = 'G:i'
-DATETIME_FORMAT = 'j E Y г. G:i'
-YEAR_MONTH_FORMAT = 'F Y г.'
+DATETIME_FORMAT = 'j E Y, G:i'
+YEAR_MONTH_FORMAT = 'F Y'
 MONTH_DAY_FORMAT = 'j F'
 SHORT_DATE_FORMAT = 'd.m.Y'
 SHORT_DATETIME_FORMAT = 'd.m.Y H:i'


### PR DESCRIPTION
Removed invalid character from datetime format in Azerbaijani locale.

Character is in cyrillic alphabet, meaning is year. Azerbaijani switched to latin letters after Soviets and we don't add il (meaning year) in when writing date time format (we use it in a long form like: 18 May 2016[-cı, -ci, -cu, -cü - depending on number] il, 18:00. Without adding that affix to year value there is no meaning for using word "year" (il).)