### PR TITLE
Fixed #20705 -- Made PasswordResetForm usable for user models that use an email field not named 'email'.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -138,5 +138,12 @@ class AbstractBaseUser(models.Model):
         return salted_hmac(key_salt, self.password).hexdigest()
 
     @classmethod
+    def get_email_field_name(cls):
+        try:
+            return cls.EMAIL_FIELD
+        except AttributeError:
+            return 'email'
+
+    @classmethod
     def normalize_username(cls, username):
         return unicodedata.normalize('NFKC', force_text(username))

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -248,14 +248,17 @@ class PasswordResetForm(forms.Form):
         email_message.send()
 
     def get_users(self, email):
-        """Given an email, return matching user(s) who should receive a reset.
+        """
+        Given an email , return matching user(s) who should receive a reset.
 
         This allows subclasses to more easily customize the default policies
         that prevent inactive users and users with unusable passwords from
         resetting their password.
         """
-        active_users = get_user_model()._default_manager.filter(
-            email__iexact=email, is_active=True)
+        UserModel = get_user_model()
+        active_users = UserModel._default_manager.filter(**{
+            '%s__iexact' % UserModel.get_email_field_name(): email,
+            'is_active': True, })
         return (u for u in active_users if u.has_usable_password())
 
     def save(self, domain_override=None,
@@ -277,7 +280,7 @@ class PasswordResetForm(forms.Form):
             else:
                 site_name = domain = domain_override
             context = {
-                'email': user.email,
+                'email': email,
                 'domain': domain,
                 'site_name': site_name,
                 'uid': urlsafe_base64_encode(force_bytes(user.pk)),
@@ -289,7 +292,7 @@ class PasswordResetForm(forms.Form):
                 context.update(extra_email_context)
             self.send_mail(
                 subject_template_name, email_template_name, context, from_email,
-                user.email, html_email_template_name=html_email_template_name,
+                email, html_email_template_name=html_email_template_name,
             )
 
 

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -334,6 +334,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
     objects = UserManager()
 
     USERNAME_FIELD = 'username'
+    EMAIL_FIELD = 'email'
     REQUIRED_FIELDS = ['email']
 
     class Meta:

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -256,6 +256,11 @@ Forms
   <django.forms.Form.get_initial_for_field>` method returns initial data for a
   form field.
 
+* :class:`~django.contrib.auth.forms.PasswordResetForm` supports custom user
+  models that use an email field named something other than ``'email'``.
+  Set :attr:`~django.contrib.auth.models.CustomUser.EMAIL_FIELD` to the name
+  of the field.
+
 Generic Views
 ~~~~~~~~~~~~~
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -547,6 +547,14 @@ password resets. You must then provide some key implementation details:
         value (the :attr:`~django.db.models.Field.primary_key` by default) of an
         existing instance.
 
+    .. attribute:: EMAIL_FIELD
+
+        .. versionadded:: 1.11
+
+        A string describing the name of the email field on the ``User`` model.
+        This value is returned by
+        :func:`~django.contrib.auth.models.AbstractBaseUser.get_email_field_name()`.
+
     .. attribute:: REQUIRED_FIELDS
 
         A list of the field names that will be prompted for when creating a
@@ -702,6 +710,14 @@ The following attributes and methods are available on any subclass of
         Returns an HMAC of the password field. Used for
         :ref:`session-invalidation-on-password-change`.
 
+    .. classmethod:: get_email_field_name(cls)
+
+       .. versionadded:: 1.11
+
+       Returns the name of the email field specified by the model attribute
+       ``EMAIL_FIELD``. If ``EMAIL_FIELD`` is not specified, ``'email'`` is
+       returned.
+
 :class:`~models.AbstractUser` subclasses :class:`~models.AbstractBaseUser`:
 
 .. class:: models.AbstractUser
@@ -810,9 +826,12 @@ The following forms make assumptions about the user model and can be used as-is
 if those assumptions are met:
 
 * :class:`~django.contrib.auth.forms.PasswordResetForm`: Assumes that the user
-  model has a field named ``email`` that can be used to identify the user and a
-  boolean field named ``is_active`` to prevent password resets for inactive
-  users.
+  model has a field that can be used to identify the user. By default, the
+  expected field name is ``email`` which can be changed by setting the
+  ``User`` model attribute
+  :attr:`~django.contrib.auth.models.CustomUser.EMAIL_FIELD`. Additionally,
+  a boolean field named ``is_active`` is required in order to prevent password
+  resets for inactive users.
 
 Finally, the following forms are tied to
 :class:`~django.contrib.auth.models.User` and need to be rewritten or extended

--- a/tests/auth_tests/models/with_custom_email_field.py
+++ b/tests/auth_tests/models/with_custom_email_field.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import BaseUserManager
+from django.db import models
+
+
+class CustomEmailFieldUserManager(BaseUserManager):
+    def create_user(self, username, password, email):
+        user = self.model(username=username)
+        user.set_password(password)
+        user.email_address = email
+        user.save(using=self._db)
+        return user
+
+    def get_by_natural_key(self, username):
+        return self.get(username=username)
+
+
+class CustomEmailField(AbstractBaseUser):
+    username = models.CharField(max_length=255)
+    password = models.CharField(max_length=255)
+    email_address = models.EmailField()
+    is_active = models.BooleanField(default=True)
+
+    EMAIL_FIELD = 'email_address'
+
+    objects = CustomEmailFieldUserManager()

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -26,6 +26,7 @@ from django.utils.translation import ugettext as _
 from .models.custom_user import (
     CustomUser, CustomUserWithoutIsActiveField, ExtensionUser,
 )
+from .models.with_custom_email_field import CustomEmailField
 from .models.with_integer_username import IntegerUsernameUser
 from .settings import AUTH_TEMPLATES
 
@@ -811,6 +812,16 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
             r'^<html><a href="http://example.com/reset/[\w/-]+/">Link</a></html>$',
             message.get_payload(1).get_payload()
         ))
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomEmailField')
+    def test_custom_email_field(self):
+        email = 'test@mail.com'
+        CustomEmailField.objects.create_user('test name', 'test password', email)
+        form = PasswordResetForm({'email': email})
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(form.cleaned_data['email'], email)
+        self.assertEqual(len(mail.outbox), 1)
 
 
 class ReadOnlyPasswordHashTest(SimpleTestCase):

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.conf.global_settings import PASSWORD_HASHERS
 from django.contrib.auth import get_user_model
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.hashers import get_hasher
 from django.contrib.auth.models import (
     AbstractUser, Group, Permission, User, UserManager,
@@ -11,6 +12,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.db.models.signals import post_save
 from django.test import TestCase, mock, override_settings
+
+from .models.with_custom_email_field import CustomEmailField
 
 
 class NaturalKeysTestCase(TestCase):
@@ -159,6 +162,14 @@ class AbstractBaseUserTests(TestCase):
                 username = user.get_username()
                 self.assertNotEqual(username, ohm_username)
                 self.assertEqual(username, 'iamtheΩ')  # U+03A9 GREEK CAPITAL LETTER OMEGA
+
+    def test_default_email(self):
+        user = AbstractBaseUser()
+        self.assertEqual(user.get_email_field_name(), 'email')
+
+    def test_custom_email(self):
+        user = CustomEmailField()
+        self.assertEqual(user.get_email_field_name(), 'email_address')
 
 
 class AbstractUserTestCase(TestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/20705