### PR TITLE
Fixed #27244 -- Corrected thousand separator for the Greek locale

### DIFF
--- a/django/conf/locale/el/formats.py
+++ b/django/conf/locale/el/formats.py
@@ -34,5 +34,5 @@ DATETIME_INPUT_FORMATS = [
     '%Y-%m-%d',              # '2006-10-25'
 ]
 DECIMAL_SEPARATOR = ','
-THOUSAND_SEPARATOR = '\xa0'  # non-breaking space
+THOUSAND_SEPARATOR = '.'
 NUMBER_GROUPING = 3


### PR DESCRIPTION
Direct link to ticket: https://code.djangoproject.com/ticket/27244. Pinging @spapas @pmav99 for a +1.