### PR TITLE
Refs #27025 -- Fixed ArrayField querying on Python 3.6.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -129,13 +129,14 @@ class ArrayField(Field):
         transform = super(ArrayField, self).get_transform(name)
         if transform:
             return transform
-        try:
-            index = int(name)
-        except ValueError:
-            pass
-        else:
-            index += 1  # postgres uses 1-indexing
-            return IndexTransformFactory(index, self.base_field)
+        if '_' not in name:
+            try:
+                index = int(name)
+            except ValueError:
+                pass
+            else:
+                index += 1  # postgres uses 1-indexing
+                return IndexTransformFactory(index, self.base_field)
         try:
             start, end = name.split('_')
             start = int(start) + 1

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -5,6 +5,7 @@ import uuid
 
 from django import forms
 from django.core import exceptions, serializers, validators
+from django.core.exceptions import FieldError
 from django.core.management import call_command
 from django.db import IntegrityError, connection, models
 from django.test import TransactionTestCase, override_settings
@@ -304,6 +305,15 @@ class TestQuerying(PostgreSQLTestCase):
             ),
             [self.objs[3]]
         )
+
+    def test_unsupported_lookup(self):
+        msg = "Unsupported lookup '0_bar' for ArrayField or join on the field not permitted."
+        with self.assertRaisesMessage(FieldError, msg):
+            list(NullableIntegerArrayModel.objects.filter(field__0_bar=[2]))
+
+        msg = "Unsupported lookup '0bar' for ArrayField or join on the field not permitted."
+        with self.assertRaisesMessage(FieldError, msg):
+            list(NullableIntegerArrayModel.objects.filter(field__0bar=[2]))
 
 
 class TestDateTimeExactQuerying(PostgreSQLTestCase):


### PR DESCRIPTION
Python 3.6 parses strings like '0_1' as numeric literals.
http://bugs.python.org/issue26331

With a couple extra tests so I didn't break some things while refactoring.