### PR TITLE
Optimization for get_search_results() in admin

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -899,10 +899,12 @@ class ModelAdmin(BaseModelAdmin):
         if search_fields and search_term:
             orm_lookups = [construct_search(str(search_field))
                            for search_field in search_fields]
+            and_queries = []
             for bit in search_term.split():
                 or_queries = [models.Q(**{orm_lookup: bit})
                               for orm_lookup in orm_lookups]
-                queryset = queryset.filter(reduce(operator.or_, or_queries))
+                and_queries.append(reduce(operator.or_, or_queries))
+            queryset = queryset.filter(reduce(operator.and_, and_queries))
             if not use_distinct:
                 for search_spec in orm_lookups:
                     if lookup_needs_distinct(self.opts, search_spec):


### PR DESCRIPTION
When searching in fields of reverse relations, the previous implementation for constructing the queryset inside the get_search_results() method, caused Django ORM to introduce unnecessary JOINs in the final query (related issues: https://code.djangoproject.com/ticket/16603 and https://code.djangoproject.com/ticket/25789). The more words were in the search term the more inefficient was the query. This small patch seems that it makes Django ORM take a different path that does not introduce unnecessary JOINs. Searching with a great number of words in the searching term is not a problem anymore.