### PR TITLE
Fixed #25361: Unpickling of QuerySet fails in presence of abstract intermediate model

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -66,6 +66,11 @@ def _load_field(app_label, model_name, field_name):
     return apps.get_model(app_label, model_name)._meta.get_field(field_name)
 
 
+def _load_field_for_abstract(app_label, model_name, field_name):
+    from django.utils.module_loading import import_string
+    return import_string('%s.models.%s'%(app_label, model_name))._meta.get_field(field_name)
+
+
 # A guide to Field parameters:
 #
 #   * name:      The name of the field specified in the model.
@@ -503,7 +508,11 @@ class Field(RegisterLookupMixin):
             # Deferred model will not be found from the app registry. This
             # could be fixed by reconstructing the deferred model on unpickle.
             raise RuntimeError("Fields of deferred models can't be reduced")
-        return _load_field, (self.model._meta.app_label, self.model._meta.object_name,
+        if self.model._meta.abstract:
+            func = _load_field_for_abstract
+        else:
+            func = _load_field
+        return func, (self.model._meta.app_label, self.model._meta.object_name,
                              self.name)
 
     def get_pk_value_on_save(self, instance):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -68,7 +68,7 @@ def _load_field(app_label, model_name, field_name):
 
 def _load_field_for_abstract(app_label, model_name, field_name):
     from django.utils.module_loading import import_string
-    return import_string('%s.models.%s'%(app_label, model_name))._meta.get_field(field_name)
+    return import_string('%s.models.%s' % (app_label, model_name))._meta.get_field(field_name)
 
 
 # A guide to Field parameters:
@@ -512,8 +512,9 @@ class Field(RegisterLookupMixin):
             func = _load_field_for_abstract
         else:
             func = _load_field
-        return func, (self.model._meta.app_label, self.model._meta.object_name,
-                             self.name)
+        return func, (
+            self.model._meta.app_label, self.model._meta.object_name, self.name
+        )
 
     def get_pk_value_on_save(self, instance):
         """


### PR DESCRIPTION
This is to fix this issue with pickling fields on abstract models.

https://code.djangoproject.com/ticket/25361#comment:2