### PR TITLE
Removed unused regexes from django.utils.html.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -33,14 +33,6 @@ word_split_re = re.compile(r'''([\s<>"']+)''')
 simple_url_re = re.compile(r'^https?://\[?\w', re.IGNORECASE)
 simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)($|/.*)$', re.IGNORECASE)
 simple_email_re = re.compile(r'^\S+@\S+\.\S+$')
-link_target_attribute_re = re.compile(r'(<a [^>]*?)target=[^\s>]+')
-html_gunk_re = re.compile(
-    r'(?:<br clear="all">|<i><\/i>|<b><\/b>|<em><\/em>|<strong><\/strong>|'
-    r'<\/?smallcaps>|<\/?uppercase>)', re.IGNORECASE)
-hard_coded_bullets_re = re.compile(
-    r'((?:<p>(?:%s).*?[a-zA-Z].*?</p>\s*)+)' % '|'.join(re.escape(x) for x in DOTS), re.DOTALL
-)
-trailing_empty_content_re = re.compile(r'(?:<p>(?:&nbsp;|\s|<br \/>)*?</p>\s*)+\Z')
 
 
 @keep_lazy(six.text_type, SafeText)


### PR DESCRIPTION
Last uses removed in commit 8b81dee60c1533e714a310fa5c3907356042a64c.

---

Wanted to check these weren't intentionally left in.

I noticed that some of these are mentioned in the test file [`strip_tags1.html`](https://github.com/django/django/blob/master/tests/utils_tests/files/strip_tags1.html). It looks to be used as a pathological test case? Not sure if I should remove these as well.