### PR TITLE
Removed unused SubqueryConstraint.relabel_aliases() and clone() methods.

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -214,11 +214,3 @@ class SubqueryConstraint(object):
 
         query_compiler = query.get_compiler(connection=connection)
         return query_compiler.as_subquery_condition(self.alias, self.columns, compiler)
-
-    def relabel_aliases(self, change_map):
-        self.alias = change_map.get(self.alias, self.alias)
-
-    def clone(self):
-        return self.__class__(
-            self.alias, self.columns, self.targets,
-            self.query_object)


### PR DESCRIPTION
Unused since b68212f539f206679580afbfd008e7d329c9cd31 although no tests
fail if clone() is removed in the commit in which it was introduced,
d467e117856a7fa6da5e90471144aaa82d822065.

Possibly some test coverage is missing here, not sure.