### PR TITLE
Fixed #27276 -- Add login to Reverse admin URL's list at docs

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2881,6 +2881,7 @@ The :class:`AdminSite` provides the following named URL patterns:
 Page                       URL name                  Parameters
 =========================  ========================  ==================================
 Index                      ``index``
+Login                      ``login``
 Logout                     ``logout``
 Password change            ``password_change``
 Password change done       ``password_change_done``


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27276

This was overlooked at 5848bea9dc9458a9517d4c98993d742976771342 when the named `url()` for `login` was added.