### PR TITLE
Removed bad name 'backend' django.db's __all__

### DIFF
--- a/django/db/__init__.py
+++ b/django/db/__init__.py
@@ -7,19 +7,16 @@ from django.db.utils import (
 )
 
 __all__ = [
-    'backend', 'connection', 'connections', 'router', 'DatabaseError',
-    'IntegrityError', 'InternalError', 'ProgrammingError', 'DataError',
-    'NotSupportedError', 'Error', 'InterfaceError', 'OperationalError',
-    'DEFAULT_DB_ALIAS', 'DJANGO_VERSION_PICKLE_KEY'
+    'connection', 'connections', 'router', 'DatabaseError', 'IntegrityError',
+    'InternalError', 'ProgrammingError', 'DataError', 'NotSupportedError',
+    'Error', 'InterfaceError', 'OperationalError', 'DEFAULT_DB_ALIAS',
+    'DJANGO_VERSION_PICKLE_KEY',
 ]
 
 connections = ConnectionHandler()
 
 router = ConnectionRouter()
 
-
-# `connection`, `DatabaseError` and `IntegrityError` are convenient aliases
-# for backend bits.
 
 # DatabaseWrapper.__init__() takes a dictionary, not a settings module, so we
 # manually create the dictionary from the settings, passing only the settings


### PR DESCRIPTION
This hasn't existed since 051c666acac770dea1af2fc223cc695f985f02f7 and thus `from django.db import *` has been broken since. This also comes with the discovery that the `pyflakes` checker for this (`flake8` code F821) doesn't work unless `__all__` is a `tuple`, presumably because if it's a `list` it's mutable.