### PR TITLE
Fixed #27282 -- Allowed using an integer DATABASES['PORT'] for Oracle.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -191,7 +191,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         settings_dict = self.settings_dict
         if not settings_dict['HOST'].strip():
             settings_dict['HOST'] = 'localhost'
-        if settings_dict['PORT'].strip():
+        if settings_dict['PORT']:
             dsn = Database.makedsn(settings_dict['HOST'],
                                    int(settings_dict['PORT']),
                                    settings_dict['NAME'])


### PR DESCRIPTION
this change fixes https://code.djangoproject.com/ticket/27282#ticket