### PR TITLE
Fixed #27268 --  Regression on error message for invalid related fields lookup in QuerySet.get()

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1192,6 +1192,8 @@ class Query(object):
                 raise FieldError('Related Field got invalid lookup: {}'.format(lookups[0]))
             assert num_lookups > 0  # Likely a bug in Django if this fails.
             lookup_class = field.get_lookup(lookups[0])
+            if lookup_class is None:
+                raise FieldError('Related Field got invalid lookup: {}'.format(lookups[0]))
             if len(targets) == 1:
                 lhs = targets[0].get_col(alias, field)
             else:

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -515,6 +515,9 @@ class LookupTests(TestCase):
         msg = 'Related Field got invalid lookup: editor'
         with self.assertRaisesMessage(FieldError, msg):
             Article.objects.filter(author__editor__name='James')
+        msg = 'Related Field got invalid lookup: foo'
+        with self.assertRaisesMessage(FieldError, msg):
+            Tag.objects.filter(articles__foo='bar')
 
     def test_regex(self):
         # Create some articles with a bit more interesting headlines for testing field lookups:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27268