### PR TITLE
Fixed #11078 -- Doc'd meta attributes present in proxy models

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -1084,6 +1084,8 @@ created directly as a ``Place`` object or was the parent of some other class),
 referring to ``p.restaurant`` would raise a ``Restaurant.DoesNotExist``
 exception.
 
+.. _meta-and-multi-table-inheritance:
+
 ``Meta`` and multi-table inheritance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1237,6 +1239,8 @@ number of proxy models that share a common non-abstract parent class.
 
     In earlier versions, a proxy model couldn't inherit more than one proxy
     model that shared the same parent class.
+
+Proxy model ``Meta`` inheritance works the same as described in :ref:`meta-and-multi-table-inheritance`.
 
 Proxy model managers
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://code.djangoproject.com/ticket/11078

Proxy models `Meta` inheritance works the same as described in Meta
and multi table inheritance.