### PR TITLE
Fix django.contrib.postgres typo in documentation

### DIFF
--- a/docs/ref/contrib/gis/install/postgis.txt
+++ b/docs/ref/contrib/gis/install/postgis.txt
@@ -67,7 +67,7 @@ The database user must be a superuser in order to run
 ``CREATE EXTENSION postgis;``. The command is run during the :djadmin:`migrate`
 process. An alternative is to use a migration operation in your project::
 
-    from django.contrib.postgresql.operations import CreateExtension
+    from django.contrib.postgres.operations import CreateExtension
     from django.db import migrations
 
     class Migration(migrations.Migration):


### PR DESCRIPTION
The documentation points to the non-existent `django.contrib.postgresql` module, which this commit replaces with `django.contrib.postgres`.