### PR TITLE
Timezone docs fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -253,6 +253,7 @@ answer newbie questions, and generally made Django that much better:
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
     Frank Tegtmeyer <fte@fte.to>
     Frank Wierzbicki
+    Frank Wiles <frank@revsys.com>
     František Malina <fmalina@gmail.com>
     Fraser Nevett <mail@nevett.org>
     Gabriel Grant <g@briel.ca>

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -252,7 +252,7 @@ Methods
         behind multiple proxies. One solution is to use middleware to rewrite
         the proxy headers, as in the following example::
 
-            from django.django.utils.deprecation import MiddlewareMixin
+            from django.utils.deprecation import MiddlewareMixin
 
             class MultipleProxyMiddleware(MiddlewareMixin):
                 FORWARDED_FOR_FIELDS = [

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -178,7 +178,7 @@ Add the following middleware to :setting:`MIDDLEWARE`::
     import pytz
 
     from django.utils import timezone
-    from django.django.utils.deprecation import MiddlewareMixin
+    from django.utils.deprecation import MiddlewareMixin
 
     class TimezoneMiddleware(MiddlewareMixin):
         def process_request(self, request):


### PR DESCRIPTION
Docs have typo in some imports that are sure to confuse users. Also apparently I never added myself to the AUTHORS file in the past. 