### PR TITLE
Fixed #27193 -- Preserved ordering in select_for_update() subqueries.

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -476,8 +476,10 @@ class SQLCompiler(object):
         Used when nesting this query inside another.
         """
         obj = self.query.clone()
-        if obj.low_mark == 0 and obj.high_mark is None and not self.query.distinct_fields:
-            # If there is no slicing in use, then we can safely drop all ordering
+        # It's safe to drop ordering if the queryset isn't using slicing, distinct(*fields) or select_for_update
+        if (obj.low_mark == 0 and obj.high_mark is None and
+                not self.query.distinct_fields and
+                not self.query.select_for_update):
             obj.clear_ordering(True)
         nested_sql = obj.get_compiler(connection=self.connection).as_sql(subquery=True)
         if nested_sql == ('', ()):

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -306,5 +306,6 @@ class SelectForUpdateTests(TransactionTestCase):
         Subqueries should respect ordering as an ORDER BY clause may be useful
         to specify a row locking order to prevent deadlocks (#27193).
         """
-        qs = Person.objects.filter(id__in=Person.objects.order_by('-id').select_for_update())
-        self.assertIn('ORDER BY', str(qs.query))
+        with transaction.atomic():
+            qs = Person.objects.filter(id__in=Person.objects.order_by('-id').select_for_update())
+            self.assertIn('ORDER BY', str(qs.query))

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -300,3 +300,11 @@ class SelectForUpdateTests(TransactionTestCase):
     def test_nowait_and_skip_locked(self):
         with self.assertRaisesMessage(ValueError, 'The nowait option cannot be used with skip_locked.'):
             Person.objects.select_for_update(nowait=True, skip_locked=True)
+
+    def test_ordered_select_for_update(self):
+        """
+        Subqueries should respect ordering as an ORDER BY clause may be useful
+        to specify a row locking order to prevent deadlocks (#27193).
+        """
+        qs = Person.objects.filter(id__in=Person.objects.order_by('-id').select_for_update())
+        self.assertIn('ORDER BY', str(qs.query))


### PR DESCRIPTION
A user should be able to control the rows' locking order on the DB when using select_for_update in a sub-query. One possible goal would be to prevent deadlocks.

Trac ticket: https://code.djangoproject.com/ticket/27193.