### PR TITLE
Fixed #26541 -- Allowed MySQL transaction detection to work without table creation.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -78,3 +78,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             cursor.execute('SELECT @@SQL_AUTO_IS_NULL')
             result = cursor.fetchone()
             return result and result[0] == 1
+
+    @cached_property
+    def supports_transactions(self):
+        """
+        All MySQL storage engines except MyISAM support transactions.
+        """
+        return self._mysql_storage_engine != 'MyISAM'

--- a/tests/backends/test_features.py
+++ b/tests/backends/test_features.py
@@ -1,8 +1,25 @@
+from unittest import skipUnless
+
 from django.db import connection
-from django.test import TestCase
+from django.test import TestCase, mock
 
 
 class TestDatabaseFeatures(TestCase):
 
     def test_nonexistent_feature(self):
         self.assertFalse(hasattr(connection.features, 'nonexistent'))
+
+
+@skipUnless(connection.vendor == 'mysql', 'MySQL specific test.')
+class TestMySQLFeatures(TestCase):
+
+    def test_mysql_supports_transactions(self):
+        """
+        Check that mySQL supports_transactions feature depends on storage engine.
+        """
+        with mock.patch('django.db.connection.features._mysql_storage_engine', 'InnoDB'):
+            self.assertTrue(connection.features.supports_transactions)
+        del connection.features.supports_transactions
+        with mock.patch('django.db.connection.features._mysql_storage_engine', 'MyISAM'):
+            self.assertFalse(connection.features.supports_transactions)
+        del connection.features.supports_transactions


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26541

New algorithm for mySQL that determines whether the database supports transactions.