### PR TITLE
Reverted "Fixed #26140 -- Suppressed MySQL warning when inserting binary content"

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -581,13 +581,6 @@ class BaseDatabaseOperations(object):
     def combine_duration_expression(self, connector, sub_expressions):
         return self.combine_expression(connector, sub_expressions)
 
-    def binary_placeholder_sql(self, value):
-        """
-        Some backends require special syntax to insert binary content (MySQL
-        for example uses '_binary %s').
-        """
-        return '%s'
-
     def modify_insert_params(self, placeholder, params):
         """Allow modification of insert parameters. Needed for Oracle Spatial
         backend due to #10888.

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -235,9 +235,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             value = uuid.UUID(value)
         return value
 
-    def binary_placeholder_sql(self, value):
-        return '_binary %s' if value is not None else '%s'
-
     def subtract_temporals(self, internal_type, lhs, rhs):
         lhs_sql, lhs_params = lhs
         rhs_sql, rhs_params = rhs

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2320,9 +2320,6 @@ class BinaryField(Field):
     def get_internal_type(self):
         return "BinaryField"
 
-    def get_placeholder(self, value, compiler, connection):
-        return connection.ops.binary_placeholder_sql(value)
-
     def get_default(self):
         if self.has_default() and not callable(self.default):
             return self.default

--- a/docs/releases/1.10.2.txt
+++ b/docs/releases/1.10.2.txt
@@ -25,3 +25,6 @@ Bugfixes
 
 * Fixed a crash in ``runserver`` logging during a "Broken pipe" error
   (:ticket:`27271`).
+
+* Fixed compatibility with binary content on mysqlclient 1.3.8+
+  (:ticket:`26140`).


### PR DESCRIPTION
This reverts commit 204e00c0c57c34528157a739389b6935e4af2f36 as mysqlclient
1.3.8 is now handling the issue.