### PR TITLE
Fixed #27300 -- Fixed encoding of makemigrations output

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -18,6 +18,7 @@ from django.db.migrations.state import ProjectState
 from django.db.migrations.utils import get_migration_name_timestamp
 from django.db.migrations.writer import MigrationWriter
 from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.encoding import force_text
 from django.utils.six import iteritems
 from django.utils.six.moves import zip
 
@@ -231,7 +232,7 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.MIGRATE_HEADING(
                         "Full migrations file '%s':" % writer.filename) + "\n"
                     )
-                    self.stdout.write("%s\n" % writer.as_string())
+                    self.stdout.write("%s\n" % force_text(writer.as_string()))
 
     def handle_merge(self, loader, conflicts):
         """

--- a/docs/releases/1.10.2.txt
+++ b/docs/releases/1.10.2.txt
@@ -25,3 +25,6 @@ Bugfixes
 
 * Fixed a crash in ``runserver`` logging during a "Broken pipe" error
   (:ticket:`27271`).
+
+* Fixed an encoding issue when outputting the content of a migration file to
+  stdout (:ticket:`27300`).

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -969,6 +969,7 @@ class MakeMigrationsTests(MigrationTestBase):
 
         # Additional output caused by verbosity 3
         # The complete migrations file that would be written
+        self.assertNotIn('b"', out.getvalue())
         self.assertIn("# -*- coding: utf-8 -*-", out.getvalue())
         self.assertIn("class Migration(migrations.Migration):", out.getvalue())
         self.assertIn("dependencies = [", out.getvalue())


### PR DESCRIPTION
When using --dry-run and -v 3 with makemigrations on Python 3 the
content of the migration file is not properly decoded.