### PR TITLE
Fixed #27218 -- Returned LogEntry instances from log_addition, log_change, log_deletion

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -23,7 +23,7 @@ class LogEntryManager(models.Manager):
     def log_action(self, user_id, content_type_id, object_id, object_repr, action_flag, change_message=''):
         if isinstance(change_message, list):
             change_message = json.dumps(change_message)
-        self.model.objects.create(
+        return self.model.objects.create(
             user_id=user_id,
             content_type_id=content_type_id,
             object_id=force_text(object_id),

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -712,7 +712,7 @@ class ModelAdmin(BaseModelAdmin):
         The default implementation creates an admin LogEntry object.
         """
         from django.contrib.admin.models import LogEntry, ADDITION
-        LogEntry.objects.log_action(
+        return LogEntry.objects.log_action(
             user_id=request.user.pk,
             content_type_id=get_content_type_for_model(object).pk,
             object_id=object.pk,
@@ -728,7 +728,7 @@ class ModelAdmin(BaseModelAdmin):
         The default implementation creates an admin LogEntry object.
         """
         from django.contrib.admin.models import LogEntry, CHANGE
-        LogEntry.objects.log_action(
+        return LogEntry.objects.log_action(
             user_id=request.user.pk,
             content_type_id=get_content_type_for_model(object).pk,
             object_id=object.pk,
@@ -745,7 +745,7 @@ class ModelAdmin(BaseModelAdmin):
         The default implementation creates an admin LogEntry object.
         """
         from django.contrib.admin.models import LogEntry, DELETION
-        LogEntry.objects.log_action(
+        return LogEntry.objects.log_action(
             user_id=request.user.pk,
             content_type_id=get_content_type_for_model(object).pk,
             object_id=object.pk,

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -163,6 +163,14 @@ class LogEntryTests(TestCase):
         log_entry.action_flag = 4
         self.assertEqual(six.text_type(log_entry), 'LogEntry Object')
 
+    def test_logaction(self):
+        content_type_pk = ContentType.objects.get_for_model(Article).pk
+        log_entry = LogEntry.objects.log_action(
+            self.user.pk, content_type_pk, self.a1.pk, repr(self.a1), CHANGE,
+            change_message='Changed something else'
+        )
+        self.assertEqual(log_entry, LogEntry.objects.latest('action_time'))
+
     def test_recentactions_without_content_type(self):
         """
         If a LogEntry is missing content_type it will not display it in span

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -4,11 +4,13 @@ from datetime import date
 
 from django import forms
 from django.contrib.admin import BooleanFieldListFilter, SimpleListFilter
+from django.contrib.admin.models import LogEntry
 from django.contrib.admin.options import (
     HORIZONTAL, VERTICAL, ModelAdmin, TabularInline,
 )
 from django.contrib.admin.sites import AdminSite
 from django.contrib.admin.widgets import AdminDateWidget, AdminRadioSelect
+from django.contrib.auth.models import User
 from django.core.checks import Error
 from django.forms.models import BaseModelFormSet
 from django.forms.widgets import Select
@@ -532,6 +534,18 @@ class ModelAdminTests(TestCase):
             list(list(ma.get_formsets_with_inlines(request))[0][0]().forms[0].fields),
             ['extra', 'transport', 'id', 'DELETE', 'main_band']
         )
+
+    # custom log actions behaviour ####################################
+    def test_custom_log_actions(self):
+        class BandAdmin(ModelAdmin):
+            pass
+
+        ma = BandAdmin(Band, self.site)
+        mock_request = MockRequest()
+        mock_request.user = User.objects.create(username='bill')
+        self.assertEqual(ma.log_addition(mock_request, self.band, 'added'), LogEntry.objects.latest('action_time'))
+        self.assertEqual(ma.log_change(mock_request, self.band, 'changed'), LogEntry.objects.latest('action_time'))
+        self.assertEqual(ma.log_change(mock_request, self.band, 'deleted'), LogEntry.objects.latest('action_time'))
 
 
 class CheckTestCase(SimpleTestCase):


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/27218

This change makes it easier to alter a `LogEntry` in a custom `ModelAdmin` subclass overriding `log_addition`, `log_change` or `log_deletion`.