### PR TITLE
Fixed #27262 -- Delegated URL resolver checks to URL classes.

### DIFF
--- a/django/core/checks/urls.py
+++ b/django/core/checks/urls.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.utils import six
 
-from . import Error, Tags, Warning, register
+from . import Error, Tags, register
 
 
 @register(Tags.urls)
@@ -19,23 +19,13 @@ def check_resolver(resolver):
     """
     Recursively check the resolver.
     """
-    from django.urls import RegexURLPattern, RegexURLResolver
-    warnings = []
-    for pattern in resolver.url_patterns:
-        if isinstance(pattern, RegexURLResolver):
-            warnings.extend(check_include_trailing_dollar(pattern))
-            # Check resolver recursively
-            warnings.extend(check_resolver(pattern))
-        elif isinstance(pattern, RegexURLPattern):
-            warnings.extend(check_pattern_name(pattern))
-        else:
-            # This is not a url() instance
-            warnings.extend(get_warning_for_invalid_pattern(pattern))
-
-        if not warnings:
-            warnings.extend(check_pattern_startswith_slash(pattern))
-
-    return warnings
+    check_method = getattr(resolver, 'check', None)
+    if check_method is not None:
+        return check_method()
+    elif not hasattr(resolver, 'resolve'):
+        return get_warning_for_invalid_pattern(resolver)
+    else:
+        return []
 
 
 def get_warning_for_invalid_pattern(pattern):
@@ -61,68 +51,3 @@ def get_warning_for_invalid_pattern(pattern):
         hint=hint,
         id="urls.E004",
     )]
-
-
-def describe_pattern(pattern):
-    """
-    Format the URL pattern for display in warning messages.
-    """
-    description = "'{}'".format(pattern.regex.pattern)
-    if getattr(pattern, 'name', False):
-        description += " [name='{}']".format(pattern.name)
-    return description
-
-
-def check_include_trailing_dollar(pattern):
-    """
-    Check that include is not used with a regex ending with a dollar.
-    """
-    regex_pattern = pattern.regex.pattern
-    if regex_pattern.endswith('$') and not regex_pattern.endswith(r'\$'):
-        warning = Warning(
-            "Your URL pattern {} uses include with a regex ending with a '$'. "
-            "Remove the dollar from the regex to avoid problems including "
-            "URLs.".format(describe_pattern(pattern)),
-            id="urls.W001",
-        )
-        return [warning]
-    else:
-        return []
-
-
-def check_pattern_startswith_slash(pattern):
-    """
-    Check that the pattern does not begin with a forward slash.
-    """
-    regex_pattern = pattern.regex.pattern
-    if not settings.APPEND_SLASH:
-        # Skip check as it can be useful to start a URL pattern with a slash
-        # when APPEND_SLASH=False.
-        return []
-    if regex_pattern.startswith('/') or regex_pattern.startswith('^/'):
-        warning = Warning(
-            "Your URL pattern {} has a regex beginning with a '/'. Remove this "
-            "slash as it is unnecessary. If this pattern is targeted in an "
-            "include(), ensure the include() pattern has a trailing '/'.".format(
-                describe_pattern(pattern)
-            ),
-            id="urls.W002",
-        )
-        return [warning]
-    else:
-        return []
-
-
-def check_pattern_name(pattern):
-    """
-    Check that the pattern name does not contain a colon.
-    """
-    if pattern.name is not None and ":" in pattern.name:
-        warning = Warning(
-            "Your URL pattern {} has a name including a ':'. Remove the colon, to "
-            "avoid ambiguous namespace references.".format(describe_pattern(pattern)),
-            id="urls.W003",
-        )
-        return [warning]
-    else:
-        return []


### PR DESCRIPTION
I cleaned up  `check_resolver()` to check for a contract (`check(self)`) instead of the patter's type.
By making all individual `check_*()` functions private members of the classes they were written to work with in the first place, the coupling is taken care of. 
Finally, if I am not missing anyhing, the old code would only alert about `startswith_slash` if no other warning (specific to the class) was found (because of `if not warning:` which would't be empty otherwise). **Now** `startswith_slash` is checked by the base class of both patterns `LocaleRegexProvider` regardless of other warnings found.