### PR TITLE
Fixed #27309 -- Added CallableBool.__hash__().

### DIFF
--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -119,6 +119,9 @@ class CallableBool:
     def __or__(self, other):
         return bool(self.value or other)
 
+    def __hash__(self):
+        return hash(self.value)
+
 CallableFalse = CallableBool(False)
 CallableTrue = CallableBool(True)
 

--- a/docs/releases/1.10.3.txt
+++ b/docs/releases/1.10.3.txt
@@ -9,4 +9,5 @@ Django 1.10.3 fixes several bugs in 1.10.2.
 Bugfixes
 ========
 
-* ...
+* Allowed ``User.is_authenticated`` and ``User.is_anonymous`` properties to be
+  tested for ``set`` membership (:ticket:`27309`).

--- a/tests/utils_tests/test_deprecation.py
+++ b/tests/utils_tests/test_deprecation.py
@@ -25,3 +25,7 @@ class TestCallableBool(SimpleTestCase):
         self.assertIs(CallableTrue | False, True)
         self.assertIs(CallableFalse | True, True)
         self.assertFalse(CallableFalse | False, False)
+
+    def test_set_membership(self):
+        self.assertIs(CallableTrue in {True}, True)
+        self.assertIs(CallableFalse not in {True}, True)


### PR DESCRIPTION
Add hash method to CallableBool to support membership test operations for sets.