### PR TITLE
Fixed #27118 -- Allowed using pk as a field for get_or_create and update_or_create.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -532,7 +532,8 @@ class QuerySet(object):
             try:
                 self.model._meta.get_field(param)
             except exceptions.FieldDoesNotExist:
-                invalid_params.append(param)
+                if param != 'pk':  # Allow to use model's pk property
+                    invalid_params.append(param)
         if invalid_params:
             raise exceptions.FieldError(
                 "Invalid field name(s) for model %s: '%s'." % (

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -71,6 +71,13 @@ class GetOrCreateTests(TestCase):
         with self.assertRaises(IntegrityError):
             Person.objects.get_or_create(first_name="Tom", last_name="Smith")
 
+    def test_get_or_create_with_pk_property(self):
+        """
+        Using the pk property of a model should be allowed, even though pk is
+        not a model field.
+        """
+        Thing.objects.get_or_create(pk=1)
+
     def test_get_or_create_on_related_manager(self):
         p = Publisher.objects.create(name="Acme Publishing")
         # Create a book through the publisher.
@@ -323,6 +330,13 @@ class UpdateOrCreateTests(TestCase):
         with self.assertRaises(IntegrityError):
             ManualPrimaryKeyTest.objects.update_or_create(id=1, data="Different")
         self.assertEqual(ManualPrimaryKeyTest.objects.get(id=1).data, "Original")
+
+    def test_with_pk_property(self):
+        """
+        Using the pk property of a model should be allowed, even though pk is
+        not a model field.
+        """
+        Thing.objects.update_or_create(pk=1)
 
     def test_error_contains_full_traceback(self):
         """


### PR DESCRIPTION
Re-opened ticket: https://code.djangoproject.com/ticket/27118#comment:4

The `pk` property should be ignored when validating `get_or_create` / `update_or_create` field names. The patch feels a bit hacky but I do not see a cleaner way to ignore the property.