### PR TITLE
Fixed #9363 -- Added callstack capture to CursorDebugWrapper

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -4,6 +4,7 @@ import datetime
 import decimal
 import hashlib
 import logging
+import traceback
 from time import time
 
 from django.conf import settings
@@ -76,9 +77,11 @@ class CursorDebugWrapper(CursorWrapper):
             stop = time()
             duration = stop - start
             sql = self.db.ops.last_executed_query(self.cursor, sql, params)
+            callstack = traceback.format_stack()
             self.db.queries.append({
                 'sql': sql,
                 'time': "%.3f" % duration,
+                'traceback': callstack,
             })
             logger.debug('(%.3f) %s; args=%s' % (duration, sql, params),
                 extra={'duration': duration, 'sql': sql, 'params': params}

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -213,6 +213,11 @@ class AssertNumQueriesContextManagerTests(TestCase):
             self.client.get("/test_utils/get_person/%s/" % person.pk)
             self.client.get("/test_utils/get_person/%s/" % person.pk)
 
+    def test_callstack_captured(self):
+        with self.assertNumQueries(1) as queries:
+            Person.objects.count()
+        self.assertIn('traceback', queries.connection.queries[0])
+
 
 class AssertTemplateUsedContextManagerTests(TestCase):
     urls = 'test_utils.urls'


### PR DESCRIPTION
Keeps a track of the callstack for each query executed to aid
debugging of assertNumQueries failures.

https://code.djangoproject.com/ticket/9363
