### PR TITLE
Fixed #27318 -- Return list of failing keys with set_many()

### DIFF
--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -147,7 +147,8 @@ class BaseMemcachedCache(BaseCache):
         for key, value in data.items():
             key = self.make_key(key, version=version)
             safe_data[key] = value
-        self._cache.set_multi(safe_data, self.get_backend_timeout(timeout))
+        # return the list of failing keys
+        return self._cache.set_multi(safe_data, self.get_backend_timeout(timeout))
 
     def delete_many(self, keys, version=None):
         self._cache.delete_multi(self.make_key(key, version=version) for key in keys)


### PR DESCRIPTION
Both python-memcached and pylibmc return the list of failing keys, but
we (previously) not give this list to the caller.
