### PR TITLE
update documentation

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -161,6 +161,11 @@ permissions to specific users and groups of users.
 It's used by the Django admin site, but you're welcome to use it in your own
 code.
 
+.. note::
+
+        Make sure you have enabled `django.contrib.auth.backends.ModelBackend`
+        in the AUTHENTICATION_BACKENDS in app's settings if you are using the default auth Models.
+
 The Django admin site uses permissions as follows:
 
 * Access to view the "add" form and add an object is limited to users with

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -164,7 +164,7 @@ code.
 .. note::
 
         Make sure you have enabled `django.contrib.auth.backends.ModelBackend`
-        in the AUTHENTICATION_BACKENDS in app's settings if you are using the default auth Models.
+        in the AUTHENTICATION_BACKENDS in your app's settings if you are using the default auth Models.
 
 The Django admin site uses permissions as follows:
 


### PR DESCRIPTION
For newbies to Django, it can be pretty confusing if they miss `django.contrib.auth.backends.ModelBackend` in their default Authentication backends.

e.g: Permissions assigned to a group won't propagate to its member users. This might be a simple added hint when debugging that may save time.