### PR TITLE
Do not rely on isinstance to find the default engine.

### DIFF
--- a/django/template/__init__.py
+++ b/django/template/__init__.py
@@ -42,9 +42,7 @@ Shared:
 # Multiple Template Engines
 
 from .engine import Engine
-from .utils import EngineHandler
-
-engines = EngineHandler()
+from .utils import engines
 
 __all__ = ('Engine', 'engines')
 

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -7,6 +7,7 @@ from .base import Context, Template
 from .context import _builtin_context_processors
 from .exceptions import TemplateDoesNotExist
 from .library import import_library
+from .utils import engines
 
 
 class Engine(object):
@@ -68,16 +69,11 @@ class Engine(object):
         >>> template.render(context)
         'Hello world!'
         """
-        # Since Engine is imported in django.template and since
-        # DjangoTemplates is a wrapper around this Engine class,
-        # local imports are required to avoid import loops.
-        from django.template import engines
-        from django.template.backends.django import DjangoTemplates
-        django_engines = [engine for engine in engines.all()
-                          if isinstance(engine, DjangoTemplates)]
+        django_engines = [engine for engine in engines.templates.values()
+                          if engine['BACKEND'] == 'django.template.backends.django.DjangoTemplates']
         if len(django_engines) == 1:
             # Unwrap the Engine instance inside DjangoTemplates
-            return django_engines[0].engine
+            return engines[django_engines[0]['NAME']].engine
         elif len(django_engines) == 0:
             raise ImproperlyConfigured(
                 "No DjangoTemplates backend is configured.")

--- a/django/template/utils.py
+++ b/django/template/utils.py
@@ -89,6 +89,9 @@ class EngineHandler(object):
         return [self[alias] for alias in self]
 
 
+engines = EngineHandler()
+
+
 @lru_cache.lru_cache()
 def get_app_template_dirs(dirname):
     """

--- a/tests/template_backends/test_django.py
+++ b/tests/template_backends/test_django.py
@@ -1,8 +1,8 @@
 from template_tests.test_response import test_processor_name
 
-from django.template import EngineHandler
 from django.template.backends.django import DjangoTemplates
 from django.template.library import InvalidTemplateLibrary
+from django.template.utils import EngineHandler
 from django.test import RequestFactory, override_settings
 
 from .test_dummy import TemplateStringsTests


### PR DESCRIPTION
This allows django_coverage_plugin to work again. (I still have to test django_coverage_plugin ;))
