### PR TITLE
Fixed #26954 -- Prevented ModelAdmin.has_module_permission()=False from blocking access to the app index page.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.admin import ModelAdmin, actions
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -399,8 +399,6 @@ class AdminSite(object):
 
             has_module_perms = model_admin.has_module_permission(request)
             if not has_module_perms:
-                if label:
-                    raise PermissionDenied
                 continue
 
             perms = model_admin.get_model_perms(request)

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -1019,3 +1019,4 @@ site2.register(Person, save_as_continue=False)
 
 site7 = admin.AdminSite(name="admin7")
 site7.register(Article, ArticleAdmin2)
+site7.register(Section)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26954
I added an additional test to https://github.com/django/django/pull/6999.