### PR TITLE
Fixed #27295 -- Added a system check to prohibit model names that start/end with an underscore or contain double underscores.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -141,6 +141,10 @@ Models
 * **models.E022**: ``<function>`` contains a lazy reference to
   ``<app label>.<model>``, but app ``<app label>`` isn't installed or
   doesn't provide model ``<model>``.
+* **models.E023**: The model name ``<model>`` cannot start or end with an
+  underscore as it collides with the query lookup syntax.
+* **models.E024**: The model name ``<model>`` cannot contain double underscores
+  as it collides with the query lookup syntax.
 
 Fields
 ~~~~~~

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -689,6 +689,45 @@ class OtherModelTests(SimpleTestCase):
 
         self.assertFalse(Child.check())
 
+    def test_name_beginning_with_underscore(self):
+        class _Model(models.Model):
+            pass
+
+        self.assertEqual(_Model.check(), [
+            Error(
+                "The model name '_Model' cannot start or end with an underscore "
+                "as it collides with the query lookup syntax.",
+                obj=_Model,
+                id='models.E023',
+            )
+        ])
+
+    def test_name_ending_with_underscore(self):
+        class Model_(models.Model):
+            pass
+
+        self.assertEqual(Model_.check(), [
+            Error(
+                "The model name 'Model_' cannot start or end with an underscore "
+                "as it collides with the query lookup syntax.",
+                obj=Model_,
+                id='models.E023',
+            )
+        ])
+
+    def test_name_contains_double_underscores(self):
+        class Test__Model(models.Model):
+            pass
+
+        self.assertEqual(Test__Model.check(), [
+            Error(
+                "The model name 'Test__Model' cannot contain double underscores "
+                "as it collides with the query lookup syntax.",
+                obj=Test__Model,
+                id='models.E024',
+            )
+        ])
+
     @override_settings(TEST_SWAPPED_MODEL_BAD_VALUE='not-a-model')
     def test_swappable_missing_app_name(self):
         class Model(models.Model):

--- a/tests/invalid_models_tests/test_relative_fields.py
+++ b/tests/invalid_models_tests/test_relative_fields.py
@@ -794,7 +794,7 @@ class RelativeFieldTests(SimpleTestCase):
             pass
 
         for related_name in related_names:
-            Child = type(str('Child_%s') % str(related_name), (models.Model,), {
+            Child = type(str('Child%s') % str(related_name), (models.Model,), {
                 'parent': models.ForeignKey('Parent', models.CASCADE, related_name=related_name),
                 '__module__': Parent.__module__,
             })


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27295