### PR TITLE
Refs #19705 -- Changed GZipMiddleware to make ETags weak

### DIFF
--- a/django/middleware/gzip.py
+++ b/django/middleware/gzip.py
@@ -41,8 +41,12 @@ class GZipMiddleware(MiddlewareMixin):
             response.content = compressed_content
             response['Content-Length'] = str(len(response.content))
 
-        if response.has_header('ETag'):
-            response['ETag'] = re.sub('"$', ';gzip"', response['ETag'])
+        # If there is a strong ETag, make it weak. That fulfills the
+        # requirements of RFC 7232 while still allowing conditional
+        # request matches on ETags.
+        etag = response.get('ETag')
+        if etag and etag.startswith('"'):
+            response['ETag'] = 'W/' + etag
         response['Content-Encoding'] = 'gzip'
 
         return response

--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -155,6 +155,9 @@ It will NOT compress content if any of the following are true:
 * The request (the browser) hasn't sent an ``Accept-Encoding`` header
   containing ``gzip``.
 
+If the response has an ``ETag`` header, the header will be changed to a weak
+``ETag`` to comply with :rfc:`7232`.
+
 You can apply GZip compression to individual views using the
 :func:`~django.views.decorators.gzip.gzip_page()` decorator.
 
@@ -163,6 +166,7 @@ You can apply GZip compression to individual views using the
     In older versions, Django's CSRF protection mechanism was vulnerable to
     BREACH attacks when compression was used. This is no longer the case, but
     you should still take care not to compromise your own secrets this way.
+
 
 Conditional GET middleware
 --------------------------


### PR DESCRIPTION
This change allows Django's conditional request facilities to produce
304 Not Modified responses for content that is subject to compression.