### PR TITLE
Fixed #27334 -- TemporaryUploadedFile moved to destination when possible

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -293,7 +293,7 @@ class FileField(Field):
         file = super(FileField, self).pre_save(model_instance, add)
         if file and not file._committed:
             # Commit the file to storage prior to saving the model
-            file.save(file.name, file, save=False)
+            file.save(file.name, file.file, save=False)
         return file
 
     def contribute_to_class(self, cls, name, **kwargs):


### PR DESCRIPTION
When a FileField is set to an instance of File that is not also an
instance of FieldFile, pre_save will pass that object as the contents to
Storage.save().

As a result, when an uploaded file is written to temporary storage,
if possible it will be moved (rather than copied) to the upload
destination.

All tests pass under Linux & Windows. The tests will pass without the changes to files.py on Windows however, because Windows does not support moving open files. On Linux they will fail without the changes to files.py, thus verifying that the test is actually testing something.