### PR TITLE
Fixed #25809 -- Added BRINIndex support in django.contrib.postgres.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -470,6 +470,7 @@ answer newbie questions, and generally made Django that much better:
     Luke Plant <L.Plant.98@cantab.net>
     Maciej Fijalkowski
     Maciej Wiśniowski <pigletto@gmail.com>
+    Mads Jensen <https://github.com/atombrella>
     Makoto Tsuyuki <mtsuyuki@gmail.com>
     Malcolm Tredinnick
     Manuel Saelices <msaelices@yaco.es>

--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -1,8 +1,40 @@
 from __future__ import unicode_literals
 
-from django.db.models import Index
+from django.db.models.indexes import Index
 
-__all__ = ['GinIndex']
+__all__ = ['BrinIndex', 'GinIndex']
+
+
+class BrinIndex(Index):
+    suffix = 'brin'
+
+    def __init__(self, fields=[], name=None, pages_per_range=None):
+        if pages_per_range is not None and not (isinstance(pages_per_range, int) and pages_per_range > 0):
+            raise ValueError('pages_per_range must be None or a positive integer for BRIN indexes')
+        self.pages_per_range = pages_per_range
+        return super(BrinIndex, self).__init__(fields, name)
+
+    def __repr__(self):
+        if self.pages_per_range is not None:
+            return '<%(name)s: fields=%(fields)s, pages_per_range=%(pages_per_range)s>' % {
+                'name': self.__class__.__name__,
+                'fields': "'{}'".format(', '.join(self.fields)),
+                'pages_per_range': self.pages_per_range,
+            }
+        else:
+            return super(BrinIndex, self).__repr__()
+
+    def deconstruct(self):
+        path, args, kwargs = super(BrinIndex, self).deconstruct()
+        kwargs['pages_per_range'] = self.pages_per_range
+        return path, args, kwargs
+
+    def get_sql_create_template_values(self, model, schema_editor, using):
+        parameters = super(BrinIndex, self).get_sql_create_template_values(model, schema_editor, using=' USING brin')
+        if self.pages_per_range is not None:
+            parameters['extra'] = ' WITH (pages_per_range={})'.format(
+                schema_editor.quote_value(self.pages_per_range)) + parameters['extra']
+        return parameters
 
 
 class GinIndex(Index):

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -38,6 +38,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return self.connection.pg_version >= 90500
 
     @cached_property
+    def has_brin_index_support(self):
+        return self.connection.pg_version >= 90500
+
+    @cached_property
     def has_jsonb_datatype(self):
         return self.connection.pg_version >= 90400
 

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -9,6 +9,16 @@ PostgreSQL specific model indexes
 The following are PostgreSQL specific :doc:`indexes </ref/models/indexes>`
 available from the ``django.contrib.postgres.indexes`` module.
 
+``BrinIndex``
+=============
+
+.. class:: BrinIndex(pages_per_range=None)
+
+    Creates a `BRIN index
+    <https://www.postgresql.org/docs/current/static/brin-intro.html>`_. For
+    performance considerations and use cases of the index, please consult the
+    documentation.
+
 ``GinIndex``
 ============
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -212,8 +212,9 @@ Minor features
   :class:`~django.contrib.postgres.aggregates.StringAgg` determines if
   concatenated values will be distinct.
 
-* The new :class:`~django.contrib.postgres.indexes.GinIndex` class allows
-  creating gin indexes in the database.
+* The new :class:`~django.contrib.postgres.indexes.GinIndex` and
+  :class:`~django.contrib.postgres.indexes.BrinIndex` classes allow
+  creating ``GIN`` and ``BRIN`` indexes in the database.
 
 * :class:`~django.contrib.postgres.fields.JSONField` accepts a new ``encoder``
   parameter to specify a custom class to encode data types not supported by the

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -1,8 +1,45 @@
-from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.indexes import BrinIndex, GinIndex
 from django.db import connection
+from django.test import skipUnlessDBFeature
 
 from . import PostgreSQLTestCase
-from .models import IntegerArrayModel
+from .models import CharFieldModel, IntegerArrayModel
+
+
+@skipUnlessDBFeature('has_brin_index_support')
+class BrinIndexTests(PostgreSQLTestCase):
+
+    def test_repr(self):
+        index = BrinIndex(fields=['title'], pages_per_range=4)
+        another_index = BrinIndex(fields=['title'])
+        self.assertEqual(repr(index), "<BrinIndex: fields='title', pages_per_range=4>")
+        self.assertEqual(repr(another_index), "<BrinIndex: fields='title'>")
+
+    def test_not_eq(self):
+        index = BrinIndex(fields=['title'])
+        index_with_page_range = BrinIndex(fields=['title'], pages_per_range=16)
+        self.assertNotEqual(index, index_with_page_range)
+
+    def test_deconstruction(self):
+        index = BrinIndex(fields=['title'], name='test_title_brin')
+        path, args, kwargs = index.deconstruct()
+        self.assertEqual(path, 'django.contrib.postgres.indexes.BrinIndex')
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_brin', 'pages_per_range': None})
+
+    def test_deconstruction_with_pages_per_rank(self):
+        index = BrinIndex(fields=['title'], name='test_title_brin', pages_per_range=16)
+        path, args, kwargs = index.deconstruct()
+        self.assertEqual(path, 'django.contrib.postgres.indexes.BrinIndex')
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_brin', 'pages_per_range': 16})
+
+    def test_invalid_pages_per_range(self):
+        with self.assertRaises(ValueError):
+            BrinIndex(fields=['title'], name='test_title_brin', pages_per_range='Charles Babbage')
+
+        with self.assertRaises(ValueError):
+            BrinIndex(fields=['title'], name='test_title_brin', pages_per_range=0)
 
 
 class GinIndexTests(PostgreSQLTestCase):
@@ -55,3 +92,16 @@ class SchemaTests(PostgreSQLTestCase):
         with connection.schema_editor() as editor:
             editor.remove_index(IntegerArrayModel, index)
         self.assertNotIn(index_name, self.get_constraints(IntegerArrayModel._meta.db_table))
+
+    @skipUnlessDBFeature('has_brin_index_support')
+    def test_brin_index(self):
+        index_name = 'char_field_model_field_brin'
+        index = BrinIndex(fields=['field'], name=index_name, pages_per_range=4)
+        with connection.schema_editor() as editor:
+            editor.add_index(CharFieldModel, index)
+        constraints = self.get_constraints(CharFieldModel._meta.db_table)
+        self.assertEqual(constraints[index_name]['type'], 'brin')
+        self.assertEqual(constraints[index_name]['options'], ['pages_per_range=4'])
+        with connection.schema_editor() as editor:
+            editor.remove_index(CharFieldModel, index)
+        self.assertNotIn(index_name, self.get_constraints(CharFieldModel._meta.db_table))


### PR DESCRIPTION
Preliminary work to add support for BRIN indexes in `django.contrib.postgres`.

I've added a link to Python sweetness in the documentation. 

The code is mostly adapted from `GinIndex`. I was tempted to include some more columns in the introspection to add some tests that `pages_per_range` is included properly.
