### PR TITLE
migrate is breaking with an AttributeError when extensions are providing names in bytes

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -120,6 +120,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         return 18446744073709551615
 
     def quote_name(self, name):
+        if type(name) is bytes :
+            name = name.decode("utf-8")
         if name.startswith("`") and name.endswith("`"):
             return name  # Quoting once is enough.
         return "`%s`" % name


### PR DESCRIPTION
This was breaking the migrate script, such as when a db-file package used, where the name was passed into as  a byte string instead of the expected str type.

It would be safe to cast it to str before returning the quoted string.