### PR TITLE
Refs #20888 -- Updated indexes ordering introspection for PostgreSQL 9.6

### DIFF
--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -207,8 +207,8 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                         WHEN idx.indexprs IS NOT NULL THEN
                             pg_get_indexdef(idx.indexrelid)
                     END AS exprdef,
-                    CASE
-                        WHEN am.amcanorder THEN
+                    CASE am.amname
+                        WHEN 'btree' THEN
                             CASE (option & 1)
                                 WHEN 1 THEN 'DESC' ELSE 'ASC'
                             END


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/20888

PostgreSQL 9.6 gets rid of most of pg_am columns[0]. In particular, `amcanorder` disappears and should be replaced with calls to `pg_index_column_has_property()`. PostgreSQL versions < 9.6 do not provide this method, hence we are forced to rely on a brittle query.

Since only B-tree indexes support ordering[1], this is the only type of index to consider. This solution relies on the access method implementation[2] to determine whether `ASC` or `DESC` ordering is in use.

Let's hope that a new view is added to information_schema[3] in the future.

[0] https://www.postgresql.org/docs/9.6/static/release-9-6.html
[1] https://www.postgresql.org/docs/current/static/indexes-ordering.html
[2] https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/catalog/pg_index.h;h=ee97c5dec836ad82c5b75440fcba51d4c106fc33;hb=HEAD#l99
[3] http://stackoverflow.com/questions/18121103/how-to-get-the-index-column-orderasc-desc-nulls-first-from-postgresql#comment64529591_18128104

Thanks @timgraham for the first version of this patch.