### PR TITLE
Fixed #27372 -- Fixed inspectdb not handling SQLite3 tables with foreign keys that have spaces.

### DIFF
--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -132,7 +132,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             if field_desc.startswith("FOREIGN KEY"):
                 # Find name of the target FK field
-                m = re.match(r'FOREIGN KEY\(([^\)]*)\).*', field_desc, re.I)
+                m = re.match(r'FOREIGN KEY ?\(([^\)]*)\).*', field_desc, re.I)
                 field_name = m.groups()[0].strip('"')
             else:
                 field_name = field_desc.split()[0].strip('"')


### PR DESCRIPTION
Running `python manage.py inspectdb` with an sqlite3 database resulted in output missing numerous tables with errors of "Unable to inspect table" due to "'NoneType' object has no attribute 'groups'". It turns out the regular expression was not matching the string "FOREIGN KEY (skill_type) REFERENCES skill_type(id)" due to a single space character. Adding the optional space to the regular expression fixed my issue.

https://code.djangoproject.com/ticket/27372