### PR TITLE
Documentation: Fix import reverse

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -71,7 +71,7 @@ create a real version. Add the following to ``polls/views.py``:
 
     from django.shortcuts import get_object_or_404, render
     from django.http import HttpResponseRedirect, HttpResponse
-    from django.urls import reverse
+    from django.core.urlresolvers import reverse
 
     from .models import Choice, Question
     # ...


### PR DESCRIPTION
Import from the correct location as stated in the note here https://docs.djangoproject.com/en/1.10/ref/urlresolvers/

Apologies if there is anything missing in this PR. It's my first contribution as I noticed an error while following the tutorial