### PR TITLE
Fix KeyError bug when 'no_color' is not specified (#27366)

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -305,7 +305,7 @@ class BaseCommand(object):
         controlled by the ``requires_system_checks`` attribute, except if
         force-skipped).
         """
-        if options['no_color']:
+        if options.get('no_color'):
             self.style = no_style()
             self.stderr.style_func = None
         if options.get('stdout'):


### PR DESCRIPTION
Associated ticket: https://code.djangoproject.com/ticket/27366#ticket

Works fine now.