### PR TITLE
Fixed #27335 - Avoid object save during QuerySet.update_or_create() when there were no changes

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -485,9 +485,15 @@ class QuerySet(object):
                 obj, created = self._create_object_from_params(lookup, params)
                 if created:
                     return obj, created
+
+            changed = False
             for k, v in six.iteritems(defaults):
-                setattr(obj, k, v() if callable(v) else v)
-            obj.save(using=self.db)
+                value = v() if callable(v) else v
+                if value != getattr(obj, k):
+                    changed = True
+                    setattr(obj, k, value)
+            if changed:
+                obj.save(using=self.db)  # save only if there were changes
         return obj, False
 
     def _create_object_from_params(self, lookup, params):

--- a/tests/get_or_create/models.py
+++ b/tests/get_or_create/models.py
@@ -11,8 +11,17 @@ class Person(models.Model):
     birthday = models.DateField()
     defaults = models.TextField()
 
+    save_count_called = 0
+
     def __str__(self):
         return '%s %s' % (self.first_name, self.last_name)
+
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+        """
+        Overriding save method to count how much save() method was called.
+        """
+        Person.save_count_called += 1
+        super(Person, self).save(force_insert, force_update, using, update_fields)
 
 
 class DefaultPerson(models.Model):

--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -441,6 +441,17 @@ class UpdateOrCreateTests(TestCase):
         self.assertIs(created, False)
         self.assertEqual(obj.last_name, 'NotHarrison')
 
+    def test_save_not_called_when_no_changes(self):
+        before_count = Person.save_count_called
+        Person.objects.update_or_create(
+            first_name='George', last_name='Harrison', birthday=date(1942, 2, 25),
+        )
+        Person.objects.update_or_create(
+            first_name='George'
+        )
+        after_count = Person.save_count_called
+        self.assertEqual(after_count - before_count, 1)
+
 
 class UpdateOrCreateTransactionTests(TransactionTestCase):
     available_apps = ['get_or_create']


### PR DESCRIPTION
`QuerySet.update_or_create()` was optimized.
See https://code.djangoproject.com/ticket/27335 for more details.

To collect `save` method call count I used similar technique like it's done here https://github.com/django/django/blob/master/tests/generic_views/views.py#L156
