### PR TITLE
Fixed #27360 -- Exposes more information about offending models in an AlreadyRegistered exception.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -90,7 +90,15 @@ class AdminSite(object):
                 )
 
             if model in self._registry:
-                raise AlreadyRegistered('The model %s is already registered' % model.__name__)
+                registered_admin = self._registry[model]
+                registered_model = registered_admin.model
+                raise AlreadyRegistered(
+                    'Cannot register %s for %s, because %s is already registered.' % (
+                        model._meta.label,
+                        registered_admin,
+                        registered_model._meta.label,
+                    )
+                )
 
             # Ignore the registration if the model has been
             # swapped out.


### PR DESCRIPTION
Fixes ticket 27360 by adding more information about the models involved in an AdminSite's AlreadyRegistered exception. Let me know if the error message needs to be more clear or changed around. 
