### PR TITLE
Fixed #26789 -- Fixed handling of empty geometries in BaseSpatialField.get_db_prep_save

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -26,6 +26,8 @@ class BaseSpatialFeatures(object):
     supports_real_shape_operations = True
     # Can geometry fields be null?
     supports_null_geometries = True
+    # Are empty geometries supported?
+    supports_empty_geometries = False
     # Can the the function be applied on geodetic coordinate systems?
     supports_distance_geodetic = True
     supports_length_geodetic = True

--- a/django/contrib/gis/db/backends/postgis/features.py
+++ b/django/contrib/gis/db/backends/postgis/features.py
@@ -8,3 +8,4 @@ class DatabaseFeatures(BaseSpatialFeatures, Psycopg2DatabaseFeatures):
     supports_3d_functions = True
     supports_left_right_lookups = True
     supports_raster = True
+    supports_empty_geometries = True

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -177,10 +177,10 @@ class BaseSpatialField(Field):
         """
         Prepare the value for saving in the database.
         """
-        if not value:
-            return None
-        else:
+        if isinstance(value, Geometry) or value:
             return connection.ops.Adapter(self.get_prep_value(value))
+        else:
+            return None
 
     def get_raster_prep_value(self, value, is_candidate):
         """

--- a/tests/gis_tests/geos_tests/test_io.py
+++ b/tests/gis_tests/geos_tests/test_io.py
@@ -4,7 +4,8 @@ import binascii
 from unittest import skipUnless
 
 from django.contrib.gis.geos import (
-    HAS_GEOS, GEOSGeometry, Point, WKBReader, WKBWriter, WKTReader, WKTWriter,
+    HAS_GEOS, GEOSGeometry, Point, Polygon, WKBReader, WKBWriter, WKTReader,
+    WKTWriter,
 )
 from django.test import SimpleTestCase
 from django.utils.six import memoryview
@@ -155,3 +156,41 @@ class GEOSIOTest(SimpleTestCase):
 
         with self.assertRaisesMessage(AttributeError, 'WKT output rounding precision must be '):
             wkt_w.precision = 'potato'
+
+    def test_empty_point_wkb(self):
+        p = Point(srid=4326)
+        wkb_w = WKBWriter()
+
+        wkb_w.srid = False
+        with self.assertRaisesMessage(ValueError, 'Empty point is not representable in WKB.'):
+            wkb_w.write(p)
+        with self.assertRaisesMessage(ValueError, 'Empty point is not representable in WKB.'):
+            wkb_w.write_hex(p)
+
+        wkb_w.srid = True
+        for byteorder, hex in enumerate([
+            b'0020000001000010E67FF80000000000007FF8000000000000',
+            b'0101000020E6100000000000000000F87F000000000000F87F',
+        ]):
+            wkb_w.byteorder = byteorder
+            self.assertEqual(wkb_w.write_hex(p), hex)
+            self.assertEqual(GEOSGeometry(wkb_w.write_hex(p)), p)
+            self.assertEqual(wkb_w.write(p), memoryview(binascii.a2b_hex(hex)))
+            self.assertEqual(GEOSGeometry(wkb_w.write(p)), p)
+
+    def test_empty_polygon_wkb(self):
+        p = Polygon(srid=4326)
+        p_no_srid = Polygon()
+        wkb_w = WKBWriter()
+        wkb_w.srid = True
+        for byteorder, hexes in enumerate([
+            (b'000000000300000000', b'0020000003000010E600000000'),
+            (b'010300000000000000', b'0103000020E610000000000000'),
+        ]):
+            wkb_w.byteorder = byteorder
+            for srid, hex in enumerate(hexes):
+                wkb_w.srid = srid
+                self.assertEqual(wkb_w.write_hex(p), hex)
+                self.assertEqual(GEOSGeometry(wkb_w.write_hex(p)), p if srid else p_no_srid)
+                self.assertEqual(wkb_w.write(p), memoryview(binascii.a2b_hex(hex)))
+                self.assertEqual(GEOSGeometry(wkb_w.write(p)), p if srid else p_no_srid)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26789
