### PR TITLE
Fixed #27381 - Add operation for pg_prewarm extension (Postgres)

### DIFF
--- a/django/contrib/postgres/operations.py
+++ b/django/contrib/postgres/operations.py
@@ -58,3 +58,9 @@ class UnaccentExtension(CreateExtension):
 
     def __init__(self):
         self.name = 'unaccent'
+
+
+class PrewarmExtension(CreateExtension):
+
+    def __init__(self):
+        self.name = 'pg_prewarm'

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -44,6 +44,13 @@ the ``django.contrib.postgres.operations`` module.
     Installs the ``hstore`` extension and also sets up the connection to
     interpret hstore data for possible use in subsequent migrations.
 
+``PrewarmExtension``
+===================
+
+.. class:: PrewarmExtension()
+
+    Installs the ``pg_prewarm`` extension.
+
 ``TrigramExtension``
 ====================
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -179,6 +179,9 @@ Minor features
 * The new :class:`~django.contrib.postgres.aggregates.JsonAgg` allows
   aggregating values as a JSON array.
 
+* The new :class:`~django.contrib.postgres.operations.PrewarmExtension`
+  migration operation allow using PostgreSQL's ``pg_prewarm`` extension.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/postgres_tests/migrations/0001_setup_extensions.py
+++ b/tests/postgres_tests/migrations/0001_setup_extensions.py
@@ -6,13 +6,14 @@ from django.db import migrations
 try:
     from django.contrib.postgres.operations import (
         BtreeGinExtension, CITextExtension, CreateExtension, HStoreExtension,
-        TrigramExtension, UnaccentExtension,
+        PrewarmExtension, TrigramExtension, UnaccentExtension,
     )
 except ImportError:
     from django.test import mock
     BtreeGinExtension = mock.Mock()
     CreateExtension = mock.Mock()
     HStoreExtension = mock.Mock()
+    PrewarmExtension = mock.Mock()
     TrigramExtension = mock.Mock()
     UnaccentExtension = mock.Mock()
     CITextExtension = mock.Mock()
@@ -26,6 +27,7 @@ class Migration(migrations.Migration):
         # dash in its name.
         CreateExtension('uuid-ossp'),
         HStoreExtension(),
+        PrewarmExtension(),
         TrigramExtension(),
         UnaccentExtension(),
         CITextExtension(),


### PR DESCRIPTION
"The pg_prewarm module provides a convenient way to load relation data into either the operating system buffer cache or the PostgreSQL buffer cache."

It is packaged with Postgres starting from 9.4.

Ticket: https://code.djangoproject.com/ticket/27381#ticket