### PR TITLE
Fixed #27363 -- Fixed redirecting issue when session destroyed while request is processing.

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -3,7 +3,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.sessions.backends.base import UpdateError
-from django.shortcuts import redirect
+from django.core.exceptions import SuspiciousOperation
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.http import cookie_date
@@ -57,10 +57,9 @@ class SessionMiddleware(MiddlewareMixin):
                         try:
                             request.session.save()
                         except UpdateError:
-                            # The user is now logged out; redirecting to same
-                            # page will result in a redirect to the login page
-                            # if required.
-                            return redirect(request.path)
+                            msg = 'The request\'s session was deleted before the request completed. ' \
+                                  'The user may have logged out in a concurrent request, for example.'
+                            raise SuspiciousOperation(msg)
                         response.set_cookie(
                             settings.SESSION_COOKIE_NAME,
                             request.session.session_key, max_age=max_age,

--- a/docs/releases/1.10.3.txt
+++ b/docs/releases/1.10.3.txt
@@ -23,3 +23,6 @@ Bugfixes
 
 * Fixed ``QuerySet.bulk_create()`` on PostgreSQL when the number of objects is
   a multiple plus one of ``batch_size`` (:ticket:`27385`).
+
+* Fixed redirecting issue when session destroyed during request processing
+  (:ticket:`27363`)

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -25,7 +25,7 @@ from django.contrib.sessions.serializers import (
 from django.core import management
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.http import HttpResponse
 from django.test import (
     RequestFactory, TestCase, ignore_warnings, override_settings,
@@ -708,14 +708,13 @@ class SessionMiddlewareTests(TestCase):
         request.session.save(must_create=True)
         request.session.delete()
 
-        # Handle the response through the middleware. It will try to save the
-        # deleted session which will cause an UpdateError that's caught and
-        # results in a redirect to the original page.
-        response = middleware.process_response(request, response)
-
-        # Check that the response is a redirect.
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response['Location'], path)
+        msg = 'The request\'s session was deleted before the request completed. ' \
+              'The user may have logged out in a concurrent request, for example.'
+        with self.assertRaisesMessage(SuspiciousOperation, msg):
+            # Handle the response through the middleware. It will try to save the
+            # deleted session which will cause an UpdateError that's caught and
+            # raise SuspiciousOperation exception (400 request)
+            middleware.process_response(request, response)
 
     def test_session_delete_on_end(self):
         request = RequestFactory().get('/')


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/27363 for more details.

Imagine such case:
1. Logged in user loads a slow page in separate tab or as an ajax request, which modifies the session
2. User logs out before request in step 2 completes. This will delete the session from the db

Now when 2nd slow ajax request will be processed it will return 302 status with redirect to login page.
Actually it makes no sense for ajax request to have response with 302 status because it definitely not what we expect it to be. Same can be applied for any non-ajax request.

How it was proposed in initial ticket it's much better to return 400 status to indicate that something wrong with request (in this case - session deleted).
