### PR TITLE
Updated PostgreSQL links to https and made them canonical

### DIFF
--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -12,7 +12,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         if internal_type in ("GenericIPAddressField", "IPAddressField", "TimeField", "UUIDField"):
             # PostgreSQL will resolve a union as type 'text' if input types are
             # 'unknown'.
-            # http://www.postgresql.org/docs/9.4/static/typeconv-union-case.html
+            # https://www.postgresql.org/docs/current/static/typeconv-union-case.html
             # These fields cannot be implicitly cast back in the default
             # PostgreSQL configuration so we need to explicitly cast them.
             # We must also remove components of the type within brackets:
@@ -21,7 +21,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return '%s'
 
     def date_extract_sql(self, lookup_type, field_name):
-        # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
         if lookup_type == 'week_day':
             # For consistency across backends, we return Sunday=1, Saturday=7.
             return "EXTRACT('dow' FROM %s) + 1" % field_name
@@ -29,7 +29,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             return "EXTRACT('%s' FROM %s)" % (lookup_type, field_name)
 
     def date_trunc_sql(self, lookup_type, field_name):
-        # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
     def _convert_field_to_tz(self, field_name, tzname):
@@ -57,7 +57,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
         field_name, params = self._convert_field_to_tz(field_name, tzname)
-        # http://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        # https://www.postgresql.org/docs/current/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
         sql = "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
         return sql, params
 

--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -27,7 +27,7 @@ thrilled to be able to give something back to the open-source community.
 
 .. _Apache: https://httpd.apache.org/
 .. _Python: https://www.python.org/
-.. _PostgreSQL: http://www.postgresql.org/
+.. _PostgreSQL: https://www.postgresql.org/
 
 What does "Django" mean, and how do you pronounce it?
 =====================================================

--- a/docs/faq/install.txt
+++ b/docs/faq/install.txt
@@ -33,7 +33,7 @@ also need a database engine. PostgreSQL_ is recommended, because we're
 PostgreSQL fans, and MySQL_, `SQLite 3`_, and Oracle_ are also supported.
 
 .. _Python: https://www.python.org/
-.. _PostgreSQL: http://www.postgresql.org/
+.. _PostgreSQL: https://www.postgresql.org/
 .. _MySQL: https://www.mysql.com/
 .. _`SQLite 3`: https://www.sqlite.org/
 .. _Oracle: http://www.oracle.com/

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -19,7 +19,7 @@ only the common types, such as ``VARCHAR`` and ``INTEGER``. For more obscure
 column types, such as geographic polygons or even user-created types such as
 `PostgreSQL custom types`_, you can define your own Django ``Field`` subclasses.
 
-.. _PostgreSQL custom types: http://www.postgresql.org/docs/current/interactive/sql-createtype.html
+.. _PostgreSQL custom types: https://www.postgresql.org/docs/current/static/sql-createtype.html
 
 Alternatively, you may have a complex Python object that can somehow be
 serialized to fit into a standard database column type. This is another case

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -6,7 +6,7 @@ PostgreSQL specific aggregation functions
    :synopsis: PostgreSQL specific aggregation functions
 
 These functions are described in more detail in the `PostgreSQL docs
-<http://www.postgresql.org/docs/current/static/functions-aggregate.html>`_.
+<https://www.postgresql.org/docs/current/static/functions-aggregate.html>`_.
 
 .. note::
 

--- a/docs/ref/contrib/postgres/lookups.txt
+++ b/docs/ref/contrib/postgres/lookups.txt
@@ -17,7 +17,7 @@ similarity threshold.
 
 To use it, add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`
 and activate the `pg_trgm extension
-<http://www.postgresql.org/docs/current/interactive/pgtrgm.html>`_ on
+<https://www.postgresql.org/docs/current/static/pgtrgm.html>`_ on
 PostgreSQL. You can install the extension using the
 :class:`~django.contrib.postgres.operations.TrigramExtension` migration
 operation.
@@ -43,7 +43,7 @@ the `unaccent extension on PostgreSQL`_. The
 :class:`~django.contrib.postgres.operations.UnaccentExtension` migration
 operation is available if you want to perform this activation using migrations).
 
-.. _unaccent extension on PostgreSQL: http://www.postgresql.org/docs/current/interactive/unaccent.html
+.. _unaccent extension on PostgreSQL: https://www.postgresql.org/docs/current/static/unaccent.html
 
 The ``unaccent`` lookup can be used on
 :class:`~django.db.models.CharField` and :class:`~django.db.models.TextField`::

--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -6,7 +6,7 @@ Full text search
 
 The database functions in the ``django.contrib.postgres.search`` module ease
 the use of PostgreSQL's `full text search engine
-<http://www.postgresql.org/docs/current/static/textsearch.html>`_.
+<https://www.postgresql.org/docs/current/static/textsearch.html>`_.
 
 For the examples in this document, we'll use the models defined in
 :doc:`/topics/db/queries`.
@@ -167,7 +167,7 @@ In the event that all the fields you're querying on are contained within one
 particular model, you can create a functional index which matches the search
 vector you wish to use. The PostgreSQL documentation has details on
 `creating indexes for full text search
-<http://www.postgresql.org/docs/current/static/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX>`_.
+<https://www.postgresql.org/docs/current/static/textsearch-tables.html#TEXTSEARCH-TABLES-INDEX>`_.
 
 ``SearchVectorField``
 ---------------------
@@ -183,7 +183,7 @@ if it were an annotated ``SearchVector``::
     >>> Entry.objects.filter(search_vector='cheese')
     [<Entry: Cheese on Toast recipes>, <Entry: Pizza recipes>]
 
-.. _PostgreSQL documentation: http://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
+.. _PostgreSQL documentation: https://www.postgresql.org/docs/current/static/textsearch-features.html#TEXTSEARCH-UPDATE-TRIGGERS
 
 Trigram similarity
 ==================
@@ -193,7 +193,7 @@ three consecutive characters. In addition to the :lookup:`trigram_similar`
 lookup, you can use a couple of other expressions.
 
 To use them, you need to activate the `pg_trgm extension
-<http://www.postgresql.org/docs/current/interactive/pgtrgm.html>`_ on
+<https://www.postgresql.org/docs/current/static/pgtrgm.html>`_ on
 PostgreSQL. You can install it using the
 :class:`~django.contrib.postgres.operations.TrigramExtension` migration
 operation.

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -121,7 +121,7 @@ user with `ALTER ROLE`_.
 Django will work just fine without this optimization, but each new connection
 will do some additional queries to set these parameters.
 
-.. _ALTER ROLE: http://www.postgresql.org/docs/current/interactive/sql-alterrole.html
+.. _ALTER ROLE: https://www.postgresql.org/docs/current/static/sql-alterrole.html
 
 .. _database-isolation-level:
 
@@ -148,7 +148,7 @@ configuration in :setting:`DATABASES`::
     handle exceptions raised on serialization failures. This option is
     designed for advanced uses.
 
-.. _isolation level: http://www.postgresql.org/docs/current/static/transaction-iso.html
+.. _isolation level: https://www.postgresql.org/docs/current/static/transaction-iso.html
 
 Indexes for ``varchar`` and ``text`` columns
 --------------------------------------------
@@ -162,7 +162,7 @@ for the column.  The extra index is necessary to correctly perform
 lookups that use the ``LIKE`` operator in their SQL, as is done with the
 ``contains`` and ``startswith`` lookup types.
 
-.. _PostgreSQL operator class: http://www.postgresql.org/docs/current/static/indexes-opclass.html
+.. _PostgreSQL operator class: https://www.postgresql.org/docs/current/static/indexes-opclass.html
 
 Migration operation for adding extensions
 -----------------------------------------
@@ -185,7 +185,7 @@ Speeding up test execution with non-durable settings
 ----------------------------------------------------
 
 You can speed up test execution times by `configuring PostgreSQL to be
-non-durable <http://www.postgresql.org/docs/current/static/non-durability.html>`_.
+non-durable <https://www.postgresql.org/docs/current/static/non-durability.html>`_.
 
 .. warning::
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -765,7 +765,7 @@ object. If it's ``None``, Django uses the :ref:`current time zone
       `mysql_tzinfo_to_sql`_.
 
     .. _pytz: http://pytz.sourceforge.net/
-    .. _Time Zones: http://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-TIMEZONES
+    .. _Time Zones: https://www.postgresql.org/docs/current/static/datatype-datetime.html#DATATYPE-TIMEZONES
     .. _Choosing a Time Zone File: https://docs.oracle.com/cd/E11882_01/server.112/e10729/ch4datetime.htm#NLSPG258
     .. _mysql_tzinfo_to_sql: https://dev.mysql.com/doc/refman/en/mysql-tzinfo-to-sql.html
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -667,7 +667,7 @@ backend-specific.
 
 Supported by the PostgreSQL_ (``postgresql``) and MySQL_ (``mysql``) backends.
 
-.. _PostgreSQL: http://www.postgresql.org/docs/current/static/multibyte.html
+.. _PostgreSQL: https://www.postgresql.org/docs/current/static/multibyte.html
 .. _MySQL: https://dev.mysql.com/doc/refman/en/charset-database.html
 
 .. setting:: TEST_COLLATION

--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -30,7 +30,7 @@ able to store certain characters in the database, and information will be lost.
   for internal encoding.
 
 .. _MySQL manual: https://dev.mysql.com/doc/refman/en/charset-database.html
-.. _PostgreSQL manual: http://www.postgresql.org/docs/current/static/multibyte.html
+.. _PostgreSQL manual: https://www.postgresql.org/docs/current/static/multibyte.html
 .. _Oracle manual: https://docs.oracle.com/cd/E11882_01/server.112/e10729/toc.htm
 .. _section 2: https://docs.oracle.com/cd/E11882_01/server.112/e10729/ch2charset.htm#NLSPG002
 .. _section 11: https://docs.oracle.com/cd/E11882_01/server.112/e10729/ch11charsetmig.htm#NLSPG011

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -185,7 +185,7 @@ of people with their ages calculated by the database::
     Jane is 42.
     ...
 
-__ http://www.postgresql.org/docs/current/static/functions-datetime.html
+__ https://www.postgresql.org/docs/current/static/functions-datetime.html
 
 Passing parameters into ``raw()``
 ---------------------------------

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -115,7 +115,7 @@ see :setting:`DATABASES` for details.
 If you're using Django's :doc:`testing framework</topics/testing/index>` to test
 database queries, Django will need permission to create a test database.
 
-.. _PostgreSQL: http://www.postgresql.org/
+.. _PostgreSQL: https://www.postgresql.org/
 .. _MySQL: https://www.mysql.com/
 .. _psycopg2: http://initd.org/psycopg/
 .. _SQLite: https://www.sqlite.org/


### PR DESCRIPTION
www.postgresql.org is now https-only and no longer offers interactive documentation pages.