### PR TITLE
Fixed #27385 -- Fixed QuerySet.bulk_create() on PostgreSQL when the number of objects is a multiple plus one of batch_size.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1052,9 +1052,9 @@ class QuerySet(object):
         for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:
             if connections[self.db].features.can_return_ids_from_bulk_insert:
                 inserted_id = self._insert(item, fields=fields, using=self.db, return_id=True)
-                if len(objs) > 1:
+                if isinstance(inserted_id, list):
                     inserted_ids.extend(inserted_id)
-                if len(objs) == 1:
+                else:
                     inserted_ids.append(inserted_id)
             else:
                 self._insert(item, fields=fields, using=self.db)

--- a/docs/releases/1.10.3.txt
+++ b/docs/releases/1.10.3.txt
@@ -20,3 +20,6 @@ Bugfixes
 
 * Made the ``JavaScriptCatalog`` view respect the ``packages`` argument;
   previously it was ignored (:ticket:`27374`).
+
+* Fixed ``bulk_create`` when ``objs`` length is a multiple plus one of
+  ``batch_size`` (:ticket:`27385`).

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -171,10 +171,16 @@ class BulkCreateTests(TestCase):
 
     def test_explicit_batch_size(self):
         objs = [TwoFields(f1=i, f2=i) for i in range(0, 4)]
-        TwoFields.objects.bulk_create(objs, 2)
+        TwoFields.objects.bulk_create(objs, batch_size=1)
         self.assertEqual(TwoFields.objects.count(), len(objs))
         TwoFields.objects.all().delete()
-        TwoFields.objects.bulk_create(objs, len(objs))
+        TwoFields.objects.bulk_create(objs, batch_size=2)
+        self.assertEqual(TwoFields.objects.count(), len(objs))
+        TwoFields.objects.all().delete()
+        TwoFields.objects.bulk_create(objs, batch_size=3)
+        self.assertEqual(TwoFields.objects.count(), len(objs))
+        TwoFields.objects.all().delete()
+        TwoFields.objects.bulk_create(objs, batch_size=len(objs))
         self.assertEqual(TwoFields.objects.count(), len(objs))
 
     def test_empty_model(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27385

With the model

```python

from django.db import models

class TestModel(models.Model):
    number = models.IntegerField()

```

using a "real" db (postgresql) if I try to do this

```python
objs = [TestModel(number=n) for n in range(11)]
TestModel.objects.bulk_create(objs, batch_size=10)
```

I get this error

```python
/home/bameda/.virtualenvs/taiga/lib/python3.5/site-packages/django/db/models/manager.py in manager_method(self, *args, **kwargs)
     83         def create_method(name, method):
     84             def manager_method(self, *args, **kwargs):
---> 85                 return getattr(self.get_queryset(), name)(*args, **kwargs)
     86             manager_method.__name__ = method.__name__
     87             manager_method.__doc__ = method.__doc__

/home/bameda/.virtualenvs/taiga/lib/python3.5/site-packages/django/db/models/query.py in bulk_create(self, objs, batch_size)
    450                 if objs_without_pk:
    451                     fields = [f for f in fields if not isinstance(f, AutoField)]
--> 452                     ids = self._batched_insert(objs_without_pk, fields, batch_size)
    453                     if connection.features.can_return_ids_from_bulk_insert:
    454                         assert len(ids) == len(objs_without_pk)

/home/bameda/.virtualenvs/taiga/lib/python3.5/site-packages/django/db/models/query.py in _batched_insert(self, objs, fields, batch_size)
   1062                 inserted_id = self._insert(item, fields=fields, using=self.db, return_id=True)
   1063                 if len(objs) > 1:
-> 1064                     inserted_ids.extend(inserted_id)
   1065                 if len(objs) == 1:
   1066                     inserted_ids.append(inserted_id)

TypeError: 'int' object is not iterable
```

So this PR solve this.