### PR TITLE
Fixed #24128 -- Made admindocs' TemplateDetailView account for template loaders.

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -13,8 +13,8 @@ from django.db import models
 from django.http import Http404
 from django.template import engines
 from django.template.engine import Engine
-from django.template.loaders.filesystem import Loader
 from django.template.loaders.cached import Loader as Cached_Loader
+from django.template.loaders.filesystem import Loader
 from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
 from django.utils import six
 from django.utils.decorators import method_decorator

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -11,7 +11,6 @@ from django.contrib.admindocs import utils
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.db import models
 from django.http import Http404
-from django.template import engines
 from django.template.engine import Engine
 from django.template.loaders.cached import Loader as Cached_Loader
 from django.template.loaders.filesystem import Loader

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -11,6 +11,7 @@ from django.contrib.admindocs import utils
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.db import models
 from django.http import Http404
+from django.template import engines
 from django.template.engine import Engine
 from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
 from django.utils import six
@@ -353,8 +354,11 @@ class TemplateDetailView(BaseAdminDocsView):
             # Non-trivial TEMPLATES settings aren't supported (#24125).
             pass
         else:
-            # This doesn't account for template loaders (#24128).
-            for index, directory in enumerate(default_engine.dirs):
+            directories = set(default_engine.dirs)
+            for engine in engines.all():
+                for loader in engine.engine.template_loaders:
+                    directories.update(loader.get_dirs())
+            for index, directory in enumerate(directories):
                 template_file = os.path.join(directory, template)
                 if os.path.exists(template_file):
                     with open(template_file) as f:

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -357,13 +357,12 @@ class TemplateDetailView(BaseAdminDocsView):
             pass
         else:
             directories = set(default_engine.dirs)
-            for engine in engines.all():
-                for loader in engine.engine.template_loaders:
-                    if isinstance(loader, Loader):
-                        directories.update(loader.get_dirs())
-                    elif isinstance(loader, Cached_Loader):
-                        for cached_loader in loader.loaders:
-                            directories.update(cached_loader.get_dirs())
+            for loader in default_engine.template_loaders:
+                if isinstance(loader, Loader):
+                    directories.update(loader.get_dirs())
+                elif isinstance(loader, Cached_Loader):
+                    for cached_loader in loader.loaders:
+                        directories.update(cached_loader.get_dirs())
             for index, directory in enumerate(directories):
                 template_file = os.path.join(directory, template)
                 if os.path.exists(template_file):

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -13,6 +13,8 @@ from django.db import models
 from django.http import Http404
 from django.template import engines
 from django.template.engine import Engine
+from django.template.loaders.filesystem import Loader
+from django.template.loaders.cached import Loader as Cached_Loader
 from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
 from django.utils import six
 from django.utils.decorators import method_decorator
@@ -357,7 +359,11 @@ class TemplateDetailView(BaseAdminDocsView):
             directories = set(default_engine.dirs)
             for engine in engines.all():
                 for loader in engine.engine.template_loaders:
-                    directories.update(loader.get_dirs())
+                    if isinstance(loader, Loader):
+                        directories.update(loader.get_dirs())
+                    elif isinstance(loader, Cached_Loader):
+                        for cached_loader in loader.loaders:
+                            directories.update(cached_loader.get_dirs())
             for index, directory in enumerate(directories):
                 template_file = os.path.join(directory, template)
                 if os.path.exists(template_file):

--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -12,8 +12,6 @@ from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.db import models
 from django.http import Http404
 from django.template.engine import Engine
-from django.template.loaders.cached import Loader as Cached_Loader
-from django.template.loaders.filesystem import Loader
 from django.urls import get_mod_func, get_resolver, get_urlconf, reverse
 from django.utils import six
 from django.utils.decorators import method_decorator
@@ -357,11 +355,7 @@ class TemplateDetailView(BaseAdminDocsView):
         else:
             directories = set(default_engine.dirs)
             for loader in default_engine.template_loaders:
-                if isinstance(loader, Loader):
-                    directories.update(loader.get_dirs())
-                elif isinstance(loader, Cached_Loader):
-                    for cached_loader in loader.loaders:
-                        directories.update(cached_loader.get_dirs())
+                directories.update(loader.get_dirs())
             for index, directory in enumerate(directories):
                 template_file = os.path.join(directory, template)
                 if os.path.exists(template_file):

--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -18,11 +18,7 @@ from .base import Loader as BaseLoader
 class Loader(BaseLoader):
 
     def get_dirs(self):
-        dirs = set()
-        for loader in self.loaders:
-            if loader is not None:
-                dirs.update(loader.get_dirs())
-        return dirs
+        return {loader.get_dirs() for loader in self.loaders if loader is not None}
 
     def __init__(self, engine, loaders):
         self.template_cache = {}

--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -17,6 +17,13 @@ from .base import Loader as BaseLoader
 
 class Loader(BaseLoader):
 
+    def get_dirs(self):
+        dirs = set()
+        for loader in self.loaders:
+            if loader is not None:
+                dirs.update(loader.get_dirs())
+        return dirs
+
     def __init__(self, engine, loaders):
         self.template_cache = {}
         self.find_template_cache = {}  # RemovedInDjango20Warning

--- a/tests/admin_docs/templates/view_for_loader_test.html
+++ b/tests/admin_docs/templates/view_for_loader_test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Template for Test</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -105,6 +105,10 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         response = self.client.get(reverse('django-admindocs-templates', args=['admin_doc/template_detail.html']))
         self.assertContains(response, '<h1>Template: "admin_doc/template_detail.html"</h1>', html=True)
 
+    def test_template_detail_loader(self):
+        response = self.client.get(reverse('django-admindocs-templates', args=['view_for_loader_test.html']))
+        self.assertContains(response, 'view_for_loader_test.html</code></li>', html=True)
+
     def test_missing_docutils(self):
         utils.docutils_is_available = False
         try:

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -160,6 +160,12 @@ class AdminDocViewWithMultipleEngines(AdminDocViewTests):
         response = self.client.get(reverse('django-admindocs-tags'))
         self.assertContains(response, '<title>Template tags</title>', html=True)
 
+    def test_template_detail_loader(self):
+        # Overridden because non-trivial TEMPLATES settings aren't supported
+        # but the page shouldn't crash (#24125).
+        response = self.client.get(reverse('django-admindocs-templates', args=['view_for_loader_test.html']))
+        self.assertContains(response, '<h1>Template: "view_for_loader_test.html"</h1>', html=True)
+
 
 @unittest.skipUnless(utils.docutils_is_available, "no docutils installed.")
 class TestModelDetailView(TestDataMixin, AdminDocsTestCase):

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -107,7 +107,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
 
     def test_template_detail_loader(self):
         response = self.client.get(reverse('django-admindocs-templates', args=['view_for_loader_test.html']))
-        self.assertContains(response, 'view_for_loader_test.html</code></li>', html=True)
+        self.assertContains(response, 'view_for_loader_test.html</code></li>', html=False)
 
     def test_missing_docutils(self):
         utils.docutils_is_available = False


### PR DESCRIPTION
Modification for TemplateDetailView in admindocs to go through the directories from template loaders.

https://code.djangoproject.com/ticket/24128

Might need some improvements.
