### PR TITLE
Fixed #26578 -- Prohibited non-ASCII digits in validate_ipv4_address.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -252,7 +252,7 @@ validate_unicode_slug = RegexValidator(
     'invalid'
 )
 
-ipv4_re = _lazy_re_compile(r'^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\Z')
+ipv4_re = _lazy_re_compile(r'^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])){3}\Z')
 validate_ipv4_address = RegexValidator(ipv4_re, _('Enter a valid IPv4 address.'), 'invalid')
 
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -138,6 +138,7 @@ TEST_DATA = [
     (validate_ipv4_address, '25,1,1,1', ValidationError),
     (validate_ipv4_address, '25.1 .1.1', ValidationError),
     (validate_ipv4_address, '1.1.1.1\n', ValidationError),
+    (validate_ipv4_address, '٧.2٥.3٣.243', ValidationError),
 
     # validate_ipv6_address uses django.utils.ipv6, which
     # is tested in much greater detail in its own testcase


### PR DESCRIPTION
Could we get the ball rolling again on this ticket, it seems to have been forgotten.  Actually there are hundreds more cases where \d is being used when it probably shouldn't be, but this is the particular one that's bothering me currently.  

This responsibility is also duplicated [here](https://github.com/django/django/blob/f734e2d4b2fc4391a4d097b80357724815c1d414/django/core/validators.py#L83) in URLValidator class (with a different regex), if we are going to use a regex at all for this then ideally there should at least be one source of truth for the pattern.  