### PR TITLE
Fixed #27393 -- Aligned input boxes in admin password reset forms.

### DIFF
--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n static %}
 
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -17,11 +18,19 @@
 <p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
 
 <form method="post">{% csrf_token %}
-{{ form.new_password1.errors }}
-<p class="aligned wide"><label for="id_new_password1">{% trans 'New password:' %}</label>{{ form.new_password1 }}</p>
-{{ form.new_password2.errors }}
-<p class="aligned wide"><label for="id_new_password2">{% trans 'Confirm password:' %}</label>{{ form.new_password2 }}</p>
-<p><input type="submit" value="{% trans 'Change my password' %}" /></p>
+<fieldset class="module aligned">
+    <div class="form-row field-password1">
+        {{ form.new_password1.errors }}
+        <label for="id_new_password1">{% trans 'New password:' %}</label>
+        {{ form.new_password1 }}
+    </div>
+    <div class="form-row field-password2">
+        {{ form.new_password2.errors }}
+        <label for="id_new_password2">{% trans 'Confirm password:' %}</label>
+        {{ form.new_password2 }}
+    </div>
+    <input type="submit" value="{% trans 'Change my password' %}" />
+</fieldset>
 </form>
 
 {% else %}

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n static %}
 
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -15,8 +16,14 @@
 <p>{% trans "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one." %}</p>
 
 <form method="post">{% csrf_token %}
-{{ form.email.errors }}
-<p><label for="id_email">{% trans 'Email address:' %}</label> {{ form.email }} <input type="submit" value="{% trans 'Reset my password' %}" /></p>
+<fieldset class="module aligned">
+    <div class="form-row field-email">
+        {{ form.email.errors }}
+        <label for="id_email">{% trans 'Email address:' %}</label>
+        {{ form.email }}
+    </div>
+    <input type="submit" value="{% trans 'Reset my password' %}" />
+</fieldset>
 </form>
 
 {% endblock %}


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/27393

 The password reset and enter new password form input boxes are not aligned.
<img width="718" alt="django-password-reset" src="https://cloud.githubusercontent.com/assets/659504/19756736/08242dee-9c1f-11e6-96de-c737ebf798bb.png">

<img width="587" alt="django-enter-new-password" src="https://cloud.githubusercontent.com/assets/659504/19756743/0e76ed12-9c1f-11e6-95d7-ad419de2f001.png">

This opposed to the change password form:
<img width="1008" alt="django-password-change" src="https://cloud.githubusercontent.com/assets/659504/19756747/19b54b10-9c1f-11e6-8953-66ebe35941e2.png">

This PR fixes that:
<img width="739" alt="django-password-reset-new" src="https://cloud.githubusercontent.com/assets/659504/19756753/255c673c-9c1f-11e6-80a7-77654f90fae7.png">

<img width="677" alt="django-enter-new-password-new" src="https://cloud.githubusercontent.com/assets/659504/19756756/2a6a3f56-9c1f-11e6-9777-12748f3bd671.png">
