### PR TITLE
Fixed #27358 -- Added a system check to prohibit a leading slash in FileField's upload_to.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -251,6 +251,7 @@ answer newbie questions, and generally made Django that much better:
     flavio.curella@gmail.com
     Florian Apolloner <florian@apolloner.eu>
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
+    Frank Bijlsma <fbijlsma@gmail.com>
     Frank Tegtmeyer <fte@fte.to>
     Frank Wierzbicki
     Frank Wiles <frank@revsys.com>

--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -242,6 +242,7 @@ class FileField(Field):
         errors = super(FileField, self).check(**kwargs)
         errors.extend(self._check_unique())
         errors.extend(self._check_primary_key())
+        errors.extend(self._check_upload_to())
         return errors
 
     def _check_unique(self):
@@ -263,6 +264,20 @@ class FileField(Field):
                     "'primary_key' is not a valid argument for a %s." % self.__class__.__name__,
                     obj=self,
                     id='fields.E201',
+                )
+            ]
+        else:
+            return []
+
+    def _check_upload_to(self):
+        # Added system check based on #27358
+        if self.upload_to and self.upload_to[0] == '/':
+            return [
+                checks.Error(
+                    "'upload_to' should be a relative path, not an absolute path (remove leading slash) in %s." %
+                    self.__class__.__name__,
+                    obj=self,
+                    id='fields.E202',
                 )
             ]
         else:

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -184,6 +184,8 @@ File Fields
 
 * **fields.E200**: ``unique`` is not a valid argument for a ``FileField``.
 * **fields.E201**: ``primary_key`` is not a valid argument for a ``FileField``.
+* **fields.E202**: ``upload_to`` should be a relative path, not an absolute path
+                   (remove leading slash) in ``FileField``.
 * **fields.E210**: Cannot use ``ImageField`` because Pillow is not installed.
 
 Related Fields

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -558,6 +558,9 @@ Miscellaneous
 * ``ConditionalGetMiddleware`` no longer sets the ``Date`` header as Web
   servers set that header.
 
+* ``FileField`` now has system check checking upload_to doesn't have a leading
+  slash.
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -470,6 +470,22 @@ class FileFieldTests(SimpleTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_upload_to(self):
+        # System check added based on #27358
+        class Model(models.Model):
+            field = models.FileField(upload_to='/somewhere')
+
+        field = Model._meta.get_field('field')
+        errors = field.check()
+        expected = [
+            Error(
+                "'upload_to' should be a relative path, not an absolute path (remove leading slash) in FileField.",
+                obj=field,
+                id='fields.E202',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
 
 @isolate_apps('invalid_models_tests')
 class FilePathFieldTests(SimpleTestCase):


### PR DESCRIPTION
Added a systems check to check if upload_to in FileFields has a preceding slash also updated documentation to show the system check. Based on #27358
