### PR TITLE
Update TooManyFieldsSent comment for GET requests

### DIFF
--- a/django/core/exceptions.py
+++ b/django/core/exceptions.py
@@ -55,7 +55,7 @@ class DisallowedRedirect(SuspiciousOperation):
 
 class TooManyFieldsSent(SuspiciousOperation):
     """
-    The number of fields in a POST request exceeded
+    The number of fields in a GET or POST request exceeded
     settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.
     """
     pass


### PR DESCRIPTION
Updated the class comment for exceptions.TooManyFieldsSent to match the DATA_UPLOAD_MAX_NUMBER_FIELDS doc section.