### PR TITLE
Added pytz to test requirements

### DIFF
--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -8,6 +8,7 @@ Pillow
 PyYAML
 # pylibmc/libmemcached can't be built on Windows.
 pylibmc; sys.platform != 'win32'
+pytz
 selenium
 sqlparse
 tblib


### PR DESCRIPTION
This allows running tests w/o installing Django itself by only pointing
the Python path.