### PR TITLE
Fixed #27250 -- Removed 'for ="..."' from CheckboxSelectMultiple's <label>.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -822,6 +822,13 @@ class CheckboxSelectMultiple(RendererMixin, SelectMultiple):
         # never known if the value is actually omitted.
         return False
 
+    def id_for_label(self, id_):
+        """"
+        Don't include for="field_0" in <label> because clicking such a label
+        would toggle the first checkbox.
+        """
+        return ''
+
 
 class MultiWidget(Widget):
     """

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.forms import CheckboxSelectMultiple
 
 from .base import WidgetTest
@@ -125,3 +126,15 @@ class CheckboxSelectMultipleTest(WidgetTest):
         widget = self.widget(choices=self.beatles)
         self.assertIs(widget.value_omitted_from_data({}, {}, 'field'), False)
         self.assertIs(widget.value_omitted_from_data({'field': 'value'}, {}, 'field'), False)
+
+    def test_label(self):
+        """"
+        CheckboxSelectMultiple doesn't contain 'for="field_0"' in the <label>
+        because clicking that would toggle the first checkbox.
+        """
+        class TestForm(forms.Form):
+            f = forms.MultipleChoiceField(widget=CheckboxSelectMultiple)
+
+        bound_field = TestForm()['f']
+        self.assertEqual(bound_field.field.widget.id_for_label('id'), '')
+        self.assertEqual(bound_field.label_tag(), '<label>F:</label>')


### PR DESCRIPTION
Removes number appending on MultipleChoiceField
