### PR TITLE
 Fixed #26551 -- Prevented reuse of trimmed joins 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -258,6 +258,7 @@ answer newbie questions, and generally made Django that much better:
     flavio.curella@gmail.com
     Florian Apolloner <florian@apolloner.eu>
     Francisco Albarran Cristobal <pahko.xd@gmail.com>
+    François Freitag <mail@franek.fr>
     Frank Tegtmeyer <fte@fte.to>
     Frank Wierzbicki
     Frank Wiles <frank@revsys.com>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1192,10 +1192,12 @@ class Query:
             return self.split_exclude(filter_expr, LOOKUP_SEP.join(parts[:e.level]),
                                       can_reuse, e.names_with_path)
 
-        if can_reuse is not None:
-            can_reuse.update(join_list)
+        # used_joins should be updated before trimming since they are reused to
+        # determine which joins could be later promoted to INNER.
         used_joins = set(used_joins).union(set(join_list))
         targets, alias, join_list = self.trim_joins(sources, join_list, path)
+        if can_reuse is not None:
+            can_reuse.update(join_list)
 
         if field.is_relation:
             # No support for transforms for relational fields

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -648,8 +648,6 @@ class Employment(models.Model):
     title = models.CharField(max_length=128)
 
 
-# Bug #22429
-
 class School(models.Model):
     pass
 
@@ -659,6 +657,8 @@ class Student(models.Model):
 
 
 class Classroom(models.Model):
+    name = models.CharField(max_length=20)
+    has_blackboard = models.NullBooleanField()
     school = models.ForeignKey(School, models.CASCADE)
     students = models.ManyToManyField(Student, related_name='classroom')
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26551

The query generated by the ORM incorrecly assumes that many_to_one_city is used in the outer query, thus generates the line `AND U1."id" = ("many_to_one_city"."id")` (because alias is in `can_reuse` during the [split_exclude operation](https://github.com/francoisfreitag/django/blob/e3e6495298fe727a3281df452ee8646c55014832/django/db/models/sql/query.py#L1524-L1535)):

``` sql
SELECT "many_to_one_road"."id", "many_to_one_road"."city_id", "many_to_one_road"."name" 
FROM "many_to_one_road" 
WHERE NOT (
    "many_to_one_road"."city_id" IN (
        SELECT U2."city_id" AS Col1 
        FROM "many_to_one_district" U2 
        WHERE (U2."name" = 'Fairview' AND U2."city_id" IS NOT NULL)
    ) AND "many_to_one_road"."city_id" IN (
        SELECT U1."id" AS Col1 
        FROM "many_to_one_city" U1 
        LEFT OUTER JOIN "many_to_one_district" U2 ON (U1."id" = U2."city_id") 
        WHERE (
            U2."creation_date" IS NULL 
            AND U1."id" = ("many_to_one_city"."id")  -- Should not be here
        )
    )
)
```

The query should simply be:

``` sql
SELECT "many_to_one_road"."id", "many_to_one_road"."city_id", "many_to_one_road"."name" 
FROM "many_to_one_road" 
WHERE NOT (
    "many_to_one_road"."city_id" IN (
        SELECT U2."city_id" AS Col1 
        FROM "many_to_one_district" U2 
        WHERE (U2."name" = 'Fairview' AND U2."city_id" IS NOT NULL)
    ) AND "many_to_one_road"."city_id" IN (
        SELECT U1."id" AS Col1 
        FROM "many_to_one_city" U1 
        LEFT OUTER JOIN "many_to_one_district" U2 ON (U1."id" = U2."city_id") 
        WHERE U2."creation_date" IS NULL
    )
)
```

About the second commit, I found it surprising to update `used_joins` before trimming `join_list` and I think a comment doesn't hurt.
