### PR TITLE
Fixed #27418 -- Fixed occasional missing plural forms in JavaScriptCatalog.

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -401,7 +401,7 @@ class JavaScriptCatalog(View):
             else:
                 raise TypeError(key)
         for k, v in pdict.items():
-            catalog[k] = [v.get(i, '') for i in range(maxcnts[msgid] + 1)]
+            catalog[k] = [v.get(i, '') for i in range(maxcnts[k] + 1)]
         return catalog
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
This bug occurs when you have a missing translation in a language with more than two plural forms. In this case, you have a fallback to English and depending on the order in which the catalog is traversed in the for-loop you might end up with an msgid of a fallback English two-plural translation. When that happens, all translations will be reduced to two plural forms.

https://code.djangoproject.com/ticket/27418