### PR TITLE
Fixed #27434: Removed an edge case with model validation

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -69,7 +69,7 @@ class AbstractBaseUser(models.Model):
     def __str__(self):
         return self.get_username()
 
-    def clean(self):
+    def clean(self, exclude=None):
         setattr(self, self.USERNAME_FIELD, self.normalize_username(self.get_username()))
 
     def save(self, *args, **kwargs):

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -337,8 +337,8 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         verbose_name_plural = _('users')
         abstract = True
 
-    def clean(self):
-        super().clean()
+    def clean(self, exclude=None):
+        super().clean(exclude)
         self.email = self.__class__.objects.normalize_email(self.email)
 
     def get_full_name(self):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -64,6 +64,9 @@ details on these changes.
 * Support for ``Widget.render()`` methods without the ``renderer`` argument
   will be removed.
 
+* Support for ``Model.clean()`` methods without the ``exclude`` argument
+  will be removed.
+
 .. _deprecation-removed-in-2.0:
 
 2.0

--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -251,7 +251,11 @@ validation.
 The second step ``full_clean()`` performs is to call :meth:`Model.clean()`.
 This method should be overridden to perform custom validation on your model.
 
-.. method:: Model.clean()
+.. method:: Model.clean(exclude=exclude)
+
+.. versionchanged:: 1.11
+
+   Older versions of Django did not pass the ``exclude`` parameter.
 
 This method should be used to provide custom model validation, and to modify
 attributes on your model if desired. For instance, you could use it to
@@ -265,7 +269,7 @@ access to more than a single field::
 
     class Article(models.Model):
         ...
-        def clean(self):
+        def clean(self, exclude):
             # Don't allow draft entries to have a pub_date.
             if self.status == 'draft' and self.pub_date is not None:
                 raise ValidationError(_('Draft entries may not have a publication date.'))
@@ -295,7 +299,7 @@ error to the ``pub_date`` field::
 
     class Article(models.Model):
         ...
-        def clean(self):
+        def clean(self, exclude):
             # Don't allow draft entries to have a pub_date.
             if self.status == 'draft' and self.pub_date is not None:
                 raise ValidationError({'pub_date': _('Draft entries may not have a publication date.')})
@@ -308,6 +312,21 @@ pass a dictionary mapping field names to errors::
         'title': ValidationError(_('Missing title.'), code='required'),
         'pub_date': ValidationError(_('Invalid date.'), code='invalid'),
     })
+
+Note that you must not attempt to add errors to fields listed in the
+``exclude`` parameter. For example, if an error is related to a field that
+may not be part of some form you're using to update the model instance,
+you'll have to tie the error to the entire model instead::
+
+    class Article(models.Model):
+        ...
+        def clean(self, exclude):
+            if self.status == 'draft' and self.pub_date is not None:
+                if exclude and 'pub_date' in exclude:
+                    raise ValidationError(_('Draft entries may not have a publication date.'))
+                else:
+                    raise ValidationError({'pub_date': _('Draft entries may not have a publication date.')})
+            ...
 
 Finally, ``full_clean()`` will check any unique constraints on your model.
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -353,6 +353,10 @@ Models
 * Added :meth:`.QuerySet.union`, :meth:`~.QuerySet.intersection`, and
   :meth:`~.QuerySet.difference`.
 
+* Added optional support for passing the list of excluded fields into model's
+  own clean methods to make it possible to add errors to individual model form
+  fields if these fields are available on a particular form instance.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -315,7 +315,7 @@ class Vodcast(Media):
 class Parent(models.Model):
     name = models.CharField(max_length=128)
 
-    def clean(self):
+    def clean(self, exclude=None):
         if self.name == '_invalid':
             raise ValidationError('invalid')
 
@@ -324,7 +324,7 @@ class Child(models.Model):
     parent = models.ForeignKey(Parent, models.CASCADE, editable=False)
     name = models.CharField(max_length=30, blank=True)
 
-    def clean(self):
+    def clean(self, exclude=None):
         if self.name == '_invalid':
             raise ValidationError('invalid')
 

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -372,7 +372,7 @@ class CustomErrorMessage(models.Model):
         error_messages={'invalid': 'Model custom error message.'},
     )
 
-    def clean(self):
+    def clean(self, exclude=None):
         if self.name1 == 'FORBIDDEN_VALUE':
             raise ValidationError({'name1': [ValidationError('Model.clean() error messages.')]})
         elif self.name1 == 'FORBIDDEN_VALUE2':

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -31,7 +31,7 @@ class Book(models.Model):
     def __str__(self):
         return self.title
 
-    def clean(self):
+    def clean(self, exclude=None):
         # Ensure author is always accessible in clean method
         assert self.author.name is not None
 

--- a/tests/validation/models.py
+++ b/tests/validation/models.py
@@ -32,8 +32,8 @@ class ModelToValidate(models.Model):
                                                         validators=(validate_answer_to_universe,))
     slug = models.SlugField(blank=True)
 
-    def clean(self):
-        super().clean()
+    def clean(self, exclude=None):
+        super().clean(exclude=exclude)
         if self.number == 11:
             raise ValidationError('Invalid number supplied!')
 
@@ -83,7 +83,7 @@ class Article(models.Model):
     author = models.ForeignKey(Author, models.CASCADE)
     pub_date = models.DateTimeField(blank=True)
 
-    def clean(self):
+    def clean(self, exclude=None):
         if self.pub_date is None:
             self.pub_date = datetime.now()
 


### PR DESCRIPTION
When raising a dictionary ValidationError in Model.clean() for fields which are not part of a particular modelform, Django would raise a ValueError because it couldn't assign those errors to a form field.

This change moves errors from non-existing fields to NON_FIELD_ERRORS.

A better idea might be to check whether the field actually exists on the model and prepend the field's `verbose_name` to all error message, but I wanted to solicit some feedback first before moving forward with this patch, especially from @loic :-)

Link to related ticket for easier browsing: https://code.djangoproject.com/ticket/27434