### PR TITLE
Add 'pytz' to spelling wordlist

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -621,6 +621,7 @@ Pygments
 pysqlite
 pythonic
 Pythonista
+pytz
 qs
 Québec
 queryset


### PR DESCRIPTION
This makes the docs spelling check pass again.