### PR TITLE
Fixed #27402 - LocaleMiddleware redirecting when it should display 404.

### DIFF
--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -35,7 +35,8 @@ class LocaleMiddleware(MiddlewareMixin):
         urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
         i18n_patterns_used, prefixed_default_language = is_language_prefix_patterns_used(urlconf)
 
-        if response.status_code == 404 and not language_from_path and i18n_patterns_used:
+        if (response.status_code == 404 and not language_from_path and i18n_patterns_used and
+                (prefixed_default_language or language != settings.LANGUAGE_CODE)):
             language_path = '/%s%s' % (language, request.path_info)
             path_valid = is_valid_path(language_path, urlconf)
             path_needs_slash = (

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1859,6 +1859,16 @@ class UnprefixedDefaultLanguageTests(SimpleTestCase):
         response = self.client.get('/de-simple-page/')
         self.assertEqual(response.content, b'Yes')
 
+    def test_no_redirect_on_404(self):
+        """
+        Regression test for #27402.
+        Request for url not defined can cause an unneeded redirect to
+        /<defaut_language>/<request_url> when prefix_default_language is
+        False and /<default_language>/<request_url> has a url match.
+        """
+        response = self.client.get('/non-existent/', follow=False)
+        self.assertEqual(response.status_code, 404)
+
 
 @override_settings(
     USE_I18N=True,

--- a/tests/i18n/urls_default_unprefixed.py
+++ b/tests/i18n/urls_default_unprefixed.py
@@ -6,5 +6,6 @@ from django.utils.translation import ugettext_lazy as _
 urlpatterns = i18n_patterns(
     url(r'^(?P<arg>[\w-]+)-page', lambda request, **arg: HttpResponse(_("Yes"))),
     url(r'^simple/$', lambda r: HttpResponse(_("Yes"))),
+    url(r'^(.+)/(.+)/$', lambda *args: HttpResponse("")),
     prefix_default_language=False,
 )


### PR DESCRIPTION
That's improved version of https://github.com/django/django/pull/7461.

It's using the approach suggested by @francoisfreitag which looks correct.