### PR TITLE
Fixed #27440 -- Allowed reverse() to construct an absolute URL.

### DIFF
--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -89,13 +89,13 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None,
         if ns_pattern:
             resolver = get_ns_resolver(ns_pattern, resolver)
 
-    url = force_text(iri_to_uri(resolver._reverse_with_prefix(
+    uri = force_text(iri_to_uri(resolver._reverse_with_prefix(
         view, prefix, *args, **kwargs)))
 
     if request:
-        url = request.build_absolute_uri(url)
+        uri = request.build_absolute_uri(uri)
 
-    return url
+    return uri
 
 
 reverse_lazy = lazy(reverse, six.text_type)

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -27,7 +27,8 @@ def resolve(path, urlconf=None):
     return get_resolver(urlconf).resolve(path)
 
 
-def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
+def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None,
+            request=None):
     if urlconf is None:
         urlconf = get_urlconf()
     resolver = get_resolver(urlconf)
@@ -88,7 +89,14 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
         if ns_pattern:
             resolver = get_ns_resolver(ns_pattern, resolver)
 
-    return force_text(iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs)))
+    url = force_text(iri_to_uri(resolver._reverse_with_prefix(
+        view, prefix, *args, **kwargs)))
+
+    if request:
+        url = request.build_absolute_uri(url)
+
+    return url
+
 
 reverse_lazy = lazy(reverse, six.text_type)
 

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -75,6 +75,10 @@ construct a fully qualified URL when using the method. For example::
     >>> reverse('admin:app_list', kwargs={'app_label': 'auth'}, request=request)
     'htttp://example.com/admin/auth/'
 
+.. versionchanged:: 1.11
+
+    The ``request``argument was added.
+
 .. note::
 
     The string returned by ``reverse()`` is already

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -77,7 +77,7 @@ construct a fully qualified URL when using the method. For example::
 
 .. versionchanged:: 1.11
 
-    The ``request``argument was added.
+    The ``request`` argument was added.
 
 .. note::
 

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -16,7 +16,7 @@
 If you need to use something similar to the :ttag:`url` template tag in
 your code, Django provides the following function:
 
-.. function:: reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None)
+.. function:: reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None, request=None)
 
 ``viewname`` can be a :ref:`URL pattern name <naming-url-patterns>` or the
 callable view object. For example, given the following ``url``::
@@ -68,6 +68,13 @@ namespaces into URLs on specific application instances, according to the
 The ``urlconf`` argument is the URLconf module containing the URL patterns to
 use for reversing. By default, the root URLconf for the current thread is used.
 
+The ``request`` argument must be an instance of
+:class:`django.core.handlers.wsgi.WSGIRequest`  and it provides you a way to
+construct a fully qualified URL when using the method. For example::
+
+    >>> reverse('admin:app_list', kwargs={'app_label': 'auth'}, request=request)
+    'htttp://example.com/admin/auth/'
+
 .. note::
 
     The string returned by ``reverse()`` is already
@@ -85,7 +92,7 @@ use for reversing. By default, the root URLconf for the current thread is used.
 
 A lazily evaluated version of `reverse()`_.
 
-.. function:: reverse_lazy(viewname, urlconf=None, args=None, kwargs=None, current_app=None)
+.. function:: reverse_lazy(viewname, urlconf=None, args=None, kwargs=None, current_app=None, request=None)
 
 It is useful for when you need to use a URL reversal before your project's
 URLConf is loaded. Some common cases where this function is necessary are:

--- a/docs/ref/urlresolvers.txt
+++ b/docs/ref/urlresolvers.txt
@@ -69,7 +69,7 @@ The ``urlconf`` argument is the URLconf module containing the URL patterns to
 use for reversing. By default, the root URLconf for the current thread is used.
 
 The ``request`` argument must be an instance of
-:class:`django.core.handlers.wsgi.WSGIRequest`  and it provides you a way to
+``django.core.handlers.wsgi.WSGIRequest``  and it provides you a way to
 construct a fully qualified URL when using the method. For example::
 
     >>> reverse('admin:app_list', kwargs={'app_label': 'auth'}, request=request)

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -383,7 +383,9 @@ Tests
 URLs
 ~~~~
 
-* ...
+* Added `request` as an optional argument to :func:`~django.urls.base.reverse`
+  and :func:`~django.urls.base.reverse_lazy` to be able to get a fully
+  qualified URL.
 
 Validators
 ~~~~~~~~~~

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -383,8 +383,8 @@ Tests
 URLs
 ~~~~
 
-* Added `request` as an optional argument to :func:`~django.urls.base.reverse`
-  and :func:`~django.urls.base.reverse_lazy` to be able to get a fully
+* Added `request` as an optional argument to :func:`django.urls.reverse`
+  and :func:`django.urls.reverse_lazy` to be able to get a fully
   qualified URL.
 
 Validators

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -20,6 +20,7 @@ from django.http import (
 from django.shortcuts import redirect
 from django.test import (
     SimpleTestCase, TestCase, ignore_warnings, override_settings,
+    RequestFactory,
 )
 from django.test.utils import override_script_prefix
 from django.urls import (
@@ -332,6 +333,15 @@ class URLPatternReverse(SimpleTestCase):
             six.text_type
         )
 
+    def test_reverse_with_request(self):
+        factory = RequestFactory()
+        request = factory.get('/')
+
+        name, expected, args, kwargs = test_data[0]
+        resolved_url = reverse(name, args=args, kwargs=kwargs, request=request)
+
+        self.assertEqual(resolved_url, 'http://testserver/places/3/')
+
 
 class ResolverTests(SimpleTestCase):
     @ignore_warnings(category=RemovedInDjango20Warning)
@@ -476,6 +486,15 @@ class ReverseLazyTest(TestCase):
                 b'Some URL: %s' % reverse_lazy('some-login-page'),
                 'Some URL: /login/'
             )
+
+    def test_reverse_lazy_with_request(self):
+        factory = RequestFactory()
+        request = factory.get('/')
+
+        self.assertEqual(
+            reverse_lazy('some-login-page', request=request),
+            'http://testserver/login/'
+        )
 
 
 class ReverseLazySettingsTest(AdminScriptTestCase):

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -19,8 +19,8 @@ from django.http import (
 )
 from django.shortcuts import redirect
 from django.test import (
-    SimpleTestCase, TestCase, ignore_warnings, override_settings,
-    RequestFactory,
+    RequestFactory, SimpleTestCase, TestCase, ignore_warnings,
+    override_settings,
 )
 from django.test.utils import override_script_prefix
 from django.urls import (


### PR DESCRIPTION
trac issue: https://code.djangoproject.com/ticket/27440