### PR TITLE
Fixed #27372 -- Fixed inspectdb not handling SQLite3 tables with foreign keys that have spaces

### DIFF
--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -132,7 +132,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             if field_desc.startswith("FOREIGN KEY"):
                 # Find name of the target FK field
-                m = re.match(r'FOREIGN KEY\(([^\)]*)\).*', field_desc, re.I)
+                m = re.match(r'FOREIGN KEY\s*\(([^\)]*)\).*', field_desc, re.I)
                 field_name = m.groups()[0].strip('"')
             else:
                 field_name = field_desc.split()[0].strip('"')

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -143,17 +143,20 @@ class IntrospectionTests(TransactionTestCase):
 
     @skipUnless(connection.vendor == 'sqlite', "This is an sqlite-specific issue")
     def test_get_relations_alt_format(self):
-        """With SQLite, foreign keys can be added with different syntaxes."""
-        with connection.cursor() as cursor:
-            cursor.fetchone = mock.Mock(
-                return_value=[
-                    "CREATE TABLE track(id, art_id INTEGER, FOREIGN KEY(art_id) REFERENCES {}(id));".format(
-                        Article._meta.db_table
-                    )
-                ]
-            )
-            relations = connection.introspection.get_relations(cursor, 'mocked_table')
-        self.assertEqual(relations, {'art_id': ('id', Article._meta.db_table)})
+        """With SQLite, foreign keys can be added with different syntaxes and formatting."""
+        create_table_statements = [
+            "CREATE TABLE track(id, art_id INTEGER, FOREIGN KEY(art_id) REFERENCES {}(id));",
+            "CREATE TABLE track(id, art_id INTEGER, FOREIGN KEY (art_id) REFERENCES {}(id));"
+        ]
+        for create_table_stmt in create_table_statements:
+            with connection.cursor() as cursor:
+                cursor.fetchone = mock.Mock(
+                    return_value=[
+                        create_table_stmt.format(Article._meta.db_table)
+                    ]
+                )
+                relations = connection.introspection.get_relations(cursor, 'mocked_table')
+            self.assertEqual(relations, {'art_id': ('id', Article._meta.db_table)})
 
     @skipUnlessDBFeature('can_introspect_foreign_keys')
     def test_get_key_columns(self):


### PR DESCRIPTION
SQLite inspectdb didn't handle spaces between FOREIGN KEY and
parenthesis.

Based on https://github.com/django/django/pull/7402

https://code.djangoproject.com/ticket/27372