### PR TITLE
Fixed #25569 -- Expanded error message for select_related() on reverse relations.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -766,6 +766,7 @@ answer newbie questions, and generally made Django that much better:
     Ville Säävuori <http://www.unessa.net/>
     Vinay Sajip <vinay_sajip@yahoo.co.uk>
     Vincent Foley <vfoleybourgon@yahoo.ca>
+    Vincent Perez <perezv815@gmail.com>
     Vitaly Babiy <vbabiy86@gmail.com>
     Vladimir Kuzma <vladimirkuzma.ch@gmail.com>
     Vlado <vlado@labath.org>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1,7 +1,9 @@
 import re
 from itertools import chain
 
-from django.core.exceptions import EmptyResultSet, FieldError
+from django.core.exceptions import (
+    EmptyResultSet, FieldDoesNotExist, FieldError,
+)
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import OrderBy, Random, RawSQL, Ref
 from django.db.models.query_utils import QueryWrapper, select_related_descend
@@ -631,6 +633,22 @@ class SQLCompiler(object):
             )
             return chain(direct_choices, reverse_choices)
 
+        def _build_error_msg(field_name):
+            try:
+                field = opts.get_field(field_name)
+            except FieldDoesNotExist:
+                return "'%s' (reason: non existing field)" % field_name
+            if field_name in opts.fields_map:
+                return "'%s' (reason: reverse relational field)" % field_name
+            if field.is_relation and field.many_to_many:
+                return "'%s' (reason: many to many field)" % field_name
+            if field.is_relation and field.one_to_many:
+                return "'%s' (reason: generic relation)" % field_name
+            if (field.is_relation and field.many_to_one and
+                    not hasattr(field.remote_field, 'model')):
+                return "'%s' (reason: generic foreign key)" % field_name
+            return "'%s'" % field_name
+
         related_klass_infos = []
         if not restricted and self.query.max_depth and cur_depth > self.query.max_depth:
             # We've recursed far enough; bail out.
@@ -735,7 +753,7 @@ class SQLCompiler(object):
                 get_related_klass_infos(klass_info, next_klass_infos)
             fields_not_found = set(requested.keys()).difference(fields_found)
             if fields_not_found:
-                invalid_fields = ("'%s'" % s for s in fields_not_found)
+                invalid_fields = (_build_error_msg(field_name) for field_name in fields_not_found)
                 raise FieldError(
                     'Invalid field name(s) given in select_related: %s. '
                     'Choices are: %s' % (

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -179,7 +179,7 @@ class SelectRelatedValidationTests(SimpleTestCase):
     non-relational fields.
     """
     non_relational_error = "Non-relational field given in select_related: '%s'. Choices are: %s"
-    invalid_error = "Invalid field name(s) given in select_related: '%s'. Choices are: %s"
+    invalid_error = "Invalid field name(s) given in select_related: %s. Choices are: %s"
 
     def test_non_relational_field(self):
         with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', 'genus')):
@@ -196,26 +196,33 @@ class SelectRelatedValidationTests(SimpleTestCase):
             list(Species.objects.select_related('genus__name'))
 
     def test_many_to_many_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('toppings', '(none)')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'toppings' (reason: many to many field)", '(none)')):
             list(Pizza.objects.select_related('toppings'))
 
     def test_reverse_relational_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('child_1', 'genus')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'child_1' (reason: reverse relational field)", 'genus')):
             list(Species.objects.select_related('child_1'))
 
     def test_invalid_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('invalid_field', 'genus')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'invalid_field' (reason: non existing field)", 'genus')):
             list(Species.objects.select_related('invalid_field'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('related_invalid_field', 'family')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'related_invalid_field' (reason: non existing field)", 'family')):
             list(Species.objects.select_related('genus__related_invalid_field'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('invalid_field', '(none)')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'invalid_field' (reason: non existing field)", '(none)')):
             list(Domain.objects.select_related('invalid_field'))
 
     def test_generic_relations(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('tags', '')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'tags' (reason: generic relation)", '')):
             list(Bookmark.objects.select_related('tags'))
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('content_object', 'content_type')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'content_object' (reason: generic foreign key)", 'content_type')):
             list(TaggedItem.objects.select_related('content_object'))

--- a/tests/select_related_onetoone/tests.py
+++ b/tests/select_related_onetoone/tests.py
@@ -214,12 +214,13 @@ class ReverseSelectRelatedValidationTests(SimpleTestCase):
     invalid field is given in select_related().
     """
     non_relational_error = "Non-relational field given in select_related: '%s'. Choices are: %s"
-    invalid_error = "Invalid field name(s) given in select_related: '%s'. Choices are: %s"
+    invalid_error = "Invalid field name(s) given in select_related: %s. Choices are: %s"
 
     def test_reverse_related_validation(self):
         fields = 'userprofile, userstat'
 
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('foobar', fields)):
+        with self.assertRaisesMessage(FieldError, self.invalid_error %
+                                      ("'foobar' (reason: non existing field)", fields)):
             list(User.objects.select_related('foobar'))
 
         with self.assertRaisesMessage(FieldError, self.non_relational_error % ('username', fields)):


### PR DESCRIPTION
Improved the error message when an invalid select_related call is made.
In particular, this commit aims to give a more specific reason about
why the call is invalid.