### PR TITLE
Fixed #21963 -- Allowed translator comments on non-EOL positions.

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -26,10 +26,6 @@ __all__ = [
 LANGUAGE_SESSION_KEY = '_language'
 
 
-class TranslatorCommentWarning(SyntaxWarning):
-    pass
-
-
 # Here be dragons, so a short explanation of the logic won't hurt:
 # We are trying to solve two problems: (1) access settings, in particular
 # settings.USE_I18N, as late as possible, so that modules can be imported

--- a/tests/i18n/commands/templates/comments.thtml
+++ b/tests/i18n/commands/templates/comments.thtml
@@ -1,13 +1,19 @@
 {% load i18n %}
 
 {# ignored comment #1 #}{% trans "Translatable literal #9a" %}
-{# Translators: ignored i18n comment #1 #}{% trans "Translatable literal #9b" %}
-{# Translators: ignored i18n comment #2 #}{# ignored comment #2 #}{% trans "Translatable literal #9c" %}
-{# ignored comment #3 #}{# Translators: ignored i18n comment #3 #}{% trans "Translatable literal #9d" %}
+{# Translators: i18n comment #1 #}{% trans "Translatable literal #9b" %}
+{# Translators: i18n comment #2 #}{# ignored comment #2 #}{% trans "Translatable literal #9c" %}
+{# ignored comment #3 #}{# Translators: i18n comment #3 #}{% trans "Translatable literal #9d" %}
 {# ignored comment #4 #}{% trans "Translatable literal #9e" %}{# ignored comment #5 #}
-{# Translators: ignored i18n comment #4 #}{% trans "Translatable literal #9f" %}{# Translators: valid i18n comment #5 #}
+{# Translators: i18n comment #4 #}{% trans "Translatable literal #9f" %}{# Translators: valid i18n comment #5 #}
 {% trans "Translatable literal #9g" %}{# Translators: valid i18n comment #6 #}
 {# ignored comment #6 #}{% trans "Translatable literal #9h" %}{# Translators: valid i18n comment #7 #}
 {% trans "Translatable literal #9i" %}
 {# Translators: valid i18n comment #8 #}{# Translators: valid i18n comment #9 #}
 {% trans "Translatable literal #9j" %}
+{% comment %}Translators: i18n comment #9w{% endcomment %}{% trans "Translatable literal #9w" %} {% comment %}Translators: i18n comment #9w after{% endcomment %}
+something {% comment %}Translators: i18n comment #9z{% endcomment %}  DEMO DATA IN BETWEEN {% trans "Translatable literal #9z" %}
+{% comment %}Translators: i18n comment #9x{% endcomment %}
+{% trans "Translatable literal #9x" %}
+
+{# Translators: valid i18n comment #10 #}{# Translators: valid i18n comment #11 #} {% trans "Translatable literal #10a" %}

--- a/tests/i18n/commands/templates/translators.thtml
+++ b/tests/i18n/commands/templates/translators.thtml
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+{# Translators: Abbreviated month name 'Jan' #}
+{% trans "Jan" %}
+
+{# Translators: Abbreviated month name 'Feb'#}{% trans "Feb" %}
+
+{% comment %}Translators: Abbreviated month name 'Mar'{% endcomment %}{% trans "Mar" %}
+
+{# Translators: Abbreviated month name 'Apr' #} {% trans "Apr" %}
+
+{% comment %}Translators: Abbreviated month name 'May'{% endcomment %} {% trans "May" %}
+
+{# Translators: Abbreviated month name 'Jun'#}
+{% trans "Jun" %}
+
+{# Translators: Abbreviated month name 'Jul'#}
+
+{% trans "Jul" %}
+
+{% comment %}Translators: Abbreviated month name 'Aug'{% endcomment %}
+
+{% trans "Aug" %}
+
+{% trans "Sep" %} {#Translators: Abbreviated month name 'Sep'#} some text after
+
+{% trans "Oct" %} some text in between {% comment %}Translators: Abbreviated month name 'Oct'{% endcomment %}


### PR DESCRIPTION
This patch is based on #2410 by @dzhibas. I've made a few cleanups and upgraded it to play nicely with the master branch.

Description from the original PR:

> Inline translators comment and comment blocks in PO files now are in correct places and not ignored.
> 
> New test case added with months from ticket #21963, previous test for issue #19552 is modified because of incorrect behavior (ignoring inline comments in front and placing others for wrong translation strings)

The implementation reverts most of https://github.com/django/django/commit/47ddd6a4082d55d8856b7e6beac553485dd627f7 (authored by @ramiro), while leaves documentation in place, thus the latter may need updating.

If the approach is still considered valid, I'll proceed with this patch.

The only thing which currently concerns me is that this implementation naively concats multiple translator comments found on a single line, e. g.:

```
#. Translators: valid i18n comment #8 # Translators: valid i18n comment #9
#: templates/comments.thtml:13
msgid "Translatable literal #9j"
msgstr ""
```