### PR TITLE
Fixed #27355 -- Added “Create extension using migrations”

### DIFF
--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -59,3 +59,34 @@ the ``django.contrib.postgres.operations`` module.
 .. class:: UnaccentExtension()
 
     Installs the ``unaccent`` extension.
+
+    ``Create extension using migrations``
+    =====================================
+
+    You can create a PostgreSQL Extension in your database through the generated
+    migration file. Following example will cover creating of hstore extension,
+    but same usage principles apply for all other extensions, mentioned above.
+
+    1. Add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`.
+    2. Setup the hstore extension in PostgreSQL before the first ``CreateModel``
+       or ``AddField`` operation by adding a migration with the
+       :class:`~django.contrib.postgres.operations.HStoreExtension` operation.
+       For example::
+
+            from django.contrib.postgres.operations import HStoreExtension
+
+            class Migration(migrations.Migration):
+                ...
+
+                operations = [
+                    HStoreExtension(),
+                    ...
+                ]
+
+       Creating the extension requires a database user with superuser
+       privileges. If the Django database user doesn't have superuser
+       privileges, you'll have to create the extension outside of Django
+       migrations with a user that has the appropriate privileges.
+
+       For hstore extension, connect to your Django database and run the query:
+       ``CREATE EXTENSION IF NOT EXISTS hstore;``

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -63,8 +63,8 @@ the ``django.contrib.postgres.operations`` module.
 ``Create extension using migrations``
 =====================================
 
-You can create a PostgreSQL Extension in your database through the generated
-migration file. Following example will cover creating of hstore extension,
+You can create a PostgreSQL Extension in your database using a migration file.
+The following example will cover creating of hstore extension,
 but same usage principles apply for all other extensions, mentioned above.
 
 1. Add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`.
@@ -88,5 +88,6 @@ but same usage principles apply for all other extensions, mentioned above.
    privileges, you'll have to create the extension outside of Django
    migrations with a user that has the appropriate privileges.
 
-   For hstore extension, connect to your Django database and run the query:
+   For example, doing this manually with the hstore extension,
+   you would connect to your Django database and run the following query:
    ``CREATE EXTENSION IF NOT EXISTS hstore;``

--- a/docs/ref/contrib/postgres/operations.txt
+++ b/docs/ref/contrib/postgres/operations.txt
@@ -60,33 +60,33 @@ the ``django.contrib.postgres.operations`` module.
 
     Installs the ``unaccent`` extension.
 
-    ``Create extension using migrations``
-    =====================================
+``Create extension using migrations``
+=====================================
 
-    You can create a PostgreSQL Extension in your database through the generated
-    migration file. Following example will cover creating of hstore extension,
-    but same usage principles apply for all other extensions, mentioned above.
+You can create a PostgreSQL Extension in your database through the generated
+migration file. Following example will cover creating of hstore extension,
+but same usage principles apply for all other extensions, mentioned above.
 
-    1. Add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`.
-    2. Setup the hstore extension in PostgreSQL before the first ``CreateModel``
-       or ``AddField`` operation by adding a migration with the
-       :class:`~django.contrib.postgres.operations.HStoreExtension` operation.
-       For example::
+1. Add ``'django.contrib.postgres'`` in your :setting:`INSTALLED_APPS`.
+2. Setup the hstore extension in PostgreSQL before the first ``CreateModel``
+   or ``AddField`` operation by adding a migration with the
+   :class:`~django.contrib.postgres.operations.HStoreExtension` operation.
+   For example::
 
-            from django.contrib.postgres.operations import HStoreExtension
+        from django.contrib.postgres.operations import HStoreExtension
 
-            class Migration(migrations.Migration):
+        class Migration(migrations.Migration):
+            ...
+
+            operations = [
+                HStoreExtension(),
                 ...
+            ]
 
-                operations = [
-                    HStoreExtension(),
-                    ...
-                ]
+   Creating the extension requires a database user with superuser
+   privileges. If the Django database user doesn't have superuser
+   privileges, you'll have to create the extension outside of Django
+   migrations with a user that has the appropriate privileges.
 
-       Creating the extension requires a database user with superuser
-       privileges. If the Django database user doesn't have superuser
-       privileges, you'll have to create the extension outside of Django
-       migrations with a user that has the appropriate privileges.
-
-       For hstore extension, connect to your Django database and run the query:
-       ``CREATE EXTENSION IF NOT EXISTS hstore;``
+   For hstore extension, connect to your Django database and run the query:
+   ``CREATE EXTENSION IF NOT EXISTS hstore;``


### PR DESCRIPTION
Additional explanation for PostreSQL extensions installation via migrations, with hstore extension as an example.