### PR TITLE
Fixed #24195 -- Deconstructed the limit_choices_to option of related fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
     Abhishek Gautam <abhishekg1128@yahoo.com>
+    Adam Bogdał <adam@bogdal.pl>
     Adam Johnson <https://github.com/adamchainz>
     Adam Malinowski <http://adammalinowski.co.uk>
     Adam Vandenberg

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -322,6 +322,10 @@ class RelatedField(Field):
         name, path, args, kwargs = super().deconstruct()
         if self.remote_field.limit_choices_to:
             kwargs['limit_choices_to'] = self.remote_field.limit_choices_to
+        if self.remote_field.related_name is not None:
+            kwargs['related_name'] = self.remote_field.related_name
+        if self.remote_field.related_query_name is not None:
+            kwargs['related_query_name'] = self.remote_field.related_query_name
         return name, path, args, kwargs
 
     def get_forward_related_filter(self, obj):
@@ -561,10 +565,6 @@ class ForeignObject(RelatedField):
         kwargs['from_fields'] = self.from_fields
         kwargs['to_fields'] = self.to_fields
 
-        if self.remote_field.related_name is not None:
-            kwargs['related_name'] = self.remote_field.related_name
-        if self.remote_field.related_query_name is not None:
-            kwargs['related_query_name'] = self.remote_field.related_query_name
         if self.remote_field.parent_link:
             kwargs['parent_link'] = self.remote_field.parent_link
         # Work out string form of "to"
@@ -1395,10 +1395,6 @@ class ManyToManyField(RelatedField):
             kwargs['db_table'] = self.db_table
         if self.remote_field.db_constraint is not True:
             kwargs['db_constraint'] = self.remote_field.db_constraint
-        if self.remote_field.related_name is not None:
-            kwargs['related_name'] = self.remote_field.related_name
-        if self.remote_field.related_query_name is not None:
-            kwargs['related_query_name'] = self.remote_field.related_query_name
         # Rel needs more work.
         if isinstance(self.remote_field.model, str):
             kwargs['to'] = self.remote_field.model

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -318,6 +318,12 @@ class RelatedField(Field):
                 field.do_related_class(related, model)
             lazy_related_operation(resolve_related_class, cls, self.remote_field.model, field=self)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        if self.remote_field.limit_choices_to:
+            kwargs['limit_choices_to'] = self.remote_field.limit_choices_to
+        return name, path, args, kwargs
+
     def get_forward_related_filter(self, obj):
         """
         Return the keyword arguments that when supplied to

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -444,6 +444,10 @@ Miscellaneous
 * A model instance's primary key now appears in the default ``Model.__str__()``
   method, e.g. ``Question object (1)``.
 
+* ``makemigrations`` now detects changes to the model field ``limit_choices_to``
+  option. Add this to your existing migrations or accept an auto-generated
+  migration for fields that use it.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -214,6 +214,15 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.ForeignKey")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "foobar", "on_delete": models.CASCADE})
+        # Test limit_choices_to
+        field = models.ForeignKey("auth.Permission", models.CASCADE, limit_choices_to={'foo': 'bar'})
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ForeignKey")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {"to": "auth.Permission", "limit_choices_to": {'foo': 'bar'}, "on_delete": models.CASCADE}
+        )
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_foreign_key_swapped(self):
@@ -227,6 +236,17 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "on_delete": models.CASCADE})
         self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
+
+    def test_one_to_one(self):
+        # Test limit_choices_to
+        field = models.OneToOneField("auth.Permission", models.CASCADE, limit_choices_to={'foo': 'bar'})
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {"to": "auth.Permission", "limit_choices_to": {'foo': 'bar'}, "on_delete": models.CASCADE}
+        )
 
     def test_image_field(self):
         field = models.ImageField(upload_to="foo/barness", width_field="width", height_field="height")
@@ -294,6 +314,12 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.ManyToManyField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "custom_table"})
+        # Test limit_choices_to
+        field = models.ManyToManyField("auth.Permission", limit_choices_to={'foo': 'bar'})
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ManyToManyField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "limit_choices_to": {'foo': 'bar'}})
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_many_to_many_field_swapped(self):

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -214,6 +214,15 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.ForeignKey")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "foobar", "on_delete": models.CASCADE})
+        # Test related_query_name
+        field = models.ForeignKey("auth.Permission", models.CASCADE, related_query_name="foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ForeignKey")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {"to": "auth.Permission", "related_query_name": "foobar", "on_delete": models.CASCADE}
+        )
         # Test limit_choices_to
         field = models.ForeignKey("auth.Permission", models.CASCADE, limit_choices_to={'foo': 'bar'})
         name, path, args, kwargs = field.deconstruct()
@@ -223,6 +232,12 @@ class FieldDeconstructionTests(SimpleTestCase):
             kwargs,
             {"to": "auth.Permission", "limit_choices_to": {'foo': 'bar'}, "on_delete": models.CASCADE}
         )
+        # Test unique
+        field = models.ForeignKey("auth.Permission", models.CASCADE, unique=True)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ForeignKey")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "unique": True, "on_delete": models.CASCADE})
 
     @override_settings(AUTH_USER_MODEL="auth.Permission")
     def test_foreign_key_swapped(self):
@@ -238,6 +253,56 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
 
     def test_one_to_one(self):
+        # Test basic pointing
+        from django.contrib.auth.models import Permission
+        field = models.OneToOneField("auth.Permission", models.CASCADE)
+        field.remote_field.model = Permission
+        field.remote_field.field_name = "id"
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "on_delete": models.CASCADE})
+        self.assertFalse(hasattr(kwargs['to'], "setting_name"))
+        # Test swap detection for swappable model
+        field = models.OneToOneField("auth.User", models.CASCADE)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.User", "on_delete": models.CASCADE})
+        self.assertEqual(kwargs['to'].setting_name, "AUTH_USER_MODEL")
+        # Test nonexistent (for now) model
+        field = models.OneToOneField("something.Else", models.CASCADE)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "something.Else", "on_delete": models.CASCADE})
+        # Test on_delete
+        field = models.OneToOneField("auth.User", models.SET_NULL)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.User", "on_delete": models.SET_NULL})
+        # Test to_field
+        field = models.OneToOneField("auth.Permission", models.CASCADE, to_field="foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "to_field": "foobar", "on_delete": models.CASCADE})
+        # Test related_name
+        field = models.OneToOneField("auth.Permission", models.CASCADE, related_name="foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "foobar", "on_delete": models.CASCADE})
+        # Test related_query_name
+        field = models.OneToOneField("auth.Permission", models.CASCADE, related_query_name="foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(
+            kwargs,
+            {"to": "auth.Permission", "related_query_name": "foobar", "on_delete": models.CASCADE}
+        )
         # Test limit_choices_to
         field = models.OneToOneField("auth.Permission", models.CASCADE, limit_choices_to={'foo': 'bar'})
         name, path, args, kwargs = field.deconstruct()
@@ -247,6 +312,12 @@ class FieldDeconstructionTests(SimpleTestCase):
             kwargs,
             {"to": "auth.Permission", "limit_choices_to": {'foo': 'bar'}, "on_delete": models.CASCADE}
         )
+        # Test unique
+        field = models.OneToOneField("auth.Permission", models.CASCADE, unique=True)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.OneToOneField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "on_delete": models.CASCADE})
 
     def test_image_field(self):
         field = models.ImageField(upload_to="foo/barness", width_field="width", height_field="height")
@@ -314,6 +385,12 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.ManyToManyField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"to": "auth.Permission", "related_name": "custom_table"})
+        # Test related_query_name
+        field = models.ManyToManyField("auth.Permission", related_query_name="foobar")
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.ManyToManyField")
+        self.assertEqual(args, [])
+        self.assertEqual(kwargs, {"to": "auth.Permission", "related_query_name": "foobar"})
         # Test limit_choices_to
         field = models.ManyToManyField("auth.Permission", limit_choices_to={'foo': 'bar'})
         name, path, args, kwargs = field.deconstruct()


### PR DESCRIPTION
This PR fixes https://code.djangoproject.com/ticket/24195