### PR TITLE
Fixed #27119 -- management_form property as a cached_property

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -87,7 +87,7 @@ class BaseFormSet(object):
     def __nonzero__(self):      # Python 2 compatibility
         return type(self).__bool__(self)
 
-    @property
+    @cached_property
     def management_form(self):
         """Returns the ManagementForm instance for this FormSet."""
         if self.is_bound:


### PR DESCRIPTION
Wrapped management_form property with cached_property, because of multiple usage of management_form in BaseFormSet class.