### PR TITLE
Fixed #27029 -- Added validator for utf-8 compatible email adresses

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -238,6 +238,13 @@ class EmailValidator(object):
 
 validate_email = EmailValidator()
 
+validate_email_utf8 = EmailValidator()
+validate_email_utf8.user_regex = _lazy_re_compile(
+    r"(^[-!#$%&'*+/=?^`{}|~\w]+(\.[-!#$%&'*+/=?^`{}|~\w]+)*\Z"  # dot-atom
+    r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
+    re.IGNORECASE + (re.UNICODE if six.PY2 else 0)
+)
+
 slug_re = _lazy_re_compile(r'^[-a-zA-Z0-9_]+\Z')
 validate_slug = RegexValidator(
     slug_re,

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -174,6 +174,15 @@ to, or in lieu of custom ``field.clean()`` methods.
 
     An :class:`EmailValidator` instance without any customizations.
 
+``validate_email_utf8``
+------------------
+
+.. data:: validate_email_utf8
+
+    An :class:`EmailValidator` instance with support for utf-8
+    in the local-part of the address.
+
+
 ``validate_slug``
 -----------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -393,6 +393,9 @@ Validators
   :data:`~django.core.validators.validate_image_file_extension` to validate
   image files.
 
+* Added :data:`django.core.validators.validate_email_utf8` to validate email
+  addresses that support utf-8 in the local-part of the address.
+
 .. _backwards-incompatible-1.11:
 
 Backwards incompatible changes in 1.11

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -14,7 +14,7 @@ from django.core.validators import (
     BaseValidator, DecimalValidator, EmailValidator, FileExtensionValidator,
     MaxLengthValidator, MaxValueValidator, MinLengthValidator,
     MinValueValidator, RegexValidator, URLValidator, int_list_validator,
-    validate_comma_separated_integer_list, validate_email,
+    validate_comma_separated_integer_list, validate_email, validate_email_utf8,
     validate_image_file_extension, validate_integer, validate_ipv4_address,
     validate_ipv6_address, validate_ipv46_address, validate_slug,
     validate_unicode_slug,
@@ -94,6 +94,15 @@ TEST_DATA = [
     (validate_email, 'a\n@b.com', ValidationError),
     (validate_email, '"test@test"\n@example.com', ValidationError),
     (validate_email, 'a@[127.0.0.1]\n', ValidationError),
+
+    (validate_email_utf8, 'normal_ascii_email@here.com', None),
+    (validate_email_utf8, 'ʬ你@here.com', None),
+    (validate_email_utf8, 'ʬ-ʬ你@好ʬ.com', None),
+    (validate_email_utf8, 'うえあいお@えあい.com', None),
+    (validate_email_utf8, 'test@うえあ.com', None),
+    # Emoji shouldn't be supported
+    (validate_email_utf8, '💩@domain.com', ValidationError),
+    (validate_email_utf8, 'えあい💩えあい@えあいdomain.com', ValidationError),
 
     (validate_slug, 'slug-ok', None),
     (validate_slug, 'longer-slug-still-ok', None),


### PR DESCRIPTION
Link to trac ticket:
https://code.djangoproject.com/ticket/27029

Worked further on some of the changes in https://github.com/django/django/pull/7039 of https://github.com/claudep