### PR TITLE
Fixed #27088 -- Allowed GEOSGeometry to accept Python 2.7 memoryview.

### DIFF
--- a/django/contrib/gis/db/models/proxy.py
+++ b/django/contrib/gis/db/models/proxy.py
@@ -68,7 +68,7 @@ class SpatialProxy(DeferredAttribute):
             if value.srid is None:
                 # Assigning the field SRID if the geometry has no SRID.
                 value.srid = self._field.srid
-        elif value is None or isinstance(value, six.string_types + (six.memoryview,)):
+        elif value is None or isinstance(value, six.string_types + six.buffer_types):
             # Set geometries with None, WKT, HEX, or WKB
             pass
         else:

--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -96,7 +96,10 @@ class OGRGeometry(GDALBase):
                 OGRGeomType(geom_input)
                 g = capi.create_geom(OGRGeomType(geom_input).num)
         elif isinstance(geom_input, six.buffer_types):
-            geom_input_bytes = bytes(geom_input)
+            if hasattr(geom_input, 'tobytes'):
+                geom_input_bytes = geom_input.tobytes()
+            else:
+                geom_input_bytes = bytes(geom_input)
             # WKB was passed in
             g = capi.from_wkb(geom_input_bytes, None, byref(c_void_p()), len(geom_input_bytes))
         elif isinstance(geom_input, OGRGeomType):

--- a/django/contrib/gis/gdal/geometries.py
+++ b/django/contrib/gis/gdal/geometries.py
@@ -95,9 +95,10 @@ class OGRGeometry(GDALBase):
                 # (e.g., 'Point', 'POLYGON').
                 OGRGeomType(geom_input)
                 g = capi.create_geom(OGRGeomType(geom_input).num)
-        elif isinstance(geom_input, six.memoryview):
+        elif isinstance(geom_input, six.buffer_types):
+            geom_input_bytes = bytes(geom_input)
             # WKB was passed in
-            g = capi.from_wkb(bytes(geom_input), None, byref(c_void_p()), len(geom_input))
+            g = capi.from_wkb(geom_input_bytes, None, byref(c_void_p()), len(geom_input_bytes))
         elif isinstance(geom_input, OGRGeomType):
             # OGRGeomType was passed in, an empty geometry will be created.
             g = capi.create_geom(geom_input.num)

--- a/django/contrib/gis/gdal/raster/band.py
+++ b/django/contrib/gis/gdal/raster/band.py
@@ -207,7 +207,7 @@ class GDALBand(GDALBase):
             access_flag = 1
 
             # Instantiate ctypes array holding the input data
-            if isinstance(data, (bytes, six.memoryview)) or (numpy and isinstance(data, numpy.ndarray)):
+            if isinstance(data, (bytes,) + six.buffer_types) or (numpy and isinstance(data, numpy.ndarray)):
                 data_array = ctypes_array.from_buffer_copy(data)
             else:
                 data_array = ctypes_array(*data)

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -70,7 +70,7 @@ class GEOSGeometry(GEOSBase, ListMixin):
         elif isinstance(geo_input, GEOM_PTR):
             # When the input is a pointer to a geometry (GEOM_PTR).
             g = geo_input
-        elif isinstance(geo_input, six.memoryview):
+        elif isinstance(geo_input, six.buffer_types):
             # When the input is a buffer (WKB).
             g = wkb_r().read(geo_input)
         elif isinstance(geo_input, GEOSGeometry):

--- a/django/contrib/gis/geos/prototypes/io.py
+++ b/django/contrib/gis/geos/prototypes/io.py
@@ -152,8 +152,11 @@ class _WKBReader(IOBase):
 
     def read(self, wkb):
         "Returns a _pointer_ to C GEOS Geometry object from the given WKB."
-        if isinstance(wkb, six.memoryview):
-            wkb_s = bytes(wkb)
+        if isinstance(wkb, six.buffer_types):
+            if hasattr(wkb, 'tobytes'):
+                wkb_s = wkb.tobytes()
+            else:
+                wkb_s = bytes(wkb)
             return wkb_reader_read(self.ptr, wkb_s, len(wkb_s))
         elif isinstance(wkb, (bytes, six.string_types)):
             return wkb_reader_read_hex(self.ptr, wkb, len(wkb))

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -54,7 +54,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             return "'%s'" % six.text_type(value).replace("\'", "\'\'")
         elif value is None:
             return "NULL"
-        elif isinstance(value, (bytes, bytearray, six.memoryview)):
+        elif isinstance(value, six.buffer_types):
             # Bytes are only allowed for BLOB fields, encoded as string
             # literals containing hexadecimal data and preceded by a single "X"
             # character:

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -59,6 +59,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             # literals containing hexadecimal data and preceded by a single "X"
             # character:
             # value = b'\x01\x02' => value_hex = b'0102' => return X'0102'
+            if hasattr(value, 'tobytes'):
+                value = value.tobytes()
+            else:
+                value = bytes(value)
             value = bytes(value)
             hex_encoder = codecs.getencoder('hex_codec')
             value_hex, _length = hex_encoder(value)

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -124,7 +124,7 @@ def force_bytes(s, encoding='utf-8', strings_only=False, errors='strict'):
             return s.decode('utf-8', errors).encode(encoding, errors)
     if strings_only and is_protected_type(s):
         return s
-    if isinstance(s, six.memoryview):
+    if isinstance(s, six.buffer_types):
         return bytes(s)
     if isinstance(s, Promise):
         return six.text_type(s).encode(encoding, errors)

--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -125,7 +125,10 @@ def force_bytes(s, encoding='utf-8', strings_only=False, errors='strict'):
     if strings_only and is_protected_type(s):
         return s
     if isinstance(s, six.buffer_types):
-        return bytes(s)
+        if hasattr(s, 'tobytes'):
+            return s.tobytes()
+        else:
+            return bytes(s)
     if isinstance(s, Promise):
         return six.text_type(s).encode(encoding, errors)
     if not isinstance(s, six.string_types):


### PR DESCRIPTION
:warning: This PR should be treated as introduce to discussion.
 
It looked like simple fix but it reviled some dipper problems. I can't just simple use `memoryview` in `six.memoryview` many python 2.7 libraries rely on `buffer` (ex. [sqlite3](http://bugs.python.org/issue7723)). Se we need to use `buffer` as fallback.

 I took assumption from the [six module](https://github.com/django/django/blob/master/django/utils/six.py#L877):

> memoryview and buffer are not strictly equivalent, but should be fine for django core usage.

and I try to change comparison from single `six.memoryview` to `six.buffer_types`. In python 2.7 `six.buffer_types` will contains both `buffer` and `memoryview` in my proposal.

After some refactoring I discover that `memoryview` act not as expected with the `bytes` function which is used in many places outside the GIS lib as well.

```python
Python 2.7
>>> bytes(memoryview(b'foo'))
'<memory at 0x7f3c2cd00640>'

Python 3.5
>>> bytes(memoryview(b'foo'))
b'foo'
```

I stop in here and I think this whole approach with additional `six` patches need to be rethink. `memoryview` from python 2.7 doesn't act exactly the same like in python 3.5. And unfortunately differences between `buffer` and `memoryview` are to big, we can't use them interchangeable. What do you think @claudep ?