### PR TITLE
[Experiment] Unsafe queryset (non)copying

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -202,7 +202,9 @@ class BaseExpression(object):
 
         Returns: an Expression to be added to the query.
         """
-        c = self.copy()
+        c = self
+        if not query.is_unsafe:
+            c = self.copy()
         c.is_summary = summarize
         c.set_source_expressions([
             expr.resolve_expression(query, allow_joins, reuse, summarize)
@@ -398,7 +400,9 @@ class CombinedExpression(Expression):
         return expression_wrapper % sql, expression_params
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        c = self.copy()
+        c = self
+        if not query.is_unsafe:
+            c = self.copy()
         c.is_summary = summarize
         c.lhs = c.lhs.resolve_expression(query, allow_joins, reuse, summarize, for_save)
         c.rhs = c.rhs.resolve_expression(query, allow_joins, reuse, summarize, for_save)
@@ -507,7 +511,9 @@ class Func(Expression):
         self.source_expressions = exprs
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        c = self.copy()
+        c = self
+        if not query.is_unsafe:
+            c = self.copy()
         c.is_summary = summarize
         for pos, arg in enumerate(c.source_expressions):
             c.source_expressions[pos] = arg.resolve_expression(query, allow_joins, reuse, summarize, for_save)
@@ -756,7 +762,9 @@ class When(Expression):
         return [self.result._output_field_or_none]
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        c = self.copy()
+        c = self
+        if not query.is_unsafe:
+            c = self.copy()
         c.is_summary = summarize
         if hasattr(c.condition, 'resolve_expression'):
             c.condition = c.condition.resolve_expression(query, allow_joins, reuse, summarize, False)
@@ -823,7 +831,9 @@ class Case(Expression):
         self.default = exprs[-1]
 
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        c = self.copy()
+        c = self
+        if not query.is_unsafe:
+            c = self.copy()
         c.is_summary = summarize
         for pos, case in enumerate(c.cases):
             c.cases[pos] = case.resolve_expression(query, allow_joins, reuse, summarize, for_save)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -170,6 +170,7 @@ class QuerySet(object):
         self._known_related_objects = {}  # {rel_field, {pk: rel_obj}}
         self._iterable_class = ModelIterable
         self._fields = None
+        self.is_unsafe = False
 
     def as_manager(cls):
         # Address the circular dependency between `Queryset` and `Manager`.
@@ -769,6 +770,8 @@ class QuerySet(object):
     ##################################################################
 
     def unsafe(self):
+        self.is_unsafe = True
+        self.query.is_unsafe = True
         return self
 
     def all(self):
@@ -1062,6 +1065,8 @@ class QuerySet(object):
         return inserted_ids
 
     def _clone(self, **kwargs):
+        if self.is_unsafe:
+            return self
         query = self.query.clone()
         if self._sticky_filter:
             query.filter_is_sticky = True

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -768,6 +768,9 @@ class QuerySet(object):
     # PUBLIC METHODS THAT ALTER ATTRIBUTES AND RETURN A NEW QUERYSET #
     ##################################################################
 
+    def unsafe(self):
+        return self
+
     def all(self):
         """
         Returns a new QuerySet that is a copy of the current one. This allows a

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -203,6 +203,7 @@ class Query(object):
         self.deferred_loading = (set(), True)
 
         self.context = {}
+        self.is_unsafe = False
 
     @property
     def extra(self):
@@ -235,6 +236,8 @@ class Query(object):
         return self.get_compiler(DEFAULT_DB_ALIAS).as_sql()
 
     def __deepcopy__(self, memo):
+        if self.is_unsafe:
+            return self
         result = self.clone(memo=memo)
         memo[id(self)] = result
         return result
@@ -262,7 +265,10 @@ class Query(object):
         Creates a copy of the current instance. The 'kwargs' parameter can be
         used by clients to update attributes after copying has taken place.
         """
+        if self.is_unsafe:
+            return self
         obj = Empty()
+        obj.is_unsafe = self.is_unsafe
         obj.__class__ = klass or self.__class__
         obj.model = self.model
         obj.alias_refcount = self.alias_refcount.copy()


### PR DESCRIPTION
I thought it would be interesting to check what performance would look like if we were to disable certain safety mechanisms the ORM imposes. I've done this by adding an `unsafe` queryset method which, currently, only disables the copy procedure when chaining queryset methods together.

I benchmarked the following queryset using djangobench, and it's consistently about 1.3 - 1.4 times faster. Note that no actual SQL is being generated and sent to the server. Improvements diminish as soon as you interact with the database because it's responsible for a larger percentage of overall time. I also benchmarked the memory usage which is close enough to 1kb less.

```
qs = Book.objects.unsafe().filter(
        pages__lte=1000
    ).filter(
        author__region__startswith='region_'
    ).values('author__name').annotate(
        pagesum=Sum('pages'),
        counted=Count('*'),
        avgpg=Avg('pages')
    )
```

I think for querysets where the number of chained methods grows quite large there's value in looking to provide opt-in optimisations. Would anyone else be interested in something like this?