### PR TITLE
Fixed #26920 -- Made GEOSGeometry equality check consider the srid.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -174,12 +174,14 @@ class GEOSGeometry(GEOSBase, ListMixin):
     def __eq__(self, other):
         """
         Equivalence testing, a Geometry may be compared with another Geometry
-        or a WKT representation.
+        or a WKT or EWKT representation.
         """
         if isinstance(other, six.string_types):
+            if other.startswith('SRID'):
+                return self.ewkt == other
             return self.wkt == other
         elif isinstance(other, GEOSGeometry):
-            return self.equals_exact(other)
+            return self.srid == other.srid and self.equals_exact(other)
         else:
             return False
 

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -178,7 +178,7 @@ class GEOSGeometry(GEOSBase, ListMixin):
         """
         if isinstance(other, six.string_types):
             if other.startswith('SRID=0;'):
-                return self.wkt == other[7:]  # Test only WKT part of other
+                return self.ewkt == other[7:]  # Test only WKT part of other
             return self.ewkt == other
         elif isinstance(other, GEOSGeometry):
             return self.srid == other.srid and self.equals_exact(other)

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -177,9 +177,7 @@ class GEOSGeometry(GEOSBase, ListMixin):
         or a WKT or EWKT representation.
         """
         if isinstance(other, six.string_types):
-            if other.startswith('SRID'):
-                return self.ewkt == other
-            return self.wkt == other
+            return self.ewkt == other
         elif isinstance(other, GEOSGeometry):
             return self.srid == other.srid and self.equals_exact(other)
         else:

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -174,9 +174,11 @@ class GEOSGeometry(GEOSBase, ListMixin):
     def __eq__(self, other):
         """
         Equivalence testing, a Geometry may be compared with another Geometry
-        or a WKT or EWKT representation.
+        or an EWKT representation.
         """
         if isinstance(other, six.string_types):
+            if other.startswith('SRID=0;'):
+                return self.wkt == other[7:]  # Test only WKT part of other
             return self.ewkt == other
         elif isinstance(other, GEOSGeometry):
             return self.srid == other.srid and self.equals_exact(other)

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -173,10 +173,10 @@ Geometries support set-like operators::
         >>> ls3 == ls2  # different SRIDs
         False
 
-        .. versionchanged:: 1.11
+    .. versionchanged:: 1.11
 
-            Added a check on the ``srid`` property when comparing
-            ``GEOSGeometry`` objects using the equality operator.
+        Added a check on the ``srid`` property when comparing
+        ``GEOSGeometry`` objects using the equality operator.
 
 Geometry Objects
 ================

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -160,14 +160,17 @@ Geometries support set-like operators::
     The :class:`~GEOSGeometry` equality operator uses
     :meth:`~GEOSGeometry.equals_exact`, not :meth:`~GEOSGeometry.equals`, i.e.
     it requires the compared geometries to have the same coordinates in the
-    same positions::
+    same positions (and additionally, have the same srids)::
 
         >>> from django.contrib.gis.geos import LineString
         >>> ls1 = LineString((0, 0), (1, 1))
         >>> ls2 = LineString((1, 1), (0, 0))
+        >>> ls3 = LineString((1, 1), (0, 0), srid=4326)
         >>> ls1.equals(ls2)
         True
         >>> ls1 == ls2
+        False
+        >>> ls3 == ls2  # different srids
         False
 
 Geometry Objects

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -175,7 +175,7 @@ Geometries support set-like operators::
 
     .. versionchanged:: 1.11
 
-        Added a check on the ``srid`` property when comparing
+        Older versions didn't check the ``srid`` when comparing
         ``GEOSGeometry`` objects using the equality operator.
 
 Geometry Objects

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -160,7 +160,7 @@ Geometries support set-like operators::
     The :class:`~GEOSGeometry` equality operator uses
     :meth:`~GEOSGeometry.equals_exact`, not :meth:`~GEOSGeometry.equals`, i.e.
     it requires the compared geometries to have the same coordinates in the
-    same positions (and additionally, have the same SRIDs)::
+    same positions with the same SRIDs::
 
         >>> from django.contrib.gis.geos import LineString
         >>> ls1 = LineString((0, 0), (1, 1))
@@ -172,6 +172,11 @@ Geometries support set-like operators::
         False
         >>> ls3 == ls2  # different SRIDs
         False
+
+        .. versionchanged:: 1.11
+
+            Added a check on the ``srid`` property when comparing
+            ``GEOSGeometry`` objects using the equality operator.
 
 Geometry Objects
 ================

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -160,7 +160,7 @@ Geometries support set-like operators::
     The :class:`~GEOSGeometry` equality operator uses
     :meth:`~GEOSGeometry.equals_exact`, not :meth:`~GEOSGeometry.equals`, i.e.
     it requires the compared geometries to have the same coordinates in the
-    same positions (and additionally, have the same srids)::
+    same positions (and additionally, have the same SRIDs)::
 
         >>> from django.contrib.gis.geos import LineString
         >>> ls1 = LineString((0, 0), (1, 1))
@@ -170,7 +170,7 @@ Geometries support set-like operators::
         True
         >>> ls1 == ls2
         False
-        >>> ls3 == ls2  # different srids
+        >>> ls3 == ls2  # different SRIDs
         False
 
 Geometry Objects

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -409,7 +409,7 @@ Backwards incompatible changes in 1.11
   the Google Maps API and seems to be unmaintained. If you're using it, `let
   us know <https://code.djangoproject.com/ticket/14284>`_.
 
-* The ``GEOSGeometry`` equality operator now also checks on SRID.
+* The ``GEOSGeometry`` equality operator now also compares SRID.
 
 Database backend API
 --------------------

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -409,6 +409,8 @@ Backwards incompatible changes in 1.11
   the Google Maps API and seems to be unmaintained. If you're using it, `let
   us know <https://code.djangoproject.com/ticket/14284>`_.
 
+* The ``GEOSGeometry`` equality operator now also checks on SRID.
+
 Database backend API
 --------------------
 

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -266,7 +266,7 @@ class GISFunctionsTests(TestCase):
         State.objects.create(name='invalid', poly=invalid_geom)
         invalid = State.objects.filter(name='invalid').annotate(repaired=functions.MakeValid('poly')).first()
         self.assertIs(invalid.repaired.valid, True)
-        self.assertEqual(invalid.repaired, fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'))
+        self.assertEqual(invalid.repaired, fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))', srid=invalid.repaired.srid))
 
     @skipUnlessDBFeature("has_MemSize_function")
     def test_memsize(self):

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -266,7 +266,7 @@ class GISFunctionsTests(TestCase):
         State.objects.create(name='invalid', poly=invalid_geom)
         invalid = State.objects.filter(name='invalid').annotate(repaired=functions.MakeValid('poly')).first()
         self.assertIs(invalid.repaired.valid, True)
-        self.assertEqual(invalid.repaired, fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))', srid=invalid.repaired.srid))
+        self.assertEqual(invalid.repaired, fromstr('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))', srid=invalid.poly.srid))
 
     @skipUnlessDBFeature("has_MemSize_function")
     def test_memsize(self):

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -479,8 +479,11 @@ class GeoQuerySetTest(TestCase):
                 # SpatiaLite).
                 pass
             else:
-                self.assertEqual(c.mpoly.difference(geom), c.difference)
-                if not spatialite:
+                if spatialite:
+                    # Spatialite `difference` doesn't have an SRID
+                    self.assertEqual(c.mpoly.difference(geom).wkt, c.difference.wkt)
+                else:
+                    self.assertEqual(c.mpoly.difference(geom), c.difference)
                     self.assertEqual(c.mpoly.intersection(geom), c.intersection)
                 # Ordering might differ in collections
                 self.assertSetEqual(set(g.wkt for g in c.mpoly.sym_difference(geom)),

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -65,8 +65,7 @@ class GeoModelTest(TestCase):
         # Checking assignments pre & post-save.
         self.assertNotEqual(Point(23, 5, srid=4326), City.objects.get(name='NullCity').point)
         nullcity.save()
-        self.assertEqual(Point(23, 5, srid=4326),
-                         City.objects.get(name='NullCity').point)
+        self.assertEqual(Point(23, 5, srid=4326), City.objects.get(name='NullCity').point)
         nullcity.delete()
 
         # Testing on a Polygon

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -63,9 +63,11 @@ class GeoModelTest(TestCase):
         nullcity.point.x = 23
         nullcity.point.y = 5
         # Checking assignments pre & post-save.
-        self.assertNotEqual(Point(23, 5), City.objects.get(name='NullCity').point)
+        self.assertNotEqual(Point(23, 5, srid=4326),
+                            City.objects.get(name='NullCity').point)
         nullcity.save()
-        self.assertEqual(Point(23, 5), City.objects.get(name='NullCity').point)
+        self.assertEqual(Point(23, 5, srid=4326),
+                         City.objects.get(name='NullCity').point)
         nullcity.delete()
 
         # Testing on a Polygon

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -63,8 +63,7 @@ class GeoModelTest(TestCase):
         nullcity.point.x = 23
         nullcity.point.y = 5
         # Checking assignments pre & post-save.
-        self.assertNotEqual(Point(23, 5, srid=4326),
-                            City.objects.get(name='NullCity').point)
+        self.assertNotEqual(Point(23, 5, srid=4326), City.objects.get(name='NullCity').point)
         nullcity.save()
         self.assertEqual(Point(23, 5, srid=4326),
                          City.objects.get(name='NullCity').point)

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -244,6 +244,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         self.assertEqual(p2, p2.ewkt)
         # WKT contains no SRID so will not equal
         self.assertNotEqual(p2, p2.wkt)
+        # SRID of 0
+        self.assertEqual(p0, 'SRID=0;POINT (5 23)')
 
     def test_points(self):
         "Testing Point objects."

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -227,6 +227,22 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
             self.assertNotEqual(g, {'foo': 'bar'})
             self.assertNotEqual(g, False)
 
+    def test_eq_with_srid(self):
+        "Testing non-equivalence with different srids."
+        p0 = Point(5, 23)
+        p1 = Point(5, 23, srid=4326)
+        p2 = Point(5, 23, srid=32632)
+        # GEOS
+        self.assertNotEqual(p0, p1)
+        self.assertNotEqual(p1, p2)
+        # EWKT
+        self.assertNotEqual(p0, p1.ewkt)
+        self.assertNotEqual(p1, p2.ewkt)
+        # Equivalence with matching srids
+        self.assertEqual(p2, p2)
+        self.assertEqual(p2, p2.wkt)
+        self.assertEqual(p2, p2.ewkt)
+
     def test_points(self):
         "Testing Point objects."
         prev = fromstr('POINT(0 0)')

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -246,6 +246,7 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         self.assertNotEqual(p2, p2.wkt)
         # SRID of 0
         self.assertEqual(p0, 'SRID=0;POINT (5 23)')
+        self.assertNotEqual(p1, 'SRID=0;POINT (5 23)')
 
     def test_points(self):
         "Testing Point objects."

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -237,11 +237,13 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         self.assertNotEqual(p1, p2)
         # EWKT
         self.assertNotEqual(p0, p1.ewkt)
+        self.assertNotEqual(p1, p0.ewkt)
         self.assertNotEqual(p1, p2.ewkt)
-        # Equivalence with matching srids
+        # Equivalence with matching SRIDs
         self.assertEqual(p2, p2)
-        self.assertEqual(p2, p2.wkt)
         self.assertEqual(p2, p2.ewkt)
+        # WKT contains no SRID so will not equal
+        self.assertNotEqual(p2, p2.wkt)
 
     def test_points(self):
         "Testing Point objects."

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -36,8 +36,7 @@ class RelatedGeoModelTest(TestCase):
                 nm, st, lon, lat = ref
                 self.assertEqual(nm, c.name)
                 self.assertEqual(st, c.state)
-                self.assertEqual(Point(lon, lat, srid=c.location.point.srid),
-                                 c.location.point)
+                self.assertEqual(Point(lon, lat, srid=c.location.point.srid), c.location.point)
 
     @skipUnlessDBFeature("has_transform_method")
     def test03_transform_related(self):

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -36,7 +36,8 @@ class RelatedGeoModelTest(TestCase):
                 nm, st, lon, lat = ref
                 self.assertEqual(nm, c.name)
                 self.assertEqual(st, c.state)
-                self.assertEqual(Point(lon, lat), c.location.point)
+                self.assertEqual(Point(lon, lat, srid=c.location.point.srid),
+                                 c.location.point)
 
     @skipUnlessDBFeature("has_transform_method")
     def test03_transform_related(self):

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -55,7 +55,8 @@ class GeometryFieldTest(SimpleTestCase):
         pnt_fld = forms.GeometryField(geom_type='POINT')
         self.assertEqual(GEOSGeometry('POINT(5 23)', srid=pnt_fld.widget.map_srid), pnt_fld.clean('POINT(5 23)'))
         # a WKT for any other geom_type will be properly transformed by `to_python`
-        self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)', srid=pnt_fld.widget.map_srid), pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
+        self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)', srid=pnt_fld.widget.map_srid),
+                         pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
         # but rejected by `clean`
         with self.assertRaises(forms.ValidationError):
             pnt_fld.clean('LINESTRING(0 0, 1 1)')

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -48,12 +48,14 @@ class GeometryFieldTest(SimpleTestCase):
         # By default, all geometry types are allowed.
         fld = forms.GeometryField()
         for wkt in ('POINT(5 23)', 'MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'LINESTRING(0 0, 1 1)'):
-            self.assertEqual(GEOSGeometry(wkt), fld.clean(wkt))
+            # GeometryField.to_python will use the SRID of OpenLayersWidget if
+            # the converted value doesn't have an SRID itself.
+            self.assertEqual(GEOSGeometry(wkt, srid=fld.widget.map_srid), fld.clean(wkt))
 
         pnt_fld = forms.GeometryField(geom_type='POINT')
-        self.assertEqual(GEOSGeometry('POINT(5 23)'), pnt_fld.clean('POINT(5 23)'))
+        self.assertEqual(GEOSGeometry('POINT(5 23)', srid=pnt_fld.widget.map_srid), pnt_fld.clean('POINT(5 23)'))
         # a WKT for any other geom_type will be properly transformed by `to_python`
-        self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)'), pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
+        self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)', srid=pnt_fld.widget.map_srid), pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
         # but rejected by `clean`
         with self.assertRaises(forms.ValidationError):
             pnt_fld.clean('LINESTRING(0 0, 1 1)')
@@ -66,7 +68,7 @@ class GeometryFieldTest(SimpleTestCase):
         fld = forms.GeometryField()
         # to_python returns the same GEOSGeometry for a WKT
         for wkt in ('POINT(5 23)', 'MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'LINESTRING(0 0, 1 1)'):
-            self.assertEqual(GEOSGeometry(wkt), fld.to_python(wkt))
+            self.assertEqual(GEOSGeometry(wkt, srid=fld.widget.map_srid), fld.to_python(wkt))
         # but raises a ValidationError for any other string
         for wkt in ('POINT(5)', 'MULTI   POLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'BLAH(0 0, 1 1)'):
             with self.assertRaises(forms.ValidationError):
@@ -78,7 +80,7 @@ class GeometryFieldTest(SimpleTestCase):
 
         form = PointForm()
         cleaned_pt = form.fields['pt'].clean('POINT(5 23)')
-        self.assertEqual(cleaned_pt, GEOSGeometry('POINT(5 23)'))
+        self.assertEqual(cleaned_pt, GEOSGeometry('POINT(5 23)', srid=4326))
         self.assertEqual(4326, cleaned_pt.srid)
 
         point = GEOSGeometry('SRID=4326;POINT(5 23)')

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -48,8 +48,8 @@ class GeometryFieldTest(SimpleTestCase):
         # By default, all geometry types are allowed.
         fld = forms.GeometryField()
         for wkt in ('POINT(5 23)', 'MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'LINESTRING(0 0, 1 1)'):
-            # GeometryField.to_python will use the SRID of OpenLayersWidget if
-            # the converted value doesn't have an SRID itself.
+            # to_python() uses the SRID of OpenLayersWidget if the converted
+            # value doesn't have an SRID itself.
             self.assertEqual(GEOSGeometry(wkt, srid=fld.widget.map_srid), fld.clean(wkt))
 
         pnt_fld = forms.GeometryField(geom_type='POINT')

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -48,7 +48,7 @@ class GeometryFieldTest(SimpleTestCase):
         # By default, all geometry types are allowed.
         fld = forms.GeometryField()
         for wkt in ('POINT(5 23)', 'MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))', 'LINESTRING(0 0, 1 1)'):
-            # to_python() uses the SRID of OpenLayersWidget if the converted
+            # `to_python` uses the SRID of OpenLayersWidget if the converted
             # value doesn't have an SRID itself.
             self.assertEqual(GEOSGeometry(wkt, srid=fld.widget.map_srid), fld.clean(wkt))
 

--- a/tests/gis_tests/test_geoforms.py
+++ b/tests/gis_tests/test_geoforms.py
@@ -55,8 +55,10 @@ class GeometryFieldTest(SimpleTestCase):
         pnt_fld = forms.GeometryField(geom_type='POINT')
         self.assertEqual(GEOSGeometry('POINT(5 23)', srid=pnt_fld.widget.map_srid), pnt_fld.clean('POINT(5 23)'))
         # a WKT for any other geom_type will be properly transformed by `to_python`
-        self.assertEqual(GEOSGeometry('LINESTRING(0 0, 1 1)', srid=pnt_fld.widget.map_srid),
-                         pnt_fld.to_python('LINESTRING(0 0, 1 1)'))
+        self.assertEqual(
+            GEOSGeometry('LINESTRING(0 0, 1 1)', srid=pnt_fld.widget.map_srid),
+            pnt_fld.to_python('LINESTRING(0 0, 1 1)')
+        )
         # but rejected by `clean`
         with self.assertRaises(forms.ValidationError):
             pnt_fld.clean('LINESTRING(0 0, 1 1)')


### PR DESCRIPTION
This fixes: https://code.djangoproject.com/ticket/26920
See also: https://groups.google.com/forum/#!topic/geodjango/_UQx1OnAZhM

This PR will make checking `GEOSGeometry` equality take into account the `srid` property. Because the `__eq__` method also accepts a WKT as argument which does not contain any srid information, I've updated it so that it will also check EWKTs if possible (which do contain srid information).