### PR TITLE
Fixed #27236 -- Deprecated model Meta.index_together in favor of Meta.indexes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -579,6 +579,7 @@ answer newbie questions, and generally made Django that much better:
     Oliver Beattie <oliver@obeattie.com>
     Oliver Rutherfurd <http://rutherfurd.net/>
     Olivier Sels <olivier.sels@gmail.com>
+    Olivier Tabone <olivier.tabone@ripplemotion.fr>
     Orestis Markou <orestis@orestis.gr>
     Orne Brocaar <http://brocaar.com/>
     Oscar Ramirez <tuxskar@gmail.com>

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from django.db.models.fields import NOT_PROVIDED
+from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.functional import cached_property
 
 from .base import Operation
 
 
 class FieldOperation(Operation):
+
     def __init__(self, model_name, name):
         self.model_name = model_name
         self.name = name
@@ -276,21 +280,31 @@ class RenameField(FieldOperation):
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, to_model):
             from_model = from_state.apps.get_model(app_label, self.model_name)
-            schema_editor.alter_field(
-                from_model,
-                from_model._meta.get_field(self.old_name),
-                to_model._meta.get_field(self.new_name),
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", "'index_together' is deprecated in favor of 'indexes'",
+                    RemovedInDjango21Warning)
+
+                schema_editor.alter_field(
+                    from_model,
+                    from_model._meta.get_field(self.old_name),
+                    to_model._meta.get_field(self.new_name),
+                )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, to_model):
             from_model = from_state.apps.get_model(app_label, self.model_name)
-            schema_editor.alter_field(
-                from_model,
-                from_model._meta.get_field(self.new_name),
-                to_model._meta.get_field(self.old_name),
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", "'index_together' is deprecated in favor of 'indexes'",
+                    RemovedInDjango21Warning)
+
+                schema_editor.alter_field(
+                    from_model,
+                    from_model._meta.get_field(self.new_name),
+                    to_model._meta.get_field(self.old_name),
+                )
 
     def describe(self):
         return "Rename field %s on %s to %s" % (self.old_name, self.model_name, self.new_name)

--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -14,7 +14,9 @@ from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT
 from django.db.models.options import DEFAULT_NAMES, normalize_together
 from django.db.models.utils import make_model_tuple
 from django.utils import six
-from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.deprecation import (
+    RemovedInDjango20Warning, RemovedInDjango21Warning,
+)
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
@@ -567,6 +569,9 @@ class ModelState(object):
             warnings.filterwarnings(
                 "ignore", "Managers from concrete parents will soon qualify as default managers",
                 RemovedInDjango20Warning)
+            warnings.filterwarnings(
+                "ignore", "'index_together' is deprecated in favor of 'indexes'",
+                RemovedInDjango21Warning)
 
             # Then, make a Model object (apps.register_model is called in __new__)
             return type(

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -17,7 +17,8 @@ from django.db.models.fields.related import OneToOneField
 from django.utils import six
 from django.utils.datastructures import ImmutableList, OrderedSet
 from django.utils.deprecation import (
-    RemovedInDjango20Warning, warn_about_renamed_method,
+    RemovedInDjango20Warning, RemovedInDjango21Warning,
+    warn_about_renamed_method,
 )
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
@@ -192,7 +193,11 @@ class Options(object):
 
             self.unique_together = normalize_together(self.unique_together)
             self.index_together = normalize_together(self.index_together)
-
+            if self.index_together:
+                warnings.warn(
+                    "'index_together' is deprecated in favor of 'indexes'",
+                    RemovedInDjango21Warning
+                )
             # verbose_name_plural is a special case because it uses a 's'
             # by default.
             if self.verbose_name_plural is None:

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -443,6 +443,10 @@ Django quotes column and table names behind the scenes.
 ``index_together``
 ------------------
 
+.. deprecated:: 1.11
+
+    Use :attr:`~django.db.models.Options.indexes` instead.
+
 .. attribute:: Options.index_together
 
     Sets of field names that, taken together, are indexed::

--- a/tests/indexes/models.py
+++ b/tests/indexes/models.py
@@ -32,9 +32,7 @@ class Article(models.Model):
     translation = CurrentTranslation(ArticleTranslation, models.CASCADE, ['id'], ['article'])
 
     class Meta:
-        index_together = [
-            ["headline", "pub_date"],
-        ]
+        indexes = [models.Index(fields=['headline', 'pub_date'])]
 
 
 # Model for index_together being used only with single list
@@ -43,7 +41,7 @@ class IndexTogetherSingleList(models.Model):
     pub_date = models.DateTimeField()
 
     class Meta:
-        index_together = ["headline", "pub_date"]
+        indexes = [models.Index(fields=['headline', 'pub_date'])]
 
 # Indexing a TextField on Oracle or MySQL results in index creation error.
 if connection.vendor == 'postgresql':

--- a/tests/indexes/test_deprecated.py
+++ b/tests/indexes/test_deprecated.py
@@ -1,0 +1,22 @@
+import warnings
+
+from django.db import models
+from django.test import SimpleTestCase
+
+
+class DeprecateIndexTogetherTests(SimpleTestCase):
+
+    def test_deprecation_warning_is_raised(self):
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+
+            class ArticleDeprecated(models.Model):
+                headline = models.CharField(max_length=100)
+                pub_date = models.DateTimeField()
+
+                class Meta:
+                    index_together = ['headline', 'pub_date']
+
+        self.assertEqual(len(warns), 1)
+        msg = str(warns[0].message)
+        self.assertEqual(msg, "'index_together' is deprecated in favor of 'indexes'")

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -54,9 +54,9 @@ class SchemaIndexesTests(TestCase):
         # Ensure the index name is properly quoted
         self.assertIn(
             connection.ops.quote_name(
-                editor._create_index_name(Article, ['headline', 'pub_date'], suffix='_idx')
+                Article._meta.indexes[0].create_sql(Article, editor)
             ),
-            index_sql[0]
+            connection.ops.quote_name(index_sql[0])
         )
 
     def test_index_together_single_list(self):

--- a/tests/introspection/models.py
+++ b/tests/introspection/models.py
@@ -52,9 +52,7 @@ class Article(models.Model):
 
     class Meta:
         ordering = ('headline',)
-        index_together = [
-            ["headline", "pub_date"],
-        ]
+        indexes = [models.Index(fields=['headline', 'pub_date'])]
 
 
 class ArticleReporter(models.Model):

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -10,7 +10,8 @@ from django.core.checks.model_checks import _check_lazy_references
 from django.db import connections, models
 from django.db.models.signals import post_init
 from django.test import SimpleTestCase
-from django.test.utils import isolate_apps, override_settings
+from django.test.utils import ignore_warnings, isolate_apps, override_settings
+from django.utils.deprecation import RemovedInDjango21Warning
 
 
 def get_max_column_name_length():
@@ -34,9 +35,11 @@ def get_max_column_name_length():
 
 
 @isolate_apps('invalid_models_tests')
+@ignore_warnings(category=RemovedInDjango21Warning)
 class IndexTogetherTests(SimpleTestCase):
 
     def test_non_iterable(self):
+
         class Model(models.Model):
             class Meta:
                 index_together = 42
@@ -67,6 +70,7 @@ class IndexTogetherTests(SimpleTestCase):
         self.assertEqual(errors, expected)
 
     def test_list_containing_non_iterable(self):
+
         class Model(models.Model):
             class Meta:
                 index_together = [('a', 'b'), 42]
@@ -82,6 +86,7 @@ class IndexTogetherTests(SimpleTestCase):
         self.assertEqual(errors, expected)
 
     def test_pointing_to_missing_field(self):
+
         class Model(models.Model):
             class Meta:
                 index_together = [
@@ -99,6 +104,7 @@ class IndexTogetherTests(SimpleTestCase):
         self.assertEqual(errors, expected)
 
     def test_pointing_to_non_local_field(self):
+
         class Foo(models.Model):
             field1 = models.IntegerField()
 
@@ -123,6 +129,7 @@ class IndexTogetherTests(SimpleTestCase):
         self.assertEqual(errors, expected)
 
     def test_pointing_to_m2m_field(self):
+
         class Model(models.Model):
             m2m = models.ManyToManyField('self')
 

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -8,9 +8,10 @@ from django.db.migrations.operations import (
 from django.db.migrations.state import (
     ModelState, ProjectState, get_related_models_recursive,
 )
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, ignore_warnings, override_settings
 from django.test.utils import isolate_apps
 from django.utils import six
+from django.utils.deprecation import RemovedInDjango21Warning
 
 from .models import (
     FoodManager, FoodQuerySet, ModelWithCustomBase, NoMigrationFoodManager,
@@ -23,6 +24,7 @@ class StateTests(SimpleTestCase):
     Tests state construction, rendering and modification by operations.
     """
 
+    @ignore_warnings(category=RemovedInDjango21Warning)
     def test_create(self):
         """
         Tests making a ProjectState from an Apps

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -139,7 +139,7 @@ class TagIndexed(models.Model):
 
     class Meta:
         apps = new_apps
-        index_together = [["slug", "title"]]
+        indexes = [models.Index(fields=['slug', 'title'])]
 
 
 class TagM2MTest(models.Model):


### PR DESCRIPTION
in favour of Model.Meta.indexes

https://code.djangoproject.com/ticket/27236


migrate existing tests to use Meta.indexes instead of Meta.index_together
created a test to ensure deprecation warning is raised
deprecation warning not raise when running migrations, so that 'old' data models with index_together do not pollute migration messages