### PR TITLE
Skipped makemessages -l tests when gettext tools are not installed

### DIFF
--- a/tests/i18n/test_extraction.py
+++ b/tests/i18n/test_extraction.py
@@ -717,6 +717,7 @@ class CustomLayoutExtractionTests(ExtractorTests):
                 self.assertMsgId('This app has a locale directory', po_contents)
 
 
+@skipUnless(has_xgettext, 'xgettext is mandatory for extraction tests')
 class NoSettingsExtractionTests(AdminScriptTestCase):
     def test_makemessages_no_settings(self):
         out, err = self.run_django_admin(['makemessages', '-l', 'en', '-v', '0'])


### PR DESCRIPTION
I didn't create a Trac ticket because I think this is "a really trivial issue" per Django's patch guideline. But I can do that if you consider it necessary.