### PR TITLE
Fixed #3461 -- Made DatabaseWrapper.cursor() pass args/kwargs to the database adapter.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -577,6 +577,7 @@ answer newbie questions, and generally made Django that much better:
     Oliver Beattie <oliver@obeattie.com>
     Oliver Rutherfurd <http://rutherfurd.net/>
     Olivier Sels <olivier.sels@gmail.com>
+    Olivier Tabone <olivier.tabone@ripplemotion.fr>
     Orestis Markou <orestis@orestis.gr>
     Orne Brocaar <http://brocaar.com/>
     Oscar Ramirez <tuxskar@gmail.com>

--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -165,7 +165,7 @@ class BaseDatabaseWrapper(object):
         """Initializes the database connection settings."""
         raise NotImplementedError('subclasses of BaseDatabaseWrapper may require an init_connection_state() method')
 
-    def create_cursor(self):
+    def create_cursor(self, *args, **kwargs):
         """Creates a cursor. Assumes that a connection is established."""
         raise NotImplementedError('subclasses of BaseDatabaseWrapper may require a create_cursor() method')
 
@@ -214,10 +214,10 @@ class BaseDatabaseWrapper(object):
 
     # ##### Backend-specific wrappers for PEP-249 connection methods #####
 
-    def _cursor(self):
+    def _cursor(self, *args, **kwargs):
         self.ensure_connection()
         with self.wrap_database_errors:
-            return self.create_cursor()
+            return self.create_cursor(*args, **kwargs)
 
     def _commit(self):
         if self.connection is not None:
@@ -236,15 +236,18 @@ class BaseDatabaseWrapper(object):
 
     # ##### Generic wrappers for PEP-249 connection methods #####
 
-    def cursor(self):
+    def cursor(self, *args, **kwargs):
         """
         Creates a cursor, opening a connection if necessary.
+        args and kwargs will be passed unchanged to underlying connection's
+        cursor.
+
         """
         self.validate_thread_sharing()
         if self.queries_logged:
-            cursor = self.make_debug_cursor(self._cursor())
+            cursor = self.make_debug_cursor(self._cursor(*args, **kwargs))
         else:
-            cursor = self.make_cursor(self._cursor())
+            cursor = self.make_cursor(self._cursor(*args, **kwargs))
         return cursor
 
     def commit(self):

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -270,8 +270,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 # with SQL standards.
                 cursor.execute('SET SQL_AUTO_IS_NULL = 0')
 
-    def create_cursor(self):
-        cursor = self.connection.cursor()
+    def create_cursor(self, *args, **kwargs):
+        cursor = self.connection.cursor(*args, **kwargs)
         return CursorWrapper(cursor)
 
     def _rollback(self):

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -205,8 +205,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             if not self.get_autocommit():
                 self.connection.commit()
 
-    def create_cursor(self):
-        cursor = self.connection.cursor()
+    def create_cursor(self, *args, **kwargs):
+        cursor = self.connection.cursor(*args, **kwargs)
         cursor.tzinfo_factory = utc_tzinfo_factory if settings.USE_TZ else None
         return cursor
 

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -214,8 +214,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def init_connection_state(self):
         pass
 
-    def create_cursor(self):
-        return self.connection.cursor(factory=SQLiteCursorWrapper)
+    def create_cursor(self, *args, **kwargs):
+        kwargs.setdefault('factory', SQLiteCursorWrapper)
+        return self.connection.cursor(*args, **kwargs)
 
     def close(self):
         self.validate_thread_sharing()

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -334,6 +334,9 @@ Also note that Django expects the ``"%s"`` placeholder, *not* the ``"?"``
 placeholder, which is used by the SQLite Python bindings. This is for the sake
 of consistency and sanity.
 
+Any argument given to the cursor will pass through to the underlying database
+adapter.
+
 Using a cursor as a context manager::
 
     with connection.cursor() as c:

--- a/tests/backends/cursors/__init__.py
+++ b/tests/backends/cursors/__init__.py
@@ -1,0 +1,4 @@
+
+from . import mysql, postgres, sqlite
+
+__all__ = ['postgres', 'sqlite', 'mysql']

--- a/tests/backends/cursors/mysql.py
+++ b/tests/backends/cursors/mysql.py
@@ -1,0 +1,31 @@
+
+try:
+    from MySQLdb.cursors import Cursor
+    HAS_MYSQL = True
+except ImportError as exc:
+    HAS_MYSQL = False
+
+if HAS_MYSQL:
+    class LoggingCursor(Cursor):
+        """
+        A cursor that will log all statements in it's bucket
+        """
+        def __init__(self, *args, **kwargs):
+            bucket = kwargs.pop('bucket')
+            super(LoggingCursor, self).__init__(*args, **kwargs)
+            self.bucket = bucket
+
+        def execute(self, query, args=None):
+            self.bucket.append(query)
+            super(LoggingCursor, self).execute(query, args)
+
+    class LoggingCursorFactory(object):
+        def __init__(self, bucket=None):
+            super(LoggingCursorFactory, self).__init__()
+            if bucket is None:
+                bucket = list()
+            self.bucket = bucket
+
+        def create(self, *args, **kwargs):
+            kwargs.setdefault('bucket', self.bucket)
+            return LoggingCursor(*args, **kwargs)

--- a/tests/backends/cursors/postgres.py
+++ b/tests/backends/cursors/postgres.py
@@ -1,0 +1,32 @@
+try:
+    import psycopg2
+    import psycopg2.extensions
+    HAS_PSYCOPG2 = True
+except ImportError:
+    HAS_PSYCOPG2 = False
+    pass
+
+if HAS_PSYCOPG2:
+    class LoggingCursor(psycopg2.extensions.cursor):
+        def __init__(self, *args, **kwargs):
+            bucket = kwargs.pop('bucket')
+            super(LoggingCursor, self).__init__(*args, **kwargs)
+            self.bucket = bucket
+
+        def execute(self, sql, args=None):
+            self.bucket.append(self.mogrify(sql, args))
+            psycopg2.extensions.cursor.execute(self, sql, args)
+
+    class LoggingCursorFactory(object):
+        """docstring for LoggingCursorFactory."""
+        def __init__(self, bucket=None):
+            super(LoggingCursorFactory, self).__init__()
+            if bucket is None:
+                bucket = list()
+            self.bucket = bucket
+
+        def create(self, *args, **kwargs):
+            kwargs.update({
+                'bucket': self.bucket
+            })
+            return LoggingCursor(*args, **kwargs)

--- a/tests/backends/cursors/sqlite.py
+++ b/tests/backends/cursors/sqlite.py
@@ -1,0 +1,38 @@
+
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    from django.db.backends.sqlite3.base import SQLiteCursorWrapper
+    HAS_SQLITE = True
+except ImproperlyConfigured as exc:
+    HAS_SQLITE = False
+
+if HAS_SQLITE:
+    class LoggingCursor(SQLiteCursorWrapper):
+        """
+        A cursor that will log all statements in it's bucket
+        """
+
+        def __init__(self, *args, **kwargs):
+            bucket = kwargs.pop('bucket')
+            super(LoggingCursor, self).__init__(*args, **kwargs)
+            self.bucket = bucket
+
+        def execute(self, sql, *args, **kwargs):
+            self.bucket.append(sql)
+            super(LoggingCursor, self).execute(sql, *args, **kwargs)
+
+    class LoggingCursorFactory(object):
+        """
+        Factory class, will create intances of the logging cursor with a
+        shared bucket.
+        """
+        def __init__(self, bucket=None):
+            super(LoggingCursorFactory, self).__init__()
+            if bucket is None:
+                bucket = list()
+            self.bucket = bucket
+
+        def create(self, *args, **kwargs):
+            kwargs.setdefault('bucket', self.bucket)
+            return LoggingCursor(*args, **kwargs)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/3461

added tests for mysql, postgresql, and sqlite3

