### PR TITLE
Fixed #21454 -- Added readonly attribute to Model Fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ answer newbie questions, and generally made Django that much better:
     Batiste Bieler <batiste.bieler@gmail.com>
     Batman
     Baurzhan Ismagulov <ibr@radix50.net>
+    Ben Cole <wengole@gmail.com>
     Ben Dean Kawamura <ben.dean.kawamura@gmail.com>
     Ben Firshman <ben@firshman.co.uk>
     Ben Godfrey <http://aftnn.org>

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -835,11 +835,9 @@ class Model(six.with_metaclass(ModelBase)):
         self._state.adding = False
 
         # Readonly fields are computed by the Database. If there are any,
-        # we should fetch their value.
-        if self._meta.has_readonly_fields:
-            self.refresh_from_db(fields=[
-                field.name for field in self._meta.get_fields()
-                if getattr(field, 'readonly', False)])
+        # we should fetch their value. (refresh_from_db does nothing if the
+        # field list is empty)
+        self.refresh_from_db(fields=self._meta.readonly_fields)
 
         # Signal that the save is complete
         if not meta.auto_created:

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -834,6 +834,13 @@ class Model(six.with_metaclass(ModelBase)):
         # Once saved, this is no longer a to-be-added instance.
         self._state.adding = False
 
+        # Readonly fields are computed by the Database. If there are any,
+        # we should fetch their value.
+        if self._meta.has_readonly_fields:
+            self.refresh_from_db(fields=[
+                field.name for field in self._meta.get_fields()
+                if getattr(field, 'readonly', False)])
+
         # Signal that the save is complete
         if not meta.auto_created:
             signals.post_save.send(sender=origin, instance=self, created=(not updated),

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -837,7 +837,7 @@ class Model(six.with_metaclass(ModelBase)):
         # Readonly fields are computed by the Database. If there are any,
         # we should fetch their value. (refresh_from_db does nothing if the
         # field list is empty)
-        self.refresh_from_db(fields=self._meta.readonly_fields)
+        self.refresh_from_db(fields=[field.name for field in self._meta.readonly_fields])
 
         # Signal that the save is complete
         if not meta.auto_created:

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -143,7 +143,7 @@ class Field(RegisterLookupMixin):
                  serialize=True, unique_for_date=None, unique_for_month=None,
                  unique_for_year=None, choices=None, help_text='', db_column=None,
                  db_tablespace=None, auto_created=False, validators=(),
-                 error_messages=None):
+                 error_messages=None, readonly=False):
         self.name = name
         self.verbose_name = verbose_name  # May be set by set_attributes_from_name
         self._verbose_name = verbose_name  # Store original for deconstruction
@@ -166,6 +166,7 @@ class Field(RegisterLookupMixin):
         self.db_column = db_column
         self.db_tablespace = db_tablespace or settings.DEFAULT_INDEX_TABLESPACE
         self.auto_created = auto_created
+        self.readonly = readonly
 
         # Adjust the appropriate creation counter, and save our local copy.
         if auto_created:
@@ -702,6 +703,9 @@ class Field(RegisterLookupMixin):
         if self.choices:
             setattr(cls, 'get_%s_display' % self.name,
                     curry(cls._get_FIELD_display, field=self))
+
+        if self.readonly:
+            cls._meta.has_readonly_fields = True
 
     def get_filter_kwargs_for_object(self, obj):
         """

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -77,7 +77,7 @@ class Options(object):
     FORWARD_PROPERTIES = {
         'fields', 'many_to_many', 'concrete_fields', 'local_concrete_fields',
         '_forward_fields_map', 'managers', 'managers_map', 'base_manager',
-        'default_manager',
+        'default_manager', 'readonly_fields',
     }
     REVERSE_PROPERTIES = {'related_objects', 'fields_map', '_relation_tree'}
 
@@ -115,7 +115,6 @@ class Options(object):
         self.pk = None
         self.has_auto_field = False
         self.auto_field = None
-        self.has_readonly_fields = False
         self.abstract = False
         self.managed = True
         self.proxy = False
@@ -597,6 +596,13 @@ class Options(object):
             except AttributeError:
                 pass
         return res
+
+    @cached_property
+    def readonly_fields(self):
+        return make_immutable_fields_list(
+            "readonly_fields",
+            (field for field in self.fields if field.readonly)
+        )
 
     def get_field(self, field_name):
         """

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -115,6 +115,7 @@ class Options(object):
         self.pk = None
         self.has_auto_field = False
         self.auto_field = None
+        self.has_readonly_fields = False
         self.abstract = False
         self.managed = True
         self.proxy = False

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -316,6 +316,25 @@ Note that when ``unique`` is ``True``, you don't need to specify
 
     In older versions, ``unique=True`` can't be used on :class:`FileField`.
 
+``readonly``
+------------
+
+.. versionadded:: 1.11
+
+.. attribute:: Field.readonly
+
+If ``True``, this field will be excluded from ``INSERT`` and ``UPDATE``
+queries at the SQL level.
+
+This allows for database level population and updating of the field by
+making use of features such as triggers and functions.
+
+If a model has any ``readonly`` fields, calls to
+:meth:`Model.save() <django.db.models.Model.save>` will result
+in an additional ``SELECT`` query as
+:meth:`Model.refresh_from_db() <django.db.models.Model.refresh_from_db>` is called
+to ensure the model instance has the field values as set by the database.
+
 ``unique_for_date``
 -------------------
 

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -389,13 +389,12 @@ class UUIDGrandchild(UUIDChild):
     pass
 
 ###############################################################################
-# This model is used for Readonly test cases
 
 
 class ModelWithReadonlyField(models.Model):
     """
-    This model is quite linked with the ReadonlyTestsMixin and its
-    SQL will be modified by ReadonlyTestsMixin subclasses.
+    This model is quite linked with ReadonlyTests and its
+    SQL will be modified by ReadonlyTests.
     Make sure it's not used in any other test otherwise there will be
     isolation problems.
     """

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -387,3 +387,26 @@ class UUIDChild(PrimaryKeyUUIDModel):
 
 class UUIDGrandchild(UUIDChild):
     pass
+
+###############################################################################
+# This model is used for Readonly test cases
+
+
+class ModelWithReadonlyField(models.Model):
+    """
+    This model is quite linked with the ReadonlyTestsMixin and its
+    SQL will be modified by ReadonlyTestsMixin subclasses.
+    Make sure it's not used in any other test otherwise there will be
+    isolation problems.
+    """
+    not_readonly = models.CharField(max_length=60)
+    readonly_int1 = models.IntegerField(readonly=True)
+    readonly_int2 = models.IntegerField(readonly=True)
+
+
+class ModelReferencingReadonly(models.Model):
+    """
+    This model solely exists so that there's a relation in
+    ModelWithReadonlyField
+    """
+    fk = models.ForeignKey(ModelWithReadonlyField, models.CASCADE)

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -409,3 +409,13 @@ class ModelReferencingReadonly(models.Model):
     ModelWithReadonlyField
     """
     fk = models.ForeignKey(ModelWithReadonlyField, models.CASCADE)
+
+
+class ModelWithReadonlyPk(models.Model):
+    """
+    This model is quite linked with ReadonlyTests and its
+    SQL will be modified by ReadonlyTests.
+    Make sure it's not used in any other test otherwise there will be
+    isolation problems.
+    """
+    id = models.AutoField(primary_key=True, readonly=True)

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -1,10 +1,16 @@
+import json
+import unittest
+
 from django import forms
-from django.db import models
+from django.core import serializers
+from django.db import connection, models
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils.encoding import force_str
 
 from .models import (
-    Foo, RenamedField, VerboseNameField, Whiz, WhizIter, WhizIterEmpty,
+    Foo, ModelWithReadonlyField, RenamedField, VerboseNameField, Whiz,
+    WhizIter, WhizIterEmpty,
 )
 
 
@@ -60,6 +66,207 @@ class BasicFieldTests(TestCase):
         self.assertEqual(force_str(f), 'model_fields.Foo.a')
 
 
+class ReadonlyTestsMixin(object):
+
+    @classmethod
+    def populate_database_fields(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def setUpClass(cls):
+        super(ReadonlyTestsMixin, cls).setUpClass()
+
+        cls.populate_database_fields()
+
+    def test_readonly_option(self):
+        # Default value
+        self.assertFalse(ModelWithReadonlyField._meta.get_field('not_readonly').readonly)
+
+        # When the readonly attribute is set
+        self.assertTrue(ModelWithReadonlyField._meta.get_field('readonly_int1').readonly)
+
+    def test_create(self):
+        with CaptureQueriesContext(connection=connection) as capture:
+            inst = ModelWithReadonlyField.objects.create(
+                not_readonly='not_readonly',
+                readonly_int1=3,
+            )
+
+        self.assertEqual(len(capture.captured_queries), 2)
+        query = capture.captured_queries[0]
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+        self.assertEqual(inst.readonly_int1, 1)
+        self.assertEqual(inst.readonly_int2, 2)
+
+    def test_save_new(self):
+        with CaptureQueriesContext(connection=connection) as capture:
+            inst = ModelWithReadonlyField(
+                not_readonly='not_readonly',
+                readonly_int1=1,
+            )
+            inst.save()
+
+        self.assertEqual(len(capture.captured_queries), 2)
+        query = capture.captured_queries[0]
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+        self.assertEqual(inst.readonly_int1, 1)
+        self.assertEqual(inst.readonly_int2, 2)
+
+    def test_save_update(self):
+        inst = ModelWithReadonlyField.objects.create(
+            not_readonly="not_readonly",
+            readonly_int1=5,
+        )
+        inst.not_readonly = 'foo'
+        inst.readonly_int1 = 42
+
+        with CaptureQueriesContext(connection=connection) as capture:
+            inst.save()
+
+        query = capture.captured_queries[0]
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+        self.assertEqual(inst.readonly_int1, 1)
+        self.assertEqual(inst.readonly_int2, 2)
+
+    def test_update(self):
+        inst = ModelWithReadonlyField.objects.create(
+            not_readonly='not_readonly',
+            readonly_int1=1,
+        )
+        qs = ModelWithReadonlyField.objects.filter(pk=inst.pk)
+
+        with CaptureQueriesContext(connection=connection) as capture:
+            qs.update(
+                not_readonly='foo',
+                readonly_int1=42,
+            )
+
+        query = capture.captured_queries[0]
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+
+    def test_get_or_create(self):
+        with CaptureQueriesContext(connection=connection) as capture:
+            inst, _ = ModelWithReadonlyField.objects.get_or_create(
+                not_readonly='not_readonly',
+                readonly_int1=3,
+            )
+        insert_queries = [
+            query for query in capture.captured_queries
+            if query['sql'].startswith('INSERT')]
+
+        self.assertEqual(len(insert_queries), 1)
+        query = insert_queries[0]
+        self.assertTrue(query['sql'].startswith('INSERT'), '{} is not INSERT'.format(query['sql']))
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+        self.assertEqual(inst.readonly_int1, 1)
+        self.assertEqual(inst.readonly_int2, 2)
+
+    def test_bulk_create(self):
+        with CaptureQueriesContext(connection=connection) as capture:
+            ModelWithReadonlyField.objects.bulk_create([
+                ModelWithReadonlyField(
+                    not_readonly='not_readonly',
+                    readonly_int1=1,
+                ),
+                ModelWithReadonlyField(
+                    not_readonly='rabble rabble',
+                    readonly_int2=9001,
+                )
+            ])
+
+        self.assertEqual(len(capture.captured_queries), 1)
+        query = capture.captured_queries[0]
+
+        self.assertIn('not_readonly', query['sql'])
+        self.assertNotIn('readonly_int1', query['sql'])
+        self.assertNotIn('readonly_int2', query['sql'])
+
+        # bulk_create won't fetch the database computed
+        # values so it's no use trying to check it.
+
+    def test_deserialize(self):
+        try:
+            pk = ModelWithReadonlyField.objects.latest('id').id + 1
+        except ModelWithReadonlyField.DoesNotExist:
+            pk = 1
+
+        json_inst = json.dumps(
+            [{
+                'model': 'model_fields.modelwithreadonlyfield',
+                'pk': pk,
+                'fields': {
+                    'not_readonly': 'All your base',
+                    'readonly_int1': 12,
+                },
+            }]
+        )
+
+        # Check that the save works
+        deserialized = serializers.deserialize('json', json_inst)
+        inst = next(deserialized)
+        with CaptureQueriesContext(connection=connection) as capture:
+            inst.save()
+
+        # Because a pk is specified, Django will try to do an UPDATE and then
+        # an INSERT when the UPDATE returns with 0 rows affected
+        self.assertEqual(len(capture.captured_queries), 3)
+        query_1 = capture.captured_queries[0]['sql']
+
+        self.assertTrue(query_1.startswith('UPDATE'), '{} is not UPDATE'.format(query_1))
+        self.assertIn('not_readonly', query_1)
+        self.assertNotIn('readonly_int1', query_1)
+        self.assertNotIn('readonly_int2', query_1)
+
+        query_2 = capture.captured_queries[1]['sql']
+        self.assertTrue(query_2.startswith('INSERT'), '{} is not INSERT'.format(query_2))
+        self.assertIn('not_readonly', query_2)
+        self.assertNotIn('readonly_int1', query_2)
+        self.assertNotIn('readonly_int2', query_2)
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL-specific tests")
+class PostgreSQLReadonlyTests(ReadonlyTestsMixin, TestCase):
+
+    @classmethod
+    def populate_database_fields(cls):
+        connection.cursor().execute(
+            '''ALTER TABLE "model_fields_modelwithreadonlyfield" '''
+            '''ALTER COLUMN "readonly_int1" SET DEFAULT 1 ''')
+        connection.cursor().execute(
+            '''ALTER TABLE "model_fields_modelwithreadonlyfield" '''
+            '''ALTER COLUMN "readonly_int2" SET DEFAULT 2;''')
+
+
+@unittest.skipUnless(connection.vendor == 'sqlite', "Sqlite-specific tests")
+class SQLiteReadonlyTests(ReadonlyTestsMixin, TestCase):
+
+    @classmethod
+    def populate_database_fields(cls):
+        connection.cursor().execute(
+            '''DROP TABLE "model_fields_modelwithreadonlyfield"''')
+        connection.cursor().execute(
+            '''CREATE TABLE "model_fields_modelwithreadonlyfield" '''
+            '''(id INTEGER PRIMARY KEY AUTOINCREMENT, '''
+            ''' not_readonly TEXT, '''
+            ''' readonly_int1 INTEGER DEFAULT 1, '''
+            ''' readonly_int2 INTEGER DEFAULT 2);''')
+
+
 class ChoicesTests(SimpleTestCase):
 
     def test_choices_and_field_display(self):
@@ -86,7 +293,7 @@ class ChoicesTests(SimpleTestCase):
         """
         get_choices() works with empty iterators.
         """
-        self.assertEqual(WhizIterEmpty(c="a").c, "a")      # A nested value
-        self.assertEqual(WhizIterEmpty(c="b").c, "b")      # Invalid value
-        self.assertIsNone(WhizIterEmpty(c=None).c)         # Blank value
-        self.assertEqual(WhizIterEmpty(c='').c, '')        # Empty value
+        self.assertEqual(WhizIterEmpty(c="a").c, "a")  # A nested value
+        self.assertEqual(WhizIterEmpty(c="b").c, "b")  # Invalid value
+        self.assertIsNone(WhizIterEmpty(c=None).c)  # Blank value
+        self.assertEqual(WhizIterEmpty(c='').c, '')  # Empty value


### PR DESCRIPTION
DutH 2016 sprints : Pair coded with @wengole.
Made SQLCompiler remove readonly fields from INSERT and UPDATE queries.
Made model instances refresh themselves after save when appropriate.

https://groups.google.com/forum/#!topic/django-developers/BDAlTyJwQeY