### PR TITLE
Fixed #27318 -- Made cache.set_many() return a list of failing keys.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -609,6 +609,7 @@ answer newbie questions, and generally made Django that much better:
     Oliver Beattie <oliver@obeattie.com>
     Oliver Rutherfurd <http://rutherfurd.net/>
     Olivier Sels <olivier.sels@gmail.com>
+    Olivier Tabone <olivier.tabone@ripplemotion.fr>
     Orestis Markou <orestis@orestis.gr>
     Orne Brocaar <http://brocaar.com/>
     Oscar Ramirez <tuxskar@gmail.com>

--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -206,9 +206,13 @@ class BaseCache:
 
         If timeout is given, use that timeout for the key; otherwise use the
         default cache timeout.
+
+        On backends that support it, return a list of keys that failed
+        insertion, or an empty list if all keys were inserted successfully.
         """
         for key, value in data.items():
             self.set(key, value, timeout=timeout, version=version)
+        return []
 
     def delete_many(self, keys, version=None):
         """

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -157,7 +157,8 @@ Minor features
 Cache
 ~~~~~
 
-* ...
+* On memcached, ``cache.set_many()`` returns a list of keys that failed to be
+  inserted.
 
 CSRF
 ~~~~

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -881,6 +881,13 @@ of key-value pairs::
 
 Like ``cache.set()``, ``set_many()`` takes an optional ``timeout`` parameter.
 
+On supported backends (memcached), ``set_many()`` returns a list of keys that
+failed to be inserted.
+
+.. versionchanged:: 2.0
+
+    The return value containing list of failing keys was added.
+
 You can delete keys explicitly with ``delete()``. This is an easy way of
 clearing the cache for a particular object::
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27318

implemented a test that inserts an invalid value in memcached
other backends (Dummy, Locmem)  never fails inserts thus do not need special testing