### PR TITLE
Fixed #24370 -- Recommended new projects start with a custom user model.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -395,32 +395,47 @@ This dotted pair describes the name of the Django app (which must be in your
 :setting:`INSTALLED_APPS`), and the name of the Django model that you wish to
 use as your User model.
 
-.. warning::
+.. admonition:: Custom user model in new projects
 
-   Changing :setting:`AUTH_USER_MODEL` has a big effect on your database
-   structure. It changes the tables that are available, and it will affect the
-   construction of foreign keys and many-to-many relationships. If you intend
-   to set :setting:`AUTH_USER_MODEL`, you should set it before creating
+   If you are starting a fresh new project, it is highly recommended to set up
+   a custom user model - even if the initial model provided by Django is
+   sufficient for you. The simplest option is creating a model:
+
+   .. code-block:: python
+
+       from django.conf.auth.models import AbstractUser
+
+       class User(AbstractUser):
+           pass
+
+   and pointing :setting:`AUTH_USER_MODEL` to it. Do this before creating
    any migrations or running ``manage.py migrate`` for the first time.
-
-   Changing this setting after you have tables created is not supported
-   by :djadmin:`makemigrations` and will result in you having to manually
-   fix your schema, port your data from the old user table, and possibly
-   manually reapply some migrations.
+   This model will behave the same as Django's default user model,
+   but you will be able to change it in the future if the need arises.
 
 .. warning::
+
+   Changing :setting:`AUTH_USER_MODEL` after you have tables created
+   (in an existing project) is significantly more difficult
+   and has a big effect on your database structure.
+   It changes the tables that are available, and it will affect the
+   construction of foreign keys and many-to-many relationships.
+
+   This change is not supported by :djadmin:`makemigrations` and
+   will result in you having to manually fix your schema, port your data
+   from the old user table, and possibly manually reapply some migrations.
 
    Due to limitations of Django's dynamic dependency feature for swappable
    models, you must ensure that the model referenced by :setting:`AUTH_USER_MODEL`
    is created in the first migration of its app (usually called ``0001_initial``);
    otherwise, you will have dependency issues.
 
-   In addition, you may run into a CircularDependencyError when running your
+   In addition, you may run into a ``CircularDependencyError`` when running your
    migrations as Django won't be able to automatically break the dependency
    loop due to the dynamic dependency. If you see this error, you should
    break the loop by moving the models depended on by your User model
    into a second migration (you can try making two normal models that
-   have a ForeignKey to each other and seeing how ``makemigrations`` resolves that
+   have a ``ForeignKey`` to each other and seeing how ``makemigrations`` resolves that
    circular dependency if you want to see how it's usually done)
 
 .. admonition:: Reusable apps and ``AUTH_USER_MODEL``
@@ -486,7 +501,7 @@ Specifying a custom ``User`` model
 .. admonition:: Model design considerations
 
     Think carefully before handling information not directly related to
-    authentication in your custom User Model.
+    authentication in your custom User model.
 
     It may be better to store app-specific user information in a model
     that has a relation with the User model. That allows each app to specify


### PR DESCRIPTION
Recommend to create a custom user model in documentation, as suggested in https://code.djangoproject.com/ticket/24370.

I merged the two warnings, since they both concern the situation when AUTH_USER_MODEL is changed in an existing project.

This does not solve #24370 completely (there are suggestions to add this to tutorial or create a management command `startuserapp`), but should be a step in the right direction.