### PR TITLE
Fixed #27461 -- Fixed incorrect allow_migrate() arguments in makemigrations.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
                     # At least one model must be migrated to the database.
                     router.allow_migrate(connection.alias, app_label, model_name=model._meta.object_name)
                     for app_label in consistency_check_labels
-                    for model in apps.get_models(app_label)
+                    for model in apps.get_app_config(app_label).get_models()
             )):
                 loader.check_consistent_history(connection)
 

--- a/docs/releases/1.10.4.txt
+++ b/docs/releases/1.10.4.txt
@@ -12,3 +12,7 @@ Bugfixes
 * Quoted the Oracle test user's password in queries to fix the "ORA-00922:
   missing or invalid option" error when the password starts with a number or
   special character (:ticket:`27420`).
+
+* Fixed incorrect ``app_label`` / ``model_name`` arguments for
+  ``allow_migrate()`` in ``makemigrations`` migration consistency checks
+  (:ticket:`27461`).


### PR DESCRIPTION
The args before was incorrect, it was interpreted as a boolean. This should use the correct method to call the models for that app.

ticket: https://code.djangoproject.com/ticket/27461