### PR TITLE
Refs #27420 -- Removed "if" that hides exceptions from Oracle DB crea…

### DIFF
--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -77,9 +77,6 @@ class DatabaseCreation(BaseDatabaseCreation):
             try:
                 self._create_test_user(cursor, parameters, verbosity, keepdb)
             except Exception as e:
-                # If we want to keep the db, then we want to also keep the user.
-                if keepdb:
-                    return
                 sys.stderr.write("Got an error creating the test user: %s\n" % e)
                 if not autoclobber:
                     confirm = input(


### PR DESCRIPTION
…te test user with `keepdb` flag.

Due to [comment](https://code.djangoproject.com/ticket/27420#comment:6). See also [PR 7463](https://github.com/django/django/pull/7463).