### PR TITLE
Use function-argument for tzinfo in test_datetime.

### DIFF
--- a/tests/db_functions/test_datetime.py
+++ b/tests/db_functions/test_datetime.py
@@ -745,7 +745,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
 
         melb = pytz.timezone('Australia/Melbourne')
 
-        def test_datetime_kind(kind, tzinfo=melb):
+        def test_datetime_kind(kind):
             self.assertQuerysetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc('start_datetime', kind, output_field=DateTimeField(), tzinfo=melb)
@@ -757,7 +757,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                 lambda m: (m.start_datetime, m.truncated)
             )
 
-        def test_date_kind(kind, tzinfo=melb):
+        def test_date_kind(kind):
             self.assertQuerysetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc('start_date', kind, output_field=DateField(), tzinfo=melb)
@@ -769,7 +769,7 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
                 lambda m: (m.start_datetime, m.truncated)
             )
 
-        def test_time_kind(kind, tzinfo=melb):
+        def test_time_kind(kind):
             self.assertQuerysetEqual(
                 DTModel.objects.annotate(
                     truncated=Trunc('start_time', kind, output_field=TimeField(), tzinfo=melb)


### PR DESCRIPTION
A bit of cleanup (PyCharm highlighted it). I don't know if the commit message needs to be modified. 