### PR TITLE
Fixed #26822: Don't keep database clones when using keepdb option if new migrations are non applied

### DIFF
--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 
 from django.db.backends.base.creation import BaseDatabaseCreation
+from django.db.migrations.loader import has_unapplied_migrations
 
 from .client import DatabaseClient
 
@@ -26,7 +27,7 @@ class DatabaseCreation(BaseDatabaseCreation):
             try:
                 cursor.execute("CREATE DATABASE %s" % qn(target_database_name))
             except Exception as e:
-                if keepdb:
+                if keepdb and not has_unapplied_migrations(self.connection):
                     return
                 try:
                     if verbosity >= 1:

--- a/django/db/backends/postgresql/creation.py
+++ b/django/db/backends/postgresql/creation.py
@@ -1,6 +1,7 @@
 import sys
 
 from django.db.backends.base.creation import BaseDatabaseCreation
+from django.db.migrations.loader import has_unapplied_migrations
 
 
 class DatabaseCreation(BaseDatabaseCreation):
@@ -42,7 +43,7 @@ class DatabaseCreation(BaseDatabaseCreation):
             try:
                 cursor.execute(creation_sql)
             except Exception as e:
-                if keepdb:
+                if keepdb and not has_unapplied_migrations(self.connection):
                     return
                 try:
                     if verbosity >= 1:

--- a/django/db/backends/sqlite3/creation.py
+++ b/django/db/backends/sqlite3/creation.py
@@ -4,6 +4,7 @@ import sys
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.base.creation import BaseDatabaseCreation
+from django.db.migrations.loader import has_unapplied_migrations
 from django.utils.encoding import force_text
 from django.utils.six.moves import input
 
@@ -76,7 +77,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         if not self.is_in_memory_db(source_database_name):
             # Erase the old test database
             if os.access(target_database_name, os.F_OK):
-                if keepdb:
+                if keepdb and not has_unapplied_migrations(self.connection):
                     return
                 if verbosity >= 1:
                     print("Destroying old test database for alias %s..." % (


### PR DESCRIPTION
When using --keepdb option, cloned databases created with --parallel option are not recreated or updated, which make them out-to-date as soon as we add a new migration in the project.
This patch forces the cloned databases to be recreated if they are out-to-date.

Second try after #6884 for issue https://code.djangoproject.com/ticket/26822