### PR TITLE
Fixed #26985 -- Doc'd ForeignKey.to_field bonds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -382,6 +382,7 @@ answer newbie questions, and generally made Django that much better:
     Jökull Sólberg Auðunsson <jokullsolberg@gmail.com>
     Jon Dufresne <jon.dufresne@gmail.com>
     Jonas Haag <jonas@lophus.org>
+    Jonatas C. D. <jonatas.cd@gmail.com>
     Jonathan Buchanan <jonathan.buchanan@gmail.com>
     Jonathan Daugherty (cygnus) <http://www.cprogrammer.org/>
     Jonathan Feignberg <jdf@pobox.com>

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1424,7 +1424,8 @@ The possible values for :attr:`~ForeignKey.on_delete` are found in
 .. attribute:: ForeignKey.to_field
 
     The field on the related object that the relation is to. By default, Django
-    uses the primary key of the related object.
+    uses the primary key of the related object, therefore be sure the field you
+    are referencing is ``unique=True`` in order to keep the relation correct.
 
 .. attribute:: ForeignKey.db_constraint
 


### PR DESCRIPTION
Make explicit in the documentation the requirement for the field referenced at ForeignKey.to_field to be `unique=True`.

https://code.djangoproject.com/ticket/26985