### PR TITLE
Refs #26327 -- Renamed JsonAgg to JSONBAgg.

### DIFF
--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -2,7 +2,7 @@ from django.contrib.postgres.fields import JSONField
 from django.db.models.aggregates import Aggregate
 
 __all__ = [
-    'ArrayAgg', 'BitAnd', 'BitOr', 'BoolAnd', 'BoolOr', 'JsonAgg', 'StringAgg',
+    'ArrayAgg', 'BitAnd', 'BitOr', 'BoolAnd', 'BoolOr', 'JSONBAgg', 'StringAgg',
 ]
 
 
@@ -31,7 +31,7 @@ class BoolOr(Aggregate):
     function = 'BOOL_OR'
 
 
-class JsonAgg(Aggregate):
+class JSONBAgg(Aggregate):
     function = 'JSONB_AGG'
     _output_field = JSONField()
 

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -40,3 +40,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def has_jsonb_datatype(self):
         return self.connection.pg_version >= 90400
+
+    @cached_property
+    def has_jsonb_agg(self):
+        return self.connection.pg_version >= 90500

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -58,14 +58,15 @@ General-purpose aggregation functions
     Returns ``True`` if at least one input value is true, ``None`` if all
     values are null or if there are no values, otherwise ``False``.
 
-``JsonAgg``
------------
+``JSONBAgg``
+------------
 
-.. class:: JsonAgg(expressions, **extra)
+.. class:: JSONBAgg(expressions, **extra)
 
     .. versionadded:: 1.11
 
-    Returns the input values as a ``JSON`` array.
+    Returns the input values as a ``JSON`` array. ``JSONB_AGG`` requires
+    PostgreSQL 9.5+.
 
 ``StringAgg``
 -------------

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -183,7 +183,7 @@ Minor features
   operation allow using PostgreSQL's ``citext`` extension for case-insensitive
   lookups.
 
-* The new :class:`~django.contrib.postgres.aggregates.JsonAgg` allows
+* The new :class:`~django.contrib.postgres.aggregates.JSONBAgg` allows
   aggregating values as a JSON array.
 
 :mod:`django.contrib.redirects`

--- a/tests/postgres_tests/test_aggregates.py
+++ b/tests/postgres_tests/test_aggregates.py
@@ -9,7 +9,7 @@ from .models import AggregateTestModel, StatTestModel
 
 try:
     from django.contrib.postgres.aggregates import (
-        ArrayAgg, BitAnd, BitOr, BoolAnd, BoolOr, Corr, CovarPop, JsonAgg,
+        ArrayAgg, BitAnd, BitOr, BoolAnd, BoolOr, Corr, CovarPop, JSONBAgg,
         RegrAvgX, RegrAvgY, RegrCount, RegrIntercept, RegrR2, RegrSlope,
         RegrSXX, RegrSXY, RegrSYY, StatAggregate, StringAgg,
     )
@@ -117,14 +117,14 @@ class TestGeneralAggregate(PostgreSQLTestCase):
         values = AggregateTestModel.objects.aggregate(stringagg=StringAgg('char_field', delimiter=';'))
         self.assertEqual(values, {'stringagg': ''})
 
-    @skipUnlessDBFeature('has_jsonb_datatype')
+    @skipUnlessDBFeature('has_jsonb_agg')
     def test_json_agg(self):
-        values = AggregateTestModel.objects.aggregate(jsonagg=JsonAgg('char_field'))
+        values = AggregateTestModel.objects.aggregate(jsonagg=JSONBAgg('char_field'))
         self.assertEqual(values, {'jsonagg': ['Foo1', 'Foo2', 'Foo3', 'Foo4']})
 
-    @skipUnlessDBFeature('has_jsonb_datatype')
+    @skipUnlessDBFeature('has_jsonb_agg')
     def test_json_agg_empty(self):
-        values = AggregateTestModel.objects.none().aggregate(jsonagg=JsonAgg('integer_field'))
+        values = AggregateTestModel.objects.none().aggregate(jsonagg=JSONBAgg('integer_field'))
         self.assertEqual(values, json.loads('{"jsonagg": []}'))
 
 


### PR DESCRIPTION
Thanks to Christian von Roques for the report.

I added a new flag to indicate availability of ``JSONB_AGG`` and fallback to ``json_agg`` on PostgreSQL. I tried to test locally for things highlighted in https://www.postgresql.org/docs/9.4/static/datatype-json.html#JSON-KEYS-ELEMENTS but get the same result on both 9.5 and 9.4 using ``FloatField`` with the value 1.230e-5.

Are more tests needed? Alternatively, it may be better to disallow use of this function on PostgreSQL 9.4?