### PR TITLE
Fixed #27486 -- Fixed intword/filesizeformat filters passing non-ints to gettext.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -135,7 +135,7 @@ def intword(value):
         large_number = 10 ** exponent
         if value < large_number * 1000:
             new_value = value / float(large_number)
-            return _check_for_i18n(new_value, *converters(new_value))
+            return _check_for_i18n(new_value, *converters(int(new_value)))
     return value
 
 

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -892,7 +892,7 @@ def filesizeformat(bytes_):
         bytes_ = -bytes_  # Allow formatting of negative numbers.
 
     if bytes_ < KB:
-        value = ungettext("%(size)d byte", "%(size)d bytes", bytes_) % {'size': bytes_}
+        value = ungettext("%(size)d byte", "%(size)d bytes", int(bytes_)) % {'size': bytes_}
     elif bytes_ < MB:
         value = ugettext("%s KB") % filesize_number_format(bytes_ / KB)
     elif bytes_ < GB:

--- a/tests/humanize_tests/tests.py
+++ b/tests/humanize_tests/tests.py
@@ -125,7 +125,7 @@ class HumanizeTests(SimpleTestCase):
             '6000000000000',
         )
         result_list = (
-            '100', '1,0 Million', '1,2 Millionen', '1,3 Millionen',
+            '100', '1,0 Million', '1,2 Million', '1,3 Million',
             '1,0 Milliarde', '2,0 Milliarden', '6,0 Billionen',
         )
         with self.settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27486