### PR TITLE
Added raw sql streaming example with headers to docs/howto/outputting-csv

### DIFF
--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -120,28 +120,32 @@ adding column names for the first row::
     import csv
     import datetime
 
-    from StringIO import StringIO
     from django.db import connection
     from django.http import StreamingHttpResponse
+
+    class Echo(object):
+        """An object that implements just the write method of the file-like
+        interface for csv.writer.
+        """
+        def write(self, value):
+            """Write the value by returning it, instead of storing in a buffer."""
+            return value
 
     def export_csv(request):
         """Export raw sql as a csv with column headers"""
         def stream():
             """Generator function to yield cursor rows with a header."""
-            buffer = StringIO()
-            writer = csv.writer(buffer)
+            pseudo_buffer = Echo()
+            writer = csv.writer(pseudo_buffer)
             columns = True
             for row in cursor.fetchall():
+                data = ''
                 if columns:
-                    # Write header columns
+                    # Write the columns if this is the first row
                     columns = [col[0] for col in cursor.description]
-                    writer.writerow(columns)
+                    data = writer.writerow(columns)
                     columns = False
-                writer.writerow(row)
-                buffer.seek(0)
-                data = buffer.read()
-                buffer.seek(0)
-                buffer.truncate()
+                data = data + writer.writerow(row)
                 yield data
 
         # Create a unique file name for the download

--- a/docs/howto/outputting-csv.txt
+++ b/docs/howto/outputting-csv.txt
@@ -113,6 +113,51 @@ the assembly and transmission of a large CSV file::
         response['Content-Disposition'] = 'attachment; filename="somefilename.csv"'
         return response
 
+This example is useful for large volumes of data from a database. A generator
+function streams rows returned from a cursor as they arrive from the database,
+adding column names for the first row::
+
+    import csv
+    import datetime
+
+    from StringIO import StringIO
+    from django.db import connection
+    from django.http import StreamingHttpResponse
+
+    def export_csv(request):
+        """Export raw sql as a csv with column headers"""
+        def stream():
+            """Generator function to yield cursor rows with a header."""
+            buffer = StringIO()
+            writer = csv.writer(buffer)
+            columns = True
+            for row in cursor.fetchall():
+                if columns:
+                    # Write header columns
+                    columns = [col[0] for col in cursor.description]
+                    writer.writerow(columns)
+                    columns = False
+                writer.writerow(row)
+                buffer.seek(0)
+                data = buffer.read()
+                buffer.seek(0)
+                buffer.truncate()
+                yield data
+
+        # Create a unique file name for the download
+        dt = datetime.datetime.now()
+        cd = 'attachment; filename="myfile-{}.csv"'.format(dt.strftime('%Y-%m-%d-%H%M%S'))
+
+        # Execute raw SQL
+        sql = "SELECT * FROM myapp_foo WHERE bar = %s"
+        cursor = connection.cursor()
+        cursor.execute(sql, ['baz'])
+
+        response = StreamingHttpResponse(stream(), content_type="text/csv")
+        response['Content-Disposition'] = cd
+
+        return response
+
 Using the template system
 =========================
 


### PR DESCRIPTION
Example of a lightweight wrapper streaming results from raw sql
with headers.  Demonstrates adding headers in a generator function,
using datetime to format an attachment filename, and using
cursor.execute with params.