### PR TITLE
Refs #23811 -- Eased git bisect run usage when triaging tickets

### DIFF
--- a/docs/internals/contributing/triaging-tickets.txt
+++ b/docs/internals/contributing/triaging-tickets.txt
@@ -460,7 +460,7 @@ find a revision where your test passes, mark it as "good"::
 Now we're ready for the fun part: using ``git bisect run`` to automate the rest
 of the process::
 
-    $ git bisect run python runtests.py migrations.test_regression
+    $ git bisect run tests/runtests.py migrations.test_regression
 
 You should see ``git bisect`` use a binary search to automatically checkout
 revisions between the good and bad commits until it finds the first "bad"


### PR DESCRIPTION
`git bisect` can only be run from the toplevel of the working tree. The example command would not run unless one modifies its `PYTHONPATH` to include Django's tests directory.

Unless I have missed something, the command given in [triaging tickets](https://docs.djangoproject.com/en/dev/internals/contributing/triaging-tickets/) does not run from the top directory.

This is really a small edit, I do not think a ticket is required. I will be pleased to create one if I'm wrong.