### PR TITLE
Fixed #27493 -- Fix test failure with recent GDAL versions

### DIFF
--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -99,11 +99,13 @@ class RasterFieldTest(TransactionTestCase):
         # Confirm raster has been transformed to the default srid
         self.assertEqual(r.rast.srs.srid, 4326)
         # Confirm geotransform is in lat/lon
-        self.assertEqual(
-            r.rast.geotransform,
-            [-87.9298551266551, 9.459646421449934e-06, 0.0,
-             23.94249275457565, 0.0, -9.459646421449934e-06]
-        )
+        geotransform = r.rast.geotransform
+        self.assertAlmostEqual(geotransform[0], -87.9298551266551)
+        self.assertAlmostEqual(geotransform[1], 9.459646421449934e-06)
+        self.assertAlmostEqual(geotransform[2], 0.0)
+        self.assertAlmostEqual(geotransform[3], 23.94249275457565)
+        self.assertAlmostEqual(geotransform[4], 0.0)
+        self.assertAlmostEqual(geotransform[5], -9.459646421449934e-06)
 
     def test_verbose_name_arg(self):
         """


### PR DESCRIPTION
Test can now accomodate small precision changes in different environments.

When updating GDAL to fix this (1.11.3 -> 1.11.5). I also noticed a few other issues/warning with GeoDjango tests. Will investigate and open new tickets as required.