### PR TITLE
Fixed #27507 -- Used SchemaEditor.execute() to run deferred_sql in migrate's sync_apps().

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -312,8 +312,9 @@ class Command(BaseCommand):
 
                 if self.verbosity >= 1:
                     self.stdout.write("    Running deferred SQL...\n")
-                for statement in deferred_sql:
-                    cursor.execute(statement)
+                with connection.schema_editor() as editor:
+                    for statement in deferred_sql:
+                        editor.execute(statement)
         finally:
             cursor.close()
 

--- a/tests/migrations/migrations_test_apps/unmigrated_app_syncdb/models.py
+++ b/tests/migrations/migrations_test_apps/unmigrated_app_syncdb/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class Classroom(models.Model):
+    pass
+
+
+class Lesson(models.Model):
+    classroom = models.ForeignKey(Classroom, on_delete=models.CASCADE)

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -12,6 +12,7 @@ from django.core.management import CommandError, call_command
 from django.db import (
     ConnectionHandler, DatabaseError, connection, connections, models,
 )
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.exceptions import (
     InconsistentMigrationHistory, MigrationSchemaMissing,
 )
@@ -460,6 +461,20 @@ class MigrateTests(MigrationTestBase):
         # registry never sees it and the reference is left dangling. Remove it
         # to avoid problems in subsequent tests.
         del apps._pending_operations[('migrations', 'tribble')]
+
+    @override_settings(INSTALLED_APPS=[
+        'migrations.migrations_test_apps.unmigrated_app_syncdb',
+    ])
+    def test_migrate_syncdb_deferred_sql_executed_with_schemaeditor(self):
+        """
+        For an app without migrations, editor.execute() is used for executing
+        the syncdb deferred SQL.
+        """
+        with mock.patch.object(BaseDatabaseSchemaEditor, 'execute') as execute:
+            call_command('migrate', run_syncdb=True, verbosity=0)
+            self.assertGreater(len(execute.mock_calls), 0)
+            # The CREATE INDEX SQL is deferred.
+            self.assertTrue(any('CREATE INDEX' in str(call) for call in execute.mock_calls))
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
     def test_migrate_record_replaced(self):

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -472,9 +472,10 @@ class MigrateTests(MigrationTestBase):
         """
         with mock.patch.object(BaseDatabaseSchemaEditor, 'execute') as execute:
             call_command('migrate', run_syncdb=True, verbosity=0)
-            self.assertGreater(len(execute.mock_calls), 0)
-            # The CREATE INDEX SQL is deferred.
-            self.assertTrue(any('CREATE INDEX' in str(call) for call in execute.mock_calls))
+            table_creates = len([call for call in execute.mock_calls if 'CREATE TABLE' in str(call)])
+            self.assertEqual(table_creates, 2)
+            # there should be more queries than the table creates (usually the deferred ones)
+            self.assertGreater(len(execute.mock_calls), 2)
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
     def test_migrate_record_replaced(self):


### PR DESCRIPTION
Associated Django Ticket: https://code.djangoproject.com/ticket/27507

This is a very simple fix for the `sync_app` method in the `migration` command that uses `editor.execute()` to execute deferred sql instead of directly using `cursor.execute()`.

There are two reasons for this:

1. This is consistent with the normal migrateable apps workflow where deferred SQL is executed using `editor.execute()`. See: [django/db/backends/base/schema.py#L91](https://github.com/django/django/blob/371adc472a2a1f09923101e3c4fda60cdff96028/django/db/backends/base/schema.py#L91)

2. When `cursor.execute()` is hard coded in `sync_app` it is not possible to do custom processing of the SQL (as could be done with a custom `DatabaseSchemaEditor.execute()`).

This pull request does not change any existing functionality and is backwards compatible but it provides a more consistent, intuitive and predictable behavior when extending `DatabaseSchemaEditor`.