### PR TITLE
Increased test coverage of Signal to 100%

### DIFF
--- a/tests/dispatch/test_removedindjango20.py
+++ b/tests/dispatch/test_removedindjango20.py
@@ -1,0 +1,24 @@
+import warnings
+
+from django.dispatch import Signal
+from django.test import SimpleTestCase
+
+a_signal = Signal(providing_args=["val"])
+
+
+def receiver_1_arg(val, **kwargs):
+    return val
+
+
+class DispatcherTests(SimpleTestCase):
+
+    def test_disconnect_weak_deprecated(self):
+        a_signal.connect(receiver_1_arg)
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+            a_signal.disconnect(receiver_1_arg, weak=True)
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(
+            str(warns[0].message),
+            'Passing `weak` to disconnect has no effect.',
+        )


### PR DESCRIPTION
Added and renamed tests to cover the lines not to do with Python 2 compat as seen at http://djangoci.com/view/coverage/job/django-coverage/HTML_Coverage_Report/_home_jenkins_workspace_django-coverage_django_dispatch_dispatcher_py.html