### PR TITLE
Refs #26207 -- Removed references to deferred model classes from comments

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -179,7 +179,6 @@ class AppConfig(object):
 
         - auto-created models for many-to-many relations without
           an explicit intermediate table,
-        - models created to satisfy deferred attribute queries,
         - models that have been swapped out.
 
         Set the corresponding keyword argument to True to include such models.

--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -165,7 +165,6 @@ class Apps(object):
 
         - auto-created models for many-to-many relations without
           an explicit intermediate table,
-        - models created to satisfy deferred attribute queries,
         - models that have been swapped out.
 
         Set the corresponding keyword argument to True to include such models.

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -605,12 +605,6 @@ class Model(six.with_metaclass(ModelBase)):
         return hash(self._get_pk_val())
 
     def __reduce__(self):
-        """
-        Provides pickling support. Normally, this just dispatches to Python's
-        standard handling. However, for models with deferred field loading, we
-        need to do things manually, as they're dynamically created classes and
-        only module-level classes can be pickled by the default path.
-        """
         data = self.__dict__
         data[DJANGO_VERSION_PICKLE_KEY] = get_version()
         class_id = self._meta.app_label, self._meta.object_name

--- a/tests/update_only_fields/tests.py
+++ b/tests/update_only_fields/tests.py
@@ -72,8 +72,7 @@ class UpdateOnlyFieldsTests(TestCase):
         s1.gender = 'M'
         with self.assertNumQueries(1):
             s1.save()
-        # The deferred class does not remember that gender was
-        # set, instead the instance should remember this.
+        # save() should not fetch deferred fields
         s1 = Person.objects.only('name').get(pk=s.pk)
         with self.assertNumQueries(1):
             s1.save()


### PR DESCRIPTION
Missed in [#26207](https://code.djangoproject.com/ticket/26207).