### PR TITLE
Fixed #27517 -- Fixed charset param in SimpleTemplateResponse.__init__().

### DIFF
--- a/django/template/response.py
+++ b/django/template/response.py
@@ -34,7 +34,7 @@ class SimpleTemplateResponse(HttpResponse):
         # content argument doesn't make sense here because it will be replaced
         # with rendered template so we always pass empty string in order to
         # prevent errors and provide shorter signature.
-        super(SimpleTemplateResponse, self).__init__('', content_type=content_type, status=status, charset=charset)
+        super(SimpleTemplateResponse, self).__init__('', content_type, status, charset=charset)
 
         # _is_rendered tracks whether the template and context has been baked
         # into a final response.

--- a/django/template/response.py
+++ b/django/template/response.py
@@ -34,7 +34,7 @@ class SimpleTemplateResponse(HttpResponse):
         # content argument doesn't make sense here because it will be replaced
         # with rendered template so we always pass empty string in order to
         # prevent errors and provide shorter signature.
-        super(SimpleTemplateResponse, self).__init__('', content_type, status, charset)
+        super(SimpleTemplateResponse, self).__init__('', content_type=content_type, status=status, charset=charset)
 
         # _is_rendered tracks whether the template and context has been baked
         # into a final response.

--- a/tests/template_tests/test_response.py
+++ b/tests/template_tests/test_response.py
@@ -122,9 +122,10 @@ class SimpleTemplateResponseTest(SimpleTestCase):
         self.assertEqual(response.content, b'bar')
 
     def test_kwargs(self):
-        response = self._response(content_type='application/json', status=504)
+        response = self._response(content_type='application/json', status=504, charset='ascii')
         self.assertEqual(response['content-type'], 'application/json')
         self.assertEqual(response.status_code, 504)
+        self.assertEqual(response.charset, 'ascii')
 
     def test_args(self):
         response = SimpleTemplateResponse('', {}, 'application/json', 504)


### PR DESCRIPTION
Refs [ticket 27517](https://code.djangoproject.com/ticket/27517)

Call `HttpResponse.__init__` with keyword args.