### PR TITLE
fix docs: changed link to virtualenv website

### DIFF
--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -108,7 +108,7 @@ string to ``WSGIPythonPath`` must be quoted:
 Make sure you give the correct path to your virtualenv, and replace
 ``python3.X`` with the correct Python version (e.g. ``python3.4``).
 
-.. _virtualenv: http://www.virtualenv.org
+.. _virtualenv: https://virtualenv.pypa.io/
 
 .. _daemon-mode:
 

--- a/docs/howto/deployment/wsgi/modwsgi.txt
+++ b/docs/howto/deployment/wsgi/modwsgi.txt
@@ -108,7 +108,7 @@ string to ``WSGIPythonPath`` must be quoted:
 Make sure you give the correct path to your virtualenv, and replace
 ``python3.X`` with the correct Python version (e.g. ``python3.4``).
 
-.. _virtualenv: https://virtualenv.pypa.io/
+.. _virtualenv: https://virtualenv.pypa.io
 
 .. _daemon-mode:
 

--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -95,7 +95,7 @@ If you use some other installation process, you might have to manually
 should look at the complete installation instructions.
 
 .. _pip: https://pip.pypa.io/
-.. _virtualenv: http://www.virtualenv.org/
+.. _virtualenv: https://virtualenv.pypa.io//
 
 Testing
 =======

--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -95,7 +95,7 @@ If you use some other installation process, you might have to manually
 should look at the complete installation instructions.
 
 .. _pip: https://pip.pypa.io/
-.. _virtualenv: https://virtualenv.pypa.io//
+.. _virtualenv: https://virtualenv.pypa.io/
 
 Testing
 =======

--- a/docs/internals/team.txt
+++ b/docs/internals/team.txt
@@ -151,7 +151,7 @@ Karen Tracey
 
     .. _Jannis Leidel: https://jezdez.com/
     .. _Bauhaus-University Weimar: http://www.uni-weimar.de/
-    .. _virtualenv: https://virtualenv.pypa.io//
+    .. _virtualenv: https://virtualenv.pypa.io/
     .. _pip: https://pip.pypa.io/
     .. _Mozilla: https://www.mozilla.org/
 

--- a/docs/internals/team.txt
+++ b/docs/internals/team.txt
@@ -151,7 +151,7 @@ Karen Tracey
 
     .. _Jannis Leidel: https://jezdez.com/
     .. _Bauhaus-University Weimar: http://www.uni-weimar.de/
-    .. _virtualenv: http://www.virtualenv.org/
+    .. _virtualenv: https://virtualenv.pypa.io//
     .. _pip: https://pip.pypa.io/
     .. _Mozilla: https://www.mozilla.org/
 

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -321,6 +321,6 @@ disadvantages:
 
 Typically, these situations only arise once you're maintaining several Django
 projects. When they do, the best solution is to use `virtualenv
-<http://www.virtualenv.org/>`_. This tool allows you to maintain multiple
+<https://virtualenv.pypa.io//>`_. This tool allows you to maintain multiple
 isolated Python environments, each with its own copy of the libraries and
 package namespace.

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -321,6 +321,6 @@ disadvantages:
 
 Typically, these situations only arise once you're maintaining several Django
 projects. When they do, the best solution is to use `virtualenv
-<https://virtualenv.pypa.io//>`_. This tool allows you to maintain multiple
+<https://virtualenv.pypa.io/>`_. This tool allows you to maintain multiple
 isolated Python environments, each with its own copy of the libraries and
 package namespace.

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -177,7 +177,7 @@ This is the recommended way to install Django.
    ``pip install Django`` at the shell prompt.
 
 .. _pip: https://pip.pypa.io/
-.. _virtualenv: http://www.virtualenv.org/
+.. _virtualenv: https://virtualenv.pypa.io//
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
 .. _standalone pip installer: https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py
 

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -177,7 +177,7 @@ This is the recommended way to install Django.
    ``pip install Django`` at the shell prompt.
 
 .. _pip: https://pip.pypa.io/
-.. _virtualenv: https://virtualenv.pypa.io//
+.. _virtualenv: https://virtualenv.pypa.io/
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
 .. _standalone pip installer: https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py
 


### PR DESCRIPTION
Hello.

As freenode user lantern pointed out the docs point to a parked page notice for virtualenv. I fixed that.