### PR TITLE
added example migration for setting domain in django.contrib.sites

### DIFF
--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -275,7 +275,21 @@ To enable the sites framework, follow these steps:
 default site named ``example.com`` with the domain ``example.com``. This site
 will also be created after Django creates the test database. To set the
 correct name and domain for your project, you can use a :ref:`data migration
-<data-migrations>`.
+<data-migrations>`.  Below is an example migration for mycoolsite.com::
+
+    from django.db import migrations
+    from django.contrib.sites.models import Site
+    
+    def changeHostname(apps, schemd_editor):
+        mySite          = Site.objects.get_current()
+        mySite.name     = 'My Cool Site'
+        mySite.domain   = 'mycoolsite.com'
+        mySite.save()
+
+    class Migration(migrations.Migration):
+        dependencies    = [ ('myCoolApp', 'prevMigration') ]
+        operations      = [ migrations.RunPython(changeHostname) ]
+
 
 In order to serve different sites in production, you'd create a separate
 settings file with each ``SITE_ID`` (perhaps importing from a common settings

--- a/docs/ref/contrib/sites.txt
+++ b/docs/ref/contrib/sites.txt
@@ -275,15 +275,15 @@ To enable the sites framework, follow these steps:
 default site named ``example.com`` with the domain ``example.com``. This site
 will also be created after Django creates the test database. To set the
 correct name and domain for your project, you can use a :ref:`data migration
-<data-migrations>`.  Below is an example migration for mycoolsite.com::
+<data-migrations>`.  Below is an example migration for foo.com::
 
     from django.db import migrations
     from django.contrib.sites.models import Site
     
     def changeHostname(apps, schemd_editor):
         mySite          = Site.objects.get_current()
-        mySite.name     = 'My Cool Site'
-        mySite.domain   = 'mycoolsite.com'
+        mySite.name     = 'Foo Site'
+        mySite.domain   = 'foo.com'
         mySite.save()
 
     class Migration(migrations.Migration):


### PR DESCRIPTION
I'm new to Django, but I had to reviewing the source of django.contrib.sites.models before I could figure out how to set new domains using Migrations.  I added a short example in the manual, which would have helped me out a great deal.

Please let me know what you think.  If I need to make any changes don't hesitate to contact me.

-Dave