### PR TITLE
Fixed #27524 -- Use get_user_model() instead of user instance to call class method

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -133,7 +133,7 @@ def login(request, user, backend=None):
                 '`backend` attribute on the user.'
             )
 
-    request.session[SESSION_KEY] = user._meta.pk.value_to_string(user)
+    request.session[SESSION_KEY] = get_user_model()._meta.pk.value_to_string(user)
     request.session[BACKEND_SESSION_KEY] = backend
     request.session[HASH_SESSION_KEY] = session_auth_hash
     if hasattr(request, 'user'):


### PR DESCRIPTION
Using get_user_model() instead of the user instance avoids issues when a custom user model is provided.

For example, when the user model was overridden, we were seeing errors like this on 1.8.16:

```
File "[...snip...]/django/contrib/auth/__init__.py", line 111, in login
    request.session[SESSION_KEY] = user._meta.pk.value_to_string(user)
AttributeError: 'MetaDict' object has no attribute 'pk'
```

Going through the object returned by get_user_model() also matches what's done in other places in the codebase (for example, in _get_user_session_key(request)).