### PR TITLE
Fixed #27321 -- Added detection for table case name sensitivity on MySQL

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -224,9 +224,9 @@ class BaseDatabaseFeatures(object):
     # Defaults to False to allow third-party backends to opt-in.
     can_clone_databases = False
 
-    # Does the backend consider quoted identifiers with different casing to
+    # Does the backend consider table names with different casing to
     # be equal?
-    ignores_quoted_identifier_case = False
+    ignores_table_name_case = False
 
     # Place FOR UPDATE right after FROM clause. Used on MSSQL.
     for_update_after_from = False

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -375,7 +375,7 @@ class BaseDatabaseSchemaEditor(object):
         Renames the table a model points to.
         """
         if (old_db_table == new_db_table or
-            (self.connection.features.ignores_quoted_identifier_case and
+            (self.connection.features.ignores_table_name_case and
                 old_db_table.lower() == new_db_table.lower())):
             return
         self.execute(self.sql_rename_table % {

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -72,3 +72,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         All storage engines except MyISAM support transactions.
         """
         return self._mysql_storage_engine != 'MyISAM'
+
+    @cached_property
+    def ignores_table_name_case(self):
+        with self.connection.cursor() as cursor:
+            cursor.execute('SELECT @@LOWER_CASE_TABLE_NAMES')
+            result = cursor.fetchone()
+            return result and result[0] != 0

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -37,7 +37,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_temporal_subtraction = True
     # Oracle doesn't ignore quoted identifiers case but the current backend
     # does by uppercasing all identifiers.
-    ignores_quoted_identifier_case = True
+    ignores_table_name_case = True
 
     def introspected_boolean_field_type(self, field=None, created_separately=False):
         """

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -33,7 +33,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_sequence_reset = False
     can_clone_databases = True
     supports_temporal_subtraction = True
-    ignores_quoted_identifier_case = True
+    ignores_table_name_case = True
 
     @cached_property
     def uses_savepoints(self):

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -453,6 +453,9 @@ Database backend API
   which is deprecated. Custom database backends should ensure all types of
   indexes are returned by ``DatabaseIntrospection.get_constraints()``.
 
+* Renamed the ``ignores_quoted_identifier_case`` feature to
+  ``ignores_table_name_case`` to more accurately reflect how it is used.
+
 Dropped support for PostgreSQL 9.2 and PostGIS 2.0
 --------------------------------------------------
 


### PR DESCRIPTION
It depends on the value of the `lower_case_table_names` setting, plus the case sensitivity of the filesystem that the table is on.