### PR TITLE
Fixed #27358 -- Added a system check for FileField upload_to starting with a slash.

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -242,6 +242,7 @@ class FileField(Field):
         errors = super(FileField, self).check(**kwargs)
         errors.extend(self._check_unique())
         errors.extend(self._check_primary_key())
+        errors.extend(self._check_upload_to())
         return errors
 
     def _check_unique(self):
@@ -263,6 +264,19 @@ class FileField(Field):
                     "'primary_key' is not a valid argument for a %s." % self.__class__.__name__,
                     obj=self,
                     id='fields.E201',
+                )
+            ]
+        else:
+            return []
+
+    def _check_upload_to(self):
+        if isinstance(self.upload_to, six.string_types) and self.upload_to[0] == '/':
+            return [
+                checks.Error(
+                    "'upload_to' should be a relative path, not an absolute path (remove leading slash) in %s." %
+                    self.__class__.__name__,
+                    obj=self,
+                    id='fields.E202',
                 )
             ]
         else:

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -184,6 +184,8 @@ File Fields
 
 * **fields.E200**: ``unique`` is not a valid argument for a ``FileField``.
 * **fields.E201**: ``primary_key`` is not a valid argument for a ``FileField``.
+* **fields.E202**: ``upload_to`` should be a relative path, not an absolute path
+  (remove leading slash) in ``FileField``.
 * **fields.E210**: Cannot use ``ImageField`` because Pillow is not installed.
 
 Related Fields

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -470,6 +470,33 @@ class FileFieldTests(SimpleTestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_upload_to(self):
+        class Model(models.Model):
+            field = models.FileField(upload_to='/somewhere')
+
+        field = Model._meta.get_field('field')
+        errors = field.check()
+        expected = [
+            Error(
+                "'upload_to' should be a relative path, not an absolute path (remove leading slash) in FileField.",
+                obj=field,
+                id='fields.E202',
+            )
+        ]
+        self.assertEqual(errors, expected)
+
+    def test_upload_to_callable(self):
+        def callable(instance, filename):
+            return '/' + instance + '_' + filename
+
+        class Model(models.Model):
+            field = models.FileField(upload_to=callable)
+
+        field = Model._meta.get_field('field')
+        errors = field.check()
+        expected = []
+        self.assertEqual(errors, expected)
+
 
 @isolate_apps('invalid_models_tests')
 class FilePathFieldTests(SimpleTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27358

Made fixes for https://github.com/django/django/pull/7442


