### PR TITLE
Fixed #25569 -- Improved error message for select_related

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -766,6 +766,7 @@ answer newbie questions, and generally made Django that much better:
     Ville Säävuori <http://www.unessa.net/>
     Vinay Sajip <vinay_sajip@yahoo.co.uk>
     Vincent Foley <vfoleybourgon@yahoo.ca>
+    Vincent Perez <perezv815@gmail.com>
     Vitaly Babiy <vbabiy86@gmail.com>
     Vladimir Kuzma <vladimirkuzma.ch@gmail.com>
     Vlado <vlado@labath.org>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -736,13 +736,16 @@ class SQLCompiler(object):
             fields_not_found = set(requested.keys()).difference(fields_found)
             if fields_not_found:
                 invalid_fields = ("'%s'" % s for s in fields_not_found)
-                raise FieldError(
-                    'Invalid field name(s) given in select_related: %s. '
+                error_msg = 'Invalid field name(s) given in select_related: %s. ' \
                     'Choices are: %s' % (
                         ', '.join(invalid_fields),
                         ', '.join(_get_field_choices()) or '(none)',
                     )
-                )
+                has_reverse_relations = any((field_name in opts.fields_map
+                                             for field_name in fields_not_found))
+                if has_reverse_relations:
+                    error_msg += '. Reverse relations cannot be used in select_related'
+                raise FieldError(error_msg)
         return related_klass_infos
 
     def deferred_to_columns(self):

--- a/tests/select_related/tests.py
+++ b/tests/select_related/tests.py
@@ -180,6 +180,8 @@ class SelectRelatedValidationTests(SimpleTestCase):
     """
     non_relational_error = "Non-relational field given in select_related: '%s'. Choices are: %s"
     invalid_error = "Invalid field name(s) given in select_related: '%s'. Choices are: %s"
+    invalid_error_with_reverse = "Invalid field name(s) given in select_related: '%s'. " \
+        "Choices are: %s. Reverse relations cannot be used in select_related"
 
     def test_non_relational_field(self):
         with self.assertRaisesMessage(FieldError, self.non_relational_error % ('name', 'genus')):
@@ -200,7 +202,7 @@ class SelectRelatedValidationTests(SimpleTestCase):
             list(Pizza.objects.select_related('toppings'))
 
     def test_reverse_relational_field(self):
-        with self.assertRaisesMessage(FieldError, self.invalid_error % ('child_1', 'genus')):
+        with self.assertRaisesMessage(FieldError, self.invalid_error_with_reverse % ('child_1', 'genus')):
             list(Species.objects.select_related('child_1'))
 
     def test_invalid_field(self):


### PR DESCRIPTION
Improved the error message when a select_related call is made with a
reverse relational field. If there is at least one reverse relational
field amongst the fields given to select_related, the error message is
improved.