### PR TITLE
Fixed #27518 -- Avoided password reset link leak on password reset confirmation page.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -662,6 +662,7 @@ answer newbie questions, and generally made Django that much better:
     Robert Wittams
     Rob Hudson <http://rob.cogit8.org/>
     Robin Munn <http://www.geekforgod.com/>
+    Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <http://ronny.haryan.to/>
     Ross Poulton <ross@rossp.org>
     Rozza <ross.lawley@gmail.com>

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -24,6 +24,8 @@ class PasswordResetTokenGenerator(object):
         """
         Check that a password reset token is correct for a given user.
         """
+        if not (user and token):
+            return False
         # Parse the token
         try:
             ts_b36, hash = token.split("-")

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -116,6 +116,14 @@ Minor features
   :class:`~django.contrib.auth.views.PasswordResetConfirmView` allows
   automatically logging in a user after a successful password reset.
 
+* To avoid the possibility of leaking a password reset token via the HTTP
+  Referer header (for example, if the reset page includes a reference to CSS or
+  JavaScript hosted on another domain), the
+  :class:`~django.contrib.auth.views.PasswordResetConfirmView` (but not the
+  deprecated ``password_reset_confirm()`` function-based view) stores the token
+  in a session and redirects to itself to present the password change form to
+  the user without the token in the URL.
+
 * :func:`~django.contrib.auth.update_session_auth_hash` now rotates the session
   key to allow a password change to invalidate stolen session cookies.
 

--- a/tests/auth_tests/client.py
+++ b/tests/auth_tests/client.py
@@ -1,0 +1,41 @@
+import re
+
+from django.contrib.auth.views import (
+    INTERNAL_RESET_SESSION_TOKEN, INTERNAL_RESET_URL_TOKEN,
+)
+from django.test import Client
+
+
+def extract_token_from_url(url):
+    token_search = re.search(r'/reset/.*/(.+?)/', url)
+    if token_search:
+        return token_search.group(1)
+
+
+class PasswordResetConfirmClient(Client):
+    """
+    This client eases testing the password reset flow by emulating the
+    PasswordResetConfirmView's redirect and saving of the reset token in the
+    user's session. This request puts 'my-token' in the session and redirects
+    to '/reset/bla/set-password/':
+
+    >>> client = PasswordResetConfirmClient()
+    >>> client.get('/reset/bla/my-token/')
+    """
+    def _get_password_reset_confirm_redirect_url(self, url):
+        token = extract_token_from_url(url)
+        if not token:
+            return url
+        # Add the token to the session
+        session = self.session
+        session[INTERNAL_RESET_SESSION_TOKEN] = token
+        session.save()
+        return url.replace(token, INTERNAL_RESET_URL_TOKEN)
+
+    def get(self, path, *args, **kwargs):
+        redirect_url = self._get_password_reset_confirm_redirect_url(path)
+        return super(PasswordResetConfirmClient, self).get(redirect_url, *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        redirect_url = self._get_password_reset_confirm_redirect_url(path)
+        return super(PasswordResetConfirmClient, self).post(redirect_url, *args, **kwargs)

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -62,3 +62,10 @@ class TokenGeneratorTest(TestCase):
         # This will put a 14-digit base36 timestamp into the token, which is too large.
         with self.assertRaises(ValueError):
             p0._make_token_with_timestamp(user, 175455491841851871349)
+
+    def test_check_token_with_nonexistent_token_and_user(self):
+        user = User.objects.create_user('tokentestuser', 'test2@example.com', 'testpw')
+        p0 = PasswordResetTokenGenerator()
+        tk1 = p0.make_token(user)
+        self.assertIs(p0.check_token(None, tk1), False)
+        self.assertIs(p0.check_token(user, None), False)


### PR DESCRIPTION
On password reset confirm page, if the user has included some links to external sources, the HTTP header `Referer` sent to these sources will contain the full password reset URL.
That can allow external systems to reset password in behalf of the concerned user, if he doesn't
reset his password immediately after landing on password reset confirm page.
To avoid that, the user is redirected to the same page, but we remove the token and save it in the
user session instead.
The issue and the solution are detailed in [related ticket](https://code.djangoproject.com/ticket/27518).