### PR TITLE
docs: typo fix

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -241,7 +241,7 @@ for example, to control anonymous access.
 Authorization for inactive users
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An inactive user is a one that has its
+An inactive user is a user that has its
 :attr:`~django.contrib.auth.models.User.is_active` field set to ``False``. The
 :class:`~django.contrib.auth.backends.ModelBackend` and
 :class:`~django.contrib.auth.backends.RemoteUserBackend` authentication


### PR DESCRIPTION
"is a one" -> "is a user"