### PR TITLE
Fixed #27542 -- Made Client.force_login() skip auth backends missing get_user().

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -631,8 +631,14 @@ class Client(RequestFactory):
             return False
 
     def force_login(self, user, backend=None):
+        def get_backend():
+            from django.contrib.auth import load_backend
+            for backend_path in settings.AUTHENTICATION_BACKENDS:
+                backend = load_backend(backend_path)
+                if hasattr(backend, 'get_user'):
+                    return backend_path
         if backend is None:
-            backend = settings.AUTHENTICATION_BACKENDS[0]
+            backend = get_backend()
         user.backend = backend
         self._login(user, backend)
 

--- a/tests/test_client/auth_backends.py
+++ b/tests/test_client/auth_backends.py
@@ -3,3 +3,7 @@ from django.contrib.auth.backends import ModelBackend
 
 class TestClientBackend(ModelBackend):
     pass
+
+
+class BackendWithoutGetUserMethod(object):
+    pass

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -549,6 +549,17 @@ class ClientTest(TestCase):
         self.assertEqual(response.context['user'].username, 'testclient')
         self.assertEqual(self.u1.backend, 'django.contrib.auth.backends.ModelBackend')
 
+    @override_settings(AUTHENTICATION_BACKENDS=[
+        'test_client.auth_backends.BackendWithoutGetUserMethod',
+        'django.contrib.auth.backends.ModelBackend',
+    ])
+    def test_force_login_with_backend_missing_get_user(self):
+        """
+        force_login() skips auth backends without a get_user() method.
+        """
+        self.client.force_login(self.u1)
+        self.assertEqual(self.u1.backend, 'django.contrib.auth.backends.ModelBackend')
+
     @override_settings(SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies")
     def test_logout_cookie_sessions(self):
         self.test_logout()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27542