### PR TITLE
Refs #27358 -- Fixed system check crash with an empty FileField.upload_to.

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -256,7 +256,7 @@ class FileField(Field):
             return []
 
     def _check_upload_to(self):
-        if isinstance(self.upload_to, six.string_types) and self.upload_to[0] == '/':
+        if isinstance(self.upload_to, six.string_types) and self.upload_to.startswith('/'):
             return [
                 checks.Error(
                     "%s's 'upload_to' argument must be a relative path, not an "

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -431,6 +431,15 @@ class DecimalFieldTests(SimpleTestCase):
 @isolate_apps('invalid_models_tests')
 class FileFieldTests(SimpleTestCase):
 
+    def test_valid_default_case(self):
+        class Model(models.Model):
+            field = models.FileField()
+
+        field = Model._meta.get_field('field')
+        errors = field.check()
+        expected = []
+        self.assertEqual(errors, expected)
+
     def test_valid_case(self):
         class Model(models.Model):
             field = models.FileField(upload_to='somewhere')


### PR DESCRIPTION
This is a fix for `FileField` where the default use case always throws index out of range error.

Previous pull request related to this: https://github.com/django/django/pull/7621