### PR TITLE
[1.10.x] Refs #27558 -- Prevented redundant index on InnoDB ForeignKey.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -418,7 +418,7 @@ class BaseDatabaseSchemaEditor(object):
             }
             self.execute(sql)
         # Add an index, if required
-        if field.db_index and not field.unique:
+        if self._field_should_be_indexed(model, field):
             self.deferred_sql.append(self._create_index_sql(model, [field]))
         # Add any FK constraints later
         if field.remote_field and self.connection.features.supports_foreign_keys and field.db_constraint:

--- a/docs/releases/1.10.4.txt
+++ b/docs/releases/1.10.4.txt
@@ -26,3 +26,6 @@ Bugfixes
 
 * Prevented ``LocaleMiddleware`` from redirecting on URLs that should return
   404 when using ``prefix_default_language=False`` (:ticket:`27402`).
+
+* Prevented an unnecessary index from being created on an InnoDB ``ForeignKey``
+  when the field was added after the model was created (:ticket:`27558`).

--- a/tests/indexes/tests.py
+++ b/tests/indexes/tests.py
@@ -1,6 +1,8 @@
 from unittest import skipUnless
 
 from django.db import connection
+from django.db.models.deletion import CASCADE
+from django.db.models.fields.related import ForeignKey
 from django.test import TestCase
 
 from .models import Article, ArticleTranslation, IndexTogetherSingleList
@@ -74,3 +76,15 @@ class SchemaIndexesTests(TestCase):
             'CREATE INDEX `indexes_articletranslation_99fb53c2` '
             'ON `indexes_articletranslation` (`article_no_constraint_id`)'
         ])
+
+        # The index also shouldn't be created if the ForeignKey is added after
+        # the model was created.
+        with connection.schema_editor() as editor:
+            new_field = ForeignKey(Article, CASCADE)
+            new_field.set_attributes_from_name('new_foreign_key')
+            editor.add_field(ArticleTranslation, new_field)
+            self.assertEqual(editor.deferred_sql, [
+                'ALTER TABLE `indexes_articletranslation` '
+                'ADD CONSTRAINT `indexes_articl_new_foreign_key_id_d27a9146_fk_indexes_article_id` '
+                'FOREIGN KEY (`new_foreign_key_id`) REFERENCES `indexes_article` (`id`)'
+            ])


### PR DESCRIPTION
The MySQL backend overrides _field_should_be_indexed() so that it skips index creation for ForeignKeys when using InnoDB.

This was fixed on master inadvertently in #6917, via a more invasive change that isn't suitable for backporting to the `1.10.x` branch. The test here is being added to master too, in #7648.