### PR TITLE
Fixed #25753 -- Made get_format() cache the formats from Django settings

### DIFF
--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -10,6 +10,7 @@ from django.db import connections, router
 from django.db.utils import ConnectionRouter
 from django.dispatch import Signal, receiver
 from django.utils import six, timezone
+from django.utils.formats import FORMAT_SETTINGS, reset_format_cache
 from django.utils.functional import empty
 
 template_rendered = Signal(providing_args=["template", "context"])
@@ -115,6 +116,12 @@ def language_changed(**kwargs):
         from django.utils.translation import trans_real
         trans_real._translations = {}
         trans_real.check_for_language.cache_clear()
+
+
+@receiver(setting_changed)
+def localize_settings_changed(**kwargs):
+    if kwargs['setting'] in FORMAT_SETTINGS or kwargs['setting'] == 'USE_THOUSAND_SEPARATOR':
+        reset_format_cache()
 
 
 @receiver(setting_changed)

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -112,32 +112,40 @@ def get_format(format_type, lang=None, use_l10n=None):
     be localized (or not), overriding the value of settings.USE_L10N.
     """
     format_type = force_str(format_type)
-    if use_l10n or (use_l10n is None and settings.USE_L10N):
-        if lang is None:
-            lang = get_language()
-        cache_key = (format_type, lang)
-        try:
-            cached = _format_cache[cache_key]
-            if cached is not None:
-                return cached
-        except KeyError:
-            for module in get_format_modules(lang):
-                try:
-                    val = getattr(module, format_type)
-                    for iso_input in ISO_INPUT_FORMATS.get(format_type, ()):
-                        if iso_input not in val:
-                            if isinstance(val, tuple):
-                                val = list(val)
-                            val.append(iso_input)
-                    _format_cache[cache_key] = val
-                    return val
-                except AttributeError:
-                    pass
-            _format_cache[cache_key] = None
-    if format_type not in FORMAT_SETTINGS:
-        return format_type
-    # Return the general setting by default
-    return getattr(settings, format_type)
+    use_l10n = use_l10n or (use_l10n is None and settings.USE_L10N)
+    if use_l10n and lang is None:
+        lang = get_language()
+    cache_key = (format_type, lang)
+    try:
+        return _format_cache[cache_key]
+    except KeyError:
+        pass
+
+    # The requested format_type has not been cached yet. Try to find it in any
+    # of the format_modules for the given lang if l10n is enabled. If it's not
+    # there or if l10n is disabled, fall back to the project settings.
+    val = None
+    if use_l10n:
+        for module in get_format_modules(lang):
+            try:
+                val = getattr(module, format_type)
+                if val is not None:
+                    break
+            except AttributeError:
+                pass
+    if val is None:
+        if format_type not in FORMAT_SETTINGS:
+            return format_type
+        val = getattr(settings, format_type)
+    elif format_type in ISO_INPUT_FORMATS.keys():
+        # If a list of input formats from one of the format_modules was
+        # retrieved, make sure the ISO_INPUT_FORMATS are in this list.
+        val = list(val)
+        for iso_input in ISO_INPUT_FORMATS.get(format_type, ()):
+            if iso_input not in val:
+                val.append(iso_input)
+    _format_cache[cache_key] = val
+    return val
 
 
 get_format_lazy = lazy(get_format, six.text_type, list, tuple)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -186,9 +186,6 @@ class AdminViewBasicTestCase(TestCase):
     def setUp(self):
         self.client.force_login(self.superuser)
 
-    def tearDown(self):
-        formats.reset_format_cache()
-
     def assertContentBefore(self, response, text1, text2, failing_msg=None):
         """
         Testing utility asserting that text1 appears before text2 in response
@@ -5300,9 +5297,6 @@ class DateHierarchyTests(TestCase):
 
     def setUp(self):
         self.client.force_login(self.superuser)
-
-    def tearDown(self):
-        formats.reset_format_cache()
 
     def assert_non_localized_year(self, response, year):
         """

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -731,17 +731,16 @@ class FormattingTests(SimpleTestCase):
         even if they would be interpreted as False in a conditional test
         (e.g. 0 or empty string) (#16938).
         """
-        with patch_formats('fr', THOUSAND_SEPARATOR='', FIRST_DAY_OF_WEEK=0):
-            with translation.override('fr'):
-                with self.settings(USE_THOUSAND_SEPARATOR=True, THOUSAND_SEPARATOR='!'):
-                    self.assertEqual('', get_format('THOUSAND_SEPARATOR'))
-                    # Even a second time (after the format has been cached)...
-                    self.assertEqual('', get_format('THOUSAND_SEPARATOR'))
+        with translation.override('fr'):
+            with self.settings(USE_THOUSAND_SEPARATOR=True, THOUSAND_SEPARATOR='!'):
+                self.assertEqual('\xa0', get_format('THOUSAND_SEPARATOR'))
+                # Even a second time (after the format has been cached)...
+                self.assertEqual('\xa0', get_format('THOUSAND_SEPARATOR'))
 
-                with self.settings(FIRST_DAY_OF_WEEK=1):
-                    self.assertEqual(0, get_format('FIRST_DAY_OF_WEEK'))
-                    # Even a second time (after the format has been cached)...
-                    self.assertEqual(0, get_format('FIRST_DAY_OF_WEEK'))
+            with self.settings(FIRST_DAY_OF_WEEK=0):
+                self.assertEqual(1, get_format('FIRST_DAY_OF_WEEK'))
+                # Even a second time (after the format has been cached)...
+                self.assertEqual(1, get_format('FIRST_DAY_OF_WEEK'))
 
     def test_l10n_enabled(self):
         self.maxDiff = 3000
@@ -1161,8 +1160,8 @@ class FormattingTests(SimpleTestCase):
             with self.settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=False):
                 self.assertEqual(sanitize_separators('12\xa0345'), '12\xa0345')
 
-        with patch_formats(get_language(), THOUSAND_SEPARATOR='.', DECIMAL_SEPARATOR=','):
-            with self.settings(USE_THOUSAND_SEPARATOR=True):
+        with self.settings(USE_THOUSAND_SEPARATOR=True):
+            with patch_formats(get_language(), THOUSAND_SEPARATOR='.', DECIMAL_SEPARATOR=','):
                 self.assertEqual(sanitize_separators('10.234'), '10234')
                 # Suspicion that user entered dot as decimal separator (#22171)
                 self.assertEqual(sanitize_separators('10.10'), '10.10')


### PR DESCRIPTION
I took and polished Jaap's patch from #5655.