### PR TITLE
Refs #27025 -- Fixed Python 3.6 deprecation warning for empty model super() calls.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -89,7 +89,11 @@ class ModelBase(type):
 
         # Create the class.
         module = attrs.pop('__module__')
-        new_class = super_new(cls, name, bases, {'__module__': module})
+        new_attrs = {'__module__': module}
+        classcell = attrs.pop('__classcell__', None)
+        if classcell is not None:
+            new_attrs['__classcell__'] = classcell
+        new_class = super_new(cls, name, bases, new_attrs)
         attr_meta = attrs.pop('Meta', None)
         abstract = getattr(attr_meta, 'abstract', False)
         if not attr_meta:


### PR DESCRIPTION
https://bugs.python.org/issue23722