### PR TITLE
Fixed #27567 -- Avoid a crash the exception view when the user is unavailable.

### DIFF
--- a/docs/releases/1.10.5.txt
+++ b/docs/releases/1.10.5.txt
@@ -9,4 +9,5 @@ Django 1.10.5 fixes several bugs in 1.10.4.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash in the debug view if ``request.user`` can't be retrieved, such
+  as if the database is unavailable (:ticket:`27567`).

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -515,6 +515,33 @@ class ExceptionReporterTests(SimpleTestCase):
         html = reporter.get_traceback_html()
         self.assertInHTML('<td>items</td><td class="code"><pre>&#39;Oops&#39;</pre></td>', html)
 
+    def test_exception_fetching_user(self):
+        """
+        The error page can be rendered if the current user can't be retrieved
+        (such as when the database is unavailable).
+        """
+        class ExceptionUser(object):
+            def __str__(self):
+                raise Exception()
+
+        request = self.rf.get('/test_view/')
+        request.user = ExceptionUser()
+
+        try:
+            raise ValueError('Oops')
+        except ValueError:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(request, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn('<h1>ValueError at /test_view/</h1>', html)
+        self.assertIn('<pre class="exception_value">Oops</pre>', html)
+        self.assertIn('<h3 id="user-info">USER</h3>', html)
+        self.assertIn('<p>[unable to retrieve the current user]</p>', html)
+
+        text = reporter.get_traceback_text()
+        self.assertIn('USER: [unable to retrieve the current user]', text)
+
 
 class PlainTextReportTests(SimpleTestCase):
     rf = RequestFactory()


### PR DESCRIPTION
When the database is down it is not possible to get information about
the currently logged in user. This commit catches the error and state
that the user could not be retrieved.

https://code.djangoproject.com/ticket/27567