### PR TITLE
Fixed #27576 -- Made gis.db.models.fields.get_srid_info to fallback to GDAL if SpatialRefSys is unavailable.

### DIFF
--- a/docs/ref/contrib/gis/functions.txt
+++ b/docs/ref/contrib/gis/functions.txt
@@ -41,8 +41,12 @@ Measurement         Relationships             Operations              Editors   
 
 Accepts a single geographic field or expression and returns the area of the
 field as an :class:`~django.contrib.gis.measure.Area` measure. On MySQL, a raw
-float value is returned, as it's not possible to automatically determine the
-unit of the field.
+float value is returned when the coordinates are geodetic.
+
+.. versionchanged:: 1.11
+
+    In older versions, a raw value was returned on MySQL when used on
+    projected SRS.
 
 ``AsGeoJSON``
 =============
@@ -211,8 +215,7 @@ geometry B.
 
 Accepts two geographic fields or expressions and returns the distance between
 them, as a :class:`~django.contrib.gis.measure.Distance` object. On MySQL, a raw
-float value is returned, as it's not possible to automatically determine the
-unit of the field.
+float value is returned when the coordinates are geodetic.
 
 On backends that support distance calculation on geodetic coordinates, the
 proper backend function is automatically chosen depending on the SRID value of
@@ -245,6 +248,11 @@ queryset is calculated::
     the distance value in miles and ``city.distance.km`` is the distance value
     in kilometers. See :doc:`measure` for usage details and the list of
     :ref:`supported_units`.
+
+.. versionchanged:: 1.11
+
+    In older versions, a raw value was returned on MySQL when used on
+    projected SRS.
 
 ``Envelope``
 ============
@@ -325,13 +333,18 @@ Returns ``True`` if its value is a valid geometry and ``False`` otherwise.
 
 Accepts a single geographic linestring or multilinestring field or expression
 and returns its length as an :class:`~django.contrib.gis.measure.Distance`
-measure. On MySQL, a raw float value is returned, as it's not possible to
-automatically determine the unit of the field.
+measure. On MySQL, a raw float value is returned when the coordinates
+are geodetic.
 
 On PostGIS and SpatiaLite, when the coordinates are geodetic (angular), you can
 specify if the calculation should be based on a simple sphere (less
 accurate, less resource-intensive) or on a spheroid (more accurate, more
 resource-intensive) with the ``spheroid`` keyword argument.
+
+.. versionchanged:: 1.11
+
+    In older versions, a raw value was returned on MySQL when used on
+    projected SRS.
 
 ``MakeValid``
 =============

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -475,8 +475,7 @@ class DistanceFunctionsTests(TestCase):
         # Tolerance has to be lower for Oracle
         tol = 2
         for i, z in enumerate(SouthTexasZipcode.objects.annotate(area=Area('poly')).order_by('name')):
-            # MySQL is returning a raw float value
-            self.assertAlmostEqual(area_sq_m[i], z.area.sq_m if hasattr(z.area, 'sq_m') else z.area, tol)
+            self.assertAlmostEqual(area_sq_m[i], z.area.sq_m, tol)
 
     @skipUnlessDBFeature("has_Distance_function")
     def test_distance_simple(self):
@@ -488,7 +487,7 @@ class DistanceFunctionsTests(TestCase):
         houston = SouthTexasCity.objects.annotate(dist=Distance('point', lagrange)).order_by('id').first()
         tol = 2 if oracle else 5
         self.assertAlmostEqual(
-            houston.dist.m if hasattr(houston.dist, 'm') else houston.dist,
+            houston.dist.m,
             147075.069813,
             tol
         )
@@ -656,7 +655,7 @@ class DistanceFunctionsTests(TestCase):
 
         # Now doing length on a projected coordinate system.
         i10 = SouthTexasInterstate.objects.annotate(length=Length('path')).get(name='I-10')
-        self.assertAlmostEqual(len_m2, i10.length.m if isinstance(i10.length, D) else i10.length, 2)
+        self.assertAlmostEqual(len_m2, i10.length.m, 2)
         self.assertTrue(
             SouthTexasInterstate.objects.annotate(length=Length('path')).filter(length__gt=4000).exists()
         )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27576