### PR TITLE
Fixed #9435 -- Redirected on empty path_info when APPEND_SLASH is set.

### DIFF
--- a/django/core/handlers/wsgi.py
+++ b/django/core/handlers/wsgi.py
@@ -77,13 +77,16 @@ class LimitedStream(object):
 class WSGIRequest(http.HttpRequest):
     def __init__(self, environ):
         script_name = get_script_name(environ)
-        path_info = get_path_info(environ)
+        path_info = environ_path_info = get_path_info(environ)
         if not path_info:
             # Sometimes PATH_INFO exists, but is empty (e.g. accessing
             # the SCRIPT_NAME URL without a trailing slash). We really need to
             # operate as if they'd requested '/'. Not amazingly nice to force
             # the path like this, but should be harmless.
+            self.path_info_is_empty = True
             path_info = '/'
+        else:
+            self.path_info_is_empty = False
         self.environ = environ
         self.path_info = path_info
         # be careful to only replace the first slash in the path because of
@@ -92,7 +95,7 @@ class WSGIRequest(http.HttpRequest):
         self.path = '%s/%s' % (script_name.rstrip('/'),
                                path_info.replace('/', '', 1))
         self.META = environ
-        self.META['PATH_INFO'] = path_info
+        self.META['PATH_INFO'] = environ_path_info
         self.META['SCRIPT_NAME'] = script_name
         self.method = environ['REQUEST_METHOD'].upper()
         self.content_type, self.content_params = cgi.parse_header(environ.get('CONTENT_TYPE', ''))

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -60,6 +60,7 @@ class HttpRequest(object):
 
         self.path = ''
         self.path_info = ''
+        self.path_info_is_empty = True
         self.method = None
         self.resolver_match = None
         self._post_parse_error = False

--- a/django/middleware/common.py
+++ b/django/middleware/common.py
@@ -58,14 +58,19 @@ class CommonMiddleware(MiddlewareMixin):
         must_prepend = settings.PREPEND_WWW and host and not host.startswith('www.')
         redirect_url = ('%s://www.%s' % (request.scheme, host)) if must_prepend else ''
 
-        # Check if a slash should be appended
-        if self.should_redirect_with_slash(request):
+        # Check if a slash should be appended to the URL
+        should_redirect_with_slash = self.should_redirect_with_slash(request)
+
+        # If a slash should be appended, use the full path with a slash.
+        # Otherwise, just get the full path without forcing a slash.
+        if should_redirect_with_slash:
             path = self.get_full_path_with_slash(request)
         else:
             path = request.get_full_path()
 
-        # Return a redirect if necessary
-        if redirect_url or path != request.get_full_path():
+        # If we need to redirect either based on settings.PREPEND_WWW
+        # or to append a slash, do so.
+        if redirect_url or should_redirect_with_slash:
             redirect_url += path
             return self.response_redirect_class(redirect_url)
 
@@ -74,11 +79,12 @@ class CommonMiddleware(MiddlewareMixin):
         Return True if settings.APPEND_SLASH is True and appending a slash to
         the request path turns an invalid path into a valid one.
         """
-        if settings.APPEND_SLASH and not request.path_info.endswith('/'):
+        path_info = '' if request.path_info_is_empty else request.path_info
+        if settings.APPEND_SLASH and not path_info.endswith('/'):
             urlconf = getattr(request, 'urlconf', None)
             return (
-                not is_valid_path(request.path_info, urlconf) and
-                is_valid_path('%s/' % request.path_info, urlconf)
+                not is_valid_path(path_info, urlconf) and
+                is_valid_path('%s/' % path_info, urlconf)
             )
         return False
 

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -109,6 +109,54 @@ class HandlerTests(SimpleTestCase):
         # Expect "bad request" response
         self.assertEqual(response.status_code, 400)
 
+    @override_settings(ROOT_URLCONF='handlers.urls')
+    def test_root_path_info_with_slash(self):
+        """
+        If PATH_INFO is '/' and APPEND_SLASH is True, and a url pattern
+        is defined for '^/$', then Django should render a response
+        from the corresponding view.
+        """
+        environ = RequestFactory().get('/').environ
+        handler = WSGIHandler()
+        response = handler(environ, lambda *a, **k: None)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'Index')
+
+    @override_settings(ROOT_URLCONF='handlers.urls')
+    def test_root_path_info_without_slash(self):
+        """
+        If PATH_INFO is empty and APPEND_SLASH is True, and a url pattern
+        is defined for '^/$' but not for '^$', then Django should issue a
+        redirect.
+        """
+        environ = RequestFactory().get('').environ
+        handler = WSGIHandler()
+        response = handler(environ, lambda *a, **k: None)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.url, '/')
+
+    @override_settings(APPEND_SLASH=False,
+                       ROOT_URLCONF='handlers.urls')
+    def test_root_path_info_nonempty_script_name_no_append_slash(self):
+        environ = RequestFactory().get('').environ
+        environ['SCRIPT_NAME'] = 'site-root'
+        environ['PATH_INFO'] = ''
+        handler = WSGIHandler()
+        response = handler(environ, lambda *a, **k: None)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'Index')
+
+    @override_settings(APPEND_SLASH=True,
+                       ROOT_URLCONF='handlers.urls')
+    def test_root_path_info_nonempty_script_name_with_append_slash(self):
+        environ = RequestFactory().get('').environ
+        environ['SCRIPT_NAME'] = 'site-root'
+        environ['PATH_INFO'] = ''
+        handler = WSGIHandler()
+        response = handler(environ, lambda *a, **k: None)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.url, 'site-root/')
+
 
 @override_settings(ROOT_URLCONF='handlers.urls')
 class TransactionsPerRequestTests(TransactionTestCase):

--- a/tests/handlers/urls.py
+++ b/tests/handlers/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     url(r'^suspicious/$', views.suspicious),
     url(r'^malformed_post/$', views.malformed_post),
     url(r'^httpstatus_enum/$', views.httpstatus_enum),
+    url(r'^$', views.index)
 ]

--- a/tests/handlers/views.py
+++ b/tests/handlers/views.py
@@ -11,6 +11,10 @@ except ImportError:  # Python < 3.5
     pass
 
 
+def index(request):
+    return HttpResponse(b"Index")
+
+
 def regular(request):
     return HttpResponse(b"regular content")
 

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -269,6 +269,38 @@ class CommonMiddlewareTest(SimpleTestCase):
         self.assertEqual(r.status_code, 301)
         self.assertEqual(r.url, 'http://www.testserver/customurlconf/slash/')
 
+    @override_settings(APPEND_SLASH=True)
+    def test_empty_path_info_not_found_with_append_slash(self):
+        req = HttpRequest()
+        req.urlconf = 'middleware.urls'
+        res = HttpResponseNotFound()
+        middleware_res = CommonMiddleware().process_response(req, res)
+        self.assertEqual(middleware_res.status_code, 301)
+
+    @override_settings(APPEND_SLASH=False)
+    def test_empty_path_info_not_found_without_append_slash(self):
+        req = HttpRequest()
+        req.urlconf = 'middleware.urls'
+        res = HttpResponseNotFound()
+        middleware_res = CommonMiddleware().process_response(req, res)
+        self.assertEqual(middleware_res.status_code, 404)
+
+    @override_settings(APPEND_SLASH=True)
+    def test_empty_path_info_200_with_append_slash(self):
+        req = HttpRequest()
+        req.urlconf = 'middleware.urls'
+        res = HttpResponse('content')
+        middleware_res = CommonMiddleware().process_response(req, res)
+        self.assertEqual(middleware_res.status_code, 200)
+
+    @override_settings(APPEND_SLASH=False)
+    def test_empty_path_info_200_without_append_slash(self):
+        req = HttpRequest()
+        req.urlconf = 'middleware.urls'
+        res = HttpResponse('content')
+        middleware_res = CommonMiddleware().process_response(req, res)
+        self.assertEqual(middleware_res.status_code, 200)
+
     # ETag + If-Not-Modified support tests
 
     @ignore_warnings(category=RemovedInDjango21Warning)

--- a/tests/middleware/urls.py
+++ b/tests/middleware/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^noslash$', views.empty_view),
     url(r'^slash/$', views.empty_view),
     url(r'^needsquoting#/$', views.empty_view),
+    url(r'^$', views.empty_view)
 ]


### PR DESCRIPTION
This fixes the bug #6978 was intended to fix: namely, that `APPEND_SLASH` does not cause a trailing slash to be appended to the root URL of a Django project that is at a sub-path of its domain. Tests are included. However, I am not certain that this will not cause problems when an `HttpRequest` object is created that is not a `WSGIRequest`, and when the common middleware is used. Will the line `full_path = '' if request.path_info_is_empty else request.get_full_path()` cause problems in that case, since `request` will be of a different class than `WSGIRequest` and therefore will not have `path_info_is_empty`? How would I add a test for this case?

https://code.djangoproject.com/ticket/9435