### PR TITLE
#27537 -- Added options IP, Port for runserver in settings.py

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -181,6 +181,10 @@ FILE_CHARSET = 'utf-8'
 # Email address that error messages come from.
 SERVER_EMAIL = 'root@localhost'
 
+# The default IP and port for local development server to use.
+RUNSERVER_IP = ''
+RUNSERVER_PORT = ''
+
 # Database connection info. If left empty, will default to the dummy backend.
 DATABASES = {}
 

--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -27,6 +27,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+RUNSERVER_IP = '127.0.0.1'
+
+RUNSERVER_PORT = '8000'
 
 # Application definition
 

--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
     requires_system_checks = False
     leave_locale_alone = True
 
-    default_port = '8000'
+    default_port = settings.RUNSERVER_PORT
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -75,7 +75,7 @@ class Command(BaseCommand):
         self._raw_ipv6 = False
         if not options['addrport']:
             self.addr = ''
-            self.port = self.default_port
+            self.port = settings.RUNSERVER_PORT
         else:
             m = re.match(naiveip_re, options['addrport'])
             if m is None:
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                 elif self.use_ipv6 and not _fqdn:
                     raise CommandError('"%s" is not a valid IPv6 address.' % self.addr)
         if not self.addr:
-            self.addr = '::1' if self.use_ipv6 else '127.0.0.1'
+            self.addr = '::1' if self.use_ipv6 else settings.RUNSERVER_IP
             self._raw_ipv6 = self.use_ipv6
         self.run(**options)
 


### PR DESCRIPTION
./manage.py runserver
now checks project_dir/settings.py for RUNSERVER_IP and
RUNSERVER_PORT to serve.

./manage.py runserver IP:PORT
runs as earlier

https://code.djangoproject.com/ticket/27537

Signed-off-by: Kamalavelan <sskamalavelan@gmail.com>