### PR TITLE
Fixed #27583 -- MultiValueDict.getlist crash when values for key is None.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -146,7 +146,7 @@ class MultiValueDict(dict):
             return default
         else:
             if force_list:
-                values = list(values)
+                values = list(values) if values is not None else None
             return values
 
     def getlist(self, key, default=None):

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -119,6 +119,11 @@ class MultiValueDictTests(SimpleTestCase):
         values = x.getlist('b', default=MISSING)
         self.assertIs(values, MISSING)
 
+    def test_getlist_none_empty_values(self):
+        x = MultiValueDict({'a': None, 'b': []})
+        self.assertIsNone(x.getlist('a'))
+        self.assertEqual(x.getlist('b'), [])
+
 
 class ImmutableListTests(SimpleTestCase):
 


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/27583).