### PR TITLE
Fixed #27498 -- Added missing CAST AS NUMERIC in Decimal comparison

### DIFF
--- a/tests/lookup/models.py
+++ b/tests/lookup/models.py
@@ -86,3 +86,13 @@ class MyISAMArticle(models.Model):
     class Meta:
         db_table = 'myisam_article'
         managed = False
+
+
+class Product(models.Model):
+    name = models.CharField(max_length=80)
+    qty_target = models.DecimalField(max_digits=6, decimal_places=2)
+
+
+class Stock(models.Model):
+    product = models.ForeignKey(Product, models.CASCADE)
+    qty_available = models.DecimalField(max_digits=6, decimal_places=2)

--- a/tests/lookup/test_decimalfield.py
+++ b/tests/lookup/test_decimalfield.py
@@ -1,0 +1,38 @@
+from django.db.models.aggregates import Sum
+from django.db.models.expressions import F
+from django.test import TestCase
+
+from .models import Product, Stock
+
+
+class DecimalFieldLookupTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.p1 = Product.objects.create(name='Product1', qty_target=10)
+        Stock.objects.create(product=cls.p1, qty_available=5)
+        Stock.objects.create(product=cls.p1, qty_available=6)
+        cls.p2 = Product.objects.create(name='Product2', qty_target=10)
+        Stock.objects.create(product=cls.p2, qty_available=5)
+        Stock.objects.create(product=cls.p2, qty_available=5)
+        cls.p3 = Product.objects.create(name='Product3', qty_target=10)
+        Stock.objects.create(product=cls.p3, qty_available=5)
+        Stock.objects.create(product=cls.p3, qty_available=4)
+        cls.queryset = Product.objects.annotate(
+            qty_available_sum=Sum('stock__qty_available'),
+        ).annotate(qty_needed=F('qty_target') - F('qty_available_sum'))
+
+    def test_gt(self):
+        qs = self.queryset.filter(qty_needed__gt=0)
+        self.assertCountEqual(qs, [self.p3])
+
+    def test_gte(self):
+        qs = self.queryset.filter(qty_needed__gte=0)
+        self.assertCountEqual(qs, [self.p2, self.p3])
+
+    def test_lt(self):
+        qs = self.queryset.filter(qty_needed__lt=0)
+        self.assertCountEqual(qs, [self.p1])
+
+    def test_lte(self):
+        qs = self.queryset.filter(qty_needed__lte=0)
+        self.assertCountEqual(qs, [self.p1, self.p2])


### PR DESCRIPTION
Ensured Decimal value is always CAST AS NUMERIC in comparison on SQLite.