### PR TITLE
Fixed #27589 -- Added managed triggers for SearchVectorField.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -450,6 +450,7 @@ answer newbie questions, and generally made Django that much better:
     Leo Shklovskii
     Leo Soto <leo.soto@gmail.com>
     lerouxb@gmail.com
+    Lex Berezhny <lex@damoti.com>
     Liang Feng <hutuworm@gmail.com>
     limodou
     Loek van Gent <loek@barakken.nl>

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -3,6 +3,7 @@ from django.db.models import Field, FloatField
 from django.db.models.expressions import CombinedExpression, Func, Value
 from django.db.models.functions import Coalesce
 from django.db.models.lookups import Lookup
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -33,7 +34,7 @@ class WeightedColumn:
 
     def deconstruct(self):
         path = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
-        return path, [self.name, self.weight], {}
+        return path, [force_text(self.name), force_text(self.weight)], {}
 
 
 class SearchVectorField(Field):
@@ -51,7 +52,7 @@ class SearchVectorField(Field):
         if self.columns is not None:
             kwargs['columns'] = self.columns
         if self.language is not None:
-            kwargs['language'] = self.language
+            kwargs['language'] = force_text(self.language)
         del kwargs['db_index']
         del kwargs['null']
         return name, path, args, kwargs

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -65,7 +65,7 @@ class SearchVectorField(Field):
 
     def _check_columns_attribute(self, **kwargs):
         if not isinstance(self.columns, (list, tuple)) or \
-             not all(isinstance(tsv, WeightedColumn) for tsv in self.columns):
+                not all(isinstance(tsv, WeightedColumn) for tsv in self.columns):
             return [
                 checks.Error(
                     "'columns' must be a list or tuple of WeightedColumn instances.",

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -1,9 +1,10 @@
 from django.core import checks
-from django.db.models import Field, FloatField
+from django.db.models import CharField, Field, FloatField, TextField
 from django.db.models.expressions import CombinedExpression, Func, Value
 from django.db.models.functions import Coalesce
 from django.db.models.lookups import Lookup
 from django.utils.encoding import force_text
+from django.utils.itercompat import is_iterable
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -26,11 +27,35 @@ class SearchVectorExact(Lookup):
 
 class WeightedColumn:
 
+    WEIGHTS = ('A', 'B', 'C', 'D')
+
     def __init__(self, name, weight):
-        assert isinstance(name, str)
-        assert weight in ('A', 'B', 'C', 'D')
         self.name = name
         self.weight = weight
+
+    def check(self, field, searchable_columns):
+        errors = []
+        errors.extend(self._check_column_name(field, searchable_columns))
+        errors.extend(self._check_weight(field, self.WEIGHTS))
+        return errors
+
+    def _check_column_name(self, field, columns):
+        if self.name not in columns:
+            yield checks.Error(
+                '{}.name "{}" is not one of the available columns ({})'.format(
+                    self.__class__.__name__, self.name,
+                    ', '.join(['"{}"'.format(c) for c in columns])
+                ), obj=field, id='postgres.E110',
+            )
+
+    def _check_weight(self, field, weights):
+        if self.weight not in weights:
+            yield checks.Error(
+                '{}.weight "{}" is not one of the available weights ({})'.format(
+                    self.__class__.__name__, self.weight,
+                    ', '.join(['"{}"'.format(w) for w in weights])
+                ), obj=field, id='postgres.E111',
+            )
 
     def deconstruct(self):
         path = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
@@ -38,11 +63,13 @@ class WeightedColumn:
 
 
 class SearchVectorField(Field):
-    description = _("PostgreSQL tsvector field.")
+    description = _("PostgreSQL tsvector field")
 
     def __init__(self, columns=None, language=None, *args, **kwargs):
         self.columns = columns
         self.language = language
+        self.language_column = kwargs.pop('language_column', None)
+        self.force_update = kwargs.pop('force_update', False)
         kwargs['db_index'] = True
         kwargs['null'] = True
         super(SearchVectorField, self).__init__(*args, **kwargs)
@@ -53,49 +80,77 @@ class SearchVectorField(Field):
             kwargs['columns'] = self.columns
         if self.language is not None:
             kwargs['language'] = force_text(self.language)
+        if self.language_column is not None:
+            kwargs['language_column'] = force_text(self.language_column)
+        if self.force_update is not False:
+            kwargs['force_update'] = self.force_update
         del kwargs['db_index']
         del kwargs['null']
         return name, path, args, kwargs
 
     def check(self, **kwargs):
         errors = super(SearchVectorField, self).check(**kwargs)
-        if self.columns is not None:
-            errors.extend(self._check_columns_attribute(**kwargs))
-            errors.extend(self._check_language_attribute(**kwargs))
+        textual_columns = self._find_textual_columns()
+        errors.extend(self._check_columns_attribute(textual_columns))
+        errors.extend(self._check_language_attributes(textual_columns))
+        errors.extend(self._check_force_update_attribute())
         return errors
 
-    def _check_columns_attribute(self, **kwargs):
-        if not isinstance(self.columns, (list, tuple)) or \
-                not all(isinstance(tsv, WeightedColumn) for tsv in self.columns):
-            return [
-                checks.Error(
-                    "'columns' must be a list or tuple of WeightedColumn instances.",
-                    obj=self,
-                    id='fields.E402',
-                )
-            ]
-        else:
-            return []
+    def _find_textual_columns(self):
+        columns = []
+        # PostgreSQL trigger only has access to fields in the table, so we
+        # need to make sure to exclude any fields from multi-table inheritance
+        for field in self.model._meta.get_fields(include_parents=False):
+            # too restrictive?
+            if isinstance(field, (CharField, TextField)):
+                columns.append(field.column)
+        return columns
 
-    def _check_language_attribute(self, **kwargs):
-        if self.language is None:
-            return [
-                checks.Error(
-                    "{} must define a 'language' attribute.".format(self.__class__.__name__),
-                    obj=self,
-                    id='fields.E403',
-                )
-            ]
-        elif not isinstance(self.language, str):
-            return [
-                checks.Error(
-                    "'language' must be a string.",
-                    obj=self,
-                    id='fields.E404',
-                )
-            ]
+    def _check_columns_attribute(self, textual_columns):
+        if not self.columns:
+            return
+        if not textual_columns:
+            yield checks.Error(
+                "No textual columns available in this model for search vector indexing.",
+                obj=self, id='postgres.E100',
+            )
+        elif not is_iterable(self.columns) or \
+                not all(isinstance(wc, WeightedColumn) for wc in self.columns):
+            yield checks.Error(
+                "'columns' must be an iterable containing WeightedColumn instances",
+                obj=self, id='postgres.E101',
+            )
         else:
-            return []
+            for column in self.columns:
+                for error in column.check(self, textual_columns):
+                    yield error
+
+    def _check_language_attributes(self, textual_columns):
+        if self.columns and not any((self.language, self.language_column)):
+            yield checks.Error(
+                "'language' or 'language_column' is required when 'columns' is provided",
+                obj=self, id='postgres.E102',
+            )
+            return
+        if self.language and not isinstance(self.language, str):
+            # can we get list of available langauges?
+            yield checks.Error(
+                "'language' must be a valid language",
+                obj=self, id='postgres.E103',
+            )
+        if self.language_column and self.language_column not in textual_columns:
+            yield checks.Error(
+                """'language_column' "{}" is not one of the available columns ({})""".format(
+                    self.name, ', '.join(['"{}"'.format(c) for c in textual_columns])
+                ), obj=self, id='postgres.E104',
+            )
+
+    def _check_force_update_attribute(self):
+        if self.force_update not in (None, True, False):
+            yield checks.Error(
+                "'force_update' must be None, True or False.",
+                obj=self, id='postgres.E105',
+            )
 
     def db_type(self, connection):
         return 'tsvector'

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -1,7 +1,7 @@
 import psycopg2
 
-from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.contrib.postgres.search import SearchVectorField
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -132,52 +132,104 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 self.deferred_sql.extend(self._drop_tsvector_trigger(model, old_field))
                 self.deferred_sql.extend(self._create_tsvector_trigger(model, new_field))
 
-    sql_create_trigger = (
-        "CREATE TRIGGER {trigger} BEFORE INSERT OR UPDATE"
-        " ON {table} FOR EACH ROW EXECUTE PROCEDURE {function}()"
-    )
-    sql_drop_trigger = "DROP TRIGGER IF EXISTS {trigger} ON {table}"
+    def _tsvector_setweight(self, field):
 
-    sql_create_function = (
+        if field.language_column and field.language:
+            language = 'COALESCE(NEW.{}::regconfig, {})'.format(
+                self.quote_name(field.language_column),
+                self.quote_value(field.language)
+            )
+        elif field.language_column:
+            language = 'NEW.{}::regconfig'.format(
+                self.quote_name(field.language_column)
+            )
+        else:
+            language = self.quote_value(field.language or 'english')
+
+        sql_setweight = (
+            "setweight(to_tsvector({language}, COALESCE(NEW.{column}, '')), {weight}) ||"
+        )
+
+        weights = []
+        for column in field.columns:
+            weights.append(sql_setweight.format(
+                language=language,
+                column=self.quote_name(column.name),
+                weight=self.quote_value(column.weight)
+            ))
+        weights[-1] = weights[-1][:-3] + ';'
+        return weights
+
+    def _tsvector_update_column_checks(self, field):
+        checks = []
+        for column in field.columns:
+            checks.append(
+                "ELSIF (NEW.{column} <> OLD.{column}) THEN do_update = true;".format(
+                    column=self.quote_name(column.name)
+                )
+            )
+        checks[0] = checks[0][3:]
+        checks.append('END IF;')
+        return checks
+
+    sql_tsvector_create_trigger_function = (
         "CREATE FUNCTION {function}() RETURNS trigger AS $$\n"
+        "DECLARE\n"
+        " do_update bool default false;\n"
         "BEGIN\n"
-        " NEW.{column} :=\n{weights};\n"
+        " {update_checks}\n"
+        " IF do_update THEN\n"
+        "  {update_body}\n"
+        " END IF;\n"
         " RETURN NEW;\n"
         "END\n"
         "$$ LANGUAGE plpgsql"
     )
-    sql_drop_function = "DROP FUNCTION IF EXISTS {function}()"
 
-    sql_setweight = (
-        "  setweight(to_tsvector('pg_catalog.{lang}', COALESCE(NEW.{column}, '')), '{weight}') "
+    def _create_tsvector_update_function(self, function, field):
+
+        update_checks = ["do_update = true;"]
+        if not field.force_update:
+            update_checks = [
+                "IF (TG_OP = 'INSERT') THEN do_update = true;",
+                "ELSIF (TG_OP = 'UPDATE') THEN"] + [
+                ' ' + check for check in self._tsvector_update_column_checks(field)] + [
+                "END IF;"
+            ]
+
+        update_body = [
+            "NEW.{} :=".format(self.quote_name(field.column))] + [
+            ' ' + weight for weight in self._tsvector_setweight(field)
+        ]
+
+        return self.sql_tsvector_create_trigger_function.format(
+            function=function,
+            update_checks='\n '.join(update_checks),
+            update_body='\n  '.join(update_body)
+        )
+
+    sql_create_insert_or_update_trigger = (
+        "CREATE TRIGGER {trigger} BEFORE INSERT OR UPDATE"
+        " ON {table} FOR EACH ROW EXECUTE PROCEDURE {function}()"
     )
 
     def _create_tsvector_trigger(self, model, field):
 
+        assert field.columns, "Cannot create text search trigger without 'columns'."
+
         tsvector_function = self._create_index_name(model, [field.column], '_func')
         tsvector_trigger = self._create_index_name(model, [field.column], '_trig')
 
-        weights = []
-        for tsv in field.columns:
-            weights.append(
-                self.sql_setweight.format(
-                    lang=field.language,
-                    column=self.quote_name(tsv.name),
-                    weight=tsv.weight
-                )
-            )
+        yield self._create_tsvector_update_function(tsvector_function, field)
 
-        yield self.sql_create_function.format(
-            function=tsvector_function,
-            column=self.quote_name(field.column),
-            weights='||\n'.join(weights)
-        )
-
-        yield self.sql_create_trigger.format(
+        yield self.sql_create_insert_or_update_trigger.format(
             table=self.quote_name(model._meta.db_table),
             trigger=self.quote_name(tsvector_trigger),
             function=tsvector_function,
         )
+
+    sql_drop_trigger = "DROP TRIGGER IF EXISTS {trigger} ON {table}"
+    sql_drop_trigger_function = "DROP FUNCTION IF EXISTS {function}()"
 
     def _drop_tsvector_trigger(self, model, field):
 
@@ -189,7 +241,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             trigger=tsvector_trigger,
         )
 
-        yield self.sql_drop_function.format(
+        yield self.sql_drop_trigger_function.format(
             function=tsvector_function,
         )
 

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -14,6 +14,27 @@ from django.test import modify_settings
 from . import PostgreSQLTestCase
 from .models import Character, Line, Scene
 
+VERSES = [
+    (
+        'Bravely bold Sir Robin, rode forth from Camelot. '
+        'He was not afraid to die, o Brave Sir Robin. '
+        'He was not at all afraid to be killed in nasty ways. '
+        'Brave, brave, brave, brave Sir Robin!'
+    ),
+    (
+        'He was not in the least bit scared to be mashed into a pulp, '
+        'Or to have his eyes gouged out, and his elbows broken. '
+        'To have his kneecaps split, and his body burned away, '
+        'And his limbs all hacked and mangled, brave Sir Robin!'
+    ),
+    (
+        'His head smashed in and his heart cut out, '
+        'And his liver removed and his bowels unplugged, '
+        'And his nostrils ripped and his bottom burned off,'
+        'And his --'
+    ),
+]
+
 
 class GrailTestData(object):
 
@@ -21,31 +42,11 @@ class GrailTestData(object):
     def setUpTestData(cls):
         cls.robin = Scene.objects.create(scene='Scene 10', setting='The dark forest of Ewing')
         cls.minstrel = Character.objects.create(name='Minstrel')
-        verses = [
-            (
-                'Bravely bold Sir Robin, rode forth from Camelot. '
-                'He was not afraid to die, o Brave Sir Robin. '
-                'He was not at all afraid to be killed in nasty ways. '
-                'Brave, brave, brave, brave Sir Robin!'
-            ),
-            (
-                'He was not in the least bit scared to be mashed into a pulp, '
-                'Or to have his eyes gouged out, and his elbows broken. '
-                'To have his kneecaps split, and his body burned away, '
-                'And his limbs all hacked and mangled, brave Sir Robin!'
-            ),
-            (
-                'His head smashed in and his heart cut out, '
-                'And his liver removed and his bowels unplugged, '
-                'And his nostrils ripped and his bottom burned off,'
-                'And his --'
-            ),
-        ]
         cls.verses = [Line.objects.create(
             scene=cls.robin,
             character=cls.minstrel,
             dialogue=verse,
-        ) for verse in verses]
+        ) for verse in VERSES]
         cls.verse0, cls.verse1, cls.verse2 = cls.verses
 
         cls.witch_scene = Scene.objects.create(scene='Scene 5', setting="Sir Bedemir's Castle")

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -1,0 +1,281 @@
+"""
+Test PostgreSQL full text search vector field.
+"""
+from django.contrib.postgres.search import (
+    SearchQuery, SearchRank, SearchVectorField, WeightedColumn
+)
+from django.db import models, connection, migrations
+from django.db.migrations.state import ProjectState
+from django.db.migrations.writer import MigrationWriter
+from django.db.models.expressions import F
+from django.test import TestCase
+from django.test.utils import isolate_apps
+
+
+class SearchVectorFieldMigrationWriterTests(TestCase):
+
+    def test_deconstruct_no_columns(self):
+
+        svf = SearchVectorField()
+
+        self.assertEqual(
+            ("django.contrib.postgres.search.SearchVectorField()",
+             {'import django.contrib.postgres.search'}),
+            MigrationWriter.serialize(svf)
+        )
+
+    def test_deconstruct(self):
+
+        svf = SearchVectorField([
+            WeightedColumn('name', 'A'),
+            WeightedColumn('description', 'D'),
+        ], 'english')
+
+        self.assertEqual(
+            ("django.contrib.postgres.search.SearchVectorField("
+             "columns=["
+             "django.contrib.postgres.search.WeightedColumn('name', 'A'), "
+             "django.contrib.postgres.search.WeightedColumn('description', 'D')], "
+             "language='english')",
+             {'import django.contrib.postgres.search'}),
+            MigrationWriter.serialize(svf)
+        )
+
+
+@isolate_apps('postgres_tests')
+class SearchVectorFieldDDLTests(TestCase):
+
+    def test_sql_create_model_no_weightedcolumns(self):
+        """
+        If user does not provide 'columns' we still generate the index.
+        Presumably, they will have to update the column themselves either in Python
+        or via an unmanaged custom postgres trigger function.
+        """
+
+        class NoWeightedColumns(models.Model):
+            search = SearchVectorField()
+
+        with connection.schema_editor() as schema_editor:
+            schema_editor.create_model(NoWeightedColumns)
+            self.assertEqual([
+                'CREATE INDEX "postgres_tests_noweightedcolumns_search_7d3fd766"'
+                ' ON "postgres_tests_noweightedcolumns" ("search")',
+            ], schema_editor.deferred_sql)
+
+    def test_sql_create_model_with_weightedcolumns(self):
+
+        class TextDocument(models.Model):
+            title = models.CharField(max_length=128)
+            body = models.TextField()
+            search = SearchVectorField([
+                WeightedColumn('title', 'A'),
+                WeightedColumn('body', 'D'),
+            ], 'english')
+
+        with connection.schema_editor() as schema_editor:
+            schema_editor.create_model(TextDocument)
+            self.assertEqual([
+                'CREATE INDEX "postgres_tests_textdocument_search_9f678d09" ON "postgres_tests_textdocument" ("search")',
+
+                'CREATE FUNCTION postgres_tests_textdocument_search_9f678d09_func() RETURNS trigger AS $$\n'
+                'BEGIN\n'
+                ' NEW."search" :=\n'
+                '  setweight(to_tsvector(\'pg_catalog.english\', COALESCE(NEW."title", \'\')), \'A\') ||\n'
+                '  setweight(to_tsvector(\'pg_catalog.english\', COALESCE(NEW."body", \'\')), \'D\') ;\n'
+                ' RETURN NEW;\n'
+                'END\n'
+                '$$ LANGUAGE plpgsql',
+
+                'CREATE TRIGGER "postgres_tests_textdocument_search_9f678d09_trig" BEFORE INSERT OR UPDATE'
+                ' ON "postgres_tests_textdocument" FOR EACH ROW'
+                ' EXECUTE PROCEDURE postgres_tests_textdocument_search_9f678d09_func()'
+            ], schema_editor.deferred_sql)
+
+
+@isolate_apps('postgres_tests', attr_name='apps')
+class SearchVectorFieldMigrationTests(TestCase):
+
+    create_model = migrations.CreateModel(
+        'textdocument', [
+            ('title', models.CharField(max_length=128)),
+            ('body', models.TextField()),
+            ('search', SearchVectorField([WeightedColumn('body', 'A')], 'english')),
+        ]
+    )
+
+    delete_model = migrations.DeleteModel('textdocument')
+
+    create_model_without_search = migrations.CreateModel(
+        'textdocument', [
+            ('body', models.TextField()),
+        ]
+    )
+
+    add_field = migrations.AddField(
+        'textdocument', 'search',
+        SearchVectorField([WeightedColumn('body', 'A')], 'english')
+    )
+
+    alter_field = migrations.AlterField(
+        'textdocument', 'search',
+        SearchVectorField([WeightedColumn('title', 'A'), WeightedColumn('body', 'D')], 'english')
+    )
+
+    remove_field = migrations.RemoveField(
+        'textdocument', 'search'
+    )
+
+    def starting_state(self, operation):
+        project_state = ProjectState.from_apps(self.apps)
+        new_state = project_state.clone()
+        with connection.schema_editor() as schema_editor:
+            operation.state_forwards("postgres_tests", new_state)
+            operation.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+            return new_state, new_state.clone()
+
+    def test_create_model(self):
+
+        project_state = ProjectState.from_apps(self.apps)
+        new_state = project_state.clone()
+
+        self.assertFITNotExists()
+
+        with connection.schema_editor() as schema_editor:
+            self.create_model.state_forwards("postgres_tests", new_state)
+            self.create_model.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+
+        self.assertFITExists()
+
+    def test_add_field(self):
+        project_state, new_state = self.starting_state(self.create_model_without_search)
+
+        self.assertFITNotExists()
+
+        with connection.schema_editor() as schema_editor:
+            self.add_field.state_forwards("postgres_tests", new_state)
+            self.add_field.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+
+        self.assertFITExists()
+
+    def test_remove_field(self):
+        project_state, new_state = self.starting_state(self.create_model)
+
+        self.assertFITExists()
+
+        with connection.schema_editor() as schema_editor:
+            self.remove_field.state_forwards("postgres_tests", new_state)
+            self.remove_field.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+
+        self.assertFITNotExists()
+
+    def test_alter_field(self):
+        project_state, new_state = self.starting_state(self.create_model)
+
+        self.assertFITExists()
+        self.assertNotIn('title', self.get_function_src('search'))
+
+        with connection.schema_editor() as schema_editor:
+            self.alter_field.state_forwards("postgres_tests", new_state)
+            self.alter_field.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+
+        self.assertFITExists()
+        self.assertIn('title', self.get_function_src('search'))
+
+    def test_delete_model(self):
+        project_state, new_state = self.starting_state(self.create_model)
+
+        self.assertFITExists()
+
+        with connection.schema_editor() as schema_editor:
+            self.delete_model.state_forwards("postgres_tests", new_state)
+            self.delete_model.database_forwards("postgres_tests", schema_editor, project_state, new_state)
+
+        self.assertFITNotExists()
+
+    SEARCH_COL = 'postgres_tests_{table}_{column}_.{{8}}'
+    FIT = [SEARCH_COL+'_func', SEARCH_COL, SEARCH_COL+'_trig']
+
+    def assertFITExists(self, column='search', table='textdocument'):
+        with_column = [fit.format(column=column, table=table) for fit in self.FIT]
+        self.assertFunctionExists(with_column[0])
+        self.assertIndexExists(with_column[1])
+        self.assertTriggerExists(with_column[2])
+
+    def assertFITNotExists(self, column='search', table='textdocument'):
+        with_column = [fit.format(column=column, table=table) for fit in self.FIT]
+        self.assertFunctionNotExists(with_column[0])
+        self.assertIndexNotExists(with_column[1])
+        self.assertTriggerNotExists(with_column[2])
+
+    _sql_check_function = "select proname from pg_proc where proname ~ %s"
+    assertFunctionExists = lambda self, x: self.assertXExists(self._sql_check_function, x)
+    assertFunctionNotExists = lambda self, x: self.assertXNotExists(self._sql_check_function, x)
+
+    _sql_check_trigger = "select tgname from pg_trigger where tgname ~ %s"
+    assertTriggerExists = lambda self, x: self.assertXExists(self._sql_check_trigger, x)
+    assertTriggerNotExists = lambda self, x: self.assertXNotExists(self._sql_check_trigger, x)
+
+    _sql_check_index = "select indexname from pg_indexes where indexname ~ %s"
+    assertIndexExists = lambda self, x: self.assertXExists(self._sql_check_index, x)
+    assertIndexNotExists = lambda self, x: self.assertXNotExists(self._sql_check_index, x)
+
+    def assertXExists(self, sql, x):
+        self.assertTrue(self._does_x_exist(sql, x), x)
+
+    def assertXNotExists(self, sql, x):
+        self.assertFalse(self._does_x_exist(sql, x), x)
+
+    def _does_x_exist(self, sql, x):
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [x])
+            return len(cursor.fetchall()) > 0
+
+    def get_function_src(self, column='search', table='textdocument'):
+        func = self.FIT[0].format(column=column, table=table)
+        with connection.cursor() as cursor:
+            cursor.execute("select prosrc from pg_proc where proname ~ %s", [func])
+            return cursor.fetchone()[0]
+
+
+@isolate_apps('postgres_tests')
+class SearchVectorFieldQueryTests(TestCase):
+
+    def setUp(self):
+
+        class TextDocument(models.Model):
+            title = models.CharField(max_length=128)
+            body = models.TextField()
+            search = SearchVectorField([
+                WeightedColumn('title', 'A'),
+                WeightedColumn('body', 'D'),
+            ], 'english')
+
+        with connection.schema_editor() as schema_editor:
+            schema_editor.create_model(TextDocument)
+
+        TextDocument.objects.create(
+            title="My hovercraft is full of eels.",
+            body="Spam! Spam! Spam! Spam! Spam! Spam!",
+        )
+        TextDocument.objects.create(
+            title="Spam! Spam! Spam! Spam! Spam! Spam!",
+            body="My hovercraft is full of eels."
+        )
+        self.doc = TextDocument
+
+    def search(self, terms):
+        return list(self.doc.objects.filter(search=terms).values_list('id', flat=True))
+
+    def test_search(self):
+        self.assertEqual(self.search('hovercraft'), [1, 2])
+        self.assertEqual(self.search('spam'), [1, 2])
+
+    def ranked_search(self, terms):
+        return list(self.doc.objects
+                    .annotate(rank=SearchRank(F('search'), SearchQuery(terms, config='english')))
+                    .order_by('-rank')
+                    .values_list('id', flat=True))
+
+    def test_rank_search(self):
+        self.assertEqual(self.ranked_search('hovercraft'), [1, 2])
+        self.assertEqual(self.ranked_search('spam'), [2, 1])

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -8,11 +8,11 @@ from django.db import connection, migrations, models
 from django.db.migrations.state import ProjectState
 from django.db.migrations.writer import MigrationWriter
 from django.db.models.expressions import F
-from django.test import TestCase
+from . import PostgreSQLTestCase
 from django.test.utils import isolate_apps
 
 
-class SearchVectorFieldMigrationWriterTests(TestCase):
+class SearchVectorFieldMigrationWriterTests(PostgreSQLTestCase):
 
     def test_deconstruct_no_columns(self):
 
@@ -43,7 +43,7 @@ class SearchVectorFieldMigrationWriterTests(TestCase):
 
 
 @isolate_apps('postgres_tests')
-class SearchVectorFieldDDLTests(TestCase):
+class SearchVectorFieldDDLTests(PostgreSQLTestCase):
 
     def test_sql_create_model_no_weightedcolumns(self):
         """
@@ -94,7 +94,7 @@ class SearchVectorFieldDDLTests(TestCase):
 
 
 @isolate_apps('postgres_tests', attr_name='apps')
-class SearchVectorFieldMigrationTests(TestCase):
+class SearchVectorFieldMigrationTests(PostgreSQLTestCase):
 
     create_model = migrations.CreateModel(
         'textdocument', [
@@ -251,7 +251,7 @@ class SearchVectorFieldMigrationTests(TestCase):
 
 
 @isolate_apps('postgres_tests')
-class SearchVectorFieldQueryTests(TestCase):
+class SearchVectorFieldQueryTests(PostgreSQLTestCase):
 
     def setUp(self):
 

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -8,8 +8,9 @@ from django.db import connection, migrations, models
 from django.db.migrations.state import ProjectState
 from django.db.migrations.writer import MigrationWriter
 from django.db.models.expressions import F
-from . import PostgreSQLTestCase
 from django.test.utils import isolate_apps
+
+from . import PostgreSQLTestCase
 
 
 class SearchVectorFieldMigrationWriterTests(PostgreSQLTestCase):

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -2,9 +2,9 @@
 Test PostgreSQL full text search vector field.
 """
 from django.contrib.postgres.search import (
-    SearchQuery, SearchRank, SearchVectorField, WeightedColumn
+    SearchQuery, SearchRank, SearchVectorField, WeightedColumn,
 )
-from django.db import models, connection, migrations
+from django.db import connection, migrations, models
 from django.db.migrations.state import ProjectState
 from django.db.migrations.writer import MigrationWriter
 from django.db.models.expressions import F

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -32,14 +32,20 @@ class SearchVectorFieldMigrationWriterTests(PostgreSQLTestCase):
             WeightedColumn('description', 'D'),
         ], 'english')
 
+        definition, path = MigrationWriter.serialize(svf)
+
         self.assertEqual(
-            ("django.contrib.postgres.search.SearchVectorField("
-             "columns=["
-             "django.contrib.postgres.search.WeightedColumn('name', 'A'), "
-             "django.contrib.postgres.search.WeightedColumn('description', 'D')], "
-             "language='english')",
-             {'import django.contrib.postgres.search'}),
-            MigrationWriter.serialize(svf)
+            "django.contrib.postgres.search.SearchVectorField("
+            "columns=["
+            "django.contrib.postgres.search.WeightedColumn('name', 'A'), "
+            "django.contrib.postgres.search.WeightedColumn('description', 'D')], "
+            "language='english')",
+            definition
+        )
+
+        self.assertSetEqual(
+            {'import django.contrib.postgres.search'},
+            path
         )
 
 

--- a/tests/postgres_tests/test_search_field.py
+++ b/tests/postgres_tests/test_search_field.py
@@ -75,7 +75,8 @@ class SearchVectorFieldDDLTests(TestCase):
         with connection.schema_editor() as schema_editor:
             schema_editor.create_model(TextDocument)
             self.assertEqual([
-                'CREATE INDEX "postgres_tests_textdocument_search_9f678d09" ON "postgres_tests_textdocument" ("search")',
+                'CREATE INDEX "postgres_tests_textdocument_search_9f678d09"'
+                ' ON "postgres_tests_textdocument" ("search")',
 
                 'CREATE FUNCTION postgres_tests_textdocument_search_9f678d09_func() RETURNS trigger AS $$\n'
                 'BEGIN\n'
@@ -193,7 +194,7 @@ class SearchVectorFieldMigrationTests(TestCase):
         self.assertFITNotExists()
 
     SEARCH_COL = 'postgres_tests_{table}_{column}_.{{8}}'
-    FIT = [SEARCH_COL+'_func', SEARCH_COL, SEARCH_COL+'_trig']
+    FIT = [SEARCH_COL + '_func', SEARCH_COL, SEARCH_COL + '_trig']
 
     def assertFITExists(self, column='search', table='textdocument'):
         with_column = [fit.format(column=column, table=table) for fit in self.FIT]
@@ -208,16 +209,28 @@ class SearchVectorFieldMigrationTests(TestCase):
         self.assertTriggerNotExists(with_column[2])
 
     _sql_check_function = "select proname from pg_proc where proname ~ %s"
-    assertFunctionExists = lambda self, x: self.assertXExists(self._sql_check_function, x)
-    assertFunctionNotExists = lambda self, x: self.assertXNotExists(self._sql_check_function, x)
+
+    def assertFunctionExists(self, name):
+        return self.assertXExists(self._sql_check_function, name)
+
+    def assertFunctionNotExists(self, name):
+        return self.assertXNotExists(self._sql_check_function, name)
 
     _sql_check_trigger = "select tgname from pg_trigger where tgname ~ %s"
-    assertTriggerExists = lambda self, x: self.assertXExists(self._sql_check_trigger, x)
-    assertTriggerNotExists = lambda self, x: self.assertXNotExists(self._sql_check_trigger, x)
+
+    def assertTriggerExists(self, name):
+        return self.assertXExists(self._sql_check_trigger, name)
+
+    def assertTriggerNotExists(self, name):
+        return self.assertXNotExists(self._sql_check_trigger, name)
 
     _sql_check_index = "select indexname from pg_indexes where indexname ~ %s"
-    assertIndexExists = lambda self, x: self.assertXExists(self._sql_check_index, x)
-    assertIndexNotExists = lambda self, x: self.assertXNotExists(self._sql_check_index, x)
+
+    def assertIndexExists(self, name):
+        return self.assertXExists(self._sql_check_index, name)
+
+    def assertIndexNotExists(self, name):
+        return self.assertXNotExists(self._sql_check_index, name)
 
     def assertXExists(self, sql, x):
         self.assertTrue(self._does_x_exist(sql, x), x)


### PR DESCRIPTION
This is a significantly enhanced version of `django.contrib.postgresql.search.SearchVectorField` with automatically generated and managed database trigger.

Remaining todo's:

- [ ] documentation
- [x] only update the `tsvector` column if the fields on which it depends have changed (need to add a conditional in the pl/pgsql function check if relevant columns have changed)
- [x] instead of hard coding language in the field definition, also support column name

There are probably a lot of other things that will need to be done. Please provide feedback, thanks!

https://code.djangoproject.com/ticket/27589