### PR TITLE
Fixed #27600 -- Improved the way the 'shell' command reads python code from stdin.

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
             return
 
         # Execute stdin if it has anything to read and exit
-        if sys.platform == "win32" and select.select([sys.stdin], [], [], 0)[0]:
+        if sys.platform != "win32" and select.select([sys.stdin], [], [], 0)[0]:
             exec(sys.stdin.read())
             return
 

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -10,8 +10,9 @@ from django.utils.deprecation import RemovedInDjango20Warning
 
 class Command(BaseCommand):
     help = (
-        "Runs a Python interactive interpreter. Tries to use IPython or bpython, if one of them is available"
-        "If there is standard input, it will be immediately executed as code and then the command will exit"
+        "Runs a Python interactive interpreter. Tries to use IPython or "
+        "bpython, if one of them is available. Any standard input is executed "
+        "as code."
     )
 
     requires_system_checks = False

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
             return
 
         # Execute stdin if it has anything to read and exit
-        if select.select([sys.stdin], [], [], 0)[0]:
+        if sys.platform == "win32" and select.select([sys.stdin], [], [], 0)[0]:
             exec(sys.stdin.read())
             return
 

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -1,4 +1,6 @@
 import os
+import select
+import sys
 import warnings
 
 from django.core.management.base import BaseCommand
@@ -7,7 +9,11 @@ from django.utils.deprecation import RemovedInDjango20Warning
 
 
 class Command(BaseCommand):
-    help = "Runs a Python interactive interpreter. Tries to use IPython or bpython, if one of them is available."
+    help = (
+        "Runs a Python interactive interpreter. Tries to use IPython or bpython, if one of them is available"
+        "If there is standard input, it will be immediately executed as code and then the command will exit"
+    )
+
     requires_system_checks = False
     shells = ['ipython', 'bpython', 'python']
 
@@ -112,6 +118,11 @@ class Command(BaseCommand):
         # Execute the command and exit.
         if options['command']:
             exec(options['command'])
+            return
+
+        # Execute stdin if it has anything to read and exit
+        if select.select([sys.stdin], [], [], 0)[0]:
+            exec(sys.stdin.read())
             return
 
         available_shells = [options['interface']] if options['interface'] else self.shells

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -979,6 +979,19 @@ Lets you pass a command as a string to execute it as Django, like so::
 
     django-admin shell --command="import django; print(django.__version__)"
 
+.. versionchanged:: 1.11
+
+You can now pass code in on standard input and it will be executed without any
+extra output from the REPL. For example::
+
+    django-admin shell <<EOF
+    import django
+    print(django.__version__)
+    EOF
+
+On Windows the REPL is still output, due to limitations in its implementation
+of ``select()``.
+
 ``showmigrations``
 ------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -314,6 +314,9 @@ Management Commands
 * The new :option:`diffsettings --default` option allows specifying a settings
   module other than Django's default settings to compare against.
 
+* Improved the way the :djadmin:`shell` command reads python code from standard
+  input.
+
 Migrations
 ~~~~~~~~~~
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -314,8 +314,8 @@ Management Commands
 * The new :option:`diffsettings --default` option allows specifying a settings
   module other than Django's default settings to compare against.
 
-* Improved the way the :djadmin:`shell` command reads python code from standard
-  input.
+* Suppressed REPL output when the :djadmin:`shell` command reads python code
+  from standard input on POSIX compatible systems.
 
 Migrations
 ~~~~~~~~~~

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -1,3 +1,5 @@
+import sys
+
 from django import __version__
 from django.core.management import call_command
 from django.test import SimpleTestCase, mock
@@ -18,6 +20,7 @@ class ShellCommandTestCase(SimpleTestCase):
             self.assertEqual(len(logger), 1)
             self.assertEqual(logger[0], __version__)
 
+    @unittest.skipIf(sys.platform == 'win32', "Python on Windows doesn't have working select().")
     @mock.patch('django.core.management.commands.shell.select')
     def test_stdin_read(self, select):
         with captured_stdin() as stdin, captured_stdout() as stdout:

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -23,6 +23,5 @@ class ShellCommandTestCase(SimpleTestCase):
         with captured_stdin() as stdin, captured_stdout() as stdout:
             stdin.write('print(100)\n')
             stdin.seek(0)
-
             call_command('shell')
         self.assertEqual(stdout.getvalue().strip(), '100')

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -1,3 +1,4 @@
+import unittest
 import sys
 
 from django import __version__

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -20,7 +20,7 @@ class ShellCommandTestCase(SimpleTestCase):
             self.assertEqual(len(logger), 1)
             self.assertEqual(logger[0], __version__)
 
-    @unittest.skipIf(sys.platform == 'win32', "Python on Windows doesn't have working select().")
+    @unittest.skipIf(sys.platform == 'win32', "Windows select() doesn't support file descriptors.")
     @mock.patch('django.core.management.commands.shell.select')
     def test_stdin_read(self, select):
         with captured_stdin() as stdin, captured_stdout() as stdout:

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -1,7 +1,7 @@
 from django import __version__
 from django.core.management import call_command
-from django.test import SimpleTestCase
-from django.test.utils import patch_logger
+from django.test import SimpleTestCase, mock
+from django.test.utils import captured_stdin, captured_stdout, patch_logger
 
 
 class ShellCommandTestCase(SimpleTestCase):
@@ -17,3 +17,12 @@ class ShellCommandTestCase(SimpleTestCase):
             )
             self.assertEqual(len(logger), 1)
             self.assertEqual(logger[0], __version__)
+
+    @mock.patch('django.core.management.commands.shell.select')
+    def test_stdin_read(self, select):
+        with captured_stdin() as stdin, captured_stdout() as stdout:
+            stdin.write('print(100)\n')
+            stdin.seek(0)
+
+            call_command('shell')
+        self.assertEqual(stdout.getvalue().strip(), '100')

--- a/tests/shell/tests.py
+++ b/tests/shell/tests.py
@@ -1,5 +1,5 @@
-import unittest
 import sys
+import unittest
 
 from django import __version__
 from django.core.management import call_command


### PR DESCRIPTION
Fun automation with standard input pipes::
```
$ ./manage.py shell <<EOF
> import pprint
> import json
> pprint.pprint(json.dumps('fun'))
> EOF
 'fun'
```
https://code.djangoproject.com/ticket/27600