### PR TITLE
Fixed #27598 -- Allowed specifying directories for a filesystem template loader.

### DIFF
--- a/django/template/loaders/filesystem.py
+++ b/django/template/loaders/filesystem.py
@@ -16,8 +16,12 @@ from .base import Loader as BaseLoader
 
 class Loader(BaseLoader):
 
+    def __init__(self, engine, dirs=None):
+        super(Loader, self).__init__(engine)
+        self.dirs = dirs
+
     def get_dirs(self):
-        return self.engine.dirs
+        return self.dirs if self.dirs is not None else self.engine.dirs
 
     def get_contents(self, origin):
         try:

--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -847,6 +847,26 @@ loaders that come with Django:
             'DIRS': [os.path.join(BASE_DIR, 'templates')],
         }]
 
+    You can also override ``'DIRS'`` and specify specific directories for a
+    particular filesystem loader::
+
+        TEMPLATES = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'OPTIONS': {
+                'loaders': [
+                    (
+                        'django.template.loaders.filesystem.Loader',
+                        [os.path.join(BASE_DIR, 'templates')],
+                    ),
+                ],
+            },
+        }]
+
+    .. versionchanged:: 1.11
+
+        The ability to specify directories for a particular filesystem loader
+        was added.
+
 ``django.template.loaders.app_directories.Loader``
 
 .. class:: app_directories.Loader

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -391,6 +391,9 @@ Templates
 * Added a :ttag:`resetcycle` template tag to allow resetting the sequence of
   the :ttag:`cycle` template tag.
 
+* You can now specify specific directories for a particular
+  :class:`filesystem.Loader <django.template.loaders.filesystem.Loader>`.
+
 Tests
 ~~~~~
 

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -312,6 +312,17 @@ class FileSystemLoaderTests(SimpleTestCase):
         self.assertEqual(template.origin.loader, self.engine.template_loaders[0])
         self.assertEqual(template.origin.loader_name, 'django.template.loaders.filesystem.Loader')
 
+    def test_loaders_dirs(self):
+        engine = Engine(loaders=[('django.template.loaders.filesystem.Loader', [TEMPLATE_DIR])])
+        template = engine.get_template('index.html')
+        self.assertEqual(template.origin.name, os.path.join(TEMPLATE_DIR, 'index.html'))
+
+    def test_loaders_dirs_empty(self):
+        """An empty dirs list in loaders overrides top level dirs."""
+        engine = Engine(dirs=[TEMPLATE_DIR], loaders=[('django.template.loaders.filesystem.Loader', [])])
+        with self.assertRaises(TemplateDoesNotExist):
+            engine.get_template('index.html')
+
     @ignore_warnings(category=RemovedInDjango20Warning)
     def test_load_template_source(self):
         loader = self.engine.template_loaders[0]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27598#ticket