### PR TITLE
Fixed #27599 -- Fixed Field.__str__() crash for fields not attached to models.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -186,7 +186,12 @@ class Field(RegisterLookupMixin):
         self.error_messages = messages
 
     def __str__(self):
-        """ Return "app_label.model_label.field_name". """
+        """
+        Return "app_label.model_label.field_name" for fields attached to
+        models.
+        """
+        if not hasattr(self, 'model'):
+            return super(Field, self).__str__()
         model = self.model
         app = model._meta.app_label
         return '%s.%s.%s' % (app, model._meta.object_name, self.name)

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.db import models
 from django.test import SimpleTestCase, TestCase
-from django.utils.encoding import force_str
 
 from .models import (
     Foo, RenamedField, VerboseNameField, Whiz, WhizIter, WhizIterEmpty,
@@ -56,8 +55,10 @@ class BasicFieldTests(TestCase):
         self.assertIsInstance(field.formfield(choices_form_class=klass), klass)
 
     def test_field_str(self):
+        f = models.Field()
+        self.assertEqual(str(f), '<django.db.models.fields.Field>')
         f = Foo._meta.get_field('a')
-        self.assertEqual(force_str(f), 'model_fields.Foo.a')
+        self.assertEqual(str(f), 'model_fields.Foo.a')
 
     def test_field_ordering(self):
         """Fields are ordered based on their creation."""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27599