### PR TITLE
Refs #16859 -- Disable an useless security check

### DIFF
--- a/django/core/checks/security/csrf.py
+++ b/django/core/checks/security/csrf.py
@@ -43,6 +43,7 @@ def check_csrf_middleware(app_configs, **kwargs):
 @register(Tags.security, deploy=True)
 def check_csrf_cookie_secure(app_configs, **kwargs):
     passed_check = (
+        settings.CSRF_USE_SESSIONS or
         not _csrf_middleware() or
         settings.CSRF_COOKIE_SECURE
     )
@@ -52,6 +53,7 @@ def check_csrf_cookie_secure(app_configs, **kwargs):
 @register(Tags.security, deploy=True)
 def check_csrf_cookie_httponly(app_configs, **kwargs):
     passed_check = (
+        settings.CSRF_USE_SESSIONS or
         not _csrf_middleware() or
         settings.CSRF_COOKIE_HTTPONLY
     )

--- a/tests/check_framework/test_security.py
+++ b/tests/check_framework/test_security.py
@@ -166,6 +166,17 @@ class CheckCSRFCookieSecureTest(SimpleTestCase):
         """
         self.assertEqual(self.func(None), [csrf.W016])
 
+    @override_settings(
+        MIDDLEWARE=["django.middleware.csrf.CsrfViewMiddleware"],
+        CSRF_USE_SESSIONS=True,
+        CSRF_COOKIE_SECURE=False)
+    def test_use_sessions_with_csrf_cookie_secure_false(self):
+        """
+        No warning if CSRF_COOKIE_SECURE isn't True while CSRF_USE_SESSIONS
+        is True.
+        """
+        self.assertEqual(self.func(None), [])
+
     @override_settings(MIDDLEWARE=[], MIDDLEWARE_CLASSES=[], CSRF_COOKIE_SECURE=False)
     def test_with_csrf_cookie_secure_false_no_middleware(self):
         """
@@ -196,6 +207,17 @@ class CheckCSRFCookieHttpOnlyTest(SimpleTestCase):
         CSRF_COOKIE_HTTPONLY isn't True.
         """
         self.assertEqual(self.func(None), [csrf.W017])
+
+    @override_settings(
+        MIDDLEWARE=["django.middleware.csrf.CsrfViewMiddleware"],
+        CSRF_USE_SESSIONS=True,
+        CSRF_COOKIE_HTTPONLY=False)
+    def test_use_sessions_with_csrf_cookie_httponly_false(self):
+        """
+        No warning if CSRF_COOKIE_HTTPONLY isn't True while CSRF_USE_SESSIONS
+        is True.
+        """
+        self.assertEqual(self.func(None), [])
 
     @override_settings(MIDDLEWARE=[], MIDDLEWARE_CLASSES=[], CSRF_COOKIE_HTTPONLY=False)
     def test_with_csrf_cookie_httponly_false_no_middleware(self):


### PR DESCRIPTION
If CSRF_USE_SESSIONS is used, there is no need to check that CSRF_COOKIE_SECURE is True.

(As requested by @timgraham in #5600)
