### PR TITLE
Fixed #27606 -- Prevent HttpResponseRedirectBase erroring in formatting

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -420,11 +420,11 @@ class HttpResponseRedirectBase(HttpResponse):
     allowed_schemes = ['http', 'https', 'ftp']
 
     def __init__(self, redirect_to, *args, **kwargs):
+        super(HttpResponseRedirectBase, self).__init__(*args, **kwargs)
+        self['Location'] = iri_to_uri(redirect_to)
         parsed = urlparse(force_text(redirect_to))
         if parsed.scheme and parsed.scheme not in self.allowed_schemes:
             raise DisallowedRedirect("Unsafe redirect to URL with protocol '%s'" % parsed.scheme)
-        super(HttpResponseRedirectBase, self).__init__(*args, **kwargs)
-        self['Location'] = iri_to_uri(redirect_to)
 
     url = property(lambda self: self['Location'])
 


### PR DESCRIPTION
The `__str__` method of HttpResponseRedirectBase depends on self._headers
being set, which happens in the initialization of the base class.
This would otherwise error when attempting to format a response that
was given unsafe redirect schemes.