### PR TITLE
Refs #19884 -- Removed DatabaseFeatures.can_introspect_max_length.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -116,9 +116,6 @@ class BaseDatabaseFeatures(object):
     # Does the backend reset sequences between tests?
     supports_sequence_reset = True
 
-    # Can the backend determine reliably the length of a CharField?
-    can_introspect_max_length = True
-
     # Can the backend determine reliably if a field is nullable?
     # Note that this is separate from interprets_empty_strings_as_nulls,
     # although the latter feature, when true, interferes with correct

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -59,37 +59,27 @@ class InspectDBTestCase(TestCase):
 
         # Inspecting Oracle DB doesn't produce correct results (#19884):
         # - it reports fields as blank=True when they aren't.
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        if not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('char_field', "models.CharField(max_length=10)")
             assertFieldType('null_char_field', "models.CharField(max_length=10, blank=True, null=True)")
             assertFieldType('comma_separated_int_field', "models.CharField(max_length=99)")
-        assertFieldType('date_field', "models.DateField()")
-        assertFieldType('date_time_field', "models.DateTimeField()")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
             assertFieldType('email_field', "models.CharField(max_length=254)")
             assertFieldType('file_field', "models.CharField(max_length=100)")
             assertFieldType('file_path_field', "models.CharField(max_length=100)")
+            assertFieldType('slug_field', "models.CharField(max_length=50)")
+            assertFieldType('text_field', "models.TextField()")
+            assertFieldType('url_field', "models.CharField(max_length=200)")
+        assertFieldType('date_field', "models.DateField()")
+        assertFieldType('date_time_field', "models.DateTimeField()")
         if connection.features.can_introspect_ip_address_field:
             assertFieldType('gen_ip_adress_field', "models.GenericIPAddressField()")
-        elif (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        elif not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('gen_ip_adress_field', "models.CharField(max_length=39)")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
-            assertFieldType('slug_field', "models.CharField(max_length=50)")
-        if not connection.features.interprets_empty_strings_as_nulls:
-            assertFieldType('text_field', "models.TextField()")
         if connection.features.can_introspect_time_field:
             assertFieldType('time_field', "models.TimeField()")
-        if (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
-            assertFieldType('url_field', "models.CharField(max_length=200)")
         if connection.features.has_native_uuid_field:
             assertFieldType('uuid_field', "models.UUIDField()")
-        elif (connection.features.can_introspect_max_length and
-                not connection.features.interprets_empty_strings_as_nulls):
+        elif not connection.features.interprets_empty_strings_as_nulls:
             assertFieldType('uuid_field', "models.CharField(max_length=32)")
 
     def test_number_field_types(self):

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -83,7 +83,6 @@ class IntrospectionTests(TransactionTestCase):
              'SmallIntegerField' if connection.features.can_introspect_small_integer_field else 'IntegerField']
         )
 
-    @skipUnlessDBFeature('can_introspect_max_length')
     def test_get_table_description_col_lengths(self):
         with connection.cursor() as cursor:
             desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)


### PR DESCRIPTION
Unused (always True) after 3e43d24.

From the official [3rd-party-database-backends](https://docs.djangoproject.com/en/1.10/ref/databases/#using-a-3rd-party-database-backend) only [IBM DB2](https://github.com/ibmdb/python-ibmdb) and [Firebird](https://github.com/maxirobaina/django-firebird) are using `can_introspect_max_length`. I created appropriate PRs (IBM DB2 - [PR](https://github.com/ibmdb/python-ibmdb/issues/252), Firebird - [PR](https://github.com/maxirobaina/django-firebird/issues/67)).