### PR TITLE
Fixed #27615 -- Used timedeltas as arguments to Oracle database driver.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -68,12 +68,6 @@ class BaseDatabaseFeatures(object):
     # by returning the type used to store duration field?
     supports_temporal_subtraction = False
 
-    # Does the database driver support timedeltas as arguments?
-    # This is only relevant when there is a native duration field.
-    # Specifically, there is a bug with cx_Oracle:
-    # https://bitbucket.org/anthony_tuininga/cx_oracle/issue/7/
-    driver_supports_timedelta_args = False
-
     # Do time/datetime fields have microsecond precision?
     supports_microsecond_precision = True
 

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -17,7 +17,6 @@ from django.db import utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils import six, timezone
 from django.utils.deprecation import RemovedInDjango20Warning
-from django.utils.duration import duration_string
 from django.utils.encoding import force_bytes, force_text
 from django.utils.functional import cached_property
 
@@ -344,11 +343,6 @@ class OracleParam(object):
                 param = param.astimezone(timezone.utc).replace(tzinfo=None)
             param = Oracle_datetime.from_datetime(param)
 
-        if isinstance(param, datetime.timedelta):
-            param = duration_string(param)
-            if ' ' not in param:
-                param = '0 ' + param
-
         string_size = 0
         # Oracle doesn't recognize True and False correctly in Python 3.
         # The conversion done below works both in 2 and 3.
@@ -358,7 +352,7 @@ class OracleParam(object):
             param = 0
         if hasattr(param, 'bind_parameter'):
             self.force_bytes = param.bind_parameter(cursor)
-        elif isinstance(param, Database.Binary):
+        elif isinstance(param, (Database.Binary, datetime.timedelta)):
             self.force_bytes = param
         else:
             # To transmit to the database, we need Unicode if supported

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -10,7 +10,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_real_datatype = True
     has_native_uuid_field = True
     has_native_duration_field = True
-    driver_supports_timedelta_args = True
     can_defer_constraint_checks = True
     has_select_for_update = True
     has_select_for_update_nowait = True

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -600,8 +600,7 @@ class Value(Expression):
 class DurationValue(Value):
     def as_sql(self, compiler, connection):
         connection.ops.check_expression_support(self)
-        if (connection.features.has_native_duration_field and
-                connection.features.driver_supports_timedelta_args):
+        if connection.features.has_native_duration_field:
             return super(DurationValue, self).as_sql(compiler, connection)
         return connection.ops.date_interval_sql(self.value)
 


### PR DESCRIPTION
Ticket [#27615](https://code.djangoproject.com/ticket/27615).
Used `datetime.timedeltas` as a arguments to the Oracle database driver.
Removed `DatabaseFeatures.driver_supports_timedeltas`.