### PR TITLE
Documented the 'regex' arg to url()

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -33,6 +33,13 @@ Helper function to return a URL pattern for serving files in debug mode::
         ...
     ]
 
+The ``regex`` parameter should be a string or
+:func:`~django.utils.translation.ugettext_lazy()` (see
+:ref:`translating-urlpatterns`) that contains a regular expression compatible
+with Python's :py:mod:`re` module. Strings typically use raw string syntax
+(``r''``) so that they can contain sequences like ``\d`` without the need to
+escape the backslash with another backslash.
+
 The ``view`` parameter is a view function or the result of
 :meth:`~django.views.generic.base.View.as_view` for class-based views. It can
 also be an :func:`include`.

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1533,6 +1533,7 @@ will be::
     Ensure that you don't have non-prefixed URL patterns that might collide
     with an automatically-added language prefix.
 
+.. _translating-urlpatterns:
 
 Translating URL patterns
 ------------------------


### PR DESCRIPTION
Noticed it was missing during the [mailing list discussion about flags](https://groups.google.com/forum/#!topic/django-developers/Y51CKkqq6Ng). Learnt for myself that `gettext_lazy` support was added in django 1.4 (896e3c69c7).