### PR TITLE
Explain the $ prefix for the shell.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -19,6 +19,16 @@ tell Django is installed and which version by running the following command:
 
     $ python -m django --version
 
+.. note::
+
+    The ``$`` before the command is special. It indicates that you are supposed
+    to type the command into your shell prompt, as opposed to a Python terminal.
+    The ``$`` is not part of the command, and you should not type it.
+    
+    This tutorial will consistently use the ``$`` to indicate a shell prompt,
+    and ``>>>`` to indicate something you should type into a Python terminal
+    (you will come across that soon).
+
 If Django is installed, you should see the version of your installation. If it
 isn't, you'll get an error telling "No module named django".
 


### PR DESCRIPTION
A friend of mine began teaching herself Python (and Django) today, and had a real struggle when she got to the first command that the tutorial required her to type into a shell that began with a $ character.

She is on Windows, and there was nothing to indicate to her that `$` meant "type this on a command prompt" as opposed to "type the $ as the first character of this command". The syntax highlighting has very little meaning to a fresh face. It makes sense to a seasoned face who has spent time on a Linux terminal, but not someone trying to use the documentation to learn this stuff for the first time.

Therefore, I would like to add a note explaining this, as I have done in this pull request.