### PR TITLE
 Fixed #27631 -- Prevented execution of unsupported transactional DDL statements.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from datetime import datetime
 
-from django.db.transaction import atomic
+from django.db.transaction import TransactionManagementError, atomic
 from django.utils import six, timezone
 from django.utils.encoding import force_bytes
 
@@ -98,6 +98,13 @@ class BaseDatabaseSchemaEditor(object):
         """
         Executes the given SQL statement, with optional parameters.
         """
+        # Don't perform the transactional DDL check if SQL is being collected
+        # as it's not going to be executed anyway.
+        if not self.collect_sql and self.connection.in_atomic_block and not self.connection.features.can_rollback_ddl:
+            raise TransactionManagementError(
+                "Executing DDL statements while in a transaction on databases "
+                "that can't perform a rollback is prohibited."
+            )
         # Log the command we're running, then run it
         logger.debug("%s; (params %r)", sql, params, extra={'params': params, 'sql': sql})
         if self.collect_sql:


### PR DESCRIPTION
This is a follow up of the discussion in #7694 with @adamchainz.

Executing a DDL statement during a transaction on backends that don't support it silently commits, leaving `atomic()` in an incoherent state.

While `schema_editor.execute()` could technically be used to execute DML statements such usage should be uncommon as these are usually performed through the ORM. In other cases `schema_editor.connection.execute()` can be used to circumvent this check.