### PR TITLE
Fixed #26423 -- Match email validation with html

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -169,21 +169,19 @@ def validate_integer(value):
 
 @deconstructible
 class EmailValidator(object):
+    # Matches https://html.spec.whatwg.org/multipage/forms.html#valid-e-mail-address
     message = _('Enter a valid email address.')
     code = 'invalid'
     user_regex = _lazy_re_compile(
-        r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"  # dot-atom
-        r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"\Z)',  # quoted-string
+        r"^[a-z0-9.!#$%&'*+\/=?^_`{|}~-]+\Z",
         re.IGNORECASE)
     domain_regex = _lazy_re_compile(
-        # max length for domain name labels is 63 characters per RFC 1034
-        r'((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+)(?:[A-Z0-9-]{2,63}(?<!-))\Z',
+        r'[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\Z',
         re.IGNORECASE)
     literal_regex = _lazy_re_compile(
         # literal form, ipv4 or ipv6 address (SMTP 4.1.3)
         r'\[([A-f0-9:\.]+)\]\Z',
         re.IGNORECASE)
-    domain_whitelist = ['localhost']
 
     def __init__(self, message=None, code=None, whitelist=None):
         if message is not None:
@@ -191,7 +189,7 @@ class EmailValidator(object):
         if code is not None:
             self.code = code
         if whitelist is not None:
-            self.domain_whitelist = whitelist
+            pass # deprecated
 
     def __call__(self, value):
         value = force_text(value)
@@ -204,15 +202,12 @@ class EmailValidator(object):
         if not self.user_regex.match(user_part):
             raise ValidationError(self.message, code=self.code)
 
-        if (domain_part not in self.domain_whitelist and
-                not self.validate_domain_part(domain_part)):
-            # Try for possible IDN domain-part
-            try:
-                domain_part = domain_part.encode('idna').decode('ascii')
-                if self.validate_domain_part(domain_part):
-                    return
-            except UnicodeError:
-                pass
+        try:
+            domain_part = domain_part.encode('idna').decode()
+        except UnicodeError:
+            raise ValidationError(self.message, code=self.code)
+
+        if not self.validate_domain_part(domain_part):
             raise ValidationError(self.message, code=self.code)
 
     def validate_domain_part(self, domain_part):
@@ -232,7 +227,6 @@ class EmailValidator(object):
     def __eq__(self, other):
         return (
             isinstance(other, EmailValidator) and
-            (self.domain_whitelist == other.domain_whitelist) and
             (self.message == other.message) and
             (self.code == other.code)
         )

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -56,7 +56,6 @@ TEST_DATA = [
     (validate_email, 'test@domain.with.idn.tld.उदाहरण.परीक्षा', None),
     (validate_email, 'email@localhost', None),
     (EmailValidator(whitelist=['localdomain']), 'email@localdomain', None),
-    (validate_email, '"test@test"@example.com', None),
     (validate_email, 'example@atm.%s' % ('a' * 63), None),
     (validate_email, 'example@%s.atm' % ('a' * 63), None),
     (validate_email, 'example@%s.%s.atm' % ('a' * 63, 'b' * 10), None),
@@ -67,11 +66,11 @@ TEST_DATA = [
     (validate_email, '', ValidationError),
     (validate_email, 'abc', ValidationError),
     (validate_email, 'abc@', ValidationError),
-    (validate_email, 'abc@bar', ValidationError),
+    (validate_email, 'abc@bar', None),
     (validate_email, 'a @x.cz', ValidationError),
     (validate_email, 'abc@.com', ValidationError),
     (validate_email, 'something@@somewhere.com', ValidationError),
-    (validate_email, 'email@127.0.0.1', ValidationError),
+    (validate_email, 'email@127.0.0.1', None),
     (validate_email, 'email@[127.0.0.256]', ValidationError),
     (validate_email, 'email@[2001:db8::12345]', ValidationError),
     (validate_email, 'email@[2001:db8:0:0:0:0:1]', ValidationError),
@@ -83,7 +82,7 @@ TEST_DATA = [
     (validate_email, 'example@inv-.-alid.com', ValidationError),
     (validate_email, 'test@example.com\n\n<script src="x.js">', ValidationError),
     # Quoted-string format (CR not allowed)
-    (validate_email, '"\\\011"@here.com', None),
+    (validate_email, '"\\\011"@here.com', ValidationError),
     (validate_email, '"\\\012"@here.com', ValidationError),
     (validate_email, 'trailingdot@shouldfail.com.', ValidationError),
     # Max length of domain name labels is 63 characters per RFC 1034.
@@ -94,6 +93,7 @@ TEST_DATA = [
     (validate_email, 'a\n@b.com', ValidationError),
     (validate_email, '"test@test"\n@example.com', ValidationError),
     (validate_email, 'a@[127.0.0.1]\n', ValidationError),
+    (validate_email, '"test@test"@example.com', ValidationError),
 
     (validate_slug, 'slug-ok', None),
     (validate_slug, 'longer-slug-still-ok', None),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26423

This is more strict in some cases, and less strict in other cases.
- this allows any local domain on the right.
- html does not allow quoted strings in the user part
- html does not allow ip addresses (but I kept django's logic for that)
- html does not allow unicode

Unfortunately, Chrome, Firefox, and IE don't allow unicode email addresses (besides domain names), so this doesn't fix https://code.djangoproject.com/ticket/27029. I assume that at some point in the future they will accept some unicode, but currently no. https://bugs.chromium.org/p/chromium/issues/detail?id=431550