### PR TITLE
Fixed #27642 -- Made `forms.utils.flatatt` not add values which are `None` to attrs

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -40,7 +40,7 @@ def flatatt(attrs):
         if isinstance(value, bool):
             if value:
                 boolean_attrs.append((attr,))
-        else:
+        elif value is not None:
             key_value_attrs.append((attr, value))
 
     return (

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -34,6 +34,7 @@ class FormsUtilsTestCase(SimpleTestCase):
             flatatt({'class': "news", 'title': "Read this", 'required': False}),
             ' class="news" title="Read this"'
         )
+        self.assertEqual(flatatt({'class': None}), '')
         self.assertEqual(flatatt({}), '')
 
     def test_flatatt_no_side_effects(self):


### PR DESCRIPTION
I think, when a person adds arguments like
```python
{'id': None, 'class': 'smth'}
```
to an `<input>` tag, one does not expect it to turn into 
```html
<input ... id="None" class="smth">
```
---
I have fixed it in this PR.