### PR TITLE
Fixed #27640 -- Fixed HttpResponse's __repr__()  without a 'Content-Type' header.

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -107,6 +107,10 @@ class HttpResponseBase(six.Iterator):
     else:
         __str__ = serialize_headers
 
+    @property
+    def _content_type_for_repr(self):
+        return ', "%s"' % self['Content-Type'] if 'Content-Type' in self else ''
+
     def _convert_to_charset(self, value, charset, mime_encode=False):
         """Converts headers key/value to ascii/latin-1 native strings.
 
@@ -299,10 +303,10 @@ class HttpResponse(HttpResponseBase):
         self.content = content
 
     def __repr__(self):
-        return '<%(cls)s status_code=%(status_code)d, "%(content_type)s">' % {
+        return '<%(cls)s status_code=%(status_code)d%(content_type)s>' % {
             'cls': self.__class__.__name__,
             'status_code': self.status_code,
-            'content_type': self['Content-Type'],
+            'content_type': self._content_type_for_repr,
         }
 
     def serialize(self):
@@ -429,10 +433,10 @@ class HttpResponseRedirectBase(HttpResponse):
     url = property(lambda self: self['Location'])
 
     def __repr__(self):
-        return '<%(cls)s status_code=%(status_code)d, "%(content_type)s", url="%(url)s">' % {
+        return '<%(cls)s status_code=%(status_code)d%(content_type)s, url="%(url)s">' % {
             'cls': self.__class__.__name__,
             'status_code': self.status_code,
-            'content_type': self['Content-Type'],
+            'content_type': self._content_type_for_repr,
             'url': self.url,
         }
 
@@ -479,10 +483,10 @@ class HttpResponseNotAllowed(HttpResponse):
         self['Allow'] = ', '.join(permitted_methods)
 
     def __repr__(self):
-        return '<%(cls)s [%(methods)s] status_code=%(status_code)d, "%(content_type)s">' % {
+        return '<%(cls)s [%(methods)s] status_code=%(status_code)d%(content_type)s>' % {
             'cls': self.__class__.__name__,
             'status_code': self.status_code,
-            'content_type': self['Content-Type'],
+            'content_type': self._content_type_for_repr,
             'methods': self['Allow'],
         }
 

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -536,6 +536,10 @@ class HttpResponseSubclassesTests(SimpleTestCase):
             response.content = "Hello dear"
         self.assertNotIn('content-type', response)
 
+    def test_not_modified_repr(self):
+        response = HttpResponseNotModified()
+        self.assertEqual(repr(response), '<HttpResponseNotModified status_code=304>')
+
     def test_not_allowed(self):
         response = HttpResponseNotAllowed(['GET'])
         self.assertEqual(response.status_code, 405)
@@ -547,6 +551,11 @@ class HttpResponseSubclassesTests(SimpleTestCase):
         response = HttpResponseNotAllowed(['GET', 'OPTIONS'], content_type='text/plain')
         expected = '<HttpResponseNotAllowed [GET, OPTIONS] status_code=405, "text/plain">'
         self.assertEqual(repr(response), expected)
+
+    def test_not_allowed_repr_no_content_type(self):
+        response = HttpResponseNotAllowed(('GET', 'POST'))
+        del response['Content-Type']
+        self.assertEqual(repr(response), '<HttpResponseNotAllowed [GET, POST] status_code=405>')
 
 
 class JsonResponseTests(SimpleTestCase):

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -136,6 +136,11 @@ class HttpResponseTests(SimpleTestCase):
         expected = '<HttpResponse status_code=201, "text/html; charset=utf-8">'
         self.assertEqual(repr(response), expected)
 
+    def test_repr_no_content_type(self):
+        response = HttpResponse(status=204)
+        del response['Content-Type']
+        self.assertEqual(repr(response), '<HttpResponse status_code=204>')
+
     def test_wrap_textiowrapper(self):
         content = "Café :)"
         r = HttpResponse()


### PR DESCRIPTION
Fixes [27640](https://code.djangoproject.com/ticket/27640).
Fixed `__repr__` for responses with no 'Content-Type' header in `HttpResponse`, `HttpResponseNotAllowed` and `HttpResponseNotModified`.