### PR TITLE
Fixed #24994 -- Documented the expected type of settings.SECRET_KEY.

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2036,6 +2036,10 @@ unpredictable value.
 :djadmin:`django-admin startproject <startproject>` automatically adds a
 randomly-generated ``SECRET_KEY`` to each new project.
 
+Uses of the key shouldn't assume that it's text or bytes. Every use should go
+through :func:`~django.utils.encoding.force_text` or
+:func:`~django.utils.encoding.force_bytes` to convert it to the desired type.
+
 Django will refuse to start if :setting:`SECRET_KEY` is not set.
 
 .. warning::


### PR DESCRIPTION
As discussed at https://groups.google.com/d/topic/django-developers/SOKz1e3TTcg/discussion