### PR TITLE
Refs #27632 -- Unified query parameters by their types and values on Oracle.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -464,17 +464,22 @@ class FormatStylePlaceholderCursor(object):
             # Handle params as dict
             args = {k: ":%s" % k for k in params.keys()}
             query = convert_unicode(query % args, self.charset)
-        elif unify_by_values:
+        elif unify_by_values and len(params) > 0:
             # Handle params as a dict with unified query parameters by their
             # values. It can be used only in single query execute() because
             # executemany() shares the formatted query with each of the params
             # list. e.g. for input params = [0.75, 2, 0.75, 'sth', 0.75]
-            # params_dict = {0.75: ':arg0', 2: ':arg1', 'sth': ':arg2'}
+            # params_dict = {
+            #   (2, <type 'int'>): ':arg2',
+            #   (0.75, <type 'float'>): ':arg1',
+            #   ('sth', <type 'str'>): ':arg0',
+            # }
             # args = [':arg0', ':arg1', ':arg0', ':arg2', ':arg0']
             # params = {':arg0': 0.75, ':arg1': 2, ':arg2': 'sth'}
+            params = [(param, type(param)) for param in params]
             params_dict = {param: ':arg%d' % i for i, param in enumerate(set(params))}
             args = [params_dict[param] for param in params]
-            params = dict(zip(params_dict.values(), params_dict.keys()))
+            params = dict(zip(params_dict.values(), list(zip(*params_dict.keys()))[0]))
             query = convert_unicode(query % tuple(args), self.charset)
         else:
             # Handle params as sequence


### PR DESCRIPTION
Ticket [#27632](https://code.djangoproject.com/ticket/27632). Fixed regression on python 2 in 6dbe56e.

Unified query parameters by their types and values on Oracle.