### PR TITLE
Fixed #27635 -- Use secrets on Python 3.6+ in django.utils.crypto.

### DIFF
--- a/django/utils/crypto.py
+++ b/django/utils/crypto.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import random
 import struct
+import sys
 import time
 
 from django.conf import settings
@@ -17,7 +18,11 @@ from django.utils.six.moves import range
 
 # Use the system PRNG if possible
 try:
-    random = random.SystemRandom()
+    if sys.version_info >= (3, 6):
+        import secrets
+        random = secrets.SystemRandom()
+    else:
+        random = random.SystemRandom()
     using_sysrandom = True
 except NotImplementedError:
     import warnings


### PR DESCRIPTION
In addition to the change I made, I'm not sure if random should also be switched in these 2 files: 
- django/core/mail/message.py
- django/template/defaultfilters.py
However the ticket says just django.utils.crypto so it should be good.