### PR TITLE
 Fixed #27658 -- Prevented collectstatic from overwriting newer files in remote storages.

### DIFF
--- a/docs/releases/1.10.5.txt
+++ b/docs/releases/1.10.5.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Fixed a regression in the ``timesince`` and ``timeuntil`` filters that caused
   incorrect results for dates in a leap year (:ticket:`27637`).
+
+* Fixed a regression where ``collectstatic`` overwrote newer files in remote
+  storages (:ticket:`27658`).

--- a/tests/staticfiles_tests/cases.py
+++ b/tests/staticfiles_tests/cases.py
@@ -82,7 +82,8 @@ class CollectionTestCase(BaseStaticFilesMixin, SimpleTestCase):
         super(CollectionTestCase, self).tearDown()
 
     def run_collectstatic(self, **kwargs):
-        call_command('collectstatic', interactive=False, verbosity=0,
+        verbosity = kwargs.pop('verbosity', 0)
+        call_command('collectstatic', interactive=False, verbosity=verbosity,
                      ignore_patterns=['*.ignoreme'], **kwargs)
 
     def _get_file(self, filepath):

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -1,6 +1,6 @@
 import errno
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import CachedStaticFilesStorage
@@ -57,6 +57,14 @@ class PathNotImplementedStorage(storage.Storage):
 
     def path(self, name):
         raise NotImplementedError
+
+
+class NeverCopyRemoteStorage(PathNotImplementedStorage):
+    """
+    Return a future modified time for all files so that nothing is collected.
+    """
+    def get_modified_time(self, name):
+        return datetime.now() + timedelta(days=30)
 
 
 class QueryStringStorage(storage.Storage):

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -399,6 +399,23 @@ class TestCollectionNonLocalStorage(TestNoFilesCreated, CollectionTestCase):
             storage.path('name')
 
 
+class TestCollectionNeverCopyStorage(CollectionTestCase):
+
+    @override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.NeverCopyRemoteStorage')
+    def test_skips_newer_files_in_remote_storage(self):
+        """
+        collectstatic skips newer files in a remote storage.
+        run_collectstatic() in setUp() copies the static files, then files are
+        always skipped after NeverCopyRemoteStorage is activated since
+        NeverCopyRemoteStorage.get_modified_time() returns a datetime in the
+        future to simulate an unmodified file.
+        """
+        stdout = six.StringIO()
+        self.run_collectstatic(stdout=stdout, verbosity=2)
+        output = force_text(stdout.getvalue())
+        self.assertIn("Skipping 'test.txt' (not modified)", output)
+
+
 @unittest.skipUnless(symlinks_supported(), "Must be able to symlink to run this test.")
 class TestCollectionLinks(TestDefaults, CollectionTestCase):
     """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27658