### PR TITLE
Refs #27632 -- Simplified params dict creation for Oracle

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -466,7 +466,7 @@ class FormatStylePlaceholderCursor(object):
             params = [(param, type(param)) for param in params]
             params_dict = {param: ':arg%d' % i for i, param in enumerate(set(params))}
             args = [params_dict[param] for param in params]
-            params = dict(zip(params_dict.values(), list(zip(*params_dict.keys()))[0]))
+            params = {value: key[0] for key, value in params_dict.items()}
             query = query % tuple(args)
         else:
             # Handle params as sequence


### PR DESCRIPTION
I've simplified flipping the dict using a dict comprehension. The comprehension was twice as fast before we introduced the type into the key, now it's 2 - 3 times as fast because we're avoiding the extra `list()` and `zip()` call.

Microbenchmarks:

```
In [32]: %timeit {v: k[0] for k,v in params_dict.items()}
The slowest run took 4.42 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 718 ns per loop

In [34]: %timeit dict(zip(params_dict.values(), list(zip(*params_dict.keys()))[0]))
The slowest run took 4.17 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 2.25 µs per loop
```

And for just a single execution:

```
In [43]: %time {v: k[0] for k,v in params_dict.items()}
CPU times: user 5 µs, sys: 0 ns, total: 5 µs
Wall time: 7.87 µs
Out[43]: {':arg0': 2, ':arg1': 0.75, ':arg2': 'sth'}

In [45]: %time dict(zip(params_dict.values(), list(zip(*params_dict.keys()))[0]))
CPU times: user 10 µs, sys: 0 ns, total: 10 µs
Wall time: 13.1 µs
Out[45]: {':arg0': 2, ':arg1': 0.75, ':arg2': 'sth'}
```