### PR TITLE
 Refs #27637 -- Fixed timesince, timeuntil on New Year's Eve in a leap year.

### DIFF
--- a/django/utils/timesince.py
+++ b/django/utils/timesince.py
@@ -46,8 +46,11 @@ def timesince(d, now=None, reversed=False):
 
     # Deal with leapyears by subtracing the number of leapdays
     leapdays = calendar.leapdays(d.year, now.year)
-    if leapdays != 0 and calendar.isleap(d.year):
-        leapdays -= 1
+    if leapdays != 0:
+        if calendar.isleap(d.year):
+            leapdays -= 1
+        elif calendar.isleap(now.year):
+            leapdays += 1
     delta -= datetime.timedelta(leapdays)
 
     # ignore microseconds

--- a/docs/releases/1.10.5.txt
+++ b/docs/releases/1.10.5.txt
@@ -16,4 +16,4 @@ Bugfixes
   (:ticket:`27418`).
 
 * Fixed a regression in the ``timesince`` and ``timeuntil`` filters that caused
-  incorrect results for dates in a leap year.
+  incorrect results for dates in a leap year (:ticket:`27637`).

--- a/docs/releases/1.9.13.txt
+++ b/docs/releases/1.9.13.txt
@@ -10,4 +10,4 @@ Bugfixes
 ========
 
 * Fixed a regression in the ``timesince`` and ``timeuntil`` filters that caused
-  incorrect results for dates in a leap year.
+  incorrect results for dates in a leap year (:ticket:`27637`).

--- a/tests/utils_tests/test_timesince.py
+++ b/tests/utils_tests/test_timesince.py
@@ -110,6 +110,12 @@ class TimesinceTests(unittest.TestCase):
         self.assertEqual(timeuntil(start_date + self.oneweek, start_date), '1\xa0week')
         self.assertEqual(timesince(start_date, start_date + self.oneweek), '1\xa0week')
 
+    def test_leap_year_new_years_eve(self):
+        t = datetime.date(2016, 12, 31)
+        now = datetime.datetime(2016, 12, 31, 18, 0, 0)
+        self.assertEqual(timesince(t + self.oneday, now), '0\xa0minutes')
+        self.assertEqual(timeuntil(t - self.oneday, now), '0\xa0minutes')
+
     def test_naive_datetime_with_tzinfo_attribute(self):
         class naive(datetime.tzinfo):
             def utcoffset(self, dt):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27637