### PR TITLE
Fixes #27676 -- Made MySQL backend allow database level defaults for text/blob/json columns on MariaDB 10.2+

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -360,11 +360,18 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return True
 
     @cached_property
-    def mysql_version(self):
+    def mysql_version_string(self):
         with self.temporary_connection() as cursor:
             cursor.execute('SELECT VERSION()')
-            server_info = cursor.fetchone()[0]
-        match = server_version_re.match(server_info)
+            return cursor.fetchone()[0]
+
+    @property
+    def mysql_version(self):
+        match = server_version_re.match(self.mysql_version_string)
         if not match:
-            raise Exception('Unable to determine MySQL version from version string %r' % server_info)
+            raise Exception('Unable to determine MySQL version from version string %r' % self.mysql_version_string)
         return tuple(int(x) for x in match.groups())
+
+    @property
+    def mysql_is_mariadb(self):
+        return 'MariaDB' in self.mysql_version_string

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -32,8 +32,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def skip_default(self, field):
         """
         MySQL doesn't accept default values for some data types and implicitly
-        treats these columns as nullable.
+        treats these columns as nullable. MariaDB 10.2+ fixes this.
         """
+        if self.connection.mysql_is_mariadb and self.connection.mysql_version[:2] > (10, 2):
+            return False
         db_type = field.db_type(self.connection)
         return (
             db_type is not None and


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/27676)