### PR TITLE
Fixed #27677 -- Allowed disabling MySQL's savepoints and disabled them on NDBCLUSTER engine.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -82,7 +82,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def uses_savepoints(self):
         """
-        All storage engines except NDB/NDBCLUSTER support savepoints.
+        All storage engines supporting transactions do support savepoints, except NDB/NDBCLUSTER.
         But allow the user to overwrite explicitly if some new engine got used.
         """
         if self.connection.settings_dict.get('USES_SAVEPOINTS', None) is None:

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -88,4 +88,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         if self.connection.settings_dict.get('USES_SAVEPOINTS', None) is None:
             return self._mysql_storage_engine.lower() not in ('ndbcluster', 'ndb')
         else:
-            return self.connection.settings_dict.get['USES_SAVEPOINTS']
+            return self.connection.settings_dict['USES_SAVEPOINTS']

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -23,7 +23,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_timezones = False
     requires_explicit_null_ordering_when_grouping = True
     allows_auto_pk_0 = False
-    uses_savepoints = True
     can_release_savepoints = True
     atomic_transactions = False
     supports_column_check_constraints = False
@@ -79,3 +78,14 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             cursor.execute('SELECT @@LOWER_CASE_TABLE_NAMES')
             result = cursor.fetchone()
             return result and result[0] != 0
+
+    @cached_property
+    def uses_savepoints(self):
+        """
+        All storage engines except NDB/NDBCLUSTER support savepoints.
+        But allow the user to overwrite explicitly if some new engine got used.
+        """
+        if self.connection.settings_dict.get('USES_SAVEPOINTS', None) is None:
+            return self._mysql_storage_engine.lower() not in ('ndbcluster', 'ndb')
+        else:
+            return self.connection.settings_dict.get['USES_SAVEPOINTS']


### PR DESCRIPTION
MySQL NDB Cluster does not support savepoints. This disables savepoints for NDB/NDBCLUSTER but allows user to explicitly enable/disable savepoints for this and other engines in the future.

(Cross posted with https://code.djangoproject.com/ticket/27677#ticket)