### PR TITLE
Fixed #27587 -- Doc'd how to see the ORM generated SQL in a QuerySet.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -119,6 +119,21 @@ described here.
     unpickle a queryset in a Django version that is different than the one in
     which it was pickled.
 
+Generated queries
+-----------------
+
+It's difficult to intuit how the ORM will translate complex querysets into SQL
+queries so when in doubt, inspect the SQL with ``str(queryset.query)`` and
+write plenty of tests.
+
+The queries returned by ``str(queryset.query)`` may be incorrect. The following
+should be taken into consideration
+
+* Strings in returned queries may not be quoted correctly according to the
+  database adapter. Not in all cases is the quoting and escaping done
+  correctly. Thus, it may be needed to manually modify the query and handle
+  escaping according to the database backend.
+
 .. _queryset-api:
 
 ``QuerySet`` API

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -172,6 +172,8 @@ Models
 
 * The new :class:`~django.db.models.functions.StrIndex` database function
   finds the starting index of a string inside another string.
+* A debug method ``_get_called_qs`` for getting the ``SQLCompiler`` instance
+  was added to :class:`~django.db.models.query.QuerySet`.
 
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -403,7 +403,9 @@ ratings exceeding 3.0.
 
 It's difficult to intuit how the ORM will translate complex querysets into SQL
 queries so when in doubt, inspect the SQL with ``str(queryset.query)`` and
-write plenty of tests.
+write plenty of tests.  The query returned by ``str(queryset.query)`` may be
+wrong, e.g., parameters may not be quoted correctly or may not be escaped
+correctly.
 
 ``order_by()``
 --------------


### PR DESCRIPTION
Just copied the remark from the aggregation-documentation (it's a good remark, so no harm in repeating it). It's a big tricky to see where else it fits, and thus I created a new section. 