### PR TITLE
Refs #2856 -- Removed redundant escaping in admin's "Perhaps it was deleted?" message.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -41,7 +41,7 @@ from django.urls import reverse
 from django.utils import six
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text, python_2_unicode_compatible
-from django.utils.html import escape, format_html
+from django.utils.html import format_html
 from django.utils.http import urlencode, urlquote
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst, format_lazy, get_text_list
@@ -1394,9 +1394,9 @@ class ModelAdmin(BaseModelAdmin):
         Create a message informing the user that the object doesn't exist
         and return a redirect to the admin index page.
         """
-        msg = _("%(name)s with ID %(key)s doesn't exist. Perhaps it was deleted?") % {
+        msg = _("""%(name)s with ID "%(key)s" doesn't exist. Perhaps it was deleted?""") % {
             'name': force_text(opts.verbose_name),
-            'key': escape(object_id),
+            'key': unquote(object_id),
         }
         self.message_user(request, msg, messages.WARNING)
         url = reverse('admin:index', current_app=self.admin_site.name)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -249,11 +249,11 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         model with an integer PK field) redirects to the index page with a
         message saying the object doesn't exist.
         """
-        response = self.client.get(reverse('admin:admin_views_section_change', args=('abc',)), follow=True)
+        response = self.client.get(reverse('admin:admin_views_section_change', args=(quote("abc/<b>"),)), follow=True)
         self.assertRedirects(response, reverse('admin:index'))
         self.assertEqual(
             [m.message for m in response.context['messages']],
-            ["section with ID abc doesn't exist. Perhaps it was deleted?"]
+            ["""section with ID "abc/<b>" doesn't exist. Perhaps it was deleted?"""]
         )
 
     def test_basic_edit_GET_old_url_redirect(self):
@@ -274,7 +274,7 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertRedirects(response, reverse('admin:index'))
         self.assertEqual(
             [m.message for m in response.context['messages']],
-            ["super villain with ID abc doesn't exist. Perhaps it was deleted?"]
+            ["""super villain with ID "abc" doesn't exist. Perhaps it was deleted?"""]
         )
 
     def test_basic_add_POST(self):
@@ -1801,7 +1801,7 @@ class AdminViewPermissionsTest(TestCase):
         self.assertRedirects(response, reverse('admin:index'))
         self.assertEqual(
             [m.message for m in response.context['messages']],
-            ["article with ID nonexistent doesn't exist. Perhaps it was deleted?"]
+            ["""article with ID "nonexistent" doesn't exist. Perhaps it was deleted?"""]
         )
 
     def test_history_view(self):
@@ -1849,7 +1849,7 @@ class AdminViewPermissionsTest(TestCase):
         self.assertRedirects(response, reverse('admin:index'))
         self.assertEqual(
             [m.message for m in response.context['messages']],
-            ["article with ID foo doesn't exist. Perhaps it was deleted?"]
+            ["""article with ID "foo" doesn't exist. Perhaps it was deleted?"""]
         )
 
     def test_conditionally_show_add_section_link(self):
@@ -3638,7 +3638,7 @@ class AdminCustomQuerysetTest(TestCase):
                 self.assertRedirects(response, reverse('admin:index'))
                 self.assertEqual(
                     [m.message for m in response.context['messages']],
-                    ["empty model with ID 1 doesn't exist. Perhaps it was deleted?"]
+                    ["""empty model with ID "1" doesn't exist. Perhaps it was deleted?"""]
                 )
 
     def test_add_model_modeladmin_defer_qs(self):


### PR DESCRIPTION
As reported by Florian: 

> I think this results in double escaping -- it is hard to spot since the admin applies weird quoting, but ' (single apostrophe) in the object_id now ends up as `&#39;`. Do you see any downside to removing escape here?
> Even preferably, can we unquote the `object_id`, if you enter:
> ```
> <script type="text/javascript">alert('1');</script>
> ```
> you end up with
> ```
>  _3Cscript type_3D_22text_2Fjavascript_22_3Ealert(&#39;1&#39;)_3B_3C_2Fscript_3E
> ```
> in the change message (maybe also add some quotes around like the normal views do: XXX with ID "YYY" > go successfully added)