### PR TITLE
Add autoreload file tracking options setting

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -102,7 +102,8 @@ def gen_filenames(only_new=False):
     new_filenames = clean_files(
         [filename.__file__ for filename in new_modules
          if hasattr(filename, '__file__')])
-    new_filenames = new_filenames + settings.WATCH_FILES
+    if hasattr('WATCH_FILES'):
+        new_filenames = new_filenames + settings.WATCH_FILES
 
     if not _cached_filenames and settings.USE_I18N:
         # Add the names of the .mo files that can be generated

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -102,7 +102,7 @@ def gen_filenames(only_new=False):
     new_filenames = clean_files(
         [filename.__file__ for filename in new_modules
          if hasattr(filename, '__file__')])
-    if hasattr('WATCH_FILES'):
+    if hasattr(settings, 'WATCH_FILES'):
         new_filenames = new_filenames + settings.WATCH_FILES
 
     if not _cached_filenames and settings.USE_I18N:

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -102,6 +102,7 @@ def gen_filenames(only_new=False):
     new_filenames = clean_files(
         [filename.__file__ for filename in new_modules
          if hasattr(filename, '__file__')])
+    new_filenames = new_filenames + settings.WATCH_FILES
 
     if not _cached_filenames and settings.USE_I18N:
         # Add the names of the .mo files that can be generated


### PR DESCRIPTION
Right now, Django only tracks Python module files for autoreload during development.  As a project starts to include more custom files, such as Javascript, SQL, Makefiles, etc.., the autoreload function doesn't apply to these.

With this pull request, we can add a manual list of files to track for autoreload.  

In your project's settings.py file, assign a variable TRACK_FILES containing a list of full file paths to track.  This will track files to autoreload the development run server as these files are updated.