### PR TITLE
Fixed #27690 -- Removed sleep before test db drop

### DIFF
--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 from django.apps import apps
 from django.conf import settings
@@ -277,8 +276,6 @@ class BaseDatabaseCreation(object):
         # to do so, because it's not allowed to delete a database while being
         # connected to it.
         with self.connection._nodb_connection.cursor() as cursor:
-            # Wait to avoid "database is being accessed by other users" errors.
-            time.sleep(1)
             cursor.execute("DROP DATABASE %s"
                            % self.connection.ops.quote_name(test_database_name))
 


### PR DESCRIPTION
Removed the call to `time.sleep` before dropping the test db