### PR TITLE
Fixed #25006 -- Allowed custom time shortcuts in admin's time picker.

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -8,6 +8,15 @@
         calendars: [],
         calendarInputs: [],
         clockInputs: [],
+        clockHours: {
+            default_: [
+                ['Now', -1],
+                ['Midnight', 0],
+                ['6 a.m.', 6],
+                ['Noon', 12],
+                ['6 p.m.', 18]
+            ]
+        },
         dismissClockFunc: [],
         dismissCalendarFunc: [],
         calendarDivName1: 'calendarbox', // name of calendar <div> that gets toggled
@@ -157,30 +166,16 @@
             quickElement('h2', clock_box, gettext('Choose a time'));
             var time_list = quickElement('ul', clock_box);
             time_list.className = 'timelist';
-            var time_link = quickElement("a", quickElement("li", time_list), gettext("Now"), "href", "#");
-            addEvent(time_link, 'click', function(e) {
-                e.preventDefault();
-                DateTimeShortcuts.handleClockQuicklink(num, -1);
-            });
-            time_link = quickElement("a", quickElement("li", time_list), gettext("Midnight"), "href", "#");
-            addEvent(time_link, 'click', function(e) {
-                e.preventDefault();
-                DateTimeShortcuts.handleClockQuicklink(num, 0);
-            });
-            time_link = quickElement("a", quickElement("li", time_list), gettext("6 a.m."), "href", "#");
-            addEvent(time_link, 'click', function(e) {
-                e.preventDefault();
-                DateTimeShortcuts.handleClockQuicklink(num, 6);
-            });
-            time_link = quickElement("a", quickElement("li", time_list), gettext("Noon"), "href", "#");
-            addEvent(time_link, 'click', function(e) {
-                e.preventDefault();
-                DateTimeShortcuts.handleClockQuicklink(num, 12);
-            });
-            time_link = quickElement("a", quickElement("li", time_list), gettext("6 p.m."), "href", "#");
-            addEvent(time_link, 'click', function(e) {
-                e.preventDefault();
-                DateTimeShortcuts.handleClockQuicklink(num, 18);
+            // The list of choices can be overridden in JavaScript like this:
+            // DateTimeShortcuts.clockHours.name = [['3 a.m.', 3]];
+            // where name is the name attribute of the <input>.
+            var name = typeof DateTimeShortcuts.clockHours[inp.name] === 'undefined' ? 'default_' : inp.name;
+            DateTimeShortcuts.clockHours[name].forEach(function(element) {
+                var time_link = quickElement('a', quickElement('li', time_list), gettext(element[0]), 'href', '#');
+                addEvent(time_link, 'click', function(e) {
+                    e.preventDefault();
+                    DateTimeShortcuts.handleClockQuicklink(num, element[1]);
+                });
             });
 
             var cancel_p = quickElement('p', clock_box);

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -21,3 +21,12 @@ QUnit.test('init', function(assert) {
     // should be 0 when a timezone offset isn't set in the HTML body attribute.
     assert.equal(DateTimeShortcuts.timezoneOffset, 0);
 });
+
+QUnit.test('custom time shortcuts', function(assert) {
+    var $ = django.jQuery;
+    var timeField = $('<input type="text" name="time_test" class="vTimeField">');
+    $('#qunit-fixture').append(timeField);
+    DateTimeShortcuts.clockHours.time_test = [['3 a.m.', 3]];
+    DateTimeShortcuts.init();
+    assert.equal($('.clockbox').find('a').first().text(), '3 a.m.');
+});


### PR DESCRIPTION
The list of hours can be overridden for each field in javascript like this:
```
DateTimeShortcuts.clockHours.name = [
    ['3 a.m.', 3]
]
```
where name is the name attribute of the input tag.