### PR TITLE
Fixed #27686 -- Fixed Vary: Cookie header being sent needlessly on empty sessions.

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -41,7 +41,9 @@ class SessionMiddleware(MiddlewareMixin):
                     domain=settings.SESSION_COOKIE_DOMAIN,
                 )
             else:
-                if accessed:
+                # Only set Vary: Cookie if the is there is a non-empty session.
+                # If it is empty then there is no reason to set header
+                if accessed and not empty:
                     patch_vary_headers(response, ('Cookie',))
                 if (modified or settings.SESSION_SAVE_EVERY_REQUEST) and not empty:
                     if request.session.get_expire_at_browser_close():

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -849,7 +849,6 @@ class SessionMiddlewareTests(TestCase):
 
         # Handle the response through the middleware
         response = session_middleware.process_response(request, response)
-        print response
         self.assertNotIn("Vary", response)
 
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -852,6 +852,7 @@ class SessionMiddlewareTests(TestCase):
         print response
         self.assertNotIn("Vary", response)
 
+
 # Don't need DB flushing for these tests, so can use unittest.TestCase as base class
 class CookieSessionTests(SessionTestsMixin, unittest.TestCase):
 

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -8,6 +8,7 @@ import unittest
 from datetime import timedelta
 
 from django.conf import settings
+from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.sessions.backends.base import UpdateError
 from django.contrib.sessions.backends.cache import SessionStore as CacheSession
 from django.contrib.sessions.backends.cached_db import \
@@ -789,8 +790,6 @@ class SessionMiddlewareTests(TestCase):
 
         # A cookie should not be set.
         self.assertEqual(response.cookies, {})
-        # The session is accessed so "Vary: Cookie" should be set.
-        self.assertEqual(response['Vary'], 'Cookie')
 
     def test_empty_session_saved(self):
         """
@@ -831,6 +830,27 @@ class SessionMiddlewareTests(TestCase):
         )
         self.assertEqual(response['Vary'], 'Cookie')
 
+    def test_calling_is_authenticated_gives_no_vary_header(self):
+        """
+        No vary header should be returned for an anonymous user with no
+        session
+        """
+        request = RequestFactory().get('/')
+        response = HttpResponse('Session test')
+        session_middleware = SessionMiddleware()
+        authentication_middleware = AuthenticationMiddleware()
+
+        # Simulate a request that passes to auth middleware to add a user
+        session_middleware.process_request(request)
+        authentication_middleware.process_request(request)
+
+        # Calling to see if the user is authenticated
+        request.user.is_authenticated
+
+        # Handle the response through the middleware
+        response = session_middleware.process_response(request, response)
+        print response
+        self.assertNotIn("Vary", response)
 
 # Don't need DB flushing for these tests, so can use unittest.TestCase as base class
 class CookieSessionTests(SessionTestsMixin, unittest.TestCase):


### PR DESCRIPTION
- The sessions middleware was sending vary by cookie header even
when there was an empty session and no cookie being sent,
interfering with downstream caching.

- This fix will ensure that there is a non empty session before
sending the vary by cookie header