### PR TITLE
Fixed #27655 - Mentioned the preference for single quote strings in the documentation

### DIFF
--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -297,6 +297,9 @@ Miscellaneous
 * Mark all strings for internationalization; see the :doc:`i18n
   documentation </topics/i18n/index>` for details.
 
+* Use single quotes for strings instead of double quotes unless the string
+  contains single quotes.
+
 * Remove ``import`` statements that are no longer used when you change code.
   `flake8`_ will identify these imports for you. If an unused import needs to
   remain for backwards-compatibility, mark the end of with ``# NOQA`` to


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27655
As the ticket mentions, the preferred use of single quotes over double quotes is not explicitly mentioned in the documentation. I thought this was a nice first commit to familiarize myself with the contributing workflow.

This was a pretty simple change but any comments welcomed : )