### PR TITLE
Reenabled support for Jinja 2.9 (requires 2.9.2 or higher) in test re…

### DIFF
--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -2,7 +2,7 @@ argon2-cffi >= 16.1.0
 bcrypt
 docutils
 geoip2
-jinja2 >= 2.7,<2.9
+jinja2 >= 2.7
 numpy
 Pillow
 PyYAML


### PR DESCRIPTION
…quirements