### PR TITLE
Fixed #27699 -- Fixed parse_duration() with a negative number of seconds.

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -30,9 +30,9 @@ datetime_re = re.compile(
 standard_duration_re = re.compile(
     r'^'
     r'(?:(?P<days>-?\d+) (days?, )?)?'
-    r'((?:(?P<hours>\d+):)(?=\d+:\d+))?'
-    r'(?:(?P<minutes>\d+):)?'
-    r'(?P<seconds>\d+)'
+    r'((?:(?P<hours>-?\d+):)(?=-?\d+:-?\d+))?'
+    r'(?:(?P<minutes>-?\d+):)?'
+    r'(?P<seconds>-?\d+)'
     r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
     r'$'
 )
@@ -122,8 +122,10 @@ def parse_duration(value):
         match = iso8601_duration_re.match(value)
     if match:
         kw = match.groupdict()
-        sign = -1 if kw.pop('sign', '+') == '-' else 1
+        """sign = -1 if kw.pop('sign', '+') == '-' else 1"""
         if kw.get('microseconds'):
             kw['microseconds'] = kw['microseconds'].ljust(6, '0')
+        if kw.get('seconds') and kw['seconds'].startswith('-') and kw.get('microseconds'):
+            kw['microseconds']='-'.__add__(kw['microseconds'])
         kw = {k: float(v) for k, v in six.iteritems(kw) if v is not None}
-        return sign * datetime.timedelta(**kw)
+        return datetime.timedelta(**kw)

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -108,6 +108,12 @@ class DurationParseTests(unittest.TestCase):
 
     def test_negative(self):
         self.assertEqual(parse_duration('-4 15:30'), timedelta(days=-4, minutes=15, seconds=30))
+		self.assertEqual(parse_duration('-8 10:15:30'), timedelta(days=-8, hours=10, minutes=15, seconds=30))
+		self.assertEqual(parse_duration('-172800'), timedelta(seconds=-172800))
+		self.assertEqual(parse_duration('-8 -15:30'), timedelta(days=-8, minutes=-15, seconds=30))
+		self.assertEqual(parse_duration('-8 10:15:-30'), timedelta(days=-8, hours=10, minutes=15, seconds=-30))
+		self.assertEqual(parse_duration('10:15:-30.0001'), timedelta(hours=10, minutes=15, seconds=-30, milliseconds=-0.0001))
+		self.assertEqual(parse_duration('-8 10:15:30'), timedelta(days=-8, hours=10, minutes=15, seconds=30))
 
     def test_iso_8601(self):
         self.assertIsNone(parse_duration('P4Y'))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27699