### PR TITLE
Refs #15667 -- Removed hardcoded icon size for related widget wrapper.

### DIFF
--- a/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
+++ b/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
@@ -6,21 +6,21 @@
         <a class="related-widget-wrapper-link change-related" id="change_id_{{ widget.name }}"
             data-href-template="{{ change_related_template_url }}?{{ url_params }}"
             title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-changelink.svg' %}" width="10" height="10" alt="{% trans 'Change' %}"/>
+            <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}"/>
         </a>
         {% endif %}
         {% if can_add_related %}
         <a class="related-widget-wrapper-link add-related" id="add_id_{{ widget.name }}"
             href="{{ add_related_url }}?{{ url_params }}"
             title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-addlink.svg' %}" width="10" height="10" alt="{% trans 'Add' %}"/>
+            <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}"/>
         </a>
         {% endif %}
         {% if can_delete_related %}
         <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ widget.name }}"
             data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
             title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-deletelink.svg' %}" width="10" height="10" alt="{% trans 'Delete' %}"/>
+            <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}"/>
         </a>
         {% endif %}
     {% endblock %}


### PR DESCRIPTION
Just noticed that all icons in Related Widget became smaller. Probably `width` and `height` were added accidentally [here](https://github.com/django/django/commit/b52c73008a9d67e9ddbb841872dc15cdd3d6ee01#diff-5259f408db66c0fd643a9b52c2743a34) during template-based widgets development.

It's trivial change, let me know if I need to create ticket in Trac for this.