### PR TITLE
Change case of full capital sentence in doc examples

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -513,11 +513,9 @@ the intermediate model::
 Unlike normal many-to-many fields, you *can't* use ``add()``, ``create()``,
 or ``set()`` to create relationships::
 
-    >>> # THIS WILL NOT WORK
+    >>> # The following statements will not work
     >>> beatles.members.add(john)
-    >>> # NEITHER WILL THIS
     >>> beatles.members.create(name="George Harrison")
-    >>> # AND NEITHER WILL THIS
     >>> beatles.members.set([john, paul, ringo, george])
 
 Why? You can't just create a relationship between a ``Person`` and a ``Group``
@@ -539,7 +537,7 @@ information as to which intermediate model instance should be deleted::
     ...     invite_reason="You've been gone for a month and we miss you.")
     >>> beatles.members.all()
     <QuerySet [<Person: Ringo Starr>, <Person: Paul McCartney>, <Person: Ringo Starr>]>
-    >>> # THIS WILL NOT WORK BECAUSE IT CANNOT TELL WHICH MEMBERSHIP TO REMOVE
+    >>> # This will not work because it cannot tell which membership to remove
     >>> beatles.members.remove(ringo)
 
 However, the :meth:`~django.db.models.fields.related.RelatedManager.clear`

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -1059,7 +1059,7 @@ introduce joins when you use ``F()`` objects in an update -- you can only
 reference fields local to the model being updated. If you attempt to introduce
 a join with an ``F()`` object, a ``FieldError`` will be raised::
 
-    # THIS WILL RAISE A FieldError
+    # This will raise a FieldError
     >>> Entry.objects.update(headline=F('blog__name'))
 
 .. _topics-db-queries-related:


### PR DESCRIPTION
Cosmetic change, so I won't create a Trac ticket for that.

I'm wondering however if some conventions exist about the presence of `>>>` at the beginning of snippet. Some documentation pages does not include them (e.g https://docs.djangoproject.com/en/1.10/topics/db/queries/) while this one has them almost everywhere.