### PR TITLE
Fixed #27683 -- Allowed transaction isolation level to be chosen on MySQL

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -18,7 +18,9 @@ from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils import six, timezone
-from django.utils.deprecation import RemovedInDjango20Warning
+from django.utils.deprecation import (
+    RemovedInDjango20Warning, RemovedInDjango21Warning,
+)
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.safestring import SafeBytes, SafeText
@@ -276,6 +278,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             # levels, and in that form we say "set tx_isolation='repeatable-read'" rather
             # than "set transaction isolation level repeatable read"
             self.isolation_level_value = "'%s'" % self.isolation_level.replace(' ', '-')
+        else:
+            if 'isolation_level' not in settings_dict['OPTIONS']:
+                warnings.warn(
+                    "Django's default transaction isolation level on MySQL is going to "
+                    "change from REPEATABLE READ (MySQL's default) to READ COMMITTED. "
+                    "Specify an explicit level by setting 'isolation_level' in "
+                    "'OPTIONS' in the connection settings.", RemovedInDjango21Warning)
         kwargs.update(options)
         return kwargs
 

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -6,12 +6,14 @@ MySQLdb is supported for Python 2 only: http://sourceforge.net/projects/mysql-py
 """
 from __future__ import unicode_literals
 
+import copy
 import datetime
 import re
 import sys
 import warnings
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
@@ -24,7 +26,6 @@ from django.utils.safestring import SafeBytes, SafeText
 try:
     import MySQLdb as Database
 except ImportError as e:
-    from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured(
         'Error loading MySQLdb module: %s.\n'
         'Did you install mysqlclient or MySQL-python?' % e
@@ -48,7 +49,6 @@ from .validation import DatabaseValidation                  # isort:skip
 version = Database.version_info
 if (version < (1, 2, 1) or (
         version[:3] == (1, 2, 1) and (len(version) < 5 or version[3] != 'final' or version[4] < 2))):
-    from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("MySQLdb-1.2.1p2 or newer is required; you have %s" % Database.__version__)
 
 
@@ -220,6 +220,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'iendswith': "LIKE CONCAT('%%', {})",
     }
 
+    isolation_levels = {
+        'read uncommitted',
+        'read committed',
+        'repeatable read',
+        'serializable',
+    }
+
     Database = Database
     SchemaEditorClass = DatabaseSchemaEditor
     # Classes instantiated in __init__().
@@ -253,7 +260,23 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # We need the number of potentially affected rows after an
         # "UPDATE", not the number of changed rows.
         kwargs['client_flag'] = CLIENT.FOUND_ROWS
-        kwargs.update(settings_dict['OPTIONS'])
+        # Special handling for transaction isolation level
+        options = copy.copy(settings_dict['OPTIONS'])
+        self.isolation_level = options.pop('isolation_level', None)
+        if self.isolation_level:
+            self.isolation_level = self.isolation_level.lower()
+            if self.isolation_level not in self.isolation_levels:
+                raise ImproperlyConfigured(
+                    "Invalid transaction isolation level '%s' specified.\n"
+                    "Use one of %s or None." % (
+                        self.isolation_level,
+                        ", ".join(repr(str(s)) for s in self.isolation_levels)
+                    ))
+            # We are going to use the var-assignment form of setting transaction isolation
+            # levels, and in that form we say "set tx_isolation='repeatable-read'" rather
+            # than "set transaction isolation level repeatable read"
+            self.isolation_level_value = "'%s'" % self.isolation_level.replace(' ', '-')
+        kwargs.update(options)
         return kwargs
 
     def get_new_connection(self, conn_params):
@@ -263,13 +286,20 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return conn
 
     def init_connection_state(self):
+        assignments = []
         if self.features.is_sql_auto_is_null_enabled:
+            # SQL_AUTO_IS_NULL controls whether an AUTO_INCREMENT column on
+            # a recently inserted row will return when the field is tested
+            # for NULL. Disabling this brings this aspect of MySQL in line
+            # with SQL standards.
+            assignments.append('SQL_AUTO_IS_NULL = 0')
+
+        if self.isolation_level:
+            assignments.append('TX_ISOLATION = %s' % self.isolation_level_value)
+
+        if assignments:
             with self.cursor() as cursor:
-                # SQL_AUTO_IS_NULL controls whether an AUTO_INCREMENT column on
-                # a recently inserted row will return when the field is tested
-                # for NULL. Disabling this brings this aspect of MySQL in line
-                # with SQL standards.
-                cursor.execute('SET SQL_AUTO_IS_NULL = 0')
+                cursor.execute('SET ' + ', '.join(assignments))
 
     def create_cursor(self):
         cursor = self.connection.cursor()

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -474,6 +474,32 @@ like other MySQL options: either in a config file or with the entry
 ``'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"`` in the
 :setting:`OPTIONS` part of your database configuration in :setting:`DATABASES`.
 
+.. _mysql-tx-isolation-level:
+
+Transaction isolation levels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.11
+
+When running concurrent loads, database transactions from different sessions
+(say, separate threads handling different requests) may interact with each
+other.  These interactions are affected by the respective sessions'
+`transaction isolation levels`_. You can set your connection's transaction
+isolation level via a ``'isolation_level'`` entry in the :setting:`OPTIONS`
+part of your database configuration in :setting:`DATABASES`. Valid values for
+this entry are the four standard isolation levels (``'read uncommitted'``,
+``'read committed'``, ``'repeatable read'`` and ``'serializable'``), or
+``None`` to explicitly use the server's configured default.
+
+.. _transaction isolation levels: https://dev.mysql.com/doc/refman/en/innodb-transaction-isolation-levels.html
+
+MySQL's default transaction isolation level, ``REPEATABLE READ``, implies some
+`surprising behaviors`_. The Django project recommends using the ``READ COMMITTED``
+transaction isolation level instead, and we intend to make it Django's default
+in a future release.
+
+.. _surprising behaviors: https://dev.mysql.com/doc/refman/en/innodb-consistent-read.html
+
 Creating your tables
 --------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -275,7 +275,8 @@ Database backends
 
 * Added the ``'isolation_level'`` setting in :setting:`OPTIONS` to
   let MySQL users specify the :ref:`transaction isolation level
-  <mysql-tx-isolation-level>`.
+  <mysql-tx-isolation-level>`. Also added a check to warn users against
+  using MySQL's ``REPEATABLE READ`` isolation level by default.
 
 Email
 ~~~~~

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -273,6 +273,10 @@ Database backends
 * Added the :setting:`TEST['TEMPLATE'] <TEST_TEMPLATE>` setting to let
   PostgreSQL users specify a template for creating the test database.
 
+* Added the ``'isolation_level'`` setting in :setting:`OPTIONS` to
+  let MySQL users specify the :ref:`transaction isolation level
+  <mysql-tx-isolation-level>`.
+
 Email
 ~~~~~
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -815,3 +815,9 @@ Miscellaneous
 * The ``renderer`` argument is added to the :meth:`Widget.render()
   <django.forms.Widget.render>` method. Methods that don't accept that argument
   will work through a deprecation period.
+
+* On MySQL, defaulting to MySQL's server-configured transaction isolation level
+  is deprecated because MySQL's own default for that is ``REPEATABLE READ``,
+  and the behavior under that level can be surprising and is inconsistent with
+  the default behavior of other backends. In Django 2.1, the default transaction
+  isolation level for MySQL will be ``READ COMMITTED``.

--- a/tests/backends/test_mysql.py
+++ b/tests/backends/test_mysql.py
@@ -23,27 +23,28 @@ class MySQLTests(TestCase):
         """
         Inspired by a similarly-named PostrgreSQL test in tests.py
         """
-        read_committed = 'READ COMMITTED'
-        repeatable_read = 'REPEATABLE READ'
+        read_committed = 'read committed'
+        repeatable_read = 'repeatable read'
 
         isolation_values = {
-            level: level.replace(' ', '-')
+            level: level.replace(' ', '-').upper()
             for level in (read_committed, repeatable_read)
         }
 
-        # This test assumes that MySQL is configured with the default isolation level.
+        configured_level = connection.isolation_level or repeatable_read
+        other_level = read_committed if configured_level != read_committed else repeatable_read
 
         with connection.cursor() as cursor:
             cursor.execute("SELECT @@session.tx_isolation")
             tx_isolation = cursor.fetchone()[0]
-        self.assertEqual(tx_isolation, isolation_values[repeatable_read])
+        self.assertEqual(tx_isolation, isolation_values[configured_level])
 
         new_connection = connection.copy()
-        new_connection.settings_dict['OPTIONS']['isolation_level'] = read_committed
+        new_connection.settings_dict['OPTIONS']['isolation_level'] = other_level
         try:
             with new_connection.cursor() as cursor:
                 cursor.execute("SELECT @@session.tx_isolation")
                 tx_isolation = cursor.fetchone()[0]
-            self.assertEqual(tx_isolation, isolation_values[read_committed])
+            self.assertEqual(tx_isolation, isolation_values[other_level])
         finally:
             new_connection.close()


### PR DESCRIPTION
Also added a deprecation warning and a check, both triggered when the
user isolation level is not specified. For now, the default level is
not changed.

Not quite sure about the duplication of a check and a deprecation warning
about the same thing, although they are each justified in their own right...