### PR TITLE
Fixed #27712 -- Reallowed Input widget's attrs argument to set the input type.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -268,6 +268,7 @@ class Input(Widget):
 
     def __init__(self, attrs=None):
         if attrs is not None:
+            attrs = attrs.copy()
             self.input_type = attrs.pop('type', self.input_type)
         super(Input, self).__init__(attrs)
 

--- a/tests/forms_tests/widget_tests/test_input.py
+++ b/tests/forms_tests/widget_tests/test_input.py
@@ -1,0 +1,25 @@
+from django.forms.widgets import Input
+
+from .base import WidgetTest
+
+
+class InputWidgetTests(WidgetTest):
+
+    def test_no_trailing_newline_in_attrs(self):
+        self.check_html(Input(), 'name', 'value', strict=True, html='<input type="None" name="name" value="value" />')
+
+    def test_attrs_with_type_passed(self):
+        attrs = {'type': 'date'}
+        widget = Input(attrs)
+        self.check_html(widget, 'name', 'value', html=(
+            '<input type="date" name="name" value="value" />'
+        ))
+        # reuse the same attrs for another widget
+        self.check_html(Input(attrs), 'name', 'value', html=(
+            '<input type="date" name="name" value="value" />'
+        ))
+        # shouldn't cause type of widget to become 'number'
+        attrs['type'] = 'number'
+        self.check_html(widget, 'name', 'value', html=(
+            '<input type="date" name="name" value="value" />'
+        ))

--- a/tests/forms_tests/widget_tests/test_widget.py
+++ b/tests/forms_tests/widget_tests/test_widget.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.forms import Widget
-from django.forms.widgets import Input
 
 from .base import WidgetTest
 
@@ -12,6 +11,3 @@ class WidgetTests(WidgetTest):
         widget = Widget()
         self.assertIs(widget.value_omitted_from_data({}, {}, 'field'), True)
         self.assertIs(widget.value_omitted_from_data({'field': 'value'}, {}, 'field'), False)
-
-    def test_no_trailing_newline_in_attrs(self):
-        self.check_html(Input(), 'name', 'value', strict=True, html='<input type="None" name="name" value="value" />')


### PR DESCRIPTION
Ticket [27712](https://code.djangoproject.com/ticket/27712).
Regression in b52c73008a9d67e9ddbb841872dc15cdd3d6ee01.