### PR TITLE
Fixed #27717 -- Allowed migration optimization across AlterModelOptions.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -151,6 +151,18 @@ class CreateModel(ModelOperation):
                     managers=self.managers,
                 ),
             ]
+        elif isinstance(operation, AlterModelOptions) and self.name_lower == operation.name_lower:
+            new_options = self.options.copy()
+            new_options.update(operation.options)
+            return [
+                CreateModel(
+                    self.name,
+                    fields=self.fields,
+                    options=new_options,
+                    bases=self.bases,
+                    managers=self.managers,
+                ),
+            ]
         elif isinstance(operation, FieldOperation) and self.name_lower == operation.model_name_lower:
             if isinstance(operation, AddField):
                 # Don't allow optimizations of FKs through models they reference

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -101,6 +101,17 @@ class OptimizerTests(SimpleTestCase):
             ],
         )
 
+    def test_create_alter_model_options(self):
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel('Foo', fields=[]),
+                migrations.AlterModelOptions(name='Foo', options={'verbose_name_plural': 'Foozes'}),
+            ],
+            [
+                migrations.CreateModel('Foo', fields=[], options={'verbose_name_plural': 'Foozes'}),
+            ]
+        )
+
     def _test_create_alter_foo_delete_model(self, alter_foo):
         """
         CreateModel, AlterModelTable, AlterUniqueTogether/AlterIndexTogether/


### PR DESCRIPTION
See [ticket #27717](https://code.djangoproject.com/ticket/27717).

Side note: Python 3.5's [PEP 448](https://www.python.org/dev/peps/pep-0448/) unpacking would be much cleaner here:
```python
options={**self.options, **operation.options}
```

One day!