### PR TITLE
Fixed #27723 -- Passed MultiWidget's attrs argument to widgets constructors to set the input type.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -808,9 +808,12 @@ class MultiWidget(Widget):
             value = self.decompress(value)
 
         final_attrs = context['widget']['attrs']
+        input_type = final_attrs.pop('type', None)
         id_ = final_attrs.get('id')
         subwidgets = []
         for i, widget in enumerate(self.widgets):
+            if input_type is not None:
+                widget.input_type = input_type
             widget_name = '%s_%s' % (name, i)
             try:
                 widget_value = value[i]

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -118,6 +118,19 @@ class MultiWidgetTest(WidgetTest):
             '<input id="bar_1" type="text" class="small" value="lennon" name="name_1" />'
         ))
 
+    def test_constructor_attrs_with_type(self):
+        attrs = {'type': 'number'}
+        widget = MyMultiWidget(widgets=(TextInput, TextInput()), attrs=attrs)
+        self.check_html(widget, 'code', ['1', '2'], html=(
+            '<input type="number" value="1" name="code_0" />'
+            '<input type="number" value="2" name="code_1" />'
+        ))
+        widget = MyMultiWidget(widgets=(TextInput(attrs), TextInput(attrs)), attrs={'class': 'bar'})
+        self.check_html(widget, 'code', ['1', '2'], html=(
+            '<input type="number" value="1" name="code_0" class="bar" />'
+            '<input type="number" value="2" name="code_1" class="bar" />'
+        ))
+
     def test_value_omitted_from_data(self):
         widget = MyMultiWidget(widgets=(TextInput(), TextInput()))
         self.assertIs(widget.value_omitted_from_data({}, {}, 'field'), True)


### PR DESCRIPTION
Ticket [27723](https://code.djangoproject.com/ticket/27723).
Regression in b52c73008a9d67e9ddbb841872dc15cdd3d6ee01.