### PR TITLE
Prevented database errors from being masked by cursor close

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -830,9 +830,14 @@ class SQLCompiler(object):
         try:
             cursor.execute(sql, params)
         except Exception:
-            with self.connection.wrap_database_errors:
-                # Closing a server-side cursor could yield an error
+            try:
+                # Might fail for server-side cursors (eg: connection closed)
                 cursor.close()
+            except Exception:
+                # Ignore clean-up errors. Raise the original error instead.
+                # Python 2 does not chain exception, remove error silencing
+                # when dropping backward compatibility for Python 2.
+                pass
             raise
 
         if result_type == CURSOR:


### PR DESCRIPTION
When an error occurred during the cursor.execute statement, the cursor
is closed. This operation did not fail with client-side cursors. Now,
with server-side cursors, the close operation might fail (example
below). The original error should be raised, not the one raised by
cursor.close(), this is only clean-up code.

For example, one can attempt to create a named cursor for an invalid
query. psycopg will raise an error about the invalid query and the
server-side cursor will not be created on PostgreSQL. When the code
attempts to cursor.close(), it asks psycopg to close the cursor, which
was not created. pyscopg raises a new error: psycopg2.OperationalError:
cursor "_django_curs_140365867840512_20" does not exist.