### PR TITLE
Refs #25226 -- Cloned ArrayField.base_field on deconstruction.

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -92,7 +92,7 @@ class ArrayField(Field):
         if path == 'django.contrib.postgres.fields.array.ArrayField':
             path = 'django.contrib.postgres.fields.ArrayField'
         kwargs.update({
-            'base_field': self.base_field,
+            'base_field': self.base_field.clone(),
             'size': self.size,
         })
         return name, path, args, kwargs

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -441,6 +441,7 @@ class TestMigrations(TransactionTestCase):
         name, path, args, kwargs = field.deconstruct()
         new = ArrayField(*args, **kwargs)
         self.assertEqual(type(new.base_field), type(field.base_field))
+        self.assertIsNot(new.base_field, field.base_field)
 
     def test_deconstruct_with_size(self):
         field = ArrayField(models.IntegerField(), size=3)


### PR DESCRIPTION
This will prevent the base_field from sharing attributes with the one used during migrations.

@timgraham this fixed the `--reverse` test suite for me on PostgreSQL.