### PR TITLE
Backport #27544 -- Fixed QuerySet.update(dt=F('dt') + timedelta) crash on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -212,7 +212,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         if value is not None:
             if not isinstance(value, datetime.datetime):
                 value = parse_datetime(value)
-            if settings.USE_TZ:
+            if settings.USE_TZ and not timezone.is_aware(value):
                 value = timezone.make_aware(value, self.connection.timezone)
         return value
 

--- a/docs/releases/1.9.13.txt
+++ b/docs/releases/1.9.13.txt
@@ -4,10 +4,13 @@ Django 1.9.13 release notes
 
 *Under development*
 
-Django 1.9.13 fixes a bug in 1.9.12.
+Django 1.9.13 fixes several bugs in 1.9.12.
 
 Bugfixes
 ========
 
 * Fixed a regression in the ``timesince`` and ``timeuntil`` filters that caused
   incorrect results for dates in a leap year (:ticket:`27637`).
+* Fixed a ``QuerySet.update()`` crash on SQLite when updating a
+  ``DateTimeField`` with an ``F()`` expression and a ``timedelta``
+  (:ticket:`27544`).

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -13,7 +13,7 @@ from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.db import connection, connections
-from django.db.models import Max, Min
+from django.db.models import F, Max, Min
 from django.http import HttpRequest
 from django.template import (
     Context, RequestContext, Template, TemplateSyntaxError, context_processors,
@@ -24,6 +24,7 @@ from django.test import (
 )
 from django.test.utils import requires_tz_support
 from django.utils import six, timezone
+from django.utils.timezone import timedelta
 
 from .forms import (
     EventForm, EventLocalizedForm, EventLocalizedModelForm, EventModelForm,
@@ -589,6 +590,13 @@ class NewDatabaseTests(TestCase):
         # Regression test for #17294
         e = MaybeEvent.objects.create()
         self.assertEqual(e.dt, None)
+
+    def test_update_with_timedelta(self):
+        initial_dt = timezone.now().replace(microsecond=0)
+        event = Event.objects.create(dt=initial_dt)
+        Event.objects.update(dt=F('dt') + timedelta(hours=2))
+        event.refresh_from_db()
+        self.assertEqual(event.dt, initial_dt + timedelta(hours=2))
 
 
 @override_settings(TIME_ZONE='Africa/Nairobi', USE_TZ=True)


### PR DESCRIPTION
This backports the fix for #27544 into the `stable/1.9.x` branch.