### PR TITLE
Add signals for Django management commands

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -12,6 +12,7 @@ from argparse import ArgumentParser
 import django
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management import signals
 from django.core.management.color import color_style, no_style
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.exceptions import MigrationSchemaMissing
@@ -305,6 +306,7 @@ class BaseCommand(object):
         controlled by the ``requires_system_checks`` attribute, except if
         force-skipped).
         """
+        signals.pre_command.send(sender=self.__class__, instance=self)
         if options['no_color']:
             self.style = no_style()
             self.stderr.style_func = None
@@ -340,6 +342,7 @@ class BaseCommand(object):
         finally:
             if saved_locale is not None:
                 translation.activate(saved_locale)
+        signals.post_command.send(sender=self.__class__, instance=self)
         return output
 
     def _run_checks(self, **kwargs):

--- a/django/core/management/signals.py
+++ b/django/core/management/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+pre_command = Signal(providing_args=['instance'], use_caching=True)
+post_command = Signal(providing_args=['instance'], use_caching=True)

--- a/tests/management_signals/tests.py
+++ b/tests/management_signals/tests.py
@@ -1,0 +1,34 @@
+from django.core.management import call_command, signals
+from django.test import SimpleTestCase, mock
+from django.utils.six import StringIO
+
+
+class ManagementSignalsTestCase(SimpleTestCase):
+
+    def setUp(self):
+        from django.core.management.commands.runserver import Command
+
+        def monkey_run(*args, **options):
+            return
+
+        self.output = StringIO()
+        self.cmd = Command(stdout=self.output)
+        self.cmd.run = monkey_run
+
+    def test_pre_command_signal(self):
+        handler = mock.Mock()
+        signals.pre_command.connect(handler, sender=self.cmd.__class__)
+        call_command(self.cmd, verbosity=0, interactive=False)
+        handler.assert_called_once()
+        args, kwargs = handler.call_args
+        self.assertEqual(kwargs['instance'], self.cmd)
+        self.assertEqual(kwargs['sender'], self.cmd.__class__)
+
+    def test_post_command_signal(self):
+        handler = mock.Mock()
+        signals.post_command.connect(handler, sender=self.cmd.__class__)
+        call_command(self.cmd, verbosity=0, interactive=False)
+        handler.assert_called_once()
+        args, kwargs = handler.call_args
+        self.assertEqual(kwargs['instance'], self.cmd)
+        self.assertEqual(kwargs['sender'], self.cmd.__class__)


### PR DESCRIPTION
This is a followup implementation of my suggestion: https://groups.google.com/d/msg/django-developers/JwYKEemPHFs/ATd_UKCaBAAJ

This PR contains no docs yet, but the usage example is following:

```python
from django.core.management import signals
from django.core.management.commands.runserver import \
    Command as RunserverCommand


def handle_pre(sender, instance):
    instance.stdout.write('Hello World')

def handle_post(sender, instance):
    instance.stdout.write('Bye World')

signals.pre_command.connect(handle_pre, sender=RunserverCommand)
signals.post_command.connect(handle_post, sender=RunserverCommand)
```

Please let me know what you think!