### PR TITLE
Fixed #27748 -- Switched HTTP error handlers to reference callables instead of strings.

### DIFF
--- a/django/conf/urls/__init__.py
+++ b/django/conf/urls/__init__.py
@@ -4,13 +4,14 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import (
     LocaleRegexURLResolver, RegexURLPattern, RegexURLResolver,
 )
+from django.views import defaults
 
 __all__ = ['handler400', 'handler403', 'handler404', 'handler500', 'include', 'url']
 
-handler400 = 'django.views.defaults.bad_request'
-handler403 = 'django.views.defaults.permission_denied'
-handler404 = 'django.views.defaults.page_not_found'
-handler500 = 'django.views.defaults.server_error'
+handler400 = defaults.bad_request
+handler403 = defaults.permission_denied
+handler404 = defaults.page_not_found
+handler500 = defaults.server_error
 
 
 def include(arg, namespace=None):

--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -90,12 +90,9 @@ A callable, or a string representing the full Python import path to the view
 that should be called if the HTTP client has sent a request that caused an error
 condition and a response with a status code of 400.
 
-By default, this is ``'django.views.defaults.bad_request'``. If you
+By default, this is :func:`django.views.defaults.bad_request`. If you
 implement a custom view, be sure it returns an
 :class:`~django.http.HttpResponseBadRequest`.
-
-See the documentation about :ref:`the 400 (bad request) view
-<http_bad_request_view>` for more information.
 
 ``handler403``
 ==============
@@ -106,12 +103,9 @@ A callable, or a string representing the full Python import path to the view
 that should be called if the user doesn't have the permissions required to
 access a resource.
 
-By default, this is ``'django.views.defaults.permission_denied'``. If you
+By default, this is :func:`django.views.defaults.permission_denied`. If you
 implement a custom view, be sure it returns an
 :class:`~django.http.HttpResponseForbidden`.
-
-See the documentation about :ref:`the 403 (HTTP Forbidden) view
-<http_forbidden_view>` for more information.
 
 ``handler404``
 ==============
@@ -121,12 +115,9 @@ See the documentation about :ref:`the 403 (HTTP Forbidden) view
 A callable, or a string representing the full Python import path to the view
 that should be called if none of the URL patterns match.
 
-By default, this is ``'django.views.defaults.page_not_found'``. If you
+By default, this is :func:`django.views.defaults.page_not_found`. If you
 implement a custom view, be sure it returns an
 :class:`~django.http.HttpResponseNotFound`.
-
-See the documentation about :ref:`the 404 (HTTP Not Found) view
-<http_not_found_view>` for more information.
 
 ``handler500``
 ==============
@@ -137,9 +128,6 @@ A callable, or a string representing the full Python import path to the view
 that should be called in case of server errors. Server errors happen when you
 have runtime errors in view code.
 
-By default, this is ``'django.views.defaults.server_error'``. If you
+By default, this is :func:`django.views.defaults.server_error`. If you
 implement a custom view, be sure it returns an
 :class:`~django.http.HttpResponseServerError`.
-
-See the documentation about :ref:`the 500 (HTTP Internal Server Error) view
-<http_internal_server_error_view>` for more information.

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -217,6 +217,10 @@ Miscellaneous
   functionality since session authentication is unconditionally enabled in
   Django 1.10.
 
+* The default HTTP error handlers (``handler404``, etc.) are now callables
+  instead of dotted Python path strings. Django favors callable references
+  since they provide better performance and debugging experience.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0


### PR DESCRIPTION
Updated version of https://github.com/django/django/pull/6206.
https://code.djangoproject.com/ticket/27748