### PR TITLE
Refs #27683 -- Allowed setting isolation level in DATABASES ['OPTIONS'] on MySQL.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -492,6 +492,32 @@ like other MySQL options: either in a config file or with the entry
 ``'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"`` in the
 :setting:`OPTIONS` part of your database configuration in :setting:`DATABASES`.
 
+.. _mysql-isolation-level:
+
+Isolation level
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.11
+
+When running concurrent loads, database transactions from different sessions
+(say, separate threads handling different requests) may interact with each
+other. These interactions are affected by each session's `transaction isolation
+level`_. You can set a connection's isolation level with an
+``'isolation_level'`` entry in the :setting:`OPTIONS` part of your database
+configuration in :setting:`DATABASES`. Valid values for
+this entry are the four standard isolation levels:
+
+* ``'read uncommitted'``
+* ``'read committed'``
+* ``'repeatable read'``
+* ``'serializable'``
+
+or ``None`` to use the server's configured isolation level. However, Django
+works best with read committed rather than MySQL's default, repeatable read.
+Data loss is possible with repeatable read.
+
+.. _transaction isolation level: https://dev.mysql.com/doc/refman/en/innodb-transaction-isolation-levels.html
+
 Creating your tables
 --------------------
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -255,6 +255,11 @@ Database backends
   the worker memory load (used to hold query results) to the database and might
   increase database memory usage.
 
+* Added MySQL support for the ``'isolation_level'`` option in
+  :setting:`OPTIONS` to allow specifying the :ref:`transaction isolation level
+  <mysql-isolation-level>`. To avoid possible data loss, it's recommended to
+  switch from MySQL's default level, repeatable read, to read committed.
+
 Email
 ~~~~~
 

--- a/tests/backends/test_mysql.py
+++ b/tests/backends/test_mysql.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import unittest
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db import connection
 from django.test import TestCase, override_settings
 
@@ -9,6 +10,12 @@ from django.test import TestCase, override_settings
 @override_settings(DEBUG=True)
 @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL specific test.')
 class MySQLTests(TestCase):
+
+    @staticmethod
+    def get_isolation_level(connection):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT @@session.tx_isolation")
+            return cursor.fetchone()[0]
 
     def test_auto_is_null_auto_config(self):
         query = 'set sql_auto_is_null = 0'
@@ -18,3 +25,42 @@ class MySQLTests(TestCase):
             self.assertIn(query, last_query)
         else:
             self.assertNotIn(query, last_query)
+
+    def test_connect_isolation_level(self):
+        read_committed = 'read committed'
+        repeatable_read = 'repeatable read'
+        isolation_values = {
+            level: level.replace(' ', '-').upper()
+            for level in (read_committed, repeatable_read)
+        }
+        configured_level = connection.isolation_level or isolation_values[repeatable_read]
+        configured_level = configured_level.upper()
+        other_level = read_committed if configured_level != isolation_values[read_committed] else repeatable_read
+
+        self.assertEqual(self.get_isolation_level(connection), configured_level)
+
+        new_connection = connection.copy()
+        new_connection.settings_dict['OPTIONS']['isolation_level'] = other_level
+        try:
+            self.assertEqual(self.get_isolation_level(new_connection), isolation_values[other_level])
+        finally:
+            new_connection.close()
+
+        # Upper case values are also accepted in 'isolation_level'.
+        new_connection = connection.copy()
+        new_connection.settings_dict['OPTIONS']['isolation_level'] = other_level.upper()
+        try:
+            self.assertEqual(self.get_isolation_level(new_connection), isolation_values[other_level])
+        finally:
+            new_connection.close()
+
+    def test_isolation_level_validation(self):
+        new_connection = connection.copy()
+        new_connection.settings_dict['OPTIONS']['isolation_level'] = 'xxx'
+        msg = (
+            "Invalid transaction isolation level 'xxx' specified.\n"
+            "Use one of 'read committed', 'read uncommitted', "
+            "'repeatable read', 'serializable', or None."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            new_connection.cursor()


### PR DESCRIPTION
Updated from https://github.com/django/django/pull/7826.