### PR TITLE
Refs #27537 -- Allowed easier overriding of default runserver address.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -29,6 +29,8 @@ class Command(BaseCommand):
     requires_system_checks = False
     leave_locale_alone = True
 
+    default_addr = '127.0.0.1'
+    default_addr_ipv6 = '::1'
     default_port = '8000'
     protocol = 'http'
     server_cls = WSGIServer
@@ -94,7 +96,7 @@ class Command(BaseCommand):
                 elif self.use_ipv6 and not _fqdn:
                     raise CommandError('"%s" is not a valid IPv6 address.' % self.addr)
         if not self.addr:
-            self.addr = '::1' if self.use_ipv6 else '127.0.0.1'
+            self.addr = self.default_addr_ipv6 if self.use_ipv6 else self.default_addr
             self._raw_ipv6 = self.use_ipv6
         self.run(**options)
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1314,6 +1314,18 @@ class ManageRunserver(AdminScriptTestCase):
         call_command(self.cmd, addrport="test.domain.local:7000", use_ipv6=True)
         self.assertServerSettings('test.domain.local', '7000', ipv6=True)
 
+    def test_runner_custom_defaults(self):
+        self.cmd.default_addr = '0.0.0.0'
+        self.cmd.default_port = '5000'
+        call_command(self.cmd)
+        self.assertServerSettings('0.0.0.0', '5000')
+
+    @unittest.skipUnless(socket.has_ipv6, "platform doesn't support IPv6")
+    def test_runner_custom_defaults_ipv6(self):
+        self.cmd.default_addr_ipv6 = '::'
+        call_command(self.cmd, use_ipv6=True)
+        self.assertServerSettings('::', '8000', ipv6=True, raw_ipv6=True)
+
     def test_runner_ambiguous(self):
         # Only 4 characters, all of which could be in an ipv6 address
         call_command(self.cmd, addrport="beef:7654")


### PR DESCRIPTION
Subclasses of the RunServer command can now alter the default address
without having to override `handle()`.