### PR TITLE
Refs #23919 -- Removed Python 2 workaround for hashing Oracle params.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -443,17 +443,12 @@ class FormatStylePlaceholderCursor(object):
             # values. It can be used only in single query execute() because
             # executemany() shares the formatted query with each of the params
             # list. e.g. for input params = [0.75, 2, 0.75, 'sth', 0.75]
-            # params_dict = {
-            #   (2, <type 'int'>): ':arg2',
-            #   (0.75, <type 'float'>): ':arg1',
-            #   ('sth', <type 'str'>): ':arg0',
-            # }
+            # params_dict = {0.75: ':arg0', 2: ':arg1', 'sth': ':arg2'}
             # args = [':arg0', ':arg1', ':arg0', ':arg2', ':arg0']
             # params = {':arg0': 0.75, ':arg1': 2, ':arg2': 'sth'}
-            params = [(param, type(param)) for param in params]
             params_dict = {param: ':arg%d' % i for i, param in enumerate(set(params))}
             args = [params_dict[param] for param in params]
-            params = {value: key[0] for key, value in params_dict.items()}
+            params = {value: key for key, value in params_dict.items()}
             query = query % tuple(args)
         else:
             # Handle params as sequence


### PR DESCRIPTION
In the Oracle backend we unified query parameters by their values. Hashing on Python 2 returns the same value for: ```hash(b'foo') == hash(u'foo')```, hence we added (4579c3f6b8d3a5ebd6c570836cd0552892eb0d61) tuple workaround based on parameters types and values (see [discussion](https://github.com/django/django/pull/7752#discussion_r94071557)).