### PR TITLE
Fixed #27775 -- Respect custom expiry in signed cookies.

### DIFF
--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -842,11 +842,6 @@ class CookieSessionTests(SessionTestsMixin, unittest.TestCase):
         """
         pass
 
-    @unittest.expectedFailure
-    def test_actual_expiry(self):
-        # The cookie backend doesn't handle non-default expiry dates, see #19201
-        super(CookieSessionTests, self).test_actual_expiry()
-
     def test_unpickling_exception(self):
         # signed_cookies backend should handle unpickle exceptions gracefully
         # by creating a new session


### PR DESCRIPTION
The custom expiry value `_session_expiry` is stored in the session
itself. The signed cookie needs to first be loaded, and then the value
needs to be checked for validity.

This PR calls `signing.loads()` twice which may incur a small performance
penalty. The proper solution would be to refactor the session expiry
as discussed in #19201. However, this fix should not really make that
refactor any harder an may be an acceptable fix in the meantime.

Refs #19200, #19201.