### PR TITLE
Refs #23919 -- Removed usage of django.utils.decorators.ContextDecorator.

### DIFF
--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -1,7 +1,8 @@
+from contextlib import ContextDecorator
+
 from django.db import (
     DEFAULT_DB_ALIAS, DatabaseError, Error, ProgrammingError, connections,
 )
-from django.utils.decorators import ContextDecorator
 
 
 class TransactionManagementError(ProgrammingError):

--- a/django/utils/decorators.py
+++ b/django/utils/decorators.py
@@ -1,10 +1,7 @@
 "Functions that help with dynamically creating decorators for views."
 
-try:
-    from contextlib import ContextDecorator
-except ImportError:
-    ContextDecorator = None
-
+# For backwards compatibility in Django 2.0.
+from contextlib import ContextDecorator  # noqa
 from functools import WRAPPER_ASSIGNMENTS, update_wrapper, wraps
 
 
@@ -164,21 +161,6 @@ def make_middleware_decorator(middleware_class):
             return _wrapped_view
         return _decorator
     return _make_decorator
-
-
-if ContextDecorator is None:
-    # ContextDecorator was introduced in Python 3.2
-    # See https://docs.python.org/3/library/contextlib.html#contextlib.ContextDecorator
-    class ContextDecorator:
-        """
-        A base class that enables a context manager to also be used as a decorator.
-        """
-        def __call__(self, func):
-            @wraps(func, assigned=available_attrs(func))
-            def inner(*args, **kwargs):
-                with self:
-                    return func(*args, **kwargs)
-            return inner
 
 
 class classproperty:

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -3,13 +3,13 @@ Timezone-related classes and functions.
 """
 
 import functools
+from contextlib import ContextDecorator
 from datetime import datetime, timedelta, tzinfo
 from threading import local
 
 import pytz
 
 from django.conf import settings
-from django.utils.decorators import ContextDecorator
 
 __all__ = [
     'utc', 'get_fixed_timezone',

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -3,8 +3,8 @@ Internationalization support.
 """
 import re
 import warnings
+from contextlib import ContextDecorator
 
-from django.utils.decorators import ContextDecorator
 from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.encoding import force_text
 from django.utils.functional import lazy


### PR DESCRIPTION
ContextDecorator is available in standard library from Python3.2