### PR TITLE
Refs #23919 -- Removed SessionBase.iterkeys(), itervalues(), iteritems().

### DIFF
--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -131,15 +131,6 @@ class SessionBase:
     def items(self):
         return self._session.items()
 
-    def iterkeys(self):
-        return self._session.iterkeys()
-
-    def itervalues(self):
-        return self._session.itervalues()
-
-    def iteritems(self):
-        return self._session.iteritems()
-
     def clear(self):
         # To avoid unnecessary persistent storage accesses, we set up the
         # internals directly (loading data wastes time, since we are going to

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -116,37 +116,27 @@ class SessionTestsMixin:
         self.assertEqual(list(self.session.values()), [])
         self.assertTrue(self.session.accessed)
         self.session['some key'] = 1
+        self.session.modified = False
+        self.session.accessed = False
         self.assertEqual(list(self.session.values()), [1])
+        self.assertTrue(self.session.accessed)
+        self.assertFalse(self.session.modified)
 
-    def test_iterkeys(self):
+    def test_keys(self):
         self.session['x'] = 1
         self.session.modified = False
         self.session.accessed = False
-        i = iter(self.session.keys())
-        self.assertTrue(hasattr(i, '__iter__'))
+        self.assertEqual(list(self.session.keys()), ['x'])
         self.assertTrue(self.session.accessed)
         self.assertFalse(self.session.modified)
-        self.assertEqual(list(i), ['x'])
 
-    def test_itervalues(self):
+    def test_items(self):
         self.session['x'] = 1
         self.session.modified = False
         self.session.accessed = False
-        i = iter(self.session.values())
-        self.assertTrue(hasattr(i, '__iter__'))
+        self.assertEqual(list(self.session.items()), [('x', 1)])
         self.assertTrue(self.session.accessed)
         self.assertFalse(self.session.modified)
-        self.assertEqual(list(i), [1])
-
-    def test_iteritems(self):
-        self.session['x'] = 1
-        self.session.modified = False
-        self.session.accessed = False
-        i = iter(self.session.items())
-        self.assertTrue(hasattr(i, '__iter__'))
-        self.assertTrue(self.session.accessed)
-        self.assertFalse(self.session.modified)
-        self.assertEqual(list(i), [('x', 1)])
 
     def test_clear(self):
         self.session['x'] = 1


### PR DESCRIPTION
These methods only work on Python 2.