### PR TITLE
Refs #23919 -- Replaced smart/force_text by smart/force_str.

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -22,7 +22,7 @@ class DjangoUnicodeDecodeError(UnicodeDecodeError):
 python_2_unicode_compatible = six.python_2_unicode_compatible
 
 
-def smart_text(s, encoding='utf-8', strings_only=False, errors='strict'):
+def smart_str(s, encoding='utf-8', strings_only=False, errors='strict'):
     """
     Returns a text object representing 's' -- unicode on Python 2 and str on
     Python 3. Treats bytestrings using the 'encoding' codec.
@@ -32,7 +32,7 @@ def smart_text(s, encoding='utf-8', strings_only=False, errors='strict'):
     if isinstance(s, Promise):
         # The input is the result of a gettext_lazy() call.
         return s
-    return force_text(s, encoding, strings_only, errors)
+    return force_str(s, encoding, strings_only, errors)
 
 
 _PROTECTED_TYPES = (
@@ -44,14 +44,14 @@ def is_protected_type(obj):
     """Determine if the object instance is of a protected type.
 
     Objects of protected types are preserved as-is when passed to
-    force_text(strings_only=True).
+    force_str(strings_only=True).
     """
     return isinstance(obj, _PROTECTED_TYPES)
 
 
-def force_text(s, encoding='utf-8', strings_only=False, errors='strict'):
+def force_str(s, encoding='utf-8', strings_only=False, errors='strict'):
     """
-    Similar to smart_text, except that lazy instances are resolved to
+    Similar to smart_str, except that lazy instances are resolved to
     strings, rather than kept as lazy objects.
 
     If strings_only is True, don't convert (some) non-string-like objects.
@@ -81,7 +81,7 @@ def force_text(s, encoding='utf-8', strings_only=False, errors='strict'):
             # working unicode method. Try to handle this without raising a
             # further exception by individually forcing the exception args
             # to unicode.
-            s = ' '.join(force_text(arg, encoding, strings_only, errors)
+            s = ' '.join(force_str(arg, encoding, strings_only, errors)
                          for arg in s)
     return s
 
@@ -132,18 +132,9 @@ def force_bytes(s, encoding='utf-8', strings_only=False, errors='strict'):
         return s.encode(encoding, errors)
 
 
-smart_str = smart_text
-force_str = force_text
-
-smart_str.__doc__ = """
-Apply smart_text in Python 3 and smart_bytes in Python 2.
-
-This is suitable for writing to sys.stdout (for instance).
-"""
-
-force_str.__doc__ = """
-Apply force_text in Python 3 and force_bytes in Python 2.
-"""
+# For backwards-compatibility.
+smart_text = smart_str
+force_text = force_str
 
 
 def iri_to_uri(iri):

--- a/docs/howto/custom-model-fields.txt
+++ b/docs/howto/custom-model-fields.txt
@@ -706,7 +706,7 @@ smoothly:
 
 2. Put a ``__str__()`` method on the class you're wrapping up as a field. There
    are a lot of places where the default behavior of the field code is to call
-   :func:`~django.utils.encoding.force_text` on the value. (In our
+   :func:`~django.utils.encoding.force_str` on the value. (In our
    examples in this document, ``value`` would be a ``Hand`` instance, not a
    ``HandField``). So if your ``__str__()`` method automatically converts to
    the string form of your Python object, you can save yourself a lot of work.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2010,7 +2010,7 @@ unpredictable value.
 randomly-generated ``SECRET_KEY`` to each new project.
 
 Uses of the key shouldn't assume that it's text or bytes. Every use should go
-through :func:`~django.utils.encoding.force_text` or
+through :func:`~django.utils.encoding.force_str` or
 :func:`~django.utils.encoding.force_bytes` to convert it to the desired type.
 
 Django will refuse to start if :setting:`SECRET_KEY` is not set.

--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -111,7 +111,7 @@ Conversion functions
 The ``django.utils.encoding`` module contains a few functions that are handy
 for converting back and forth between Unicode and bytestrings.
 
-* ``smart_text(s, encoding='utf-8', strings_only=False, errors='strict')``
+* ``smart_str(s, encoding='utf-8', strings_only=False, errors='strict')``
   converts its input to a Unicode string. The ``encoding`` parameter
   specifies the input encoding. (For example, Django uses this internally
   when processing form input data, which might not be UTF-8 encoded.) The
@@ -121,24 +121,24 @@ for converting back and forth between Unicode and bytestrings.
   that are accepted by Python's ``str()`` function for its error
   handling.
 
-* ``force_text(s, encoding='utf-8', strings_only=False,
-  errors='strict')`` is identical to ``smart_text()`` in almost all
+* ``force_str(s, encoding='utf-8', strings_only=False,
+  errors='strict')`` is identical to ``smart_str()`` in almost all
   cases. The difference is when the first argument is a :ref:`lazy
-  translation <lazy-translations>` instance. While ``smart_text()``
-  preserves lazy translations, ``force_text()`` forces those objects to a
+  translation <lazy-translations>` instance. While ``smart_str()``
+  preserves lazy translations, ``force_str()`` forces those objects to a
   Unicode string (causing the translation to occur). Normally, you'll want
-  to use ``smart_text()``. However, ``force_text()`` is useful in
+  to use ``smart_str()``. However, ``force_str()`` is useful in
   template tags and filters that absolutely *must* have a string to work
   with, not just something that can be converted to a string.
 
 * ``smart_bytes(s, encoding='utf-8', strings_only=False, errors='strict')``
-  is essentially the opposite of ``smart_text()``. It forces the first
+  is essentially the opposite of ``smart_str()``. It forces the first
   argument to a bytestring. The ``strings_only`` parameter has the same
-  behavior as for ``smart_text()`` and ``force_text()``. This is
+  behavior as for ``smart_str()`` and ``force_str()``. This is
   slightly different semantics from Python's builtin ``str()`` function,
   but the difference is needed in a few places within Django's internals.
 
-Normally, you'll only need to use ``force_text()``. Call it as early as
+Normally, you'll only need to use ``force_str()``. Call it as early as
 possible on any input data that might be either Unicode or a bytestring, and
 from then on, you can treat the result as always being Unicode.
 
@@ -297,7 +297,7 @@ A couple of tips to remember when writing your own template tags and filters:
 * Always return Unicode strings from a template tag's ``render()`` method
   and from template filters.
 
-* Use ``force_text()`` in preference to ``smart_text()`` in these
+* Use ``force_str()`` in preference to ``smart_str()`` in these
   places. Tag rendering and filter calls occur as the template is being
   rendered, so there is no advantage to postponing the conversion of lazy
   translation objects into strings. It's easier to work solely with Unicode

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -201,7 +201,7 @@ The functions defined in this module share the following properties:
     To support Python 2 and 3 with a single code base, define a ``__str__``
     method returning text and apply this decorator to the class.
 
-.. function:: smart_text(s, encoding='utf-8', strings_only=False, errors='strict')
+.. function:: smart_str(s, encoding='utf-8', strings_only=False, errors='strict')
 
     Returns a ``str`` object representing ``s``. Treats bytestrings using the
     ``encoding`` codec.
@@ -214,11 +214,11 @@ The functions defined in this module share the following properties:
     Determine if the object instance is of a protected type.
 
     Objects of protected types are preserved as-is when passed to
-    ``force_text(strings_only=True)``.
+    ``force_str(strings_only=True)``.
 
-.. function:: force_text(s, encoding='utf-8', strings_only=False, errors='strict')
+.. function:: force_str(s, encoding='utf-8', strings_only=False, errors='strict')
 
-    Similar to ``smart_text``, except that lazy instances are resolved to
+    Similar to ``smart_str``, except that lazy instances are resolved to
     strings, rather than kept as lazy objects.
 
     If ``strings_only`` is ``True``, don't convert (some) non-string-like
@@ -240,22 +240,15 @@ The functions defined in this module share the following properties:
     If ``strings_only`` is ``True``, don't convert (some) non-string-like
     objects.
 
-.. function:: smart_str(s, encoding='utf-8', strings_only=False, errors='strict')
+.. function:: smart_text(s, encoding='utf-8', strings_only=False, errors='strict')
 
-    Alias of :func:`smart_text`. This function returns a ``str`` or a lazy
-    string.
+    Alias of :func:`force_str` for backwards-compatibility, especially in code
+    that still supports Python 2.
 
-    For instance, this is suitable for writing to :data:`sys.stdout`.
+.. function:: force_text(s, encoding='utf-8', strings_only=False, errors='strict')
 
-    Alias of :func:`smart_bytes` on Python 2 (in older versions of Django that
-    support it).
-
-.. function:: force_str(s, encoding='utf-8', strings_only=False, errors='strict')
-
-    Alias of :func:`force_text`. This function always returns a ``str``.
-
-    Alias of :func:`force_bytes` on Python 2 (in older versions of Django that
-    support it).
+    Alias of :func:`force_str` for backwards-compatibility, especially in code
+    that still supports Python 2.
 
 .. function:: iri_to_uri(iri)
 
@@ -590,7 +583,7 @@ escaping HTML.
 
     Returns the given text with ampersands, quotes and angle brackets encoded
     for use in HTML. The input is first passed through
-    :func:`~django.utils.encoding.force_text` and the output has
+    :func:`~django.utils.encoding.force_str` and the output has
     :func:`~django.utils.safestring.mark_safe` applied.
 
 .. function:: conditional_escape(text)
@@ -632,7 +625,7 @@ escaping HTML.
     interpolation, some of the formatting options provided by ``str.format()``
     (e.g. number formatting) will not work, since all arguments are passed
     through :func:`conditional_escape` which (ultimately) calls
-    :func:`~django.utils.encoding.force_text` on the values.
+    :func:`~django.utils.encoding.force_str` on the values.
 
 .. function:: format_html_join(sep, format_string, args_generator)
 

--- a/docs/topics/serialization.txt
+++ b/docs/topics/serialization.txt
@@ -256,13 +256,13 @@ For example, if you have some custom type in an object to be serialized, you'll
 have to write a custom :mod:`json` encoder for it. Something like this will
 work::
 
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_str
     from django.core.serializers.json import DjangoJSONEncoder
 
     class LazyEncoder(DjangoJSONEncoder):
         def default(self, obj):
             if isinstance(obj, YourCustomType):
-                return force_text(obj)
+                return force_str(obj)
             return super().default(obj)
 
 You can then pass ``cls=LazyEncoder`` to the ``serializers.serialize()``

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -2,15 +2,15 @@ import datetime
 import unittest
 
 from django.utils.encoding import (
-    escape_uri_path, filepath_to_uri, force_bytes, force_text, iri_to_uri,
-    smart_text, uri_to_iri,
+    escape_uri_path, filepath_to_uri, force_bytes, force_str, iri_to_uri,
+    smart_str, uri_to_iri,
 )
 from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlquote_plus
 
 
 class TestEncodingUtils(unittest.TestCase):
-    def test_force_text_exception(self):
+    def test_force_str_exception(self):
         """
         Broken __str__ actually raises an error.
         """
@@ -20,11 +20,11 @@ class TestEncodingUtils(unittest.TestCase):
 
         # str(s) raises a TypeError if the result is not a text type.
         with self.assertRaises(TypeError):
-            force_text(MyString())
+            force_str(MyString())
 
-    def test_force_text_lazy(self):
+    def test_force_str_lazy(self):
         s = SimpleLazyObject(lambda: 'x')
-        self.assertTrue(type(force_text(s)), str)
+        self.assertTrue(type(force_str(s)), str)
 
     def test_force_bytes_exception(self):
         """
@@ -40,7 +40,7 @@ class TestEncodingUtils(unittest.TestCase):
         today = datetime.date.today()
         self.assertEqual(force_bytes(today, strings_only=True), today)
 
-    def test_smart_text(self):
+    def test_smart_str(self):
         class Test:
             def __str__(self):
                 return 'ŠĐĆŽćžšđ'
@@ -52,10 +52,10 @@ class TestEncodingUtils(unittest.TestCase):
             def __bytes__(self):
                 return b'Foo'
 
-        self.assertEqual(smart_text(Test()), '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
-        self.assertEqual(smart_text(TestU()), '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
-        self.assertEqual(smart_text(1), '1')
-        self.assertEqual(smart_text('foo'), 'foo')
+        self.assertEqual(smart_str(Test()), '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
+        self.assertEqual(smart_str(TestU()), '\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111')
+        self.assertEqual(smart_str(1), '1')
+        self.assertEqual(smart_str('foo'), 'foo')
 
 
 class TestRFC3987IEncodingUtils(unittest.TestCase):


### PR DESCRIPTION
Keeping smart/force_str and smart/force_bytes in Python 3 is more
sensible because that mirrors the str and bytes types.

smart/force_str and smart/force_text were identical on Python 3.
However smart/force_text was much more commonly used given Django's
strong support for unicode.