### PR TITLE
Fixed #27743 -- Admin CSS "+" button icon overlaps text

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -738,7 +738,7 @@ a.deletelink:focus, a.deletelink:hover {
 
 .object-tools a.viewsitelink, .object-tools a.golink,.object-tools a.addlink {
     background-repeat: no-repeat;
-    background-position: 93% center;
+    background-position: right 7px center;
     padding-right: 26px;
 }
 


### PR DESCRIPTION
Applied "background-position edge offset" to "viewsitelink", "golink"
and "addlink" classes to avoid "+" (plus) icon to overlap long
long text.