### PR TITLE
Removed MySQL decimal casting.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -52,8 +52,6 @@ if (version < (1, 2, 1) or (
 django_conversions = conversions.copy()
 django_conversions.update({
     FIELD_TYPE.TIME: backend_utils.typecast_time,
-    FIELD_TYPE.DECIMAL: backend_utils.typecast_decimal,
-    FIELD_TYPE.NEWDECIMAL: backend_utils.typecast_decimal,
 })
 
 # This should match the numerical portion of the version numbers (we can treat


### PR DESCRIPTION
Added in Django 1.0: 92c35a0617836b09aef3b6909579ee368004969b
Unknown when it became obsolete.