### PR TITLE
Fixed #26993 -- Increased User.last_name max_length to 150 characters.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -738,6 +738,7 @@ answer newbie questions, and generally made Django that much better:
     thebjorn <bp@datakortet.no>
     Thejaswi Puthraya <thejaswi.puthraya@gmail.com>
     Thijs van Dien <thijs@vandien.net>
+    Thom Wiggers
     Thomas Chaumeny <t.chaumeny@gmail.com>
     Thomas Güttler <hv@tbz-pariv.de>
     Thomas Kerpe <thomas@kerpe.net>

--- a/django/contrib/auth/migrations/0009_alter_user_last_name_max_length.py
+++ b/django/contrib/auth/migrations/0009_alter_user_last_name_max_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0008_alter_user_username_max_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='last_name',
+            field=models.CharField(blank=True, max_length=150, verbose_name='last name'),
+        ),
+    ]

--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -311,7 +311,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
         },
     )
     first_name = models.CharField(_('first name'), max_length=30, blank=True)
-    last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    last_name = models.CharField(_('last name'), max_length=150, blank=True)
     email = models.EmailField(_('email address'), blank=True)
     is_staff = models.BooleanField(
         _('staff status'),

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -47,7 +47,11 @@ Fields
 
     .. attribute:: last_name
 
-        Optional. 30 characters or fewer.
+        Optional. 150 characters or fewer.
+
+        .. versionchanged:: 2.0
+
+            The ``max_length`` increased from 30 to 150 characters.
 
     .. attribute:: email
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -217,6 +217,33 @@ The end of upstream support for Oracle 11.2 is Dec. 2020. Django 1.11 will be
 supported until April 2020 which almost reaches this date. Django 2.0
 officially supports Oracle 12.1+.
 
+:attr:`AbstractUser.last_name <django.contrib.auth.models.User.last_name>` ``max_length`` increased to 150
+----------------------------------------------------------------------------------------------------------
+
+A migration for :attr:`django.contrib.auth.models.User.last_name` is included.
+If you have a custom user model inheriting from ``AbstractUser``, you'll need
+to generate and apply a database migration for your user model.
+
+If you want to preserve the 30 character limit for last names, use a custom
+form::
+
+    from django.contrib.auth.forms import UserChangeForm
+
+    class MyUserChangeForm(UserChangeForm):
+        last_name = forms.CharField(max_length=30, required=False)
+
+If you wish to keep this restriction in the admin when editing users, set
+``UserAdmin.form`` to use this form::
+
+    from django.contrib.auth.admin import UserAdmin
+    from django.contrib.auth.models import User
+
+    class MyUserAdmin(UserAdmin):
+        form = MyUserChangeForm
+
+    admin.site.unregister(User)
+    admin.site.register(User, MyUserAdmin)
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
Increases the max_length of last_name in django.contrib.auth to 100 characters to facilitate longer last_names.

Fixes [ticket 26993](https://code.djangoproject.com/ticket/26993)