### PR TITLE
Fixing deprecated import of urlresolvers in tutorial

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -71,7 +71,7 @@ create a real version. Add the following to ``polls/views.py``:
 
     from django.shortcuts import get_object_or_404, render
     from django.http import HttpResponseRedirect, HttpResponse
-    from django.urls import reverse
+    from django.core.urlresolvers import reverse
 
     from .models import Choice, Question
     # ...

--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -264,7 +264,7 @@ views and use Django's generic views instead. To do so, open the
 
     from django.shortcuts import get_object_or_404, render
     from django.http import HttpResponseRedirect
-    from django.urls import reverse
+    from django.core.urlresolvers import reverse
     from django.views import generic
 
     from .models import Choice, Question

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -366,7 +366,7 @@ With that ready, we can ask the client to do some work for us::
     404
     >>> # on the other hand we should expect to find something at '/polls/'
     >>> # we'll use 'reverse()' rather than a hardcoded URL
-    >>> from django.urls import reverse
+    >>> from django.core.urlresolvers import reverse
     >>> response = client.get(reverse('polls:index'))
     >>> response.status_code
     200
@@ -439,7 +439,7 @@ Add the following to ``polls/tests.py``:
 .. snippet::
     :filename: polls/tests.py
 
-    from django.urls import reverse
+    from django.core.urlresolvers import reverse
 
 and we'll create a shortcut function to create questions as well as a new test
 class:


### PR DESCRIPTION
Following the tutorial produces the following error:
```python
...
     from django.urls import reverse
ImportError: No module named urls
...
```
