### PR TITLE
Refs #23919 -- Removed a MySQLdb workaround (refs #6052) for Python 2.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -10,7 +10,6 @@ from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils.functional import cached_property
-from django.utils.safestring import SafeBytes, SafeText
 
 try:
     import MySQLdb as Database
@@ -43,9 +42,7 @@ if (version < (1, 2, 1) or (
 
 # MySQLdb-1.2.1 returns TIME columns as timedelta -- they are more like
 # timedelta in terms of actual behavior as they are signed and include days --
-# and Django expects time, so we still need to override that. We also need to
-# add special handling for SafeText and SafeBytes as MySQLdb's type
-# checking is too tight to catch those (see Django ticket #6052).
+# and Django expects time.
 django_conversions = conversions.copy()
 django_conversions.update({
     FIELD_TYPE.TIME: backend_utils.typecast_time,
@@ -249,10 +246,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return kwargs
 
     def get_new_connection(self, conn_params):
-        conn = Database.connect(**conn_params)
-        conn.encoders[SafeText] = conn.encoders[str]
-        conn.encoders[SafeBytes] = conn.encoders[bytes]
-        return conn
+        return Database.connect(**conn_params)
 
     def init_connection_state(self):
         assignments = []


### PR DESCRIPTION
On Python 2, the removed test fails with:
```
======================================================================
ERROR: test_safestr (i18n.tests.TestModels)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/media/sf_django/tests/i18n/tests.py", line 1269, in test_safestr
    c.save()
  File "/media/sf_django/django/db/models/base.py", line 734, in save
    force_update=force_update, update_fields=update_fields)
  File "/media/sf_django/django/db/models/base.py", line 762, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/media/sf_django/django/db/models/base.py", line 846, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/media/sf_django/django/db/models/base.py", line 885, in _do_insert
    using=using, raw=raw)
  File "/media/sf_django/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/media/sf_django/django/db/models/query.py", line 920, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/media/sf_django/django/db/models/sql/compiler.py", line 974, in execute_sql
    cursor.execute(sql, params)
  File "/media/sf_django/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/media/sf_django/django/db/backends/mysql/base.py", line 124, in execute
    return self.cursor.execute(query, args)
  File "/home/tim/.virtualenvs/djangotests-py2/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 234, in execute
    args = tuple(map(db.literal, args))
  File "/home/tim/.virtualenvs/djangotests-py2/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 291, in literal
    s = self.escape(o, self.encoders)
  File "/home/tim/.virtualenvs/djangotests-py2/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 202, in string_literal
    return db.string_literal(obj)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 1: ordinal not in range(128)
```
Does the test add value on Python 3?