### PR TITLE
Refs #25175 -- Deprecated db.backends.postgresql_psycopg2 module.

### DIFF
--- a/django/db/backends/postgresql_psycopg2/__init__.py
+++ b/django/db/backends/postgresql_psycopg2/__init__.py
@@ -1,0 +1,9 @@
+import warnings
+
+from django.utils.deprecation import RemovedInDjango30Warning
+
+warnings.warn(
+    "The django.db.backends.postgresql_psycopg2 module is deprecated in "
+    "favor of django.db.backends.postgresql.",
+    RemovedInDjango30Warning, stacklevel=2
+)

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -15,6 +15,8 @@ about each item can often be found in the release notes of two versions prior.
 See the :ref:`Django 2.0 release notes<deprecated-features-2.0>` for more
 details on these changes.
 
+* The ``django.db.backends.postgresql_psycopg2`` module will be removed.
+
 .. _deprecation-removed-in-2.1:
 
 2.1

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -225,7 +225,12 @@ Features deprecated in 2.0
 Miscellaneous
 -------------
 
-* ...
+* The ``django.db.backends.postgresql_psycopg2`` module is deprecated in favor
+  of ``django.db.backends.postgresql``. It's been an alias since Django 1.9.
+  This only affects code that imports from the module directly. The
+  ``DATABASES`` setting can still use
+  ``'django.db.backends.postgresql_psycopg2'``, though you can simplify that by
+  using the ``'django.db.backends.postgresql'`` name added in Django 1.9.
 
 .. _removed-features-2.0:
 


### PR DESCRIPTION
Deprecating vs. immediate removal to be discussed at:
https://groups.google.com/d/topic/django-developers/o7qFItlHILc/discussion