### PR TITLE
Fixed #27776 -- Merge py3.txt tests requirements files into base.txt

### DIFF
--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -31,7 +31,7 @@ Next, clone your fork, install some requirements, and run the tests::
    $ git clone git@github.com:YourGitHubName/django.git django-repo
    $ cd django-repo/tests
    $ pip install -e ..
-   $ pip install -r requirements/py3.txt
+   $ pip install -r requirements/base.txt
    $ ./runtests.py
 
 Installing the requirements will likely require some operating system packages
@@ -239,7 +239,7 @@ You can find these dependencies in `pip requirements files`_ inside the
 ``tests/requirements`` directory of the Django source tree and install them
 like so::
 
-   $ pip install -r tests/requirements/py3.txt
+   $ pip install -r tests/requirements/base.txt
 
 If you encounter an error during the installation, your system might be missing
 a dependency for one or more of the Python packages. Consult the failing

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -251,7 +251,7 @@ into the Django ``tests/`` directory and then running:
 
 .. code-block:: console
 
-    $ pip install -r requirements/py3.txt
+    $ pip install -r requirements/base.txt
 
 If you encounter an error during the installation, your system might be missing
 a dependency for one or more of the Python packages. Consult the failing

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -3,7 +3,7 @@ install some requirements and run the tests::
 
     $ cd tests
     $ pip install -e ..
-    $ pip install -r requirements/py3.txt
+    $ pip install -r requirements/base.txt
     $ ./runtests.py
 
 For more information about the test suite, see

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -12,3 +12,4 @@ pytz
 selenium
 sqlparse
 tblib
+python3-memcached

--- a/tests/requirements/py3.txt
+++ b/tests/requirements/py3.txt
@@ -1,2 +1,0 @@
--r base.txt
-python3-memcached

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv = DJANGO_SETTINGS_MODULE PYTHONPATH HOME DISPLAY
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    py{3,34,35,36}: -rtests/requirements/py3.txt
+    py{3,34,35,36}: -rtests/requirements/base.txt
     postgres: -rtests/requirements/postgres.txt
     mysql: -rtests/requirements/mysql.txt
     oracle: -rtests/requirements/oracle.txt


### PR DESCRIPTION
Now django is moving away from python 2 some files within the
`test/requirements` directory can now be merged, cleaned
and removed. This commit also updates the documentation around
installing requirements for tests.

