### PR TITLE
Fixed #27768 -- Allowed migration optimisation of CreateModel order.

### DIFF
--- a/django/db/migrations/operations/base.py
+++ b/django/db/migrations/operations/base.py
@@ -112,7 +112,7 @@ class Operation:
 
         return router.allow_migrate_model(connection_alias, model)
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         """
         Return either a list of operations the actual operation should be
         replaced with or a boolean that indicates whether or not the specified

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -29,9 +29,9 @@ class FieldOperation(Operation):
     def references_field(self, model_name, name, app_label=None):
         return self.references_model(model_name) and name.lower() == self.name_lower
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         return (
-            super().reduce(operation, in_between, app_label=app_label) or
+            super().reduce(operation, in_between, after, app_label=app_label) or
             not operation.references_field(self.model_name, self.name, app_label)
         )
 
@@ -94,7 +94,7 @@ class AddField(FieldOperation):
     def describe(self):
         return "Add field %s to %s" % (self.name, self.model_name)
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if isinstance(operation, FieldOperation) and self.is_same_field_operation(operation):
             if isinstance(operation, AlterField):
                 return [
@@ -114,7 +114,7 @@ class AddField(FieldOperation):
                         field=self.field,
                     ),
                 ]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class RemoveField(FieldOperation):
@@ -220,7 +220,7 @@ class AlterField(FieldOperation):
     def describe(self):
         return "Alter field %s on %s" % (self.name, self.model_name)
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if isinstance(operation, RemoveField) and self.is_same_field_operation(operation):
             return [operation]
         elif isinstance(operation, RenameField) and self.is_same_field_operation(operation):
@@ -232,7 +232,7 @@ class AlterField(FieldOperation):
                     field=self.field,
                 ),
             ]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class RenameField(FieldOperation):
@@ -316,7 +316,7 @@ class RenameField(FieldOperation):
             name.lower() == self.new_name_lower
         )
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if (isinstance(operation, RenameField) and
                 self.is_same_model_operation(operation) and
                 self.new_name_lower == operation.old_name_lower):
@@ -330,6 +330,6 @@ class RenameField(FieldOperation):
         # Skip `FieldOperation.reduce` as we want to run `references_field`
         # against self.new_name.
         return (
-            super(FieldOperation, self).reduce(operation, in_between, app_label=app_label) or
+            super(FieldOperation, self).reduce(operation, in_between, after, app_label=app_label) or
             not operation.references_field(self.model_name, self.new_name, app_label)
         )

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -31,9 +31,9 @@ class ModelOperation(Operation):
     def references_model(self, name, app_label=None):
         return name.lower() == self.name_lower
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         return (
-            super().reduce(operation, in_between, app_label=app_label) or
+            super().reduce(operation, in_between, after, app_label=app_label) or
             not operation.references_model(self.name, app_label)
         )
 
@@ -133,7 +133,7 @@ class CreateModel(ModelOperation):
         else:
             return model._meta.app_label, model._meta.object_name
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if (isinstance(operation, DeleteModel) and
                 self.name_lower == operation.name_lower and
                 not self.options.get("proxy", False)):
@@ -223,7 +223,7 @@ class CreateModel(ModelOperation):
                         managers=self.managers,
                     ),
                 ]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class DeleteModel(ModelOperation):
@@ -405,7 +405,7 @@ class RenameModel(ModelOperation):
     def describe(self):
         return "Rename model %s to %s" % (self.old_name, self.new_name)
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if (isinstance(operation, RenameModel) and
                 self.new_name_lower == operation.old_name_lower):
             return [
@@ -417,7 +417,7 @@ class RenameModel(ModelOperation):
         # Skip `ModelOperation.reduce` as we want to run `references_model`
         # against self.new_name.
         return (
-            super(ModelOperation, self).reduce(operation, in_between, app_label=app_label) or
+            super(ModelOperation, self).reduce(operation, in_between, after, app_label=app_label) or
             not operation.references_model(self.new_name, app_label)
         )
 
@@ -473,26 +473,26 @@ class AlterModelTable(ModelOperation):
             self.table if self.table is not None else "(default)"
         )
 
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if isinstance(operation, (AlterModelTable, DeleteModel)) and self.name_lower == operation.name_lower:
             return [operation]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class ModelOptionOperation(ModelOperation):
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if isinstance(operation, (self.__class__, DeleteModel)) and self.name_lower == operation.name_lower:
             return [operation]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class FieldRelatedOptionOperation(ModelOptionOperation):
-    def reduce(self, operation, in_between, app_label=None):
+    def reduce(self, operation, in_between, after, app_label=None):
         if (isinstance(operation, FieldOperation) and
                 self.name_lower == operation.model_name_lower and
                 not self.references_field(operation.model_name, operation.name)):
             return [operation, self]
-        return super().reduce(operation, in_between, app_label=app_label)
+        return super().reduce(operation, in_between, after, app_label=app_label)
 
 
 class AlterUniqueTogether(FieldRelatedOptionOperation):

--- a/django/db/migrations/optimizer.py
+++ b/django/db/migrations/optimizer.py
@@ -47,12 +47,13 @@ class MigrationOptimizer:
             # Compare it to each operation after it
             for j, other in enumerate(operations[i + 1:]):
                 in_between = operations[i + 1:i + j + 1]
-                result = operation.reduce(other, in_between, app_label)
+                after = operations[i + j + 2:]
+                result = operation.reduce(other, in_between, after, app_label)
                 if isinstance(result, list):
                     # Optimize! Add result, then remaining others, then return
                     new_operations.extend(result)
                     new_operations.extend(in_between)
-                    new_operations.extend(operations[i + j + 2:])
+                    new_operations.extend(after)
                     return new_operations
                 if not result:
                     # We can't optimize across `other`.

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -952,10 +952,9 @@ class AutodetectorTests(TestCase):
         changes = self.get_changes([], [self.author_with_publisher, self.publisher])
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)
-        self.assertOperationTypes(changes, 'testapp', 0, ["CreateModel", "CreateModel", "AddField"])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Author")
-        self.assertOperationAttributes(changes, "testapp", 0, 1, name="Publisher")
-        self.assertOperationAttributes(changes, "testapp", 0, 2, name="publisher")
+        self.assertOperationTypes(changes, 'testapp', 0, ["CreateModel", "CreateModel"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Publisher")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="Author")
         self.assertMigrationDependencies(changes, 'testapp', 0, [])
 
     def test_circular_fk_dependency(self):
@@ -1675,13 +1674,12 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "testapp", 1)
         self.assertOperationTypes(changes, "testapp", 0, [
-            "CreateModel", "CreateModel", "CreateModel", "AddField", "AddField"
+            "CreateModel", "CreateModel", "CreateModel", "AddField"
         ])
-        self.assertOperationAttributes(changes, 'testapp', 0, 0, name="Author")
-        self.assertOperationAttributes(changes, 'testapp', 0, 1, name="Contract")
-        self.assertOperationAttributes(changes, 'testapp', 0, 2, name="Publisher")
-        self.assertOperationAttributes(changes, 'testapp', 0, 3, model_name='contract', name='publisher')
-        self.assertOperationAttributes(changes, 'testapp', 0, 4, model_name='author', name='publishers')
+        self.assertOperationAttributes(changes, 'testapp', 0, 0, name="Publisher")
+        self.assertOperationAttributes(changes, 'testapp', 0, 1, name="Author")
+        self.assertOperationAttributes(changes, 'testapp', 0, 2, name="Contract")
+        self.assertOperationAttributes(changes, 'testapp', 0, 3, model_name='author', name='publishers')
 
     def test_many_to_many_removed_before_through_model(self):
         """

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1791,9 +1791,9 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[1], [])
         self.assertEqual(sorted(definition[2]), ["reverse_sql", "sql", "state_operations"])
         # And elidable reduction
-        self.assertIs(False, operation.reduce(operation, []))
+        self.assertIs(False, operation.reduce(operation, [], []))
         elidable_operation = migrations.RunSQL('SELECT 1 FROM void;', elidable=True)
-        self.assertEqual(elidable_operation.reduce(operation, []), [operation])
+        self.assertEqual(elidable_operation.reduce(operation, [], []), [operation])
 
     def test_run_sql_params(self):
         """
@@ -1964,9 +1964,9 @@ class OperationTests(OperationTestBase):
         self.assertEqual(project_state.apps.get_model("test_runpython", "Pony").objects.count(), 6)
         self.assertEqual(project_state.apps.get_model("test_runpython", "ShetlandPony").objects.count(), 2)
         # And elidable reduction
-        self.assertIs(False, operation.reduce(operation, []))
+        self.assertIs(False, operation.reduce(operation, [], []))
         elidable_operation = migrations.RunPython(inner_method, elidable=True)
-        self.assertEqual(elidable_operation.reduce(operation, []), [operation])
+        self.assertEqual(elidable_operation.reduce(operation, [], []), [operation])
 
     def test_run_python_atomic(self):
         """


### PR DESCRIPTION
**1) Allowed migration optimisation to view later operations.**
The optimisation of certain migration operation sequences can only be made if the `reduce()` method can tell which operations occur after `operation`.

**2) Allowed migration optimisation of CreateModel order.**
An `AddField` operation that adds a `ForeignKey` between two models can only be folded into its `CreateModel` if the `ForeignKey` target model was created earlier in the list of operations. As such, reordering the `CreateModel` operations allows for greater optimisation.