### PR TITLE
Refs #23919 -- Used DeclarativeFieldsMetaclass.__prepare() for tracking form field order.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -54,9 +54,6 @@ class Field:
     }
     empty_values = list(validators.EMPTY_VALUES)
 
-    # Tracks each time a Field instance is created. Used to retain order.
-    creation_counter = 0
-
     def __init__(self, required=True, widget=None, label=None, initial=None,
                  help_text='', error_messages=None, show_hidden_initial=False,
                  validators=(), localize=False, disabled=False, label_suffix=None):
@@ -108,10 +105,6 @@ class Field:
             widget.attrs.update(extra_attrs)
 
         self.widget = widget
-
-        # Increase the creation counter, and save our local copy.
-        self.creation_counter = Field.creation_counter
-        Field.creation_counter += 1
 
         messages = {}
         for c in reversed(self.__class__.__mro__):

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -34,7 +34,6 @@ class DeclarativeFieldsMetaclass(MediaDefiningClass):
             if isinstance(value, Field):
                 current_fields.append((key, value))
                 attrs.pop(key)
-        current_fields.sort(key=lambda x: x[1].creation_counter)
         attrs['declared_fields'] = OrderedDict(current_fields)
 
         new_class = super(DeclarativeFieldsMetaclass, mcs).__new__(mcs, name, bases, attrs)
@@ -55,6 +54,11 @@ class DeclarativeFieldsMetaclass(MediaDefiningClass):
         new_class.declared_fields = declared_fields
 
         return new_class
+
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        # Remember the order in which form fields are defined.
+        return OrderedDict()
 
 
 @html_safe


### PR DESCRIPTION
`BaseManger.creation_counter` and model `Field.creation_counter` and `auto_creation_counter` seem a bit more complicated so I wanted to offer this first.