### PR TITLE
Fixed #27783 -- Switched VariableDoesNotExist to repr() context

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -119,7 +119,7 @@ class VariableDoesNotExist(Exception):
         self.params = params
 
     def __str__(self):
-        return self.msg % tuple(force_text(p, errors='replace') for p in self.params)
+        return self.msg % self.params
 
 
 class Origin:

--- a/tests/template_tests/test_logging.py
+++ b/tests/template_tests/test_logging.py
@@ -75,7 +75,22 @@ class VariableResolveLoggingTests(BaseTemplateLoggingTestCase):
         raised_exception = self.test_handler.log_record.exc_info[1]
         self.assertEqual(
             str(raised_exception),
-            'Failed lookup for key [author] in %r' % ("{%r: %r}" % ('section', 'News'))
+            'Failed lookup for key [author] in %r' % ({'section': 'News'},)
+        )
+
+    def test_log_on_variable_does_not_exist_does_not_stringify(self):
+        class TestObject:
+            def __str__(self):
+                return 'fail'
+
+        test_object = TestObject()
+
+        with self.assertRaises(VariableDoesNotExist) as raised_exception:
+            Variable('article').resolve(test_object)
+
+        self.assertEqual(
+            str(raised_exception.exception),
+            'Failed lookup for key [article] in %r' % (test_object,),
         )
 
     def test_no_log_when_variable_exists(self):


### PR DESCRIPTION
Ticket [27783].

Using `__str__` and then `repr`ing the result looks strange and can lead
to recursive rendering for forms that render templates in `as_table`.
`repr` exists for this.

  [27783]: https://code.djangoproject.com/ticket/27783