### PR TITLE
Tested AppConfig.__repr__().

### DIFF
--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -367,6 +367,10 @@ class AppConfigTests(SimpleTestCase):
         ac = AppConfig('label', Stub(__path__=['a', 'a']))
         self.assertEqual(ac.path, 'a')
 
+    def test_repr(self):
+        app = AppConfig('label', Stub(__path__=['a']))
+        self.assertEqual(app.__repr__(), '<AppConfig: label>')
+
 
 class NamespacePackageAppTests(SimpleTestCase):
     # We need nsapp to be top-level so our multiple-paths tests can add another


### PR DESCRIPTION
I added a test to improve test coverage. However we might not want to test `__repr__` (maybe `__str__` as well?) In that case we might want to add this to .coveragerc
```
exclude_lines =
    pragma: no cover
    def __repr__
```