### PR TITLE
Remove __repr__ method in DummyNode

### DIFF
--- a/django/db/migrations/graph.py
+++ b/django/db/migrations/graph.py
@@ -42,7 +42,7 @@ class Node:
         return str(self.key)
 
     def __repr__(self):
-        return '<Node: (%r, %r)>' % self.key
+        return '<%s: (%r, %r)>' % (self.__class__.__name__, self.key[0], self.key[1])
 
     def add_child(self, child):
         self.children.add(child)
@@ -80,9 +80,6 @@ class DummyNode(Node):
         super().__init__(key)
         self.origin = origin
         self.error_message = error_message
-
-    def __repr__(self):
-        return '<DummyNode: (%r, %r)>' % self.key
 
     def promote(self):
         """

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -278,7 +278,7 @@ class IfEqualNode(Node):
         self.negate = negate
 
     def __repr__(self):
-        return "<IfEqualNode>"
+        return '<%s>' % self.__class__.__name__
 
     def render(self, context):
         val1 = self.var1.resolve(context, True)
@@ -294,7 +294,7 @@ class IfNode(Node):
         self.conditions_nodelists = conditions_nodelists
 
     def __repr__(self):
-        return "<IfNode>"
+        return '<%s>' % self.__class__.__name__
 
     def __iter__(self):
         for _, nodelist in self.conditions_nodelists:
@@ -518,7 +518,7 @@ class WithNode(Node):
             self.extra_context[name] = var
 
     def __repr__(self):
-        return "<WithNode>"
+        return '<%s>' % self.__class__.__name__
 
     def render(self, context):
         values = {key: val.resolve(context) for key, val in self.extra_context.items()}

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -93,7 +93,7 @@ class ExtendsNode(Node):
         self.blocks = {n.name: n for n in nodelist.get_nodes_by_type(BlockNode)}
 
     def __repr__(self):
-        return '<ExtendsNode: extends %s>' % self.parent_name.token
+        return '<%s: extends %s>' % (self.__class__.__name__, self.parent_name.token)
 
     def find_template(self, template_name, context):
         """

--- a/django/templatetags/l10n.py
+++ b/django/templatetags/l10n.py
@@ -29,7 +29,7 @@ class LocalizeNode(Node):
         self.use_l10n = use_l10n
 
     def __repr__(self):
-        return "<LocalizeNode>"
+        return '<%s>' % self.__class__.__name__
 
     def render(self, context):
         old_setting = context.use_l10n

--- a/tests/template_tests/syntax_tests/i18n/test_trans.py
+++ b/tests/template_tests/syntax_tests/i18n/test_trans.py
@@ -1,6 +1,7 @@
 from threading import local
 
 from django.template import Context, Template, TemplateSyntaxError
+from django.templatetags.l10n import LocalizeNode
 from django.test import SimpleTestCase, override_settings
 from django.utils import translation
 from django.utils.safestring import mark_safe
@@ -203,3 +204,9 @@ class MultipleLocaleActivationTransTagTests(MultipleLocaleActivationTestCase):
             t = Template("{% load i18n %}{% trans 'No' %}")
         with translation.override('nl'):
             self.assertEqual(t.render(Context({})), 'Nee')
+
+
+class LocalizeNodeTests(SimpleTestCase):
+    def test_repr(self):
+        node = LocalizeNode(nodelist=[], use_l10n=True)
+        self.assertEqual(repr(node), '<LocalizeNode>')

--- a/tests/template_tests/syntax_tests/test_extends.py
+++ b/tests/template_tests/syntax_tests/test_extends.py
@@ -1,3 +1,6 @@
+from django.template import NodeList
+from django.template.base import Node
+from django.template.loader_tags import ExtendsNode
 from django.test import SimpleTestCase
 
 from ..utils import setup
@@ -396,3 +399,13 @@ class InheritanceTests(SimpleTestCase):
         """
         output = self.engine.render_to_string('inheritance42')
         self.assertEqual(output, '1234')
+
+
+class ExtendsNodeTests(SimpleTestCase):
+    def test_extends_node_repr(self):
+        extends_node = ExtendsNode(
+            nodelist=NodeList([]),
+            parent_name=Node(),
+            template_dirs=[],
+        )
+        self.assertEqual(repr(extends_node), '<ExtendsNode: extends None>')

--- a/tests/template_tests/syntax_tests/test_if.py
+++ b/tests/template_tests/syntax_tests/test_if.py
@@ -1,4 +1,5 @@
 from django.template import TemplateSyntaxError
+from django.template.defaulttags import IfNode
 from django.test import SimpleTestCase
 
 from ..utils import TestObj, setup
@@ -599,3 +600,9 @@ class IfTagTests(SimpleTestCase):
     def test_if_is_not_both_variables_missing(self):
         output = self.engine.render_to_string('template', {})
         self.assertEqual(output, 'no')
+
+
+class IfNodeTests(SimpleTestCase):
+    def test_repr(self):
+        node = IfNode(conditions_nodelists=[])
+        self.assertEqual(repr(node), '<IfNode>')

--- a/tests/template_tests/syntax_tests/test_if_equal.py
+++ b/tests/template_tests/syntax_tests/test_if_equal.py
@@ -1,3 +1,4 @@
+from django.template.defaulttags import IfEqualNode
 from django.test import SimpleTestCase
 
 from ..utils import setup
@@ -215,3 +216,9 @@ class IfNotEqualTagTests(SimpleTestCase):
     def test_ifnotequal04(self):
         output = self.engine.render_to_string('ifnotequal04', {'a': 1, 'b': 1})
         self.assertEqual(output, 'no')
+
+
+class IfEqualTests(SimpleTestCase):
+    def test_repr(self):
+        node = IfEqualNode(var1='a', var2='b', nodelist_true=[], nodelist_false=[], negate=False)
+        self.assertEqual(repr(node), '<IfEqualNode>')

--- a/tests/template_tests/syntax_tests/test_with.py
+++ b/tests/template_tests/syntax_tests/test_with.py
@@ -1,4 +1,5 @@
 from django.template import TemplateSyntaxError
+from django.template.defaulttags import WithNode
 from django.test import SimpleTestCase
 
 from ..utils import setup
@@ -50,3 +51,9 @@ class WithTagTests(SimpleTestCase):
     def test_with_error02(self):
         with self.assertRaises(TemplateSyntaxError):
             self.engine.render_to_string('with-error02', {'dict': {'key': 50}})
+
+
+class WithNodeTests(SimpleTestCase):
+    def test_repr(self):
+        node = WithNode(nodelist=[], name='a', var='dict.key')
+        self.assertEqual(repr(node), '<WithNode>')


### PR DESCRIPTION
There are no tests for either DummyNode nor Node. I suppose this would be in `test_migrations`, perhaps as a new file?