### PR TITLE
Refs #27790 -- Reverted "Removed available_apps on TestCase subclasses."

### DIFF
--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -1792,6 +1792,12 @@ class SyncOnlyDefaultDatabaseRouter:
 
 class MigrateTestCase(TestCase):
 
+    # Limit memory usage when calling 'migrate'.
+    available_apps = [
+        'multiple_database',
+        'django.contrib.auth',
+        'django.contrib.contenttypes'
+    ]
     multi_db = True
 
     def test_migrate_to_other_database(self):

--- a/tests/swappable_models/tests.py
+++ b/tests/swappable_models/tests.py
@@ -10,6 +10,13 @@ from .models import Article
 
 class SwappableModelTests(TestCase):
 
+    # Limit memory usage when calling 'migrate'.
+    available_apps = [
+        'swappable_models',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+    ]
+
     @override_settings(TEST_ARTICLE_MODEL='swappable_models.AlternateArticle')
     def test_generated_data(self):
         "Permissions and content types are not created for a swapped model"


### PR DESCRIPTION
This reverts commit 91023d79ec70df9289271e63a67675ee51e7dea8 as it
increases memory usage for the test suite.

In my naive memory profiling using the change in `runtests.py` (not meant to be merged), usage is 
~435MB before this change and ~405MB after. Based on a discussion with Simon in IRC, it might be that `available_apps` affects the memory usage of `migrate`. We might add an explanatory comment about this to prevent future removal.