### PR TITLE
Fixed # 27787 -- Raise CommandError on unrecognized option

### DIFF
--- a/django/contrib/auth/management/commands/changepassword.py
+++ b/django/contrib/auth/management/commands/changepassword.py
@@ -13,6 +13,7 @@ class Command(BaseCommand):
     help = "Change a user's password for django.contrib.auth."
     requires_migrations_checks = True
     requires_system_checks = False
+    private_options = ('stderr', 'stdout')
 
     def _get_pass(self, prompt="Password: "):
         p = getpass.getpass(prompt=prompt)

--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -20,6 +20,7 @@ class NotRunningInTTYException(Exception):
 class Command(BaseCommand):
     help = 'Used to create a superuser.'
     requires_migrations_checks = True
+    private_options = ('stdin', 'stdout', 'stderr', 'username')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -9,6 +9,8 @@ from ...management import get_contenttypes_and_models
 
 class Command(BaseCommand):
 
+    private_options = ('stdout', )
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--noinput', '--no-input',

--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
     """
     help = "Collect static files in a single location."
     requires_system_checks = False
+    private_options = ('stdout', 'stderr')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/django/contrib/staticfiles/management/commands/findstatic.py
+++ b/django/contrib/staticfiles/management/commands/findstatic.py
@@ -8,6 +8,7 @@ from django.utils.encoding import force_text
 class Command(LabelCommand):
     help = "Finds the absolute paths for the given static file(s)."
     label = 'staticfile'
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         super().add_arguments(parser)

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -120,6 +120,14 @@ def call_command(command_name, *args, **options):
     arg_options = {opt_mapping.get(key, key): value for key, value in options.items()}
     defaults = parser.parse_args(args=[force_text(a) for a in args])
     defaults = dict(defaults._get_kwargs(), **arg_options)
+    # Check if any unrecognized options were passed.
+    recognized_options = {action.dest for action in parser._actions} | set(command.private_options)
+    unrecognized_options = set(options.keys()) - recognized_options
+    if unrecognized_options:
+        print(unrecognized_options)
+        raise TypeError("Unrecognized %s: %r." % (
+            'options' if len(unrecognized_options) > 1 else 'option',
+            ', '.join(unrecognized_options)))
     # Move positional args out of options to mimic legacy optparse
     args = defaults.pop('args', ())
     if 'skip_checks' not in options:

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -183,6 +183,10 @@ class BaseCommand:
         that is locale-sensitive and such content shouldn't contain any
         translations (like it happens e.g. with django.contrib.auth
         permissions) as activating any locale might cause unintended effects.
+
+    ``private_options``
+        A tuple; containing arguments which are not defined by the parser, to 
+        prevent raising error on disallowed args.
     """
     # Metadata about this command.
     help = ''
@@ -193,6 +197,15 @@ class BaseCommand:
     leave_locale_alone = False
     requires_migrations_checks = False
     requires_system_checks = True
+
+    # Arguments which are not defined by the parser.
+    private_options = ()
+    #private_options = (
+    #    'verbosity', 'database', 'interactive', 'run_syncdb', 'allow_cascade',
+    #    'reset_sequences', 'inhibit_post_migrate', 'opt_3', 'stdin', 'stdout',
+    #    'stderr', 'commit', 'using', 'table_name_filter', 'username', 'commit',
+    #    'skip_checks',
+    #)
 
     def __init__(self, stdout=None, stderr=None, no_color=False):
         self.stdout = OutputWrapper(stdout or sys.stdout)

--- a/django/core/management/commands/check.py
+++ b/django/core/management/commands/check.py
@@ -8,6 +8,7 @@ class Command(BaseCommand):
     help = "Checks the entire Django project for potential problems."
 
     requires_system_checks = False
+    private_options = ('stderr', 'stdout')
 
     def add_arguments(self, parser):
         parser.add_argument('args', metavar='app_label', nargs='*')

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
     program = 'msgfmt'
     program_options = ['--check-format']
 
+    private_options = ('stdout', 'stderr', )
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--locale', '-l', dest='locale', action='append', default=[],

--- a/django/core/management/commands/createcachetable.py
+++ b/django/core/management/commands/createcachetable.py
@@ -11,8 +11,8 @@ from django.utils.encoding import force_text
 
 class Command(BaseCommand):
     help = "Creates the tables needed to use the SQL cache backend."
-
     requires_system_checks = False
+    private_options = ('interactive', 'stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -17,6 +17,7 @@ class Command(BaseCommand):
         "Output the contents of the database as a fixture of the given format "
         "(using each model's default manager unless --all is specified)."
     )
+    private_options = ('stdout', 'stderr')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
         'Removes ALL DATA from the database, including data added during '
         'migrations. Does not achieve a "fresh install" state.'
     )
+    private_options = ('reset_sequences', 'allow_cascade', 'inhibit_post_migrate')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -10,10 +10,9 @@ from django.utils.encoding import force_text
 
 class Command(BaseCommand):
     help = "Introspects the database tables in the given database and outputs a Django model module."
-
     requires_system_checks = False
-
     db_module = 'django.db'
+    private_options = ('stdout', 'table_name_filter')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -33,6 +33,7 @@ class Command(BaseCommand):
         "No database fixture specified. Please provide the path of at least "
         "one fixture in the command line."
     )
+    private_options = ('stdout', 'stderr', 'commit', 'using')
 
     def add_arguments(self, parser):
         parser.add_argument('args', metavar='fixture', nargs='+', help='Fixture labels.')

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -212,6 +212,8 @@ class Command(BaseCommand):
     msgattrib_options = ['--no-obsolete']
     xgettext_options = ['--from-code=UTF-8', '--add-comments=Translators']
 
+    private_options = ('stdout', )
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--locale', '-l', default=[], dest='locale', action='append',

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -20,6 +20,7 @@ from django.db.migrations.writer import MigrationWriter
 
 class Command(BaseCommand):
     help = "Creates new migration(s) for apps."
+    private_options = ('stdout', 'stderr')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -18,6 +18,7 @@ from django.utils.module_loading import module_has_submodule
 
 class Command(BaseCommand):
     help = "Updates database schema. Manages both apps with migrations and those without."
+    private_options = ('stdout', 'skip_checks')
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/showmigrations.py
+++ b/django/core/management/commands/showmigrations.py
@@ -5,6 +5,7 @@ from django.db.migrations.loader import MigrationLoader
 
 class Command(BaseCommand):
     help = "Shows all available migrations for the current project"
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -6,8 +6,8 @@ from django.db.migrations.loader import AmbiguityError
 
 class Command(BaseCommand):
     help = "Prints the SQL statements for the named migration."
-
     output_transaction = True
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument('app_label', help='App label of the application containing the migration.')

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -10,6 +10,7 @@ from django.utils.version import get_docs_version
 
 class Command(BaseCommand):
     help = "Squashes an existing set of migrations (from first until specified) into a single new one."
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -5,8 +5,8 @@ from django.db import connection
 
 class Command(BaseCommand):
     help = 'Runs a development server with data from the given fixture(s).'
-
     requires_system_checks = False
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -281,6 +281,8 @@ Miscellaneous
 * The default HTTP error handlers (``handler404``, etc.) are now callables
   instead of dotted Python path strings. Django favors callable references
   since they provide better performance and debugging experience.
+* Management command raises ``TypeError``, if an unrecognized argument is
+  supplied. Earlier, it used to ignore the unrecognized arguments silently.
 
 .. _deprecated-features-2.0:
 

--- a/tests/admin_scripts/complex_app/management/commands/duplicate.py
+++ b/tests/admin_scripts/complex_app/management/commands/duplicate.py
@@ -3,5 +3,7 @@ from django.core.management.base import BaseCommand
 
 class Command(BaseCommand):
 
+    private_options = ('stdout', )
+
     def handle(self, **options):
         self.stdout.write('complex_app')

--- a/tests/admin_scripts/simple_app/management/commands/duplicate.py
+++ b/tests/admin_scripts/simple_app/management/commands/duplicate.py
@@ -3,5 +3,7 @@ from django.core.management.base import BaseCommand
 
 class Command(BaseCommand):
 
+    private_options = ('stdout', )
+
     def handle(self, **options):
         self.stdout.write('simple_app')

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1539,6 +1539,7 @@ class CommandTypes(AdminScriptTestCase):
     def test_custom_stdout(self):
         class Command(BaseCommand):
             requires_system_checks = False
+            private_options = ('stdout', )
 
             def handle(self, *args, **options):
                 self.stdout.write("Hello, World!")
@@ -1556,6 +1557,7 @@ class CommandTypes(AdminScriptTestCase):
     def test_custom_stderr(self):
         class Command(BaseCommand):
             requires_system_checks = False
+            private_options = ('stderr', )
 
             def handle(self, *args, **options):
                 self.stderr.write("Hello, World!")

--- a/tests/user_commands/management/commands/dance.py
+++ b/tests/user_commands/management/commands/dance.py
@@ -5,6 +5,7 @@ class Command(BaseCommand):
     help = "Dance around like a madman."
     args = ''
     requires_system_checks = True
+    private_options = ('stdout', 'opt_3', 'skip_checks')
 
     def add_arguments(self, parser):
         parser.add_argument("integer", nargs='?', type=int, default=0)

--- a/tests/user_commands/management/commands/hal.py
+++ b/tests/user_commands/management/commands/hal.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 class Command(BaseCommand):
     help = "Useless command."
+    private_options = ('stdout', )
 
     def add_arguments(self, parser):
         parser.add_argument('args', metavar='app_label', nargs='*', help='Specify the app label(s) to works on.')

--- a/tests/user_commands/management/commands/leave_locale_alone_false.py
+++ b/tests/user_commands/management/commands/leave_locale_alone_false.py
@@ -5,6 +5,7 @@ from django.utils import translation
 class Command(BaseCommand):
 
     leave_locale_alone = False
+    private_options = ('stdout', )
 
     def handle(self, *args, **options):
         return translation.get_language()

--- a/tests/user_commands/management/commands/leave_locale_alone_true.py
+++ b/tests/user_commands/management/commands/leave_locale_alone_true.py
@@ -5,6 +5,7 @@ from django.utils import translation
 class Command(BaseCommand):
 
     leave_locale_alone = True
+    private_options = ('stdout', )
 
     def handle(self, *args, **options):
         return translation.get_language()

--- a/tests/user_commands/management/commands/transaction.py
+++ b/tests/user_commands/management/commands/transaction.py
@@ -5,6 +5,7 @@ class Command(BaseCommand):
     help = "Say hello."
     args = ''
     output_transaction = True
+    private_options = ('stdout', )
 
     def handle(self, *args, **options):
         return 'Hello!'

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -174,6 +174,15 @@ class CommandTests(SimpleTestCase):
                 self.assertTrue(check_migrations.called)
         finally:
             dance.Command.requires_migrations_checks = requires_migrations_checks
+    
+    def test_call_command_unrecognized_options(self):
+        """
+        When passing unrecognized options to call command, an command error
+        should be raised (#27787).
+        """
+        out = StringIO()
+        with self.assertRaises(TypeError):
+            management.call_command('dance', stdout=out, opt_3=True, unrecognized=1)
 
 
 class CommandRunTests(AdminScriptTestCase):


### PR DESCRIPTION
This commit is not complete.

There are some calls to call_command, where hidden options are passed for internal use.
For e.g. - core/management/commands/flush.py

`# The following are stealth options used by Django's internals.`
`reset_sequences = options.get('reset_sequences', True)`
`allow_cascade = options.get('allow_cascade', False)`
`inhibit_post_migrate = options.get('inhibit_post_migrate', False)`

I am not sure, how to handle these cases.