### PR TITLE
Fix incorrect namespace in sitemap's template.

### DIFF
--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -456,7 +456,7 @@ generate a Google News compatible sitemap:
     <?xml version="1.0" encoding="UTF-8"?>
     <urlset
       xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-      xmlns:news="https://www.google.com/schemas/sitemap-news/0.9">
+      xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
     {% spaceless %}
     {% for url in urlset %}
       <url>


### PR DESCRIPTION
According Google's webmaster tools namespace for news are invalid.