### PR TITLE
Refs #23919 -- Removed creation_counter from model Fields

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1,6 +1,7 @@
 import copy
 import inspect
 import warnings
+from collections import OrderedDict
 from itertools import chain
 
 from django.apps import apps
@@ -369,6 +370,16 @@ class ModelBase(type):
     @property
     def _default_manager(cls):
         return cls._meta.default_manager
+
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        """
+        Ensures field definitions maintain a guaranteed order.
+
+        Python 3.6 guarantees declared field order, so this can be removed once
+        support for < 3.6 is dropped.
+        """
+        return OrderedDict()
 
 
 class ModelState:

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -85,19 +85,7 @@ def return_None():
     return None
 
 
-class OrderedFieldClass(type):
-    """
-    Metaclass for classes requiring ordered fields.
-
-    Python 3.6 guarantees declared field order, so this can be removed once
-    support for < 3.6 is dropped.
-    """
-    @classmethod
-    def __prepare__(metacls, name, bases, **kwds):
-        return collections.OrderedDict()
-
-
-class Field(RegisterLookupMixin, metaclass=OrderedFieldClass):
+class Field(RegisterLookupMixin):
     """Base class for all field types"""
 
     # Designates whether empty strings fundamentally are allowed at the

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -6,7 +6,6 @@ import itertools
 import uuid
 import warnings
 from base64 import b64decode, b64encode
-from functools import total_ordering
 
 from django import forms
 from django.apps import apps
@@ -86,20 +85,25 @@ def return_None():
     return None
 
 
-@total_ordering
-class Field(RegisterLookupMixin):
+class OrderedFieldClass(type):
+    """
+    Metaclass for classes requiring ordered fields.
+
+    Python 3.6 guarantees declared field order, so this can be removed once
+    support for < 3.6 is dropped.
+    """
+    @classmethod
+    def __prepare__(metacls, name, bases, **kwds):
+        return collections.OrderedDict()
+
+
+class Field(RegisterLookupMixin, metaclass=OrderedFieldClass):
     """Base class for all field types"""
 
     # Designates whether empty strings fundamentally are allowed at the
     # database level.
     empty_strings_allowed = True
     empty_values = list(validators.EMPTY_VALUES)
-
-    # These track each time a Field instance is created. Used to retain order.
-    # The auto_creation_counter is used for fields that Django implicitly
-    # creates, creation_counter is used for all user-specified fields.
-    creation_counter = 0
-    auto_creation_counter = -1
     default_validators = []  # Default set of validators
     default_error_messages = {
         'invalid_choice': _('Value %(value)r is not a valid choice.'),
@@ -160,15 +164,6 @@ class Field(RegisterLookupMixin):
         self.db_column = db_column
         self.db_tablespace = db_tablespace or settings.DEFAULT_INDEX_TABLESPACE
         self.auto_created = auto_created
-
-        # Adjust the appropriate creation counter, and save our local copy.
-        if auto_created:
-            self.creation_counter = Field.auto_creation_counter
-            Field.auto_creation_counter -= 1
-        else:
-            self.creation_counter = Field.creation_counter
-            Field.creation_counter += 1
-
         self._validators = list(validators)  # Store for deconstruction later
 
         messages = {}
@@ -448,21 +443,6 @@ class Field(RegisterLookupMixin):
         """
         name, path, args, kwargs = self.deconstruct()
         return self.__class__(*args, **kwargs)
-
-    def __eq__(self, other):
-        # Needed for @total_ordering
-        if isinstance(other, Field):
-            return self.creation_counter == other.creation_counter
-        return NotImplemented
-
-    def __lt__(self, other):
-        # This is needed because bisect does not take a comparison function.
-        if isinstance(other, Field):
-            return self.creation_counter < other.creation_counter
-        return NotImplemented
-
-    def __hash__(self):
-        return hash(self.creation_counter)
 
     def __deepcopy__(self, memodict):
         # We don't have to deepcopy very much here, since most things are not

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -249,16 +249,15 @@ class Options:
         self._expire_cache()
 
     def add_field(self, field, private=False):
-        # Insert the given field in the order in which it was created, using
-        # the "creation_counter" attribute of the field.
+        # Add the given field to the model.
         # Move many-to-many related fields from self.fields into
         # self.many_to_many.
         if private:
             self.private_fields.append(field)
         elif field.is_relation and field.many_to_many:
-            self.local_many_to_many.insert(bisect(self.local_many_to_many, field), field)
+            self.local_many_to_many.append(field)
         else:
-            self.local_fields.insert(bisect(self.local_fields, field), field)
+            self.local_fields.append(field)
             self.setup_pk(field)
 
         # If the field being added is a relation to another known field,

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -130,8 +130,8 @@ def fields_for_model(model, fields=None, exclude=None, widgets=None,
     opts = model._meta
     # Avoid circular import
     from django.db.models.fields import Field as ModelField
-    sortable_private_fields = [f for f in opts.private_fields if isinstance(f, ModelField)]
-    for f in sorted(chain(opts.concrete_fields, sortable_private_fields, opts.many_to_many)):
+    private_fields = [f for f in opts.private_fields if isinstance(f, ModelField)]
+    for f in chain(opts.concrete_fields, private_fields, opts.many_to_many):
         if not getattr(f, 'editable', False):
             if (fields is not None and f.name in fields and
                     (exclude is None or f.name not in exclude)):

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -28,6 +28,10 @@ def get_foo():
     return Foo.objects.get(id=1).pk
 
 
+class OrderedFieldModel(models.Model):
+    first = models.BooleanField()
+
+
 class Bar(models.Model):
     b = models.CharField(max_length=10)
     a = models.ForeignKey(Foo, models.CASCADE, default=get_foo, related_name=b'bars')

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -3,7 +3,8 @@ from django.db import models
 from django.test import SimpleTestCase, TestCase
 
 from .models import (
-    Foo, RenamedField, VerboseNameField, Whiz, WhizIter, WhizIterEmpty,
+    Foo, OrderedFieldModel, RenamedField, VerboseNameField, Whiz, WhizIter,
+    WhizIterEmpty,
 )
 
 
@@ -62,11 +63,18 @@ class BasicFieldTests(TestCase):
 
     def test_field_ordering(self):
         """Fields are ordered based on their creation."""
-        f1 = models.Field()
-        f2 = models.Field(auto_created=True)
-        f3 = models.Field()
-        self.assertLess(f2, f1)
-        self.assertGreater(f3, f1)
+        f1 = models.Field(name='third')
+        f2 = models.Field(name='fifth', auto_created=True)
+        f3 = models.Field(name='fourth')
+        OrderedFieldModel._meta.add_field(f1)
+        OrderedFieldModel._meta.add_field(f3)
+        OrderedFieldModel._meta.add_field(f2)
+        fields = OrderedFieldModel._meta.get_fields()
+        self.assertEqual(fields[0].name, 'first')
+        self.assertEqual(fields[1].name, 'id')
+        self.assertEqual(fields[2].name, 'third')
+        self.assertEqual(fields[3].name, 'fourth')
+        self.assertEqual(fields[4].name, 'fifth')
         self.assertIsNotNone(f1)
         self.assertNotIn(f2, (None, 1, ''))
 


### PR DESCRIPTION
I'm not certain this is enough, but it passes the limited number of tests I've run.

One major consequence of this change is that fields can no longer be ordered, which may affect a large number of packages that do what Django was doing. Anything using .meta.get_fields() or related methods could possibly be affected.