### PR TITLE
[1.11.x] Fixed #25192 -- Let migrations using RunPython.noop be squashed with Python 2

### DIFF
--- a/django/db/migrations/operations/special.py
+++ b/django/db/migrations/operations/special.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import router
+from django.utils import six
 
 from .base import Operation
 
@@ -203,3 +204,14 @@ class RunPython(Operation):
     @staticmethod
     def noop(apps, schema_editor):
         return None
+
+
+# A workaround allowing migrations using RunPython.noop to be squashed with Python 2.
+# Python 2 does not support the serialization of unbound methods, and so the
+# migration writer cannot reference the RunPython.noop defined above. Instead,
+# we install a function defined at module scope.  For more details, see
+# https://docs.djangoproject.com/en/1.11/topics/migrations/#serializing-values
+if six.PY2:
+    def noop(apps, schema_editor):
+        return None
+    RunPython.noop = staticmethod(noop)

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1392,3 +1392,10 @@ class SquashMigrationsTests(MigrationTestBase):
             )
             with self.assertRaisesMessage(CommandError, msg):
                 call_command("squashmigrations", "migrations", "0003", "0002", interactive=False, verbosity=0)
+
+    def test_squashmigrations_squashes_noop(self):
+        """
+        squashmigrations squashes migrations.
+        """
+        with self.temporary_migration_module(module="migrations.test_migrations_squash_noop"):
+            call_command("squashmigrations", "migrations", "0002", interactive=False, verbosity=0)

--- a/tests/migrations/test_migrations_squash_noop/0001_initial.py
+++ b/tests/migrations/test_migrations_squash_noop/0001_initial.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    operations = []

--- a/tests/migrations/test_migrations_squash_noop/0002_second.py
+++ b/tests/migrations/test_migrations_squash_noop/0002_second.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def dummy_python_op(apps, schema_editor):
+    return None
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("migrations", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(dummy_python_op, migrations.RunPython.noop, elidable=False),
+    ]


### PR DESCRIPTION
This is suggested for 1.11.x only, as master doesn't support Python 2 anymore.