### PR TITLE
Fixed #27697 - JSONField must be required form field with proper empty value when blank=True and null=False

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -74,7 +74,11 @@ class JSONField(Field):
         return self.value_from_object(obj)
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': forms.JSONField}
+        defaults = {'form_class': forms.JSONField, 'required': not self.blank}
+        if self.blank and not self.null:
+            defaults['initial'] = {}
+            defaults['invalidate_empty'] = True
+
         defaults.update(kwargs)
         return super().formfield(**defaults)
 

--- a/django/contrib/postgres/forms/jsonb.py
+++ b/django/contrib/postgres/forms/jsonb.py
@@ -20,6 +20,10 @@ class JSONField(forms.CharField):
     }
     widget = forms.Textarea
 
+    def __init__(self, invalidate_empty=False, *args, **kwargs):
+        self.invalidate_empty = invalidate_empty
+        super().__init__(*args, **kwargs)
+
     def to_python(self, value):
         if self.disabled:
             return value
@@ -52,3 +56,12 @@ class JSONField(forms.CharField):
         if isinstance(value, InvalidJSONInput):
             return value
         return json.dumps(value)
+
+    def validate(self, value):
+        super().validate(value)
+        if self.invalidate_empty and value is None:
+            raise forms.ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+                params={'value': value},
+            )


### PR DESCRIPTION
See for details https://code.djangoproject.com/ticket/27697