### PR TITLE
Refs #27795 -- Prevented SafeText from losing safe status on str()

### DIFF
--- a/django/utils/safestring.py
+++ b/django/utils/safestring.py
@@ -54,6 +54,9 @@ class SafeText(str, SafeData):
             return SafeText(t)
         return t
 
+    def __str__(self):
+        return self
+
 
 SafeString = SafeText
 

--- a/tests/utils_tests/test_safestring.py
+++ b/tests/utils_tests/test_safestring.py
@@ -24,6 +24,13 @@ class SafeStringTest(SimpleTestCase):
         self.assertRenderEqual('{{ s }}', 'a&b', s=s)
         self.assertRenderEqual('{{ s|force_escape }}', 'a&amp;b', s=s)
 
+    def test_mark_safe_str(self):
+        """
+        Calling str() on a SafeText instance doesn't lose the safe status.
+        """
+        s = mark_safe('a&b')
+        self.assertIsInstance(str(s), type(s))
+
     def test_mark_safe_object_implementing_dunder_html(self):
         e = customescape('<a&b>')
         s = mark_safe(e)


### PR DESCRIPTION
This will allow to replace force_text() by str() in several places (as one of
the features of force_text is to keep the safe status).