### PR TITLE
Fixed #27799 -- Only add 'args' argument once to command parser.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -349,7 +349,7 @@ class BaseCommand(object):
                 help='Raise on CommandError exceptions')
             parser.add_argument('--no-color', action='store_true', dest='no_color', default=False,
                 help="Don't colorize the command output.")
-            if self.args:
+            if self.args and not isinstance(self, LabelCommand) and not isinstance(self, AppCommand):
                 # Keep compatibility and always accept positional arguments, like optparse when args is set
                 parser.add_argument('args', nargs='*')
             self.add_arguments(parser)

--- a/tests/admin_scripts/management/commands/label_command_with_args.py
+++ b/tests/admin_scripts/management/commands/label_command_with_args.py
@@ -1,0 +1,10 @@
+from django.core.management.base import LabelCommand
+
+
+class Command(LabelCommand):
+    help = "Test Label-based commands"
+    requires_system_checks = False
+    args = "<arguments>"
+
+    def handle_label(self, label, **options):
+        print('EXECUTE:LabelCommand label=%s, options=%s' % (label, sorted(options.items())))

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1683,6 +1683,14 @@ class CommandTypes(AdminScriptTestCase):
         self.assertOutput(out, "EXECUTE:LabelCommand label=testlabel, options=[('no_color', False), ('pythonpath', None), ('settings', None), ('traceback', False), ('verbosity', 1)]")
         self.assertOutput(out, "EXECUTE:LabelCommand label=anotherlabel, options=[('no_color', False), ('pythonpath', None), ('settings', None), ('traceback', False), ('verbosity', 1)]")
 
+    def test_label_command_with_args_multiple_label(self):
+        "User LabelCommands using 'args' are executed multiple times if multiple labels are provided"
+        args = ['label_command_with_args', 'testlabel', 'anotherlabel']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        self.assertOutput(out, "EXECUTE:LabelCommand label=testlabel, options=[('no_color', False), ('pythonpath', None), ('settings', None), ('traceback', False), ('verbosity', 1)]")
+        self.assertOutput(out, "EXECUTE:LabelCommand label=anotherlabel, options=[('no_color', False), ('pythonpath', None), ('settings', None), ('traceback', False), ('verbosity', 1)]")
+
     @ignore_warnings(category=RemovedInDjango19Warning)
     def test_requires_model_validation_and_requires_system_checks_both_defined(self):
         from .management.commands.validation_command import InvalidCommand


### PR DESCRIPTION
If a custom management LabelCommand or AppCommand uses 'args' then only
the last positional argument provided is passed to the command, because
argparse's behaviour when two calls to add_argument with the same name
is undefined (it appears to put all the arguments bar one in the first
'*' argument, then the last one in the '+' argument).

This shows this with a test, and fixes it by not making the first call
to parser.add_argument('args') if it's a LabelCommand or AppCommand.