### PR TITLE
Fixed #27800 -- Fixed QuerySet.annotate(Length(...)).distinct() crash.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -456,6 +456,7 @@ answer newbie questions, and generally made Django that much better:
     Leo Shklovskii
     Leo Soto <leo.soto@gmail.com>
     lerouxb@gmail.com
+    Lex Berezhny <lex@damoti.com>
     Liang Feng <hutuworm@gmail.com>
     limodou
     Loek van Gent <loek@barakken.nl>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1329,7 +1329,12 @@ class Query:
                         "querying. If it is a GenericForeignKey, consider "
                         "adding a GenericRelation." % name
                     )
-                model = field.model._meta.concrete_model
+                try:
+                    model = field.model._meta.concrete_model
+                except AttributeError:
+                    # QuerySet.annotate() may introduce fields that aren't
+                    # attached to a model.
+                    model = None
             else:
                 # We didn't find the current field, so move position back
                 # one step.

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -6,7 +6,7 @@ from django.db.models import (
     BooleanField, CharField, Count, DateTimeField, ExpressionWrapper, F, Func,
     IntegerField, NullBooleanField, Q, Sum, Value,
 )
-from django.db.models.functions import Lower
+from django.db.models.functions import Length, Lower
 from django.test import TestCase, skipUnlessDBFeature
 
 from .models import (
@@ -204,6 +204,11 @@ class NonAggregateAnnotationTestCase(TestCase):
             test_alias=F('store__name'),
         ).distinct('test_alias')
         self.assertEqual(len(people2), 1)
+
+        lengths = Employee.objects.annotate(
+            name_len=Length('first_name'),
+        ).distinct('name_len').values_list('name_len', flat=True)
+        self.assertSequenceEqual(lengths, [3, 7, 8])
 
     def test_filter_annotation(self):
         books = Book.objects.annotate(


### PR DESCRIPTION
This pull request fixes a recently introduced `.distinct()` bug by reverting 3b2db6ec12ce7d4b32f60dd7713e5f23cac498b7.

Also, I've added a unit test to prevent future regressions.

Basically the issue is that `.annotate()` introduces fields that are not attached to any particular model and therefore Django cannot assume that `field.model` would always work without throwing an exception.

Earlier tests did not catch the error because by coincidence the annotation `Func`tions forwarded the field on which they were operating as their `output_field` (possibly another bug?). The newly added test calls `Length()` `Func`tion which returns an IntegerFIeld() as the `output_field` and thus is not attached to any model fields.