### PR TITLE
MySQL backend now uses decimal instead of numeric as data type for DecimalField

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -115,7 +115,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'CharField': 'varchar(%(max_length)s)',
         'DateField': 'date',
         'DateTimeField': 'datetime',
-        'DecimalField': 'numeric(%(max_digits)s, %(decimal_places)s)',
+        'DecimalField': 'decimal(%(max_digits)s, %(decimal_places)s)',
         'DurationField': 'bigint',
         'FileField': 'varchar(%(max_length)s)',
         'FilePathField': 'varchar(%(max_length)s)',


### PR DESCRIPTION
MySQL backend currently uses **numeric** as default type for DecimalField.
Even if the MySQL documentation says: "In MySQL, NUMERIC is implemented as DECIMAL, so the following remarks about DECIMAL apply equally to NUMERIC." this is not true at the moment (maybe because of a bug), so, some operations are not available for numeric type, eg: **cast**.

In Django trying to cast to a DecimalField, an error is raised:

```
from django.db.models import DecimalField
from django.db.models.functions import Cast
from myapp.models import MyModel

MyModel.objects.annotate(as_decimal=Cast('intfield', DecimalField(max_digits=8, decimal_places=2)))

[...]
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'numeric(8, 2)) AS `as_decimal` FROM `myapp_mymodel` LIMIT 21' at line 1")
```

I made this pull request in order to fix the cast to DecimalField in Django and because it seems there isn't a good reason to use numeric instead of decimal.