### PR TITLE
Fixed #27539 -- assertNumQueries fails if debug cursor wrapper fills

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -835,6 +835,8 @@ class TransactionTestCase(SimpleTestCase):
             )
             for db_name in self._databases_names(include_mirrors=False):
                 emit_post_migrate_signal(verbosity=0, interactive=False, db=db_name)
+        for db_name in self._databases_names(include_mirrors=False):
+            connections[db_name].queries_log.clear()
         try:
             self._fixture_setup()
         except Exception:

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -151,6 +151,18 @@ class AssertNumQueriesTests(TestCase):
             self.client.get("/test_utils/get_person/%s/" % person.pk)
         self.assertNumQueries(2, test_func)
 
+    def test_for_max_query_limit(self):
+        person = Person.objects.create(name="test")
+        with self.assertNumQueries(4000):
+            for i in range(0, 4000):
+                self.client.get("/test_utils/get_person/%s/" % person.pk)
+
+    def test_for_max_query_limit_2(self):
+        person = Person.objects.create(name="test")
+        with self.assertNumQueries(5000):
+            for i in range(0, 5000):
+                self.client.get("/test_utils/get_person/%s/" % person.pk)
+
 
 class AssertQuerysetEqualTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Some doubts I have regarding the PR asked on the [Ticket](https://code.djangoproject.com/ticket/27539)