### PR TITLE
Fixed #27809 -- Added pre_add and post_add signals

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -580,6 +580,11 @@ def create_reverse_many_to_one_manager(superclass, rel):
                 setattr(obj, self.field.name, self.instance)
 
             if bulk:
+                signals.pre_add.send(
+                    sender=self.model, instance=self.instance, field=self.field.name,
+                    using=db,
+                )
+
                 pks = []
                 for obj in objs:
                     check_and_update_obj(obj)
@@ -592,6 +597,11 @@ def create_reverse_many_to_one_manager(superclass, rel):
                 self.model._base_manager.using(db).filter(pk__in=pks).update(**{
                     self.field.name: self.instance,
                 })
+
+                signals.post_add.send(
+                    sender=self.model, instance=self.instance, field=self.field.name,
+                    using=db,
+                )
             else:
                 with transaction.atomic(using=db, savepoint=False):
                     for obj in objs:

--- a/django/db/models/signals.py
+++ b/django/db/models/signals.py
@@ -45,6 +45,9 @@ post_save = ModelSignal(providing_args=["instance", "raw", "created", "using", "
 pre_delete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 post_delete = ModelSignal(providing_args=["instance", "using"], use_caching=True)
 
+pre_add = ModelSignal(providing_args=["instance", "field"], use_caching=True)
+post_add = ModelSignal(providing_args=["instance", "field"], use_caching=True)
+
 m2m_changed = ModelSignal(
     providing_args=["action", "instance", "reverse", "model", "pk_set", "using"],
     use_caching=True,

--- a/tests/signals/models.py
+++ b/tests/signals/models.py
@@ -15,6 +15,7 @@ class Person(models.Model):
 class Car(models.Model):
     make = models.CharField(max_length=20)
     model = models.CharField(max_length=20)
+    owner = models.ForeignKey(Person, on_delete=models.SET_NULL, null=True)
 
     def __str__(self):
         return "%s %s" % (self.make, self.model)


### PR DESCRIPTION
Added two simple signals that are called when adding to an object to a Many-To-One relation. To keep things simple (for the same reasons as in [#21461](https://code.djangoproject.com/ticket/21461)) this only sends the instance that you are adding to, _not_ the objects that you are adding.

https://groups.google.com/d/topic/django-developers/eLHXeMj0_m4/discussion
https://code.djangoproject.com/ticket/27809