### PR TITLE
Fixed #27805 -- Fixed ClearableFileInput's "Clear" checkbox on model fields with a default.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -420,6 +420,12 @@ class ClearableFileInput(FileInput):
     def use_required_attribute(self, initial):
         return super().use_required_attribute(initial) and not initial
 
+    def value_omitted_from_data(self, data, files, name):
+        return (
+            super().value_omitted_from_data(data, files, name) and
+            self.clear_checkbox_name(name) not in data
+        )
+
 
 class Textarea(Widget):
     template_name = 'django/forms/widgets/textarea.html'

--- a/docs/releases/1.10.6.txt
+++ b/docs/releases/1.10.6.txt
@@ -9,4 +9,5 @@ Django 1.10.6 fixes several bugs in 1.10.5.
 Bugfixes
 ========
 
-* ...
+* Fixed ``ClearableFileInput``’s "Clear" checkbox on model form fields where
+  the model field has a ``default`` (:ticket:`27805`).

--- a/tests/forms_tests/widget_tests/test_clearablefileinput.py
+++ b/tests/forms_tests/widget_tests/test_clearablefileinput.py
@@ -143,3 +143,9 @@ class ClearableFileInputTest(WidgetTest):
         # user to keep the existing, initial value.
         self.assertIs(self.widget.use_required_attribute(None), True)
         self.assertIs(self.widget.use_required_attribute('resume.txt'), False)
+
+    def test_value_omitted_from_data(self):
+        widget = ClearableFileInput()
+        self.assertIs(widget.value_omitted_from_data({}, {}, 'field'), True)
+        self.assertIs(widget.value_omitted_from_data({}, {'field': 'x'}, 'field'), False)
+        self.assertIs(widget.value_omitted_from_data({'field-clear': 'y'}, {}, 'field'), False)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27805