### PR TITLE
Fixed #27815 -- add request object as kwarg to AuthenticationForm from LoginView

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -100,6 +100,11 @@ class LoginView(SuccessURLAllowedHostsMixin, FormView):
             context.update(self.extra_context)
         return context
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['request'] = self.request
+        return kwargs
+
 
 def login(request, *args, **kwargs):
     warnings.warn(

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -594,13 +594,14 @@ class LoginTest(AuthViewsTestCase):
         self.assertEqual(response.url, settings.LOGIN_REDIRECT_URL)
 
     def test_login_form_contains_request(self):
-        # 15198
-        self.client.post('/custom_requestauth_login/', {
+        # The custom authentication form for this login requires a request to
+        # initialize it.
+        response = self.client.post('/custom_request_auth_login/', {
             'username': 'testclient',
             'password': 'password',
-        }, follow=True)
-        # the custom authentication form used by this login asserts
-        # that a request is passed to the form successfully.
+        })
+        # The login was successful.
+        self.assertRedirects(response, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False)
 
     def test_login_csrf_rotate(self):
         """


### PR DESCRIPTION
 This commit also fixes the corressponding testcase which
was failing silently due to a typo in the used URL.
No new testcase was needed.