### PR TITLE
Fixed #27820 -- avoided RequestDataTooBig in response_for_exception

### DIFF
--- a/django/core/handlers/exception.py
+++ b/django/core/handlers/exception.py
@@ -7,7 +7,9 @@ from functools import wraps
 
 from django.conf import settings
 from django.core import signals
-from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.core.exceptions import (
+    PermissionDenied, RequestDataTooBig, SuspiciousOperation,
+)
 from django.http import Http404
 from django.http.multipartparser import MultiPartParserError
 from django.urls import get_resolver, get_urlconf
@@ -65,6 +67,9 @@ def response_for_exception(request, exc):
         response = get_exception_response(request, get_resolver(get_urlconf()), 400, exc)
 
     elif isinstance(exc, SuspiciousOperation):
+        if isinstance(exc, RequestDataTooBig):
+            request._mark_post_parse_error()
+
         # The request logger receives events for any problematic request
         # The security logger receives events for all SuspiciousOperations
         security_logger = logging.getLogger('django.security.%s' % exc.__class__.__name__)


### PR DESCRIPTION
Marked request with _mark_post_parse_error in response_for_exception
if exc is RequestDataTooBig to prevent attempts to access POST data
again.