### PR TITLE
Refs #26610 -- Changed CITextField's base class to TextField.

### DIFF
--- a/django/contrib/postgres/fields/citext.py
+++ b/django/contrib/postgres/fields/citext.py
@@ -1,8 +1,8 @@
-from django.db.models import CharField
+from django.db.models import TextField
 
 __all__ = ['CITextField']
 
 
-class CITextField(CharField):
+class CITextField(TextField):
     def db_type(self, connection):
         return 'citext'

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -102,7 +102,7 @@ class Character(models.Model):
 
 
 class CITextTestModel(PostgreSQLModel):
-    name = CITextField(primary_key=True, max_length=255)
+    name = CITextField(primary_key=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
max_length isn't used by the database and shouldn't be required.

https://groups.google.com/d/topic/django-developers/jud-n1cBzdg/discussion