### PR TITLE
Added multi_db=True to test cases that access the 'other' db connection.

### DIFF
--- a/tests/check_framework/test_database.py
+++ b/tests/check_framework/test_database.py
@@ -8,6 +8,8 @@ from django.test import TestCase
 
 
 class DatabaseCheckTests(TestCase):
+    multi_db = True
+
     @property
     def func(self):
         from django.core.checks.database import check_database_backends

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -1,7 +1,6 @@
 from django.contrib.contenttypes.models import ContentType, ContentTypeManager
 from django.contrib.contenttypes.views import shortcut
 from django.contrib.sites.shortcuts import get_current_site
-from django.db import connections
 from django.http import Http404, HttpRequest
 from django.test import TestCase, override_settings
 
@@ -259,14 +258,7 @@ class TestRouter:
 
 @override_settings(DATABASE_ROUTERS=[TestRouter()])
 class ContentTypesMultidbTests(TestCase):
-
-    def setUp(self):
-        # When a test starts executing, only the "default" database is
-        # connected. Connect to the "other" database here because otherwise it
-        # will be connected later when it's queried. Some database backends
-        # perform extra queries upon connecting (MySQL executes
-        # "SET SQL_AUTO_IS_NULL = 0"), which will affect assertNumQueries().
-        connections['other'].ensure_connection()
+    multi_db = True
 
     def test_multidb(self):
         """

--- a/tests/context_processors/tests.py
+++ b/tests/context_processors/tests.py
@@ -64,6 +64,7 @@ class DebugContextProcessorTests(TestCase):
     """
     Tests for the ``django.template.context_processors.debug`` processor.
     """
+    multi_db = True
 
     def test_debug(self):
         url = '/debug/'

--- a/tests/gis_tests/layermap/tests.py
+++ b/tests/gis_tests/layermap/tests.py
@@ -334,6 +334,7 @@ class OtherRouter:
 @skipUnlessDBFeature("gis_enabled")
 @override_settings(DATABASE_ROUTERS=[OtherRouter()])
 class LayerMapRouterTest(TestCase):
+    multi_db = True
 
     @unittest.skipUnless(len(settings.DATABASES) > 1, 'multiple databases required')
     def test_layermapping_default_db(self):

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -18,6 +18,7 @@ class MigrationTestBase(TransactionTestCase):
     """
 
     available_apps = ["migrations"]
+    multi_db = True
 
     def tearDown(self):
         # Reset applied-migrations state.

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -11,6 +11,7 @@ class RecorderTests(TestCase):
     """
     Tests recording migrations as applied or not.
     """
+    multi_db = True
 
     def test_apply(self):
         """

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -202,6 +202,7 @@ class Ticket17477RegressionTests(AdminScriptTestCase):
 
 
 class Sqlite3InMemoryTestDbs(TestCase):
+    multi_db = True
 
     @unittest.skipUnless(all(db.connections[conn].vendor == 'sqlite' for conn in db.connections),
                          "This is an sqlite-specific issue")


### PR DESCRIPTION
Fixed a failure in the context processors test when running in
reverse on MySQL due to an extra query after refs #27683.