### PR TITLE
Fixed #28324 -- Made feedgenerators write feeds with deterministically ordered attributes.

### DIFF
--- a/django/utils/xmlutils.py
+++ b/django/utils/xmlutils.py
@@ -2,6 +2,7 @@
 Utilities for XML generation/parsing.
 """
 
+import collections
 import re
 from xml.sax.saxutils import XMLGenerator
 
@@ -26,3 +27,9 @@ class SimplerXMLGenerator(XMLGenerator):
             # See http://www.w3.org/International/questions/qa-controls
             raise UnserializableContentError("Control characters are not supported in XML 1.0")
         XMLGenerator.characters(self, content)
+
+    # without sorting the attribute order is random
+    # which complicates e.g. caching and creating diffs
+    def startElement(self, name, attrs):
+        xs = collections.OrderedDict(sorted(attrs.items())) if attrs else attrs
+        super().startElement(name, xs)

--- a/tests/utils_tests/test_feedgenerator.py
+++ b/tests/utils_tests/test_feedgenerator.py
@@ -120,6 +120,11 @@ class FeedgeneratorTest(unittest.TestCase):
         self.assertIn('href="/feed/"', feed_content)
         self.assertIn('rel="self"', feed_content)
 
+    def test_attribute_order(self):
+        feed = feedgenerator.Atom1Feed('title', '/link/', 'desc')
+        feed_content = feed.writeString('utf-8')
+        self.assertIn('href="/link/" rel="alternate"', feed_content)
+
 
 class FeedgeneratorDBTest(TestCase):
 


### PR DESCRIPTION
This simplifies the caching and comparison of generated feeds.
https://code.djangoproject.com/ticket/28324