### PR TITLE
Ensures that change_message is a string

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -93,8 +93,7 @@ class LogEntry(models.Model):
         If self.change_message is a JSON structure, interpret it as a change
         string, properly translated.
         """
-		if self.change_message:
-			self.change_message = str(self.change_message)
+		self.change_message = str(self.change_message)
         if self.change_message and self.change_message[0] == '[':
             try:
                 change_message = json.loads(self.change_message)

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -93,6 +93,8 @@ class LogEntry(models.Model):
         If self.change_message is a JSON structure, interpret it as a change
         string, properly translated.
         """
+		if self.change_message:
+			self.change_message = str(self.change_message)
         if self.change_message and self.change_message[0] == '[':
             try:
                 change_message = json.loads(self.change_message)

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -93,8 +93,6 @@ class LogEntry(models.Model):
         If self.change_message is a JSON structure, interpret it as a change
         string, properly translated.
         """
-		if self.change_message and not isinstance(self.change_message, str):
-			self.change_message = str(self.change_message)
         if self.change_message and self.change_message[0] == '[':
             try:
                 change_message = json.loads(self.change_message)

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -93,6 +93,8 @@ class LogEntry(models.Model):
         If self.change_message is a JSON structure, interpret it as a change
         string, properly translated.
         """
+		if self.change_message and not isinstance(self.change_message, str):
+			self.change_message = str(self.change_message)
         if self.change_message and self.change_message[0] == '[':
             try:
                 change_message = json.loads(self.change_message)


### PR DESCRIPTION
This is useful if the database returns a LOB object rather than a string.