### PR TITLE
Fixed #26167 -- Added support for functional indexes

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -235,6 +235,9 @@ class BaseDatabaseFeatures:
     # Does the backend support CAST with precision?
     supports_cast_with_precision = True
 
+    # Does the backend support indexes on expressions?
+    supports_expression_indexes = True
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -32,6 +32,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_select_difference = False
     supports_slicing_ordering_in_compound = True
     supports_index_on_text_field = False
+    supports_expression_indexes = False
     has_case_insensitive_like = False
 
     @cached_property

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -41,6 +41,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         return Database.sqlite_version_info >= (3, 3, 0)
 
     @cached_property
+    def supports_expression_indexes(self):
+        return Database.sqlite_version_info >= (3, 9, 0)
+
+    @cached_property
     def can_release_savepoints(self):
         return self.uses_savepoints
 

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -789,7 +789,7 @@ class AddIndex(IndexOperation):
     def describe(self):
         return 'Create index %s on field(s) %s of model %s' % (
             self.index.name,
-            ', '.join(self.index.fields),
+            ', '.join(str(field) for field in self.index.fields),
             self.model_name,
         )
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -698,7 +698,7 @@ class Col(Expression):
 
     def as_sql(self, compiler, connection):
         if self.index_col:
-            return "%s" % connection.ops.quote_name(self.alias), []
+            return connection.ops.quote_name(self.alias), []
 
         qn = compiler.quote_name_unless_alias
         return "%s.%s" % (qn(self.alias), qn(self.target.column)), []

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -698,7 +698,7 @@ class Col(Expression):
 
     def as_sql(self, compiler, connection):
         if self.index_col:
-            return connection.ops.quote_name(self.alias), []
+            return connection.ops.quote_name(self.target.column), []
 
         qn = compiler.quote_name_unless_alias
         return "%s.%s" % (qn(self.alias), qn(self.target.column)), []

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -713,24 +713,12 @@ class Col(Expression):
                 self.target.get_db_converters(connection))
 
 
-class IndexCol(Expression):
-    def __init__(self, field_name):
-        super().__init__()
-        self.field_name = field_name
-
-    def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.field_name)
-
-    def as_sql(self, compiler, connection):
-        return "%s" % connection.ops.quote_name(self.field_name), []
-
-
 class Ref(Expression):
     """
     Reference to column alias of the query. For example, Ref('sum_cost') in
     qs.annotate(sum_cost=Sum('cost')) query.
     """
-    def __init__(self, refs, source):
+    def __init__(self, refs, source=None):
         super().__init__()
         self.refs, self.source = refs, source
 
@@ -738,6 +726,8 @@ class Ref(Expression):
         return "{}({}, {})".format(self.__class__.__name__, self.refs, self.source)
 
     def get_source_expressions(self):
+        if self.source is None:
+            return []
         return [self.source]
 
     def set_source_expressions(self, exprs):

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -713,6 +713,18 @@ class Col(Expression):
                 self.target.get_db_converters(connection))
 
 
+class IndexCol(Expression):
+    def __init__(self, field_name):
+        super().__init__()
+        self.field_name = field_name
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.field_name)
+
+    def as_sql(self, compiler, connection):
+        return "%s" % connection.ops.quote_name(self.field_name), []
+
+
 class Ref(Expression):
     """
     Reference to column alias of the query. For example, Ref('sum_cost') in

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -322,7 +322,7 @@ class BaseExpression:
         """
         yield self
         for expr in self.get_source_expressions():
-            if expr:
+            if expr and hasattr(expr, 'flatten'):
                 yield from expr.flatten()
 
     def __eq__(self, other):

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -136,6 +136,10 @@ class FuncIndex(Index):
     def __init__(self, expression, name=None):
         self.expression, self.name = expression, name
 
+    @property
+    def fields(self):
+        return [repr(self.expression)]
+
     def create_sql(self, model, schema_editor):
         connection = schema_editor.connection
         compiler = connection.ops.compiler('SQLCompiler')(None, connection, 'default')

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from django.db import NotSupportedError
 from django.db.models import F
 from django.db.models.expressions import Expression
 from django.db.models.sql.query import ExpressionIndexQuery
@@ -8,7 +9,7 @@ from django.utils.encoding import force_bytes
 __all__ = ['Index']
 
 
-class ExpressionIndexNotSupported(ValueError):
+class ExpressionIndexNotSupported(NotSupportedError):
     pass
 
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -8,7 +8,7 @@ from django.utils.encoding import force_bytes
 __all__ = ['Index']
 
 
-class ExpressionIndexNotSupported(Exception):
+class ExpressionIndexNotSupported(ValueError):
     pass
 
 
@@ -160,7 +160,7 @@ class Index:
         self.check_name()
 
     def __repr__(self):
-        return "<%s: fields='%s'>" % (self.__class__.__name__, ', '.join(self.fields))
+        return "<%s: fields='%s'>" % (self.__class__.__name__, ', '.join(map(str, self.fields)))
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__) and (self.deconstruct() == other.deconstruct())

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -70,7 +70,7 @@ class Index:
                         'Not creating expression index:\n'
                         '   {expression}\n'
                         'Expression indexes are not supported on {vendor}.'
-                    ).format(expression=column_expression, vendor=connection.vendor),
+                    ).format(expression=column_expression, vendor=connection.display_name),
                 )
 
             expression = column_expression.resolve_expression(query)

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -62,7 +62,7 @@ class Index:
             columns.append(column_sql % params)
 
         fields_for_tablespace = [model._meta.get_field(field_name) for field_name in self.fields_names]
-        tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields_for_tablespace)
+        tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields_for_tablespace, self.db_tablespace)
 
         quote_name = schema_editor.quote_name
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -58,7 +58,7 @@ class Index:
     def get_sql_create_template_values(self, model, schema_editor, using):
         connection = schema_editor.connection
         query = ExpressionIndexQuery(model)
-        compiler = connection.ops.compiler('SQLCompiler')(query, connection, 'default')
+        compiler = connection.ops.compiler('SQLCompiler')(query, connection, using)
 
         columns = []
         supports_expression_indexes = connection.features.supports_expression_indexes

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -1,20 +1,9 @@
 import hashlib
 
-from django.db.models.expressions import Ref
+from django.db.models.sql.query import FunctionalIndexQuery
 from django.utils.encoding import force_bytes
 
 __all__ = ['FuncIndex', 'Index']
-
-
-class Query:
-
-    def __init__(self, model):
-        self.model = model
-
-    def resolve_ref(self, name, *args, **kwargs):
-        if not any(f.name == name for f in self.model._meta.concrete_fields):
-            raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
-        return Ref(name, None)
 
 
 class Index:
@@ -154,7 +143,7 @@ class FuncIndex(Index):
 
     def create_sql(self, model, schema_editor):
         connection = schema_editor.connection
-        query = Query(model)
+        query = FunctionalIndexQuery(model)
         compiler = connection.ops.compiler('SQLCompiler')(query, connection, 'default')
         expr = self.expression.resolve_expression(query)
         func_sql, params = compiler.compile(expr)

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -62,16 +62,16 @@ class Index:
         columns = []
         supports_expression_indexes = connection.features.supports_expression_indexes
         for column_expression in self.expressions:
-            if not supports_expression_indexes:
-                if (hasattr(column_expression, 'flatten') and
-                        any(isinstance(expr, Expression) for expr in column_expression.flatten())):
-                    raise ExpressionIndexNotSupported(
-                        (
-                            'Not creating expression index:\n'
-                            '   {expression}\n'
-                            'Expression indexes are not supported on {vendor}.'
-                        ).format(expression=column_expression, vendor=connection.vendor),
-                    )
+            if (not supports_expression_indexes and
+                    hasattr(column_expression, 'flatten') and
+                    any(isinstance(expr, Expression) for expr in column_expression.flatten())):
+                raise ExpressionIndexNotSupported(
+                    (
+                        'Not creating expression index:\n'
+                        '   {expression}\n'
+                        'Expression indexes are not supported on {vendor}.'
+                    ).format(expression=column_expression, vendor=connection.vendor),
+                )
 
             expression = column_expression.resolve_expression(query)
             column_sql, params = compiler.compile(expression)

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -12,6 +12,8 @@ class Query:
         self.model = model
 
     def resolve_ref(self, name, *args, **kwargs):
+        if not any(f.name == name for f in self.model._meta.concrete_fields):
+            raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
         return Ref(name, None)
 
 

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -15,7 +15,7 @@ from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import Col, Ref
+from django.db.models.expressions import Col, IndexCol, Ref
 from django.db.models.fields.related_lookups import MultiColSource
 from django.db.models.lookups import Lookup
 from django.db.models.query_utils import (
@@ -2088,4 +2088,4 @@ class ExpressionIndexQuery:
     def resolve_ref(self, name, *args, **kwargs):
         if not any(f.name == name for f in self.model._meta.concrete_fields):
             raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
-        return Ref(name, None)
+        return IndexCol(name)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2088,4 +2088,5 @@ class ExpressionIndexQuery:
     def resolve_ref(self, name, *args, **kwargs):
         if not any(f.name == name for f in self.model._meta.concrete_fields):
             raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
-        return Ref(name)
+        source_field = self.model._meta.get_field(name)
+        return Col(name, source_field, index_col=True)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -34,7 +34,7 @@ from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 from django.utils.tree import Node
 
-__all__ = ['FunctionalIndexQuery', 'Query', 'RawQuery']
+__all__ = ['ExpressionIndexQuery', 'Query', 'RawQuery']
 
 
 def get_field_names_from_opts(opts):
@@ -2080,7 +2080,7 @@ class JoinPromoter:
         return to_demote
 
 
-class FunctionalIndexQuery:
+class ExpressionIndexQuery:
 
     def __init__(self, model):
         self.model = model

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -34,7 +34,7 @@ from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 from django.utils.tree import Node
 
-__all__ = ['Query', 'RawQuery']
+__all__ = ['FunctionalIndexQuery', 'Query', 'RawQuery']
 
 
 def get_field_names_from_opts(opts):
@@ -2078,3 +2078,14 @@ class JoinPromoter:
         query.promote_joins(to_promote)
         query.demote_joins(to_demote)
         return to_demote
+
+
+class FunctionalIndexQuery:
+
+    def __init__(self, model):
+        self.model = model
+
+    def resolve_ref(self, name, *args, **kwargs):
+        if not any(f.name == name for f in self.model._meta.concrete_fields):
+            raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
+        return Ref(name, None)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -15,7 +15,7 @@ from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import Col, IndexCol, Ref
+from django.db.models.expressions import Col, Ref
 from django.db.models.fields.related_lookups import MultiColSource
 from django.db.models.lookups import Lookup
 from django.db.models.query_utils import (
@@ -2088,4 +2088,4 @@ class ExpressionIndexQuery:
     def resolve_ref(self, name, *args, **kwargs):
         if not any(f.name == name for f in self.model._meta.concrete_fields):
             raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
-        return IndexCol(name)
+        return Ref(name)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -2089,4 +2089,4 @@ class ExpressionIndexQuery:
         if not any(f.name == name for f in self.model._meta.concrete_fields):
             raise ValueError("Invalid reference to field '%s' on model '%s'" % (name, self.model._meta.label))
         source_field = self.model._meta.get_field(name)
-        return Col(name, source_field, index_col=True)
+        return Col(None, source_field, index_col=True)  # None refers to the table alias we don't have here

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -44,7 +44,9 @@ For example ``Index(fields=['headline', '-pub_date'])`` would create SQL with
 case, a descending index is created as a normal index.
 
 ``Index(fields=[Lower('title').desc()])`` would create an index on the
-lowercase value of the ``title`` field in descending order.
+lowercase value of the ``title`` field in descending order. Using ``F``
+expressions in a construct like ``Index(fields=[F('height') * F('weight')])``
+allows constructing indexes on mathematical operations.
 
 .. admonition:: Support for column ordering on SQLite
 
@@ -52,16 +54,31 @@ lowercase value of the ``title`` field in descending order.
     file formats. Refer to the `SQLite docs
     <https://www.sqlite.org/lang_createindex.html>`_ for specifics.
 
-.. admonition:: Suitable expressions on PostgreSQL
+.. admonition:: Database specific exceptions of suitable expressions
 
-    The way indexes work on PostgreSQL requires the database functions to be
-    marked as ``IMMUTABLE``. As a result, you can't use functions like
-    :class:`~.functions.Concat` in a database index. If you do use such a
-    function you'll get an error when applying a migration saying this:
+    :PostgreSQL:
+        PostgreSQL requires that "*all functions and operators used in an index
+        definition must be 'immutable'*" --- `PostgreSQL documentation
+        <https://www.postgresql.org/docs/9.6/static/sql-createindex.html#AEN80057>`_.
+        As a result, you can't use functions like :class:`~.functions.Concat`
+        in a database index. If you do use such a function you'll get an error
+        when applying a migration saying this:
+    
+        .. code-block:: text
+    
+            ERROR:  functions in index expression must be marked IMMUTABLE
 
-    .. code-block:: text
+    :MySQL:
+        MySQL doesn't support expression indexes as of version 5.7.
 
-        ERROR:  functions in index expression must be marked IMMUTABLE
+    :Oracle:
+        Oracle Database requires "*that any schema-level or package-level
+        PL/SQL function that the index expression invokes is deterministic
+        (that is, that the function always return the same result for the same
+        input).*" --- `Oracle Database documentation
+        <https://docs.oracle.com/database/121/ADFNS/adfns_indexes.htm#ADFNS257>`_.
+        However, unlike PostgreSQL, "*Oracle Database does not check this
+        assertion*".
 
 .. versionadded:: 2.0
 

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -71,6 +71,11 @@ allows constructing indexes on mathematical operations.
     :MySQL:
         MySQL doesn't support expression indexes as of version 5.7.
 
+    :SQLite3:
+        "*The ability to index expressions was added to SQLite with version
+        3.9.0 (2015-10-14)*" --- `SQLite3 documentation
+        <https://sqlite.org/expridx.html#compatibility>`_.
+
     :Oracle:
         Oracle Database requires "*that any schema-level or package-level
         PL/SQL function that the index expression invokes is deterministic

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -37,7 +37,9 @@ desired.
 
 By default, indexes are created with an ascending order for each column. To
 define an index with a descending order for a column, add a hyphen before the
-field's name. When using an expression, use ``.desc()`` for descending order.
+field's name. When using an expression, use
+:meth:`~django.db.models.Expression.asc()` for ascending (default) and
+:meth:`~django.db.models.Expression.desc()` for descending order.
 
 For example ``Index(fields=['headline', '-pub_date'])`` would create SQL with
 ``(headline, pub_date DESC)``. Index ordering isn't supported on MySQL. In that

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -59,7 +59,7 @@ allows constructing indexes on mathematical operations.
     :PostgreSQL:
         PostgreSQL requires that "*all functions and operators used in an index
         definition must be 'immutable'*" --- `PostgreSQL documentation
-        <https://www.postgresql.org/docs/9.6/static/sql-createindex.html#AEN80057>`_.
+        <https://www.postgresql.org/docs/current/static/sql-createindex.html#AEN80057>`_.
         As a result, you can't use functions like :class:`~.functions.Concat`
         in a database index. If you do use such a function you'll get an error
         when applying a migration saying this:

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -63,9 +63,9 @@ allows constructing indexes on mathematical operations.
         As a result, you can't use functions like :class:`~.functions.Concat`
         in a database index. If you do use such a function you'll get an error
         when applying a migration saying this:
-    
+
         .. code-block:: text
-    
+
             ERROR:  functions in index expression must be marked IMMUTABLE
 
     :MySQL:

--- a/docs/ref/models/indexes.txt
+++ b/docs/ref/models/indexes.txt
@@ -32,21 +32,40 @@ options`_.
 
 .. attribute:: Index.fields
 
-A list of the name of the fields on which the index is desired.
+A list of the name of the fields or database expressions on which the index is
+desired.
 
 By default, indexes are created with an ascending order for each column. To
 define an index with a descending order for a column, add a hyphen before the
-field's name.
+field's name. When using an expression, use ``.desc()`` for descending order.
 
 For example ``Index(fields=['headline', '-pub_date'])`` would create SQL with
 ``(headline, pub_date DESC)``. Index ordering isn't supported on MySQL. In that
 case, a descending index is created as a normal index.
+
+``Index(fields=[Lower('title').desc()])`` would create an index on the
+lowercase value of the ``title`` field in descending order.
 
 .. admonition:: Support for column ordering on SQLite
 
     Column ordering is supported on SQLite 3.3.0+ and only for some database
     file formats. Refer to the `SQLite docs
     <https://www.sqlite.org/lang_createindex.html>`_ for specifics.
+
+.. admonition:: Suitable expressions on PostgreSQL
+
+    The way indexes work on PostgreSQL requires the database functions to be
+    marked as ``IMMUTABLE``. As a result, you can't use functions like
+    :class:`~.functions.Concat` in a database index. If you do use such a
+    function you'll get an error when applying a migration saying this:
+
+    .. code-block:: text
+
+        ERROR:  functions in index expression must be marked IMMUTABLE
+
+.. versionadded:: 2.0
+
+    Support for functional indexes was added.
 
 ``name``
 --------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -250,6 +250,9 @@ Models
 * Added the :attr:`~django.db.models.Index.db_tablespace` parameter to
   class-based indexes.
 
+* Added expression support through Django's expression API for
+  :attr:`class-based indexes <django.db.models.Index.fields>`.
+
 * If the database supports a native duration field (Oracle and PostgreSQL),
   :class:`~django.db.models.functions.datetime.Extract` now works with
   :class:`~django.db.models.DurationField`.

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1801,6 +1801,12 @@ class SchemaTests(TransactionTestCase):
         self.assertIn('LOWER', sql)
         self.assertIn('TITLE', sql)
 
+        func_index = FuncIndex(expression=Lower('blub'), name='title_lower_idx')
+        with self.assertRaisesMessage(ValueError, "Invalid reference to field 'blub' on model 'schema.Book'"):
+            with connection.schema_editor() as editor:
+                sql = func_index.create_sql(Book, editor)
+
+
     def test_primary_key(self):
         """
         Tests altering of the primary key

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -19,7 +19,7 @@ from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
 )
 from django.db.models.functions import Lower
-from django.db.models.indexes import Index, ExpressionIndexNotSupported
+from django.db.models.indexes import ExpressionIndexNotSupported, Index
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import (
     TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -18,7 +18,7 @@ from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
 )
 from django.db.models.functions import Lower
-from django.db.models.indexes import FuncIndex, Index
+from django.db.models.indexes import Index
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import (
     TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
@@ -1793,7 +1793,7 @@ class SchemaTests(TransactionTestCase):
         assertion('text_field', self.get_indexes(AuthorTextFieldWithIndex._meta.db_table))
 
     def test_func_index(self):
-        func_index = FuncIndex(expression=Lower('title'), name='title_lower_idx')
+        func_index = Index(fields=[Lower('title').desc()], name='title_lower_idx')
         with connection.schema_editor() as editor:
             sql = func_index.create_sql(Book, editor)
 
@@ -1801,11 +1801,10 @@ class SchemaTests(TransactionTestCase):
         self.assertIn('LOWER', sql)
         self.assertIn('TITLE', sql)
 
-        func_index = FuncIndex(expression=Lower('blub'), name='title_lower_idx')
+        func_index = Index(fields=[Lower('blub')], name='title_lower_idx')
         with self.assertRaisesMessage(ValueError, "Invalid reference to field 'blub' on model 'schema.Book'"):
             with connection.schema_editor() as editor:
                 sql = func_index.create_sql(Book, editor)
-
 
     def test_primary_key(self):
         """

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1795,6 +1795,9 @@ class SchemaTests(TransactionTestCase):
     def test_func_index(self):
         func_index = Index(fields=[Lower('title').desc()], name='lorem_ipsum_idx')
         with connection.schema_editor() as editor:
+            editor.create_model(Author)
+            editor.create_model(Book)
+            editor.add_index(Book, func_index)
             sql = func_index.create_sql(Book, editor)
 
         sql = sql.upper()
@@ -1804,22 +1807,9 @@ class SchemaTests(TransactionTestCase):
 
         with connection.schema_editor() as editor:
             sql = func_index.remove_sql(Book, editor)
-
-        sql = sql.upper()
-        self.assertIn('LOREM_IPSUM_IDX', sql)
-
-    def test_func_index_source_field(self):
-        func_index = Index(fields=[ExtractMonth('pub_date')], name='lorem_ipsum_idx')
-        with connection.schema_editor() as editor:
-            sql = func_index.create_sql(Book, editor)
-
-        sql = sql.upper()
-        self.assertIn('MONTH', sql)
-        self.assertIn('PUB_DATE', sql)
-        self.assertIn('LOREM_IPSUM_IDX', sql)
-
-        with connection.schema_editor() as editor:
-            sql = func_index.remove_sql(Book, editor)
+            editor.remove_index(Book, func_index)
+            editor.delete_model(Book)
+            editor.delete_model(Author)
 
         sql = sql.upper()
         self.assertIn('LOREM_IPSUM_IDX', sql)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -19,7 +19,7 @@ from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
 )
 from django.db.models.functions import Lower
-from django.db.models.indexes import Index
+from django.db.models.indexes import Index, ExpressionIndexNotSupported
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import (
     TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature,
@@ -1864,7 +1864,7 @@ class SchemaTests(TransactionTestCase):
 
         for index in indexes:
             with self.subTest(index=index):
-                with self.assertRaisesRegex(ValueError, "Not creating expression index:.*"):
+                with self.assertRaisesMessage(ExpressionIndexNotSupported, "Not creating expression index:"):
                     with connection.schema_editor() as editor:
                         index.create_sql(Author, editor)
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -9,6 +9,7 @@ from django.db import (
 )
 from django.db.models import Model, F, Value
 from django.db.models.deletion import CASCADE, PROTECT
+from django.db.models.expressions import OrderBy
 from django.db.models.fields import (
     AutoField, BigAutoField, BigIntegerField, BinaryField, BooleanField,
     CharField, DateField, DateTimeField, IntegerField, PositiveIntegerField,
@@ -1854,6 +1855,10 @@ class SchemaTests(TransactionTestCase):
         indexes = [
             Index(fields=[Lower('name')], name='dolor_idx'),
             Index(fields=[Lower('name').desc()], name='dolor_idx'),
+            Index(
+                fields=[OrderBy(OrderBy(Lower(Lower(F('name')), descending=True), descending=False))],
+                name='dolor_idx'
+            ),
             Index(fields=['height', Lower('name').asc()], name='dolor_idx'),
         ]
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -7,9 +7,9 @@ from unittest import mock
 from django.db import (
     DatabaseError, IntegrityError, OperationalError, connection,
 )
-from django.db.models import Model, F, Value
+from django.db.models import Model
 from django.db.models.deletion import CASCADE, PROTECT
-from django.db.models.expressions import OrderBy
+from django.db.models.expressions import F, OrderBy, Value
 from django.db.models.fields import (
     AutoField, BigAutoField, BigIntegerField, BinaryField, BooleanField,
     CharField, DateField, DateTimeField, IntegerField, PositiveIntegerField,

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1793,15 +1793,16 @@ class SchemaTests(TransactionTestCase):
         assertion('text_field', self.get_indexes(AuthorTextFieldWithIndex._meta.db_table))
 
     def test_func_index(self):
-        func_index = Index(fields=[Lower('title').desc()], name='title_lower_idx')
+        func_index = Index(fields=[Lower('title').desc()], name='lorem_ipsum_idx')
         with connection.schema_editor() as editor:
             sql = func_index.create_sql(Book, editor)
 
         sql = sql.upper()
-        self.assertIn('LOWER', sql)
+        self.assertIn('LOWER(', sql)
         self.assertIn('TITLE', sql)
+        self.assertIn('LOREM_IPSUM_IDX', sql)
 
-        func_index = Index(fields=[Lower('blub')], name='title_lower_idx')
+        func_index = Index(fields=[Lower('blub')], name='dolor_idx')
         with self.assertRaisesMessage(ValueError, "Invalid reference to field 'blub' on model 'schema.Book'"):
             with connection.schema_editor() as editor:
                 sql = func_index.create_sql(Book, editor)


### PR DESCRIPTION
This is a first shot at it would or could look like. There are probably dozens more things to look into and consider.

```bash
$ cat app/models.py
```
```python
from django.db import models
from django.db.models.expressions import Ref, Value
from django.db.models.functions import Concat, Lower


class Foo(models.Model):
    name = models.CharField(max_length=255)

    class Meta:
        indexes = [
            models.FuncIndex(
                Concat(
                    Lower(Ref('name', None), output_field=models.CharField()),
                    Value('blub'),
                    output_field=models.CharField(),
                ),
                name='some_func_index'
            ),
        ]
```
```bash
$ python manage.py makemigrations -v 3
Migrations for 'app':
  app/migrations/0001_initial.py
    - Create model Foo
    - Create index some_func_index for model foo
```
```bash
$ cat app/migrations/0001_initial.py
```
```python
# Generated by Django 2.0.dev20170212181215 on 2017-02-12 18:14

from django.db import migrations, models
import django.db.models.expressions
import django.db.models.functions.base


class Migration(migrations.Migration):

    initial = True

    dependencies = [
    ]

    operations = [
        migrations.CreateModel(
            name='Foo',
            fields=[
                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                ('name', models.CharField(max_length=255)),
            ],
        ),
        migrations.AddIndex(
            model_name='foo',
            index=models.FuncIndex(expression=django.db.models.functions.base.Concat(django.db.models.functions.base.Lower(django.db.models.expressions.Ref('name', None), output_field=models.CharField()), django.db.models.expressions.Value('blub'), output_field=models.CharField()), name='some_func_index'),
        ),
    ]
```
```bash
$ python manage.py migrate app
Operations to perform:
  Apply all migrations: app
Running migrations:
  Applying app.0001_initial... OK
```
```bash
$ sqlite3 db.sqlite3
SQLite version 3.16.2 2017-01-06 16:32:41
Enter ".help" for usage hints.
sqlite> .schema
CREATE TABLE IF NOT EXISTS "django_migrations" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "app" varchar(255) NOT NULL, "name" varchar(255) NOT NULL, "applied" datetime NOT NULL);
CREATE TABLE IF NOT EXISTS "app_foo" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "name" varchar(255) NOT NULL);
CREATE INDEX "some_func_index" ON "app_foo" (COALESCE(LOWER("name"), '') || COALESCE('blub', ''));
sqlite> .quit
```