### PR TITLE
contenttypes: fix the model name passed as a hint

### DIFF
--- a/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
+++ b/django/contrib/contenttypes/migrations/0002_remove_content_type_name.py
@@ -30,7 +30,11 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             migrations.RunPython.noop,
             add_legacy_name,
-            hints={'model_name': 'contenttype'},
+            hints={
+                'model': 'contenttype',
+                # Keep backwards compatibility from 1.9 for anyone expecting this, see #27832
+                'model_name': 'contenttype',
+            },
         ),
         migrations.RemoveField(
             model_name='contenttype',


### PR DESCRIPTION
Maybe it lacks a deprecation flag to clean this up some time in the
future.