### PR TITLE
Fixed #27840 -- Fixed KeyError in PasswordResetConfirmView.form_valid().

### DIFF
--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -460,9 +460,9 @@ class PasswordResetConfirmView(PasswordContextMixin, FormView):
 
     def form_valid(self, form):
         user = form.save()
+        del self.request.session[INTERNAL_RESET_SESSION_TOKEN]
         if self.post_reset_login:
             auth_login(self.request, user)
-        del self.request.session[INTERNAL_RESET_SESSION_TOKEN]
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -327,6 +327,14 @@ class PasswordResetTest(AuthViewsTestCase):
         self.assertRedirects(response, '/reset/done/', fetch_redirect_response=False)
         self.assertIn(SESSION_KEY, self.client.session)
 
+    def test_confirm_login_post_reset_already_logged_in(self):
+        url, path = self._test_confirm_start()
+        path = path.replace('/reset/', '/reset/post_reset_login/')
+        self.login()
+        response = self.client.post(path, {'new_password1': 'anewpassword', 'new_password2': 'anewpassword'})
+        self.assertRedirects(response, '/reset/done/', fetch_redirect_response=False)
+        self.assertIn(SESSION_KEY, self.client.session)
+
     def test_confirm_display_user_from_form(self):
         url, path = self._test_confirm_start()
         response = self.client.get(path)


### PR DESCRIPTION
When a user is already logged in when submitting the the password and
password confirmation to reset a password, a KeyError occurred while
removing the reset session token from the session.

Refs #17209

Thanks Quentin Marlats for the report.

Ticket: https://code.djangoproject.com/ticket/27840