### PR TITLE
Fixed #27842 -- Allowed specifying 'protocol' in GenericSitemap's constructor.

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -142,11 +142,12 @@ class GenericSitemap(Sitemap):
     priority = None
     changefreq = None
 
-    def __init__(self, info_dict, priority=None, changefreq=None):
+    def __init__(self, info_dict, priority=None, changefreq=None, protocol=None):
         self.queryset = info_dict['queryset']
         self.date_field = info_dict.get('date_field')
         self.priority = priority
         self.changefreq = changefreq
+        self.protocol = protocol
 
     def items(self):
         # Make sure to return a clone; we don't want premature evaluation.

--- a/docs/ref/contrib/sitemaps.txt
+++ b/docs/ref/contrib/sitemaps.txt
@@ -259,7 +259,7 @@ Shortcuts
 
 The sitemap framework provides a convenience class for a common case:
 
-.. class:: GenericSitemap
+.. class:: GenericSitemap(info_dict, priority=None, changefreq=None, protocol=None)
 
     The :class:`django.contrib.sitemaps.GenericSitemap` class allows you to
     create a sitemap by passing it a dictionary which has to contain at least
@@ -267,10 +267,15 @@ The sitemap framework provides a convenience class for a common case:
     of the sitemap. It may also have a ``date_field`` entry that
     specifies a date field for objects retrieved from the ``queryset``.
     This will be used for the :attr:`~Sitemap.lastmod` attribute in the
-    generated sitemap. You may also pass :attr:`~Sitemap.priority` and
-    :attr:`~Sitemap.changefreq` keyword arguments to the
-    :class:`~django.contrib.sitemaps.GenericSitemap`  constructor to specify
-    these attributes for all URLs.
+    generated sitemap.
+
+    The :attr:`~Sitemap.priority`, :attr:`~Sitemap.changefreq`,
+    and :attr:`~Sitemap.protocol` keyword arguments allow specifying these
+    attributes for all URLs.
+
+    .. versionadded:: 2.0
+
+        The ``protocol`` keyword argument was added.
 
 Example
 -------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -89,7 +89,8 @@ Minor features
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Added the ``protocol`` keyword argument to the
+  :class:`~django.contrib.sitemaps.GenericSitemap` constructor.
 
 :mod:`django.contrib.sites`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/sitemaps_tests/test_generic.py
+++ b/tests/sitemaps_tests/test_generic.py
@@ -20,11 +20,13 @@ class GenericViewsSitemapTests(SitemapTestsBase):
             },
             priority=0.6,
             changefreq='monthly',
+            protocol='https',
         )
         attr_values = (
             ('date_field', datetime_value),
             ('priority', 0.6),
             ('changefreq', 'monthly'),
+            ('protocol', 'https'),
         )
         for attr_name, expected_value in attr_values:
             with self.subTest(attr_name=attr_name):


### PR DESCRIPTION
[ticket #27842](https://code.djangoproject.com/ticket/27842)
