### PR TITLE
Made a sentence in default_if_none docs consistent with other template filters.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1499,7 +1499,7 @@ For example::
 
     {{ value|default_if_none:"nothing" }}
 
-If ``value`` is ``None``, the output will be the string ``"nothing"``.
+If ``value`` is ``None``, the output will be ``nothing``.
 
 .. templatefilter:: dictsort
 


### PR DESCRIPTION
In my views
``` python
value1 = ""
value2 = None
```


In my templates
```django
{{ value1|default:"nothing" }} {{ value2|default_if_none:"nothing" }}
```
in browser
```
nothing nothing
```
as same result.

Therefore, i think they use same result in documents, may be less confusing.