### PR TITLE
Fixed psycopg version parsing

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -4,6 +4,7 @@ PostgreSQL database backend for Django.
 Requires psycopg 2: http://initd.org/projects/psycopg2
 """
 
+import re
 import threading
 import warnings
 
@@ -24,8 +25,11 @@ except ImportError as e:
 
 
 def psycopg2_version():
-    version = psycopg2.__version__.split(' ', 1)[0]
-    return tuple(int(v) for v in version.split('.') if v.isdigit())
+    m = re.match(r'^\d+(?:\.\d+)*', psycopg2.__version__)
+    if m is None:
+        # Failed to parse: it will fail later displaying the version number
+        return ()
+    return tuple(map(int, m.group().split('.')))
 
 
 PSYCOPG2_VERSION = psycopg2_version()


### PR DESCRIPTION
Psycopg uses PEP 440 (https://www.python.org/dev/peps/pep-0440/) to
represent version numbers. The current algorithm doesn't parse correctly
version '2.7b2' (see https://github.com/psycopg/psycopg2/issues/510).