### PR TITLE
Fixed #27858 -- Prevented read-only commands from creating the django_migrations table.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -506,6 +506,7 @@ answer newbie questions, and generally made Django that much better:
     Markus Amalthea Magnuson <markus.magnuson@gmail.com>
     Markus Holtermann <https://markusholtermann.eu>
     Marten Kenbeek <marten.knbk+django@gmail.com>
+    Marti Raudsepp <marti@juffo.org>
     martin.glueck@gmail.com
     Martin Green
     Martin Kosír <martin@martinkosir.net>

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -12,7 +12,6 @@ from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style, no_style
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.db.migrations.exceptions import MigrationSchemaMissing
 
 
 class CommandError(Exception):
@@ -428,11 +427,6 @@ class BaseCommand:
             executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
         except ImproperlyConfigured:
             # No databases are configured (or the dummy one)
-            return
-        except MigrationSchemaMissing:
-            self.stdout.write(self.style.NOTICE(
-                "\nNot checking migrations as it is not possible to access/create the django_migrations table."
-            ))
             return
 
         plan = executor.migration_plan(executor.loader.graph.leaf_nodes())

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -86,6 +86,10 @@ class MigrationExecutor:
         Django first needs to create all project states before a migration is
         (un)applied and in a second step run all the database operations.
         """
+        # The django_migrations table must be present to record applied
+        # migrations.
+        self.recorder.ensure_schema()
+
         if plan is None:
             plan = self.migration_plan(targets)
         # Create the forwards plan Django would follow on an empty database

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -39,11 +39,15 @@ class MigrationRecorder:
     def migration_qs(self):
         return self.Migration.objects.using(self.connection.alias)
 
+    def has_table(self):
+        """Return True if the django_migrations table exists."""
+        return self.Migration._meta.db_table in self.connection.introspection.table_names(self.connection.cursor())
+
     def ensure_schema(self):
         """Ensure the table exists and has the correct schema."""
         # If the table's there, that's fine - we've never changed its schema
         # in the codebase.
-        if self.Migration._meta.db_table in self.connection.introspection.table_names(self.connection.cursor()):
+        if self.has_table():
             return
         # Make the table
         try:
@@ -54,8 +58,12 @@ class MigrationRecorder:
 
     def applied_migrations(self):
         """Return a set of (app, name) of applied migrations."""
-        self.ensure_schema()
-        return {tuple(x) for x in self.migration_qs.values_list("app", "name")}
+        if self.has_table():
+            return {tuple(x) for x in self.migration_qs.values_list('app', 'name')}
+        else:
+            # If the django_migrations table doesn't eixst, then no migrations
+            # are applied.
+            return set()
 
     def record_applied(self, app, name):
         """Record that a migration was applied."""

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -876,9 +876,6 @@ If the :doc:`staticfiles</ref/contrib/staticfiles>` contrib app is enabled
 (default in new projects) the :djadmin:`runserver` command will be overridden
 with its own :ref:`runserver<staticfiles-runserver>` command.
 
-If :djadmin:`migrate` was not previously executed, the table that stores the
-history of migrations is created at first run of ``runserver``.
-
 Logging of each request and response of the server is sent to the
 :ref:`django-server-logger` logger.
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -22,7 +22,6 @@ from django.core.management import (
     BaseCommand, CommandError, call_command, color,
 )
 from django.db import ConnectionHandler
-from django.db.migrations.exceptions import MigrationSchemaMissing
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import (
     LiveServerTestCase, SimpleTestCase, TestCase, override_settings,
@@ -1339,15 +1338,12 @@ class ManageRunserver(AdminScriptTestCase):
 
     def test_readonly_database(self):
         """
-        Ensure runserver.check_migrations doesn't choke when a database is read-only
-        (with possibly no django_migrations table).
+        runserver.check_migrations() doesn't choke when a database is read-only.
         """
-        with mock.patch.object(
-                MigrationRecorder, 'ensure_schema',
-                side_effect=MigrationSchemaMissing()):
+        with mock.patch.object(MigrationRecorder, 'has_table', return_value=False):
             self.cmd.check_migrations()
-        # Check a warning is emitted
-        self.assertIn("Not checking migrations", self.output.getvalue())
+        # You have # ...
+        self.assertIn('unapplied migration(s)', self.output.getvalue())
 
 
 class ManageRunserverMigrationWarning(TestCase):


### PR DESCRIPTION
MigrationRecorder is changed so that for read-only operations, if the
django_migrations table doesn't exist, it's assumed that no migrations
have been applied, instead of trying to create it.

Reverted documentation change from refs #23808.