### PR TITLE
Fixed typo in DurationField's docs [skip ci]

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1571,7 +1571,7 @@ class DecimalField(Field):
 class DurationField(Field):
     """Stores timedelta objects.
 
-    Uses interval on postgres, INVERAL DAY TO SECOND on Oracle, and bigint of
+    Uses interval on postgres, INTERVAL DAY TO SECOND on Oracle, and bigint of
     microseconds on other databases.
     """
     empty_strings_allowed = False


### PR DESCRIPTION
http://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements003.htm#i38598