### PR TITLE
Fixed #27836 -- Allowed FileSystemStorage.delete() to remove directories.

### DIFF
--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -293,12 +293,15 @@ class FileSystemStorage(Storage):
     def delete(self, name):
         assert name, "The name argument is not allowed to be empty."
         name = self.path(name)
-        # If the file exists, delete it from the filesystem.
+        # If the file or directory exists, delete it from the filesystem.
         try:
-            os.remove(name)
+            if os.path.isdir(name):
+                os.rmdir(name)
+            else:
+                os.remove(name)
         except FileNotFoundError:
-            # If os.remove() fails with FileNotFoundError, the file may have
-            # been removed concurrently.
+            # If removal fails, the file or directory may have been removed
+            # concurrently.
             pass
 
     def exists(self, name):

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -495,6 +495,11 @@ class FileStorageTests(SimpleTestCase):
         with self.assertRaises(AssertionError):
             self.storage.delete('')
 
+    def test_delete_deletes_directories(self):
+        tmp_dir = tempfile.TemporaryDirectory(dir=self.storage.location)
+        self.storage.delete(tmp_dir.name)
+        self.assertFalse(os.path.exists(tmp_dir.name))
+
     @override_settings(
         MEDIA_ROOT='media_root',
         MEDIA_URL='media_url/',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27836