### PR TITLE
Fixed #27873 -- Fixed crash in setup_test_environment() if ALLOWED_HOSTS is a tuple.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -124,7 +124,7 @@ def setup_test_environment(debug=None):
 
     saved_data.allowed_hosts = settings.ALLOWED_HOSTS
     # Add the default host of the test client.
-    settings.ALLOWED_HOSTS = settings.ALLOWED_HOSTS + ['testserver']
+    settings.ALLOWED_HOSTS = list(settings.ALLOWED_HOSTS) + ['testserver']
 
     saved_data.debug = settings.DEBUG
     settings.DEBUG = debug

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -2,7 +2,9 @@ import os
 import sys
 import unittest
 from io import StringIO
+from unittest import mock
 
+from django.conf import settings
 from django.conf.urls import url
 from django.contrib.staticfiles.finders import get_finder, get_finders
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -865,6 +867,16 @@ class SetupTestEnvironmentTests(SimpleTestCase):
     def test_setup_test_environment_calling_more_than_once(self):
         with self.assertRaisesMessage(RuntimeError, "setup_test_environment() was already called"):
             setup_test_environment()
+
+    def test_allowed_hosts(self):
+        for type_ in (list, tuple):
+            with self.subTest(type_=type_):
+                allowed_hosts = type_('*')
+                with mock.patch('django.test.utils._TestState') as x:
+                    del x.saved_data
+                    with self.settings(ALLOWED_HOSTS=allowed_hosts):
+                        setup_test_environment()
+                        self.assertEqual(settings.ALLOWED_HOSTS, ['*', 'testserver'])
 
 
 class OverrideSettingsTests(SimpleTestCase):


### PR DESCRIPTION
We previously let ALLOWED_HOSTS to be a tuple but 17e6616 (re. #26666)
regressed on this.

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>