### PR TITLE
WIP: Refs #27656 removing PEP warnings from code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/coverage_html/
 tests/.coverage
 build/
 tests/report/
+.idea/

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -16,7 +16,7 @@ __all__ = ('BoundField',)
 
 @html_safe
 class BoundField:
-    "A Field plus data"
+    """A Field plus data"""
     def __init__(self, form, field, name):
         self.form = form
         self.field = field
@@ -124,7 +124,7 @@ class BoundField:
         return self.as_widget(TextInput(), attrs, **kwargs)
 
     def as_textarea(self, attrs=None, **kwargs):
-        "Returns a string of HTML for representing this as a <textarea>."
+        """Returns a string of HTML for representing this as a <textarea>."""
         return self.as_widget(Textarea(), attrs, **kwargs)
 
     def as_hidden(self, attrs=None, **kwargs):
@@ -202,7 +202,7 @@ class BoundField:
 
     @property
     def is_hidden(self):
-        "Returns True if this BoundField's widget is hidden."
+        """Returns True if this BoundField's widget is hidden."""
         return self.field.widget.is_hidden
 
     @property

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -63,10 +63,12 @@ class DeclarativeFieldsMetaclass(MediaDefiningClass):
 
 @html_safe
 class BaseForm:
-    # This is the main implementation of all the Form logic. Note that this
-    # class is different than Form. See the comments by the Form class for more
-    # information. Any improvements to the form API should be made to *this*
-    # class, not to the Form class.
+    """
+    This is the main implementation of all the Form logic. Note that this
+    class is different than Form. See the comments by the Form class for more
+    information. Any improvements to the form API should be made to *this*
+    class, not to the Form class.
+    """
     default_renderer = None
     field_order = None
     prefix = None
@@ -153,7 +155,7 @@ class BaseForm:
             yield self[name]
 
     def __getitem__(self, name):
-        "Returns a BoundField with the given name."
+        """Returns a BoundField with the given name."""
         try:
             field = self.fields[name]
         except KeyError:
@@ -170,7 +172,7 @@ class BaseForm:
 
     @property
     def errors(self):
-        "Returns an ErrorDict for the data provided for the form"
+        """Returns an ErrorDict for the data provided for the form"""
         if self._errors is None:
             self.full_clean()
         return self._errors
@@ -198,7 +200,7 @@ class BaseForm:
         return 'initial-%s' % self.add_prefix(field_name)
 
     def _html_output(self, normal_row, error_row, row_ender, help_text_html, errors_on_separate_row):
-        "Helper function for outputting HTML. Used by as_table(), as_ul(), as_p()."
+        """Helper function for outputting HTML. Used by as_table(), as_ul(), as_p()."""
         top_errors = self.non_field_errors()  # Errors that should be displayed above all fields.
         output, hidden_fields = [], []
 
@@ -276,7 +278,7 @@ class BaseForm:
         return mark_safe('\n'.join(output))
 
     def as_table(self):
-        "Returns this form rendered as HTML <tr>s -- excluding the <table></table>."
+        """Returns this form rendered as HTML <tr>s -- excluding the <table></table>."""
         return self._html_output(
             normal_row='<tr%(html_class_attr)s><th>%(label)s</th><td>%(errors)s%(field)s%(help_text)s</td></tr>',
             error_row='<tr><td colspan="2">%s</td></tr>',
@@ -285,7 +287,7 @@ class BaseForm:
             errors_on_separate_row=False)
 
     def as_ul(self):
-        "Returns this form rendered as HTML <li>s -- excluding the <ul></ul>."
+        """Returns this form rendered as HTML <li>s -- excluding the <ul></ul>."""
         return self._html_output(
             normal_row='<li%(html_class_attr)s>%(errors)s%(label)s %(field)s%(help_text)s</li>',
             error_row='<li>%s</li>',
@@ -294,7 +296,7 @@ class BaseForm:
             errors_on_separate_row=False)
 
     def as_p(self):
-        "Returns this form rendered as HTML <p>s."
+        """Returns this form rendered as HTML <p>s."""
         return self._html_output(
             normal_row='<p%(html_class_attr)s>%(label)s %(field)s%(help_text)s</p>',
             error_row='%s',
@@ -508,7 +510,7 @@ class BaseForm:
 
 
 class Form(BaseForm, metaclass=DeclarativeFieldsMetaclass):
-    "A collection of Fields, plus their associated data."
+    """A collection of Fields, plus their associated data."""
     # This is a separate class from BaseForm in order to abstract the way
     # self.fields is specified. This class (Form) is the one that does the
     # fancy metaclass stuff purely for the semantic sugar -- it allows one

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -74,6 +74,7 @@ class BaseFormSet:
     def __len__(self):
         return len(self.forms)
 
+    @staticmethod
     def __bool__(self):
         """All formsets have a management form which is not included in the length"""
         return True

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -254,8 +254,7 @@ class ModelFormMetaclass(DeclarativeFieldsMetaclass):
                               set(new_class.declared_fields.keys()))
             if missing_fields:
                 message = 'Unknown field(s) (%s) specified for %s'
-                message = message % (', '.join(missing_fields),
-                                     opts.model.__name__)
+                message = message % (', '.join(missing_fields), opts.model.__name__)
                 raise FieldError(message)
             # Override default model fields with any custom declared ones
             # (plus, include all the other declared fields).

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -84,7 +84,7 @@ class Media:
         return static(path)
 
     def __getitem__(self, name):
-        "Returns a Media object that only contains media of the given type"
+        """Returns a Media object that only contains media of the given type"""
         if name in MEDIA_TYPES:
             return Media(**{str(name): getattr(self, '_' + name)})
         raise KeyError('Unknown media type "%s"' % name)
@@ -210,7 +210,7 @@ class Widget(metaclass=MediaDefiningClass):
         return mark_safe(renderer.render(template_name, context))
 
     def build_attrs(self, base_attrs, extra_attrs=None):
-        "Helper function for building an attribute dictionary."
+        """Helper function for building an attribute dictionary."""
         attrs = base_attrs.copy()
         if extra_attrs is not None:
             attrs.update(extra_attrs)


### PR DESCRIPTION
# Need some comments 
### There are multiple problems in current master code
If you open django project in PyCharm then you can see all the warnings visually

Most frequent warning are
1. `python 2.7 compatablity issues eg (use of normal super() is not supported in python 2.7 )`
2. `using shoadow builtin variable names like (file, list , next etc)`
3. `Doc string should use triple double quotes`
4. `access to protected member __meta of a class` 