### PR TITLE
Fixed #27724 -- SelectDateWidget clears date and month if year is not selected

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -912,7 +912,7 @@ class SelectDateWidget(Widget):
     template_name = 'django/forms/widgets/select_date.html'
     input_type = 'select'
     select_widget = Select
-    date_re = re.compile(r'(\d{4})-(\d\d?)-(\d\d?)$')
+    date_re = re.compile(r'(\d{4}|0)-(\d\d?)-(\d\d?)$')
 
     def __init__(self, attrs=None, years=None, months=None, empty_label=None):
         self.attrs = attrs or {}

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -487,23 +487,37 @@ class SelectDateWidgetTest(WidgetTest):
         self.assertIs(self.widget.value_omitted_from_data(data, {}, 'field'), False)
 
     def test_regexp_date_re(self):
-        # valid formats
-        self.assertIsNotNone(self.widget.date_re.match('2000-1-1'))  # 1 digit for (day & month)
-        self.assertIsNotNone(self.widget.date_re.match('2000-10-15'))  # 2 digit for (day & month)
-        self.assertIsNotNone(self.widget.date_re.match('2000-01-01'))  # 2 digit for (day & month) starting on 0
-        # valid formats with empty values
-        self.assertIsNotNone(self.widget.date_re.match('2000-01-0'))  # day not provided
-        self.assertIsNotNone(self.widget.date_re.match('2000-0-01'))  # month not provided
-        self.assertIsNotNone(self.widget.date_re.match('0-01-01'))  # year not provided
-        self.assertIsNotNone(self.widget.date_re.match('2000-0-0'))  # day & month not provided
-        self.assertIsNotNone(self.widget.date_re.match('0-01-0'))  # day & year not provided
-        self.assertIsNotNone(self.widget.date_re.match('0-0-01'))  # month & year not provided
-        self.assertIsNotNone(self.widget.date_re.match('0-0-0'))  # day, month & year not provided
-        # invalid formats
-        self.assertIsNone(self.widget.date_re.match('2000-01-001'))  # invalid day
-        self.assertIsNone(self.widget.date_re.match('2000-001-01'))  # invalid month
+        # check valid formats
+        # 1 digit for (day & month)
+        self.assertDictEqual(self.widget.format_value('2000-1-1'), {'day': 1, 'month': 1, 'year': 2000})
+        # 2 digit for (day & month)
+        self.assertDictEqual(self.widget.format_value('2000-10-15'), {'day': 15, 'month': 10, 'year': 2000})
+        # 2 digit for (day & month) starting on 0
+        self.assertDictEqual(self.widget.format_value('2000-01-01'), {'day': 1, 'month': 1, 'year': 2000})
+
+        # check valid formats with empty values
+        # day not provided
+        self.assertDictEqual(self.widget.format_value('2000-01-0'), {'day': 0, 'month': 1, 'year': 2000})
+        # month not provided
+        self.assertDictEqual(self.widget.format_value('2000-0-01'), {'day': 1, 'month': 0, 'year': 2000})
+        # year not provided
+        self.assertDictEqual(self.widget.format_value('0-01-01'), {'day': 1, 'month': 1, 'year': 0})
+        # day & month not provided
+        self.assertDictEqual(self.widget.format_value('2000-0-0'), {'day': 0, 'month': 0, 'year': 2000})
+        # day & year not provided
+        self.assertDictEqual(self.widget.format_value('0-01-0'), {'day': 0, 'month': 1, 'year': 0})
+        # month & year not provided
+        self.assertDictEqual(self.widget.format_value('0-0-01'), {'day': 1, 'month': 0, 'year': 0})
+        # day, month & year not provided
+        self.assertDictEqual(self.widget.format_value('0-0-0'), {'day': 0, 'month': 0, 'year': 0})
+
+        # check invalid formats
+        # invalid day
+        self.assertDictEqual(self.widget.format_value('2000-01-001'), {'day': None, 'month': None, 'year': None})
+        # invalid month
+        self.assertDictEqual(self.widget.format_value('2000-001-01'), {'day': None, 'month': None, 'year': None})
         # invalid year formats (year accept only 4 digits or 0)
-        self.assertIsNone(self.widget.date_re.match('2-01-01'))
-        self.assertIsNone(self.widget.date_re.match('20-01-01'))
-        self.assertIsNone(self.widget.date_re.match('200-01-01'))
-        self.assertIsNone(self.widget.date_re.match('20000-01-01'))
+        self.assertDictEqual(self.widget.format_value('2-01-01'), {'day': None, 'month': None, 'year': None})
+        self.assertDictEqual(self.widget.format_value('20-01-01'), {'day': None, 'month': None, 'year': None})
+        self.assertDictEqual(self.widget.format_value('200-01-01'), {'day': None, 'month': None, 'year': None})
+        self.assertDictEqual(self.widget.format_value('20000-01-01'), {'day': None, 'month': None, 'year': None})

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -485,3 +485,17 @@ class SelectDateWidgetTest(WidgetTest):
         self.assertIs(self.widget.value_omitted_from_data({'field_day': '1'}, {}, 'field'), False)
         data = {'field_day': '1', 'field_month': '12', 'field_year': '2000'}
         self.assertIs(self.widget.value_omitted_from_data(data, {}, 'field'), False)
+
+    def test_regexp_date_re(self):
+        # valid formats
+        self.assertIsNotNone(self.widget.date_re.match('2000-1-1'))  # 1 digit for (day & month)
+        self.assertIsNotNone(self.widget.date_re.match('2000-10-15'))  # 2 digit for (day & month)
+        self.assertIsNotNone(self.widget.date_re.match('2000-01-01'))  # 2 digit for (day & month) starting on 0
+        # invalid formats
+        self.assertIsNone(self.widget.date_re.match('2000-01-001'))  # invalid day
+        self.assertIsNone(self.widget.date_re.match('2000-001-01'))  # invalid month
+        # invalid year formats (year accept only 4 digits)
+        self.assertIsNone(self.widget.date_re.match('2-01-01'))
+        self.assertIsNone(self.widget.date_re.match('20-01-01'))
+        self.assertIsNone(self.widget.date_re.match('200-01-01'))
+        self.assertIsNone(self.widget.date_re.match('20000-01-01'))

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -491,10 +491,18 @@ class SelectDateWidgetTest(WidgetTest):
         self.assertIsNotNone(self.widget.date_re.match('2000-1-1'))  # 1 digit for (day & month)
         self.assertIsNotNone(self.widget.date_re.match('2000-10-15'))  # 2 digit for (day & month)
         self.assertIsNotNone(self.widget.date_re.match('2000-01-01'))  # 2 digit for (day & month) starting on 0
+        # valid formats with empty values
+        self.assertIsNotNone(self.widget.date_re.match('2000-01-0'))  # day not provided
+        self.assertIsNotNone(self.widget.date_re.match('2000-0-01'))  # month not provided
+        self.assertIsNotNone(self.widget.date_re.match('0-01-01'))  # year not provided
+        self.assertIsNotNone(self.widget.date_re.match('2000-0-0'))  # day & month not provided
+        self.assertIsNotNone(self.widget.date_re.match('0-01-0'))  # day & year not provided
+        self.assertIsNotNone(self.widget.date_re.match('0-0-01'))  # month & year not provided
+        self.assertIsNotNone(self.widget.date_re.match('0-0-0'))  # day, month & year not provided
         # invalid formats
         self.assertIsNone(self.widget.date_re.match('2000-01-001'))  # invalid day
         self.assertIsNone(self.widget.date_re.match('2000-001-01'))  # invalid month
-        # invalid year formats (year accept only 4 digits)
+        # invalid year formats (year accept only 4 digits or 0)
         self.assertIsNone(self.widget.date_re.match('2-01-01'))
         self.assertIsNone(self.widget.date_re.match('20-01-01'))
         self.assertIsNone(self.widget.date_re.match('200-01-01'))


### PR DESCRIPTION
Fixed #27724 `SelectDateWidget` clears date and month if year is not selected.

If year is not selected in `SelectDateWidget`, then all the inputs are cleared as opposed to a state where date or month is missing.