### PR TITLE
Fixed #27879 -- Fixed crash if enclosures aren't provided to Atom1Feed.add_item().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -612,6 +612,7 @@ answer newbie questions, and generally made Django that much better:
     Paulo Scardine <paulo@scardine.com.br>
     Paul Smith <blinkylights23@gmail.com>
     pavithran s <pavithran.s@gmail.com>
+    Pavlo Kapyshin <i@93z.org>
     permonik@mesias.brnonet.cz
     Petar Marić <http://www.petarmaric.com/>
     Pete Crosier <pete.crosier@gmail.com>

--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -137,7 +137,7 @@ class SyndicationFeed:
             'comments': to_str(comments),
             'unique_id': to_str(unique_id),
             'unique_id_is_permalink': unique_id_is_permalink,
-            'enclosures': enclosures,
+            'enclosures': enclosures or (),
             'categories': categories or (),
             'item_copyright': to_str(item_copyright),
             'ttl': ttl,

--- a/tests/utils_tests/test_feedgenerator.py
+++ b/tests/utils_tests/test_feedgenerator.py
@@ -120,6 +120,12 @@ class FeedgeneratorTest(unittest.TestCase):
         self.assertIn('href="/feed/"', feed_content)
         self.assertIn('rel="self"', feed_content)
 
+    def test_atom_add_item(self):
+        # Not providing any optional arguments to Atom1Feed.add_item()
+        feed = feedgenerator.Atom1Feed('title', '/link/', 'descr')
+        feed.add_item('item_title', 'item_link', 'item_description')
+        feed.writeString('utf-8')
+
 
 class FeedgeneratorDBTest(TestCase):
 


### PR DESCRIPTION
[Ticket #27879](https://code.djangoproject.com/ticket/27879)