### PR TITLE
Fixed #27862 -- Fixed incorrectly quoted table aliases in Subquery SQL.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -940,10 +940,15 @@ class Subquery(Expression):
 
         def resolve(child):
             if hasattr(child, 'resolve_expression'):
-                return child.resolve_expression(
+                resolved = child.resolve_expression(
                     query=query, allow_joins=allow_joins, reuse=reuse,
                     summarize=summarize, for_save=for_save,
                 )
+                # Add table alias to the parent query's aliases to prevent
+                # quoting.
+                if hasattr(resolved, 'alias'):
+                    clone.queryset.query.external_aliases.add(resolved.alias)
+                return resolved
             return child
 
         resolve_all(clone.queryset.query.where)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -516,6 +516,15 @@ class BasicExpressionsTests(TestCase):
             [{'salary': 10, 'total_employees': 2300}, {'salary': 20, 'total_employees': 35}],
         )
 
+    def test_subquery_references_joined_table_twice(self):
+        inner = Company.objects.filter(
+            num_chairs__gte=OuterRef('ceo__salary'),
+            num_employees__gte=OuterRef('point_of_contact__salary'),
+        )
+        # Another contrived example (there is no need to have a subquery here)
+        outer = Company.objects.filter(pk__in=Subquery(inner.values('pk')))
+        self.assertFalse(outer.exists())
+
 
 class IterableLookupInnerExpressionsTests(TestCase):
     @classmethod


### PR DESCRIPTION
Exists() feature generates invalid SQL query on postgres backend