### PR TITLE
Refs #27025 -- Removed unneeded sqlite3 transaction management workaround in Python 3.6

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -395,7 +395,7 @@ class BaseDatabaseWrapper:
 
         start_transaction_under_autocommit = (
             force_begin_transaction_with_broken_autocommit and not autocommit and
-            self.features.autocommits_when_autocommit_is_off
+            hasattr(self, '_start_transaction_under_autocommit')
         )
 
         if start_transaction_under_autocommit:
@@ -593,15 +593,6 @@ class BaseDatabaseWrapper:
             {**self.settings_dict, 'NAME': None},
             alias=NO_DB_ALIAS,
             allow_thread_sharing=False,
-        )
-
-    def _start_transaction_under_autocommit(self):
-        """
-        Only required when autocommits_when_autocommit_is_off = True.
-        """
-        raise NotImplementedError(
-            'subclasses of BaseDatabaseWrapper may require a '
-            '_start_transaction_under_autocommit() method'
         )
 
     def schema_editor(self, *args, **kwargs):

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.db import utils
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.utils.functional import cached_property
@@ -13,7 +15,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_timezones = False
     max_query_params = 999
     supports_mixed_date_datetime_comparisons = False
-    autocommits_when_autocommit_is_off = True
+    autocommits_when_autocommit_is_off = sys.version_info < (3, 6)
     can_introspect_decimal_field = False
     can_introspect_duration_field = False
     can_introspect_positive_integer_field = True

--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -173,8 +173,8 @@ class Atomic(ContextDecorator):
             connection.commit_on_exit = True
             connection.needs_rollback = False
             if not connection.get_autocommit():
-                # Some database adapters (namely sqlite3) don't handle
-                # transactions and savepoints properly when autocommit is off.
+                # sqlite3 in Python < 3.6 doesn't handle transactions and
+                # savepoints properly when autocommit is off.
                 # Turning autocommit back on isn't an option; it would trigger
                 # a premature commit. Give up if that happens.
                 if connection.features.autocommits_when_autocommit_is_off:


### PR DESCRIPTION
Obsolete per https://bugs.python.org/issue10740#msg274816