### PR TITLE
Fixed #27882 -- Allowed {% cache %} to cache indefinitely.

### DIFF
--- a/django/templatetags/cache.py
+++ b/django/templatetags/cache.py
@@ -20,10 +20,11 @@ class CacheNode(Node):
             expire_time = self.expire_time_var.resolve(context)
         except VariableDoesNotExist:
             raise TemplateSyntaxError('"cache" tag got an unknown variable: %r' % self.expire_time_var.var)
-        try:
-            expire_time = int(expire_time)
-        except (ValueError, TypeError):
-            raise TemplateSyntaxError('"cache" tag got a non-integer timeout value: %r' % expire_time)
+        if expire_time is not None:
+            try:
+                expire_time = int(expire_time)
+            except (ValueError, TypeError):
+                raise TemplateSyntaxError('"cache" tag got a non-integer timeout value: %r' % expire_time)
         if self.cache_name:
             try:
                 cache_name = self.cache_name.resolve(context)

--- a/docs/topics/cache.txt
+++ b/docs/topics/cache.txt
@@ -659,8 +659,9 @@ the ``cache`` template tag. To give your template access to this tag, put
 
 The ``{% cache %}`` template tag caches the contents of the block for a given
 amount of time. It takes at least two arguments: the cache timeout, in seconds,
-and the name to give the cache fragment. The name will be taken as is, do not
-use a variable. For example:
+and the name to give the cache fragment. The fragment is cached forever if
+timeout is ``None``. The name will be taken as is, do not use a variable. For
+example:
 
 .. code-block:: html+django
 
@@ -668,6 +669,10 @@ use a variable. For example:
     {% cache 500 sidebar %}
         .. sidebar ..
     {% endcache %}
+
+.. versionchanged:: 2.0
+
+    Older versions don't allow a ``None`` timeout.
 
 Sometimes you might want to cache multiple copies of a fragment depending on
 some dynamic data that appears inside the fragment. For example, you might want a

--- a/tests/template_tests/syntax_tests/test_cache.py
+++ b/tests/template_tests/syntax_tests/test_cache.py
@@ -122,6 +122,17 @@ class CacheTagTests(SimpleTestCase):
         output = self.engine.render_to_string('cache18')
         self.assertEqual(output, 'cache18')
 
+    @setup({
+        'first': '{% load cache %}{% cache None fragment19 %}content{% endcache %}',
+        'second': '{% load cache %}{% cache None fragment19 %}not rendered{% endcache %}'
+    })
+    def test_none_timeout(self):
+        """A timeout of None means "cache forever"."""
+        output = self.engine.render_to_string('first')
+        self.assertEqual(output, 'content')
+        output = self.engine.render_to_string('second')
+        self.assertEqual(output, 'content')
+
 
 class CacheTests(SimpleTestCase):
 


### PR DESCRIPTION
Fixed the cache templatetag so that fragments will be cached
forever when the cache timeout is set to None.