### PR TITLE
Fixed #27539 -- Made TransactionTestCase._pre_setup() clear the queries_log so it's less likely to overflow.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -827,6 +827,11 @@ class TransactionTestCase(SimpleTestCase):
                     enter=False,
                 )
             raise
+        # Clear the queries_log so that it's less likley to overflow (a single
+        # test probably won't execute 9K queries). If queries_log overflows,
+        # then assertNumQueries() doesn't work.
+        for db_name in self._databases_names(include_mirrors=False):
+            connections[db_name].queries_log.clear()
 
     @classmethod
     def _databases_names(cls, include_mirrors=True):


### PR DESCRIPTION
Following the [PR](https://github.com/django/django/pull/8013). I was unable to make the test case asked by @timgraham. I could use some help. In my opinion the test case should be similar to backends.tests.BackendTestCase.test_queries_limit. The problem I encountered was testing assertNumQueries with the new_connection. Although the test provided works, it increases the time from 0.1 to 6 seconds.