### PR TITLE
No sha1

### DIFF
--- a/django/core/signing.py
+++ b/django/core/signing.py
@@ -98,7 +98,7 @@ class JSONSerializer(object):
 
 def dumps(obj, key=None, salt='django.core.signing', serializer=JSONSerializer, compress=False):
     """
-    Returns URL-safe, sha1 signed base64 compressed JSON string. If key is
+    Returns URL-safe, hmac/SHA1 signed base64 compressed JSON string. If key is
     None, settings.SECRET_KEY is used instead.
 
     If compress is True (not the default) checks if compressing using zlib can

--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -82,7 +82,7 @@ class Loader(BaseLoader):
         return ("%s-%s-%s" % (template_name, skip_prefix, dirs_prefix)).strip('-')
 
     def generate_hash(self, values):
-        return hashlib.sha1(force_bytes('|'.join(values))).hexdigest()
+        return hashlib.sha256(force_bytes('|'.join(values))).hexdigest()
 
     @property
     def supports_recursion(self):


### PR DESCRIPTION
This removes a non-security critical use of sha1. It was being used to generate a cache key. Sha256 is longer than sha1 in this casase (64 vs 40), is that a problem? If so sha256 can be truncated.

I also add a note to a function that is using hmac/SHA1 to sign a string.