### PR TITLE
Refs #27836 -- Fixed ignored exception in test cleanup.

### DIFF
--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -496,9 +496,9 @@ class FileStorageTests(SimpleTestCase):
             self.storage.delete('')
 
     def test_delete_deletes_directories(self):
-        tmp_dir = tempfile.TemporaryDirectory(dir=self.storage.location)
-        self.storage.delete(tmp_dir.name)
-        self.assertFalse(os.path.exists(tmp_dir.name))
+        tmp_dir = tempfile.mkdtemp(dir=self.storage.location)
+        self.storage.delete(tmp_dir)
+        self.assertFalse(os.path.exists(tmp_dir))
 
     @override_settings(
         MEDIA_ROOT='media_root',


### PR DESCRIPTION
Since e4025563ea87b0e3acb1d617ebfcc0b8789f75e7 I started seeing this exception in `runtests.py` output:
```
test_delete_deletes_directories (file_storage.tests.FileStorageTests) ... Exception ignored in: <finalize object at 0x7fc6fc1724d0; dead>
Traceback (most recent call last):
  File "/usr/lib64/python3.4/weakref.py", line 519, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "/usr/lib64/python3.4/tempfile.py", line 698, in _cleanup
    _shutil.rmtree(name)
  File "/usr/lib64/python3.4/shutil.py", line 459, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib64/python3.4/shutil.py", line 457, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/django_5ol7ugyk/tmpdw2jd793/tmpn6qee0gk'
ok
```

This happens because `TemporaryDirectory` tries to delete the directory that test already deleted. The exception doesn't fail any tests because it happen during `weakref.finalize` cleanup handler.

Replacing `TemporaryDirectory` with `mkdtemp` fixes this error.