### PR TITLE
Fixed a typo in the 1.10.6 release notes

### DIFF
--- a/docs/releases/1.10.6.txt
+++ b/docs/releases/1.10.6.txt
@@ -19,7 +19,7 @@ Bugfixes
   or ``IntegerField`` from ``DateField`` (:ticket:`27828`).
 
 * Fixed query expression date subtraction accuracy on PostgreSQL for
-  differences large an a month (:ticket:`27856`).
+  differences larger than a month (:ticket:`27856`).
 
 * Fixed a ``GDALException`` raised by ``GDALClose`` on GDAL ≥ 2.0
   (:ticket:`27479`).


### PR DESCRIPTION
Just a small one.