### PR TITLE
Make the name of the simple template tag consistent

### DIFF
--- a/docs/howto/custom-template-tags.txt
+++ b/docs/howto/custom-template-tags.txt
@@ -490,7 +490,7 @@ you see fit:
 
 .. code-block:: html+django
 
-    {% get_current_time "%Y-%m-%d %I:%M %p" as the_time %}
+    {% current_time "%Y-%m-%d %I:%M %p" as the_time %}
     <p>The time is {{ the_time }}.</p>
 
 .. _howto-custom-template-tags-inclusion-tags:


### PR DESCRIPTION
`get_current_time` was the name of the tag in the assignment tag example which has been removed. In the simple tag example `current_time` is used, so I have updated the assignment example to be consistent and remove a possible question mark from a reader.