### PR TITLE
Fixed #26522 -- Reuse join aliases in-order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ answer newbie questions, and generally made Django that much better:
     berto
     Bill Fenner <fenner@gmail.com>
     Bjørn Stabell <bjorn@exoweb.net>
+    Bo Marchman <bo.marchman@gmail.com>
     Bojan Mihelac <bmihelac@mihelac.org>
     Bouke Haarsma <bouke@haarsma.eu>
     Božidar Benko <bbenko@gmail.com>

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -126,7 +126,7 @@ class Query:
         # types they are. The key is the alias of the joined table (possibly
         # the table name) and the value is a Join-like object (see
         # sql.datastructures.Join for more information).
-        self.alias_map = {}
+        self.alias_map = OrderedDict()
         # Sometimes the query contains references to aliases in outer queries (as
         # a result of split_exclude). Correct alias quoting needs to know these
         # aliases too.

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -663,6 +663,11 @@ class Classroom(models.Model):
     students = models.ManyToManyField(Student, related_name='classroom')
 
 
+class Teacher(models.Model):
+    schools = models.ManyToManyField(School)
+    friends = models.ManyToManyField('self')
+
+
 class Ticket23605AParent(models.Model):
     pass
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -24,8 +24,9 @@ from .models import (
     ProxyCategory, ProxyObjectA, ProxyObjectB, Ranking, Related,
     RelatedIndividual, RelatedObject, Report, ReservedName, Responsibility,
     School, SharedConnection, SimpleCategory, SingleObject, SpecialCategory,
-    Staff, StaffUser, Student, Tag, Task, Ticket21203Child, Ticket21203Parent,
-    Ticket23605A, Ticket23605B, Ticket23605C, TvChef, Valid, X,
+    Staff, StaffUser, Student, Tag, Task, Teacher, Ticket21203Child,
+    Ticket21203Parent, Ticket23605A, Ticket23605B, Ticket23605C, TvChef, Valid,
+    X,
 )
 
 
@@ -1381,6 +1382,18 @@ class Queries4Tests(TestCase):
         self.assertEqual(str(combined.query).count('JOIN'), 2)
         self.assertEqual(len(combined), 1)
         self.assertEqual(combined[0].name, 'a1')
+
+    def test_join_reuse_order(self):
+        # Join aliases are reused in order. This shouldn't raise AssertionError
+        # because change_map contains a circular reference (#26522).
+        s1 = School.objects.create()
+        s2 = School.objects.create()
+        s3 = School.objects.create()
+        t1 = Teacher.objects.create()
+        otherteachers = Teacher.objects.exclude(pk=t1.pk).exclude(friends=t1)
+        qs1 = otherteachers.filter(schools=s1).filter(schools=s2)
+        qs2 = otherteachers.filter(schools=s1).filter(schools=s3)
+        self.assertQuerysetEqual(qs1 | qs2, [])
 
     def test_ticket7095(self):
         # Updates that are filtered on the model being updated are somewhat


### PR DESCRIPTION
Solved a non-deterministic AssertionError raised by circular
references in change_map.

Thanks Andrew Brown for the minimal test case.