### PR TITLE
Fixed #27905 – Added RelatedFieldWidgetWrapper.value_omitted_from_data().

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -303,6 +303,9 @@ class RelatedFieldWidgetWrapper(forms.Widget):
     def value_from_datadict(self, data, files, name):
         return self.widget.value_from_datadict(data, files, name)
 
+    def value_omitted_from_data(self, data, files, name):
+        return self.widget.value_omitted_from_data(data, files, name)
+
     def id_for_label(self, id_):
         return self.widget.id_for_label(id_)
 

--- a/docs/releases/1.10.7.txt
+++ b/docs/releases/1.10.7.txt
@@ -9,4 +9,5 @@ Django 1.10.7 fixes several bugs in 1.10.6.
 Bugfixes
 ========
 
-* ...
+* Made admin's ``RelatedFieldWidgetWrapper`` use the wrapped widget's
+  ``value_omitted_from_data()`` method (:ticket:`27905`).

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -646,6 +646,15 @@ class RelatedFieldWidgetWrapperTests(SimpleTestCase):
         output = wrapper.render('name', 'value')
         self.assertIn('custom render output', output)
 
+    def test_widget_delegates_value_omitted_from_data(self):
+        class CustomWidget(forms.Select):
+            def value_omitted_from_data(self, data, files, name):
+                return False
+        rel = Album._meta.get_field('band').remote_field
+        widget = CustomWidget()
+        wrapper = widgets.RelatedFieldWidgetWrapper(widget, rel, widget_admin_site)
+        self.assertIs(wrapper.value_omitted_from_data({}, {}, 'band'), False)
+
 
 @override_settings(ROOT_URLCONF='admin_widgets.urls')
 class AdminWidgetSeleniumTestCase(AdminSeleniumTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27850

In `RelatedFieldWidgetWrapper`, `value_omitted_from_data` should be delegated to the wrapped widget.