### PR TITLE
Fix libgdal.py crash under Windows if PATH containes non-ascii symbols

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -23,7 +23,7 @@ if lib_path:
     lib_names = None
 elif os.name == 'nt':
     # Windows NT shared libraries
-    lib_names = ['gdal111', 'gdal110', 'gdal19', 'gdal18', 'gdal17']
+    lib_names = [str('gdal111'), str('gdal110'), str('gdal19'), str('gdal18'), str('gdal17')]
 elif os.name == 'posix':
     # *NIX library names.
     lib_names = ['gdal', 'GDAL', 'gdal1.11.0', 'gdal1.10.0', 'gdal1.9.0', 'gdal1.8.0', 'gdal1.7.0']


### PR DESCRIPTION
Problem: 
application crashes under Windows, if PATH contain non-ascii symbols (%USERPROFILE% for users with non-ascii names for example).

Reason:
Function find_library splits os.environ['PATH'] into individual directories and tries them all one by one. In python 2.x os.environ contains strings, not unicode (that is bad, but probably would not be fixed soon), so inside it tries to add non-ascii str and unicode string (library name). And boom -- got an UnicodeDecodeError exception.

So, I suggest to use simple strings as library names. 
POSIX find_library much more complex, I know nothing about it and probably it is ok with unicode names.