### PR TITLE
Fixed #27924 -- Added cx_Oracle 5.3 support.

### DIFF
--- a/django/contrib/gis/db/backends/oracle/introspection.py
+++ b/django/contrib/gis/db/backends/oracle/introspection.py
@@ -36,8 +36,8 @@ class OracleIntrospection(DatabaseIntrospection):
             dim, srid = row
             if srid != 4326:
                 field_params['srid'] = srid
-            # Length of object array ( SDO_DIM_ARRAY ) is number of dimensions.
-            dim = len(dim)
+            # Size of object array (SDO_DIM_ARRAY) is number of dimensions.
+            dim = dim.size()
             if dim != 2:
                 field_params['dim'] = dim
         finally:

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -530,7 +530,8 @@ def _rowfactory(row, cursor):
     casted = []
     for value, desc in zip(row, cursor.description):
         if value is not None and desc[1] is Database.NUMBER:
-            precision, scale = desc[4:6]
+            precision = desc[4] or 0
+            scale = desc[5] or 0
             if scale == -127:
                 if precision == 0:
                     # NUMBER column: decimal-precision floating point

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -78,7 +78,13 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             name = force_text(desc[0])  # cx_Oracle always returns a 'str'
             internal_size, default = field_map[name]
             name = name % {}  # cx_Oracle, for some reason, doubles percent signs.
-            description.append(FieldInfo(*(name.lower(),) + desc[1:3] + (internal_size,) + desc[4:] + (default,)))
+            description.append(FieldInfo(*(
+                (name.lower(),) +
+                desc[1:3] +
+                (internal_size, desc[4] or 0, desc[5] or 0) +
+                desc[6:] +
+                (default,)
+            )))
         return description
 
     def table_name_converter(self, name):

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -263,6 +263,8 @@ Database backends
   <mysql-isolation-level>`. To avoid possible data loss, it's recommended to
   switch from MySQL's default level, repeatable read, to read committed.
 
+* Added support for ``cx_Oracle`` 5.3.
+
 Email
 ~~~~~
 


### PR DESCRIPTION
Fixed Oracle backend due to the `cx_Oracle` 5.3 change in a `cursor.description` behavior i.e.
`Use None instead of 0 for items in the Cursor.description attribute that do not have any validity.` (see [release notes ](http://cx-oracle.readthedocs.io/en/5.3/releasenotes.html#version-5-3-march-2017)).