### PR TITLE
[1.10.x] Refs #27924 -- Doc'd that cx_Oracle < 5.3 is required.

### DIFF
--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -720,9 +720,9 @@ rather than a list. SQLite does not support this.
 Oracle notes
 ============
 
-Django supports `Oracle Database Server`_ versions 11.2 and higher. Version
-4.3.1 or higher of the `cx_Oracle`_ Python driver is required, although we
-recommend version 5.1.3 or later as these versions support Python 3.
+Django supports `Oracle Database Server`_ versions 11.2 and higher. Versions
+4.3.1 through 5.2.1 of the `cx_Oracle`_ Python driver are supported, although
+5.1.3 or later is recommended as these versions support Python 3.
 
 Note that due to a Unicode-corruption bug in ``cx_Oracle`` 5.0, that
 version of the driver should **not** be used with Django;

--- a/tests/requirements/oracle.txt
+++ b/tests/requirements/oracle.txt
@@ -1,1 +1,1 @@
-cx_oracle
+cx_oracle < 5.3


### PR DESCRIPTION
Ticket [27924](https://code.djangoproject.com/ticket/27924) (see [comment](https://code.djangoproject.com/ticket/27924#comment:3)).