### PR TITLE
Clarified meaning of "Optional" in User model field docs.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -43,11 +43,13 @@ Fields
 
     .. attribute:: first_name
 
-        Optional. 30 characters or fewer.
+        Optional (:attr:`blank=True <django.db.models.Field.blank>`). 30
+        characters or fewer.
 
     .. attribute:: last_name
 
-        Optional. 150 characters or fewer.
+        Optional (:attr:`blank=True <django.db.models.Field.blank>`). 150
+        characters or fewer.
 
         .. versionchanged:: 2.0
 
@@ -55,7 +57,8 @@ Fields
 
     .. attribute:: email
 
-        Optional. Email address.
+        Optional (:attr:`blank=True <django.db.models.Field.blank>`). Email
+        address.
 
     .. attribute:: password
 


### PR DESCRIPTION
according to the code https://github.com/django/django/blob/master/django/contrib/auth/models.py#L333 the email field of the user model cannot be `None` and is required.

Ran into this when saving the user model without email via a regular DRF serializer:
```
  class UserSerializer(serializers.HyperlinkedModelSerializer):
      class Meta:
          model = User
          fields = ('first_name', 'last_name', 'email')
          extra_kwargs = {'email': {'required': False, 'allow_blank': True}}
```