### PR TITLE
 Fixed #27935 -- Added test for auto-generated name for BrinIndex.

### DIFF
--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -1,4 +1,6 @@
+from django.db import connection
 from django.db.models import Index
+from django.utils.functional import cached_property
 
 __all__ = ['BrinIndex', 'GinIndex']
 
@@ -33,6 +35,14 @@ class BrinIndex(Index):
             parameters['extra'] = ' WITH (pages_per_range={})'.format(
                 schema_editor.quote_value(self.pages_per_range)) + parameters['extra']
         return parameters
+
+    @cached_property
+    def max_name_length(self):
+        # Allow an index name longer than 30 characters since the suffix
+        # is 4 characters (usual limit is 3). Since this index can only be
+        # used on PostgreSQL, the 30 character limit for cross-database
+        # compatibility isn't applicable.
+        return connection.ops.max_name_length()
 
 
 class GinIndex(Index):

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -3,7 +3,7 @@ from django.db import connection
 from django.test import skipUnlessDBFeature
 
 from . import PostgreSQLTestCase
-from .models import CharFieldModel, IntegerArrayModel
+from .models import CharFieldModel, DateTimeArrayModel, IntegerArrayModel
 
 
 @skipUnlessDBFeature('has_brin_index_support')
@@ -22,6 +22,17 @@ class BrinIndexTests(PostgreSQLTestCase):
         index = BrinIndex(fields=['title'])
         index_with_page_range = BrinIndex(fields=['title'], pages_per_range=16)
         self.assertNotEqual(index, index_with_page_range)
+
+    def test_name_auto_generation(self):
+        """
+        A name longer than 30 characters (since len(BrinIndex.suffix) is 4
+        rather than usual limit of 3) is okay for PostgreSQL. For this test,
+        the name of the field ('datetimes') must be at least 7 characters to
+        generate a name longer than 30 characters.
+        """
+        index = BrinIndex(fields=['datetimes'])
+        index.set_name_with_model(DateTimeArrayModel)
+        self.assertEqual(index.name, 'postgres_te_datetim_abf104_brin')
 
     def test_deconstruction(self):
         index = BrinIndex(fields=['title'], name='test_title_brin')


### PR DESCRIPTION
Changed prefix to `brn` so the index name is at most 30 characters.

Reported in https://code.djangoproject.com/ticket/27935