### PR TITLE
Corrected number of tildes in header in aggregation documentation

### DIFF
--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -482,7 +482,7 @@ include the aggregate column.
 .. _aggregation-ordering-interaction:
 
 Interaction with default ordering or ``order_by()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Fields that are mentioned in the ``order_by()`` part of a queryset (or which
 are used in the default ordering on a model) are used when selecting the


### PR DESCRIPTION
I'm not sure if the additional tilde was there for a reason.