### PR TITLE
Refs #27563 -- Fixed ModelChoiceField.__deepcopy__() so forms don't share a queryset cache.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1155,7 +1155,7 @@ class ModelChoiceField(ChoiceField):
     def __deepcopy__(self, memo):
         result = super(ChoiceField, self).__deepcopy__(memo)
         # Need to force a new ModelChoiceIterator to be created, bug #11183
-        result.queryset = result.queryset
+        result.queryset = self.queryset.all()
         return result
 
     def _get_queryset(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1631,6 +1631,15 @@ class ModelChoiceFieldTests(TestCase):
         self.assertIsNot(field1, ModelChoiceForm.base_fields['category'])
         self.assertIs(field1.widget.choices.field, field1)
 
+    def test_modelchoicefield_result_cache_not_shared(self):
+        class ModelChoiceForm(forms.Form):
+            category = forms.ModelChoiceField(Category.objects.all())
+
+        form1 = ModelChoiceForm()
+        self.assertCountEqual(form1.fields['category'].queryset, [self.c1, self.c2, self.c3])
+        form2 = ModelChoiceForm()
+        self.assertIsNone(form2.fields['category'].queryset._result_cache)
+
     def test_modelchoicefield_22745(self):
         """
         #22745 -- Make sure that ModelChoiceField with RadioSelect widget


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27563