### PR TITLE
Correct checkout URL for Django development branch

### DIFF
--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -220,7 +220,7 @@ latest bug fixes and improvements, follow these instructions:
 
    .. code-block:: console
 
-        $ git clone git://github.com/django/django.git
+        $ git clone https://github.com/django/django.git
 
    This will create a directory ``django`` in your current directory.
 


### PR DESCRIPTION
In the detailed installation instructions, the checkout URL of the Django development branch `git://github.com/django/django.git` doesn't seem to be valid. It's either `https://github.com/django/django.git` or `git@github.com:django/django.git`. 

As this is a fairly trivial change, it doesn't have a Trac ticket.