### PR TITLE
Replaced type-specific assertions with assertEqual().

### DIFF
--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -812,11 +812,7 @@ class ChangeListTests(TestCase):
             cl.page_num = page_num
             cl.get_results(request)
             real_page_range = pagination(cl)['page_range']
-
-            self.assertListEqual(
-                expected_page_range,
-                list(real_page_range),
-            )
+            self.assertEqual(expected_page_range, list(real_page_range))
 
     def test_object_tools_displayed_no_add_permission(self):
         """

--- a/tests/admin_ordering/tests.py
+++ b/tests/admin_ordering/tests.py
@@ -49,7 +49,7 @@ class TestAdminOrdering(TestCase):
         """
         ma = ModelAdmin(Band, site)
         names = [b.name for b in ma.get_queryset(request)]
-        self.assertListEqual(['Aerosmith', 'Radiohead', 'Van Halen'], names)
+        self.assertEqual(['Aerosmith', 'Radiohead', 'Van Halen'], names)
 
     def test_specified_ordering(self):
         """
@@ -60,7 +60,7 @@ class TestAdminOrdering(TestCase):
             ordering = ('rank',)  # default ordering is ('name',)
         ma = BandAdmin(Band, site)
         names = [b.name for b in ma.get_queryset(request)]
-        self.assertListEqual(['Radiohead', 'Van Halen', 'Aerosmith'], names)
+        self.assertEqual(['Radiohead', 'Van Halen', 'Aerosmith'], names)
 
     def test_dynamic_ordering(self):
         """
@@ -72,10 +72,10 @@ class TestAdminOrdering(TestCase):
         request.user = super_user
         ma = DynOrderingBandAdmin(Band, site)
         names = [b.name for b in ma.get_queryset(request)]
-        self.assertListEqual(['Radiohead', 'Van Halen', 'Aerosmith'], names)
+        self.assertEqual(['Radiohead', 'Van Halen', 'Aerosmith'], names)
         request.user = other_user
         names = [b.name for b in ma.get_queryset(request)]
-        self.assertListEqual(['Aerosmith', 'Radiohead', 'Van Halen'], names)
+        self.assertEqual(['Aerosmith', 'Radiohead', 'Van Halen'], names)
 
 
 class TestInlineModelAdminOrdering(TestCase):
@@ -99,7 +99,7 @@ class TestInlineModelAdminOrdering(TestCase):
         """
         inline = SongInlineDefaultOrdering(self.band, site)
         names = [s.name for s in inline.get_queryset(request)]
-        self.assertListEqual(['Dude (Looks Like a Lady)', 'Jaded', 'Pink'], names)
+        self.assertEqual(['Dude (Looks Like a Lady)', 'Jaded', 'Pink'], names)
 
     def test_specified_ordering(self):
         """
@@ -107,7 +107,7 @@ class TestInlineModelAdminOrdering(TestCase):
         """
         inline = SongInlineNewOrdering(self.band, site)
         names = [s.name for s in inline.get_queryset(request)]
-        self.assertListEqual(['Jaded', 'Pink', 'Dude (Looks Like a Lady)'], names)
+        self.assertEqual(['Jaded', 'Pink', 'Dude (Looks Like a Lady)'], names)
 
 
 class TestRelatedFieldsAdminOrdering(TestCase):
@@ -130,9 +130,8 @@ class TestRelatedFieldsAdminOrdering(TestCase):
     def check_ordering_of_field_choices(self, correct_ordering):
         fk_field = site._registry[Song].formfield_for_foreignkey(Song.band.field, request=None)
         m2m_field = site._registry[Song].formfield_for_manytomany(Song.other_interpreters.field, request=None)
-
-        self.assertListEqual(list(fk_field.queryset), correct_ordering)
-        self.assertListEqual(list(m2m_field.queryset), correct_ordering)
+        self.assertEqual(list(fk_field.queryset), correct_ordering)
+        self.assertEqual(list(m2m_field.queryset), correct_ordering)
 
     def test_no_admin_fallback_to_model_ordering(self):
         # should be ordered by name (as defined by the model)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3491,7 +3491,7 @@ action)</option>
             reverse('admin:admin_views_actor_add') + '?%s=1' % IS_POPUP_VAR,
             {'name': 'Troy McClure', 'age': '55', IS_POPUP_VAR: '1'})
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual(response.template_name, [
+        self.assertEqual(response.template_name, [
             'admin/admin_views/actor/popup_response.html',
             'admin/admin_views/popup_response.html',
             'admin/popup_response.html',
@@ -3505,7 +3505,7 @@ action)</option>
             {'name': 'David Tennant', 'age': '46', IS_POPUP_VAR: '1'}
         )
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual(response.template_name, [
+        self.assertEqual(response.template_name, [
             'admin/admin_views/actor/popup_response.html',
             'admin/admin_views/popup_response.html',
             'admin/popup_response.html',
@@ -3519,7 +3519,7 @@ action)</option>
             {IS_POPUP_VAR: '1'}
         )
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual(response.template_name, [
+        self.assertEqual(response.template_name, [
             'admin/admin_views/actor/popup_response.html',
             'admin/admin_views/popup_response.html',
             'admin/popup_response.html',

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -97,9 +97,7 @@ class AppsTests(SimpleTestCase):
         Tests apps.get_app_configs().
         """
         app_configs = apps.get_app_configs()
-        self.assertListEqual(
-            [app_config.name for app_config in app_configs],
-            SOME_INSTALLED_APPS_NAMES)
+        self.assertEqual([app_config.name for app_config in app_configs], SOME_INSTALLED_APPS_NAMES)
 
     @override_settings(INSTALLED_APPS=SOME_INSTALLED_APPS)
     def test_get_app_config(self):
@@ -201,7 +199,7 @@ class AppsTests(SimpleTestCase):
         body['__module__'] = TotallyNormal.__module__
         temp_model = type("SouthPonies", (models.Model,), body)
         # Make sure it appeared in the right place!
-        self.assertListEqual(list(apps.get_app_config("apps").get_models()), old_models)
+        self.assertEqual(list(apps.get_app_config("apps").get_models()), old_models)
         with self.assertRaises(LookupError):
             apps.get_model("apps", "SouthPonies")
         self.assertEqual(new_apps.get_model("apps", "SouthPonies"), temp_model)
@@ -275,7 +273,7 @@ class AppsTests(SimpleTestCase):
 
         # LazyModelA shouldn't be waited on since it's already registered,
         # and LazyModelC shouldn't be waited on until LazyModelB exists.
-        self.assertSetEqual(set(apps._pending_operations) - initial_pending, {('apps', 'lazyb')})
+        self.assertEqual(set(apps._pending_operations) - initial_pending, {('apps', 'lazyb')})
 
         # Multiple operations can wait on the same model
         apps.lazy_model_operation(test_func, ('apps', 'lazyb'))
@@ -283,16 +281,16 @@ class AppsTests(SimpleTestCase):
         class LazyB(models.Model):
             pass
 
-        self.assertListEqual(model_classes, [LazyB])
+        self.assertEqual(model_classes, [LazyB])
 
         # Now we are just waiting on LazyModelC.
-        self.assertSetEqual(set(apps._pending_operations) - initial_pending, {('apps', 'lazyc')})
+        self.assertEqual(set(apps._pending_operations) - initial_pending, {('apps', 'lazyc')})
 
         class LazyC(models.Model):
             pass
 
         # Everything should be loaded - make sure the callback was executed properly.
-        self.assertListEqual(model_classes, [LazyA, LazyB, LazyB, LazyC, LazyA])
+        self.assertEqual(model_classes, [LazyA, LazyB, LazyB, LazyC, LazyA])
 
 
 class Stub:

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -290,8 +290,8 @@ class BaseCacheTests:
         cache.set('b', 'b')
         cache.set('c', 'c')
         cache.set('d', 'd')
-        self.assertDictEqual(cache.get_many(['a', 'c', 'd']), {'a': 'a', 'c': 'c', 'd': 'd'})
-        self.assertDictEqual(cache.get_many(['a', 'b', 'e']), {'a': 'a', 'b': 'b'})
+        self.assertEqual(cache.get_many(['a', 'c', 'd']), {'a': 'a', 'c': 'c', 'd': 'd'})
+        self.assertEqual(cache.get_many(['a', 'b', 'e']), {'a': 'a', 'b': 'b'})
 
     def test_delete(self):
         # Cache keys can be deleted
@@ -763,43 +763,43 @@ class BaseCacheTests:
     def test_cache_versioning_get_set_many(self):
         # set, using default version = 1
         cache.set_many({'ford1': 37, 'arthur1': 42})
-        self.assertDictEqual(cache.get_many(['ford1', 'arthur1']), {'ford1': 37, 'arthur1': 42})
-        self.assertDictEqual(cache.get_many(['ford1', 'arthur1'], version=1), {'ford1': 37, 'arthur1': 42})
-        self.assertDictEqual(cache.get_many(['ford1', 'arthur1'], version=2), {})
+        self.assertEqual(cache.get_many(['ford1', 'arthur1']), {'ford1': 37, 'arthur1': 42})
+        self.assertEqual(cache.get_many(['ford1', 'arthur1'], version=1), {'ford1': 37, 'arthur1': 42})
+        self.assertEqual(cache.get_many(['ford1', 'arthur1'], version=2), {})
 
-        self.assertDictEqual(caches['v2'].get_many(['ford1', 'arthur1']), {})
-        self.assertDictEqual(caches['v2'].get_many(['ford1', 'arthur1'], version=1), {'ford1': 37, 'arthur1': 42})
-        self.assertDictEqual(caches['v2'].get_many(['ford1', 'arthur1'], version=2), {})
+        self.assertEqual(caches['v2'].get_many(['ford1', 'arthur1']), {})
+        self.assertEqual(caches['v2'].get_many(['ford1', 'arthur1'], version=1), {'ford1': 37, 'arthur1': 42})
+        self.assertEqual(caches['v2'].get_many(['ford1', 'arthur1'], version=2), {})
 
         # set, default version = 1, but manually override version = 2
         cache.set_many({'ford2': 37, 'arthur2': 42}, version=2)
-        self.assertDictEqual(cache.get_many(['ford2', 'arthur2']), {})
-        self.assertDictEqual(cache.get_many(['ford2', 'arthur2'], version=1), {})
-        self.assertDictEqual(cache.get_many(['ford2', 'arthur2'], version=2), {'ford2': 37, 'arthur2': 42})
+        self.assertEqual(cache.get_many(['ford2', 'arthur2']), {})
+        self.assertEqual(cache.get_many(['ford2', 'arthur2'], version=1), {})
+        self.assertEqual(cache.get_many(['ford2', 'arthur2'], version=2), {'ford2': 37, 'arthur2': 42})
 
-        self.assertDictEqual(caches['v2'].get_many(['ford2', 'arthur2']), {'ford2': 37, 'arthur2': 42})
-        self.assertDictEqual(caches['v2'].get_many(['ford2', 'arthur2'], version=1), {})
-        self.assertDictEqual(caches['v2'].get_many(['ford2', 'arthur2'], version=2), {'ford2': 37, 'arthur2': 42})
+        self.assertEqual(caches['v2'].get_many(['ford2', 'arthur2']), {'ford2': 37, 'arthur2': 42})
+        self.assertEqual(caches['v2'].get_many(['ford2', 'arthur2'], version=1), {})
+        self.assertEqual(caches['v2'].get_many(['ford2', 'arthur2'], version=2), {'ford2': 37, 'arthur2': 42})
 
         # v2 set, using default version = 2
         caches['v2'].set_many({'ford3': 37, 'arthur3': 42})
-        self.assertDictEqual(cache.get_many(['ford3', 'arthur3']), {})
-        self.assertDictEqual(cache.get_many(['ford3', 'arthur3'], version=1), {})
-        self.assertDictEqual(cache.get_many(['ford3', 'arthur3'], version=2), {'ford3': 37, 'arthur3': 42})
+        self.assertEqual(cache.get_many(['ford3', 'arthur3']), {})
+        self.assertEqual(cache.get_many(['ford3', 'arthur3'], version=1), {})
+        self.assertEqual(cache.get_many(['ford3', 'arthur3'], version=2), {'ford3': 37, 'arthur3': 42})
 
-        self.assertDictEqual(caches['v2'].get_many(['ford3', 'arthur3']), {'ford3': 37, 'arthur3': 42})
-        self.assertDictEqual(caches['v2'].get_many(['ford3', 'arthur3'], version=1), {})
-        self.assertDictEqual(caches['v2'].get_many(['ford3', 'arthur3'], version=2), {'ford3': 37, 'arthur3': 42})
+        self.assertEqual(caches['v2'].get_many(['ford3', 'arthur3']), {'ford3': 37, 'arthur3': 42})
+        self.assertEqual(caches['v2'].get_many(['ford3', 'arthur3'], version=1), {})
+        self.assertEqual(caches['v2'].get_many(['ford3', 'arthur3'], version=2), {'ford3': 37, 'arthur3': 42})
 
         # v2 set, default version = 2, but manually override version = 1
         caches['v2'].set_many({'ford4': 37, 'arthur4': 42}, version=1)
-        self.assertDictEqual(cache.get_many(['ford4', 'arthur4']), {'ford4': 37, 'arthur4': 42})
-        self.assertDictEqual(cache.get_many(['ford4', 'arthur4'], version=1), {'ford4': 37, 'arthur4': 42})
-        self.assertDictEqual(cache.get_many(['ford4', 'arthur4'], version=2), {})
+        self.assertEqual(cache.get_many(['ford4', 'arthur4']), {'ford4': 37, 'arthur4': 42})
+        self.assertEqual(cache.get_many(['ford4', 'arthur4'], version=1), {'ford4': 37, 'arthur4': 42})
+        self.assertEqual(cache.get_many(['ford4', 'arthur4'], version=2), {})
 
-        self.assertDictEqual(caches['v2'].get_many(['ford4', 'arthur4']), {})
-        self.assertDictEqual(caches['v2'].get_many(['ford4', 'arthur4'], version=1), {'ford4': 37, 'arthur4': 42})
-        self.assertDictEqual(caches['v2'].get_many(['ford4', 'arthur4'], version=2), {})
+        self.assertEqual(caches['v2'].get_many(['ford4', 'arthur4']), {})
+        self.assertEqual(caches['v2'].get_many(['ford4', 'arthur4'], version=1), {'ford4': 37, 'arthur4': 42})
+        self.assertEqual(caches['v2'].get_many(['ford4', 'arthur4'], version=2), {})
 
     def test_incr_version(self):
         cache.set('answer', 42, version=2)

--- a/tests/foreign_object/test_empty_join.py
+++ b/tests/foreign_object/test_empty_join.py
@@ -21,7 +21,7 @@ class RestrictedConditionsTests(TestCase):
         use any joining columns, as long as an extra restriction is supplied.
         """
         a = SlugPage.objects.get(slug='a')
-        self.assertListEqual(
+        self.assertEqual(
             [p.slug for p in SlugPage.objects.filter(ascendants=a)],
             ['a', 'a/a', 'a/b', 'a/b/a'],
         )
@@ -31,11 +31,11 @@ class RestrictedConditionsTests(TestCase):
         )
 
         aba = SlugPage.objects.get(slug='a/b/a')
-        self.assertListEqual(
+        self.assertEqual(
             [p.slug for p in SlugPage.objects.filter(descendants__in=[aba])],
             ['a', 'a/b', 'a/b/a'],
         )
-        self.assertListEqual(
+        self.assertEqual(
             [p.slug for p in aba.ascendants.all()],
             ['a', 'a/b', 'a/b/a'],
         )

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -255,7 +255,7 @@ class FormsTestCase(SimpleTestCase):
         self.assertEqual(p.errors['first_name'], ['This field is required.'])
         self.assertEqual(p.errors['birthday'], ['This field is required.'])
         self.assertFalse(p.is_valid())
-        self.assertDictEqual(
+        self.assertEqual(
             p.errors,
             {'birthday': ['This field is required.'], 'first_name': ['This field is required.']}
         )

--- a/tests/gis_tests/distapp/tests.py
+++ b/tests/gis_tests/distapp/tests.py
@@ -94,7 +94,7 @@ class DistanceTest(TestCase):
                 with self.assertRaises(ValueError):
                     AustraliaCity.objects.filter(point__dwithin=(self.au_pnt, dist)).count()
             else:
-                self.assertListEqual(au_cities, self.get_names(qs.filter(point__dwithin=(self.au_pnt, dist))))
+                self.assertEqual(au_cities, self.get_names(qs.filter(point__dwithin=(self.au_pnt, dist))))
 
     @skipUnlessDBFeature("supports_distances_lookups")
     def test_distance_lookups(self):

--- a/tests/gis_tests/geo3d/tests.py
+++ b/tests/gis_tests/geo3d/tests.py
@@ -184,7 +184,7 @@ class Geo3DTest(Geo3DLoadingHelper, TestCase):
         union = City3D.objects.aggregate(Union('point'))['point__union']
         self.assertTrue(union.hasz)
         # Ordering of points in the resulting geometry may vary between implementations
-        self.assertSetEqual({p.ewkt for p in ref_union}, {p.ewkt for p in union})
+        self.assertEqual({p.ewkt for p in ref_union}, {p.ewkt for p in union})
 
     @skipUnlessDBFeature("supports_3d_functions")
     def test_extent(self):

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -196,7 +196,7 @@ class GeoModelTest(TestCase):
             tmp.write(result)
             tmp.seek(0)
             call_command('loaddata', tmp.name, verbosity=0)
-        self.assertListEqual(original_data, list(City.objects.all().order_by('name')))
+        self.assertEqual(original_data, list(City.objects.all().order_by('name')))
 
     @skipUnlessDBFeature("supports_empty_geometries")
     def test_empty_geometries(self):

--- a/tests/gis_tests/relatedapp/tests.py
+++ b/tests/gis_tests/relatedapp/tests.py
@@ -99,9 +99,9 @@ class RelatedGeoModelTest(TestCase):
 
         # Ordering of points in the result of the union is not defined and
         # implementation-dependent (DB backend, GEOS version)
-        self.assertSetEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u1})
-        self.assertSetEqual({p.ewkt for p in ref_u2}, {p.ewkt for p in u2})
-        self.assertSetEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u3})
+        self.assertEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u1})
+        self.assertEqual({p.ewkt for p in ref_u2}, {p.ewkt for p in u2})
+        self.assertEqual({p.ewkt for p in ref_u1}, {p.ewkt for p in u3})
 
     def test05_select_related_fk_to_subclass(self):
         "Testing that calling select_related on a query over a model with an FK to a model subclass works"

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -56,7 +56,7 @@ class HandlerTests(SimpleTestCase):
             request = WSGIRequest(environ)
             got.append(request.GET['want'])
         # %E9 is converted to the unicode replacement character by parse_qsl
-        self.assertListEqual(got, ['café', 'café', 'caf\ufffd', 'café'])
+        self.assertEqual(got, ['café', 'café', 'caf\ufffd', 'café'])
 
     def test_non_ascii_cookie(self):
         """Non-ASCII cookies set in JavaScript are properly decoded (#20557)."""

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -143,10 +143,10 @@ class QueryDictTests(SimpleTestCase):
         self.assertEqual(q['foo'], 'another')
         self.assertIn('foo', q)
 
-        self.assertListEqual(sorted(q.items()), [('foo', 'another'), ('name', 'john')])
-        self.assertListEqual(sorted(q.lists()), [('foo', ['bar', 'baz', 'another']), ('name', ['john'])])
-        self.assertListEqual(sorted(q.keys()), ['foo', 'name'])
-        self.assertListEqual(sorted(q.values()), ['another', 'john'])
+        self.assertCountEqual(q.items(), [('foo', 'another'), ('name', 'john')])
+        self.assertCountEqual(q.lists(), [('foo', ['bar', 'baz', 'another']), ('name', ['john'])])
+        self.assertCountEqual(q.keys(), ['foo', 'name'])
+        self.assertCountEqual(q.values(), ['another', 'john'])
 
         q.update({'foo': 'hello'})
         self.assertEqual(q['foo'], 'hello')

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -261,7 +261,7 @@ class URLRedirectWithoutTrailingSlashTests(URLTestCaseBase):
     def test_en_redirect(self):
         response = self.client.get('/account/register', HTTP_ACCEPT_LANGUAGE='en', follow=True)
         # We only want one redirect, bypassing CommonMiddleware
-        self.assertListEqual(response.redirect_chain, [('/en/account/register/', 302)])
+        self.assertEqual(response.redirect_chain, [('/en/account/register/', 302)])
         self.assertRedirects(response, '/en/account/register/', 302)
 
         response = self.client.get('/prefixed.xml', HTTP_ACCEPT_LANGUAGE='en', follow=True)

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -940,18 +940,18 @@ class ConnectionRouterTestCase(SimpleTestCase):
         'multiple_database.tests.WriteRouter'])
     def test_router_init_default(self):
         connection_router = ConnectionRouter()
-        self.assertListEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
+        self.assertEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
 
     def test_router_init_arg(self):
         connection_router = ConnectionRouter([
             'multiple_database.tests.TestRouter',
             'multiple_database.tests.WriteRouter'
         ])
-        self.assertListEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
+        self.assertEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
 
         # Init with instances instead of strings
         connection_router = ConnectionRouter([TestRouter(), WriteRouter()])
-        self.assertListEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
+        self.assertEqual([r.__class__.__name__ for r in connection_router.routers], ['TestRouter', 'WriteRouter'])
 
 
 # Make the 'other' database appear to be a replica of the 'default'

--- a/tests/order_with_respect_to/base_tests.py
+++ b/tests/order_with_respect_to/base_tests.py
@@ -48,9 +48,7 @@ class BaseOrderWithRespectToTests:
         # It doesn't matter which answer we use to check the order, it will
         # always be the same.
         a2 = self.Answer.objects.create(text="Number five", question=self.q1)
-        self.assertListEqual(
-            list(a1.question.get_answer_order()), list(a2.question.get_answer_order())
-        )
+        self.assertEqual(list(a1.question.get_answer_order()), list(a2.question.get_answer_order()))
 
     def test_change_ordering(self):
         # The ordering can be altered

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -47,13 +47,13 @@ class SimpleTests(HStoreTestCase):
 
         instance = HStoreModel.objects.create(field=value)
         instance = HStoreModel.objects.get()
-        self.assertDictEqual(instance.field, expected_value)
+        self.assertEqual(instance.field, expected_value)
 
         instance = HStoreModel.objects.get(field__a=1)
-        self.assertDictEqual(instance.field, expected_value)
+        self.assertEqual(instance.field, expected_value)
 
         instance = HStoreModel.objects.get(field__has_keys=[2, 'a', 'ï'])
-        self.assertDictEqual(instance.field, expected_value)
+        self.assertEqual(instance.field, expected_value)
 
 
 class TestQuerying(HStoreTestCase):

--- a/tests/postgres_tests/test_search.py
+++ b/tests/postgres_tests/test_search.py
@@ -218,13 +218,13 @@ class TestCombinations(GrailTestData, PostgreSQLTestCase):
 
     def test_query_or(self):
         searched = Line.objects.filter(dialogue__search=SearchQuery('kneecaps') | SearchQuery('nostrils'))
-        self.assertSequenceEqual(set(searched), {self.verse1, self.verse2})
+        self.assertEqual(set(searched), {self.verse1, self.verse2})
 
     def test_query_multiple_or(self):
         searched = Line.objects.filter(
             dialogue__search=SearchQuery('kneecaps') | SearchQuery('nostrils') | SearchQuery('Sir Robin')
         )
-        self.assertSequenceEqual(set(searched), {self.verse1, self.verse2, self.verse0})
+        self.assertEqual(set(searched), {self.verse1, self.verse2, self.verse0})
 
     def test_query_invert(self):
         searched = Line.objects.filter(character=self.minstrel, dialogue__search=~SearchQuery('kneecaps'))

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1306,12 +1306,12 @@ class Ticket25546Tests(TestCase):
             book1, book2 = list(books)
 
         with self.assertNumQueries(0):
-            self.assertListEqual(list(book1.first_time_authors.all()), [self.author11, self.author12])
-            self.assertListEqual(list(book2.first_time_authors.all()), [self.author21])
+            self.assertSequenceEqual(book1.first_time_authors.all(), [self.author11, self.author12])
+            self.assertSequenceEqual(book2.first_time_authors.all(), [self.author21])
 
-            self.assertListEqual(list(book1.first_time_authors.all()[0].addresses.all()), [self.author1_address1])
-            self.assertListEqual(list(book1.first_time_authors.all()[1].addresses.all()), [])
-            self.assertListEqual(list(book2.first_time_authors.all()[0].addresses.all()), [self.author2_address1])
+            self.assertSequenceEqual(book1.first_time_authors.all()[0].addresses.all(), [self.author1_address1])
+            self.assertSequenceEqual(book1.first_time_authors.all()[1].addresses.all(), [])
+            self.assertSequenceEqual(book2.first_time_authors.all()[0].addresses.all(), [self.author2_address1])
 
         self.assertEqual(
             list(book1.first_time_authors.all()), list(book1.first_time_authors.all().all())
@@ -1352,9 +1352,9 @@ class Ticket25546Tests(TestCase):
             book1, book2 = list(books)
 
         with self.assertNumQueries(0):
-            self.assertListEqual(book1.first_authors, [self.author11, self.author12])
-            self.assertListEqual(book2.first_authors, [self.author21])
+            self.assertEqual(book1.first_authors, [self.author11, self.author12])
+            self.assertEqual(book2.first_authors, [self.author21])
 
-            self.assertListEqual(book1.first_authors[0].happy_place, [self.author1_address1])
-            self.assertListEqual(book1.first_authors[1].happy_place, [])
-            self.assertListEqual(book2.first_authors[0].happy_place, [self.author2_address1])
+            self.assertEqual(book1.first_authors[0].happy_place, [self.author1_address1])
+            self.assertEqual(book1.first_authors[1].happy_place, [])
+            self.assertEqual(book2.first_authors[0].happy_place, [self.author2_address1])

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -24,8 +24,8 @@ class FullyDecoratedTranTestCase(TransactionTestCase):
     available_apps = []
 
     def test_override(self):
-        self.assertListEqual(settings.ITEMS, ['b', 'c', 'd'])
-        self.assertListEqual(settings.ITEMS_OUTER, [1, 2, 3])
+        self.assertEqual(settings.ITEMS, ['b', 'c', 'd'])
+        self.assertEqual(settings.ITEMS_OUTER, [1, 2, 3])
         self.assertEqual(settings.TEST, 'override')
         self.assertEqual(settings.TEST_OUTER, 'outer')
 
@@ -35,8 +35,8 @@ class FullyDecoratedTranTestCase(TransactionTestCase):
         'remove': ['d', 'c'],
     })
     def test_method_list_override(self):
-        self.assertListEqual(settings.ITEMS, ['a', 'b', 'e', 'f'])
-        self.assertListEqual(settings.ITEMS_OUTER, [1, 2, 3])
+        self.assertEqual(settings.ITEMS, ['a', 'b', 'e', 'f'])
+        self.assertEqual(settings.ITEMS_OUTER, [1, 2, 3])
 
     @modify_settings(ITEMS={
         'append': ['b'],
@@ -44,7 +44,7 @@ class FullyDecoratedTranTestCase(TransactionTestCase):
         'remove': ['a', 'c', 'e'],
     })
     def test_method_list_override_no_ops(self):
-        self.assertListEqual(settings.ITEMS, ['b', 'd'])
+        self.assertEqual(settings.ITEMS, ['b', 'd'])
 
     @modify_settings(ITEMS={
         'append': 'e',
@@ -52,12 +52,12 @@ class FullyDecoratedTranTestCase(TransactionTestCase):
         'remove': 'c',
     })
     def test_method_list_override_strings(self):
-        self.assertListEqual(settings.ITEMS, ['a', 'b', 'd', 'e'])
+        self.assertEqual(settings.ITEMS, ['a', 'b', 'd', 'e'])
 
     @modify_settings(ITEMS={'remove': ['b', 'd']})
     @modify_settings(ITEMS={'append': ['b'], 'prepend': ['d']})
     def test_method_list_override_nested_order(self):
-        self.assertListEqual(settings.ITEMS, ['d', 'c', 'b'])
+        self.assertEqual(settings.ITEMS, ['d', 'c', 'b'])
 
     @override_settings(TEST='override2')
     def test_method_override(self):
@@ -80,7 +80,7 @@ class FullyDecoratedTranTestCase(TransactionTestCase):
 class FullyDecoratedTestCase(TestCase):
 
     def test_override(self):
-        self.assertListEqual(settings.ITEMS, ['b', 'c', 'd'])
+        self.assertEqual(settings.ITEMS, ['b', 'c', 'd'])
         self.assertEqual(settings.TEST, 'override')
 
     @modify_settings(ITEMS={
@@ -90,7 +90,7 @@ class FullyDecoratedTestCase(TestCase):
     })
     @override_settings(TEST='override2')
     def test_method_override(self):
-        self.assertListEqual(settings.ITEMS, ['a', 'b', 'd', 'e'])
+        self.assertEqual(settings.ITEMS, ['a', 'b', 'd', 'e'])
         self.assertEqual(settings.TEST, 'override2')
 
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -960,9 +960,9 @@ class OverrideSettingsTests(SimpleTestCase):
         """
         Overriding DATABASE_ROUTERS should update the master router.
         """
-        test_routers = (object(),)
+        test_routers = [object()]
         with self.settings(DATABASE_ROUTERS=test_routers):
-            self.assertSequenceEqual(router.routers, test_routers)
+            self.assertEqual(router.routers, test_routers)
 
     def test_override_static_url(self):
         """

--- a/tests/timezones/tests.py
+++ b/tests/timezones/tests.py
@@ -217,7 +217,7 @@ class LegacyDatabaseTests(TestCase):
         # Regression test for #17755
         dt = datetime.datetime(2011, 9, 1, 13, 20, 30)
         event = Event.objects.create(dt=dt)
-        self.assertSequenceEqual(list(Event.objects.raw('SELECT * FROM timezones_event WHERE dt = %s', [dt])), [event])
+        self.assertEqual(list(Event.objects.raw('SELECT * FROM timezones_event WHERE dt = %s', [dt])), [event])
 
     def test_cursor_execute_accepts_naive_datetime(self):
         dt = datetime.datetime(2011, 9, 1, 13, 20, 30)

--- a/tests/utils_tests/test_jslex.py
+++ b/tests/utils_tests/test_jslex.py
@@ -118,7 +118,7 @@ def make_function(input, toks):
     def test_func(self):
         lexer = JsLexer()
         result = ["%s %s" % (name, tok) for name, tok in lexer.lex(input) if name != 'ws']
-        self.assertListEqual(result, toks)
+        self.assertEqual(result, toks)
     return test_func
 
 
@@ -220,7 +220,7 @@ class JsToCForGettextTest(SimpleTestCase):
 
 def make_function(js, c):
     def test_func(self):
-        self.assertMultiLineEqual(prepare_js_for_gettext(js), c)
+        self.assertEqual(prepare_js_for_gettext(js), c)
     return test_func
 
 


### PR DESCRIPTION
Python docs say, "it's usually not necessary to invoke these methods directly."