### PR TITLE
[RFC] template: do not apply string_if_invalid with 'default' filter

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -678,6 +678,9 @@ class FilterExpression:
             except VariableDoesNotExist:
                 if ignore_failures:
                     obj = None
+                elif (len(self.filters) and
+                      self.filters[0][0]._filter_name == 'default'):
+                    obj = None
                 else:
                     string_if_invalid = context.template.engine.string_if_invalid
                     if string_if_invalid:

--- a/tests/template_tests/syntax_tests/test_invalid_string.py
+++ b/tests/template_tests/syntax_tests/test_invalid_string.py
@@ -9,10 +9,7 @@ class InvalidStringTests(SimpleTestCase):
     @setup({'invalidstr01': '{{ var|default:"Foo" }}'})
     def test_invalidstr01(self):
         output = self.engine.render_to_string('invalidstr01')
-        if self.engine.string_if_invalid:
-            self.assertEqual(output, 'INVALID')
-        else:
-            self.assertEqual(output, 'Foo')
+        self.assertEqual(output, 'Foo')
 
     @setup({'invalidstr02': '{{ var|default_if_none:"Foo" }}'})
     def test_invalidstr02(self):


### PR DESCRIPTION
While the usage of string_if_invalid is discouraged, it can be
beneficial in CI to catch mistakes in template.

Therefore however `{{ request.id | default:"unknown" }}` should not
cause it to fail.