### PR TITLE
Fixed #27945 -- Clarified RegexValidator doc

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -52,7 +52,7 @@ class RegexValidator:
 
     def __call__(self, value):
         """
-        Validate that the input matches the regular expression
+        Validate that the input contains a match for the regular expression
         if inverse_match is False, otherwise raise ValidationError.
         """
         if not (self.inverse_match is not bool(self.regex.search(

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -85,8 +85,8 @@ to, or in lieu of custom ``field.clean()`` methods.
 
     .. attribute:: regex
 
-        The regular expression pattern to search for the provided ``value``,
-        or a pre-compiled regular expression. By default, raises a
+        The regular expression pattern to search for within the provided
+        ``value``, or a pre-compiled regular expression. By default, raises a
         :exc:`~django.core.exceptions.ValidationError` with :attr:`message`
         and :attr:`code` if a match is not found. That standard behavior can
         be reversed by setting :attr:`inverse_match` to ``True``, in which case


### PR DESCRIPTION
Clarified that the validator searches throughout value for a match with
regex, rather than requiring an exact match.