### PR TITLE
Removed unused parameter in Query.try_transform

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1095,13 +1095,13 @@ class Query:
                     # We didn't find a lookup. We are going to interpret
                     # the name as transform, and do an Exact lookup against
                     # it.
-                    lhs = self.try_transform(lhs, name, lookups)
+                    lhs = self.try_transform(lhs, name)
                     final_lookup = lhs.get_lookup('exact')
                 return final_lookup(lhs, rhs)
-            lhs = self.try_transform(lhs, name, lookups)
+            lhs = self.try_transform(lhs, name)
             lookups = lookups[1:]
 
-    def try_transform(self, lhs, name, rest_of_lookups):
+    def try_transform(self, lhs, name):
         """
         Helper method for build_lookup(). Try to fetch and initialize
         a transform for name parameter from lhs.

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1116,7 +1116,7 @@ class Query:
                 (name, lhs.output_field.__class__.__name__))
 
     def build_filter(self, filter_expr, branch_negated=False, current_negated=False,
-                     can_reuse=None, connector=AND, allow_joins=True, split_subq=True):
+                     can_reuse=None, allow_joins=True, split_subq=True):
         """
         Build a WhereNode for a single filter clause but don't add it
         to this Query. Query.add_q() will then add this filter to the where
@@ -1268,8 +1268,8 @@ class Query:
             else:
                 child_clause, needed_inner = self.build_filter(
                     child, can_reuse=used_aliases, branch_negated=branch_negated,
-                    current_negated=current_negated, connector=connector,
-                    allow_joins=allow_joins, split_subq=split_subq,
+                    current_negated=current_negated, allow_joins=allow_joins,
+                    split_subq=split_subq,
                 )
                 joinpromoter.add_votes(needed_inner)
             if child_clause:


### PR DESCRIPTION
It's not a documented function, so I think it should be OK. `connector=AND` in build_filter is also an unused parameter, and the function is also not documented, so perhaps this could be removed, too?