### PR TITLE
Fixed #27724 -- Fixed SelectDateWidget redisplay if a year isn't chosen.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -894,7 +894,7 @@ class SelectDateWidget(Widget):
     template_name = 'django/forms/widgets/select_date.html'
     input_type = 'select'
     select_widget = Select
-    date_re = re.compile(r'(\d{4})-(\d\d?)-(\d\d?)$')
+    date_re = re.compile(r'(\d{4}|0)-(\d\d?)-(\d\d?)$')
 
     def __init__(self, attrs=None, years=None, months=None, empty_label=None):
         self.attrs = attrs or {}

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -482,6 +482,7 @@ class SelectDateWidgetTest(WidgetTest):
         valid_formats = [
             '2000-1-1', '2000-10-15', '2000-01-01',
             '2000-01-0', '2000-0-01', '2000-0-0',
+            '0-01-01', '0-01-0', '0-0-01', '0-0-0',
         ]
         for value in valid_formats:
             year, month, day = (int(x) for x in value.split('-'))


### PR DESCRIPTION
This is a new PR in order to close without merge the PR [8108](https://github.com/django/django/pull/8108) 
and avoid the following commit [6a2bc33](https://github.com/django/django/pull/8108/commits/6a2bc334531dfad84fb3d8ea037787067d925a3f). That commit became to the PR [8206](https://github.com/django/django/pull/8206).

Fixed #27724 SelectDateWidget clears date and month if year is not selected.
If year is not selected in SelectDateWidget, then all the inputs are cleared as opposed to a state where date or month is missing.