### PR TITLE
Fixed #27890 -- Fixed FileNotFound cleanup exception in runtests.py on Python 3.6+.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -217,6 +217,12 @@ def teardown(state):
     # Restore the old settings.
     for key, value in state.items():
         setattr(settings, key, value)
+    # Discard the multiprocessing.util finalizer that tries to remove a
+    # temporary directory that's already removed by this script's
+    # atexit.register(shutil.rmtree, TMPDIR) handler. Prevents
+    # FileNotFoundError at the end of a test run on Python 3.6+ (#27890).
+    from multiprocessing.util import _finalizer_registry
+    _finalizer_registry.pop((-100, 0), None)
 
 
 def actual_test_processes(parallel):


### PR DESCRIPTION
Possible alternative to https://github.com/django/django/pull/8198.