### PR TITLE
Removed BaseSpatialOperations.truncate_params.

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -1,6 +1,4 @@
 class BaseSpatialOperations:
-    truncate_params = {}
-
     # Quick booleans for the type of this spatial backend, and
     # an attribute for the spatial database version tuple (if applicable)
     postgis = False

--- a/django/contrib/gis/db/backends/oracle/operations.py
+++ b/django/contrib/gis/db/backends/oracle/operations.py
@@ -115,8 +115,6 @@ class OracleOperations(BaseSpatialOperations, DatabaseOperations):
         'dwithin': SDODWithin(),
     }
 
-    truncate_params = {'relate': None}
-
     unsupported_functions = {
         'AsGeoJSON', 'AsKML', 'AsSVG', 'Envelope', 'ForceRHR', 'GeoHash',
         'MakeValid', 'MemSize', 'Scale', 'SnapToGrid', 'Translate',


### PR DESCRIPTION
Unused since 32969c3931dea8488ee4ad2849eab43e31e5542e.