### PR TITLE
Fixed #27931 -- Clarified meaning of django catch-all logger.

### DIFF
--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -735,7 +735,14 @@ By default, Django configures the following logging:
 When :setting:`DEBUG` is ``True``:
 
 * The ``django`` catch-all logger sends all messages at the ``INFO`` level or
-  higher to the console.
+  higher to the console. It processes only messages in the ``django`` namespace:
+
+  .. code-block:: python
+
+      import logging
+
+      logger = logging.getLogger('django')
+      logger.info(...)
 
 When :setting:`DEBUG` is ``False``:
 

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -730,19 +730,21 @@ logging module.
 Django's default logging configuration
 ======================================
 
-By default, Django configures the following logging:
+The ``django`` default logger processes only messages in the ``django`` namespace:
+
+.. code-block:: python
+
+  import logging
+
+  logger = logging.getLogger('django')
+  logger.info(...)
+
+and, by default, Django configures the following logging:
 
 When :setting:`DEBUG` is ``True``:
 
 * The ``django`` catch-all logger sends all messages at the ``INFO`` level or
-  higher to the console. It processes only messages in the ``django`` namespace:
-
-  .. code-block:: python
-
-      import logging
-
-      logger = logging.getLogger('django')
-      logger.info(...)
+  higher to the console.
 
 When :setting:`DEBUG` is ``False``:
 


### PR DESCRIPTION
Two different commits with two different approaches, I prefer the second one.
https://code.djangoproject.com/ticket/27931