### PR TITLE
Removed obsolete temporal reference in docs/faq/general.txt.

### DIFF
--- a/docs/faq/general.txt
+++ b/docs/faq/general.txt
@@ -122,9 +122,8 @@ to add a given feature to Django.
 Why did you write all of Django from scratch, instead of using other Python libraries?
 ======================================================================================
 
-When Django was originally written a couple of years ago, Adrian and Simon
-spent quite a bit of time exploring the various Python Web frameworks
-available.
+When Django was originally written, Adrian and Simon spent quite a bit of time
+exploring the various Python Web frameworks available.
 
 In our opinion, none of them were completely up to snuff.
 


### PR DESCRIPTION
I was reading the FAQ (for the first time in awhile) and notice it talked about a "couple of years ago". It has been more than a couple of years since Django was open sourced, so I thought it'd be better to remove that part of the language. 