### PR TITLE
Improved tests for django.contrib.contenttypes.views.

### DIFF
--- a/tests/contenttypes_tests/models.py
+++ b/tests/contenttypes_tests/models.py
@@ -36,6 +36,30 @@ class Article(models.Model):
         return self.title
 
 
+class ArticleManySites(models.Model):
+    title = models.CharField(max_length=100)
+    sites = models.ManyToManyField(Site)
+
+    def get_absolute_url(self):
+        return '/article/%d/' % self.pk
+
+
+class ArticleSite(models.Model):
+    title = models.CharField(max_length=100)
+    site = models.ForeignKey(Site, models.CASCADE)
+
+    def get_absolute_url(self):
+        return '/article/%d/' % self.pk
+
+
+class ArticleManyAuthors(models.Model):
+    title = models.CharField(max_length=100)
+    authors = models.ManyToManyField(Author)
+
+    def get_absolute_url(self):
+        return '/article/%d/' % self.pk
+
+
 class SchemeIncludedURL(models.Model):
     url = models.URLField(max_length=100)
 
@@ -55,31 +79,14 @@ class ProxyModel(ConcreteModel):
         proxy = True
 
 
-class FooWithoutUrl(models.Model):
-    """
-    Fake model not defining ``get_absolute_url`` for
-    ContentTypesTests.test_shortcut_view_without_get_absolute_url()
-    """
+class FooWithUrl(models.Model):
     name = models.CharField(max_length=30, unique=True)
-
-    def __str__(self):
-        return self.name
-
-
-class FooWithUrl(FooWithoutUrl):
-    """
-    Fake model defining ``get_absolute_url`` for
-    ContentTypesTests.test_shortcut_view().
-    """
 
     def get_absolute_url(self):
         return "/users/%s/" % quote(self.name)
 
 
-class FooWithBrokenAbsoluteUrl(FooWithoutUrl):
-    """
-    Fake model defining a ``get_absolute_url`` method containing an error
-    """
+class FooWithBrokenAbsoluteUrl(FooWithUrl):
 
     def get_absolute_url(self):
         return "/users/%s/" % self.unknown_field

--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -1,16 +1,26 @@
 import datetime
 from unittest import mock
 
+import django
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.db import models
-from django.test import TestCase, override_settings
+from django.test import TestCase, modify_settings, override_settings
 from django.test.utils import isolate_apps
 
 from .models import (
-    Article, Author, ModelWithNullFKToSite, SchemeIncludedURL,
+    Article, ArticleManyAuthors, ArticleManySites, ArticleSite, Author,
+    FooWithBrokenAbsoluteUrl, ModelWithNullFKToSite, SchemeIncludedURL,
     Site as MockSite,
 )
+
+get_model_original = django.apps.apps.get_model
+
+
+def mocked_get_model(*args, **kwargs):
+    if args[0] == 'sites.Site':
+        return MockSite
+    return get_model_original(*args, **kwargs)
 
 
 @override_settings(ROOT_URLCONF='contenttypes_tests.urls')
@@ -22,6 +32,8 @@ class ContentTypesViewsTests(TestCase):
         # of whether or not it already exists.
         cls.site1 = Site(pk=1, domain='testserver', name='testserver')
         cls.site1.save()
+        cls.mock_site1 = MockSite(pk=1, domain=cls.site1.domain)
+        cls.mock_site1.save()
         cls.author1 = Author.objects.create(name='Boris')
         cls.article1 = Article.objects.create(
             title='Old Article', slug='old_article', author=cls.author1,
@@ -42,12 +54,33 @@ class ContentTypesViewsTests(TestCase):
     def setUp(self):
         Site.objects.clear_cache()
 
+    def verify_redirect(self, response, obj):
+        self.assertRedirects(response, 'http://testserver%s' % obj.get_absolute_url(), fetch_redirect_response=False)
+
     def test_shortcut_with_absolute_url(self):
         "Can view a shortcut for an Author object that has a get_absolute_url method"
         for obj in Author.objects.all():
             short_url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(Author).id, obj.pk)
             response = self.client.get(short_url)
-            self.assertRedirects(response, 'http://testserver%s' % obj.get_absolute_url(), target_status_code=404)
+            self.verify_redirect(response, obj)
+
+    @modify_settings(INSTALLED_APPS={'remove': 'django.contrib.sites'})
+    def test_shortcut_with_absolute_url_no_django_contrib_sites_app(self):
+        """
+        The shortcut view (used for the admin "view on site" functionality)
+        returns a complete URL regardless of whether the sites framework is
+        installed.
+        """
+        for obj in Author.objects.all():
+            short_url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(Author).id, obj.pk)
+            response = self.client.get(short_url)
+            self.verify_redirect(response, obj)
+
+    def test_bad_model_content_type(self):
+        content_type = ContentType.objects.create(app_label='test', model='test')
+        short_url = '/shortcut/%s/%s/' % (content_type.id, 1)
+        response = self.client.get(short_url)
+        self.assertEqual(response.status_code, 404)
 
     def test_shortcut_with_absolute_url_including_scheme(self):
         """
@@ -59,7 +92,7 @@ class ContentTypesViewsTests(TestCase):
             response = self.client.get(short_url)
             self.assertRedirects(response, obj.get_absolute_url(), fetch_redirect_response=False)
 
-    def test_shortcut_no_absolute_url(self):
+    def test_no_absolute_url(self):
         """
         Shortcuts for an object that has no get_absolute_url() method raise
         404.
@@ -69,12 +102,58 @@ class ContentTypesViewsTests(TestCase):
             response = self.client.get(short_url)
             self.assertEqual(response.status_code, 404)
 
+    def test_broken_absolute_url(self):
+        """
+        The shortcut view does not catch an AttributeError raised by
+        the model's get_absolute_url() method (#8997).
+        """
+        content_type = ContentType.objects.get_for_model(FooWithBrokenAbsoluteUrl)
+        obj = FooWithBrokenAbsoluteUrl.objects.create(name='john')
+        short_url = '/shortcut/%d/%d/' % (content_type.pk, obj.pk)
+        with self.assertRaises(AttributeError):
+            self.client.get(short_url)
+
+    @mock.patch('django.apps.apps.get_model')
+    def test_site_foreignkey(self, get_model):
+        get_model.side_effect = mocked_get_model
+        content_type = ContentType.objects.get_for_model(ArticleSite)
+        obj = ArticleSite.objects.create(title='test', site=self.mock_site1)
+        short_url = '/shortcut/%d/%d/' % (content_type.pk, obj.pk)
+        response = self.client.get(short_url)
+        self.verify_redirect(response, obj)
+
+    @mock.patch('django.apps.apps.get_model')
+    def test_sites_many_to_many(self, get_model):
+        get_model.side_effect = mocked_get_model
+        content_type = ContentType.objects.get_for_model(ArticleManySites)
+        obj = ArticleManySites.objects.create(title='test')
+        obj.sites.add(self.mock_site1)
+        short_url = '/shortcut/%d/%d/' % (content_type.pk, obj.pk)
+        response = self.client.get(short_url)
+        self.verify_redirect(response, obj)
+
+    @mock.patch('django.apps.apps.get_model')
+    def test_sites_many_to_many_empty(self, get_model):
+        get_model.side_effect = mocked_get_model
+        content_type = ContentType.objects.get_for_model(ArticleManySites)
+        obj = ArticleManySites.objects.create(title='test')
+        short_url = '/shortcut/%d/%d/' % (content_type.pk, obj.pk)
+        response = self.client.get(short_url)
+        self.verify_redirect(response, obj)
+
+    def test_authors_many_to_many_empty(self):
+        content_type = ContentType.objects.get_for_model(ArticleManyAuthors)
+        obj = ArticleManyAuthors.objects.create(title='test')
+        short_url = '/shortcut/%d/%d/' % (content_type.pk, obj.pk)
+        response = self.client.get(short_url)
+        self.verify_redirect(response, obj)
+
     def test_wrong_type_pk(self):
         short_url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(Author).id, 'nobody/expects')
         response = self.client.get(short_url)
         self.assertEqual(response.status_code, 404)
 
-    def test_shortcut_bad_pk(self):
+    def test_bad_pk(self):
         short_url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(Author).id, '42424242')
         response = self.client.get(short_url)
         self.assertEqual(response.status_code, 404)
@@ -92,7 +171,7 @@ class ContentTypesViewsTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
     @mock.patch('django.apps.apps.get_model')
-    def test_shortcut_view_with_null_site_fk(self, get_model):
+    def test_shortcut_with_null_site_fk(self, get_model):
         """
         The shortcut view works if a model's ForeignKey to site is None.
         """
@@ -101,7 +180,7 @@ class ContentTypesViewsTests(TestCase):
         obj = ModelWithNullFKToSite.objects.create(title='title')
         url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(ModelWithNullFKToSite).id, obj.pk)
         response = self.client.get(url)
-        self.assertRedirects(response, '%s' % obj.get_absolute_url(), fetch_redirect_response=False)
+        self.verify_redirect(response, obj)
 
     @isolate_apps('contenttypes_tests')
     def test_create_contenttype_on_the_spot(self):


### PR DESCRIPTION
I added missing tests, renamed some tests, removed duplicated tests and moved some tests from test_models which didn't belong there.
It should be 100% covered now, except for this code: https://github.com/django/django/blob/master/django/contrib/contenttypes/views.py#L71-L72
I couldn't find a way to test it. It looks like this scenario can't happen. Please see if that is the case.