### PR TITLE
Fixed #27969 -- Fixed models.Field.formfield() setting 'disabled' for fields with choices.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -850,7 +850,7 @@ class Field(RegisterLookupMixin):
             for k in list(kwargs):
                 if k not in ('coerce', 'empty_value', 'choices', 'required',
                              'widget', 'label', 'initial', 'help_text',
-                             'error_messages', 'show_hidden_initial'):
+                             'error_messages', 'show_hidden_initial', 'disabled'):
                     del kwargs[k]
         defaults.update(kwargs)
         if form_class is None:

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -54,6 +54,12 @@ class BasicFieldTests(TestCase):
         klass = forms.TypedMultipleChoiceField
         self.assertIsInstance(field.formfield(choices_form_class=klass), klass)
 
+    def test_formfield_disabled(self):
+        """Field.formfield() sets disabled for fields with choices."""
+        field = models.CharField(choices=[('a', 'b')])
+        form_field = field.formfield(disabled=True)
+        self.assertIs(form_field.disabled, True)
+
     def test_field_str(self):
         f = models.Field()
         self.assertEqual(str(f), '<django.db.models.fields.Field>')


### PR DESCRIPTION
models.Field.formfield() allow 'disabled' keyword argument for fields with choices