### PR TITLE
Refs #27975 -- Only copy the field's queryset if it's not None

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1165,7 +1165,8 @@ class ModelChoiceField(ChoiceField):
     def __deepcopy__(self, memo):
         result = super(ChoiceField, self).__deepcopy__(memo)
         # Need to force a new ModelChoiceIterator to be created, bug #11183
-        result.queryset = self.queryset.all()
+        if self.queryset is not None:
+            result.queryset = self.queryset.all()
         return result
 
     def _get_queryset(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1646,6 +1646,17 @@ class ModelChoiceFieldTests(TestCase):
         form2 = ModelChoiceForm()
         self.assertIsNone(form2.fields['category'].queryset._result_cache)
 
+    def test_modelchoicefield_queryset_none(self):
+        class ModelChoiceForm(forms.Form):
+            category = forms.ModelChoiceField(queryset=None)
+
+            def __init__(self, *args, **kwargs):
+                super(ModelChoiceForm, self).__init__(*args, **kwargs)
+                self.fields['category'].queryset = Category.objects.filter(slug__contains='test')
+
+        form1 = ModelChoiceForm()
+        self.assertCountEqual(form1.fields['category'].queryset, [self.c2, self.c3])
+
     def test_modelchoicefield_22745(self):
         """
         #22745 -- Make sure that ModelChoiceField with RadioSelect widget


### PR DESCRIPTION
This commit fixes a regression in the ability to use `queryset=None` on `ModelChoiceField` and later set the QuerySet in the form's `__init__` method.

https://code.djangoproject.com/ticket/27975