### PR TITLE
Fixed #27956 -- Fixed display of errors in an {% extends %} child.

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -203,15 +203,17 @@ class RenderContext(BaseContext):
         return self.dicts[-1][key]
 
     @contextmanager
-    def push_state(self, template):
+    def push_state(self, template, isolated_context=True):
         initial = self.template
         self.template = template
-        self.push()
+        if isolated_context:
+            self.push()
         try:
             yield
         finally:
             self.template = initial
-            self.pop()
+            if isolated_context:
+                self.pop()
 
 
 class RequestContext(Context):

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -151,7 +151,8 @@ class ExtendsNode(Node):
 
         # Call Template._render explicitly so the parser context stays
         # the same.
-        return compiled_parent._render(context)
+        with context.render_context.push_state(compiled_parent, isolated_context=False):
+            return compiled_parent._render(context)
 
 
 class IncludeNode(Node):

--- a/tests/template_tests/templates/27956_child.html
+++ b/tests/template_tests/templates/27956_child.html
@@ -1,0 +1,3 @@
+{% extends "27956_parent.html" %}
+
+{% block content %}{% endblock %}

--- a/tests/template_tests/templates/27956_parent.html
+++ b/tests/template_tests/templates/27956_parent.html
@@ -1,0 +1,5 @@
+{% load tag_27584 %}
+
+{% badtag %}{% endbadtag %}
+
+{% block content %}{% endblock %}

--- a/tests/template_tests/tests.py
+++ b/tests/template_tests/tests.py
@@ -122,6 +122,18 @@ class TemplateTests(SimpleTestCase):
             t.render(Context())
         self.assertEqual(e.exception.template_debug['during'], '{% badtag %}')
 
+    def test_compile_tag_error_27956(self):
+        """Errors in a child of {% extends %} are displayed correctly."""
+        engine = Engine(
+            app_dirs=True,
+            debug=True,
+            libraries={'tag_27584': 'template_tests.templatetags.tag_27584'},
+        )
+        t = engine.get_template('27956_child.html')
+        with self.assertRaises(TemplateSyntaxError) as e:
+            t.render(Context())
+        self.assertEqual(e.exception.template_debug['during'], '{% badtag %}')
+
     def test_super_errors(self):
         """
         #18169 -- NoReverseMatch should not be silence in block.super.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27956