### PR TITLE
Fixed #28071 -- ExtendsNode history initialized with context origin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -390,6 +390,7 @@ answer newbie questions, and generally made Django that much better:
     Johann Queuniet <johann.queuniet@adh.naellia.eu>
     john@calixto.net
     John D'Agostino <john.dagostino@gmail.com>
+    John D'Ambrosio <dambrosioj@gmail.com>
     John Huddleston <huddlej@wwu.edu>
     John Moses <moses.john.r@gmail.com>
     John Paulett <john@paulett.org>

--- a/django/template/loader_tags.py
+++ b/django/template/loader_tags.py
@@ -103,7 +103,7 @@ class ExtendsNode(Node):
         without extending the same template twice.
         """
         history = context.render_context.setdefault(
-            self.context_key, [context.template.origin],
+            self.context_key, [self.origin],
         )
         template, origin = context.template.engine.find_template(
             template_name, skip=history,

--- a/tests/template_tests/test_extends.py
+++ b/tests/template_tests/test_extends.py
@@ -117,3 +117,24 @@ class ExtendsBehaviorTests(SimpleTestCase):
         template = engine.get_template('base.html')
         output = template.render(Context({}))
         self.assertEqual(output.strip(), 'loader2 loader1')
+
+    def test_block_override_in_extended_included_template(self):
+        """
+        ExtendsNode.find_template() initializes history with self.origin
+        (#28071).
+        """
+        engine = Engine(
+            loaders=[
+                ['django.template.loaders.locmem.Loader', {
+                    'base.html': "{% extends 'base.html' %}{% block base %}{{ block.super }}2{% endblock %}",
+                    'included.html':
+                        "{% extends 'included.html' %}{% block included %}{{ block.super }}B{% endblock %}",
+                }],
+                ['django.template.loaders.locmem.Loader', {
+                    'base.html': "{% block base %}1{% endblock %}{% include 'included.html' %}",
+                    'included.html': "{% block included %}A{% endblock %}",
+                }],
+            ],
+        )
+        template = engine.get_template('base.html')
+        self.assertEqual(template.render(Context({})), '12AB')


### PR DESCRIPTION
When including a partial template with a block that has been extended, where the extension employs {{ block.super }}, the render phase occurs twice on the child-most extension of the included template because the history is tracking the context's origin instead of the extending node's origin.