### PR TITLE
Fixed #25718 -- Made a JSONField lookup value of None match keys that have a null value.

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -88,6 +88,7 @@ JSONField.register_lookup(lookups.ContainedBy)
 JSONField.register_lookup(lookups.HasKey)
 JSONField.register_lookup(lookups.HasKeys)
 JSONField.register_lookup(lookups.HasAnyKeys)
+JSONField.register_lookup(lookups.JSONExact)
 
 
 class KeyTransform(Transform):

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -1,4 +1,5 @@
 from django.db.models import Lookup, Transform
+from django.db.models.lookups import Exact
 
 from .search import SearchVector, SearchVectorExact, SearchVectorField
 
@@ -64,3 +65,12 @@ class SearchLookup(SearchVectorExact):
 class TrigramSimilar(PostgresSimpleLookup):
     lookup_name = 'trigram_similar'
     operator = '%%'
+
+
+class JSONExact(Exact):
+    can_use_none_as_rhs = True
+
+    def process_rhs(self, compiler, connection):
+        result = super().process_rhs(compiler, connection)
+        # Treat None lookup values as null.
+        return ("'null'", []) if result == ('%s', [None]) else result

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -12,6 +12,7 @@ from django.utils.functional import cached_property
 class Lookup:
     lookup_name = None
     prepare_rhs = True
+    can_use_none_as_rhs = False
 
     def __init__(self, lhs, rhs):
         self.lhs, self.rhs = lhs, rhs

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -544,7 +544,7 @@ name::
     ...         }],
     ...     },
     ... })
-    >>> Dog.objects.create(name='Meg', data={'breed': 'collie'})
+    >>> Dog.objects.create(name='Meg', data={'breed': 'collie', 'owner': None})
 
     >>> Dog.objects.filter(data__breed='collie')
     <QuerySet [<Dog: Meg>]>
@@ -565,6 +565,23 @@ the :lookup:`jsonfield.contains` lookup instead.
 
 If only one key or index is used, the SQL operator ``->`` is used. If multiple
 operators are used then the ``#>`` operator is used.
+
+To query for ``null`` in JSON data, use ``None`` as a value::
+
+    >>> Dog.objects.filter(data__owner=None)
+    <QuerySet [<Dog: Meg>]>
+
+To query for missing keys, use the ``isnull`` lookup::
+
+    >>> Dog.objects.create(name='Shep', data={'breed': 'collie'})
+    >>> Dog.objects.filter(data__owner__isnull=True)
+    <QuerySet [<Dog: Shep>]>
+
+.. versionchanged:: 2.1
+
+    In older versions, using ``None`` as a  lookup value matches objects that
+    don't have the key rather than objects that have the key with a ``None``
+    value.
 
 .. warning::
 

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -372,6 +372,10 @@ Miscellaneous
 * Since migrations are now loaded from ``.pyc`` files, you might need to delete
   them if you're working in a mixed Python 2 and Python 3 environment.
 
+* Using ``None`` as a :class:`~django.contrib.postgres.fields.JSONField` lookup
+  value now matches objects that have the specified key and a null value rather
+  than objects that don't have the key.
+
 .. _deprecated-features-2.1:
 
 Features deprecated in 2.1

--- a/tests/lookup/models.py
+++ b/tests/lookup/models.py
@@ -5,6 +5,7 @@ This demonstrates features of the database API.
 """
 
 from django.db import models
+from django.db.models.lookups import IsNull
 
 
 class Alarm(models.Model):
@@ -53,6 +54,12 @@ class NulledTextField(models.TextField):
 class NulledTransform(models.Transform):
     lookup_name = 'nulled'
     template = 'NULL'
+
+
+@NulledTextField.register_lookup
+class IsNullWithNoneAsRHS(IsNull):
+    lookup_name = 'isnull_none_rhs'
+    can_use_none_as_rhs = True
 
 
 class Season(models.Model):


### PR DESCRIPTION
It's my follow up on #5617.
In general it provides an ability to use ``None`` in queries if querying is applied to some key inside value of ``JSONBField``.

Thank you!