### PR TITLE
Refs #21160 -- Replaced DatabaseFeatures.supports_1000_query_parameters by a DatabaseFeatures.max_query_params.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -90,8 +90,8 @@ class BaseDatabaseFeatures:
     # Does the backend order NULL values as largest or smallest?
     nulls_order_largest = False
 
-    # Is there a 1000 item limit on query parameters?
-    supports_1000_query_parameters = True
+    # The database's limit on the number of query parameters.
+    max_query_params = None
 
     # Can an object have an autoincrement primary key of 0? MySQL says No.
     allows_auto_pk_0 = True

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -14,7 +14,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     test_db_allows_multiple_connections = False
     supports_unspecified_pk = True
     supports_timezones = False
-    supports_1000_query_parameters = False
+    max_query_params = 999
     supports_mixed_date_datetime_comparisons = False
     has_bulk_insert = True
     supports_foreign_keys = False

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -21,8 +21,12 @@ class DatabaseOperations(BaseDatabaseOperations):
         If there's only a single field to insert, the limit is 500
         (SQLITE_MAX_COMPOUND_SELECT).
         """
-        limit = 999 if len(fields) > 1 else 500
-        return (limit // len(fields)) if len(fields) > 0 else len(objs)
+        if len(fields) == 1:
+            return 500
+        elif len(fields) > 1:
+            return self.connection.features.max_query_params // len(fields)
+        else:
+            return len(objs)
 
     def check_expression_support(self, expression):
         bad_fields = (fields.DateField, fields.DateTimeField, fields.TimeField)


### PR DESCRIPTION
Ticket [21160](https://code.djangoproject.com/ticket/21160).
