### PR TITLE
Remove initial attribute from data migration examples

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -721,6 +721,7 @@ answer newbie questions, and generally made Django that much better:
     Stanislaus Madueke
     starrynight <cmorgh@gmail.com>
     Stefane Fermgier <sf@fermigier.com>
+    Stefano Rivera <stefano@rivera.za.net>
     Stéphane Raimbault <stephane.raimbault@gmail.com>
     Stephan Jaekel <steph@rdev.info>
     Stephen Burrows <stephen.r.burrows@gmail.com>

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -458,7 +458,6 @@ Then, open up the file; it should look something like this::
     from django.db import migrations
 
     class Migration(migrations.Migration):
-        initial = True
 
         dependencies = [
             ('yourappname', '0001_initial'),
@@ -493,7 +492,6 @@ need to do is use the historical model and iterate over the rows::
             person.save()
 
     class Migration(migrations.Migration):
-        initial = True
 
         dependencies = [
             ('yourappname', '0001_initial'),


### PR DESCRIPTION
I don't know why these were marked as initial in
db97a8849519a3933bf4abd2184efd68ebc21965. @akulakov?

The example is of a fairly normal data migration, not something that
would want to fake with the inital model.