### PR TITLE
Fixed #27978 -- Allow loaddata to read data from stdin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -617,6 +617,7 @@ answer newbie questions, and generally made Django that much better:
     Paulo Poiati <paulogpoiati@gmail.com>
     Paulo Scardine <paulo@scardine.com.br>
     Paul Smith <blinkylights23@gmail.com>
+    Pavel Kulikov <kulikovpavel@gmail.com>
     pavithran s <pavithran.s@gmail.com>
     Pavlo Kapyshin <i@93z.org>
     permonik@mesias.brnonet.cz

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -416,6 +416,14 @@ originally generated.
 
 Specifies a single app to look for fixtures in rather than looking in all apps.
 
+.. django-admin-option:: --format FORMAT
+
+.. versionadded:: 2.0
+
+Specifies the :ref:`serialization format <serialization-formats>` (e.g.,
+``json`` or ``xml``) for fixtures :ref:`read from stdin
+<loading-fixtures-stdin>`.
+
 .. django-admin-option:: --exclude EXCLUDE, -e EXCLUDE
 
 .. versionadded:: 1.11
@@ -551,6 +559,27 @@ For example, if your :setting:`DATABASES` setting has a 'master' database
 defined, name the fixture ``mydata.master.json`` or
 ``mydata.master.json.gz`` and the fixture will only be loaded when you
 specify you want to load data into the ``master`` database.
+
+.. _loading-fixtures-stdin:
+
+Loading fixtures from ``stdin``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.0
+
+You can use a dash as the fixture name to load input from ``sys.stdin``. For
+example::
+
+    django-admin loaddata --format=json -
+
+When reading from ``stdin``, the :option:`--format <loaddata --format>` option
+is required to specify the :ref:`serialization format <serialization-formats>`
+of the input (e.g., ``json`` or ``xml``).
+
+Loading from ``stdin`` is useful with standard input and output redirections.
+For example::
+
+    django-admin dumpdata --format=json --database=test app_label.ModelName | django-admin loaddata --format=json --database=prod -
 
 ``makemessages``
 ----------------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -185,6 +185,8 @@ Management Commands
 * The new :option:`makemessages --add-location` option controls the comment
   format in PO files.
 
+* :djadmin:`loaddata` can now :ref:`read from stdin <loading-fixtures-stdin>`.
+
 Migrations
 ~~~~~~~~~~
 


### PR DESCRIPTION
Dont sure, what about license in repository from ticket.
I take idea and some code from https://github.com/squareweave/django-loaddata-stdin