### PR TITLE
Fixed #27989 -- Preserved empty QueryDicts for form's data/files args.

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -76,8 +76,8 @@ class BaseForm:
                  initial=None, error_class=ErrorList, label_suffix=None,
                  empty_permitted=False, field_order=None, use_required_attribute=None, renderer=None):
         self.is_bound = data is not None or files is not None
-        self.data = data or {}
-        self.files = files or {}
+        self.data = {} if data is None else data
+        self.files = {} if files is None else files
         self.auto_id = auto_id
         if prefix is not None:
             self.prefix = prefix

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -164,6 +164,13 @@ class FormsTestCase(SimpleTestCase):
 <input type="text" name="birthday" id="id_birthday" required /></p>"""
         )
 
+    def test_empty_querydict_args(self):
+        data = QueryDict()
+        files = QueryDict()
+        p = Person(data, files)
+        self.assertIs(p.data, data)
+        self.assertIs(p.files, files)
+
     def test_unbound_form(self):
         # If you don't pass any values to the Form's __init__(), or if you pass None,
         # the Form will be considered unbound and won't do any validation. Form.errors


### PR DESCRIPTION
This avoids empty QueryDicts being replaced by normal dictionaries because of their evaluation to False.

[Ticket #27989](https://code.djangoproject.com/ticket/27989)