### PR TITLE
Refs #26445 -- Used app config to lookup user model in _create_user.

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.contrib import auth
 from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.signals import user_logged_in
@@ -142,8 +143,12 @@ class UserManager(BaseUserManager):
         if not username:
             raise ValueError('The given username must be set')
         email = self.normalize_email(email)
-        username = self.model.normalize_username(username)
-        user = self.model(username=username, email=email, **extra_fields)
+        # Lookup the real model class from the global app registry so this
+        # manager method can be used in migrations. This is fine because
+        # managers are by definition working on the real model.
+        UserModel = apps.get_model(self.model._meta.app_label, self.model._meta.object_name)
+        username = UserModel.normalize_username(username)
+        user = UserModel(username=username, email=email, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user


### PR DESCRIPTION
I rebased from masted and finished patch [6578](https://github.com/django/django/pull/6578).

Original description:

"Ticket [comment](https://code.djangoproject.com/ticket/26445#comment:3).

Even though the UserManager is available to the user model in
migrations, one cannot use create_superuser() or create_user() due to
them using the attached model to set the password.

Since model managers used in migrations will _ALWAYS_ refer to their
current implementation and will have to work with the migration state
model and the "real" model, using the global app_registry to lookup
the user model is not a problem."