### PR TITLE
Fixed #28001 -- Removed obsolete context popping in ForNode.render().

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -186,8 +186,6 @@ class ForNode(Node):
                 # Boolean values designating first and last times through loop.
                 loop_dict['first'] = (i == 0)
                 loop_dict['last'] = (i == len_values - 1)
-
-                pop_context = False
                 if unpack:
                     # If there are multiple loop variables, unpack the item into
                     # them.
@@ -202,21 +200,12 @@ class ForNode(Node):
                             .format(num_loopvars, len_item),
                         )
                     unpacked_vars = dict(zip(self.loopvars, item))
-                    pop_context = True
                     context.update(unpacked_vars)
                 else:
                     context[self.loopvars[0]] = item
 
                 for node in self.nodelist_loop:
                     nodelist.append(node.render_annotated(context))
-
-                if pop_context:
-                    # The loop variables were pushed on to the context so pop them
-                    # off again. This is necessary because the tag lets the length
-                    # of loopvars differ to the length of each set of items and we
-                    # don't want to leave any vars from the previous loop on the
-                    # context.
-                    context.pop()
         return mark_safe(''.join(nodelist))
 
 


### PR DESCRIPTION
Unneeded since 3bbebd06adc36f31877a9c0af6c20c5b5a71a900.
https://code.djangoproject.com/ticket/28001