### PR TITLE
Removed implied default from strore_(true|false) argparse arguments

### DIFF
--- a/django/contrib/auth/management/commands/createsuperuser.py
+++ b/django/contrib/auth/management/commands/createsuperuser.py
@@ -33,8 +33,7 @@ class Command(BaseCommand):
             help='Specifies the login for the superuser.',
         )
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help=(
                 'Tells Django to NOT prompt the user for input of any kind. '
                 'You must use --%s with --noinput, along with an option for '

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -11,8 +11,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(

--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -68,8 +68,7 @@ class Command(BaseCommand):
                  'an integer or a string identifier for the layer.',
         )
         parser.add_argument(
-            '--multi-geom', action='store_true',
-            dest='multi_geom', default=False,
+            '--multi-geom', action='store_true', dest='multi_geom',
             help='Treat the geometry in the data source as a geometry collection.',
         )
         parser.add_argument(
@@ -77,7 +76,7 @@ class Command(BaseCommand):
             help='Specifies a field name to return for the __str__() method.',
         )
         parser.add_argument(
-            '--no-imports', action='store_false', dest='imports', default=True,
+            '--no-imports', action='store_false', dest='imports',
             help='Do not include `from django.contrib.gis.db import models` statement.',
         )
         parser.add_argument(

--- a/django/contrib/staticfiles/management/commands/collectstatic.py
+++ b/django/contrib/staticfiles/management/commands/collectstatic.py
@@ -37,13 +37,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help="Do NOT prompt the user for input of any kind.",
         )
         parser.add_argument(
-            '--no-post-process',
-            action='store_false', dest='post_process', default=True,
+            '--no-post-process', action='store_false', dest='post_process',
             help="Do NOT post process collected files.",
         )
         parser.add_argument(
@@ -53,24 +51,20 @@ class Command(BaseCommand):
                  "pattern. Use multiple times to ignore more.",
         )
         parser.add_argument(
-            '-n', '--dry-run',
-            action='store_true', dest='dry_run', default=False,
+            '-n', '--dry-run', action='store_true', dest='dry_run',
             help="Do everything except modify the filesystem.",
         )
         parser.add_argument(
-            '-c', '--clear',
-            action='store_true', dest='clear', default=False,
+            '-c', '--clear', action='store_true', dest='clear',
             help="Clear the existing files using the storage "
                  "before trying to copy or link the original file.",
         )
         parser.add_argument(
-            '-l', '--link',
-            action='store_true', dest='link', default=False,
+            '-l', '--link', action='store_true', dest='link',
             help="Create a symbolic link to each file instead of copying.",
         )
         parser.add_argument(
-            '--no-default-ignore', action='store_false',
-            dest='use_default_ignore_patterns', default=True,
+            '--no-default-ignore', action='store_false', dest='use_default_ignore_patterns',
             help="Don't ignore the common private glob-style patterns (defaults to 'CVS', '.*' and '*~').",
         )
 

--- a/django/contrib/staticfiles/management/commands/findstatic.py
+++ b/django/contrib/staticfiles/management/commands/findstatic.py
@@ -12,7 +12,6 @@ class Command(LabelCommand):
         super().add_arguments(parser)
         parser.add_argument(
             '--first', action='store_false', dest='all',
-            default=True,
             help="Only return the first match for each static file.",
         )
 

--- a/django/contrib/staticfiles/management/commands/runserver.py
+++ b/django/contrib/staticfiles/management/commands/runserver.py
@@ -10,11 +10,11 @@ class Command(RunserverCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
-            '--nostatic', action="store_false", dest='use_static_handler', default=True,
+            '--nostatic', action="store_false", dest='use_static_handler',
             help='Tells Django to NOT automatically serve static files at STATIC_URL.',
         )
         parser.add_argument(
-            '--insecure', action="store_true", dest='insecure_serving', default=False,
+            '--insecure', action="store_true", dest='insecure_serving',
             help='Allows serving static files even if DEBUG is False.',
         )
 

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -240,7 +240,7 @@ class BaseCommand:
         )
         parser.add_argument('--traceback', action='store_true', help='Raise on CommandError exceptions')
         parser.add_argument(
-            '--no-color', action='store_true', dest='no_color', default=False,
+            '--no-color', action='store_true', dest='no_color',
             help="Don't colorize the command output.",
         )
         self.add_arguments(parser)

--- a/django/core/management/commands/compilemessages.py
+++ b/django/core/management/commands/compilemessages.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             help='Locales to exclude. Default is none. Can be used multiple times.',
         )
         parser.add_argument(
-            '--use-fuzzy', '-f', dest='fuzzy', action='store_true', default=False,
+            '--use-fuzzy', '-f', dest='fuzzy', action='store_true',
             help='Use fuzzy translations.',
         )
 

--- a/django/core/management/commands/diffsettings.py
+++ b/django/core/management/commands/diffsettings.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--all', action='store_true', dest='all', default=False,
+            '--all', action='store_true', dest='all',
             help='Display all settings, regardless of their value. Default values are prefixed by "###".',
         )
         parser.add_argument(

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -43,15 +43,15 @@ class Command(BaseCommand):
                  '(use multiple --exclude to exclude multiple apps/models).',
         )
         parser.add_argument(
-            '--natural-foreign', action='store_true', dest='use_natural_foreign_keys', default=False,
+            '--natural-foreign', action='store_true', dest='use_natural_foreign_keys',
             help='Use natural foreign keys if they are available.',
         )
         parser.add_argument(
-            '--natural-primary', action='store_true', dest='use_natural_primary_keys', default=False,
+            '--natural-primary', action='store_true', dest='use_natural_primary_keys',
             help='Use natural primary keys if they are available.',
         )
         parser.add_argument(
-            '-a', '--all', action='store_true', dest='use_base_manager', default=False,
+            '-a', '--all', action='store_true', dest='use_base_manager',
             help="Use Django's base manager to dump all models stored in the database, "
                  "including those that would otherwise be filtered or modified by a custom manager.",
         )

--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -15,8 +15,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             help='Only look for fixtures in the specified app.',
         )
         parser.add_argument(
-            '--ignorenonexistent', '-i', action='store_true', dest='ignore', default=False,
+            '--ignorenonexistent', '-i', action='store_true', dest='ignore',
             help='Ignores entries in the serialized data for fields that do not '
                  'currently exist on the model.',
         )

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -227,7 +227,7 @@ class Command(BaseCommand):
             help='The domain of the message files (default: "django").',
         )
         parser.add_argument(
-            '--all', '-a', action='store_true', dest='all', default=False,
+            '--all', '-a', action='store_true', dest='all',
             help='Updates the message files for all existing locales.',
         )
         parser.add_argument(
@@ -237,7 +237,7 @@ class Command(BaseCommand):
                  'commas, or use -e multiple times.',
         )
         parser.add_argument(
-            '--symlinks', '-s', action='store_true', dest='symlinks', default=False,
+            '--symlinks', '-s', action='store_true', dest='symlinks',
             help='Follows symlinks to directories when examining source code '
                  'and templates for translation strings.',
         )
@@ -249,23 +249,23 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--no-default-ignore', action='store_false', dest='use_default_ignore_patterns',
-            default=True, help="Don't ignore the common glob-style patterns 'CVS', '.*', '*~' and '*.pyc'.",
+            help="Don't ignore the common glob-style patterns 'CVS', '.*', '*~' and '*.pyc'.",
         )
         parser.add_argument(
             '--no-wrap', action='store_true', dest='no_wrap',
-            default=False, help="Don't break long message lines into several lines.",
+            help="Don't break long message lines into several lines.",
         )
         parser.add_argument(
             '--no-location', action='store_true', dest='no_location',
-            default=False, help="Don't write '#: filename:line' lines.",
+            help="Don't write '#: filename:line' lines.",
         )
         parser.add_argument(
             '--no-obsolete', action='store_true', dest='no_obsolete',
-            default=False, help="Remove obsolete message strings.",
+            help="Remove obsolete message strings.",
         )
         parser.add_argument(
             '--keep-pot', action='store_true', dest='keep_pot',
-            default=False, help="Keep .pot file after making messages. Useful when debugging.",
+            help="Keep .pot file after making messages. Useful when debugging.",
         )
 
     def handle(self, *args, **options):

--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -27,20 +27,19 @@ class Command(BaseCommand):
             help='Specify the app label(s) to create migrations for.',
         )
         parser.add_argument(
-            '--dry-run', action='store_true', dest='dry_run', default=False,
+            '--dry-run', action='store_true', dest='dry_run',
             help="Just show what migrations would be made; don't actually write them.",
         )
         parser.add_argument(
-            '--merge', action='store_true', dest='merge', default=False,
+            '--merge', action='store_true', dest='merge',
             help="Enable fixing of migration conflicts.",
         )
         parser.add_argument(
-            '--empty', action='store_true', dest='empty', default=False,
+            '--empty', action='store_true', dest='empty',
             help="Create an empty migration.",
         )
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -30,8 +30,7 @@ class Command(BaseCommand):
                  'migration. Use the name "zero" to unapply all migrations.',
         )
         parser.add_argument(
-            '--noinput', '--no-input',
-            action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(
@@ -40,11 +39,11 @@ class Command(BaseCommand):
             help='Nominates a database to synchronize. Defaults to the "default" database.',
         )
         parser.add_argument(
-            '--fake', action='store_true', dest='fake', default=False,
+            '--fake', action='store_true', dest='fake',
             help='Mark migrations as run without actually running them.',
         )
         parser.add_argument(
-            '--fake-initial', action='store_true', dest='fake_initial', default=False,
+            '--fake-initial', action='store_true', dest='fake_initial',
             help='Detect if tables already exist and fake-apply initial migrations if so. Make sure '
                  'that the current database schema matches your initial migration before using this '
                  'flag. Django will only check for an existing table name.',

--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -40,15 +40,15 @@ class Command(BaseCommand):
             help='Optional port number, or ipaddr:port'
         )
         parser.add_argument(
-            '--ipv6', '-6', action='store_true', dest='use_ipv6', default=False,
+            '--ipv6', '-6', action='store_true', dest='use_ipv6',
             help='Tells Django to use an IPv6 address.',
         )
         parser.add_argument(
-            '--nothreading', action='store_false', dest='use_threading', default=True,
+            '--nothreading', action='store_false', dest='use_threading',
             help='Tells Django to NOT use threading.',
         )
         parser.add_argument(
-            '--noreload', action='store_false', dest='use_reloader', default=True,
+            '--noreload', action='store_false', dest='use_reloader',
             help='Tells Django to NOT use the auto-reloader.',
         )
 

--- a/django/core/management/commands/sendtestemail.py
+++ b/django/core/management/commands/sendtestemail.py
@@ -15,11 +15,11 @@ class Command(BaseCommand):
             help='One or more email addresses to send a test email to.',
         )
         parser.add_argument(
-            '--managers', action='store_true', dest='managers', default=False,
+            '--managers', action='store_true', dest='managers',
             help='Send a test email to the addresses specified in settings.MANAGERS.',
         )
         parser.add_argument(
-            '--admins', action='store_true', dest='admins', default=False,
+            '--admins', action='store_true', dest='admins',
             help='Send a test email to the addresses specified in settings.ADMINS.',
         )
 

--- a/django/core/management/commands/sqlmigrate.py
+++ b/django/core/management/commands/sqlmigrate.py
@@ -18,7 +18,6 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             '--backwards', action='store_true', dest='backwards',
-            default=False,
             help='Creates SQL to unapply the migration, rather than to apply it',
         )
 

--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -25,11 +25,11 @@ class Command(BaseCommand):
             help='Migrations will be squashed until and including this migration.',
         )
         parser.add_argument(
-            '--no-optimize', action='store_true', dest='no_optimize', default=False,
+            '--no-optimize', action='store_true', dest='no_optimize',
             help='Do not try to optimize the squashed operations.',
         )
         parser.add_argument(
-            '--noinput', '--no-input', action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
 

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -34,11 +34,11 @@ class Command(BaseCommand):
             help='Module paths to test; can be modulename, modulename.TestCase or modulename.TestCase.test_method'
         )
         parser.add_argument(
-            '--noinput', '--no-input', action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(
-            '--failfast', action='store_true', dest='failfast', default=False,
+            '--failfast', action='store_true', dest='failfast',
             help='Tells Django to stop running the test suite after first failed test.',
         )
         parser.add_argument(

--- a/django/core/management/commands/testserver.py
+++ b/django/core/management/commands/testserver.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             help='Path(s) to fixtures to load before running the server.',
         )
         parser.add_argument(
-            '--noinput', '--no-input', action='store_false', dest='interactive', default=True,
+            '--noinput', '--no-input', action='store_false', dest='interactive',
             help='Tells Django to NOT prompt the user for input of any kind.',
         )
         parser.add_argument(
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             help='Port number or ipaddr:port to run the server on.',
         )
         parser.add_argument(
-            '--ipv6', '-6', action='store_true', dest='use_ipv6', default=False,
+            '--ipv6', '-6', action='store_true', dest='use_ipv6',
             help='Tells Django to use an IPv6 address.',
         )
 

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -424,19 +424,19 @@ class DiscoverRunner:
             help='The test matching pattern. Defaults to test*.py.',
         )
         parser.add_argument(
-            '-k', '--keepdb', action='store_true', dest='keepdb', default=False,
+            '-k', '--keepdb', action='store_true', dest='keepdb',
             help='Preserves the test DB between runs.'
         )
         parser.add_argument(
-            '-r', '--reverse', action='store_true', dest='reverse', default=False,
+            '-r', '--reverse', action='store_true', dest='reverse',
             help='Reverses test cases order.',
         )
         parser.add_argument(
-            '--debug-mode', action='store_true', dest='debug_mode', default=False,
+            '--debug-mode', action='store_true', dest='debug_mode',
             help='Sets settings.DEBUG to True.',
         )
         parser.add_argument(
-            '-d', '--debug-sql', action='store_true', dest='debug_sql', default=False,
+            '-d', '--debug-sql', action='store_true', dest='debug_sql',
             help='Prints logged SQL queries on failure.',
         )
         parser.add_argument(

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -106,7 +106,6 @@ options can be added in the :meth:`~BaseCommand.add_arguments` method like this:
                 '--delete',
                 action='store_true',
                 dest='delete',
-                default=False,
                 help='Delete poll instead of closing it',
             )
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -388,15 +388,15 @@ if __name__ == "__main__":
         help='Verbosity level; 0=minimal output, 1=normal output, 2=all output',
     )
     parser.add_argument(
-        '--noinput', action='store_false', dest='interactive', default=True,
+        '--noinput', action='store_false', dest='interactive',
         help='Tells Django to NOT prompt the user for input of any kind.',
     )
     parser.add_argument(
-        '--failfast', action='store_true', dest='failfast', default=False,
+        '--failfast', action='store_true', dest='failfast',
         help='Tells Django to stop running the test suite after first failed test.',
     )
     parser.add_argument(
-        '-k', '--keepdb', action='store_true', dest='keepdb', default=False,
+        '-k', '--keepdb', action='store_true', dest='keepdb',
         help='Tells Django to preserve the test database between runs.',
     )
     parser.add_argument(
@@ -415,7 +415,7 @@ if __name__ == "__main__":
         help='Run the test suite in pairs with the named test to find problem pairs.',
     )
     parser.add_argument(
-        '--reverse', action='store_true', default=False,
+        '--reverse', action='store_true',
         help='Sort test suites and test cases in opposite order to debug '
              'test side effects not apparent with normal execution lineup.',
     )
@@ -424,7 +424,7 @@ if __name__ == "__main__":
         help='A comma-separated list of browsers to run the Selenium tests against.',
     )
     parser.add_argument(
-        '--debug-sql', action='store_true', dest='debug_sql', default=False,
+        '--debug-sql', action='store_true', dest='debug_sql',
         help='Turn on the SQL query logger within tests.',
     )
     parser.add_argument(

--- a/tests/user_commands/management/commands/hal.py
+++ b/tests/user_commands/management/commands/hal.py
@@ -6,7 +6,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('args', metavar='app_label', nargs='*', help='Specify the app label(s) to works on.')
-        parser.add_argument('--empty', action='store_true', dest='empty', default=False, help="Do nothing.")
+        parser.add_argument('--empty', action='store_true', dest='empty', help="Do nothing.")
 
     def handle(self, *app_labels, **options):
         app_labels = set(app_labels)


### PR DESCRIPTION
The argparse module automatically sets the default value for store_true
and store_false arguments to its opposite. It is redundant to specify it
explicitly.

See Python documentation for more details:

https://docs.python.org/3/library/argparse.html#action