### PR TITLE
Fixed #28126 -- Added GiST Index to contrib.postgres.

### DIFF
--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -1,6 +1,6 @@
 from django.db.models import Index
 
-__all__ = ['BrinIndex', 'GinIndex']
+__all__ = ['BrinIndex', 'GinIndex', 'GistIndex']
 
 
 class BrinIndex(Index):
@@ -49,6 +49,11 @@ class GinIndex(Index):
 
 class GistIndex(Index):
     suffix = 'gist'
+    # Allow an index name longer than 30 characters since the suffix is 4
+    # characters (usual limit is 3). Since this index can only be used on
+    # PostgreSQL, the 30 character limit for cross-database compatibility isn't
+    # applicable.
+    max_name_length = 31
 
     def create_sql(self, model, schema_editor):
         return super().create_sql(model, schema_editor, using=' USING gist')

--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -45,3 +45,10 @@ class GinIndex(Index):
 
     def create_sql(self, model, schema_editor):
         return super().create_sql(model, schema_editor, using=' USING gin')
+
+
+class GistIndex(Index):
+    suffix = 'gist'
+
+    def create_sql(self, model, schema_editor):
+        return super().create_sql(model, schema_editor, using=' USING gist')

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -35,10 +35,14 @@ available from the ``django.contrib.postgres.indexes`` module.
     :class:`~django.contrib.postgres.operations.BtreeGinExtension` migration
     operation.
 
-``GinIndex``
+``GistIndex``
 ============
 
-.. class:: GinIndex()
+.. class:: GistIndex()
 
-    Creates a `gist index
-    <https://www.postgresql.org/docs/current/static/gist.html>`_.
+    Creates a `GiST index
+    <https://www.postgresql.org/docs/current/static/gist.html>`_. These indexes
+    are also created on spatial fields with the
+    :attr:`~django.contrib.gis.db.models.BaseSpatialField.spatial_index` when
+    using postgis, but are also useful on some other types such as
+    :class:`~django.contrib.postgres.fields.HStoreField`.

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -38,6 +38,8 @@ available from the ``django.contrib.postgres.indexes`` module.
 ``GistIndex``
 ============
 
+.. versionadded:: 2.0
+
 .. class:: GistIndex()
 
     Creates a `GiST index

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -34,3 +34,11 @@ available from the ``django.contrib.postgres.indexes`` module.
     PostgreSQL. You can install it using the
     :class:`~django.contrib.postgres.operations.BtreeGinExtension` migration
     operation.
+
+``GinIndex``
+============
+
+.. class:: GinIndex()
+
+    Creates a `gist index
+    <https://www.postgresql.org/docs/current/static/gist.html>`_.

--- a/docs/ref/contrib/postgres/indexes.txt
+++ b/docs/ref/contrib/postgres/indexes.txt
@@ -36,7 +36,7 @@ available from the ``django.contrib.postgres.indexes`` module.
     operation.
 
 ``GistIndex``
-============
+=============
 
 .. versionadded:: 2.0
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -87,6 +87,8 @@ Minor features
   :class:`~django.contrib.postgres.aggregates.ArrayAgg` determines if
   concatenated values will be distinct.
 
+* Added :class:`~django.contrib.postgres.indexes.GistIndex`.
+
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.indexes import BrinIndex, GinIndex
+from django.contrib.postgres.indexes import BrinIndex, GinIndex, GistIndex
 from django.db import connection
 from django.test import skipUnlessDBFeature
 
@@ -80,6 +80,35 @@ class GinIndexTests(PostgreSQLTestCase):
         self.assertEqual(path, 'django.contrib.postgres.indexes.GinIndex')
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_gin'})
+
+
+class GistIndexTests(PostgreSQLTestCase):
+
+    def test_suffix(self):
+        self.assertEqual(GistIndex.suffix, 'gist')
+
+    def test_repr(self):
+        index = GistIndex(fields=['title'])
+        self.assertEqual(repr(index), "<GistIndex: fields='title'>")
+
+    def test_eq(self):
+        index = GistIndex(fields=['title'])
+        same_index = GistIndex(fields=['title'])
+        another_index = GistIndex(fields=['author'])
+        self.assertEqual(index, same_index)
+        self.assertNotEqual(index, another_index)
+
+    def test_name_auto_generation(self):
+        index = GistIndex(fields=['field'])
+        index.set_name_with_model(IntegerArrayModel)
+        self.assertEqual(index.name, 'postgres_te_field_def2f8_gist')
+
+    def test_deconstruction(self):
+        index = GistIndex(fields=['title'], name='test_title_gist')
+        path, args, kwargs = index.deconstruct()
+        self.assertEqual(path, 'django.contrib.postgres.indexes.GistIndex')
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs, {'fields': ['title'], 'name': 'test_title_gist'})
 
 
 class SchemaTests(PostgreSQLTestCase):

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -101,7 +101,7 @@ class GistIndexTests(PostgreSQLTestCase):
     def test_name_auto_generation(self):
         index = GistIndex(fields=['field'])
         index.set_name_with_model(IntegerArrayModel)
-        self.assertEqual(index.name, 'postgres_te_field_def2f8_gist')
+        self.assertEqual(index.name, 'postgres_te_field_57c7d8_gist')
 
     def test_deconstruction(self):
         index = GistIndex(fields=['title'], name='test_title_gist')


### PR DESCRIPTION
We can already create them on spatial fields, but they are generally useful for other fields such as hstore.

https://www.postgresql.org/docs/9.5/static/gist-examples.html
https://code.djangoproject.com/ticket/28126