### PR TITLE
Fixed #27849: Add support for filtering postgres aggregates

### DIFF
--- a/django/contrib/postgres/aggregates/__init__.py
+++ b/django/contrib/postgres/aggregates/__init__.py
@@ -1,2 +1,3 @@
+from .base import *  # NOQA
 from .general import *  # NOQA
 from .statistics import *  # NOQA

--- a/django/contrib/postgres/aggregates/base.py
+++ b/django/contrib/postgres/aggregates/base.py
@@ -1,0 +1,92 @@
+import copy
+
+from django.core.exceptions import FieldError
+from django.db.models import Aggregate, Expression, Q
+
+
+class FilterMixin:
+    def filter(self, **kwargs):
+        if not kwargs:
+            return self
+
+        return FilterWhere(expression=self, condition=Q(**kwargs))
+
+    def exclude(self, **kwargs):
+        if not kwargs:
+            return self
+
+        return FilterWhere(expression=self, condition=~Q(**kwargs))
+
+
+class PostgresAggregate(FilterMixin, Aggregate):
+    pass
+
+
+class FilterWhere(FilterMixin, Expression):
+    template = '%(expression)s FILTER (WHERE %(condition)s)'
+
+    def __init__(self, expression, condition, output_field=None):
+        if not expression.contains_aggregate:
+            raise TypeError('Expression must either be an aggregate function or contain an aggregate function')
+
+        if not hasattr(condition, 'resolve_expression'):
+            raise TypeError('Condition must be a class defining resolve_expression')
+
+        super().__init__(output_field=output_field)
+
+        if isinstance(expression, FilterWhere):
+            self.condition = Q(expression.condition, condition)
+            self.source_expression = expression.source_expression
+        else:
+            self.source_expression = self._parse_expressions(expression)[0]
+            self.condition = condition
+
+        if not getattr(self.source_expression, 'contains_aggregate', False):
+            raise FieldError('Window function expressions must be aggregate functions')
+
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+        c = self.copy()
+        c.source_expression = self.source_expression.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        c.condition = self.condition.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        return c
+
+    def _resolve_output_field(self):
+        if self._output_field is None:
+            self._output_field = self.source_expression.output_field
+
+    def copy(self):
+        clone = super().copy()
+        clone.source_expression = self.source_expression.copy()
+        clone.condition = copy.copy(self.condition)
+        return clone
+
+    def as_sql(self, compiler, connection):
+        connection.ops.check_expression_support(self)
+        params = []
+        condition_sql, condition_params = compiler.compile(self.condition)
+        params.extend(condition_params)
+        expr_sql, expr_params = compiler.compile(self.source_expression)
+        condition_params.extend(expr_params)
+
+        return self.template % {
+            'expression': expr_sql,
+            'condition': condition_sql,
+        }, params
+
+    def get_source_expressions(self):
+        return self.source_expression, self.condition
+
+    def set_source_expressions(self, exprs):
+        self.source_expression, self.condition = exprs[0], exprs[1]
+
+    def get_group_by_cols(self):
+        return []
+
+    def __str__(self):
+        return self.template % {
+            'expression': str(self.source_expression),
+            'condition': str(self.condition),
+        }
+
+    def __repr__(self):
+        return '<%s: %s>' % (self.__class__.__name__, self)

--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -1,12 +1,12 @@
+from django.contrib.postgres.aggregates import PostgresAggregate
 from django.contrib.postgres.fields import JSONField
-from django.db.models.aggregates import Aggregate
 
 __all__ = [
     'ArrayAgg', 'BitAnd', 'BitOr', 'BoolAnd', 'BoolOr', 'JSONBAgg', 'StringAgg',
 ]
 
 
-class ArrayAgg(Aggregate):
+class ArrayAgg(PostgresAggregate):
     function = 'ARRAY_AGG'
     template = '%(function)s(%(distinct)s%(expressions)s)'
 
@@ -19,23 +19,23 @@ class ArrayAgg(Aggregate):
         return value
 
 
-class BitAnd(Aggregate):
+class BitAnd(PostgresAggregate):
     function = 'BIT_AND'
 
 
-class BitOr(Aggregate):
+class BitOr(PostgresAggregate):
     function = 'BIT_OR'
 
 
-class BoolAnd(Aggregate):
+class BoolAnd(PostgresAggregate):
     function = 'BOOL_AND'
 
 
-class BoolOr(Aggregate):
+class BoolOr(PostgresAggregate):
     function = 'BOOL_OR'
 
 
-class JSONBAgg(Aggregate):
+class JSONBAgg(PostgresAggregate):
     function = 'JSONB_AGG'
     _output_field = JSONField()
 
@@ -45,7 +45,7 @@ class JSONBAgg(Aggregate):
         return value
 
 
-class StringAgg(Aggregate):
+class StringAgg(PostgresAggregate):
     function = 'STRING_AGG'
     template = "%(function)s(%(distinct)s%(expressions)s, '%(delimiter)s')"
 

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -1,5 +1,5 @@
+from django.contrib.postgres.aggregates import PostgresAggregate
 from django.db.models import FloatField, IntegerField
-from django.db.models.aggregates import Aggregate
 
 __all__ = [
     'CovarPop', 'Corr', 'RegrAvgX', 'RegrAvgY', 'RegrCount', 'RegrIntercept',
@@ -7,7 +7,7 @@ __all__ = [
 ]
 
 
-class StatAggregate(Aggregate):
+class StatAggregate(PostgresAggregate):
     def __init__(self, y, x, output_field=FloatField()):
         if not x or not y:
             raise ValueError('Both y and x must be provided.')

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -169,6 +169,11 @@ class Migration(migrations.Migration):
                 ('boolean_field', models.NullBooleanField()),
                 ('char_field', models.CharField(max_length=30, blank=True)),
                 ('integer_field', models.IntegerField(null=True)),
+                ('related_field', models.ForeignKey(
+                    'postgres_tests.AggregateTestModel',
+                    models.SET_NULL,
+                    null=True,
+                )),
             ]
         ),
         migrations.CreateModel(

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -158,6 +158,7 @@ class AggregateTestModel(models.Model):
     char_field = models.CharField(max_length=30, blank=True)
     integer_field = models.IntegerField(null=True)
     boolean_field = models.NullBooleanField()
+    related_field = models.ForeignKey('AggregateTestModel', models.SET_NULL, null=True)
 
 
 class StatTestModel(models.Model):


### PR DESCRIPTION
This adds support for filtering on all Postgres aggregates using the `FILTER (WHERE ...)` syntax.

I thought it would be best to make it a bit queryset-like, as in you can do `.filter()` and `.exclude()` on all Postgres aggregates, like so: `SomeModel.objects.annotate(x=ArrayAgg('y').filter(y__z=1)`.

Under the hood this just converts the keywords to `Q()` objects, but it feels a lot nicer than passing them in manually. They also support chaining.

I'm at the DjangoCon sprints if anyone wishes to comment in person about this 👍

Edit: I've added some tests specifically for the ArrayAgg aggregate, but I'd like some feedback about the implementation before I commit to writing more tests + documentation etc.

I'm also not entirely sure how I would go about writing the tests, should I write the same tests for every postgres aggregate?