### PR TITLE
Fixed #28048 -- Allowed generic date views to use related fields as date_field.

### DIFF
--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -1,3 +1,6 @@
+from django.db.models.constants import LOOKUP_SEP
+
+
 def make_model_tuple(model):
     """
     Take a model or a string of the form "app_label.ModelName" and return a
@@ -19,3 +22,16 @@ def make_model_tuple(model):
             "Invalid model reference '%s'. String model references "
             "must be of the form 'app_label.ModelName'." % model
         )
+
+
+def get_field_from_path(model, path):
+    pieces = path.split(LOOKUP_SEP)
+    fields = []
+    for piece in pieces:
+        parent = model
+        if (fields and fields[-1].is_relation and
+                    fields[-1].remote_field.model != model):
+            parent = fields[-1].remote_field.model
+        fields.append(parent._meta.get_field(piece))
+
+    return fields[-1]

--- a/django/db/models/utils.py
+++ b/django/db/models/utils.py
@@ -30,7 +30,7 @@ def get_field_from_path(model, path):
     for piece in pieces:
         parent = model
         if (fields and fields[-1].is_relation and
-                    fields[-1].remote_field.model != model):
+                fields[-1].remote_field.model != model):
             parent = fields[-1].remote_field.model
         fields.append(parent._meta.get_field(piece))
 

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.utils import get_field_from_path
 from django.http import Http404
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -256,17 +257,8 @@ class DateMixin:
         if it's a `DateField`.
         """
         model = self.get_queryset().model if self.model is None else self.model
-
-        pieces = self.get_date_field().split(LOOKUP_SEP)
-        fields = []
-        for piece in pieces:
-            parent = model
-            if (fields and fields[-1].is_relation and
-                    fields[-1].remote_field.model != model):
-                parent = fields[-1].remote_field.model
-            fields.append(parent._meta.get_field(piece))
-
-        return isinstance(fields[-1], models.DateTimeField)
+        field = get_field_from_path(model, self.get_date_field())
+        return isinstance(field, models.DateTimeField)
 
     def _make_date_lookup_arg(self, value):
         """

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.conf import settings
+from django.contrib.admin.utils import get_fields_from_path
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.http import Http404
@@ -254,7 +255,7 @@ class DateMixin:
         if it's a `DateField`.
         """
         model = self.get_queryset().model if self.model is None else self.model
-        field = model._meta.get_field(self.get_date_field())
+        field = get_fields_from_path(model, self.get_date_field())[-1]
         return isinstance(field, models.DateTimeField)
 
     def _make_date_lookup_arg(self, value):

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -707,8 +707,7 @@ def _get_next_prev(generic_view, date, is_previous, period):
         # Snag the first object from the queryset; if it doesn't exist that
         # means there's no next/previous link available.
         try:
-            result = functools.reduce(
-                getattr, date_field.split(LOOKUP_SEP), qs[0])
+            result = functools.reduce(getattr, date_field.split(LOOKUP_SEP), qs[0])
         except IndexError:
             return None
 

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -30,6 +30,14 @@ class Author(models.Model):
         return self.name
 
 
+class Series(models.Model):
+    name = models.CharField(max_length=100)
+    pubdate = models.DateField()
+
+    def __str__(self):
+        return self.name
+
+
 class DoesNotExistQuerySet(QuerySet):
     def get(self, *args, **kwargs):
         raise Author.DoesNotExist
@@ -43,6 +51,7 @@ class Book(models.Model):
     slug = models.SlugField()
     pages = models.IntegerField()
     authors = models.ManyToManyField(Author)
+    series = models.ForeignKey(Series, null=True, on_delete=models.CASCADE)
     pubdate = models.DateField()
 
     objects = models.Manager()

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 class Artist(models.Model):
     name = models.CharField(max_length=100)
-    birthdate = models.DateField()
+    birthdate = models.DateField(null=True, blank=True)
 
     class Meta:
         ordering = ['name']

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 class Artist(models.Model):
     name = models.CharField(max_length=100)
+    birthdate = models.DateField()
 
     class Meta:
         ordering = ['name']
@@ -30,14 +31,6 @@ class Author(models.Model):
         return self.name
 
 
-class Series(models.Model):
-    name = models.CharField(max_length=100)
-    pubdate = models.DateField()
-
-    def __str__(self):
-        return self.name
-
-
 class DoesNotExistQuerySet(QuerySet):
     def get(self, *args, **kwargs):
         raise Author.DoesNotExist
@@ -51,7 +44,7 @@ class Book(models.Model):
     slug = models.SlugField()
     pages = models.IntegerField()
     authors = models.ManyToManyField(Author)
-    series = models.ForeignKey(Series, null=True, on_delete=models.CASCADE)
+    artist = models.ForeignKey(Artist, models.CASCADE, null=True)
     pubdate = models.DateField()
 
     objects = models.Manager()

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -22,7 +22,10 @@ class TestDataMixin:
     @classmethod
     def setUpTestData(cls):
         cls.series1 = Series.objects.create(
-            name='Django books', pubdate=datetime.date(2003, 10, 1),
+            name='Django books 1', pubdate=datetime.date(2003, 10, 1),
+        )
+        cls.series2 = Series.objects.create(
+            name='Django books 2', pubdate=datetime.date(2003, 9, 1),
         )
         cls.artist1 = Artist.objects.create(name='Rene Magritte')
         cls.author1 = Author.objects.create(name='Roberto Bolaño', slug='roberto-bolano')
@@ -33,7 +36,8 @@ class TestDataMixin:
         )
         cls.book1.authors.add(cls.author1)
         cls.book2 = Book.objects.create(
-            name='Dreaming in Code', slug='dreaming-in-code', pages=300, pubdate=datetime.date(2006, 5, 1)
+            name='Dreaming in Code', slug='dreaming-in-code', pages=300,
+            series=cls.series2, pubdate=datetime.date(2006, 5, 1),
         )
         cls.page1 = Page.objects.create(
             content='I was once bitten by a moose.', template='generic_views/page_template.html'

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -22,14 +22,14 @@ class TestDataMixin:
     @classmethod
     def setUpTestData(cls):
         cls.series1 = Series.objects.create(
-            name='Django books', pubdate=datetime.date(2003, 10, 1)
+            name='Django books', pubdate=datetime.date(2003, 10, 1),
         )
         cls.artist1 = Artist.objects.create(name='Rene Magritte')
         cls.author1 = Author.objects.create(name='Roberto Bolaño', slug='roberto-bolano')
         cls.author2 = Author.objects.create(name='Scott Rosenberg', slug='scott-rosenberg')
         cls.book1 = Book.objects.create(
             name='2066', slug='2066', pages=800, series=cls.series1,
-            pubdate=datetime.date(2008, 10, 1)
+            pubdate=datetime.date(2008, 10, 1),
         )
         cls.book1.authors.add(cls.author1)
         cls.book2 = Book.objects.create(

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -142,7 +142,6 @@ urlpatterns = [
     url(r'^dates/books/sortedbynamedec/$',
         views.BookArchive.as_view(ordering='-name')),
 
-
     # ListView
     url(r'^list/dict/$',
         views.DictList.as_view()),
@@ -222,6 +221,8 @@ urlpatterns = [
         views.BookMonthArchive.as_view(paginate_by=30)),
     url(r'^dates/books/(?P<year>[0-9]{4})/no_month/$',
         views.BookMonthArchive.as_view()),
+    url(r'^dates/books/(?P<year>[0-9]{4})/(?P<month>[a-z]{3})/related_field/$',
+        views.BookMonthArchive.as_view(date_field='series__pubdate')),
     url(r'^dates/booksignings/(?P<year>[0-9]{4})/(?P<month>[a-z]{3})/$',
         views.BookSigningMonthArchive.as_view()),
 

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -142,6 +142,7 @@ urlpatterns = [
     url(r'^dates/books/sortedbynamedec/$',
         views.BookArchive.as_view(ordering='-name')),
 
+
     # ListView
     url(r'^list/dict/$',
         views.DictList.as_view()),

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -223,7 +223,7 @@ urlpatterns = [
     url(r'^dates/books/(?P<year>[0-9]{4})/no_month/$',
         views.BookMonthArchive.as_view()),
     url(r'^dates/books/(?P<year>[0-9]{4})/(?P<month>[a-z]{3})/related_field/$',
-        views.BookMonthArchive.as_view(date_field='series__pubdate')),
+        views.BookMonthArchive.as_view(date_field='artist__birthdate')),
     url(r'^dates/booksignings/(?P<year>[0-9]{4})/(?P<month>[a-z]{3})/$',
         views.BookSigningMonthArchive.as_view()),
 


### PR DESCRIPTION
This PR tries to resolve a small issue on the date generic views. On the date generic views right now you cannot specify as a date_field a related field (you get FieldDoesNotExist). 