### PR TITLE
Support distinct keyword in Postgres JSONBAgg

### DIFF
--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -1,17 +1,13 @@
 from django.contrib.postgres.fields import JSONField
-from django.db.models.aggregates import Aggregate
+from django.db.models.aggregates import Aggregate, DistinctAggregate
 
 __all__ = [
     'ArrayAgg', 'BitAnd', 'BitOr', 'BoolAnd', 'BoolOr', 'JSONBAgg', 'StringAgg',
 ]
 
 
-class ArrayAgg(Aggregate):
+class ArrayAgg(DistinctAggregate):
     function = 'ARRAY_AGG'
-    template = '%(function)s(%(distinct)s%(expressions)s)'
-
-    def __init__(self, expression, distinct=False, **extra):
-        super().__init__(expression, distinct='DISTINCT ' if distinct else '', **extra)
 
     def convert_value(self, value, expression, connection, context):
         if not value:
@@ -45,13 +41,12 @@ class JSONBAgg(Aggregate):
         return value
 
 
-class StringAgg(Aggregate):
+class StringAgg(DistinctAggregate):
     function = 'STRING_AGG'
     template = "%(function)s(%(distinct)s%(expressions)s, '%(delimiter)s')"
 
-    def __init__(self, expression, delimiter, distinct=False, **extra):
-        distinct = 'DISTINCT ' if distinct else ''
-        super().__init__(expression, delimiter=delimiter, distinct=distinct, **extra)
+    def __init__(self, expression, delimiter, **extra):
+        super().__init__(expression, delimiter=delimiter, **extra)
 
     def convert_value(self, value, expression, connection, context):
         if not value:

--- a/django/contrib/postgres/aggregates/general.py
+++ b/django/contrib/postgres/aggregates/general.py
@@ -31,7 +31,7 @@ class BoolOr(Aggregate):
     function = 'BOOL_OR'
 
 
-class JSONBAgg(Aggregate):
+class JSONBAgg(DistinctAggregate):
     function = 'JSONB_AGG'
     _output_field = JSONField()
 

--- a/docs/ref/contrib/postgres/aggregates.txt
+++ b/docs/ref/contrib/postgres/aggregates.txt
@@ -68,11 +68,18 @@ General-purpose aggregation functions
 ``JSONBAgg``
 ------------
 
-.. class:: JSONBAgg(expressions, **extra)
+.. class:: JSONBAgg(expressions, distinct=False, **extra)
 
     .. versionadded:: 1.11
 
     Returns the input values as a ``JSON`` array. Requires PostgreSQL ≥ 9.5.
+
+    .. attribute:: distinct
+
+        .. versionadded:: 2.0
+
+        An optional boolean argument that determines if concatenated values
+        will be distinct. Defaults to ``False``.
 
 ``StringAgg``
 -------------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -84,7 +84,8 @@ Minor features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * The new ``distinct`` argument for
-  :class:`~django.contrib.postgres.aggregates.ArrayAgg` determines if
+  :class:`~django.contrib.postgres.aggregates.ArrayAgg` and
+  :class:`~django.contrib.postgres.aggregates.JSONBAgg` determines determines if
   concatenated values will be distinct.
 
 :mod:`django.contrib.redirects`


### PR DESCRIPTION
This PR adds support for a distinct argument to JSONBAgg. As there are a number of aggregations that support this I made a base class and switched the relevant aggregations to using it.

Other aggregations like `BitAnd`, `BitOr` etc support `DISTINCT` as well, but it seems somewhat redundant to add them (I think?).