### PR TITLE
Fixed #27777 -- Made File.open() work with the with statement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -324,6 +324,7 @@ answer newbie questions, and generally made Django that much better:
     Igor Kolar <ike@email.si>
     Illia Volochii <illia.volochii@gmail.com>
     Ilya Semenov <semenov@inetss.com>
+    Ingo Klöcker <djangoproject@ingo-kloecker.de>
     I.S. van Oostveen <v.oostveen@idca.nl>
     ivan.chelubeev@gmail.com
     Ivan Sagalaev (Maniac) <http://www.softwaremaniacs.org/>

--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -125,6 +125,7 @@ class File(FileProxyMixin):
             self.file = open(self.name, mode or self.mode)
         else:
             raise ValueError("The file cannot be reopened.")
+        return self
 
     def close(self):
         self.file.close()
@@ -147,6 +148,7 @@ class ContentFile(File):
 
     def open(self, mode=None):
         self.seek(0)
+        return self
 
     def close(self):
         pass

--- a/django/core/files/uploadedfile.py
+++ b/django/core/files/uploadedfile.py
@@ -85,6 +85,7 @@ class InMemoryUploadedFile(UploadedFile):
 
     def open(self, mode=None):
         self.file.seek(0)
+        return self
 
     def chunks(self, chunk_size=None):
         self.file.seek(0)

--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -75,6 +75,7 @@ class FieldFile(File):
             self.file.open(mode)
         else:
             self.file = self.storage.open(self.name, mode)
+        return self
     # open() doesn't alter the file's contents, but it does reset the pointer
     open.alters_data = True
 

--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -56,6 +56,9 @@ The ``File`` class
         was originally opened with; ``None`` means to reopen with the original
         mode.
 
+        Returns ``self``, so that it can be used similar to Python's
+        built-in :func:`python:open()` with the ``with`` statement.
+
     .. method:: read(num_bytes=None)
 
         Read content from the file. The optional ``size`` is the number of

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -11,7 +11,7 @@ from django.core.files.base import ContentFile
 from django.core.files.move import file_move_safe
 from django.core.files.temp import NamedTemporaryFile
 from django.core.files.uploadedfile import (
-    InMemoryUploadedFile, SimpleUploadedFile, UploadedFile
+    InMemoryUploadedFile, SimpleUploadedFile, UploadedFile,
 )
 
 try:

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -47,12 +47,15 @@ class FileTests(unittest.TestCase):
             self.assertEqual(f.read(), b'content')
 
     def test_open_reopens_closed_file_and_returns_context_manager(self):
-        file = File(tempfile.NamedTemporaryFile(delete=False))
-        file.close()
-        with file.open() as f:
-            self.assertFalse(f.closed)
-        # remove temporary file
-        os.unlink(file.name)
+        temporary_file = tempfile.NamedTemporaryFile(delete=False)
+        file = File(temporary_file)
+        try:
+            file.close()
+            with file.open() as f:
+                self.assertFalse(f.closed)
+        finally:
+            # remove temporary file
+            os.unlink(file.name)
 
     def test_namedtemporaryfile_closes(self):
         """
@@ -204,7 +207,7 @@ class ContentFileTestCase(unittest.TestCase):
 
 class InMemoryUploadedFileTests(unittest.TestCase):
     def test_open_resets_file_to_start_and_returns_context_manager(self):
-        uf = InMemoryUploadedFile(six.StringIO('1'), '', 'test', 'text/plain', 1, 'utf8')
+        uf = InMemoryUploadedFile(StringIO('1'), '', 'test', 'text/plain', 1, 'utf8')
         uf.read()
         with uf.open() as f:
             self.assertEqual(f.read(), '1')

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -10,7 +10,9 @@ from django.core.files import File
 from django.core.files.base import ContentFile
 from django.core.files.move import file_move_safe
 from django.core.files.temp import NamedTemporaryFile
-from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile, SimpleUploadedFile, UploadedFile
+)
 
 try:
     from PIL import Image
@@ -37,6 +39,20 @@ class FileTests(unittest.TestCase):
             self.assertFalse(f.closed)
         self.assertTrue(f.closed)
         self.assertTrue(orig_file.closed)
+
+    def test_open_resets_opened_file_to_start_and_returns_context_manager(self):
+        file = File(BytesIO(b'content'))
+        file.read()
+        with file.open() as f:
+            self.assertEqual(f.read(), b'content')
+
+    def test_open_reopens_closed_file_and_returns_context_manager(self):
+        file = File(tempfile.NamedTemporaryFile(delete=False))
+        file.close()
+        with file.open() as f:
+            self.assertFalse(f.closed)
+        # remove temporary file
+        os.unlink(file.name)
 
     def test_namedtemporaryfile_closes(self):
         """
@@ -177,6 +193,21 @@ class ContentFileTestCase(unittest.TestCase):
         """
         self.assertIsInstance(ContentFile(b"content").read(), bytes)
         self.assertIsInstance(ContentFile("español").read(), str)
+
+    def test_open_resets_file_to_start_and_returns_context_manager(self):
+        file = ContentFile(b'content')
+        with file.open() as f:
+            self.assertEqual(f.read(), b'content')
+        with file.open() as f:
+            self.assertEqual(f.read(), b'content')
+
+
+class InMemoryUploadedFileTests(unittest.TestCase):
+    def test_open_resets_file_to_start_and_returns_context_manager(self):
+        uf = InMemoryUploadedFile(six.StringIO('1'), '', 'test', 'text/plain', 1, 'utf8')
+        uf.read()
+        with uf.open() as f:
+            self.assertEqual(f.read(), '1')
 
 
 class DimensionClosingBug(unittest.TestCase):


### PR DESCRIPTION
Made File.open() (and its overrides in File subclasses) return
self, so that it can be used similar to Python's open() with
the with statement.

https://code.djangoproject.com/ticket/27777