### PR TITLE
Fixed #27947 -- Doc'd that model Field.error_messages often don't propagate to forms.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -737,6 +737,7 @@ answer newbie questions, and generally made Django that much better:
     Sutrisno Efendi <kangfend@gmail.com>
     Swaroop C H <http://www.swaroopch.info>
     Szilveszter Farkas <szilveszter.farkas@gmail.com>
+    Taavi Teska <taaviteska@gmail.com>
     Tai Lee <real.human@mrmachine.net>
     Takashi Matsuo <matsuo.takashi@gmail.com>
     Tareque Hossain <http://www.codexn.com>

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -254,6 +254,9 @@ Error message keys include ``null``, ``blank``, ``invalid``, ``invalid_choice``,
 ``unique``, and ``unique_for_date``. Additional error message keys are
 specified for each field in the `Field types`_ section below.
 
+These error messages often don't propagate to forms. See
+:ref:`considerations-regarding-model-errormessages`.
+
 ``help_text``
 -------------
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27947