### PR TITLE
Fixed #28038 -- Restored casting to text of builtin lookups on PostgreSQL.

### DIFF
--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -74,8 +74,6 @@ class DatabaseOperations(BaseDatabaseOperations):
                            'istartswith', 'endswith', 'iendswith', 'regex', 'iregex'):
             if internal_type in ('IPAddressField', 'GenericIPAddressField'):
                 lookup = "HOST(%s)"
-            elif internal_type in ('CharField', 'TextField'):
-                lookup = '%s'
             else:
                 lookup = "%s::text"
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Made migrations respect ``Index``’s ``name`` argument. If you created a
   named index with Django 1.11, ``makemigrations`` will create a migration to
   recreate the index with the correct name (:ticket:`28051`).
+
+* Fixed a crash when using a ``__icontains`` lookup on a ``ArrayField``
+  (:ticket:`28038`).

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -216,6 +216,14 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[1:3]
         )
 
+    def test_icontains(self):
+        # Using the __icontains lookup with ArrayField is inefficient.
+        instance = CharArrayModel.objects.create(field=['FoO'])
+        self.assertSequenceEqual(
+            CharArrayModel.objects.filter(field__icontains='foo'),
+            [instance]
+        )
+
     def test_contains_charfield(self):
         # Regression for #22907
         self.assertSequenceEqual(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28038
This ended up breaking code using __icontains's implicit cast to ::text on ArrayField.

Thanks Peter J. Farrell for the report.