### PR TITLE
Fixed #27644 -- Doc'd FileSystemStorage.get_created_time().

### DIFF
--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -62,6 +62,13 @@ The ``FileSystemStorage`` class
         The ``FileSystemStorage.delete()`` method will not raise
         an exception if the given file name does not exist.
 
+    .. method:: get_created_time(name)
+
+        Returns a :class:`~datetime.datetime` of the system's ctime, i.e.
+        :func:`os.path.getctime`. On some systems (like Unix), this is the
+        time of the last metadata change, and on others (like Windows), it's
+        the creation time of the file.
+
 The ``Storage`` class
 =====================
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -130,6 +130,7 @@ csrf
 csrfmiddlewaretoken
 css
 csv
+ctime
 Ctrl
 customizability
 customizable


### PR DESCRIPTION
Clarify that the creation time of the file is returned on Windows only.

https://code.djangoproject.com/ticket/27644