### PR TITLE
Remove unnecessary check for __deepcopy__ argument

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -91,9 +91,7 @@ class MultiValueDict(dict):
             for k, v in self.lists()
         ])
 
-    def __deepcopy__(self, memo=None):
-        if memo is None:
-            memo = {}
+    def __deepcopy__(self, memo):
         result = self.__class__()
         memo[id(self)] = result
         for key, value in dict.items(self):


### PR DESCRIPTION
The implementation for `QueryDict..__depcopy__` accepts an optional `memo` argument and check that it is not `None`. However, according to https://docs.python.org/3.6/library/copy.html the memo argument is mandatory and you're guaranteed to always get a dict (the `copy.deepcopy` stdlib function takes care of ensuring this) so the check is redundant.