### PR TITLE
[WIP] Fixed #28053 -- Support db_index=Index()

### DIFF
--- a/django/contrib/gis/db/backends/mysql/schema.py
+++ b/django/contrib/gis/db/backends/mysql/schema.py
@@ -41,8 +41,8 @@ class MySQLGISSchemaEditor(DatabaseSchemaEditor):
         super().create_model(model)
         self.create_spatial_indexes()
 
-    def add_field(self, model, field):
-        super().add_field(model, field)
+    def add_field(self, model, field, to_model):
+        super().add_field(model, field, to_model)
         self.create_spatial_indexes()
 
     def remove_field(self, model, field):

--- a/django/contrib/gis/db/backends/oracle/schema.py
+++ b/django/contrib/gis/db/backends/oracle/schema.py
@@ -67,8 +67,8 @@ class OracleGISSchemaEditor(DatabaseSchemaEditor):
             'table': self.geo_quote_name(model._meta.db_table),
         })
 
-    def add_field(self, model, field):
-        super().add_field(model, field)
+    def add_field(self, model, field, to_model):
+        super().add_field(model, field, to_model)
         self.run_geometry_sql()
 
     def remove_field(self, model, field):

--- a/django/contrib/gis/db/backends/spatialite/schema.py
+++ b/django/contrib/gis/db/backends/spatialite/schema.py
@@ -100,7 +100,7 @@ class SpatialiteSchemaEditor(DatabaseSchemaEditor):
                 pass
         super().delete_model(model, **kwargs)
 
-    def add_field(self, model, field):
+    def add_field(self, model, field, to_model):
         from django.contrib.gis.db.models.fields import GeometryField
         if isinstance(field, GeometryField):
             # Populate self.geometry_sql
@@ -109,7 +109,7 @@ class SpatialiteSchemaEditor(DatabaseSchemaEditor):
                 self.execute(sql)
             self.geometry_sql = []
         else:
-            super().add_field(model, field)
+            super().add_field(model, field, to_model)
 
     def remove_field(self, model, field):
         from django.contrib.gis.db.models.fields import GeometryField

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -361,6 +361,14 @@ class BaseDatabaseSchemaEditor:
             ))
         self.execute(self._delete_constraint_sql(sql, model, constraint_names[0]))
 
+    def _get_db_specific_indexes(self, model, field):
+        """DB specific hook for additional indexes.
+
+        Examples include Postgres making varchar_pattern_ops indexes on
+        CharField.
+        """
+        pass
+
     def alter_db_table(self, model, old_db_table, new_db_table):
         """Rename the table a model points to."""
         if (old_db_table == new_db_table or

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -804,7 +804,7 @@ class BaseDatabaseSchemaEditor:
             new_field.remote_field.through._meta.get_field(new_field.m2m_field_name()),
         )
 
-    def _create_index_name(self, model, column_names, suffix="", max_length=None):
+    def _create_index_name(self, model, column_names, suffix=""):
         """
         Generate a unique name for an index/unique constraint.
 
@@ -814,8 +814,7 @@ class BaseDatabaseSchemaEditor:
         table_name = strip_quotes(model._meta.db_table)
         hash_data = [table_name] + list(column_names)
         hash_suffix_part = '%s%s' % (self._digest(*hash_data), suffix)
-        if max_length is None:
-            max_length = self.connection.ops.max_name_length() or 200
+        max_length = self.connection.ops.max_name_length() or 200
         # If everything fits into max_length, use that name.
         index_name = '%s_%s_%s' % (table_name, '_'.join(column_names), hash_suffix_part)
         if len(index_name) <= max_length:

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -379,7 +379,7 @@ class BaseDatabaseSchemaEditor:
             "new_tablespace": self.quote_name(new_db_tablespace),
         })
 
-    def add_field(self, model, field):
+    def add_field(self, model, field, to_model):
         """
         Create a field on a model. Usually involves adding a column, but may
         involve adding a table instead (for M2M fields).
@@ -414,8 +414,8 @@ class BaseDatabaseSchemaEditor:
             }
             self.execute(sql)
         # Add an index, if required
-        indexes = field.get_indexes(self, model=model)
-        self.deferred_sql.extend([index.create_sql(model, self) for index in indexes])
+        indexes = field.get_indexes(self, model=to_model)
+        self.deferred_sql.extend([index.create_sql(to_model, self) for index in indexes])
         # Add any FK constraints later
         if field.remote_field and self.connection.features.supports_foreign_keys and field.db_constraint:
             self.deferred_sql.append(self._create_fk_sql(model, field, "_fk_%(to_table)s_%(to_column)s"))

--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -44,8 +44,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             }
         )
 
-    def add_field(self, model, field):
-        super().add_field(model, field)
+    def add_field(self, model, field, to_model):
+        super().add_field(model, field, to_model)
 
         # Simulate the effect of a one-off default.
         # field.default may be unhashable, so a set isn't used for "in" check.

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -28,10 +28,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         db_type = field.db_type(connection=self.connection)
         if db_type is not None and (field.db_index or field.unique):
             if db_type.startswith('varchar') or db_type.startswith('text'):
-                # TODO: Name length problems - old version makes longer names depending on DB, Index() hates this
-                name = self._create_index_name(model, [field.column], suffix='_like', max_length=30)
                 # TODO: make this accept the ops class somehow, currently creates a normal index
-                index = Index(fields=[field.name], name=name)
+                index = Index(fields=[field.name])
+                name = self._create_index_name(model, [field.column], suffix='_like')
+                index.name = name
                 return [index]
         return []
 

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -1,7 +1,7 @@
 import psycopg2
 
-from django.db.models.indexes import Index
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.models.indexes import Index
 
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):

--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -223,7 +223,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 "table": self.quote_name(model._meta.db_table),
             })
 
-    def add_field(self, model, field):
+    def add_field(self, model, field, to_model):
         """
         Create a field on a model. Usually involves adding a column, but may
         involve adding a table instead (for M2M fields).

--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -80,6 +80,7 @@ class AddField(FieldOperation):
             schema_editor.add_field(
                 from_model,
                 field,
+                to_model,
             )
             if not self.preserve_default:
                 field.default = NOT_PROVIDED
@@ -151,7 +152,7 @@ class RemoveField(FieldOperation):
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, to_model):
             from_model = from_state.apps.get_model(app_label, self.model_name)
-            schema_editor.add_field(from_model, to_model._meta.get_field(self.name))
+            schema_editor.add_field(from_model, to_model._meta.get_field(self.name), to_model)
 
     def describe(self):
         return "Remove field %s from %s" % (self.name, self.model_name)

--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -634,6 +634,7 @@ class AlterOrderWithRespectTo(FieldRelatedOptionOperation):
                 schema_editor.add_field(
                     from_model,
                     field,
+                    to_model,
                 )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -18,6 +18,7 @@ from django.core import checks, exceptions, validators
 from django.core.exceptions import FieldDoesNotExist  # NOQA
 from django.db import connection, connections, router
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.indexes import Index
 from django.db.models.query_utils import DeferredAttribute, RegisterLookupMixin
 from django.utils import timezone
 from django.utils.datastructures import DictWrapper
@@ -267,10 +268,10 @@ class Field(RegisterLookupMixin):
             return []
 
     def _check_db_index(self):
-        if self.db_index not in (None, True, False):
+        if self.db_index not in (None, True, False) and not (isinstance(self.db_index, type) and issubclass(self.db_index, Index)):
             return [
                 checks.Error(
-                    "'db_index' must be None, True or False.",
+                    "'db_index' must be None, True or False, or a subclass of Index",
                     obj=self,
                     id='fields.E006',
                 )

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -675,19 +675,14 @@ class Field(RegisterLookupMixin):
             model = self.model
         if isinstance(self.db_index, Index):
             index = self.db_index.clone()
-            if not index.name:
-                name = schema._create_index_name(
-                    model,
-                    [self.column],
-                    suffix=index.suffix,
-                    max_length=index.max_name_length,
-                )
-                index.name = name
             index.fields = [self.name]
+            if not index.name:
+                index.set_name_with_model(model)
             indexes.append(index)
         elif self.db_index and not self.unique:
-            name = schema._create_index_name(model, [self.column], max_length=Index.max_name_length)
-            index = Index(fields=[self.name], name=name)
+            index = Index(fields=[self.name])
+            name = schema._create_index_name(model, [self.column])
+            index.name = name
             indexes.append(index)
         if hasattr(schema, '_get_like_indexes'):
             indexes.extend(schema._get_like_indexes(model, self))

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -684,8 +684,7 @@ class Field(RegisterLookupMixin):
             name = schema._create_index_name(model, [self.column])
             index.name = name
             indexes.append(index)
-        if hasattr(schema, '_get_like_indexes'):
-            indexes.extend(schema._get_like_indexes(model, self))
+        indexes.extend(schema._get_db_specific_indexes(model, self))
         return indexes
 
     def get_db_converters(self, connection):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -271,7 +271,7 @@ class Field(RegisterLookupMixin):
         if self.db_index not in (None, True, False) and not isinstance(self.db_index, Index):
             return [
                 checks.Error(
-                    "'db_index' must be None, True or False, or an instance of Index",
+                    "'db_index' must be None, True or False, or an instance of Index.",
                     obj=self,
                     id='fields.E006',
                 )
@@ -676,7 +676,12 @@ class Field(RegisterLookupMixin):
         if isinstance(self.db_index, Index):
             index = self.db_index.clone()
             if not index.name:
-                name = schema._create_index_name(model, [self.column], suffix=index.suffix, max_length=index.max_name_length)
+                name = schema._create_index_name(
+                    model,
+                    [self.column],
+                    suffix=index.suffix,
+                    max_length=index.max_name_length,
+                )
                 index.name = name
             index.fields = [self.name]
             indexes.append(index)

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -18,8 +18,8 @@ class Index:
         self.name = name or ''
         if self.name:
             errors = self.check_name()
-            # if len(self.name) > self.max_name_length:
-            #     errors.append('Index names cannot be longer than %s characters.' % self.max_name_length)
+            if len(self.name) > self.max_name_length:
+                errors.append('Index names cannot be longer than %s characters.' % self.max_name_length)
             if errors:
                 raise ValueError(errors)
 

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -14,21 +14,27 @@ class Index:
     def __init__(self, fields=[], name=None):
         if not isinstance(fields, list):
             raise ValueError('Index.fields must be a list.')
-        if not fields:
-            raise ValueError('At least one field is required to define an index.')
         self.fields = fields
+        self.name = name or ''
+        if self.name:
+            errors = self.check_name()
+            # if len(self.name) > self.max_name_length:
+            #     errors.append('Index names cannot be longer than %s characters.' % self.max_name_length)
+            if errors:
+                raise ValueError(errors)
+
+    @property
+    def fields(self):
+        return self._fields
+
+    @fields.setter
+    def fields(self, fields):
+        self._fields = fields
         # A list of 2-tuple with the field name and ordering ('' or 'DESC').
         self.fields_orders = [
             (field_name[1:], 'DESC') if field_name.startswith('-') else (field_name, '')
             for field_name in self.fields
         ]
-        self.name = name or ''
-        if self.name:
-            errors = self.check_name()
-            if len(self.name) > self.max_name_length:
-                errors.append('Index names cannot be longer than %s characters.' % self.max_name_length)
-            if errors:
-                raise ValueError(errors)
 
     def check_name(self):
         errors = []
@@ -43,6 +49,8 @@ class Index:
         return errors
 
     def get_sql_create_template_values(self, model, schema_editor, using):
+        if not self.fields:
+            raise ValueError('At least one field is required to define an index.')
         fields = [model._meta.get_field(field_name) for field_name, order in self.fields_orders]
         tablespace_sql = schema_editor._get_index_tablespace_sql(model, fields)
         quote_name = schema_editor.quote_name
@@ -124,3 +132,6 @@ class Index:
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__) and (self.deconstruct() == other.deconstruct())
+
+    def __hash__(self):
+        return hash((self.__class__.__name__, tuple(self.fields), self.name))

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -198,7 +198,7 @@ class CharFieldTests(TestCase):
         errors = field.check()
         expected = [
             Error(
-                "'db_index' must be None, True or False.",
+                "'db_index' must be None, True or False, or an instance of Index.",
                 obj=field,
                 id='fields.E006',
             ),

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -31,8 +31,9 @@ class IndexesTests(SimpleTestCase):
 
     def test_raises_error_without_field(self):
         msg = 'At least one field is required to define an index.'
+        index = models.Index()
         with self.assertRaisesMessage(ValueError, msg):
-            models.Index()
+            index.get_sql_create_template_values(None, None, None)
 
     def test_max_name_length(self):
         msg = 'Index names cannot be longer than 30 characters.'

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
-import uuid
 import unittest
+import uuid
 from copy import copy
 from unittest import mock
 


### PR DESCRIPTION
WIP PR for expanding `db_index` to allow explicitly setting an index. It moves the responsibility for the indexes on a field to the field. This is also a step towards allowing a field type to define a default index type (e.g. for JSON or HStore fields, and for GIS).

TODO:
- [ ] Allow (for PG at least) [ops classes](https://www.postgresql.org/docs/9.5/static/indexes-opclass.html) when creating an index, so the Like index can be explicitly added. This can probably be done with an expression after #8056 is complete. **At present the logic for creating the like index (named `_like`) is there, but it creates a plan btree index!**
- [ ] Handle MySQL ForeignKey special case
- [ ] Possibly also fix #8118 - relates to `TextField` not having indexes on MySQL (or Oracle?) when indexed.
- [x] Handle Postgres Like indexes naming properly - maybe allow passing a max_length to an index?
- [ ] Possibly also address [this ticket](https://code.djangoproject.com/ticket/24082) about `unique=True` and indexes on PG text fields
- [ ] Some other tests need `clone_model` adding to fix things
- [x] Handle legacy index names (see also #8329)
- [ ] Change to using `Index.set_name_from_model()` (i.e. short index names) in both cases, and update all the tests where names change.
- [ ] More tests for changing values of `db_index`, especially changing from one kind of index to another
- [ ] Docs (including documenting change to `SchemaEditor.add_field`)

Questions:
- Should we be more careful about setting `Index.fields()`? Do we need to verify that it only affects this field, or that no fields should be permitted on init when it's a `db_index`? How does this fit with indexes taking expressions?

Backwards incompatible changes:
- `SchemaEditor.add_field` now takes the `to_model` in the signature. This could possibly be handled more carefully, and the `to_model` is not *always* necessary, only when an index changes, so the code could be crafted to make `to_model` optional except where necessary for backwards compatibility reasons. I'm not sure it's worth it though.