### PR TITLE
Fixed #28042 -- Fixed crash when using a two-tuple in EmailMessage's attachments arg.

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -236,7 +236,13 @@ class EmailMessage:
         self.from_email = from_email or settings.DEFAULT_FROM_EMAIL
         self.subject = subject
         self.body = body
-        self.attachments = attachments or []
+        self.attachments = []
+        if attachments:
+            for attachment in attachments:
+                if isinstance(attachment, MIMEBase):
+                    self.attach(attachment)
+                else:
+                    self.attach(*attachment)
         self.extra_headers = headers or {}
         self.connection = connection
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -15,3 +15,6 @@ Bugfixes
 
 * Fixed a crash when using a ``__icontains`` lookup on a ``ArrayField``
   (:ticket:`28038`).
+
+* Fixed a crash when using a two-tuple in ``EmailMessage``’s ``attachments``
+  argument (:ticket:`28042`).

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -374,6 +374,12 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         self.assertEqual(payload[0].get_content_type(), 'multipart/alternative')
         self.assertEqual(payload[1].get_content_type(), 'application/pdf')
 
+    def test_attachments_MIMEText(self):
+        txt = MIMEText('content1')
+        msg = EmailMessage(attachments=[txt])
+        payload = msg.message().get_payload()
+        self.assertEqual(payload[0], txt)
+
     def test_non_ascii_attachment_filename(self):
         """Regression test for #14964"""
         headers = {"Date": "Fri, 09 Nov 2001 01:08:47 -0000", "Message-ID": "foo"}

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -374,6 +374,13 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         self.assertEqual(payload[0].get_content_type(), 'multipart/alternative')
         self.assertEqual(payload[1].get_content_type(), 'application/pdf')
 
+    def test_attachments_two_tuple(self):
+        msg = EmailMessage(attachments=[('filename1', 'content1')])
+        filename, content, mimetype = self.get_decoded_attachments(msg)[0]
+        self.assertEqual(filename, 'filename1')
+        self.assertEqual(content, b'content1')
+        self.assertEqual(mimetype, 'application/octet-stream')
+
     def test_attachments_MIMEText(self):
         txt = MIMEText('content1')
         msg = EmailMessage(attachments=[txt])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28042