### PR TITLE
Prevent late registration of models.

### DIFF
--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -7,6 +7,7 @@ from django.forms import (
 )
 from django.forms.models import ModelFormMetaclass
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
 
 from ..models import (
     BoundaryModel, ChoiceFieldModel, ChoiceModel, ChoiceOptionModel, Defaults,
@@ -235,6 +236,7 @@ class FormsModelTestCase(TestCase):
         self.assertEqual(obj.def_date, datetime.date(1999, 3, 2))
 
 
+@isolate_apps('forms_tests')
 class RelatedModelFormTests(SimpleTestCase):
     def test_invalid_loading_order(self):
         """

--- a/tests/model_fields/test_foreignkey.py
+++ b/tests/model_fields/test_foreignkey.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-from django.apps import apps
 from django.core import checks
 from django.db import models
 from django.test import TestCase, skipIfDBFeature
@@ -51,7 +50,8 @@ class ForeignKeyTests(TestCase):
         rel_name = Bar._meta.get_field('a').remote_field.related_name
         self.assertIsInstance(rel_name, str)
 
-    def test_abstract_model_pending_operations(self):
+    @isolate_apps('model_fields', kwarg_name='apps')
+    def test_abstract_model_pending_operations(self, apps):
         """
         Foreign key fields declared on abstract models should not add lazy
         relations to resolve relationship declared as string (#24215).

--- a/tests/model_fields/test_manytomanyfield.py
+++ b/tests/model_fields/test_manytomanyfield.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.db import models
 from django.test import SimpleTestCase
 from django.test.utils import isolate_apps
@@ -16,7 +15,8 @@ class ManyToManyFieldTests(SimpleTestCase):
         self.assertEqual(qs.model, ManyToManyModel)
         self.assertEqual(list(qs), [])
 
-    def test_abstract_model_pending_operations(self):
+    @isolate_apps('model_fields', kwarg_name='apps')
+    def test_abstract_model_pending_operations(self, apps):
         """
         Many-to-many fields declared on abstract models should not add lazy
         relations to resolve relationship declared as string (#24215).

--- a/tests/model_regress/test_pickle.py
+++ b/tests/model_regress/test_pickle.py
@@ -1,10 +1,13 @@
 import pickle
+from unittest import mock
 
 from django.db import DJANGO_VERSION_PICKLE_KEY, models
 from django.test import TestCase
+from django.test.utils import isolate_apps
 from django.utils.version import get_version
 
 
+@isolate_apps('model_regress', attr_name='apps')
 class ModelPickleTestCase(TestCase):
     def test_missing_django_version_unpickling(self):
         """
@@ -22,7 +25,7 @@ class ModelPickleTestCase(TestCase):
 
         p = MissingDjangoVersion(title="FooBar")
         msg = "Pickled model instance's Django version is not specified."
-        with self.assertRaisesMessage(RuntimeWarning, msg):
+        with mock.patch('django.db.models.base.apps', self.apps), self.assertRaisesMessage(RuntimeWarning, msg):
             pickle.loads(pickle.dumps(p))
 
     def test_unsupported_unpickle(self):
@@ -41,5 +44,5 @@ class ModelPickleTestCase(TestCase):
 
         p = DifferentDjangoVersion(title="FooBar")
         msg = "Pickled model instance's Django version 1.0 does not match the current version %s." % get_version()
-        with self.assertRaisesMessage(RuntimeWarning, msg):
+        with mock.patch('django.db.models.base.apps', self.apps), self.assertRaisesMessage(RuntimeWarning, msg):
             pickle.loads(pickle.dumps(p))

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -11,8 +11,10 @@ import warnings
 
 import django
 from django.apps import apps
+from django.apps.registry import Apps
 from django.conf import settings
 from django.db import connection, connections
+from django.db.models.options import Options
 from django.test import TestCase, TransactionTestCase
 from django.test.runner import default_test_processes
 from django.test.selenium import SeleniumTestCaseBase
@@ -76,6 +78,11 @@ CONTRIB_TESTS_TO_APPS = {
     'flatpages_tests': 'django.contrib.flatpages',
     'redirects_tests': 'django.contrib.redirects',
 }
+
+
+class PreventRegistrationApps(Apps):
+    def register_model(self, app_label, model):
+        raise Exception('Not Allowed.')
 
 
 def get_test_modules():
@@ -209,6 +216,8 @@ def setup(verbosity, test_labels, parallel):
         settings.INSTALLED_APPS.append(gis)
 
     apps.set_installed_apps(settings.INSTALLED_APPS)
+
+    Options.default_apps = PreventRegistrationApps()
 
     return state
 


### PR DESCRIPTION
@timgraham here's what I had in mind. There's a couple of migration tests failures that would require adjustments but I'm pretty sure they could work with `isolated_apps`.