### PR TITLE
Used NotSupportedError instead of DatabaseError in SQLCompiler.as_sql().

### DIFF
--- a/django/db/backends/oracle/compiler.py
+++ b/django/db/backends/oracle/compiler.py
@@ -20,7 +20,7 @@ class SQLCompiler(compiler.SQLCompiler):
             sql, params = super().as_sql(with_limits=False, with_col_aliases=with_col_aliases)
         elif not self.connection.features.supports_select_for_update_with_limit and self.query.select_for_update:
             raise NotSupportedError(
-                'LIMIT/OFFSET not supported with select_for_update on this '
+                'LIMIT/OFFSET is not supported with select_for_update on this '
                 'database backend.'
             )
         else:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -430,7 +430,7 @@ class SQLCompiler:
             features = self.connection.features
             if combinator:
                 if not getattr(features, 'supports_select_{}'.format(combinator)):
-                    raise DatabaseError('{} not supported on this database backend.'.format(combinator))
+                    raise NotSupportedError('{} is not supported on this database backend.'.format(combinator))
                 result, params = self.get_combinator_sql(combinator, self.query.combinator_all)
             else:
                 result = ['SELECT']
@@ -462,8 +462,8 @@ class SQLCompiler:
 
                     if with_limits and not self.connection.features.supports_select_for_update_with_limit:
                         raise NotSupportedError(
-                            'LIMIT/OFFSET not supported with select_for_update'
-                            ' on this database backend.'
+                            'LIMIT/OFFSET is not supported with '
+                            'select_for_update on this database backend.'
                         )
                     nowait = self.query.select_for_update_nowait
                     skip_locked = self.query.select_for_update_skip_locked
@@ -471,9 +471,9 @@ class SQLCompiler:
                     # doesn't support it, raise a DatabaseError to prevent a
                     # possible deadlock.
                     if nowait and not self.connection.features.has_select_for_update_nowait:
-                        raise DatabaseError('NOWAIT is not supported on this database backend.')
+                        raise NotSupportedError('NOWAIT is not supported on this database backend.')
                     elif skip_locked and not self.connection.features.has_select_for_update_skip_locked:
-                        raise DatabaseError('SKIP LOCKED is not supported on this database backend.')
+                        raise NotSupportedError('SKIP LOCKED is not supported on this database backend.')
                     for_update_part = self.connection.ops.for_update_sql(nowait=nowait, skip_locked=skip_locked)
 
                 if for_update_part and self.connection.features.for_update_after_from:

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,5 +1,5 @@
 from django.db.models import F, IntegerField, Value
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError, NotSupportedError
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import Number, ReservedName
@@ -73,8 +73,8 @@ class QuerySetSetOperationTests(TestCase):
     def test_unsupported_intersection_raises_db_error(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.all()
-        msg = 'intersection not supported on this database backend'
-        with self.assertRaisesMessage(DatabaseError, msg):
+        msg = 'intersection is not supported on this database backend'
+        with self.assertRaisesMessage(NotSupportedError, msg):
             list(qs1.intersection(qs2))
 
     def test_combining_multiple_models(self):

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -137,7 +137,7 @@ class SelectForUpdateTests(TransactionTestCase):
         DatabaseError is raised if a SELECT...FOR UPDATE NOWAIT is run on
         a database backend that supports FOR UPDATE but not NOWAIT.
         """
-        with self.assertRaisesMessage(DatabaseError, 'NOWAIT is not supported on this database backend.'):
+        with self.assertRaisesMessage(NotSupportedError, 'NOWAIT is not supported on this database backend.'):
             with transaction.atomic():
                 Person.objects.select_for_update(nowait=True).get()
 
@@ -148,7 +148,7 @@ class SelectForUpdateTests(TransactionTestCase):
         DatabaseError is raised if a SELECT...FOR UPDATE SKIP LOCKED is run on
         a database backend that supports FOR UPDATE but not SKIP LOCKED.
         """
-        with self.assertRaisesMessage(DatabaseError, 'SKIP LOCKED is not supported on this database backend.'):
+        with self.assertRaisesMessage(NotSupportedError, 'SKIP LOCKED is not supported on this database backend.'):
             with transaction.atomic():
                 Person.objects.select_for_update(skip_locked=True).get()
 


### PR DESCRIPTION
See [comments](https://github.com/django/django/pull/8330/files/6cdee8eeabb3586a8990bdfbfa8d1cb8ae31d10e#r110550238).