### PR TITLE
Fixed #28064 -- Fixed MultiValueDict's MultiValueDictKeyError double-quoting key names.

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -76,7 +76,7 @@ class MultiValueDict(dict):
         try:
             list_ = super().__getitem__(key)
         except KeyError:
-            raise MultiValueDictKeyError(repr(key))
+            raise MultiValueDictKeyError(key)
         try:
             return list_[-1]
         except IndexError:

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -48,8 +48,9 @@ class MultiValueDictTests(SimpleTestCase):
             [('name', ['Adrian', 'Simon']), ('position', ['Developer'])]
         )
 
-        with self.assertRaisesMessage(MultiValueDictKeyError, 'lastname'):
+        with self.assertRaises(MultiValueDictKeyError) as cm:
             d.__getitem__('lastname')
+        self.assertEqual(str(cm.exception), "'lastname'")
 
         self.assertIsNone(d.get('lastname'))
         self.assertEqual(d.get('lastname', 'nonexistent'), 'nonexistent')


### PR DESCRIPTION
Since 89319850 a MultiValueDictError message has looked like:

    >>> MultiValueDict()['key']
    # ...
    django.utils.datastructures.MultiValueDictKeyError: "'key'"

There's an extra pair of "s compared with the same message from
KeyError:

    >>> {}['key']
    #...
    KeyError: 'key'

This is because the missing key was passed through repr() before
being passed as a parameter to MultiValueDictError, which inherits
from KeyError. This simply removes the repr(), causing the error
message above to lose the "s and match the message from KeyError.

https://code.djangoproject.com/ticket/28064