### PR TITLE
Refs #28024 -- Optimized LineString.__init__() by avoiding superfluous index and dimension checks.

### DIFF
--- a/django/contrib/gis/geos/linestring.py
+++ b/django/contrib/gis/geos/linestring.py
@@ -73,16 +73,18 @@ class LineString(LinearGeometryMixin, GEOSGeometry):
             numpy_coords = True
 
         # Creating a coordinate sequence object because it is easier to
-        # set the points using GEOSCoordSeq.__setitem__().
+        # set the points using its methods.
         cs = GEOSCoordSeq(capi.create_cs(ncoords, ndim), z=bool(ndim == 3))
+        point_setter = cs._set_point_3d if ndim == 3 else cs._set_point_2d
 
         for i in range(ncoords):
             if numpy_coords:
-                cs[i] = coords[i, :]
+                point_coords = coords[i, :]
             elif isinstance(coords[i], Point):
-                cs[i] = coords[i].tuple
+                point_coords = coords[i].tuple
             else:
-                cs[i] = coords[i]
+                point_coords = coords[i]
+            point_setter(i, point_coords)
 
         # Calling the base geometry initialization with the returned pointer
         #  from the function.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28024
Benchmark:
`python -mtimeit -s "from django.contrib.gis.geos import LineString" "LineString([(x, x) for x in range(1000)])"`
31.4 msec => 13.3 msec per loop