### PR TITLE
Fixed #28079 -- Restored "No POST data" (rather than an empty table) in HTML debug page.

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -299,7 +299,7 @@ class ExceptionReporter:
             'frames': frames,
             'request': self.request,
             'user_str': user_str,
-            'filtered_POST_items': self.filter.get_post_parameters(self.request).items(),
+            'filtered_POST_items': list(self.filter.get_post_parameters(self.request).items()),
             'settings': get_safe_settings(),
             'sys_executable': sys.executable,
             'sys_version_info': '%d.%d.%d' % sys.version_info[0:3],

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -21,3 +21,6 @@ Bugfixes
 
 * Fixed ``QuerySet.filter()`` crash when it references the name of a
   ``OneToOneField`` primary key (:ticket:`28047`).
+
+* Fixed empty POST data table appearing instead of "No POST data" in HTML debug
+  page (:ticket:`28079`).

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -290,6 +290,7 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn('<h2>Traceback ', html)
         self.assertIn('<h2>Request information</h2>', html)
         self.assertNotIn('<p>Request data not supplied</p>', html)
+        self.assertIn('<p>No POST data</p>', html)
 
     def test_no_request(self):
         "An exception report can be generated without request"


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28079