### PR TITLE
Change "Development Status" classifier to "Mature"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     },
     zip_safe=False,
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 6 - Mature',
         'Environment :: Web Environment',
         'Framework :: Django',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Django has been around for long enough that I don't think anyone would question its maturity. [PyPI classifiers are listed here.](https://pypi.python.org/pypi?%3Aaction=list_classifiers)