### PR TITLE
Fixed #27161 -- Fixed validation of ArrayField with choices

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -44,7 +44,7 @@ class SimpleArrayField(forms.CharField):
         values = []
         for index, item in enumerate(items):
             try:
-                values.append(self.base_field.to_python(item))
+                values.append(self.base_field.clean(item))
             except ValidationError as error:
                 errors.append(prefix_validation_error(
                     error,

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -686,6 +686,12 @@ class TestSimpleFormField(PostgreSQLTestCase):
         self.assertIsInstance(form_field, SimpleArrayField)
         self.assertEqual(form_field.max_length, 4)
 
+    def test_model_field_formfield_choices(self):
+        model_field = ArrayField(models.IntegerField(choices=((1, 'One'), (2, 'Two'))))
+        form_field = model_field.formfield()
+        vals = form_field.clean('1,2')
+        model_field.clean(vals, None)
+
     def test_already_converted_value(self):
         field = SimpleArrayField(forms.CharField())
         vals = ['a', 'b', 'c']


### PR DESCRIPTION
Changed SimpleArrayField.to_python() to call clean() instead of
to_python() on each array item. If base_field form is TypedChoiceField
clean() will coerce the value to the right type.