### PR TITLE
Fixed #28058 -- Restored empty BoundFields evaluating to True.

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -53,6 +53,10 @@ class BoundField:
             for widget in self.field.widget.subwidgets(self.html_name, self.value(), attrs=attrs)
         )
 
+    def __bool__(self):
+        # BoundField evaluates to True even if it doesn't have subwidgets.
+        return True
+
     def __iter__(self):
         return iter(self.subwidgets)
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -24,3 +24,6 @@ Bugfixes
 
 * Fixed empty POST data table appearing instead of "No POST data" in HTML debug
   page (:ticket:`28079`).
+
+* Restored ``BoundField``\s without any ``choices`` evaluating to ``True``
+  (:ticket:`28058`).

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -746,6 +746,13 @@ Java</label></li>
             [str(bf[1]), str(bf[2]), str(bf[3])],
         )
 
+    def test_boundfield_bool(self):
+        """BoundField without any choices (subwidgets) evaluates to True."""
+        class TestForm(Form):
+            name = ChoiceField(choices=[])
+
+        self.assertIs(bool(TestForm()['name']), True)
+
     def test_forms_with_multiple_choice(self):
         # MultipleChoiceField is a special case, as its data is required to be a list:
         class SongForm(Form):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28058