### PR TITLE
Fixed #28059 -- Restored CSS classes in <ul> of widgets that use multiple_input.html.

### DIFF
--- a/django/forms/jinja2/django/forms/widgets/multiple_input.html
+++ b/django/forms/jinja2/django/forms/widgets/multiple_input.html
@@ -1,4 +1,4 @@
-{% set id = widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
+{% set id = widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
   <li>{{ group }}<ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}{% for widget in options %}
     <li>{% include widget.template_name %}</li>{% endfor %}{% if group %}
   </ul></li>{% endif %}{% endfor %}

--- a/django/forms/templates/django/forms/widgets/multiple_input.html
+++ b/django/forms/templates/django/forms/widgets/multiple_input.html
@@ -1,4 +1,4 @@
-{% with id=widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
+{% with id=widget.attrs.id %}<ul{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
   <li>{{ group }}<ul{% if id %} id="{{ id }}_{{ index }}"{% endif %}>{% endif %}{% for option in options %}
     <li>{% include option.template_name with widget=option %}</li>{% endfor %}{% if group %}
   </ul></li>{% endif %}{% endfor %}

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -36,3 +36,7 @@ Bugfixes
 
 * Allowed prefetch calls on managers with custom ``ModelIterable`` subclasses
   (:ticket:`28096`).
+
+* Restored the output of the ``class`` attribute in the ``<ul>`` of widgets
+  that use the ``multiple_input.html`` template. This fixes
+  ``ModelAdmin.radio_fields`` with ``admin.HORIZONTAL`` (:ticket:`28059`).

--- a/tests/forms_tests/widget_tests/test_radioselect.py
+++ b/tests/forms_tests/widget_tests/test_radioselect.py
@@ -84,3 +84,18 @@ class RadioSelectTest(WidgetTest):
         </ul>
         """
         self.check_html(self.widget(choices=self.beatles), 'beatle', 'J', attrs={'id': 'bar'}, html=html)
+
+    def test_class_attrs(self):
+        """
+        The <ul> in the multiple_input.html widget template include the class
+        attribute.
+        """
+        html = """
+        <ul class="bar">
+        <li><label><input checked type="radio" class="bar" value="J" name="beatle" /> John</label></li>
+        <li><label><input type="radio" class="bar" value="P" name="beatle" /> Paul</label></li>
+        <li><label><input type="radio" class="bar" value="G" name="beatle" /> George</label></li>
+        <li><label><input type="radio" class="bar" value="R" name="beatle" /> Ringo</label></li>
+        </ul>
+        """
+        self.check_html(self.widget(choices=self.beatles), 'beatle', 'J', attrs={'class': 'bar'}, html=html)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28059