### PR TITLE
Fixed #28082 -- Made BaseDateListView pass all context to subclasses.

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -285,13 +285,12 @@ class BaseDateListView(MultipleObjectMixin, DateMixin, View):
     """Abstract base class for date-based views displaying a list of objects."""
     allow_empty = False
     date_list_period = 'year'
-    
+
     def get(self, request, *args, **kwargs):
         self.date_list, self.object_list, extra_context = self.get_dated_items()
-        context = self.get_context_data(
-            object_list=self.object_list,
-            date_list=self.date_list,
-            **extra_context)
+        context = self.get_context_data(object_list=self.object_list,
+                                        date_list=self.date_list,
+                                        **extra_context)
         return self.render_to_response(context)
 
     def get_dated_items(self):

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -285,12 +285,13 @@ class BaseDateListView(MultipleObjectMixin, DateMixin, View):
     """Abstract base class for date-based views displaying a list of objects."""
     allow_empty = False
     date_list_period = 'year'
-
+    
     def get(self, request, *args, **kwargs):
         self.date_list, self.object_list, extra_context = self.get_dated_items()
-        context = self.get_context_data(object_list=self.object_list,
-                                        date_list=self.date_list)
-        context.update(extra_context)
+        context = self.get_context_data(
+            object_list=self.object_list,
+            date_list=self.date_list,
+            **extra_context)
         return self.render_to_response(context)
 
     def get_dated_items(self):


### PR DESCRIPTION
Pass the `extra_content` from `get_dated_items()` as kwargs into `get_context_data()` to allow users access to it.

`BaseDateListView.get()` currently modifies the context *after* calling `get_context_data()`, which prevents users from access those data in their base classes. I ran into this suprising quirk  when I wanted to access the current month in my MonthArchiveView subclass's `get_context_data()`.

(To *really* tidy things up, we could have all instances `get_dated_items()` return a single dictionary that we pass to `get_context_data` as kwargs, but I am a realist on occasion...)