### PR TITLE
Fixed #24607 -- Serialized natural keys in multi-table inheritance models.

### DIFF
--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -82,8 +82,10 @@ class Serializer:
             # Use the concrete parent class' _meta instead of the object's _meta
             # This is to avoid local_fields problems for proxy models. Refs #17717.
             concrete_model = obj._meta.concrete_model
+            pk = self.use_natural_primary_keys and concrete_model._meta.pk
+            pk_parent = pk and pk.remote_field and pk.remote_field.parent_link and pk
             for field in concrete_model._meta.local_fields:
-                if field.serialize:
+                if field.serialize or field is pk_parent:
                     if field.remote_field is None:
                         if self.selected_fields is None or field.attname in self.selected_fields:
                             self.handle_field(obj, field)

--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -82,9 +82,14 @@ class Serializer:
             # Use the concrete parent class' _meta instead of the object's _meta
             # This is to avoid local_fields problems for proxy models. Refs #17717.
             concrete_model = obj._meta.concrete_model
+            # when using natural primary keys, retrieve pk-relation field of parent
+            # if appplicable (i.e. inheritance is used)
             pk = self.use_natural_primary_keys and concrete_model._meta.pk
             pk_parent = pk and pk.remote_field and pk.remote_field.parent_link and pk
             for field in concrete_model._meta.local_fields:
+                # if field is pk-relation field of parent, then serialize it even
+                # if it has not been marked for serialization, otherwise deserialization
+                # is not possible.
                 if field.serialize or field is pk_parent:
                     if field.remote_field is None:
                         if self.selected_fields is None or field.attname in self.selected_fields:

--- a/tests/serializers/models/__init__.py
+++ b/tests/serializers/models/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # NOQA
 from .data import *  # NOQA
+from .multi_tables import * # NOQA
 from .natural import *  # NOQA

--- a/tests/serializers/models/__init__.py
+++ b/tests/serializers/models/__init__.py
@@ -1,4 +1,4 @@
 from .base import *  # NOQA
 from .data import *  # NOQA
-from .multitable import * # NOQA
+from .multitable import *  # NOQA
 from .natural import *  # NOQA

--- a/tests/serializers/models/__init__.py
+++ b/tests/serializers/models/__init__.py
@@ -1,4 +1,4 @@
 from .base import *  # NOQA
 from .data import *  # NOQA
-from .multi_tables import * # NOQA
+from .multitable import * # NOQA
 from .natural import *  # NOQA

--- a/tests/serializers/models/multi_tables.py
+++ b/tests/serializers/models/multi_tables.py
@@ -1,0 +1,45 @@
+from django.db import models
+
+
+class PersonManager(models.Manager):
+
+    def get_by_natural_key(self, lastname, firstname):
+        return self.get(lastname=lastname, firstname=firstname)
+
+
+class Person(models.Model):
+
+    objects = PersonManager()
+
+    lastname = models.CharField(max_length=20)
+    firstname = models.CharField(max_length=20)
+
+    def natural_key(self):
+        return (self.lastname, self.firstname)
+
+    def data(self):
+        return (self.lastname, self.firstname)
+
+
+class Customer(Person):
+
+    cnum = models.IntegerField()
+
+    def data(self):
+        return super(Customer, self).data() + (self.cnum,)
+
+
+class PremiumCustomer(Customer):
+
+    level = models.IntegerField()
+
+    def data(self):
+        return super(PremiumCustomer, self).data() + (self.level,)
+
+
+class Employee(Person):
+
+    enum = models.IntegerField()
+
+    def data(self):
+        return super(Employee, self).data() + (self.enum,)

--- a/tests/serializers/models/multitable.py
+++ b/tests/serializers/models/multitable.py
@@ -8,11 +8,9 @@ class PersonManager(models.Manager):
 
 
 class Person(models.Model):
-
-    objects = PersonManager()
-
-    lastname = models.CharField(max_length=20)
     firstname = models.CharField(max_length=20)
+    lastname = models.CharField(max_length=20)
+    objects = PersonManager()
 
     def natural_key(self):
         return (self.lastname, self.firstname)
@@ -22,7 +20,6 @@ class Person(models.Model):
 
 
 class Customer(Person):
-
     cnum = models.IntegerField()
 
     def data(self):
@@ -30,7 +27,6 @@ class Customer(Person):
 
 
 class PremiumCustomer(Customer):
-
     level = models.IntegerField()
 
     def data(self):
@@ -38,7 +34,6 @@ class PremiumCustomer(Customer):
 
 
 class Employee(Person):
-
     enum = models.IntegerField()
 
     def data(self):

--- a/tests/serializers/test_natural.py
+++ b/tests/serializers/test_natural.py
@@ -71,18 +71,18 @@ def natural_key_test(format, self):
 
 
 def natural_pk_mti_test(format, self):
-    x1 = Person.objects.create(firstname="alphonse", lastname="allais")
-    x2 = Customer.objects.create(firstname="alban", lastname="berg", cnum=1885)
-    x3 = PremiumCustomer.objects.create(firstname="vladimir", lastname="jankelevitch", cnum=1903, level=81)
-    x4 = Employee.objects.create(firstname="daksiputra", lastname="panini", enum=-400)
+    x1 = Person.objects.create(firstname='alphonse', lastname='allais')
+    x2 = Customer.objects.create(firstname='alban', lastname='berg', cnum=1885)
+    x3 = PremiumCustomer.objects.create(firstname='vladimir', lastname='jankelevitch', cnum=1903, level=81)
+    x4 = Employee.objects.create(firstname='daksiputra', lastname='panini', enum=-400)
 
     self.assertEqual(len(Person.objects.all()), 4)
     self.assertEqual(len(Customer.objects.all()), 2)
     self.assertEqual(len(PremiumCustomer.objects.all()), 1)
     self.assertEqual(len(Employee.objects.all()), 1)
 
-    # test with 2 different serialization order to ensure that we are not
-    # unknowningly relying on order
+    # test with 2 different serialization orders to ensure that correctness
+    # does not accidentally rely on the order in which instances are serialized
 
     objs1 = []
     objs1.extend(Person.objects.all())
@@ -96,7 +96,7 @@ def natural_pk_mti_test(format, self):
     objs2.extend(Customer.objects.all())
     objs2.extend(PremiumCustomer.objects.all())
 
-    # we will also check that we indeed get back the same data
+    # check that roundtripping through serialization indeed returns the same data
     def get_data():
         objs = []
         objs.extend(reversed(Person.objects.all()))


### PR DESCRIPTION
I slightly reworked @jpmelos earlier PR #7231 to hopefully avoid the problem with spurious migrations.  When a parent link is being promoted as a pk, I don't modify that field, but I take note of the promotion in the inheriting model's _meta (well, Options actually, but that ends up the same).  Then a field is always serialized if it has been promoted, even if it is marked `serialize=False`