### PR TITLE
[1.11.x] Fixed #28091 -- Re-raised original exception when closing cursor cleanup fails

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -874,7 +874,7 @@ class SQLCompiler(object):
             cursor = self.connection.cursor()
         try:
             cursor.execute(sql, params)
-        except Exception:
+        except Exception as original_exception:
             try:
                 # Might fail for server-side cursors (e.g. connection closed)
                 cursor.close()
@@ -883,7 +883,7 @@ class SQLCompiler(object):
                 # Python 2 doesn't chain exceptions. Remove this error
                 # silencing when dropping Python 2 compatibility.
                 pass
-            raise
+            raise original_exception
 
         if result_type == CURSOR:
             # Caller didn't specify a result_type, so just give them back the

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -30,3 +30,7 @@ Bugfixes
 
 * Prevented ``SessionBase.cycle_key()`` from losing session data if
   ``_session_cache`` isn't populated (:ticket:`28066`).
+
+* Re-raised the original exception when ``cursor.execute()`` fails and the
+  cleanup code ``cursor.close()`` fails as well, instead of raising the cleanup
+  code failure (:ticket:28091).


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28091