### PR TITLE
Fixed #28112 --  Added 'time_zone' in GeoIP2.city() dict.

### DIFF
--- a/django/contrib/gis/geoip2/resources.py
+++ b/django/contrib/gis/geoip2/resources.py
@@ -8,6 +8,7 @@ def City(response):
         'longitude': response.location.longitude,
         'postal_code': response.postal.code,
         'region': response.subdivisions[0].iso_code if len(response.subdivisions) else None,
+        'time_zone': response.location.time_zone,
     }
 
 

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -39,7 +39,8 @@ Here is an example of its usage::
     'latitude': 37.419200897216797,
     'longitude': -122.05740356445312,
     'postal_code': '94043',
-    'region': 'CA'}
+    'region': 'CA',
+    'time_zone': 'America/Los_Angeles'}
     >>> g.lat_lon('salon.com')
     (39.0437, -77.4875)
     >>> g.lon_lat('uh.edu')

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -118,6 +118,7 @@ class GeoIPTest(unittest.TestCase):
             self.assertEqual('US', d['country_code'])
             self.assertEqual('Houston', d['city'])
             self.assertEqual('TX', d['region'])
+            self.assertEqual('America/Chicago', d['time_zone'])
 
             geom = g.geos(query)
             self.assertIsInstance(geom, GEOSGeometry)


### PR DESCRIPTION
The geolocation wrapper does not forward the time zone field from the geoip2 libary.