### PR TITLE
Removed nonexistent methods from File's docs.

### DIFF
--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -59,11 +59,6 @@ The ``File`` class
         Returns ``self``, so that it can be used similar to Python's
         built-in :func:`python:open()` with the ``with`` statement.
 
-    .. method:: read(num_bytes=None)
-
-        Read content from the file. The optional ``size`` is the number of
-        bytes to read; if not specified, the file will be read to the end.
-
     .. method:: __iter__()
 
         Iterate over the file yielding one line at a time.
@@ -81,22 +76,16 @@ The ``File`` class
         Returns ``True`` if the file is large enough to require multiple chunks
         to access all of its content give some ``chunk_size``.
 
-    .. method:: write(content)
-
-        Writes the specified content string to the file. Depending on the
-        storage system behind the scenes, this content might not be fully
-        committed until :func:`close()` is called on the file.
-
     .. method:: close()
 
         Close the file.
 
     In addition to the listed methods, :class:`~django.core.files.File` exposes
     the following attributes and methods of its ``file`` object:
-    ``encoding``, ``fileno``, ``flush``, ``isatty``, ``newlines``,
-    ``read``, ``readinto``, ``readlines``, ``seek``, ``softspace``, ``tell``,
-    ``truncate``, ``writelines``, ``xreadlines``, ``readable()``,
-    ``writable()``, and ``seekable()``.
+    ``encoding``, ``fileno``, ``flush``, ``isatty``, ``newlines``, ``read``,
+    ``readinto``, ``readline``, ``readlines``, ``seek``, ``softspace``,
+    ``tell``, ``truncate``, ``write``, ``writelines``, ``xreadlines``,
+    ``readable()``, ``writable()``, and ``seekable()``.
 
     .. versionchanged:: 1.11
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -760,10 +760,9 @@ the result of the :attr:`Storage.open()<django.core.files.storage.Storage.open>`
 method, which may be a :class:`~django.core.files.File` object, or it may be a
 custom storage's implementation of the :class:`~django.core.files.File` API.
 
-In addition to the API inherited from
-:class:`~django.core.files.File` such as :meth:`~django.core.files.File.read`
-and :meth:`~django.core.files.File.write`, :class:`FieldFile` includes several
-methods that can be used to interact with the underlying file:
+In addition to the API inherited from :class:`~django.core.files.File` such as
+``read()`` and ``write()``, :class:`FieldFile` includes several methods that
+can be used to interact with the underlying file:
 
 .. warning::
 


### PR DESCRIPTION
The description of the documentation refers to ``size`` while the
method signature refers to ``num_bytes``. The former is in line with
the general Python signature for files.

There is also a [read method](https://github.com/django/django/blob/master/django/test/client.py#L63) on the undocumented ``FakePayload`` that uses it in its method signature. I could rename that as well if we wanted.