### PR TITLE
Fixed #28109 -- Adjusted stacklevel of warnings raised when paginating unordered querysets.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -100,7 +100,8 @@ class Paginator:
             warnings.warn(
                 'Pagination may yield inconsistent results with an unordered '
                 'object_list: {!r}'.format(self.object_list),
-                UnorderedObjectListWarning
+                UnorderedObjectListWarning,
+                stacklevel=3
             )
 
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -49,3 +49,6 @@ Bugfixes
 * Fixed a regression where ``CheckboxSelectMultiple``, ``NullBooleanSelect``,
   ``RadioSelect``, ``SelectMultiple``, and ``Select`` localized option values
   (:ticket:`28075`).
+
+* Corrected the stack level of unordered queryset pagination warnings
+  (:ticket:`28109`).


### PR DESCRIPTION
Refs #26290.