### PR TITLE
Update staff_member_required ...

### DIFF
--- a/django/contrib/admin/views/decorators.py
+++ b/django/contrib/admin/views/decorators.py
@@ -9,7 +9,7 @@ def staff_member_required(view_func=None, redirect_field_name=REDIRECT_FIELD_NAM
     member, redirecting to the login page if necessary.
     """
     actual_decorator = user_passes_test(
-        lambda u: u.is_active and u.is_staff,
+        lambda u: u.is_active and (u.is_staff or u.is_superuser),
         login_url=login_url,
         redirect_field_name=redirect_field_name
     )


### PR DESCRIPTION
... to reflect true staff membership

coming from https://github.com/django-ckeditor/django-ckeditor/issues/385#issuecomment-296197805

The problem is, a user with `is_superuser = True` but `is_staff = False` will not pass the `staff_member_required` decorator, however he should because as a superuser, he'll have all permissions.