### PR TITLE
Fixed #28101 -- Fixed incorrect queries for __in lookups involving ForeignKey.to_field.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -326,6 +326,7 @@ class Query:
         if hasattr(obj, '_setup_query'):
             obj._setup_query()
         obj.context = self.context.copy()
+        obj._forced_pk = getattr(self, '_forced_pk', False)
         return obj
 
     def add_context(self, key, value):

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -52,3 +52,6 @@ Bugfixes
 
 * Corrected the stack level of unordered queryset pagination warnings
   (:ticket:`28109`).
+
+* Fixed a regression causing incorrect queries for ``__in`` subquery lookups
+  when models use ``ForeignKey.to_field`` (:ticket:`28101`).

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -69,7 +69,7 @@ class Annotation(models.Model):
 
 class ExtraInfo(models.Model):
     info = models.CharField(max_length=100)
-    note = models.ForeignKey(Note, models.CASCADE)
+    note = models.ForeignKey(Note, models.CASCADE, null=True)
     value = models.IntegerField(null=True)
 
     class Meta:
@@ -112,6 +112,10 @@ class Report(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class ReportComment(models.Model):
+    report = models.ForeignKey(Report, models.CASCADE)
 
 
 class Ranking(models.Model):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -22,11 +22,11 @@ from .models import (
     Note, NullableName, Number, ObjectA, ObjectB, ObjectC, OneToOneCategory,
     Order, OrderItem, Page, Paragraph, Person, Plaything, PointerA, Program,
     ProxyCategory, ProxyObjectA, ProxyObjectB, Ranking, Related,
-    RelatedIndividual, RelatedObject, Report, ReservedName, Responsibility,
-    School, SharedConnection, SimpleCategory, SingleObject, SpecialCategory,
-    Staff, StaffUser, Student, Tag, Task, Teacher, Ticket21203Child,
-    Ticket21203Parent, Ticket23605A, Ticket23605B, Ticket23605C, TvChef, Valid,
-    X,
+    RelatedIndividual, RelatedObject, Report, ReportComment, ReservedName,
+    Responsibility, School, SharedConnection, SimpleCategory, SingleObject,
+    SpecialCategory, Staff, StaffUser, Student, Tag, Task, Teacher,
+    Ticket21203Child, Ticket21203Parent, Ticket23605A, Ticket23605B,
+    Ticket23605C, TvChef, Valid, X,
 )
 
 
@@ -2405,6 +2405,18 @@ class ToFieldTests(TestCase):
             set(Food.objects.filter(eaten__in=Eaten.objects.filter(meal='lunch'))),
             {apple}
         )
+
+    def test_nested_in_subquery(self):
+        extra = ExtraInfo.objects.create()
+        author = Author.objects.create(num=42, extra=extra)
+        report = Report.objects.create(creator=author)
+        comment = ReportComment.objects.create(report=report)
+        comments = ReportComment.objects.filter(
+            report__in=Report.objects.filter(
+                creator__in=extra.author_set.all(),
+            ),
+        )
+        self.assertSequenceEqual(comments, [comment])
 
     def test_reverse_in(self):
         apple = Food.objects.create(name="apple")


### PR DESCRIPTION
This fixes an issue with nested __in lookups on related fields relying on the `to_field` option.
https://code.djangoproject.com/ticket/28101