### PR TITLE
Renamed "Mac OS X" to "macOS" in docs.

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
             # we already know 'readline' was imported successfully.
             import rlcompleter
             readline.set_completer(rlcompleter.Completer(imported_objects).complete)
-            # Enable tab completion on systems using libedit (e.g. Mac OSX).
+            # Enable tab completion on systems using libedit (e.g. macOS).
             # These lines are copied from Python's Lib/site.py.
             readline_doc = getattr(readline, '__doc__', '')
             if readline_doc is not None and 'libedit' in readline_doc:

--- a/docs/faq/troubleshooting.txt
+++ b/docs/faq/troubleshooting.txt
@@ -24,12 +24,12 @@ If ``django-admin`` doesn't work but ``django-admin.py`` does, you're probably
 using a version of Django that doesn't match the version of this documentation.
 ``django-admin`` is new in Django 1.7.
 
-Mac OS X permissions
---------------------
+macOS permissions
+-----------------
 
-If you're using Mac OS X, you may see the message "permission denied" when
+If you're using macOS, you may see the message "permission denied" when
 you try to run ``django-admin``. This is because, on Unix-based systems like
-OS X, a file must be marked as "executable" before it can be run as a program.
+macOS, a file must be marked as "executable" before it can be run as a program.
 To do this, open Terminal.app and navigate (using the ``cd`` command) to the
 directory where :doc:`django-admin </ref/django-admin>` is installed, then
 run the command ``sudo chmod +x django-admin``.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -258,7 +258,7 @@ a dependency for one or more of the Python packages. Consult the failing
 package's documentation or search the Web with the error message that you
 encounter.
 
-Now we are ready to run the test suite. If you're using GNU/Linux, Mac OS X or
+Now we are ready to run the test suite. If you're using GNU/Linux, macOS, or
 some other flavor of Unix, run:
 
 .. code-block:: console

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -34,8 +34,8 @@ features include:
   may be used outside of a Django project/application.  In other words,
   no need to have ``DJANGO_SETTINGS_MODULE`` set or use a database, etc.
 * Mutability: :class:`GEOSGeometry` objects may be modified.
-* Cross-platform and tested; compatible with Windows, Linux, Solaris, and Mac
-  OS X platforms.
+* Cross-platform and tested; compatible with Windows, Linux, Solaris, and
+  macOS platforms.
 
 .. _geos-tutorial:
 

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -65,7 +65,7 @@ Optional packages to consider:
 * ``libgeoip1``: for :doc:`GeoIP <../geoip2>` support
 * ``python-gdal`` for GDAL's own Python bindings -- includes interfaces for raster manipulation
 
-Please also consult platform-specific instructions if you are on :ref:`macosx`
+Please also consult platform-specific instructions if you are on :ref:`macos`
 or :ref:`windows`.
 
 .. _build_from_source:
@@ -88,11 +88,9 @@ is required.
 
 .. note::
 
-    OS X users are required to install `Apple Developer Tools`_ in order
-    to compile software from source.  This is typically included on your
-    OS X installation DVDs.
+    macOS users must install `Xcode`_ in order to compile software from source.
 
-.. _Apple Developer Tools: https://developer.apple.com/technologies/tools/
+.. _Xcode: https://developer.apple.com/xcode/
 
 .. _geosbuild:
 

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -16,7 +16,7 @@ Details for each of the requirements and installation instructions
 are provided in the sections below. In addition, platform-specific
 instructions are available for:
 
-* :ref:`macosx`
+* :ref:`macos`
 * :ref:`windows`
 
 .. admonition:: Use the Source
@@ -181,12 +181,12 @@ Similarly, on Red Hat and CentOS systems::
 Platform-specific instructions
 ==============================
 
-.. _macosx:
+.. _macos:
 
-Mac OS X
---------
+macOS
+-----
 
-Because of the variety of packaging systems available for OS X, users have
+Because of the variety of packaging systems available for macOS, users have
 several different options for installing GeoDjango. These options are:
 
 * :ref:`postgresapp` (easiest and recommended)
@@ -197,17 +197,17 @@ several different options for installing GeoDjango. These options are:
 * :ref:`build_from_source`
 
 This section also includes instructions for installing an upgraded version
-of :ref:`macosx_python` from packages provided by the Python Software
+of :ref:`macos_python` from packages provided by the Python Software
 Foundation, however, this is not required.
 
-.. _macosx_python:
+.. _macos_python:
 
 Python
 ~~~~~~
 
-Although OS X comes with Python installed, users can use `framework
+Although macOS comes with Python installed, users can use `framework
 installers`__ provided by the Python Software Foundation.  An advantage to
-using the installer is that OS X's Python will remain "pristine" for internal
+using the installer is that macOS's Python will remain "pristine" for internal
 operating system use.
 
 __ https://www.python.org/ftp/python/
@@ -247,8 +247,8 @@ Homebrew
 
 `Homebrew`__ provides "recipes" for building binaries and packages from source.
 It provides recipes for the GeoDjango prerequisites on Macintosh computers
-running OS X. Because Homebrew still builds the software from source, the
-`Apple Developer Tools`_ are required.
+running macOS. Because Homebrew still builds the software from source, `Xcode`_
+is required.
 
 Summary::
 
@@ -258,7 +258,7 @@ Summary::
     $ brew install libgeoip
 
 __ http://brew.sh/
-.. _Apple Developer Tools: https://developer.apple.com/technologies/tools/
+.. _Xcode: https://developer.apple.com/xcode/
 
 .. _kyngchaos:
 
@@ -266,14 +266,13 @@ KyngChaos packages
 ~~~~~~~~~~~~~~~~~~
 
 William Kyngesburye provides a number of `geospatial library binary packages`__
-that make it simple to get GeoDjango installed on OS X without compiling
-them from source.  However, the `Apple Developer Tools`_ are still necessary
-for compiling the Python database adapters :ref:`psycopg2_kyngchaos` (for
-PostGIS).
+that make it simple to get GeoDjango installed on macOS without compiling
+them from source.  However, `Xcode`_ is still necessary for compiling the
+Python database adapters :ref:`psycopg2_kyngchaos` (for PostGIS).
 
 .. note::
 
-    SpatiaLite users should consult the :ref:`spatialite_macosx` section
+    SpatiaLite users should consult the :ref:`spatialite_macos` section
     after installing the packages for additional instructions.
 
 Download the framework packages for:
@@ -336,9 +335,9 @@ __ http://pdb.finkproject.org/pdb/browse.php?summary=django-gis
 MacPorts
 ~~~~~~~~
 
-`MacPorts`__ may be used to install GeoDjango prerequisites on Macintosh
-computers running OS X.  Because MacPorts still builds the software from source,
-the `Apple Developer Tools`_ are required.
+`MacPorts`__ may be used to install GeoDjango prerequisites on computers
+running macOS.  Because MacPorts still builds the software from source,
+`Xcode`_ is required.
 
 Summary::
 

--- a/docs/ref/contrib/gis/install/postgis.txt
+++ b/docs/ref/contrib/gis/install/postgis.txt
@@ -14,7 +14,7 @@ On Debian/Ubuntu, you are advised to install the following packages:
 postgresql-x.x, postgresql-x.x-postgis, postgresql-server-dev-x.x,
 python-psycopg2 (x.x matching the PostgreSQL version you want to install).
 Alternately, you can `build from source`_. Consult the platform-specific
-instructions if you are on :ref:`macosx` or :ref:`windows`.
+instructions if you are on :ref:`macos` or :ref:`windows`.
 
 .. _PostGIS: https://postgis.net/
 .. _psycopg2: http://initd.org/psycopg/

--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -11,7 +11,7 @@ For example, on Debian-based distributions, try to install the
 ``spatialite-bin`` package. For distributions that package SpatiaLite 4.2+,
 install ``libsqlite3-mod-spatialite``.
 
-For Mac OS X, follow the :ref:`instructions below<spatialite_macosx>`.
+For macOS, follow the :ref:`instructions below<spatialite_macos>`.
 
 For Windows, you may find binaries on the `Gaia-SINS`__ home page.
 
@@ -81,19 +81,19 @@ Get the latest SpatiaLite library source bundle from the
 
 .. note::
 
-    For Mac OS X users building from source, the SpatiaLite library *and* tools
+    For macOS users building from source, the SpatiaLite library *and* tools
     need to have their ``target`` configured::
 
         $ ./configure --target=macosx
 
 __ https://www.gaia-gis.it/gaia-sins/libspatialite-sources/
 
-.. _spatialite_macosx:
+.. _spatialite_macos:
 
-Mac OS X-specific instructions
+macOS-specific instructions
 ==============================
 
-To install the SpatiaLite library and tools, Mac OS X users can choose between
+To install the SpatiaLite library and tools, macOS users can choose between
 :ref:`kyngchaos` and `Homebrew`_.
 
 KyngChaos
@@ -103,7 +103,7 @@ First, follow the instructions in the :ref:`kyngchaos` section.
 
 When creating a SpatiaLite database, the ``spatialite`` program is required.
 However, instead of attempting to compile the SpatiaLite tools from source,
-download the `SpatiaLite Binaries`__ for OS X, and install ``spatialite`` in a
+download the `SpatiaLite Binaries`__ for macOS, and install ``spatialite`` in a
 location available in your ``PATH``.  For example::
 
     $ curl -O https://www.gaia-gis.it/spatialite/spatialite-tools-osx-x86-2.3.1.tar.gz

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -355,7 +355,7 @@ Management Commands
   accepts a command object as the first argument.
 
 * The :djadmin:`shell` command supports tab completion on systems using
-  ``libedit``, e.g. Mac OSX.
+  ``libedit``, e.g. macOS.
 
 * The :djadmin:`inspectdb` command lets you choose what tables should be
   inspected by specifying their names as arguments.

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -717,7 +717,7 @@ If your tests make any database queries, use subclasses
     ``tearDownClass()`` are run. In the case of :class:`django.test.TestCase`,
     this will leak the transaction created in ``super()``  which results in
     various symptoms including a segmentation fault on some platforms (reported
-    on OS X). If you want to intentionally raise an exception such as
+    on macOS). If you want to intentionally raise an exception such as
     :exc:`unittest.SkipTest` in ``setUpClass()``, be sure to do it before
     calling ``super()`` to avoid this.
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -672,7 +672,7 @@ class MakeMigrationsTests(MigrationTestBase):
         module = 'migrations.test_migrations_order'
         with self.temporary_migration_module(module=module) as migration_dir:
             if hasattr(importlib, 'invalidate_caches'):
-                # importlib caches os.listdir() on some platforms like Mac OS X
+                # importlib caches os.listdir() on some platforms like macOS
                 # (#23850).
                 importlib.invalidate_caches()
             call_command('makemigrations', 'migrations', '--empty', '-n', 'a', '-v', '0')
@@ -1200,7 +1200,7 @@ class MakeMigrationsTests(MigrationTestBase):
             content = cmd("0001", migration_name_0001)
             self.assertIn("dependencies=[\n]", content)
 
-            # importlib caches os.listdir() on some platforms like Mac OS X
+            # importlib caches os.listdir() on some platforms like macOS
             # (#23850).
             if hasattr(importlib, 'invalidate_caches'):
                 importlib.invalidate_caches()


### PR DESCRIPTION
Apples operating system has been rebranded to **macOS** since Sierra; the Django documentation identified it as Mac OS X, OS X or even Mac OSX. This trivial PR harmonizes that and uses **macOS** everywhere.

See also https://meta.stackoverflow.com/questions/348077/rename-osx-to-macos?cb=1