### PR TITLE
Fixed #28120 -- Checked that CharField.max_length is not a boolean.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -140,6 +140,7 @@ answer newbie questions, and generally made Django that much better:
     Cameron Knight (ckknight)
     Can Burak Çilingir <canburak@cs.bilgi.edu.tr>
     Carl Meyer <carl@oddbird.net>
+    Carles Pina i Estany <carles@pina.cat>
     Carlos Eduardo de Paula <carlosedp@gmail.com>
     Carlos Matías de la Torre <cmdelatorre@gmail.com>
     Carlton Gibson <carlton.gibson@noumenal.es>

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1040,8 +1040,8 @@ class CharField(Field):
                     id='fields.E120',
                 )
             ]
-        elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool)
-                or self.max_length <= 0):
+        elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool) or
+                self.max_length <= 0):
             return [
                 checks.Error(
                     "'max_length' must be a positive integer.",

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1040,7 +1040,8 @@ class CharField(Field):
                     id='fields.E120',
                 )
             ]
-        elif not isinstance(self.max_length, int) or self.max_length <= 0:
+        elif not isinstance(self.max_length, int) or type(self.max_length) == bool \
+                or self.max_length <= 0:
             return [
                 checks.Error(
                     "'max_length' must be a positive integer.",

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1040,8 +1040,8 @@ class CharField(Field):
                     id='fields.E120',
                 )
             ]
-        elif not isinstance(self.max_length, int) or type(self.max_length) == bool \
-                or self.max_length <= 0:
+        elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool)
+                or self.max_length <= 0):
             return [
                 checks.Error(
                     "'max_length' must be a positive integer.",

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -139,6 +139,21 @@ class CharFieldTests(TestCase):
         ]
         self.assertEqual(errors, expected)
 
+    def test_str_max_length_type(self):
+        class Model(models.Model):
+            field = models.CharField(max_length=True)
+
+        field = Model._meta.get_field('field')
+        errors = field.check()
+        expected = [
+            Error(
+                "'max_length' must be a positive integer.",
+                obj=field,
+                id='fields.E121'
+            ),
+        ]
+        self.assertEqual(errors, expected)
+
     def test_non_iterable_choices(self):
         class Model(models.Model):
             field = models.CharField(max_length=10, choices='bad')


### PR DESCRIPTION
Previously if max_length=True/False "python manage.py makemigrations"
was succeeding and "python manage.py migrate" returned SQL errors.