### PR TITLE
Fixed #28122 -- Fixed crash when overriding views.static.directory_index()'s template.

### DIFF
--- a/django/views/static.py
+++ b/django/views/static.py
@@ -91,13 +91,16 @@ def directory_index(path, fullpath):
         ])
     except TemplateDoesNotExist:
         t = Engine(libraries={'i18n': 'django.templatetags.i18n'}).from_string(DEFAULT_DIRECTORY_INDEX_TEMPLATE)
+        c = Context()
+    else:
+        c = {}
     files = []
     for f in os.listdir(fullpath):
         if not f.startswith('.'):
             if os.path.isdir(os.path.join(fullpath, f)):
                 f += '/'
             files.append(f)
-    c = Context({
+    c.update({
         'directory': path + '/',
         'file_list': files,
     })

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -55,3 +55,6 @@ Bugfixes
 
 * Fixed a regression causing incorrect queries for ``__in`` subquery lookups
   when models use ``ForeignKey.to_field`` (:ticket:`28101`).
+
+* Fixed crash when overriding the template of
+  ``django.views.static.directory_index()`` (:ticket:`28122`).

--- a/tests/view_tests/tests/test_static.py
+++ b/tests/view_tests/tests/test_static.py
@@ -112,6 +112,20 @@ class StaticTests(SimpleTestCase):
         response = self.client.get('/%s/' % self.prefix)
         self.assertContains(response, 'Index of ./')
 
+    @override_settings(TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'OPTIONS': {
+            'loaders': [
+                ('django.template.loaders.locmem.Loader', {
+                    'static/directory_index.html': 'Test index',
+                }),
+            ],
+        },
+    }])
+    def test_index_custom_template(self):
+        response = self.client.get('/%s/' % self.prefix)
+        self.assertEqual(response.content, b'Test index')
+
 
 class StaticHelperTest(StaticTests):
     """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28122