### PR TITLE
Refs #23919 -- Removed Python 2 proxied methods on File.

### DIFF
--- a/django/core/files/utils.py
+++ b/django/core/files/utils.py
@@ -18,12 +18,10 @@ class FileProxyMixin:
     readline = property(lambda self: self.file.readline)
     readlines = property(lambda self: self.file.readlines)
     seek = property(lambda self: self.file.seek)
-    softspace = property(lambda self: self.file.softspace)
     tell = property(lambda self: self.file.tell)
     truncate = property(lambda self: self.file.truncate)
     write = property(lambda self: self.file.write)
     writelines = property(lambda self: self.file.writelines)
-    xreadlines = property(lambda self: self.file.xreadlines)
 
     @property
     def closed(self):

--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -83,9 +83,9 @@ The ``File`` class
     In addition to the listed methods, :class:`~django.core.files.File` exposes
     the following attributes and methods of its ``file`` object:
     ``encoding``, ``fileno``, ``flush``, ``isatty``, ``newlines``, ``read``,
-    ``readinto``, ``readline``, ``readlines``, ``seek``, ``softspace``,
-    ``tell``, ``truncate``, ``write``, ``writelines``, ``xreadlines``,
-    ``readable()``, ``writable()``, and ``seekable()``.
+    ``readinto``, ``readline``, ``readlines``, ``seek``, ``tell``,
+    ``truncate``, ``write``, ``writelines``, ``readable()``, ``writable()``,
+    and ``seekable()``.
 
     .. versionchanged:: 1.11
 


### PR DESCRIPTION
I noticed this when looking at 98ee57e343206ef553de78b22be5e9a6dacb5060 again. Both `xreadlines` and `softspace` used to exist on file objects but were removed in Python 3. From taking a critical look at what counts as a file I'd say `.newlines` is close but I have left it for now, these 2 should be non-controversial.