### PR TITLE
Fixed #28135 -- Refactored simplify_regex()

### DIFF
--- a/django/contrib/admindocs/views.py
+++ b/django/contrib/admindocs/views.py
@@ -7,9 +7,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.admindocs import utils
-from django.contrib.admindocs.utils import (
-    replace_named_groups, replace_unnamed_groups,
-)
+from django.contrib.admindocs.utils import simplify_regex
 from django.core.exceptions import ImproperlyConfigured, ViewDoesNotExist
 from django.db import models
 from django.http import Http404
@@ -413,18 +411,3 @@ def extract_views_from_urlpatterns(urlpatterns, base='', namespace=None):
         else:
             raise TypeError(_("%s does not appear to be a urlpattern object") % p)
     return views
-
-
-def simplify_regex(pattern):
-    r"""
-    Clean up urlpattern regexes into something more readable by humans. For
-    example, turn "^(?P<sport_slug>\w+)/athletes/(?P<athlete_slug>\w+)/$"
-    into "/<sport_slug>/athletes/<athlete_slug>/".
-    """
-    pattern = replace_named_groups(pattern)
-    pattern = replace_unnamed_groups(pattern)
-    # clean up any outstanding regex-y characters.
-    pattern = pattern.replace('^', '').replace('$', '').replace('?', '')
-    if not pattern.startswith('/'):
-        pattern = '/' + pattern
-    return pattern

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -337,6 +337,21 @@ class AdminDocViewFunctionsTests(SimpleTestCase):
             (r'^(?P<a>(x|y))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
             (r'^(?P<a>(x|y)(\(|\)))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
             (r'^a/?$', '/a/'),
+            (r'^(?P<a>\w+)\.b', '/<a>.b'),
+            (r'^(?P<a>(?:\w+|\d+))', '/<a>'),
+            (r'^(?P<a>\w+(?#comment))', '/<a>'),
+            (r'^(?i)(?P<a>\w+)', '/<a>'),
+            (r'^(?P<a>\w+)(?P=a)', '/<a>'),
+            (r'^(?P<a>\w+)b{1,2}', '/<a>b'),
+            (r'^(?P<a>\w+)b+', '/<a>b'),
+            (r'^(?P<a>\w+)b*', '/<a>b'),
+            (r'^(?P<a>\w+)\b', '/<a>'),
+            (r'^(\w+)\1', '/<var>'),
+            (r'^(\w+)\12', '/<var>'),
+            (r'^(\w+)\123', '/<var>3'),
+            (r'^(\w+)\0', '/<var>\\0'),
+            (r'^(\w+)\012', '/<var>\\012'),
+            (r'^(\w+)\0123', '/<var>\\0123'),
         )
         for pattern, output in tests:
             self.assertEqual(simplify_regex(pattern), output)


### PR DESCRIPTION
While using Django REST Framework's Schema generator, I found out they're using simplify_regex(); however, current version has a few shortcomings: for instance, patterns
```python
r'^(?P<a>(?:\w+|\d+))'
r'^(?P<a>\w+(?#comment))'
r'^\b(?P<a>\w+)\b'
```

currently produce (respectively):
```python
'/(P<a><var>)'
'/(P<a>\\w+<var>)'
'/\\b<a>\\b'
```

when they should all simply produce:
```python
'/<a>'
```

This pull request features a faster simplify_regex() which also now supports patterns with:

* all capturing and non-capturing groups
* backreferences
* comments
* flags
* look ahead/behind
* yes-pattern
* special sequences

Performance gains:

```
In [1]: %%timeit
    ...: simplify_regex(pattern)
    ...:
10000 loops, best of 3: 38.9 µs per loop

In [2]: %%timeit
    ...: simplify_regex_orig(pattern)
    ...:
10000 loops, best of 3: 54.4 µs per loop
```
https://code.djangoproject.com/ticket/28135