### PR TITLE
Refs #20939 -- Moved subquery ordering clearing optimization to the _in lookup.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -367,9 +367,18 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
             placeholder = '(' + ', '.join(sqls) + ')'
             return (placeholder, sqls_params)
         else:
-            if not getattr(self.rhs, 'has_select_fields', True):
-                self.rhs.clear_select_clause()
-                self.rhs.add_fields(['pk'])
+            from django.db.models.sql.query import Query  # avoid circular import
+            if isinstance(self.rhs, Query):
+                query = self.rhs
+                # It's safe to drop ordering if the queryset isn't using
+                # slicing, distinct(*fields), or select_for_update().
+                if (query.low_mark == 0 and query.high_mark is None and
+                        not query.distinct_fields and
+                        not query.select_for_update):
+                    query.clear_ordering(True)
+                if not query.has_select_fields:
+                    query.clear_select_clause()
+                    query.add_fields(['pk'])
             return super().process_rhs(compiler, connection)
 
     def get_rhs_op(self, connection, rhs):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -981,12 +981,6 @@ class Query:
         # Subqueries need to use a different set of aliases than the outer query.
         clone.bump_prefix(query)
         clone.subquery = True
-        # It's safe to drop ordering if the queryset isn't using slicing,
-        # distinct(*fields) or select_for_update().
-        if (self.low_mark == 0 and self.high_mark is None and
-                not self.distinct_fields and
-                not self.select_for_update):
-            clone.clear_ordering(True)
         return clone
 
     def prepare_lookup_value(self, value, lookups, can_reuse, allow_joins=True):


### PR DESCRIPTION
@timgraham I'm working on making `sql.Query` completely implement the Expression API so we can remove a lot of the boiler plate in `expression.Subquery` and it made me realize some changes I made in c9159a082ebe41a1f735f8d01720e746fb43c41e should have been made in `In.process_rhs()` instead.

It only makes sense to clear ordering of a queryset when it's used in a `__in` lookup.

Sorry for the back and forth here. This should settle, `#20939`'s case :)