### PR TITLE
Fixed #28138 -- Used output type handler instead of numbersAsStrings on Oracle ​cursor.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -385,10 +385,23 @@ class FormatStylePlaceholderCursor:
 
     def __init__(self, connection):
         self.cursor = connection.cursor()
-        # Necessary to retrieve decimal values without rounding error.
-        self.cursor.numbersAsStrings = True
+        self.cursor.outputtypehandler = self._output_type_handler
         # The default for cx_Oracle < 5.3 is 50.
         self.cursor.arraysize = 100
+
+    @staticmethod
+    def _output_type_handler(cursor, name, defaultType, length, precision, scale):
+        """
+        Called for each db column fetched from cursors. Return numbers as
+        strings so that decimal values don't have rounding error.
+        """
+        if defaultType == Database.NUMBER:
+            return cursor.var(
+                Database.STRING,
+                size=255,
+                arraysize=cursor.arraysize,
+                outconverter=str,
+            )
 
     def _format_params(self, params):
         try:


### PR DESCRIPTION
Ticket [28138](https://code.djangoproject.com/ticket/28138).