### PR TITLE
Fixed #28130 -- Fixed formset min_num validation with initial, unchanged forms.

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -322,7 +322,8 @@ class BaseFormSet:
             return
         for i in range(0, self.total_form_count()):
             form = self.forms[i]
-            if not form.has_changed():
+            # Empty forms are unchanged forms beyond those with initial data.
+            if not form.has_changed() and i >= self.initial_form_count():
                 empty_forms_count += 1
 
             self._errors.append(form.errors)

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -58,3 +58,6 @@ Bugfixes
 
 * Fixed crash when overriding the template of
   ``django.views.static.directory_index()`` (:ticket:`28122`).
+
+* Fixed a regression in formset ``min_num`` validation with unchanged forms
+  that have initial data (:ticket:`28130`).

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -402,6 +402,31 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertFalse(formset.is_valid())
         self.assertEqual(formset.non_form_errors(), ['Please submit 3 or more forms.'])
 
+    def test_formset_validate_min_unchanged_forms(self):
+        """
+        min_num validation doesn't consider unchanged forms with initial data
+        as "empty".
+        """
+        initial = [
+            {'choice': 'Zero', 'votes': 0},
+            {'choice': 'One', 'votes': 0},
+        ]
+        data = {
+            'choices-TOTAL_FORMS': '2',
+            'choices-INITIAL_FORMS': '2',
+            'choices-MIN_NUM_FORMS': '0',
+            'choices-MAX_NUM_FORMS': '2',
+            'choices-0-choice': 'Zero',
+            'choices-0-votes': '0',
+            'choices-1-choice': 'One',
+            'choices-1-votes': '1',  # changed from initial
+        }
+        ChoiceFormSet = formset_factory(Choice, min_num=2, validate_min=True)
+        formset = ChoiceFormSet(data, auto_id=False, prefix='choices', initial=initial)
+        self.assertFalse(formset.forms[0].has_changed())
+        self.assertTrue(formset.forms[1].has_changed())
+        self.assertTrue(formset.is_valid())
+
     def test_formset_validate_min_excludes_empty_forms(self):
         data = {
             'choices-TOTAL_FORMS': '2',


### PR DESCRIPTION
Regression in f5c6295797b8332134fd89e0209a18a1d1d45e0c.
https://code.djangoproject.com/ticket/28130