### PR TITLE
Removed obsolete django.test.utils.strip_quotes().

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -557,7 +557,6 @@ def compare_xml(want, got):
             if node.nodeType != Node.COMMENT_NODE:
                 return node
 
-    want, got = strip_quotes(want, got)
     want = want.strip().replace('\\n', '\n')
     got = got.strip().replace('\\n', '\n')
 
@@ -573,25 +572,6 @@ def compare_xml(want, got):
     got_root = first_node(parseString(got))
 
     return check_element(want_root, got_root)
-
-
-def strip_quotes(want, got):
-    """
-    Strip quotes of doctests output values:
-
-    >>> strip_quotes("'foo'")
-    "foo"
-    >>> strip_quotes('"foo"')
-    "foo"
-    """
-    def is_quoted_string(s):
-        s = s.strip()
-        return len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'")
-
-    if is_quoted_string(want) and is_quoted_string(got):
-        want = want.strip()[1:-1]
-        got = got.strip()[1:-1]
-    return want, got
 
 
 def str_prefix(s):


### PR DESCRIPTION
Django's test runners no longer discover doctests.