### PR TITLE
Refs #16187 -- Stopped compiling query compilers during lookup rhs processing.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -89,12 +89,6 @@ class Lookup:
                 value = Value(value, output_field=self.lhs.output_field)
             value = self.apply_bilateral_transforms(value)
             value = value.resolve_expression(compiler.query)
-        # Due to historical reasons there are a couple of different
-        # ways to produce sql here. get_compiler is likely a Query
-        # instance and as_sql just something with as_sql. Finally the value
-        # can of course be just plain Python value.
-        if hasattr(value, 'get_compiler'):
-            value = value.get_compiler(connection=connection)
         if hasattr(value, 'as_sql'):
             sql, params = compiler.compile(value)
             return '(' + sql + ')', params

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -989,6 +989,9 @@ class Query:
             clone.clear_ordering(True)
         return clone
 
+    def as_sql(self, compiler, connection):
+        return self.get_compiler(connection=connection).as_sql()
+
     def prepare_lookup_value(self, value, lookups, can_reuse, allow_joins=True):
         # Default lookup if none given is exact.
         used_joins = []


### PR DESCRIPTION
Lookup [right hand side processing was compiling query compilers](https://github.com/django/django/blob/620e9dd31a2146d70de740f96a8cb9a6db054fc7/django/db/models/lookups.py#L92-L99) which [happened to work by chance](https://github.com/django/django/blob/620e9dd31a2146d70de740f96a8cb9a6db054fc7/django/db/models/sql/compiler.py#L379) as [`SQLCompiler` defines a `as_sql()`](https://github.com/django/django/blob/620e9dd31a2146d70de740f96a8cb9a6db054fc7/django/db/models/sql/compiler.py#L408) method with two optional parameters albeit it doesn't expect the same type of arguments.

I'm not sure how I can write a regression test for this as `SQLCompiler.as_sql()` first parameter `with_limits` was being passed a `compiler` object which always evaluated to a truthy value just like the default and a `connection` as the second argument which only had incidence on column aliases.

I figured that out when working on #8418 and wondering why `with_col_aliases` was a connection instance.