### PR TITLE
Revert "Refs #20939 -- Moved subquery ordering clearing optimization to the __in lookup."

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -981,6 +981,12 @@ class Query:
         # Subqueries need to use a different set of aliases than the outer query.
         clone.bump_prefix(query)
         clone.subquery = True
+        # It's safe to drop ordering if the queryset isn't using slicing,
+        # distinct(*fields) or select_for_update().
+        if (self.low_mark == 0 and self.high_mark is None and
+                not self.distinct_fields and
+                not self.select_for_update):
+            clone.clear_ordering(True)
         return clone
 
     def prepare_lookup_value(self, value, lookups, can_reuse, allow_joins=True):


### PR DESCRIPTION
This reverts commit e62ea0bb9cbb54c1eef848871fe3eab2bad268dc.

This ended up breaking multi-column __in lookups and _meta.order_wrt on Oracle.

Looks like I somehow didn't run #8417 against Oracle... I have an idea of how to fix this but in the mean time I want to avoid making Oracle CI unusable.