### PR TITLE
Fixed #28147 -- Fixed loss of parent pk in child model when saving child after parent.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -249,6 +249,7 @@ answer newbie questions, and generally made Django that much better:
     Erik Karulf <erik@karulf.com>
     Erik Romijn <django@solidlinks.nl>
     eriks@win.tue.nl
+    Erwin Junge <erwin@junge.nl>
     Esdras Beleza <linux@esdrasbeleza.com>
     Espen Grindhaug <http://grindhaug.org/>
     Eugene Lazutkin <http://lazutkin.com/blog/>

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -661,14 +661,19 @@ class Model(metaclass=ModelBase):
                 # database to raise an IntegrityError if applicable. If
                 # constraints aren't supported by the database, there's the
                 # unavoidable risk of data corruption.
-                if obj and obj.pk is None:
-                    # Remove the object from a related instance cache.
-                    if not field.remote_field.multiple:
-                        delattr(obj, field.remote_field.get_cache_name())
-                    raise ValueError(
-                        "save() prohibited to prevent data loss due to "
-                        "unsaved related object '%s'." % field.name
-                    )
+                if obj:
+                    if obj.pk is None:
+                        # Remove the object from a related instance cache.
+                        if not field.remote_field.multiple:
+                            delattr(obj, field.remote_field.get_cache_name())
+                        raise ValueError(
+                            "save() prohibited to prevent data loss due to "
+                            "unsaved related object '%s'." % field.name
+                        )
+                    elif getattr(self, field.attname) is None:
+                        # Grab pk from related object if it has been saved after
+                        # the original assignment
+                        setattr(self, field.attname, obj.pk)
 
         using = using or router.db_for_write(self.__class__, instance=self)
         if force_insert and (force_update or update_fields):

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -986,6 +986,9 @@ class OneToOneField(ForeignKey):
     def save_form_data(self, instance, data):
         if isinstance(data, self.remote_field.model):
             setattr(instance, self.name, data)
+        elif data is None:
+            setattr(instance, self.name, data)
+            setattr(instance, self.attname, data)
         else:
             setattr(instance, self.attname, data)
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -63,6 +63,7 @@ Bugfixes
   ``django.views.static.directory_index()`` (:ticket:`28122`).
 
 * Fixed unexpected data loss when saving parent object after setting on child (:ticket:`28147`).
+
 * Fixed a regression in formset ``min_num`` validation with unchanged forms
   that have initial data (:ticket:`28130`).
 

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -58,3 +58,5 @@ Bugfixes
 
 * Fixed crash when overriding the template of
   ``django.views.static.directory_index()`` (:ticket:`28122`).
+
+* Fixed unexpected data loss when saving parent object after setting on child (:ticket:`28147`).

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -510,6 +510,14 @@ class ManyToOneTests(TestCase):
         with self.assertRaisesMessage(ValueError, msg):
             ToFieldChild.objects.create(parent=p)
 
+        # Create parent and child, save parent, save child, parent_id should be set
+        p = Parent()
+        c = Child(parent=p)
+        p.save()
+        c.save()
+        c.refresh_from_db()
+        self.assertIs(c.parent, p)
+
         # Creation using attname keyword argument and an id will cause the
         # related object to be fetched.
         p = Parent.objects.get(name="Parent")


### PR DESCRIPTION
Fix for https://code.djangoproject.com/ticket/28147#ticket