### PR TITLE
Fixed #28152 -- Changed SetSerializer to serialize to set literals.

### DIFF
--- a/django/contrib/auth/migrations/0001_initial.py
+++ b/django/contrib/auth/migrations/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ('content_type__app_label', 'content_type__model', 'codename'),
-                'unique_together': set([('content_type', 'codename')]),
+                'unique_together': {('content_type', 'codename')},
                 'verbose_name': 'permission',
                 'verbose_name_plural': 'permissions',
             },

--- a/django/contrib/contenttypes/migrations/0001_initial.py
+++ b/django/contrib/contenttypes/migrations/0001_initial.py
@@ -29,6 +29,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='contenttype',
-            unique_together=set([('app_label', 'model')]),
+            unique_together={('app_label', 'model')},
         ),
     ]

--- a/django/contrib/redirects/migrations/0001_initial.py
+++ b/django/contrib/redirects/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ('old_path',),
-                'unique_together': set([('site', 'old_path')]),
+                'unique_together': {('site', 'old_path')},
                 'db_table': 'django_redirect',
                 'verbose_name': 'redirect',
                 'verbose_name_plural': 'redirects',

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -244,8 +244,9 @@ class SequenceSerializer(BaseSequenceSerializer):
 
 class SetSerializer(BaseSequenceSerializer):
     def _format(self):
-        # Don't use the literal "{%s}" as it doesn't support empty set
-        return "set([%s])"
+        # Serialize as a set literal except when value is empty because {}
+        # is an empty dict.
+        return '{%s}' if self.value else 'set(%s)'
 
 
 class SettingsReferenceSerializer(BaseSerializer):

--- a/tests/migrations/test_migrations/0001_initial.py
+++ b/tests/migrations/test_migrations/0001_initial.py
@@ -30,6 +30,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='author',
-            unique_together=set([('name', 'slug')]),
+            unique_together={('name', 'slug')},
         ),
     ]

--- a/tests/migrations/test_migrations_fake_split_initial/0001_initial.py
+++ b/tests/migrations/test_migrations_fake_split_initial/0001_initial.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='author',
-            unique_together=set([('name', 'slug')]),
+            unique_together={('name', 'slug')},
         ),
     ]

--- a/tests/migrations/test_migrations_initial_false/0001_not_initial.py
+++ b/tests/migrations/test_migrations_initial_false/0001_not_initial.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='author',
-            unique_together=set([('name', 'slug')]),
+            unique_together={('name', 'slug')},
         ),
     ]

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -505,6 +505,12 @@ class WriterTests(SimpleTestCase):
         self.assertSerializedEqual(frozenset())
         self.assertSerializedEqual(frozenset("let it go"))
 
+    def test_serialize_set(self):
+        self.assertSerializedEqual(set())
+        self.assertSerializedResultEqual(set(), ('set()', set()))
+        self.assertSerializedEqual({'a'})
+        self.assertSerializedResultEqual({'a'}, ("{'a'}", set()))
+
     def test_serialize_timedelta(self):
         self.assertSerializedEqual(datetime.timedelta())
         self.assertSerializedEqual(datetime.timedelta(minutes=42))


### PR DESCRIPTION
Creating this PR to resolve the discussion in #8432. The discussion revealed that the migration serializer renders sets as `set([...])`. When searching for code that could be converted to use set literals or set comprehension, these auto-generated code fragments surfaced.

<https://code.djangoproject.com/ticket/28152>