### PR TITLE
Easier way to populate test databases for parallel tests

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -14,8 +14,8 @@ from django.core.management import call_command
 from django.db import connections
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import (
-    setup_databases as _setup_databases, setup_test_environment,
     duplicate_database as _duplicate_database,
+    setup_databases as _setup_databases, setup_test_environment,
     teardown_databases as _teardown_databases, teardown_test_environment,
 )
 from django.utils.datastructures import OrderedSet

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -15,6 +15,7 @@ from django.db import connections
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import (
     setup_databases as _setup_databases, setup_test_environment,
+    duplicate_database as _duplicate_database,
     teardown_databases as _teardown_databases, teardown_test_environment,
 )
 from django.utils.datastructures import OrderedSet
@@ -536,10 +537,27 @@ class DiscoverRunner:
         return suite
 
     def setup_databases(self, **kwargs):
+        result = self.prepare_databases(**kwargs)
+        self.populate_databases(**kwargs)
+        self.duplicate_databases_if_necessary()
+        return result
+
+    def prepare_databases(self, **kwargs):
         return _setup_databases(
-            self.verbosity, self.interactive, self.keepdb, self.debug_sql,
-            self.parallel, **kwargs
+            self.verbosity, self.interactive, self.keepdb, self.debug_sql, **kwargs
         )
+
+    def populate_databases(self, **kwargs):
+        """
+        No Op. Override this function to populate your test databases.
+
+        This function it called before the DBs are duplicated in case tests are
+        executed in parallel. Therefore all DBs will have the same data.
+        """
+        pass
+
+    def duplicate_databases_if_necessary(self):
+        _duplicate_database(self.verbosity, keepdb=self.keepdb, parallel=self.parallel)
 
     def get_resultclass(self):
         return DebugSQLTextTestResult if self.debug_sql else None

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -468,6 +468,7 @@ outbox
 Outdim
 outfile
 paginator
+parallelisation
 parameterized
 params
 parens

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -569,7 +569,7 @@ Methods
 
 .. method:: DiscoverRunner.setup_databases(**kwargs)
 
-    versionchanged:: 2.0
+    .. versionchanged:: 2.0
 
     Runs :func:`DiscoverRunner.prepare_databases`,
     and :func:`DiscoverRunner.populate_databases`,
@@ -585,7 +585,7 @@ Methods
     Creates the test databases by calling
     :func:`~django.test.utils.setup_databases`.
 
-    Please notice this function will only create the DB(s) for running tests without paralellistion.
+    Please notice this function will only create the DB(s) for running tests without parallelisation.
     If you run tests in parallel, the copies of the DBs created in this function
     will be created by ``DiscoverRunner.duplicate_databases_if_necessary()``
 
@@ -593,7 +593,7 @@ Methods
 
     .. versionadded:: 2.0
 
-    No Op. Override this function to populate your test dabasases.
+    No Op. Override this function to populate your test databases.
 
     This function it called before the DBs are duplicated in case tests are
     executed in parallel.

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -569,8 +569,43 @@ Methods
 
 .. method:: DiscoverRunner.setup_databases(**kwargs)
 
+    versionchanged:: 2.0
+
+    Runs :func:`DiscoverRunner.prepare_databases`,
+    and :func:`DiscoverRunner.populate_databases`,
+    and :func:`DiscoverRunner.duplicate_databases_if_necessary`,
+
+    The reason this function was separated in three is to make easier the life of
+    those who extend this class.
+
+.. method:: DiscoverRunner.prepare_databases(**kwargs)
+
+    .. versionadded:: 2.0
+
     Creates the test databases by calling
     :func:`~django.test.utils.setup_databases`.
+
+    Please notice this function will only create the DB(s) for running tests without paralellistion.
+    If you run tests in parallel, the copies of the DBs created in this function
+    will be created by ``DiscoverRunner.duplicate_databases_if_necessary()``
+
+.. method:: DiscoverRunner.populate_databases(**kwargs)
+
+    .. versionadded:: 2.0
+
+    No Op. Override this function to populate your test dabasases.
+
+    This function it called before the DBs are duplicated in case tests are
+    executed in parallel.
+
+.. method:: DiscoverRunner.duplicate_databases_if_necessary()
+
+    .. versionadded:: 2.0
+
+    This is called after the test databases are created and populated.
+    Duplicate all the test database(s) for tests to run in parallel by calling
+    :func:`~django.test.utils.duplicate_database`.
+
 
 .. method:: DiscoverRunner.run_checks()
 
@@ -637,13 +672,21 @@ utility methods in the ``django.test.utils`` module.
 
 .. function:: setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, **kwargs)
 
-    .. versionadded:: 1.11
+    .. versionchanged:: 2.0
 
     Creates the test databases.
 
     Returns a data structure that provides enough detail to undo the changes
     that have been made. This data will be provided to the
     :func:`teardown_databases` function at the conclusion of testing.
+
+.. function:: duplicate_database(self.verbosity, keepdb=self.keepdb, parallel=self.parallel)
+
+    .. versionadded:: 2.0
+
+    This function duplicates all the test databases so tests can run in parallel.
+    It is called after the test databases are created and populated so all tests can
+    run consistently.
 
 .. function:: teardown_databases(old_config, parallel=0, keepdb=False)
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28153#ticket

 Although Django makes very easy for one to extend django.test.runner.DiscoverRunner , it's setup_databases() does too much.

Currently, it

    creates all the test databases (for single thread unit tests)
    duplicates all the test databases (in case of parallel unit tests) 

In case I am running not running tests in parallel, I can just populate the DB after running unit tests without any issues.

But if I care about my time and want to run tests in parallel, I can either:

a) populate my data after setup_databases() is executed, once for each thread of the parallel tests, which is slow
b) get my hands dirty and reimplement setup_databases()

I propose (and I am sending the code to do so) a better solution. We just have to break setup_databases() in 3 functions:

DiscoverRunner.prepare_databases()
DiscoverRunner.populate_databases() # noop by default
DiscoverRunner.duplicate_databases_if_necessary()

The idea is quite simple: in order to be backward compatible, setup_databases() , will still exist but only call three functions above in that order.

The first function will create all the test databases necessary for non parallel tests to run.

populate_databases() , which should be a no op, can be overwritten by the user who extends django.test.runner.DiscoverRunner so his/her data can be populated

Afterwards, all the test DBs are copied as many times as necessary in case parallel tests are run via DiscoverRunner.duplicate_databases_if_necessary()

I believe this change on Django will have no downside, will be backward compatible and help people who needs to populate real data on the DB for their tests.