### PR TITLE
Refs #27795 -- Reworked get_or_create test erroneously mixing bytes and str.

### DIFF
--- a/tests/get_or_create/tests.py
+++ b/tests/get_or_create/tests.py
@@ -6,10 +6,8 @@ from threading import Thread
 from django.core.exceptions import FieldError
 from django.db import DatabaseError, IntegrityError, connection
 from django.test import (
-    SimpleTestCase, TestCase, TransactionTestCase, ignore_warnings,
-    skipUnlessDBFeature,
+    SimpleTestCase, TestCase, TransactionTestCase, skipUnlessDBFeature,
 )
-from django.utils.encoding import DjangoUnicodeDecodeError
 
 from .models import (
     Author, Book, DefaultPerson, ManualPrimaryKeyTest, Person, Profile,
@@ -203,22 +201,18 @@ class GetOrCreateTestsWithManualPKs(TestCase):
             formatted_traceback = traceback.format_exc()
             self.assertIn('obj.save', formatted_traceback)
 
-    # MySQL emits a warning when broken data is saved
-    @ignore_warnings(module='django.db.backends.mysql.base')
     def test_savepoint_rollback(self):
         """
-        Regression test for #20463: the database connection should still be
-        usable after a DataError or ProgrammingError in .get_or_create().
+        The database connection is still usable after a DatabaseError in
+        get_or_create() (#20463).
         """
-        try:
-            Person.objects.get_or_create(
-                birthday=date(1970, 1, 1),
-                defaults={'first_name': b"\xff", 'last_name': b"\xff"})
-        except (DatabaseError, DjangoUnicodeDecodeError):
-            Person.objects.create(
-                first_name="Bob", last_name="Ross", birthday=date(1950, 1, 1))
-        else:
-            self.skipTest("This backend accepts broken utf-8.")
+        Tag.objects.create(text='foo')
+        with self.assertRaises(DatabaseError):
+            # pk 123456789 doesn't exist, so the tag object will be created.
+            # Saving triggers a unique constraint violation on 'text'.
+            Tag.objects.get_or_create(pk=123456789, defaults={'text': 'foo'})
+        # Tag objects can be created after the error.
+        Tag.objects.create(text='bar')
 
     def test_get_or_create_empty(self):
         """


### PR DESCRIPTION
As `CharField.to_python()` now always calls str(), assigning a bytes object to a CharField is no longer correct usage. Doing so results in a  runtime warning:

```
django/db/models/fields/__init__.py:1061: BytesWarning: str() on a bytes instance
```

To rework the test, use a unique constraint violation to trigger the database error instead.

Warning introduced in commit 301de774c21d055e9e5a7073e5bffdb52bc71079.