### PR TITLE
Fixed #28095 -- Document Widget.build_attrs() and its signature change

### DIFF
--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -263,6 +263,19 @@ foundation for custom widgets.
         ``Widget`` subclasses can provide custom context values by overriding
         this method.
 
+    .. method:: build_attrs(base_attrs, extra_attrs=None)
+
+        Returns a dictionary containing HTML attributes. If ``extra_attrs`` is
+        not ``None``, ``base_attrs`` is extended with its contents and returned
+        in a new dictionary. ``base_attrs`` is not modified.
+
+        .. versionchanged:: 1.11
+
+            In older versions, this method accepted a ``kwargs`` parameter.
+
+        * ``'base_attrs'``: The base attribute dictionary to extend.
+        * ``'extra_attrs'=None``: The additional attributes to add.
+
     .. method:: id_for_label(id_)
 
         Returns the HTML ID attribute of this widget for use by a ``<label>``,

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -739,6 +739,15 @@ Miscellaneous
 
 * Support for IPython < 1.0 is removed from the ``shell`` command.
 
+* :meth:`~django.forms.Widget.build_attrs` no longer accepts ``kwargs`` parameters.
+  For backwards compatibility in custom :class:`~django.forms.Widget` subclasses,
+  use something like::
+
+    def build_attrs(self, extra_attrs=None, **kwargs):
+        if extra_attrs:
+            kwargs.update(extra_attrs)
+        return super().build_attrs(extra_attrs=kwargs)
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11


### PR DESCRIPTION
Document the Widget.build_attrs() method in the Widget documentation. Also update
1.11 release note to document the change in the method signature to
Widget.build_attrs() in 1.11 that removes kwargs.

The documentation builds without warnings or errors.