### PR TITLE
Fixed #28159 -- Fixed crash in BaseInlineFormSet._construct_form() when using save_as_new.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -884,12 +884,17 @@ class BaseInlineFormSet(BaseModelFormSet):
     def _construct_form(self, i, **kwargs):
         form = super()._construct_form(i, **kwargs)
         if self.save_as_new:
+            mutable = getattr(form.data, '_mutable', None)
+            # Allow modifying an immutable QueryDict.
+            if mutable is not None:
+                form.data._mutable = True
             # Remove the primary key from the form's data, we are only
             # creating new instances
             form.data[form.add_prefix(self._pk_field.name)] = None
-
             # Remove the foreign key from the form's data
             form.data[form.add_prefix(self.fk.name)] = None
+            if mutable is not None:
+                form.data._mutable = mutable
 
         # Set the fk value here so that the form can do its validation.
         fk_value = self.instance.pk

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -81,3 +81,6 @@ Bugfixes
 
 * Fixed a regression in choice ordering in form fields with grouped and
   non-grouped options (:ticket:`28157`).
+
+* Fixed crash in  ``BaseInlineFormSet._construct_form()`` when using
+  ``save_as_new`` (:ticket:`28159`).


### PR DESCRIPTION
See TRAC: https://code.djangoproject.com/ticket/28159