### PR TITLE
Add WEEKDAY support into queries

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -27,6 +27,8 @@ class DatabaseOperations(BaseDatabaseOperations):
             # other database backends.
             # Mode 3: Monday, 1-53, with 4 or more days this year.
             return "WEEK(%s, 3)" % field_name
+        elif lookup_type == 'week_day_index':
+            return "WEEKDAY(%s)" % field_name
         else:
             # EXTRACT returns 1-53 based on ISO-8601 for the week number.
             return "EXTRACT(%s FROM %s)" % (lookup_type.upper(), field_name)

--- a/django/db/models/functions/__init__.py
+++ b/django/db/models/functions/__init__.py
@@ -4,7 +4,7 @@ from .base import (
 )
 from .datetime import (
     Extract, ExtractDay, ExtractHour, ExtractMinute, ExtractMonth,
-    ExtractSecond, ExtractWeek, ExtractWeekDay, ExtractYear, Trunc, TruncDate,
+    ExtractSecond, ExtractWeek, ExtractWeekDay, ExtractWeekDayIndex, ExtractYear, Trunc, TruncDate,
     TruncDay, TruncHour, TruncMinute, TruncMonth, TruncSecond, TruncTime,
     TruncYear,
 )
@@ -15,7 +15,7 @@ __all__ = [
     'Lower', 'Now', 'StrIndex', 'Substr', 'Upper',
     # datetime
     'Extract', 'ExtractDay', 'ExtractHour', 'ExtractMinute', 'ExtractMonth',
-    'ExtractSecond', 'ExtractWeek', 'ExtractWeekDay', 'ExtractYear',
+    'ExtractSecond', 'ExtractWeek', 'ExtractWeekDay', 'ExtractWeekDayIndex', 'ExtractYear',
     'Trunc', 'TruncDate', 'TruncDay', 'TruncHour', 'TruncMinute', 'TruncMonth',
     'TruncSecond', 'TruncTime', 'TruncYear',
 ]

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -100,6 +100,13 @@ class ExtractWeekDay(Extract):
     """
     lookup_name = 'week_day'
 
+class ExtractWeekDayIndex(Extract):
+    """
+    Return Sunday=1 through Saturday=7.
+
+    To replicate this in Python: (mydatetime.isoweekday() % 7) + 1
+    """
+    lookup_name = 'week_day_index'
 
 class ExtractHour(Extract):
     lookup_name = 'hour'
@@ -117,6 +124,7 @@ DateField.register_lookup(ExtractYear)
 DateField.register_lookup(ExtractMonth)
 DateField.register_lookup(ExtractDay)
 DateField.register_lookup(ExtractWeekDay)
+DateField.register_lookup(ExtractWeekDayIndex)
 DateField.register_lookup(ExtractWeek)
 
 TimeField.register_lookup(ExtractHour)


### PR DESCRIPTION
Adding WEEKDAY into queries functionality. Now you can use __week_day_index for querying based on weekday. Python native datetime has weekday function. Now you can easily can write queries like 

```
current_time = datetime.utcnow()
temp = MyModel.objects.get(time__week_day_index=current_time.weekday())
```
  