### PR TITLE
Fixed #28163 -- Made AUTH_PASSWORD_VALIDATORS in startproject setting fit in under 80 cols.

### DIFF
--- a/django/conf/project_template/project_name/settings.py-tpl
+++ b/django/conf/project_template/project_name/settings.py-tpl
@@ -85,18 +85,13 @@ DATABASES = {
 # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    {'NAME': 'django.contrib.auth.password_validation.%s' % validator}
+    for validator in [
+        'UserAttributeSimilarityValidator',
+        'MinimumLengthValidator',
+        'CommonPasswordValidator',
+        'NumericPasswordValidator',
+    ]
 ]
 
 


### PR DESCRIPTION
This is the only change needed to make most people's settings.py PEP8 compliant
https://code.djangoproject.com/ticket/28163
