### PR TITLE
Fixed #28165 -- Allow FileExtensionValidator's allowed_extensions to be given in non-lower case

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -459,7 +459,10 @@ class FileExtensionValidator:
     code = 'invalid_extension'
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
-        self.allowed_extensions = sorted([allowed_extension.lower() for allowed_extension in allowed_extensions])
+        if allowed_extensions is not None:
+            self.allowed_extensions = sorted([allowed_extension.lower() for allowed_extension in allowed_extensions])
+        else:
+            self.allowed_extensions = allowed_extensions
         if message is not None:
             self.message = message
         if code is not None:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -460,7 +460,7 @@ class FileExtensionValidator:
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
         if allowed_extensions is not None:
-            self.allowed_extensions = sorted(allowed_extension.casefold() for allowed_extension in allowed_extensions)
+            self.allowed_extensions = sorted(allowed_extension.lower() for allowed_extension in allowed_extensions)
         else:
             self.allowed_extensions = allowed_extensions
         if message is not None:
@@ -469,7 +469,7 @@ class FileExtensionValidator:
             self.code = code
 
     def __call__(self, value):
-        extension = os.path.splitext(value.name)[1][1:].casefold()
+        extension = os.path.splitext(value.name)[1][1:].lower()
         if self.allowed_extensions is not None and extension not in self.allowed_extensions:
             raise ValidationError(
                 self.message,

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -459,7 +459,7 @@ class FileExtensionValidator:
     code = 'invalid_extension'
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
-        self.allowed_extensions = [allowed_extension.lower() for allowed_extension in allowed_extensions]
+        self.allowed_extensions = sorted([allowed_extension.lower() for allowed_extension in allowed_extensions])
         if message is not None:
             self.message = message
         if code is not None:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -459,7 +459,7 @@ class FileExtensionValidator:
     code = 'invalid_extension'
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
-        self.allowed_extensions = allowed_extensions
+        self.allowed_extensions = [allowed_extension.lower() for allowed_extension in allowed_extensions]
         if message is not None:
             self.message = message
         if code is not None:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -460,7 +460,7 @@ class FileExtensionValidator:
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
         if allowed_extensions is not None:
-            self.allowed_extensions = sorted([allowed_extension.lower() for allowed_extension in allowed_extensions])
+            self.allowed_extensions = sorted(allowed_extension.lower() for allowed_extension in allowed_extensions)
         else:
             self.allowed_extensions = allowed_extensions
         if message is not None:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -460,7 +460,7 @@ class FileExtensionValidator:
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
         if allowed_extensions is not None:
-            self.allowed_extensions = sorted(allowed_extension.lower() for allowed_extension in allowed_extensions)
+            self.allowed_extensions = sorted(allowed_extension.casefold() for allowed_extension in allowed_extensions)
         else:
             self.allowed_extensions = allowed_extensions
         if message is not None:
@@ -469,7 +469,7 @@ class FileExtensionValidator:
             self.code = code
 
     def __call__(self, value):
-        extension = os.path.splitext(value.name)[1][1:].lower()
+        extension = os.path.splitext(value.name)[1][1:].casefold()
         if self.allowed_extensions is not None and extension not in self.allowed_extensions:
             raise ValidationError(
                 self.message,

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -285,7 +285,8 @@ to, or in lieu of custom ``field.clean()`` methods.
 
     Raises a :exc:`~django.core.exceptions.ValidationError` with a code of
     ``'invalid_extension'`` if the ``value`` cannot be found in
-    ``allowed_extensions``.
+    ``allowed_extensions``. A case-insensitive comparison is used to compare
+    ``value`` to the ``allowed_extensions``.
 
     .. warning::
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -229,7 +229,8 @@ URLs
 Validators
 ~~~~~~~~~~
 
-* ...
+* The ``~django.core.validators.FileExtensionValidator`` now performs
+  case-insensitive extension matching.
 
 .. _backwards-incompatible-2.0:
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -254,18 +254,9 @@ TEST_DATA = [
     (FileExtensionValidator([]), ContentFile('contents', name='file.txt'), ValidationError),
 
     (FileExtensionValidator(['']), ContentFile('contents', name='fileWithNoExtension'), None),
-
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.txt'), None),
-    (FileExtensionValidator(['txt']), ContentFile('contents', name='file.tXt'), None),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.TXT'), None),
-
-    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.txt'), None),
-    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.tXt'), None),
-    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.TXT'), None),
-
     (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.txt'), None),
-    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.tXt'), None),
-    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.TXT'), None),
     (FileExtensionValidator(), ContentFile('contents', name='file.jpg'), None),
 
     (validate_image_file_extension, ContentFile('contents', name='file.jpg'), None),

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -249,12 +249,25 @@ TEST_DATA = [
 
     (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.jpg'), ValidationError),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithNoExtenstion'), ValidationError),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.JPG'), ValidationError),
     (FileExtensionValidator([]), ContentFile('contents', name='file.txt'), ValidationError),
+
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.txt'), None),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='file.tXt'), None),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='file.TXT'), None),
+
+    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.txt'), None),
+    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.tXt'), None),
+    (FileExtensionValidator(['tXt']), ContentFile('contents', name='file.TXT'), None),
+
+    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.txt'), None),
+    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.tXt'), None),
+    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.TXT'), None),
     (FileExtensionValidator(), ContentFile('contents', name='file.jpg'), None),
 
     (validate_image_file_extension, ContentFile('contents', name='file.jpg'), None),
     (validate_image_file_extension, ContentFile('contents', name='file.png'), None),
+    (validate_image_file_extension, ContentFile('contents', name='file.PNG'), None),
     (validate_image_file_extension, ContentFile('contents', name='file.txt'), ValidationError),
     (validate_image_file_extension, ContentFile('contents', name='file'), ValidationError),
 ]
@@ -451,6 +464,14 @@ class TestValidatorEquality(TestCase):
         self.assertEqual(
             FileExtensionValidator(['txt']),
             FileExtensionValidator(['txt'])
+        )
+        self.assertEqual(
+            FileExtensionValidator(['TXT']),
+            FileExtensionValidator(['txt'])
+        )
+        self.assertEqual(
+            FileExtensionValidator(['TXT', 'png']),
+            FileExtensionValidator(['txt', 'png'])
         )
         self.assertEqual(
             FileExtensionValidator(['txt']),

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -477,6 +477,10 @@ class TestValidatorEquality(TestCase):
             FileExtensionValidator(['txt', 'png'])
         )
         self.assertEqual(
+            FileExtensionValidator(['png', 'txt']),
+            FileExtensionValidator(['txt', 'png'])
+        )
+        self.assertEqual(
             FileExtensionValidator(['txt']),
             FileExtensionValidator(['txt'], code='invalid_extension')
         )

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -248,9 +248,12 @@ TEST_DATA = [
     (RegexValidator('a', flags=re.IGNORECASE), 'A', None),
 
     (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.jpg'), ValidationError),
-    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithNoExtenstion'), ValidationError),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.JPG'), ValidationError),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithNoExtension'), ValidationError),
+    (FileExtensionValidator(['']), ContentFile('contents', name='fileWithAnExtension.txt'), ValidationError),
     (FileExtensionValidator([]), ContentFile('contents', name='file.txt'), ValidationError),
+
+    (FileExtensionValidator(['']), ContentFile('contents', name='fileWithNoExtension'), None),
 
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.txt'), None),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.tXt'), None),


### PR DESCRIPTION
Trac ticket: [#28165](https://code.djangoproject.com/ticket/28165)

Format the allowed_extensions to lower case, since that is also done to the value.name to be validated.
And enable equality when allowed extensions are not provided in the same order.
Also add additional test cases.
