### PR TITLE
Fixed #28167 -- Fixed cache backend's SessionStore.exists() if session_key is None

### DIFF
--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -67,7 +67,7 @@ class SessionStore(SessionBase):
             raise CreateError
 
     def exists(self, session_key):
-        return session_key and (self.cache_key_prefix + session_key) in self._cache
+        return bool(session_key) and (self.cache_key_prefix + session_key) in self._cache
 
     def delete(self, session_key=None):
         if session_key is None:

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -348,7 +348,8 @@ class SessionTestsMixin:
         session = self.backend('someunknownkey')
         session.load()
 
-        self.assertFalse(session.exists(session.session_key))
+        self.assertIsNone(session.session_key)
+        self.assertIs(session.exists(session.session_key), False)
         # provided unknown key was cycled, not reused
         self.assertNotEqual(session.session_key, 'someunknownkey')
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28167