### PR TITLE
Fixed reference to wrong number of args in the docs

### DIFF
--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -986,7 +986,7 @@ Slightly complex built-in ``Field`` classes
         Once all fields are cleaned, the list of clean values is combined into
         a single value by :meth:`~MultiValueField.compress`.
 
-    Also takes one extra optional argument:
+    Also takes some optional arguments:
 
     .. attribute:: require_all_fields
 


### PR DESCRIPTION
`widget` is easy to overlook, too, since it comes after the example block.