### PR TITLE
Fixed #28175 -- Fixed __in lookups on a foreign key when using the foreign key's parent model as the lookup value.

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -81,7 +81,8 @@ class RelatedIn(In):
                     AND)
             return root_constraint.as_sql(compiler, connection)
         else:
-            if not getattr(self.rhs, 'has_select_fields', True):
+            if (not getattr(self.rhs, 'has_select_fields', True) and
+                    not getattr(self.lhs.field.target_field, 'primary_key', False)):
                 self.rhs.clear_select_clause()
                 if (getattr(self.lhs.output_field, 'primary_key', False) and
                         self.lhs.output_field.model == self.rhs.model):

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -97,3 +97,6 @@ Bugfixes
 
 * Prevented hiding GDAL errors if it's not installed when using ``contrib.gis``
   (:ticket:`28160`). (It's a required dependency as of Django 1.11.)
+
+* Fixed a regression causing ``__in`` lookups on a foreign key to fail when
+  using the foreign key's parent model as the lookup value (:ticket:`28175`).

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -472,6 +472,12 @@ class ModelInheritanceTest(TestCase):
         jane = Supplier.objects.order_by("name").select_related("restaurant")[0]
         self.assertEqual(jane.restaurant.name, "Craft")
 
+    def test_filter_with_parent_fk(self):
+        r = Restaurant.objects.create()
+        s = Supplier.objects.create(restaurant=r)
+        # The mismatch between Restaurant and Place is intentional (#28175).
+        self.assertSequenceEqual(Supplier.objects.filter(restaurant__in=Place.objects.all()), [s])
+
     def test_ptr_accessor_assigns_db(self):
         r = Restaurant.objects.create()
         self.assertEqual(r.place_ptr._state.db, 'default')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28175