### PR TITLE
Fixed #28104 -- Prevented @condition decorator from setting ETag/Last-Modified headers for non-safe requests.

### DIFF
--- a/docs/topics/conditional-view-processing.txt
+++ b/docs/topics/conditional-view-processing.txt
@@ -66,6 +66,10 @@ last time the resource was modified, or ``None`` if the resource doesn't
 exist. The function passed to the ``etag`` decorator should return a string
 representing the `ETag`_ for the resource, or ``None`` if it doesn't exist.
 
+The decorator sets the ``ETag`` and ``Last-Modified`` headers on the response
+if they are not already set by the view and if the request's method is safe
+(``GET`` or ``HEAD``).
+
 .. versionchanged:: 1.11
 
     In older versions, the return value from ``etag_func()`` was interpreted as
@@ -197,6 +201,14 @@ The important thing this example shows is that the same functions can be used
 to compute the ETag and last modification values in all situations. In fact,
 you **should** use the same functions, so that the same values are returned
 every time.
+
+.. admonition:: Validator headers with non-safe request methods
+
+    The ``condition`` decorator only sets validator headers (``ETag`` and
+    ``Last-Modified``) for safe HTTP methods, i.e. ``GET`` and ``HEAD``. If you
+    wish to return them in other cases, set them in your view. See
+    :rfc:`7231#section-4.3.4` to learn about the distinction between setting a
+    validator header in response to requests made with ``PUT`` versus ``POST``.
 
 Comparison with middleware conditional processing
 =================================================

--- a/tests/conditional_processing/tests.py
+++ b/tests/conditional_processing/tests.py
@@ -19,10 +19,14 @@ class ConditionalGet(SimpleTestCase):
     def assertFullResponse(self, response, check_last_modified=True, check_etag=True):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, FULL_RESPONSE.encode())
-        if check_last_modified:
-            self.assertEqual(response['Last-Modified'], LAST_MODIFIED_STR)
-        if check_etag:
-            self.assertEqual(response['ETag'], ETAG)
+        if response.request['REQUEST_METHOD'] in ('GET', 'HEAD'):
+            if check_last_modified:
+                self.assertEqual(response['Last-Modified'], LAST_MODIFIED_STR)
+            if check_etag:
+                self.assertEqual(response['ETag'], ETAG)
+        else:
+            self.assertNotIn('Last-Modified', response)
+            self.assertNotIn('ETag', response)
 
     def assertNotModified(self, response):
         self.assertEqual(response.status_code, 304)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28104