### PR TITLE
Fixed #13091 — Performs unique together check if any constraint field presented in form

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -976,8 +976,9 @@ class Model(metaclass=ModelBase):
 
         for model_class, unique_together in unique_togethers:
             for check in unique_together:
-                if not any(name in exclude for name in check):
-                    # Add the check if the field isn't excluded.
+                # Skips only those checks which fields
+                # are completely excluded from the form
+                if not set(check).issubset(exclude):
                     unique_checks.append((model_class, tuple(check)))
 
         # These are checks for the unique_for_<date/year/month>.

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -42,7 +42,7 @@ from .models import (
     RelatedPrepopulated, RelatedWithUUIDPKModel, Report, Reservation,
     Restaurant, RowLevelChangePermissionModel, Section, ShortMessage, Simple,
     Sketch, State, Story, StumpJoke, Subscriber, SuperVillain, Telegram, Thing,
-    Topping, UnchangeableObject, UndeletableObject, UnorderedObject,
+    Topping, TVSeries, UnchangeableObject, UndeletableObject, UnorderedObject,
     UserMessenger, Villain, Vodcast, Whatsit, Widget, Worker, WorkHour,
 )
 
@@ -941,6 +941,11 @@ class GetFormsetsArgumentCheckingAdmin(admin.ModelAdmin):
         return super().get_formsets_with_inlines(request, obj)
 
 
+class TVSeriesAdmin(admin.ModelAdmin):
+    list_display = ('pk', 'title', 'genre')
+    list_editable = ('title', 'genre')
+
+
 site = admin.AdminSite(name="admin")
 site.site_url = '/my-site-url/'
 site.register(Article, ArticleAdmin)
@@ -1055,6 +1060,10 @@ site.register(Ingredient)
 site.register(NotReferenced)
 site.register(ExplicitlyProvidedPK, GetFormsetsArgumentCheckingAdmin)
 site.register(ImplicitlyGeneratedPK, GetFormsetsArgumentCheckingAdmin)
+
+
+# Admin for #13091
+site.register(TVSeries, TVSeriesAdmin)
 
 # Register core models we need in our tests
 site.register(User, UserAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -979,3 +979,13 @@ class Author(models.Model):
 class Authorship(models.Model):
     book = models.ForeignKey(Book, models.CASCADE)
     author = models.ForeignKey(Author, models.CASCADE)
+
+
+# Model for #13091
+
+class TVSeries(models.Model):
+    title = models.CharField(max_length=255)
+    genre = models.CharField(max_length=255)
+
+    class Meta:
+        unique_together = ('title', 'genre')

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -50,8 +50,9 @@ from .models import (
     Recommendation, Recommender, RelatedPrepopulated, RelatedWithUUIDPKModel,
     Report, Restaurant, RowLevelChangePermissionModel, SecretHideout, Section,
     ShortMessage, Simple, State, Story, SuperSecretHideout, SuperVillain,
-    Telegram, TitleTranslation, Topping, UnchangeableObject, UndeletableObject,
-    UnorderedObject, Villain, Vodcast, Whatsit, Widget, Worker, WorkHour,
+    Telegram, TitleTranslation, Topping, TVSeries, UnchangeableObject,
+    UndeletableObject, UnorderedObject, Villain, Vodcast, Whatsit, Widget,
+    Worker, WorkHour,
 )
 
 ERROR_MESSAGE = "Please enter the correct username and password \
@@ -3156,6 +3157,37 @@ class AdminViewListEditable(TestCase):
         )
         self.assertContains(response, '<th class="field-id"><a href="%s">%d</a></th>' % (link1, story1.id), 1)
         self.assertContains(response, '<th class="field-id"><a href="%s">%d</a></th>' % (link2, story2.id), 1)
+
+    def test_list_editable_with_unique_together(self):
+        series0 = TVSeries.objects.create(title='Scrubs', genre='comedy')
+        series1 = TVSeries.objects.create(title='Friends', genre='comedy')
+
+        data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "2",
+            "form-MAX_NUM_FORMS": "0",
+
+            "form-0-id": str(series0.id),
+            "form-0-title": "Scrubs",
+            "form-0-genre": "comedy",
+
+            "form-1-id": str(series1.id),
+            "form-1-title": "Scrubs",
+            "form-1-genre": "comedy",
+
+            "_save": "Save",
+        }
+        response = self.client.post(
+            reverse('admin:admin_views_tvseries_changelist'), data)
+
+        self.assertContains(
+            response,
+            '<ul class="errorlist nonfield"><li>'
+            'Tv series with this Title and Genre already exists.'
+            '</li></ul>',
+            1,
+            html=True
+        )
 
 
 @override_settings(ROOT_URLCONF='admin_views.urls')

--- a/tests/generic_inline_admin/tests.py
+++ b/tests/generic_inline_admin/tests.py
@@ -268,6 +268,44 @@ class GenericInlineAdminWithUniqueTogetherTest(TestDataMixin, TestCase):
         response = self.client.post(reverse('admin:generic_inline_admin_contact_delete', args=[c.pk]))
         self.assertContains(response, 'Are you sure you want to delete')
 
+    def test_change(self):
+        from .models import Contact
+        contact = Contact.objects.create(name='foo')
+        phone0 = PhoneNumber.objects.create(
+            content_object=contact, phone_number="000-000-000")
+        phone1 = PhoneNumber.objects.create(
+            content_object=contact, phone_number="111-111-111")
+
+        data = {
+            'name': 'foo',
+            'generic_inline_admin-phonenumber-content_type-object_id-TOTAL_FORMS': '2',
+            'generic_inline_admin-phonenumber-content_type-object_id-INITIAL_FORMS': '2',
+            'generic_inline_admin-phonenumber-content_type-object_id-MAX_NUM_FORMS': '0',
+
+            'generic_inline_admin-phonenumber-content_type-object_id-0-id': str(phone0.pk),
+            'generic_inline_admin-phonenumber-content_type-object_id-0-phone_number': '000-000-000',
+            'generic_inline_admin-phonenumber-content_type-object_id-0-contact': str(contact.pk),
+            'generic_inline_admin-phonenumber-content_type-object_id-0-category': '',
+
+            'generic_inline_admin-phonenumber-content_type-object_id-1-id': str(phone1.pk),
+            'generic_inline_admin-phonenumber-content_type-object_id-1-phone_number': '000-000-000',
+            'generic_inline_admin-phonenumber-content_type-object_id-1-contact': str(contact.pk),
+            'generic_inline_admin-phonenumber-content_type-object_id-1-category': '',
+        }
+
+        change_url = reverse(
+            'admin:generic_inline_admin_contact_change', args=[contact.pk])
+        response = self.client.post(change_url, data=data)
+
+        self.assertContains(
+            response,
+            '<ul class="errorlist nonfield"><li>'
+            'Phone number with this Content type, Object id and Phone number already exists.'
+            '</li></ul>',
+            1,
+            html=True
+        )
+
 
 @override_settings(ROOT_URLCONF='generic_inline_admin.urls')
 class NoInlineDeletionTest(SimpleTestCase):

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1527,8 +1527,7 @@ class ModelFormsetTest(TestCase):
             ['Please correct the duplicate data for price and quantity, which must be unique.']
         )
 
-        # Only the price field is specified, this should skip any unique checks since
-        # the unique_together is not fulfilled. This will fail with a KeyError if broken.
+        # Only the price field is specified, fails with unique together check.
         FormSet = modelformset_factory(Price, fields=("price",), extra=2)
         data = {
             'form-TOTAL_FORMS': '2',
@@ -1538,7 +1537,7 @@ class ModelFormsetTest(TestCase):
             'form-1-price': '24',
         }
         formset = FormSet(data)
-        self.assertTrue(formset.is_valid())
+        self.assertFalse(formset.is_valid())
 
         FormSet = inlineformset_factory(Author, Book, extra=0, fields="__all__")
         author = Author.objects.create(pk=1, name='Charles Baudelaire')


### PR DESCRIPTION
This is probably just a part of solution:
- it makes appear hidden fields (non-presented in form) in an error message which may be undesirable
- generic relation fields should probably refer to `content_object` in a message (see 6243e9b). This may be confusing to user, because "this Content type, Object id and Foo already exists" error doesn't help at all.

Both of them can be fixed by filtering them out in a message, but Model doesn't really know if they are presented in the form for real.