### PR TITLE
Fixed #27859 -- Ignored db_index for TextField/BinaryField on Oracle and MySQL.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -227,6 +227,9 @@ class BaseDatabaseFeatures:
     supports_select_difference = True
     supports_slicing_ordering_in_compound = False
 
+    # Does the backend support indexing a TextField?
+    supports_index_on_text_field = True
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -143,6 +143,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         else:
             return self._data_types
 
+    # For these columns, MySQL doesn't:
+    # - accept default values and implicitly treats these columns as nullable
+    # - support a database index
+    _limited_data_types = (
+        'tinyblob', 'blob', 'mediumblob', 'longblob', 'tinytext', 'text',
+        'mediumtext', 'longtext', 'json',
+    )
+
     operators = {
         'exact': '= %s',
         'iexact': 'LIKE %s',

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -31,6 +31,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_select_intersection = False
     supports_select_difference = False
     supports_slicing_ordering_in_compound = True
+    supports_index_on_text_field = False
 
     @cached_property
     def _mysql_storage_engine(self):

--- a/django/db/backends/mysql/validation.py
+++ b/django/db/backends/mysql/validation.py
@@ -31,6 +31,7 @@ class DatabaseValidation(BaseDatabaseValidation):
         MySQL has the following field length restriction:
         No character (varchar) fields can have a length exceeding 255
         characters if they have a unique index on them.
+        MySQL doesn't support a database index on some data types.
         """
         errors = []
         if (field_type.startswith('varchar') and field.unique and
@@ -40,6 +41,20 @@ class DatabaseValidation(BaseDatabaseValidation):
                     'MySQL does not allow unique CharFields to have a max_length > 255.',
                     obj=field,
                     id='mysql.E001',
+                )
+            )
+
+        if field.db_index and field_type.lower() in self.connection._limited_data_types:
+            errors.append(
+                checks.Warning(
+                    'MySQL does not support a database index on %s columns.'
+                    % field_type,
+                    hint=(
+                        "An index won't be created. Silence this warning if "
+                        "you don't care about it."
+                    ),
+                    obj=field,
+                    id='fields.W162',
                 )
             )
         return errors

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -55,6 +55,7 @@ from .introspection import DatabaseIntrospection            # NOQA isort:skip
 from .operations import DatabaseOperations                  # NOQA isort:skip
 from .schema import DatabaseSchemaEditor                    # NOQA isort:skip
 from .utils import Oracle_datetime                          # NOQA isort:skip
+from .validation import DatabaseValidation                  # NOQA isort:skip
 
 
 class _UninitializedOperatorsDescriptor:
@@ -115,6 +116,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'PositiveSmallIntegerField': '%(qn_column)s >= 0',
     }
 
+    # Oracle doesn't support a database index on these columns.
+    _limited_data_types = ('clob', 'nclob', 'blob')
+
     operators = _UninitializedOperatorsDescriptor()
 
     _standard_operators = {
@@ -174,6 +178,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     features_class = DatabaseFeatures
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
+    validation_class = DatabaseValidation
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -35,3 +35,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # Oracle doesn't ignore quoted identifiers case but the current backend
     # does by uppercasing all identifiers.
     ignores_table_name_case = True
+    supports_index_on_text_field = False

--- a/django/db/backends/oracle/schema.py
+++ b/django/db/backends/oracle/schema.py
@@ -119,3 +119,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def prepare_default(self, value):
         return self.quote_value(value)
+
+    def _field_should_be_indexed(self, model, field):
+        create_index = super()._field_should_be_indexed(model, field)
+        db_type = field.db_type(self.connection)
+        if db_type is not None and db_type.lower() in self.connection._limited_data_types:
+            return False
+        return create_index

--- a/django/db/backends/oracle/validation.py
+++ b/django/db/backends/oracle/validation.py
@@ -1,0 +1,22 @@
+from django.core import checks
+from django.db.backends.base.validation import BaseDatabaseValidation
+
+
+class DatabaseValidation(BaseDatabaseValidation):
+    def check_field_type(self, field, field_type):
+        """Oracle doesn't support a database index on some data types."""
+        errors = []
+        if field.db_index and field_type.lower() in self.connection._limited_data_types:
+            errors.append(
+                checks.Warning(
+                    'Oracle does not support a database index on %s columns.'
+                    % field_type,
+                    hint=(
+                        "An index won't be created. Silence this warning if "
+                        "you don't care about it."
+                    ),
+                    obj=field,
+                    id='fields.W162',
+                )
+            )
+        return errors

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -172,6 +172,8 @@ Model fields
 * **fields.E160**: The options ``auto_now``, ``auto_now_add``, and ``default``
   are mutually exclusive. Only one of these options may be present.
 * **fields.W161**: Fixed default value provided.
+* **fields.W162**: ``<database>`` does not support a database index on
+  ``<field data type>`` columns.
 * **fields.E900**: ``IPAddressField`` has been removed except for support in
   historical migrations.
 * **fields.W900**: ``IPAddressField`` has been deprecated. Support for it

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -17,6 +17,13 @@ class Author(models.Model):
         apps = new_apps
 
 
+class AuthorTextFieldWithIndex(models.Model):
+    text_field = models.TextField(db_index=True)
+
+    class Meta:
+        apps = new_apps
+
+
 class AuthorWithDefaultHeight(models.Model):
     name = models.CharField(max_length=255)
     height = models.PositiveIntegerField(null=True, blank=True, default=42)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -29,11 +29,11 @@ from .fields import (
     CustomManyToManyField, InheritedManyToManyField, MediumBlobField,
 )
 from .models import (
-    Author, AuthorWithDefaultHeight, AuthorWithEvenLongerName,
-    AuthorWithIndexedName, Book, BookForeignObj, BookWeak, BookWithLongName,
-    BookWithO2O, BookWithoutAuthor, BookWithSlug, IntegerPK, Node, Note,
-    NoteRename, Tag, TagIndexed, TagM2MTest, TagUniqueRename, Thing,
-    UniqueTest, new_apps,
+    Author, AuthorTextFieldWithIndex, AuthorWithDefaultHeight,
+    AuthorWithEvenLongerName, AuthorWithIndexedName, Book, BookForeignObj,
+    BookWeak, BookWithLongName, BookWithO2O, BookWithoutAuthor, BookWithSlug,
+    IntegerPK, Node, Note, NoteRename, Tag, TagIndexed, TagM2MTest,
+    TagUniqueRename, Thing, UniqueTest, new_apps,
 )
 
 
@@ -1748,6 +1748,13 @@ class SchemaTests(TransactionTestCase):
             "slug",
             self.get_indexes(Book._meta.db_table),
         )
+
+    def test_text_field_with_db_index(self):
+        with connection.schema_editor() as editor:
+            editor.create_model(AuthorTextFieldWithIndex)
+        # The text_field index is present if the database supports it.
+        assertion = self.assertIn if connection.features.supports_index_on_text_field else self.assertNotIn
+        assertion('text_field', self.get_indexes(AuthorTextFieldWithIndex._meta.db_table))
 
     def test_primary_key(self):
         """


### PR DESCRIPTION
Ticket [27859](https://code.djangoproject.com/ticket/27859).