### PR TITLE
Fixed #28178 -- Changed contrib.gis to raise ImproperlyConfigured if gdal isn't installed.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -26,7 +26,7 @@ elif os.name == 'posix':
     # *NIX library names.
     lib_names = ['gdal', 'GDAL', 'gdal2.1.0', 'gdal2.0.0', 'gdal1.11.0', 'gdal1.10.0', 'gdal1.9.0']
 else:
-    raise GDALException('Unsupported OS "%s"' % os.name)
+    raise ImproperlyConfigured('GDAL is unsupported on OS "%s".' % os.name)
 
 # Using the ctypes `find_library` utility  to find the
 # path to the GDAL library from the list of library names.
@@ -37,9 +37,10 @@ if lib_names:
             break
 
 if lib_path is None:
-    raise GDALException(
-        'Could not find the GDAL library (tried "%s"). Try setting '
-        'GDAL_LIBRARY_PATH in your settings.' % '", "'.join(lib_names)
+    raise ImproperlyConfigured(
+        'Could not find the GDAL library (tried "%s"). Is GDAL installed? '
+        'If it is, try setting GDAL_LIBRARY_PATH in your settings.'
+        % '", "'.join(lib_names)
     )
 
 # This loads the GDAL/OGR C library

--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Added detection for GDAL 2.1 and 2.0, and removed detection for unsupported
   versions 1.7 and 1.8 (:ticket:`28181`).
+
+* Changed ``contrib.gis`` to raise ``ImproperlyConfigured`` rather than
+  ``GDALException`` if ``gdal`` isn't installed, to allow third-party apps to
+  catch that exception (:ticket:`28178`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28178