### PR TITLE
Fixed db backend discovery in tests.

### DIFF
--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -120,11 +120,10 @@ class AdminScriptTestCase(unittest.TestCase):
         Returns the paths for any external backend packages.
         """
         paths = []
-        first_package_re = re.compile(r'(^[^\.]+)\.')
         for backend in settings.DATABASES.values():
-            result = first_package_re.findall(backend['ENGINE'])
-            if result and result != ['django']:
-                backend_pkg = __import__(result[0])
+            package = backend['ENGINE'].split('.')[0]
+            if package != 'django':
+                backend_pkg = __import__(package)
                 backend_dir = os.path.dirname(backend_pkg.__file__)
                 paths.append(os.path.dirname(backend_dir))
         return paths


### PR DESCRIPTION
Not all database backends have dots in them at all ;) Regex also seemed a bit like overkill