### PR TITLE
Fixed #28170 -- Fixed file_move_safe() crash when moving files to a CIFS mount.

### DIFF
--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -54,3 +54,6 @@ Bugfixes
 
 * Made date-based generic views return a 404 rather than crash when given an
   out of range date (:ticket:`28209`).
+
+* Fixed a regression where ``file_move_safe()`` crashed when moving files to a
+  CIFS mount (:ticket:`28170`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28170