### PR TITLE
Fixed #28275 -- Added more hooks to SchemaEditor._alter_field().

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -92,9 +92,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
             new_type += " NOT NULL"
         return new_type
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)
-        return super()._alter_column_type_sql(table, old_field, new_field, new_type)
+        return super()._alter_column_type_sql(model, old_field, new_field, new_type)
 
     def _rename_field_sql(self, table, old_field, new_field, new_type):
         new_type = self._set_field_new_type_null_status(old_field, new_type)

--- a/django/db/backends/postgresql/schema.py
+++ b/django/db/backends/postgresql/schema.py
@@ -52,8 +52,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 return self._create_index_sql(model, [field], suffix='_like', sql=self.sql_create_text_index)
         return None
 
-    def _alter_column_type_sql(self, table, old_field, new_field, new_type):
+    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
         """Make ALTER TYPE with SERIAL make sense."""
+        table = model._meta.db_table
         if new_type.lower() in ("serial", "bigserial"):
             column = new_field.column
             sequence_name = "%s_%s_seq" % (table, column)
@@ -100,7 +101,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 ],
             )
         else:
-            return super()._alter_column_type_sql(table, old_field, new_field, new_type)
+            return super()._alter_column_type_sql(model, old_field, new_field, new_type)
 
     def _alter_field(self, model, old_field, new_field, old_type, new_type,
                      old_db_params, new_db_params, strict=False):

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -289,6 +289,9 @@ Database backend API
   attribute with the name of the database that your backend works with. Django
   may use it in various messages, such as in system checks.
 
+* The first argument of ``SchemaEditor._alter_column_type_sql()`` is now
+  ``model`` rather than ``table``.
+
 * To improve performance when streaming large result sets from the database,
   :meth:`.QuerySet.iterator` now fetches 2000 rows at a time instead of 100.
   The old behavior can be restored using the ``chunk_size`` parameter. For


### PR DESCRIPTION
Note: As annoying as the latter is, the streamlining is kinda required
to have the model everywhere as opposed to just the table name.