### PR TITLE
Fixed #28197 -- Fixed introspection of index field ordering on PostgreSQL.

### DIFF
--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -23,3 +23,5 @@ Bugfixes
 
 * Fixed ``django.contrib.auth.authenticate()`` when multiple authentication
   backends don't accept a positional ``request`` argument (:ticket:`28207`).
+
+* Fixed introspection of index field ordering on PostgreSQL (:ticket:`28197`).

--- a/tests/introspection/models.py
+++ b/tests/introspection/models.py
@@ -47,6 +47,7 @@ class Article(models.Model):
         ordering = ('headline',)
         index_together = [
             ["headline", "pub_date"],
+            ['headline', 'response_to', 'pub_date', 'reporter'],
         ]
 
 

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -189,10 +189,14 @@ class IntrospectionTests(TransactionTestCase):
         with connection.cursor() as cursor:
             constraints = connection.introspection.get_constraints(cursor, Article._meta.db_table)
         index = {}
+        index2 = {}
         for key, val in constraints.items():
             if val['columns'] == ['headline', 'pub_date']:
                 index = val
+            if val['columns'] == ['headline', 'response_to_id', 'pub_date', 'reporter_id']:
+                index2 = val
         self.assertEqual(index['type'], Index.suffix)
+        self.assertEqual(index2['type'], Index.suffix)
 
     @skipUnlessDBFeature('supports_index_column_ordering')
     def test_get_constraints_indexes_orders(self):
@@ -206,13 +210,14 @@ class IntrospectionTests(TransactionTestCase):
             ['reporter_id'],
             ['headline', 'pub_date'],
             ['response_to_id'],
+            ['headline', 'response_to_id', 'pub_date', 'reporter_id'],
         ]
         for key, val in constraints.items():
             if val['index'] and not (val['primary_key'] or val['unique']):
                 self.assertIn(val['columns'], expected_columns)
                 self.assertEqual(val['orders'], ['ASC'] * len(val['columns']))
                 indexes_verified += 1
-        self.assertEqual(indexes_verified, 3)
+        self.assertEqual(indexes_verified, 4)
 
 
 def datatype(dbtype, description):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28197