### PR TITLE
Fix - Django stores empty files when it's used with S3Boto3Storage or S3BotoStorage

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -307,6 +307,7 @@ class HashedFilesMixin:
                     if self.exists(hashed_name):
                         self.delete(hashed_name)
 
+                    content_file.seek(0, os.SEEK_SET)
                     saved_name = self._save(hashed_name, content_file)
                     hashed_name = self.clean_name(saved_name)
                     # If the file hash stayed the same, this file didn't change


### PR DESCRIPTION
[We been using Amazon S3 to store Django site's static and media files](https://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/) for years now, and when we upgraded to Django 1.11 we started to see some empty files.

We debugged the issue and it seems that `StaticFilesStorage` is trying to re-save the file without resetting its pointer which led to an empty file.

This could be solved on `S3Boto3Storage` level, but from the attached image you can see that Django is storing multiple versions of the same file which is another related issue. ![multiple versions of base.css with different hashnames](https://cloud.githubusercontent.com/assets/493669/26035982/2a3c0f26-38de-11e7-9ee7-7d52953d1378.png)
