### PR TITLE
Fixed #28207 -- Fixed contrib.auth.authenticate() if multiple auth backends don't accept a request.

### DIFF
--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -20,3 +20,6 @@ Bugfixes
   (:ticket:`28142`).
 
 * Fixed regression causing pickling of model fields to crash (:ticket:`28188`).
+
+* Fixed ``django.contrib.auth.authenticate()`` when multiple authentication
+  backends don't accept a positional ``request`` argument (:ticket:`28207`).

--- a/tests/auth_tests/test_auth_backends_deprecation.py
+++ b/tests/auth_tests/test_auth_backends_deprecation.py
@@ -50,3 +50,21 @@ class AcceptsRequestBackendTest(SimpleTestCase):
             "In %s.authenticate(), move the `request` keyword argument to the "
             "first positional argument." % self.request_not_positional_backend
         )
+
+    @override_settings(AUTHENTICATION_BACKENDS=[request_not_positional_backend, no_request_backend])
+    def test_both_types_of_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter('always')
+            authenticate(mock_request, username='username', password='pass')
+
+        self.assertEqual(len(warns), 2)
+        self.assertEqual(
+            str(warns[0].message),
+            "In %s.authenticate(), move the `request` keyword argument to the "
+            "first positional argument." % self.request_not_positional_backend
+        )
+        self.assertEqual(
+            str(warns[1].message),
+            "Update %s.authenticate() to accept a positional `request` "
+            "argument." % self.no_request_backend
+        )


### PR DESCRIPTION
The easiest fix would be to just copy the contents of `credentials` at the top of the loop, but I think it is worthwhile breaking out a helper function.

IMHO the loop's body is complicated enough to warrant a new function, aligns the Single Responsibility Principle and avoids introducing an arguably ugly dictionary copy.

