### PR TITLE
Fixed #28209 Fixed year out of range bug in generic date view mixins.

### DIFF
--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -66,7 +66,10 @@ class YearMixin(object):
 
         The interval is defined by start date <= item date < next start date.
         """
-        return date.replace(year=date.year + 1, month=1, day=1)
+        try:
+            return date.replace(year=date.year + 1, month=1, day=1)
+        except ValueError:
+            raise Http404(_("Date out of range"))
 
     def _get_current_year(self, date):
         """
@@ -123,7 +126,10 @@ class MonthMixin(object):
         The interval is defined by start date <= item date < next start date.
         """
         if date.month == 12:
-            return date.replace(year=date.year + 1, month=1, day=1)
+            try:
+                return date.replace(year=date.year + 1, month=1, day=1)
+            except ValueError:
+                raise Http404(_("Date out of range"))
         else:
             return date.replace(month=date.month + 1, day=1)
 
@@ -237,7 +243,10 @@ class WeekMixin(object):
 
         The interval is defined by start date <= item date < next start date.
         """
-        return date + datetime.timedelta(days=7 - self._get_weekday(date))
+        try:
+            return date + datetime.timedelta(days=7 - self._get_weekday(date))
+        except OverflowError:
+            raise Http404(_("Date out of range"))
 
     def _get_current_week(self, date):
         """

--- a/tests/generic_views/test_dates.py
+++ b/tests/generic_views/test_dates.py
@@ -664,6 +664,16 @@ class DateDetailViewTests(TestDataMixin, TestCase):
         self.assertEqual(res.context['book'], b)
         self.assertTemplateUsed(res, 'generic_views/book_detail.html')
 
+    def test_year_out_of_range(self):
+        res = self.client.get('/dates/books/9999/')
+        self.assertEqual(res.status_code, 404)
+        res = self.client.get('/dates/books/9999/12/')
+        self.assertEqual(res.status_code, 404)
+        res = self.client.get('/dates/books/9999/dec/31/')
+        self.assertEqual(res.status_code, 404)
+        res = self.client.get('/dates/books/9999/week/52/')
+        self.assertEqual(res.status_code, 404)
+
     def test_invalid_url(self):
         with self.assertRaises(AttributeError):
             self.client.get("/dates/books/2008/oct/01/nopk/")


### PR DESCRIPTION
Added exception handling to YearMixin and MonthMixin in generic.dates
to return 404 when trying to browse years greater than 5 digits since
datetime module will throw an year out of range ValueError.