### PR TITLE
Fixed #28221 -- Fixed plural fallback translations in JavaScriptCatalog view

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -252,15 +252,24 @@ class JavaScriptCatalog(View):
         maxcnts = {}
         catalog = {}
         trans_cat = self.translation._catalog
-        trans_fallback_cat = self.translation._fallback._catalog if self.translation._fallback else {}
+        fallback_base = self.translation._fallback._catalog if self.translation._fallback else {}
+        # Only collect fallbacks for which the main catalog lacks a translation
+        trans_fallback_cat = {}
+        for key, value in fallback_base.items():
+            if key in trans_cat:
+                continue
+            if isinstance(key, tuple):
+                if (key[0], 0) in trans_cat:
+                    continue
+            trans_fallback_cat[key] = value
+
         for key, value in itertools.chain(iter(trans_cat.items()), iter(trans_fallback_cat.items())):
             if key == '' or key in catalog:
                 continue
             if isinstance(key, str):
                 catalog[key] = value
             elif isinstance(key, tuple):
-                msgid = key[0]
-                cnt = key[1]
+                msgid, cnt = key
                 maxcnts[msgid] = max(cnt, maxcnts.get(msgid, 0))
                 pdict.setdefault(msgid, {})[cnt] = value
             else:

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -272,13 +272,27 @@ class I18NViewTests(SimpleTestCase):
     def test_i18n_fallback_language_plural(self):
         """
         The fallback to a language with less plural forms maintains the real
-        language's number of plural forms.
+        language's number of plural forms and correct translations.
         """
         with self.settings(LANGUAGE_CODE='pt'), override('ru'):
             response = self.client.get('/jsi18n/')
             self.assertEqual(
                 response.context['catalog']['{count} plural3'],
-                ['{count} plural3', '{count} plural3s', '{count} plural3 p3t']
+                ['{count} plural3 p3', '{count} plural3 p3s', '{count} plural3 p3t']
+            )
+            self.assertEqual(
+                response.context['catalog']['{count} plural2'],
+                ['{count} plural2', '{count} plural2s']
+            )
+        with self.settings(LANGUAGE_CODE='ru'), override('pt'):
+            response = self.client.get('/jsi18n/')
+            self.assertEqual(
+                response.context['catalog']['{count} plural3'],
+                ['{count} plural3', '{count} plural3s']
+            )
+            self.assertEqual(
+                response.context['catalog']['{count} plural2'],
+                ['{count} plural2', '{count} plural2s']
             )
 
     def test_i18n_english_variant(self):


### PR DESCRIPTION
We've hit a bug where our translators changed a translation in the English djangojs.po files and suddenly all other languages' translations were overridden with the English (i.e. fallback) translation.
https://code.djangoproject.com/ticket/28221