### PR TITLE
Pin Sphinx version to fix docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ usedevelop = false
 whitelist_externals =
     make
 deps =
-    Sphinx
+    Sphinx==1.5.6
     pyenchant
     sphinxcontrib-spelling
 changedir = docs


### PR DESCRIPTION
Seems that the next version of Sphinx breaks the doc build by removing `SmartyPantsHTMLTranslator`. This pins to the last version that worked until someone can modify the code.