### PR TITLE
Fixed #28211 -- Stopped combining Q objects if either side is falsey.

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -5,6 +5,7 @@ Factored out from django.db.models.query to avoid making the main module very
 large and/or so that they can be used by other modules without getting into
 circular import difficulties.
 """
+import copy
 import functools
 import inspect
 from collections import namedtuple
@@ -61,6 +62,14 @@ class Q(tree.Node):
     def _combine(self, other, conn):
         if not isinstance(other, Q):
             raise TypeError(other)
+
+        # If the other Q() is empty, ignore it and just use `self`.
+        if not other:
+            return copy.deepcopy(self)
+        # Or if this Q is empty, ignore it and just use `other`.
+        elif not self:
+            return copy.deepcopy(other)
+
         obj = type(self)()
         obj.connector = conn
         obj.add(self, conn)

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -3,6 +3,14 @@ from django.test import SimpleTestCase
 
 
 class QTests(SimpleTestCase):
+    def test_combine_and_empty(self):
+        q = Q(x=1)
+        self.assertEqual(q & Q(), q)
+        self.assertEqual(Q() & q, q)
+
+    def test_combine_and_both_empty(self):
+        self.assertEqual(Q() & Q(), Q())
+
     def test_deconstruct(self):
         q = Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()

--- a/tests/queries/test_q.py
+++ b/tests/queries/test_q.py
@@ -11,6 +11,14 @@ class QTests(SimpleTestCase):
     def test_combine_and_both_empty(self):
         self.assertEqual(Q() & Q(), Q())
 
+    def test_combine_or_empty(self):
+        q = Q(x=1)
+        self.assertEqual(q | Q(), q)
+        self.assertEqual(Q() | q, q)
+
+    def test_combine_or_both_empty(self):
+        self.assertEqual(Q() | Q(), Q())
+
     def test_deconstruct(self):
         q = Q(price__gt=F('discounted_price'))
         path, args, kwargs = q.deconstruct()


### PR DESCRIPTION
Perhaps a good workaround for [#28211](https://code.djangoproject.com/ticket/28211) is to just not OR/AND Q objects unless each side is truthy.

`Q() | Q(x=1)` can be reduced down to `Q(x=1)`, and `Q() & Q(x=1)` can be reduced to just `Q(x=1)` (as far as I can tell?), so we could just reduce both these cases down to `Q(x=1)` in the `Q._combine()` function.