### PR TITLE
Fixed #28210 -- Fixed Model._state.adding on MTI parent model after saving child model.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -272,6 +272,7 @@ class ForwardOneToOneDescriptor(ForwardManyToOneDescriptor):
             if not any(field in fields for field in deferred):
                 kwargs = {field: getattr(instance, field) for field in fields}
                 obj = rel_model(**kwargs)
+                obj._state.adding = instance._state.adding
                 obj._state.db = instance._state.db
                 return obj
         return super().get_object(instance)

--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -25,3 +25,7 @@ Bugfixes
   backends don't accept a positional ``request`` argument (:ticket:`28207`).
 
 * Fixed introspection of index field ordering on PostgreSQL (:ticket:`28197`).
+
+* Fixed a regression where ``Model._state.adding`` wasn't set correctly on
+  multi-table inheritance parent models after saving a child model
+  (:ticket:`28210`).

--- a/tests/model_inheritance_regress/tests.py
+++ b/tests/model_inheritance_regress/tests.py
@@ -478,8 +478,9 @@ class ModelInheritanceTest(TestCase):
         # The mismatch between Restaurant and Place is intentional (#28175).
         self.assertSequenceEqual(Supplier.objects.filter(restaurant__in=Place.objects.all()), [s])
 
-    def test_ptr_accessor_assigns_db(self):
+    def test_ptr_accessor_assigns_state(self):
         r = Restaurant.objects.create()
+        self.assertIs(r.place_ptr._state.adding, False)
         self.assertEqual(r.place_ptr._state.db, 'default')
 
     def test_related_filtering_query_efficiency_ticket_15844(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28210