### PR TITLE
Fixed #18332 - generic function for db version

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -640,3 +640,10 @@ class BaseDatabaseWrapper:
         if allow_thread_sharing is None:
             allow_thread_sharing = self.allow_thread_sharing
         return type(self)(settings_dict, alias, allow_thread_sharing)
+
+    def backend_info(self):
+        """
+        Returns a dict that contains the vendor and version tuple
+        from the current database.
+        """
+        return self._get_backend_info()

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -351,3 +351,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if not match:
             raise Exception('Unable to determine MySQL version from version string %r' % server_info)
         return tuple(int(x) for x in match.groups())
+
+    def _get_backend_info(self):
+        kwargs = {
+            'vendor': self.vendor,
+            'version': self.mysql_version,
+        }
+        return kwargs

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -574,3 +574,10 @@ def _rowfactory(row, cursor):
                 value = int(value)
         casted.append(value)
     return tuple(casted)
+
+    def _get_backend_info(self):
+        kwargs = {
+            'vendor': self.vendor,
+            'version': tuple(map(lambda x: int(x), self.oracle_full_version.split('.'))),
+        }
+        return kwargs

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -4,7 +4,7 @@ SQLite3 backend for the sqlite3 module in the standard library.
 import decimal
 import re
 import warnings
-from sqlite3 import dbapi2 as Database
+from sqlite3 import dbapi2 as Database, sqlite_version
 
 import pytz
 
@@ -272,6 +272,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def is_in_memory_db(self):
         return self.creation.is_in_memory_db(self.settings_dict['NAME'])
+
+    def _get_backend_info(self):
+        kwargs = {
+            'vendor': self.vendor,
+            'version': tuple(map(lambda x: int(x), sqlite_version.split('.'))),
+        }
+        return kwargs
 
 
 FORMAT_QMARK_REGEX = re.compile(r'(?<!%)%s')

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -675,3 +675,8 @@ class FunctionTests(TestCase):
             Author.objects.exclude(alias=Upper(V('smithj'))),
             ['Rhonda'], lambda x: x.name
         )
+
+    def test_backend_info(self):
+        backend_info = connection.backend_info()
+        self.assertIsInstance(backend_info['vendor'], str)
+        self.assertIsInstance(backend_info['version'], tuple)


### PR DESCRIPTION
I took the old patch from https://code.djangoproject.com/ticket/18332 and brushed it up a bit. To the original SQLite implementation I added PostgreSQL, MySQL and Oracle implementations.

We also no longer return a `namedtuple` but a `dict` instead because it feels more in line with the rest of Django.

The thing I'm unsure about is if it would not be better to have the 'vendor' be the 'vendor' and a 'type' that can indicate the type. For instance for MySQL there is MySQL and MariaDB with each their own version numbering schemes.

-----

This provides an option `get_backend_info()` that allows you to retrieve the
database type (vendor) and version, as a tuple.

    >>> from django.db import connection
    >>> connection.backend_info()
    {'vendor': 'postgresql', 'version': (9, 6, 2)}
