### PR TITLE
Point Dive into Python links to python3 site

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -841,7 +841,6 @@ A big THANK YOU goes to:
 
     Ian Bicking for convincing Adrian to ditch code generation.
 
-    Mark Pilgrim for "Dive Into Python" (http://www.diveintopython.net,
-    http://www.diveintopython3.net).
+    Mark Pilgrim for "Dive Into Python" (http://www.diveintopython3.net).
 
     Guido van Rossum for creating Python.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -396,7 +396,7 @@ that passing a ``prefix`` parameter when creating an instance still works too.
     * After reading those, if you want something a little meatier to sink
       your teeth into, there's always the Python :mod:`unittest` documentation.
 
-__ http://www.diveintopython.net/unit_testing/index.html
+__ http://www.diveintopython3.net/unit-testing.html
 
 Running your new test
 ---------------------

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1560,7 +1560,7 @@ Example usage::
 
     django-admin migrate --pythonpath='/home/djangoprojects/myproject'
 
-.. _import search path: http://www.diveintopython.net/getting_to_know_python/everything_is_an_object.html
+.. _import search path: http://www.diveintopython3.net/your-first-python-program.html#importsearchpath
 
 .. django-admin-option:: --settings SETTINGS
 

--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -115,7 +115,7 @@ Example requests:
 * ``/articles/2003/03/03/`` would match the final pattern. Django would call
   the function ``views.article_detail(request, '2003', '03', '03')``.
 
-.. _Dive Into Python's explanation: http://www.diveintopython.net/regular_expressions/street_addresses.html#re.matching.2.3
+.. _Dive Into Python's explanation: http://www.diveintopython3.net/regular-expressions.html#streetaddresses
 
 Named groups
 ============

--- a/docs/topics/settings.txt
+++ b/docs/topics/settings.txt
@@ -46,7 +46,7 @@ The value of ``DJANGO_SETTINGS_MODULE`` should be in Python path syntax, e.g.
 ``mysite.settings``. Note that the settings module should be on the
 Python `import search path`_.
 
-.. _import search path: http://www.diveintopython.net/getting_to_know_python/everything_is_an_object.html
+.. _import search path: http://www.diveintopython3.net/your-first-python-program.html#importsearchpath
 
 The ``django-admin`` utility
 ----------------------------


### PR DESCRIPTION
The old site handles python2, and is thus no longer relevant for Django.
Also I pointed the search path links to the proper sections.