### PR TITLE
Fixed #28226 -- Removed obsolete use of ''.join() pattern.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -560,7 +560,7 @@ class ModelAdminChecks(BaseModelAdminChecks):
 
     def _check_inlines_item(self, obj, model, inline, label):
         """ Check one inline model admin. """
-        inline_label = '.'.join([inline.__module__, inline.__name__])
+        inline_label = inline.__module__ + '.' + inline.__name__
 
         from django.contrib.admin.options import InlineModelAdmin
 

--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -26,7 +26,7 @@ class BaseUserManager(models.Manager):
         except ValueError:
             pass
         else:
-            email = '@'.join([email_name, domain_part.lower()])
+            email = email_name + '@' + domain_part.lower()
         return email
 
     def make_random_password(self, length=10,

--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -13,10 +13,10 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
                  prefix=None, queryset=None, **kwargs):
         opts = self.model._meta
         self.instance = instance
-        self.rel_name = '-'.join((
-            opts.app_label, opts.model_name,
-            self.ct_field.name, self.ct_fk_field.name,
-        ))
+        self.rel_name = (
+            opts.app_label + '-' + opts.model_name + '-' +
+            self.ct_field.name + '-' + self.ct_fk_field.name
+        )
         if self.instance is None or self.instance.pk is None:
             qs = self.model._default_manager.none()
         else:
@@ -32,7 +32,10 @@ class BaseGenericInlineFormSet(BaseModelFormSet):
     @classmethod
     def get_default_prefix(cls):
         opts = cls.model._meta
-        return '-'.join((opts.app_label, opts.model_name, cls.ct_field.name, cls.ct_fk_field.name))
+        return (
+            opts.app_label + '-' + opts.model_name + '-' +
+            cls.ct_field.name + '-' + cls.ct_fk_field.name
+        )
 
     def save_new(self, form, commit=True):
         setattr(form.instance, self.ct_field.get_attname(), ContentType.objects.get_for_model(self.instance).pk)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -256,9 +256,9 @@ class EmailMessage:
         msg['From'] = self.extra_headers.get('From', self.from_email)
         msg['To'] = self.extra_headers.get('To', ', '.join(map(str, self.to)))
         if self.cc:
-            msg['Cc'] = ', '.join(map(str, self.cc))
+            msg['Cc'] = ', '.join(str(cc) for cc in self.cc)
         if self.reply_to:
-            msg['Reply-To'] = self.extra_headers.get('Reply-To', ', '.join(map(str, self.reply_to)))
+            msg['Reply-To'] = self.extra_headers.get('Reply-To', ', '.join(str(r) for r in self.reply_to))
 
         # Email header names are case-insensitive (RFC 2045), so we have to
         # accommodate that when doing comparisons.

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1282,8 +1282,8 @@ class Prefetch:
         return obj_dict
 
     def add_prefix(self, prefix):
-        self.prefetch_through = LOOKUP_SEP.join([prefix, self.prefetch_through])
-        self.prefetch_to = LOOKUP_SEP.join([prefix, self.prefetch_to])
+        self.prefetch_through = prefix + LOOKUP_SEP + self.prefetch_through
+        self.prefetch_to = prefix + LOOKUP_SEP + self.prefetch_to
 
     def get_current_prefetch_to(self, level):
         return LOOKUP_SEP.join(self.prefetch_to.split(LOOKUP_SEP)[:level + 1])

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -399,17 +399,17 @@ class BaseFormSet:
         # probably should be. It might make sense to render each form as a
         # table row with each field as a td.
         forms = ' '.join(form.as_table() for form in self)
-        return mark_safe('\n'.join([str(self.management_form), forms]))
+        return mark_safe(str(self.management_form) + '\n' + forms)
 
     def as_p(self):
         "Return this formset rendered as HTML <p>s."
         forms = ' '.join(form.as_p() for form in self)
-        return mark_safe('\n'.join([str(self.management_form), forms]))
+        return mark_safe(str(self.management_form) + '\n' + forms)
 
     def as_ul(self):
         "Return this formset rendered as HTML <li>s."
         forms = ' '.join(form.as_ul() for form in self)
-        return mark_safe('\n'.join([str(self.management_form), forms]))
+        return mark_safe(str(self.management_form) + '\n' + forms)
 
 
 def formset_factory(form, formset=BaseFormSet, extra=1, can_order=False,

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -401,7 +401,7 @@ class LazyStream:
             return
         self._update_unget_history(len(bytes))
         self.position -= len(bytes)
-        self._leftover = b''.join([bytes, self._leftover])
+        self._leftover = bytes + self._leftover
 
     def _update_unget_history(self, num_bytes):
         """

--- a/django/http/response.py
+++ b/django/http/response.py
@@ -92,7 +92,7 @@ class HttpResponseBase:
             return val if isinstance(val, bytes) else val.encode(encoding)
 
         headers = [
-            (b': '.join([to_bytes(key, 'ascii'), to_bytes(value, 'latin-1')]))
+            (to_bytes(key, 'ascii') + b': ' + to_bytes(value, 'latin-1'))
             for key, value in self._headers.values()
         ]
         return b'\r\n'.join(headers)

--- a/django/template/loaders/cached.py
+++ b/django/template/loaders/cached.py
@@ -85,7 +85,7 @@ class Loader(BaseLoader):
             if matching:
                 skip_prefix = self.generate_hash(matching)
 
-        return '-'.join(filter(bool, [str(template_name), skip_prefix, dirs_prefix]))
+        return '-'.join(s for s in (str(template_name), skip_prefix, dirs_prefix) if s)
 
     def generate_hash(self, values):
         return hashlib.sha1(force_bytes('|'.join(values))).hexdigest()

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -41,10 +41,10 @@ class ResolverMatch:
 
         if not hasattr(func, '__name__'):
             # A class-based view
-            self._func_path = '.'.join([func.__class__.__module__, func.__class__.__name__])
+            self._func_path = func.__class__.__module__ + '.' + func.__class__.__name__
         else:
             # A function-based view
-            self._func_path = '.'.join([func.__module__, func.__name__])
+            self._func_path = func.__module__ + '.' + func.__name__
 
         view_path = url_name or self._func_path
         self.view_name = ':'.join(self.namespaces + [view_path])

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -600,8 +600,8 @@ def _date_from_string(year, year_format, month='', month_format='', day='', day_
     Get a datetime.date object given a format string and a year, month, and day
     (only year is mandatory). Raise a 404 for an invalid date.
     """
-    format = delim.join((year_format, month_format, day_format))
-    datestr = delim.join((year, month, day))
+    format = year_format + delim + month_format + delim + day_format
+    datestr = year + delim + month + delim + day
     try:
         return datetime.datetime.strptime(datestr, format).date()
     except ValueError:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -183,7 +183,7 @@ def setup(verbosity, test_labels, parallel):
     installed_app_names = set(get_installed())
     for modpath, module_name in test_modules:
         if modpath:
-            module_label = '.'.join([modpath, module_name])
+            module_label = modpath + '.' + module_name
         else:
             module_label = module_name
         # if the module (or an ancestor) was named on the command line, or


### PR DESCRIPTION
Fixes [#28226](https://code.djangoproject.com/ticket/28226).

I removed all references of `.join()` with static arguments and replaced them with concatenation.

There is one largeish statement that's a bit big, but otherwise I think they look better. I also fixed up two cases of `map` and `filter` with generator expressions, I can leave those out and move them as a different MR as it's a bit out of scope.