### PR TITLE
Refs #16850 -- Removed obsolete simplejson support  in JSON serializer.

### DIFF
--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -21,9 +21,6 @@ class Serializer(PythonSerializer):
     internal_use_only = False
 
     def _init_options(self):
-        if json.__version__.split('.') >= ['2', '1', '3']:
-            # Use JS strings to represent Python Decimal instances (ticket #16850)
-            self.options.update({'use_decimal': False})
         self._current = None
         self.json_kwargs = self.options.copy()
         self.json_kwargs.pop('stream', None)


### PR DESCRIPTION
cpython's json version is 2.0.9 so this line is never used.