### PR TITLE
Refs #28207 -- Fixed contrib.auth.authenticate() if 'backend' is in the credentials.

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -67,7 +67,7 @@ def authenticate(request=None, **credentials):
     """
     for backend, backend_path in _get_backends(return_tuples=True):
         try:
-            user = _authenticate_with_backend(backend, backend_path, request, **credentials)
+            user = _authenticate_with_backend(backend, backend_path, request, credentials)
         except PermissionDenied:
             # This backend says to stop in our tracks - this user should not be allowed in at all.
             break
@@ -81,13 +81,14 @@ def authenticate(request=None, **credentials):
     user_login_failed.send(sender=__name__, credentials=_clean_credentials(credentials), request=request)
 
 
-def _authenticate_with_backend(backend, backend_path, request, **credentials):
+def _authenticate_with_backend(backend, backend_path, request, credentials):
     args = (request,)
     # Does the backend accept a request argument?
     try:
         inspect.getcallargs(backend.authenticate, request, **credentials)
     except TypeError:
         args = ()
+        credentials.pop('request', None)
         # Does the backend accept a request keyword argument?
         try:
             inspect.getcallargs(backend.authenticate, request=request, **credentials)


### PR DESCRIPTION
The Django Python Social Auth app passes `'backend'` as keyword argument
to `authenticate` [1], where it then causes a `TypeError`:

> TypeError: _authenticate_with_backend() got multiple values for argument 'backend'

This is a regression caused in https://github.com/django/django/commit/3008f30f.

Traceback:

    …
    File "…/app/app.py", line 375, in validate
      user = oauth2_user = request.backend.do_auth(attrs['access_token'])
    File "…/Vcs/social-core/social_core/utils.py", line 252, in wrapper
      return func(*args, **kwargs)
    File "…/Vcs/social-core/social_core/backends/oauth.py", line 409, in do_auth
      return self.strategy.authenticate(*args, **kwargs)
    File "…/Vcs/social-app-django/social_django/strategy.py", line 115, in authenticate
      return authenticate(*args, **kwargs)
    File "…/Vcs/django/django/contrib/auth/__init__.py", line 70, in authenticate
      user = _authenticate_with_backend(backend, backend_path, request, **credentials)
    TypeError: _authenticate_with_backend() got multiple values for argument 'backend'

1: https://github.com/python-social-auth/social-app-django/blob/b956d3f47aa01247258e8294a13cc806f15a5a6e/social_django/strategy.py#L111-L115