### PR TITLE
Fixed #28212 -- Allowed customizing the port that LiveServerTestCase uses.

### DIFF
--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -4,7 +4,14 @@ Django 1.11.2 release notes
 
 *Under development*
 
-Django 1.11.2 fixes several bugs in 1.11.1.
+Django 1.11.2 adds a minor feature and fixes several bugs in 1.11.1.
+
+Minor feature
+=============
+
+The new ``LiveServerTestCase.port`` attribute reallows the use case of binding
+to a specific port following the :ref:`bind to port zero
+<liveservertestcase-port-zero-change>` change in Django 1.11.
 
 Bugfixes
 ========

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -533,6 +533,8 @@ to support it.
 Also, the minimum supported version of psycopg2 is increased from 2.4.5 to
 2.5.4.
 
+.. _liveservertestcase-port-zero-change:
+
 ``LiveServerTestCase`` binds to port zero
 -----------------------------------------
 
@@ -541,6 +543,9 @@ Rather than taking a port range and iterating to find a free port,
 to assign a free port. The ``DJANGO_LIVE_TEST_SERVER_ADDRESS`` environment
 variable is no longer used, and as it's also no longer used, the
 ``manage.py test --liveserver`` option is removed.
+
+If you need to bind ``LiveServerTestCase`` to a specific port, use the ``port``
+attribute added in Django 1.11.2.
 
 Protection against insecure redirects in :mod:`django.contrib.auth` and ``i18n`` views
 --------------------------------------------------------------------------------------

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -644,6 +644,7 @@ rc
 readded
 reallow
 reallowed
+reallows
 rebase
 rebased
 rebasing

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -136,3 +136,21 @@ class LiveServerPort(LiveServerBase):
         finally:
             if hasattr(TestCase, 'server_thread'):
                 TestCase.server_thread.terminate()
+
+    def test_specified_port_bind(self):
+        """LiveServerTestCase.port customizes the server's port."""
+        TestCase = type(str('TestCase'), (LiveServerBase,), {})
+        # Find an open port and tell TestCase to use it.
+        s = socket.socket()
+        s.bind(('', 0))
+        TestCase.port = s.getsockname()[1]
+        s.close()
+        TestCase.setUpClass()
+        try:
+            self.assertEqual(
+                TestCase.port, TestCase.server_thread.port,
+                'Did not use specified port for LiveServerTestCase thread: %s' % TestCase.port
+            )
+        finally:
+            if hasattr(TestCase, 'server_thread'):
+                TestCase.server_thread.terminate()


### PR DESCRIPTION
This PR is based on ticket 28212. It allows the caller to specify which port
LiveServerTestCase listens on. This is useful in situations where you have to
expose ports before runtime (e.g. docker containers), which makes binding to
port 0 unusable.