### PR TITLE
Fixed #28229 -- Proper value of "next" template variable in LoginView

### DIFF
--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -35,3 +35,8 @@ Bugfixes
 
 * Prevented ``Paginator``’s unordered object list warning from evaluating a
   ``QuerySet`` (:ticket:`28284`).
+
+* Fixed the value of ``redirect_field_name`` in ``LoginView``’s template
+  context. It's now an empty string (as it is for the original function-based
+  ``login()`` view) if the corresponding parameter isn't sent in a request (in
+  particular, when the login page is accessed directly) (:ticket:`28229`).

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -835,6 +835,7 @@ class LoginRedirectAuthenticatedUser(AuthViewsTestCase):
         self.login()
         response = self.client.get(self.dont_redirect_url)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['next'], '')
 
     def test_guest(self):
         """If not logged in, stay on the same page."""


### PR DESCRIPTION
If LoginView was accessed directly, and "next" parameter is
specified neither in query string, nor in POST request body,
it shouldn't be replaced with the default REDIRECT_LOGIN_URL in
the template context. Otherwise it's not that easy to distinguish
that scenario from the one when user was redirected to this page
inside the template.

Meanwhile "next" is still replaced by an empty string if the URL is not
considered safe according to is_safe_url(), as it worked previously.