### PR TITLE
Fixed #28231 -- bulk_create: no conversion of objs to list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -591,6 +591,7 @@ answer newbie questions, and generally made Django that much better:
     Nicolas Lara <nicolaslara@gmail.com>
     Nicolas Noé <nicolas@niconoe.eu>
     Niran Babalola <niran@niran.org>
+    Nir Izraeli <nirizr@gmail.com>
     Nis Jørgensen <nis@superlativ.dk>
     Nowell Strite <http://nowell.strite.org/>
     Nuno Mariz <nmariz@gmail.com>

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -47,11 +47,12 @@ class BaseDatabaseOperations:
 
     def bulk_batch_size(self, fields, objs):
         """
-        Return the maximum allowed batch size for the backend. The fields
-        are the fields going to be inserted in the batch, the objs contains
-        all the objects to be inserted.
+        Return the maximum allowed batch size for the backend, or None for
+        unlimited. The fields are the fields going to be inserted in the
+        batch, the objs contains all the objects to be inserted.
+        This must always return either a positive integer or None.
         """
-        return len(objs)
+        return None
 
     def cache_key_culling_sql(self):
         """

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -24,9 +24,9 @@ class DatabaseOperations(BaseDatabaseOperations):
         if len(fields) == 1:
             return 500
         elif len(fields) > 1:
-            return self.connection.features.max_query_params // len(fields)
+            return max(self.connection.features.max_query_params // len(fields), 1)
         else:
-            return len(objs)
+            return None
 
     def check_expression_support(self, expression):
         bad_fields = (fields.DateField, fields.DateTimeField, fields.TimeField)

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -156,8 +156,8 @@ class Collector:
         """
         Return the objs in suitably sized batches for the used connection.
         """
-        conn_batch_size = max(
-            connections[self.using].ops.bulk_batch_size([field.name], objs), 1)
+        conn_batch_size = \
+            connections[self.using].ops.bulk_batch_size([field.name], objs) or len(objs)
         if len(objs) > conn_batch_size:
             return [objs[i:i + conn_batch_size]
                     for i in range(0, len(objs), conn_batch_size)]

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -425,11 +425,11 @@ class QuerySet:
                 self._populate_pk_values(objs_batch)
                 objs_with_pk, objs_without_pk = partition(lambda o: o.pk is None, objs_batch)
                 if objs_with_pk:
-                    self._insert(objs_with_pk, fields)
+                    self._insert(objs_with_pk, fields, using=self.db)
                 if objs_without_pk:
                     fields = [f for f in fields if not isinstance(f, AutoField)]
                     if connection.features.can_return_ids_from_bulk_insert:
-                        ids = self._insert(objs_without_pk, fields, return_id=True)
+                        ids = self._insert(objs_without_pk, fields, return_id=True, using=self.db)
                         if not isinstance(ids, list):
                             ids = [ids]
                         assert len(ids) == len(objs_without_pk)
@@ -438,7 +438,7 @@ class QuerySet:
                             obj_without_pk._state.adding = False
                             obj_without_pk._state.db = self.db
                     else:
-                        self._insert(objs_without_pk, fields)
+                        self._insert(objs_without_pk, fields, using=self.db)
 
         return objs
 

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1032,28 +1032,6 @@ class QuerySet:
     _insert.alters_data = True
     _insert.queryset_only = False
 
-    def _batched_insert(self, objs, fields, batch_size):
-        """
-        A helper method for bulk_create() to insert the bulk one batch at a
-        time. Insert recursively a batch from the front of the bulk and then
-        _batched_insert() the remaining objects again.
-        """
-        if not objs:
-            return
-        ops = connections[self.db].ops
-        batch_size = batch_size or ops.bulk_batch_size(fields, objs) or len(objs)
-        inserted_ids = []
-        for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:
-            if connections[self.db].features.can_return_ids_from_bulk_insert:
-                inserted_id = self._insert(item, fields=fields, using=self.db, return_id=True)
-                if isinstance(inserted_id, list):
-                    inserted_ids.extend(inserted_id)
-                else:
-                    inserted_ids.append(inserted_id)
-            else:
-                self._insert(item, fields=fields, using=self.db)
-        return inserted_ids
-
     def _clone(self, **kwargs):
         query = self.query.clone()
         if self._sticky_filter:

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -418,7 +418,7 @@ class QuerySet:
         self._for_write = True
         connection = connections[self.db]
         fields = self.model._meta.concrete_fields
-        batch_size = (batch_size or max(connection.ops.bulk_batch_size(fields, objs), 1))
+        batch_size = batch_size or connection.ops.bulk_batch_size(fields, objs)
         with transaction.atomic(using=self.db, savepoint=False):
             for objs_batch in batches(objs, batch_size):
                 objs_batch = list(objs_batch)
@@ -1041,7 +1041,7 @@ class QuerySet:
         if not objs:
             return
         ops = connections[self.db].ops
-        batch_size = (batch_size or max(ops.bulk_batch_size(fields, objs), 1))
+        batch_size = batch_size or ops.bulk_batch_size(fields, objs) or len(objs)
         inserted_ids = []
         for item in [objs[i:i + batch_size] for i in range(0, len(objs), batch_size)]:
             if connections[self.db].features.can_return_ids_from_bulk_insert:

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -1,6 +1,7 @@
 import copy
 import operator
 from functools import total_ordering, wraps
+from itertools import chain, islice
 
 
 # You can't trivially replace this with `functools.partial` because this binds
@@ -396,3 +397,24 @@ def partition(predicate, values):
     for item in values:
         results[predicate(item)].append(item)
     return results
+
+
+def batches(iterable, size):
+    """
+    Split an iterable object into multiple generator objects, each with up to
+    `size` items. This is handy to perform batch operations without first converting
+    entire generators to a list, and does not interfere with list input handling.
+    e.g.:
+
+        >>> b = batches(range(10), 3)
+
+        >>> map(list, b)
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
+    """
+    assert size is None or size > 0
+    if size is None:
+        yield iterable
+    else:
+        iterator = iter(iterable)
+        for first in iterator:
+            yield chain([first], islice(iterator, size - 1))

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -399,7 +399,7 @@ def partition(predicate, values):
     return results
 
 
-def batches(iterable, size):
+def batches(iterable, size=None):
     """
     Split an iterable object into multiple generator objects, each with up to
     `size` items. This is handy to perform batch operations without first converting

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -192,6 +192,30 @@ class BulkCreateTests(TestCase):
         TwoFields.objects.all().delete()
         TwoFields.objects.bulk_create(objs, batch_size=num_objs)
         self.assertEqual(TwoFields.objects.count(), num_objs)
+        TwoFields.objects.all().delete()
+        TwoFields.objects.bulk_create(objs, batch_size=num_objs + 1)
+        self.assertEqual(TwoFields.objects.count(), num_objs)
+
+    def test_batch_size_generators(self):
+        objs = (TwoFields(f1=i, f2=i) for i in range(0, 4))
+        num_objs = 4  # this has to be hardcoded
+        TwoFields.objects.bulk_create(objs, batch_size=1)
+        self.assertEqual(TwoFields.objects.count(), num_objs)
+        TwoFields.objects.all().delete()
+        objs = (TwoFields(f1=i, f2=i) for i in range(0, 4))
+        num_objs = 4  # this has to be hardcoded
+        TwoFields.objects.bulk_create(objs, batch_size=3)
+        self.assertEqual(TwoFields.objects.count(), num_objs)
+        TwoFields.objects.all().delete()
+        objs = (TwoFields(f1=i, f2=i) for i in range(0, 4))
+        num_objs = 4  # this has to be hardcoded
+        TwoFields.objects.bulk_create(objs, batch_size=num_objs)
+        self.assertEqual(TwoFields.objects.count(), num_objs)
+        TwoFields.objects.all().delete()
+        objs = (TwoFields(f1=i, f2=i) for i in range(0, 4))
+        num_objs = 4  # this has to be hardcoded
+        TwoFields.objects.bulk_create(objs, batch_size=num_objs + 1)
+        self.assertEqual(TwoFields.objects.count(), num_objs)
 
     def test_empty_model(self):
         NoFields.objects.bulk_create([NoFields() for i in range(2)])

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -319,7 +319,7 @@ class DeletionTests(TestCase):
         objs = [Avatar() for i in range(0, TEST_SIZE)]
         Avatar.objects.bulk_create(objs)
         # Calculate the number of queries needed.
-        batch_size = connection.ops.bulk_batch_size(['pk'], objs)
+        batch_size = connection.ops.bulk_batch_size(['pk'], objs) or len(objs)
         # The related fetches are done in batches.
         batches = int(ceil(float(len(objs)) / batch_size))
         # One query for Avatar.objects.all() and then one related fast delete for
@@ -336,7 +336,7 @@ class DeletionTests(TestCase):
         for i in range(TEST_SIZE):
             T.objects.create(s=s)
 
-        batch_size = max(connection.ops.bulk_batch_size(['pk'], range(TEST_SIZE)), 1)
+        batch_size = connection.ops.bulk_batch_size(['pk'], range(TEST_SIZE)) or TEST_SIZE
 
         # TEST_SIZE // batch_size (select related `T` instances)
         # + 1 (select related `U` instances)


### PR DESCRIPTION
Current implementation of QuerySet.bulk_create forcibly converts the iterable of objects to create(the `objs` parameter) to a list, regardless of the `batch_size` parameter. This uses newly created `utils.functional.batches` function to split objects into multiple batches with a max size of `batch_size` before iterating over the entire thing.

Some noteworthy changes:
1. This does have the caveat of splitting to batches before partitioning according to pk availability, so it has the chance of increasing the number of actually performed queries, each having less than batch_size objects. If desired, this may be mitigated by testing the type of objs or providing a default-off flag. In that case, more documentation is required.

2. Additionally, it now seems `_batched_insert` is unused (as most of it's functionality in now in batch_create), so I also suggest removing it.

3. To avoid the change of interface of bulk_batch_size (although it isn't used often), we can either add a parameter or move utils.functional.batches to QuerySet and make it a function dedicated to yielding batches, similarly to how [Collector.get_del_batches](https://github.com/django/django/blob/master/django/db/models/deletion.py#L155) is.

https://code.djangoproject.com/ticket/28231