### PR TITLE
Fix typo in contrib/admin/actions.py

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -16,7 +16,7 @@ def delete_selected(modeladmin, request, queryset):
     Default action which deletes the selected objects.
 
     This action first displays a confirmation page which shows all the
-    deleteable objects, or, if the user has no permission one of the related
+    deletable objects, or, if the user has no permission one of the related
     childs (foreignkeys), a "permission denied" message.
 
     Next, it deletes all selected objects and redirects back to the change list.


### PR DESCRIPTION
This PR fixes a typo of docstring in delete_selected method.