### PR TITLE
Refs #16870 -- Doc'd that CSRF protection requires the Referer header.

### DIFF
--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -41,6 +41,7 @@ CSRF_FAILURE_TEMPLATE = """
 {% if no_referer %}
   <p>{{ no_referer1 }}</p>
   <p>{{ no_referer2 }}</p>
+  <p>{{ no_referer3 }}</p>
 {% endif %}
 {% if no_cookie %}
   <p>{{ no_cookie1 }}</p>
@@ -119,6 +120,13 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
             "If you have configured your browser to disable 'Referer' headers, "
             "please re-enable them, at least for this site, or for HTTPS "
             "connections, or for 'same-origin' requests."),
+        'no_referer3': _(
+            "If you are using the <meta name=\"referrer\" "
+            "content=\"no-referrer\"> tag or including the 'Referrer-Policy: "
+            "no-referrer' header, please remove them. The CSRF protection "
+            "requires the 'Referer' header to do strict referer checking. If "
+            "you're concerned about privacy, use alternatives like "
+            "<a rel=\"noreferrer\" ...> for links to third-party sites."),
         'no_cookie': reason == REASON_NO_CSRF_COOKIE,
         'no_cookie1': _(
             "You are seeing this message because this site requires a CSRF "

--- a/docs/ref/csrf.txt
+++ b/docs/ref/csrf.txt
@@ -315,7 +315,19 @@ the HOST header <host-headers-virtual-hosting>` and that there aren't any
 (because XSS vulnerabilities already let an attacker do anything a CSRF
 vulnerability allows and much worse).
 
+.. admonition:: Removing the ``Referer`` header
+
+    To avoid disclosing the referrer URL to third-party sites, you might want
+    to `disable the referer`_ on your site's ``<a>`` tags. For example, you
+    might use the ``<meta name="referrer" content="no-referrer">`` tag or
+    include the ``Referrer-Policy: no-referrer`` header. Due to the CSRF
+    protection's strict referer checking on HTTPS requests, those techniques
+    cause a CSRF failure on requests with 'unsafe' methods. Instead, use
+    alternatives like ``<a rel="noreferrer" ...>"`` for links to third-party
+    sites.
+
 .. _BREACH: http://breachattack.com/
+.. _disable the referer: https://www.w3.org/TR/referrer-policy/#referrer-policy-delivery
 
 Caching
 =======

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -55,6 +55,13 @@ class CsrfViewTests(SimpleTestCase):
             'HTTPS connections, or for &#39;same-origin&#39; requests.',
             status_code=403,
         )
+        self.assertContains(
+            response,
+            'If you are using the &lt;meta name=&quot;referrer&quot; '
+            'content=&quot;no-referrer&quot;&gt; tag or including the '
+            '&#39;Referrer-Policy: no-referrer&#39; header, please remove them.',
+            status_code=403,
+        )
 
     def test_no_cookies(self):
         """


### PR DESCRIPTION
As requested in https://code.djangoproject.com/ticket/16870#comment:10
Discussed in https://groups.google.com/forum/#!topic/django-developers/ntkKUEr4sTM

Django forms break due strict referrer checking if `<meta name="referrer" content="no-referrer">` is used on the form page. Documented this behavior as a warning on docs/ref/csrf.txt and on
`csrf_failure` message if `DEBUG=True`.

I didn't suggested in docs the use of "origin-when-cross-origin" instead of "no-referrer" because some browsers (like [old Safari versions](https://bugs.webkit.org/show_bug.cgi?id=154588)) default to no-referrer if the [new spec](https://html.spec.whatwg.org/multipage/semantics.html#meta-referrer) values are used.

If messages can be improved somehow, please let me know.