### PR TITLE
Fixed typo at advanced testing docs

### DIFF
--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -203,7 +203,7 @@ example database configuration::
             },
         },
         'diamonds': {
-             ... db settings
+            # ... db settings
             'TEST': {
                 'DEPENDENCIES': [],
             },


### PR DESCRIPTION
Hi!
This PR adds slash character to code comment at [Controlling creation order for test databases](https://docs.djangoproject.com/en/1.11/topics/testing/advanced/#controlling-creation-order-for-test-databases) section of Advanced testing docs.