### PR TITLE
Update libgdal.py for OSGeo4Win compatibility.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -21,7 +21,7 @@ if lib_path:
     lib_names = None
 elif os.name == 'nt':
     # Windows NT shared libraries
-    lib_names = ['gdal21', 'gdal20', 'gdal111', 'gdal110', 'gdal19']
+    lib_names = ['gdal21', 'gdal20', 'gdal111', 'gdal110', 'gdal19', 'gdal202']
 elif os.name == 'posix':
     # *NIX library names.
     lib_names = ['gdal', 'GDAL', 'gdal2.1.0', 'gdal2.0.0', 'gdal1.11.0', 'gdal1.10.0', 'gdal1.9.0']


### PR DESCRIPTION
This fixes an issue that was preventing GeoDjango from working on Windows machines with the version of  OSGeo4Win that is linked to in the docs. 

Ticket for reference:
https://code.djangoproject.com/ticket/28237