### PR TITLE
Fix `manage.py` file command line execution

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -29,7 +29,7 @@ you're releasing the source code for your project, a common practice is to
 publish suitable settings for development, and to use a private settings
 module for production.
 
-Run ``manage.py check --deploy``
+Run ``python manage.py check --deploy``
 ================================
 
 Some of the checks described below can be automated using the :option:`check

--- a/docs/howto/initial-data.txt
+++ b/docs/howto/initial-data.txt
@@ -13,7 +13,7 @@ Providing initial data with fixtures
 
 A fixture is a collection of data that Django knows how to import into a
 database. The most straightforward way of creating a fixture if you've already
-got some data is to use the :djadmin:`manage.py dumpdata <dumpdata>` command.
+got some data is to use the :djadmin:`./manage.py dumpdata <dumpdata>` command.
 Or, you can write fixtures by hand; fixtures can be written as JSON, XML or YAML
 (with PyYAML_ installed) documents. The :doc:`serialization documentation
 </topics/serialization>` has more details about each of these supported
@@ -62,7 +62,7 @@ And here's that same fixture as YAML:
 
 You'll store this data in a ``fixtures`` directory inside your app.
 
-Loading data is easy: just call :djadmin:`manage.py loaddata <loaddata>`
+Loading data is easy: just call :djadmin:`./manage.py loaddata <loaddata>`
 ``<fixturename>``, where ``<fixturename>`` is the name of the fixture file
 you've created. Each time you run :djadmin:`loaddata`, the data will be read
 from the fixture and re-loaded into the database. Note this means that if you
@@ -76,7 +76,7 @@ By default, Django looks in the ``fixtures`` directory inside each app for
 fixtures. You can set the :setting:`FIXTURE_DIRS` setting to a list of
 additional directories where Django should look.
 
-When running :djadmin:`manage.py loaddata <loaddata>`, you can also
+When running :djadmin:`./manage.py loaddata <loaddata>`, you can also
 specify a path to a fixture file, which overrides searching the usual
 directories.
 

--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -103,7 +103,7 @@ Testing
 When the new environment is set up, :doc:`run the full test suite
 </topics/testing/overview>` for your application. Again, it's useful to turn
 on deprecation warnings on so they're shown in the test output (you can also
-use the flag if you test your app manually using ``manage.py runserver``):
+use the flag if you test your app manually using ``./manage.py runserver``):
 
 .. code-block:: console
 

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -281,7 +281,7 @@ Methods
         also raw SQL queries via ``django.db.connection``. Your
         :meth:`ready()` method will run during startup of every management
         command. For example, even though the test database configuration is
-        separate from the production settings, ``manage.py test`` would still
+        separate from the production settings, ``./manage.py test`` would still
         execute some queries against your **production** database!
 
     .. note::

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -85,7 +85,7 @@ The ``ContentType`` model
 Let's look at an example to see how this works. If you already have
 the :mod:`~django.contrib.contenttypes` application installed, and then add
 :mod:`the sites application <django.contrib.sites>` to your
-:setting:`INSTALLED_APPS` setting and run ``manage.py migrate`` to install it,
+:setting:`INSTALLED_APPS` setting and run ``./manage.py migrate`` to install it,
 the model :class:`django.contrib.sites.models.Site` will be installed into
 your database. Along with it a new instance of
 :class:`~django.contrib.contenttypes.models.ContentType` will be

--- a/docs/ref/contrib/redirects.txt
+++ b/docs/ref/contrib/redirects.txt
@@ -19,13 +19,14 @@ To install the redirects app, follow these steps:
 2. Add ``'django.contrib.redirects'`` to your :setting:`INSTALLED_APPS` setting.
 3. Add ``'django.contrib.redirects.middleware.RedirectFallbackMiddleware'``
    to your :setting:`MIDDLEWARE` setting.
-4. Run the command :djadmin:`manage.py migrate <migrate>`.
+4. Run the command :djadmin:`./manage.py migrate <migrate>`.
 
 How it works
 ============
 
-``manage.py migrate`` creates a ``django_redirect`` table in your database. This
-is a simple lookup table with ``site_id``, ``old_path`` and ``new_path`` fields.
+``./manage.py migrate`` creates a ``django_redirect`` table in your database.
+This is a simple lookup table with ``site_id``, ``old_path`` and ``new_path``
+fields.
 
 The :class:`~django.contrib.redirects.middleware.RedirectFallbackMiddleware`
 does all of the work. Each time any Django application raises a 404

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -40,7 +40,7 @@ Usage
 .. code-block:: console
 
     $ django-admin <command> [options]
-    $ manage.py <command> [options]
+    $ ./manage.py <command> [options]
     $ python -m django <command> [options]
 
 ``command`` should be one of the commands listed in this document.

--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -58,11 +58,11 @@ Table names
 To save you time, Django automatically derives the name of the database table
 from the name of your model class and the app that contains it. A model's
 database table name is constructed by joining the model's "app label" -- the
-name you used in :djadmin:`manage.py startapp <startapp>` -- to the model's
+name you used in :djadmin:`./manage.py startapp <startapp>` -- to the model's
 class name, with an underscore between them.
 
 For example, if you have an app ``bookstore`` (as created by
-``manage.py startapp bookstore``), a model defined as ``class Book`` will have
+``./manage.py startapp bookstore``), a model defined as ``class Book`` will have
 a database table named ``bookstore_book``.
 
 To override the database table name, use the ``db_table`` parameter in

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -291,7 +291,7 @@ can or cannot do with Task instances, specific to your application::
             )
 
 The only thing this does is create those extra permissions when you run
-:djadmin:`manage.py migrate <migrate>` (the function that creates permissions
+:djadmin:`./manage.py migrate <migrate>` (the function that creates permissions
 is connected to the :data:`~django.db.models.signals.post_migrate` signal).
 Your code is in charge of checking the value of these permissions when a user
 is trying to access the functionality provided by the application (viewing
@@ -404,7 +404,7 @@ model, but you'll be able to customize it in the future if the need arises::
         pass
 
 Don't forget to point :setting:`AUTH_USER_MODEL` to it. Do this before creating
-any migrations or running ``manage.py migrate`` for the first time.
+any migrations or running :djadmin:`./manage.py migrate` for the first time.
 
 Also, register the model in the app's ``admin.py``::
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -85,8 +85,8 @@ function is used when creating a user.
 
 To change a user's password, you have several options:
 
-:djadmin:`manage.py changepassword *username* <changepassword>` offers a method
-of changing a user's password from the command line. It prompts you to
+:djadmin:`./manage.py changepassword *username* <changepassword>` offers a
+method of changing a user's password from the command line. It prompts you to
 change the password of a given user which you must enter twice. If
 they both match, the new password will be changed immediately. If you
 do not supply a user, the command will attempt to change the password
@@ -202,12 +202,12 @@ setting, it will ensure that three default permissions -- add, change and
 delete -- are created for each Django model defined in one of your installed
 applications.
 
-These permissions will be created when you run :djadmin:`manage.py migrate
+These permissions will be created when you run :djadmin:`./manage.py migrate
 <migrate>`; the first time you run ``migrate`` after adding
 ``django.contrib.auth`` to :setting:`INSTALLED_APPS`, the default permissions
 will be created for all previously-installed models, as well as for any new
 models being installed at that time. Afterward, it will create default
-permissions for new models each time you run :djadmin:`manage.py migrate
+permissions for new models each time you run :djadmin:`./manage.py migrate
 <migrate>` (the function that creates permissions is connected to the
 :data:`~django.db.models.signals.post_migrate` signal).
 

--- a/docs/topics/auth/index.txt
+++ b/docs/topics/auth/index.txt
@@ -67,9 +67,9 @@ and these items in your :setting:`MIDDLEWARE` setting:
 2. :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` associates
    users with requests using sessions.
 
-With these settings in place, running the command ``manage.py migrate`` creates
-the necessary database tables for auth related models and permissions for any
-models defined in your installed apps.
+With these settings in place, running the command :djadmin:`./manage.py migrate`
+creates the necessary database tables for auth related models and permissions
+for any models defined in your installed apps.
 
 Usage
 =====

--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -67,7 +67,7 @@ your ``models.py``.
 
 For example, if the models for your application live in the module
 ``myapp.models`` (the package structure that is created for an
-application by the :djadmin:`manage.py startapp <startapp>` script),
+application by the :djadmin:`./manage.py startapp <startapp>` script),
 :setting:`INSTALLED_APPS` should read, in part::
 
     INSTALLED_APPS = [
@@ -77,8 +77,8 @@ application by the :djadmin:`manage.py startapp <startapp>` script),
     ]
 
 When you add new apps to :setting:`INSTALLED_APPS`, be sure to run
-:djadmin:`manage.py migrate <migrate>`, optionally making migrations
-for them first with :djadmin:`manage.py makemigrations <makemigrations>`.
+:djadmin:`./manage.py migrate <migrate>`, optionally making migrations
+for them first with :djadmin:`./manage.py makemigrations <makemigrations>`.
 
 Fields
 ======
@@ -1411,7 +1411,7 @@ any model field in any ancestor model.
 Organizing models in a package
 ==============================
 
-The :djadmin:`manage.py startapp <startapp>` command creates an application
+The :djadmin:`./manage.py startapp <startapp>` command creates an application
 structure that includes a ``models.py`` file. If you have many models,
 organizing them in separate files may be useful.
 

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -59,7 +59,7 @@ options that make it very powerful.
     Where did the name of the ``Person`` table come from in that example?
 
     By default, Django figures out a database table name by joining the
-    model's "app label" -- the name you used in ``manage.py startapp`` -- to
+    model's "app label" -- the name you used in ``./manage.py startapp`` -- to
     the model's class name, with an underscore between them. In the example
     we've assumed that the ``Person`` model lives in an app named ``myapp``,
     so its table would be ``myapp_person``.

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -44,7 +44,7 @@ Using database-backed sessions
 If you want to use a database-backed session, you need to add
 ``'django.contrib.sessions'`` to your :setting:`INSTALLED_APPS` setting.
 
-Once you have configured your installation, run ``manage.py migrate``
+Once you have configured your installation, run ``./manage.py migrate``
 to install the single database table that stores session data.
 
 .. _cached-sessions-backend:

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -103,7 +103,7 @@ database bindings are installed.
 * If you're using an unofficial 3rd party backend, please consult the
   documentation provided for any additional requirements.
 
-If you plan to use Django's ``manage.py migrate`` command to automatically
+If you plan to use Django's ``./manage.py migrate`` command to automatically
 create database tables for your models (after first installing Django and
 creating a project), you'll need to ensure that Django has permission to create
 and alter tables in the database you're using; if you plan to manually create

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -265,8 +265,8 @@ file, all Django tests run with :setting:`DEBUG`\=False. This is to ensure that
 the observed output of your code matches what will be seen in a production
 setting.
 
-Caches are not cleared after each test, and running "manage.py test fooapp" can
-insert data from the tests into the cache of a live system if you run your
+Caches are not cleared after each test, and running "./manage.py test fooapp"
+can insert data from the tests into the cache of a live system if you run your
 tests in production because, unlike databases, a separate "test cache" is not
 used. This behavior `may change`_ in the future.
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1037,7 +1037,7 @@ database. For example, if your site has user accounts, you might set up a
 fixture of fake user accounts in order to populate your database during tests.
 
 The most straightforward way of creating a fixture is to use the
-:djadmin:`manage.py dumpdata <dumpdata>` command. This assumes you
+:djadmin:`./manage.py dumpdata <dumpdata>` command. This assumes you
 already have some data in your database. See the :djadmin:`dumpdata
 documentation<dumpdata>` for more details.
 


### PR DESCRIPTION
Today I'm tutoring somebody as they're following the Django tutorial. As they navigated the docs they tried a `manage.py` command which returned a `bash: manage.py: command not found` error.

This commit updates the docs so `manage.py` is always run.