### PR TITLE
Refs #28181 -- Corrected detection of GDAL 2.1 on Windows.

### DIFF
--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -21,7 +21,7 @@ if lib_path:
     lib_names = None
 elif os.name == 'nt':
     # Windows NT shared libraries
-    lib_names = ['gdal21', 'gdal20', 'gdal111', 'gdal110', 'gdal19']
+    lib_names = ['gdal201', 'gdal20', 'gdal111', 'gdal110', 'gdal19']
 elif os.name == 'posix':
     # *NIX library names.
     lib_names = ['gdal', 'GDAL', 'gdal2.1.0', 'gdal2.0.0', 'gdal1.11.0', 'gdal1.10.0', 'gdal1.9.0']

--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -42,3 +42,5 @@ Bugfixes
 
 * Prevented ``Subquery`` from adding an unnecessary ``CAST`` which resulted in
   invalid SQL (:ticket:`28199`).
+
+* Corrected detection of GDAL 2.1 on Windows (:ticket:`28181`).


### PR DESCRIPTION
Follow up to a404f75f92971634c76330f3742261d33ccecca1.