### PR TITLE
Corrected REPL example in docs for Python 3

### DIFF
--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -1215,8 +1215,8 @@ by setting the name of the field to ``None`` on the subclass. For example::
     >>> class ChildForm(ParentForm):
     ...     name = None
 
-    >>> ChildForm().fields.keys()
-    ... ['age']
+    >>> list(ChildForm().fields)
+    ['age']
 
 .. _form-prefix:
 


### PR DESCRIPTION
In Python 3, dict.keys() does not return a list, it returns dict_keys.
Further, Form.fields is an OrderedDict so it would be odict_keys. Coerce
the fields to a list in the example so the output is correct.