### PR TITLE
Fixed #28248 -- Fixed password reset tokens being valid for 1 day longer than PASSWORD_RESET_TIMEOUT_DAYS.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -42,7 +42,7 @@ class PasswordResetTokenGenerator:
             return False
 
         # Check the timestamp is within limit
-        if (self._num_days(self._today()) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS:
+        if (self._num_days(self._today()) - ts) >= settings.PASSWORD_RESET_TIMEOUT_DAYS:
             return False
 
         return True

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -355,6 +355,12 @@ Miscellaneous
   connection, those queries could be included as part of the
   ``assertNumQueries()`` count.
 
+* The ``PASSWORD_RESET_TIMEOUT_DAYS`` setting is more properly respected in
+  ``contrib.auth`` password reset. Previously, resets were allowed for one day
+  longer than expected. For example, with the default of
+  ``PASSWORD_RESET_TIMEOUT_DAYS = 3``, password reset tokens are now valid for
+  72 hours rather than 96 hours.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -43,11 +43,12 @@ class TokenGeneratorTest(TestCase):
         user = User.objects.create_user('tokentestuser', 'test2@example.com', 'testpw')
         p0 = PasswordResetTokenGenerator()
         tk1 = p0.make_token(user)
-        p1 = Mocked(date.today() + timedelta(settings.PASSWORD_RESET_TIMEOUT_DAYS))
+        p1 = Mocked(date.today() + timedelta(days=settings.PASSWORD_RESET_TIMEOUT_DAYS, seconds=-1))
         self.assertTrue(p1.check_token(user, tk1))
-
-        p2 = Mocked(date.today() + timedelta(settings.PASSWORD_RESET_TIMEOUT_DAYS + 1))
+        p2 = Mocked(date.today() + timedelta(days=settings.PASSWORD_RESET_TIMEOUT_DAYS))
         self.assertFalse(p2.check_token(user, tk1))
+        p3 = Mocked(date.today() + timedelta(days=settings.PASSWORD_RESET_TIMEOUT_DAYS, seconds=1))
+        self.assertFalse(p3.check_token(user, tk1))
 
     def test_check_token_with_nonexistent_token_and_user(self):
         user = User.objects.create_user('tokentestuser', 'test2@example.com', 'testpw')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28248