### PR TITLE
Fixed dict_keys to list comparison that always evaluated as False.

### DIFF
--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -550,7 +550,7 @@ class Queries1Tests(TestCase):
         # normal. A normal dict would thus fail.)
         s = [('a', '%s'), ('b', '%s')]
         params = ['one', 'two']
-        if {'a': 1, 'b': 2}.keys() == ['a', 'b']:
+        if list({'a': 1, 'b': 2}) == ['a', 'b']:
             s.reverse()
             params.reverse()
 


### PR DESCRIPTION
In Python 3, `dict.keys()` does not return a list, it returns a dict_keys. Comparison to a list will always evaluate as False. This can be verified with the REPL:

```python
>>> {'a': 1}.keys() == ['a']
False
```

Changed to coerce the dict to a list for comparison.