### PR TITLE
Fixed #28250 -- Ignored soft applied migrations in consistency check.

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
                     for app_label in consistency_check_labels
                     for model in apps.get_app_config(app_label).get_models()
             )):
-                loader.check_consistent_history(connection)
+                loader.check_consistent_history(connection, fake_initial=True)
 
         # Before anything else, see if there's conflicting apps and drop out
         # hard if there are any and they don't want to merge

--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         executor = MigrationExecutor(connection, self.migration_progress_callback)
 
         # Raise an error if any migrations are applied before their dependencies.
-        executor.loader.check_consistent_history(connection)
+        executor.loader.check_consistent_history(connection, fake_initial=options['fake_initial'])
 
         # Before anything else, see if there's conflicting apps and drop out
         # hard if there are any

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -1,6 +1,3 @@
-from django.apps.registry import apps as global_apps
-from django.db import migrations, router
-
 from .exceptions import InvalidMigrationPlan
 from .loader import MigrationLoader
 from .recorder import MigrationRecorder
@@ -231,7 +228,7 @@ class MigrationExecutor:
         if not fake:
             if fake_initial:
                 # Test to see if this is an already-applied initial migration
-                applied, state = self.detect_soft_applied(state, migration)
+                applied, state = self.loader.detect_soft_applied(state, migration)
                 if applied:
                     fake = True
             if not fake:
@@ -283,82 +280,3 @@ class MigrationExecutor:
             all_applied = all(m in applied for m in migration.replaces)
             if all_applied and key not in applied:
                 self.recorder.record_applied(*key)
-
-    def detect_soft_applied(self, project_state, migration):
-        """
-        Test whether a migration has been implicitly applied - that the
-        tables or columns it would create exist. This is intended only for use
-        on initial migrations (as it only looks for CreateModel and AddField).
-        """
-        def should_skip_detecting_model(migration, model):
-            """
-            No need to detect tables for proxy models, unmanaged models, or
-            models that can't be migrated on the current database.
-            """
-            return (
-                model._meta.proxy or not model._meta.managed or not
-                router.allow_migrate(
-                    self.connection.alias, migration.app_label,
-                    model_name=model._meta.model_name,
-                )
-            )
-
-        if migration.initial is None:
-            # Bail if the migration isn't the first one in its app
-            if any(app == migration.app_label for app, name in migration.dependencies):
-                return False, project_state
-        elif migration.initial is False:
-            # Bail if it's NOT an initial migration
-            return False, project_state
-
-        if project_state is None:
-            after_state = self.loader.project_state((migration.app_label, migration.name), at_end=True)
-        else:
-            after_state = migration.mutate_state(project_state)
-        apps = after_state.apps
-        found_create_model_migration = False
-        found_add_field_migration = False
-        existing_table_names = self.connection.introspection.table_names(self.connection.cursor())
-        # Make sure all create model and add field operations are done
-        for operation in migration.operations:
-            if isinstance(operation, migrations.CreateModel):
-                model = apps.get_model(migration.app_label, operation.name)
-                if model._meta.swapped:
-                    # We have to fetch the model to test with from the
-                    # main app cache, as it's not a direct dependency.
-                    model = global_apps.get_model(model._meta.swapped)
-                if should_skip_detecting_model(migration, model):
-                    continue
-                if model._meta.db_table not in existing_table_names:
-                    return False, project_state
-                found_create_model_migration = True
-            elif isinstance(operation, migrations.AddField):
-                model = apps.get_model(migration.app_label, operation.model_name)
-                if model._meta.swapped:
-                    # We have to fetch the model to test with from the
-                    # main app cache, as it's not a direct dependency.
-                    model = global_apps.get_model(model._meta.swapped)
-                if should_skip_detecting_model(migration, model):
-                    continue
-
-                table = model._meta.db_table
-                field = model._meta.get_field(operation.name)
-
-                # Handle implicit many-to-many tables created by AddField.
-                if field.many_to_many:
-                    if field.remote_field.through._meta.db_table not in existing_table_names:
-                        return False, project_state
-                    else:
-                        found_add_field_migration = True
-                        continue
-
-                column_names = [
-                    column.name for column in
-                    self.connection.introspection.get_table_description(self.connection.cursor(), table)
-                ]
-                if field.column not in column_names:
-                    return False, project_state
-                found_add_field_migration = True
-        # If we get this far and we found at least one CreateModel or AddField migration,
-        # the migration is considered implicitly applied.
-        return (found_create_model_migration or found_add_field_migration), after_state

--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -2,8 +2,9 @@ import os
 import sys
 from importlib import import_module, reload
 
-from django.apps import apps
+from django.apps import apps as global_apps
 from django.conf import settings
+from django.db import migrations, router
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 
@@ -58,7 +59,7 @@ class MigrationLoader:
         if app_label in settings.MIGRATION_MODULES:
             return settings.MIGRATION_MODULES[app_label], True
         else:
-            app_package_name = apps.get_app_config(app_label).name
+            app_package_name = global_apps.get_app_config(app_label).name
             return '%s.%s' % (app_package_name, MIGRATIONS_MODULE_NAME), False
 
     def load_disk(self):
@@ -66,7 +67,7 @@ class MigrationLoader:
         self.disk_migrations = {}
         self.unmigrated_apps = set()
         self.migrated_apps = set()
-        for app_config in apps.get_app_configs():
+        for app_config in global_apps.get_app_configs():
             # Get the migrations module directory
             module_name, explicit = self.migrations_module(app_config.label)
             if module_name is None:
@@ -314,3 +315,82 @@ class MigrationLoader:
         See graph.make_state() for the meaning of "nodes" and "at_end".
         """
         return self.graph.make_state(nodes=nodes, at_end=at_end, real_apps=list(self.unmigrated_apps))
+
+    def detect_soft_applied(self, project_state, migration):
+        """
+        Test whether a migration has been implicitly applied - that the
+        tables or columns it would create exist. This is intended only for use
+        on initial migrations (as it only looks for CreateModel and AddField).
+        """
+        def should_skip_detecting_model(migration, model):
+            """
+            No need to detect tables for proxy models, unmanaged models, or
+            models that can't be migrated on the current database.
+            """
+            return (
+                model._meta.proxy or not model._meta.managed or not
+                router.allow_migrate(
+                    self.connection.alias, migration.app_label,
+                    model_name=model._meta.model_name,
+                )
+            )
+
+        if migration.initial is None:
+            # Bail if the migration isn't the first one in its app
+            if any(app == migration.app_label for app, name in migration.dependencies):
+                return False, project_state
+        elif migration.initial is False:
+            # Bail if it's NOT an initial migration
+            return False, project_state
+
+        if project_state is None:
+            after_state = self.project_state((migration.app_label, migration.name), at_end=True)
+        else:
+            after_state = migration.mutate_state(project_state)
+        apps = after_state.apps
+        found_create_model_migration = False
+        found_add_field_migration = False
+        existing_table_names = self.connection.introspection.table_names(self.connection.cursor())
+        # Make sure all create model and add field operations are done
+        for operation in migration.operations:
+            if isinstance(operation, migrations.CreateModel):
+                model = apps.get_model(migration.app_label, operation.name)
+                if model._meta.swapped:
+                    # We have to fetch the model to test with from the
+                    # main app cache, as it's not a direct dependency.
+                    model = global_apps.get_model(model._meta.swapped)
+                if should_skip_detecting_model(migration, model):
+                    continue
+                if model._meta.db_table not in existing_table_names:
+                    return False, project_state
+                found_create_model_migration = True
+            elif isinstance(operation, migrations.AddField):
+                model = apps.get_model(migration.app_label, operation.model_name)
+                if model._meta.swapped:
+                    # We have to fetch the model to test with from the
+                    # main app cache, as it's not a direct dependency.
+                    model = global_apps.get_model(model._meta.swapped)
+                if should_skip_detecting_model(migration, model):
+                    continue
+
+                table = model._meta.db_table
+                field = model._meta.get_field(operation.name)
+
+                # Handle implicit many-to-many tables created by AddField.
+                if field.many_to_many:
+                    if field.remote_field.through._meta.db_table not in existing_table_names:
+                        return False, project_state
+                    else:
+                        found_add_field_migration = True
+                        continue
+
+                column_names = [
+                    column.name for column in
+                    self.connection.introspection.get_table_description(self.connection.cursor(), table)
+                ]
+                if field.column not in column_names:
+                    return False, project_state
+                found_add_field_migration = True
+        # If we get this far and we found at least one CreateModel or AddField migration,
+        # the migration is considered implicitly applied.
+        return (found_create_model_migration or found_add_field_migration), after_state

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -326,7 +326,7 @@ class ExecutorTests(MigrationTestBase):
         global_apps.get_app_config("migrations").models["author"] = migrations_apps.get_model("migrations", "author")
         try:
             migration = executor.loader.get_migration("auth", "0001_initial")
-            self.assertIs(executor.detect_soft_applied(None, migration)[0], True)
+            self.assertIs(executor.loader.detect_soft_applied(None, migration)[0], True)
         finally:
             connection.introspection.table_names = old_table_names
             del global_apps.get_app_config("migrations").models["author"]
@@ -343,7 +343,7 @@ class ExecutorTests(MigrationTestBase):
     )
     def test_detect_soft_applied_add_field_manytomanyfield(self):
         """
-        executor.detect_soft_applied() detects ManyToManyField tables from an
+        loader.detect_soft_applied() detects ManyToManyField tables from an
         AddField operation. This checks the case of AddField in a migration
         with other operations (0001) and the case of AddField in its own
         migration (0002).
@@ -365,9 +365,9 @@ class ExecutorTests(MigrationTestBase):
             self.assertTableExists(table)
         # Table detection sees 0001 is applied but not 0002.
         migration = executor.loader.get_migration("migrations", "0001_initial")
-        self.assertIs(executor.detect_soft_applied(None, migration)[0], True)
+        self.assertIs(executor.loader.detect_soft_applied(None, migration)[0], True)
         migration = executor.loader.get_migration("migrations", "0002_initial")
-        self.assertIs(executor.detect_soft_applied(None, migration)[0], False)
+        self.assertIs(executor.loader.detect_soft_applied(None, migration)[0], False)
 
         # Create the tables for both migrations but make it look like neither
         # has been applied.
@@ -378,7 +378,7 @@ class ExecutorTests(MigrationTestBase):
         executor.migrate([("migrations", None)], fake=True)
         # Table detection sees 0002 is applied.
         migration = executor.loader.get_migration("migrations", "0002_initial")
-        self.assertIs(executor.detect_soft_applied(None, migration)[0], True)
+        self.assertIs(executor.loader.detect_soft_applied(None, migration)[0], True)
 
         # Leave the tables for 0001 except the many-to-many table. That missing
         # table should cause detect_soft_applied() to return False.
@@ -386,7 +386,7 @@ class ExecutorTests(MigrationTestBase):
             for table in tables[2:]:
                 editor.execute(editor.sql_delete_table % {"table": table})
         migration = executor.loader.get_migration("migrations", "0001_initial")
-        self.assertIs(executor.detect_soft_applied(None, migration)[0], False)
+        self.assertIs(executor.loader.detect_soft_applied(None, migration)[0], False)
 
         # Cleanup by removing the remaining tables.
         with connection.schema_editor() as editor:


### PR DESCRIPTION
Ignored initial migrations that have been soft applied and may be faked
with the --fake-initial flag in the migration history consistency
check. Does not ignore the initial migration if a later migration in
the same app has been recorded as applied.

Thanks to Raphaël Hertzog for the initial patch.

Ticket: https://code.djangoproject.com/ticket/28250