### PR TITLE
Increased initial and autoextend size of the Oracle tablespaces datafiles used for tests.

### DIFF
--- a/django/db/backends/oracle/creation.py
+++ b/django/db/backends/oracle/creation.py
@@ -189,12 +189,12 @@ class DatabaseCreation(BaseDatabaseCreation):
             print("_create_test_db(): dbname = %s" % parameters['user'])
         statements = [
             """CREATE TABLESPACE %(tblspace)s
-               DATAFILE '%(datafile)s' SIZE 20M
-               REUSE AUTOEXTEND ON NEXT 10M MAXSIZE %(maxsize)s
+               DATAFILE '%(datafile)s' SIZE 50M
+               REUSE AUTOEXTEND ON NEXT 20M MAXSIZE %(maxsize)s
             """,
             """CREATE TEMPORARY TABLESPACE %(tblspace_temp)s
-               TEMPFILE '%(datafile_tmp)s' SIZE 20M
-               REUSE AUTOEXTEND ON NEXT 10M MAXSIZE %(maxsize_tmp)s
+               TEMPFILE '%(datafile_tmp)s' SIZE 50M
+               REUSE AUTOEXTEND ON NEXT 20M MAXSIZE %(maxsize_tmp)s
             """,
         ]
         # Ignore "tablespace already exists" error when keepdb is on.


### PR DESCRIPTION
Tablespace datafile autoextend can be time-consuming, therefore I propose to increase initial and autoextend size to more reasonable values.