### PR TITLE
Fixed #28266 -- Fixed typo in docs/ref/models/instances.txt.

### DIFF
--- a/docs/ref/models/instances.txt
+++ b/docs/ref/models/instances.txt
@@ -99,7 +99,7 @@ are loaded from the database::
                 values.pop() if f.attname in field_names else DEFERRED
                 for f in cls._meta.concrete_fields
             ]
-        new = cls(*values)
+        instance = cls(*values)
         instance._state.adding = False
         instance._state.db = db
         # customization to store the original field values on the instance


### PR DESCRIPTION
The from_db example didn't work - creating a new instance called new, then referring to instance. Needed to be one or the other.