### PR TITLE
Removed unused django.contrib.gis.shortcuts.render_to_text()

### DIFF
--- a/django/contrib/gis/shortcuts.py
+++ b/django/contrib/gis/shortcuts.py
@@ -38,8 +38,3 @@ def render_to_kmz(*args, **kwargs):
         compress_kml(loader.render_to_string(*args, **kwargs)),
         content_type='application/vnd.google-earth.kmz',
     )
-
-
-def render_to_text(*args, **kwargs):
-    "Render the response using the MIME type for plain text."
-    return HttpResponse(loader.render_to_string(*args, **kwargs), content_type='text/plain')


### PR DESCRIPTION
Unused since its introduction in 79e68c225b926302ebb29c808dda8afa49856f5c.