### PR TITLE
Closed all resources after use in tests/servers/tests.py.

### DIFF
--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -69,6 +69,7 @@ class LiveServerViews(LiveServerBase):
     def test_404(self):
         with self.assertRaises(HTTPError) as err:
             self.urlopen('/')
+        err.exception.close()
         self.assertEqual(err.exception.code, 404, 'Expected 404 response')
 
     def test_view(self):
@@ -87,6 +88,7 @@ class LiveServerViews(LiveServerBase):
         """
         with self.assertRaises(HTTPError) as err:
             self.urlopen('/static/another_app/another_app_static_file.txt')
+        err.exception.close()
         self.assertEqual(err.exception.code, 404, 'Expected 404 response')
 
     def test_media_files(self):
@@ -111,7 +113,8 @@ class LiveServerDatabase(LiveServerBase):
         """
         Data written to the database by a view can be read.
         """
-        self.urlopen('/create_model_instance/')
+        with self.urlopen('/create_model_instance/'):
+            pass
         self.assertQuerysetEqual(
             Person.objects.all().order_by('pk'),
             ['jane', 'robert', 'emily'],

--- a/tests/servers/views.py
+++ b/tests/servers/views.py
@@ -29,11 +29,12 @@ def subview(request):
 
 
 def subview_calling_view(request):
-    response = urlopen(request.GET['url'] + '/subview/')
-    return HttpResponse('subview calling view: {}'.format(response.read().decode()))
+    with urlopen(request.GET['url'] + '/subview/') as response:
+        return HttpResponse('subview calling view: {}'.format(response.read().decode()))
 
 
 def check_model_instance_from_subview(request):
-    urlopen(request.GET['url'] + '/create_model_instance/')
-    response = urlopen(request.GET['url'] + '/model_view/')
-    return HttpResponse('subview calling view: {}'.format(response.read().decode()))
+    with urlopen(request.GET['url'] + '/create_model_instance/'):
+        pass
+    with urlopen(request.GET['url'] + '/model_view/') as response:
+        return HttpResponse('subview calling view: {}'.format(response.read().decode()))


### PR DESCRIPTION
Fixes warnings of the form:

```
ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
```