### PR TITLE
Refs #27308, #27753 -- Removed obsolete cookie test mixing bytes with str

### DIFF
--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -688,15 +688,6 @@ class CookieTests(unittest.TestCase):
         c3 = parse_cookie(c.output()[12:])
         self.assertEqual(c['test'].value, c3['test'])
 
-    def test_decode_2(self):
-        c = SimpleCookie()
-        c['test'] = b"\xf0"
-        c2 = SimpleCookie()
-        c2.load(c.output()[12:])
-        self.assertEqual(c['test'].value, c2['test'].value)
-        c3 = parse_cookie(c.output()[12:])
-        self.assertEqual(c['test'].value, c3['test'])
-
     def test_nonstandard_keys(self):
         """
         A single non-standard cookie name doesn't affect all cookies (#13007).


### PR DESCRIPTION
Python 3 `SimpleCookie` treats all values as strings. Passing a bytes object coerces to the repr value.

From the [Python docs](https://docs.python.org/3/library/http.cookies.html#http.cookies.SimpleCookie):

> This class derives from BaseCookie and overrides value_decode() and value_encode() to be the identity and str() respectively.

Example:

```python
>>> from http.cookies import SimpleCookie
>>> c = SimpleCookie()
>>> c['test'] = b"\xf0"
>>> c
<SimpleCookie: test="b'\\xf0'">
```

Fixes warning of the form:

```
test_decode_2 (httpwrappers.tests.CookieTests) ... /usr/lib64/python3.6/http/cookies.py:634: BytesWarning: str() on a bytes instance
  strval = str(val)
```