### PR TITLE
Fixed #28202 -- Fixed FieldListFilter.get_queryset() crash on invalid input.

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -132,7 +132,9 @@ class FieldListFilter(ListFilter):
     def queryset(self, request, queryset):
         try:
             return queryset.filter(**self.used_parameters)
-        except ValidationError as e:
+        except (ValueError, ValidationError) as e:
+            # Fields may raise a ValueError or ValidationError when converting
+            # the parameters to the correct type.
             raise IncorrectLookupParameters(e)
 
     @classmethod

--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -18,3 +18,6 @@ Bugfixes
 
 * Fixed an incorrect ``DisallowedModelAdminLookup`` exception when using
   a nested reverse relation in ``list_filter`` (:ticket:`28262`).
+
+* Fixed admin's ``FieldListFilter.get_queryset()`` crash on invalid input
+  (:ticket:`28202`).

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -6,6 +6,7 @@ from django.contrib.admin import (
     AllValuesFieldListFilter, BooleanFieldListFilter, ModelAdmin,
     RelatedOnlyFieldListFilter, SimpleListFilter, site,
 )
+from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
@@ -762,6 +763,13 @@ class ListFiltersTests(TestCase):
         # Make sure the correct queryset is returned
         queryset = changelist.get_queryset(request)
         self.assertEqual(list(queryset), [self.bio_book, self.djangonaut_book])
+
+    def test_fieldlistfilter_invalid_lookup_parameters(self):
+        """Filtering by an invalid value."""
+        modeladmin = BookAdmin(Book, site)
+        request = self.request_factory.get('/', {'author__id__exact': 'StringNotInteger!'})
+        with self.assertRaises(IncorrectLookupParameters):
+            self.get_changelist(request, Book, modeladmin)
 
     def test_simplelistfilter(self):
         modeladmin = DecadeFilterBookAdmin(Book, site)

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -165,7 +165,7 @@ class CustomArticleAdmin(admin.ModelAdmin):
 
 
 class ThingAdmin(admin.ModelAdmin):
-    list_filter = ('color__warm', 'color__value', 'pub_date',)
+    list_filter = ('color', 'color__warm', 'color__value', 'pub_date')
 
 
 class InquisitionAdmin(admin.ModelAdmin):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28202

No new tests have been added because a test for this was added in https://github.com/django/django/commit/30241385d538a9d6abb89ff9f74dfd5a424c7a87
but it didn't alter the `list_filter` attribute of the `Thing` admin. So the filter was ignored and thus the exception not raised.

Test can be found in https://github.com/django/django/blob/master/tests/admin_views/tests.py#L635

My initial approach was to alter `get_prep_value` on the `AutoField` class to call `to_python` and raise a `ValidationError` like the others (datefield, etc..) but this would be a breaking change.