### PR TITLE
Fixed #28271 -- Ensure the ajax technical_500_response has utf-8 encoding

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -86,7 +86,7 @@ def technical_500_response(request, exc_type, exc_value, tb, status_code=500):
     reporter = ExceptionReporter(request, exc_type, exc_value, tb)
     if request.is_ajax():
         text = reporter.get_traceback_text()
-        return HttpResponse(text, status=status_code, content_type='text/plain')
+        return HttpResponse(text, status=status_code, content_type='text/plain; charset=utf-8')
     else:
         html = reporter.get_traceback_html()
         return HttpResponse(html, status=status_code, content_type='text/html')

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -1079,6 +1079,11 @@ class AjaxResponseExceptionReporterFilter(ExceptionReportTestMixin, LoggingCaptu
         with self.settings(DEBUG=False):
             self.verify_unsafe_response(custom_exception_reporter_filter_view, check_for_vars=False)
 
+    @override_settings(DEBUG=True, ROOT_URLCONF='view_tests.urls')
+    def test_ajax_response_encoding(self):
+        response = self.client.get('/raises500/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response['Content-Type'], 'text/plain; charset=utf-8')
+
 
 class HelperFunctionTests(SimpleTestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28271