### PR TITLE
[1.11.x] Fixed #28269 -- Made Model._meta._property_names ignore AttributeErrors

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -882,7 +882,13 @@ class Options(object):
     @cached_property
     def _property_names(self):
         """Return a set of the names of the properties defined on the model."""
-        return frozenset({
-            attr for attr in
-            dir(self.model) if isinstance(getattr(self.model, attr), property)
-        })
+        names = []
+        for name in dir(self.model):
+            try:
+                attr = getattr(self.model, name)
+            except AttributeError:
+                pass
+            else:
+                if isinstance(attr, property):
+                    names.append(name)
+        return frozenset(names)

--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Removed an incorrect deprecation warning about a missing ``renderer``
   argument if a ``Widget.render()`` method accepts ``**kwargs``
   (:ticket:`28265`).
+
+* Fixed a regression causing ``Model.__init__()`` to crash if a field has an
+  instance only descriptor (:ticket:`28269`).

--- a/tests/model_meta/models.py
+++ b/tests/model_meta/models.py
@@ -9,6 +9,13 @@ class Relation(models.Model):
     pass
 
 
+class InstanceOnlyDescriptor(object):
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            raise AttributeError('Instance only')
+        return 1
+
+
 class AbstractPerson(models.Model):
     # DATA fields
     data_abstract = models.CharField(max_length=10)
@@ -42,6 +49,8 @@ class AbstractPerson(models.Model):
     @property
     def test_property(self):
         return 1
+
+    test_instance_only_descriptor = InstanceOnlyDescriptor()
 
 
 class BasePerson(AbstractPerson):

--- a/tests/model_meta/models.py
+++ b/tests/model_meta/models.py
@@ -39,6 +39,10 @@ class AbstractPerson(models.Model):
     class Meta:
         abstract = True
 
+    @property
+    def test_property(self):
+        return 1
+
 
 class BasePerson(AbstractPerson):
     # DATA fields

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -276,4 +276,6 @@ class ParentListTests(SimpleTestCase):
 
 class PropertyNamesTests(SimpleTestCase):
     def test_person(self):
+        # Instance only descriptors don't appear in _property_names.
+        self.assertEqual(AbstractPerson().test_instance_only_descriptor, 1)
         self.assertEqual(AbstractPerson._meta._property_names, frozenset(['pk', 'test_property']))

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -272,3 +272,8 @@ class ParentListTests(SimpleTestCase):
         self.assertEqual(FirstParent._meta.get_parent_list(), [CommonAncestor])
         self.assertEqual(SecondParent._meta.get_parent_list(), [CommonAncestor])
         self.assertEqual(Child._meta.get_parent_list(), [FirstParent, SecondParent, CommonAncestor])
+
+
+class PropertyNamesTests(SimpleTestCase):
+    def test_person(self):
+        self.assertEqual(AbstractPerson._meta._property_names, frozenset(['pk', 'test_property']))


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/28269)

1.11 version of #8599