### PR TITLE
Fixed #28165 -- Support non-lower case allowed_extensions for FileExtensionValidator

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -461,6 +461,8 @@ class FileExtensionValidator:
     code = 'invalid_extension'
 
     def __init__(self, allowed_extensions=None, message=None, code=None):
+        if allowed_extensions is not None:
+            allowed_extensions = [allowed_extension.lower() for allowed_extension in allowed_extensions]
         self.allowed_extensions = allowed_extensions
         if message is not None:
             self.message = message

--- a/docs/ref/validators.txt
+++ b/docs/ref/validators.txt
@@ -286,6 +286,7 @@ to, or in lieu of custom ``field.clean()`` methods.
     Raises a :exc:`~django.core.exceptions.ValidationError` with a code of
     ``'invalid_extension'`` if the extension of ``value.name`` (``value`` is
     a :class:`~django.core.files.File`) isn't found in ``allowed_extensions``.
+    The extension is compared case-insensitively with ``allowed_extensions``.
 
     .. warning::
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -248,13 +248,19 @@ TEST_DATA = [
     (RegexValidator('a', flags=re.IGNORECASE), 'A', None),
 
     (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.jpg'), ValidationError),
-    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithNoExtenstion'), ValidationError),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithUnsupportedExt.JPG'), ValidationError),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='fileWithNoExtension'), ValidationError),
+    (FileExtensionValidator(['']), ContentFile('contents', name='fileWithAnExtension.txt'), ValidationError),
     (FileExtensionValidator([]), ContentFile('contents', name='file.txt'), ValidationError),
+
+    (FileExtensionValidator(['']), ContentFile('contents', name='fileWithNoExtension'), None),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.txt'), None),
+    (FileExtensionValidator(['txt']), ContentFile('contents', name='file.TXT'), None),
     (FileExtensionValidator(), ContentFile('contents', name='file.jpg'), None),
 
     (validate_image_file_extension, ContentFile('contents', name='file.jpg'), None),
     (validate_image_file_extension, ContentFile('contents', name='file.png'), None),
+    (validate_image_file_extension, ContentFile('contents', name='file.PNG'), None),
     (validate_image_file_extension, ContentFile('contents', name='file.txt'), ValidationError),
     (validate_image_file_extension, ContentFile('contents', name='file'), ValidationError),
 ]

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -256,6 +256,7 @@ TEST_DATA = [
     (FileExtensionValidator(['']), ContentFile('contents', name='fileWithNoExtension'), None),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.txt'), None),
     (FileExtensionValidator(['txt']), ContentFile('contents', name='file.TXT'), None),
+    (FileExtensionValidator(['TXT']), ContentFile('contents', name='file.txt'), None),
     (FileExtensionValidator(), ContentFile('contents', name='file.jpg'), None),
 
     (validate_image_file_extension, ContentFile('contents', name='file.jpg'), None),
@@ -457,6 +458,14 @@ class TestValidatorEquality(TestCase):
         self.assertEqual(
             FileExtensionValidator(['txt']),
             FileExtensionValidator(['txt'])
+        )
+        self.assertEqual(
+            FileExtensionValidator(['TXT']),
+            FileExtensionValidator(['txt'])
+        )
+        self.assertEqual(
+            FileExtensionValidator(['TXT', 'png']),
+            FileExtensionValidator(['txt', 'png'])
         )
         self.assertEqual(
             FileExtensionValidator(['txt']),


### PR DESCRIPTION
Reworked version of #8456 as requested by @timgraham ( https://github.com/django/django/pull/8456#issuecomment-306309756 )