### PR TITLE
[1.11.x] Fixed #28241 -- Added dotted path support to module_has_submodule

### DIFF
--- a/tests/utils_tests/test_module/child_module/grandchild_module.py
+++ b/tests/utils_tests/test_module/child_module/grandchild_module.py
@@ -1,0 +1,1 @@
+content = 'Grandchild Module'

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -55,6 +55,19 @@ class DefaultLoader(unittest.TestCase):
         with self.assertRaises(ImportError):
             import_module('utils_tests.test_no_submodule.anything')
 
+    def test_has_sumbodule_with_dotted_path(self):
+        "Nested module existence can be tested (#28241)"
+        test_module = import_module('utils_tests.test_module')
+
+        # a grand-child that exists
+        self.assertTrue(module_has_submodule(test_module, 'child_module.grandchild_module'))
+
+        # a grand-child that does not exist
+        self.assertFalse(module_has_submodule(test_module, 'child_module.no_such_module'))
+
+        # a grand-child which parent does not exist
+        self.assertFalse(module_has_submodule(test_module, 'no_such_module.grandchild_module'))
+
 
 class EggLoader(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
[Ticket 28241](https://code.djangoproject.com/ticket/28241)

Enables module_has_submodule and autodiscover_modules to accept dotted paths.

Patching against 1.11.x, also works in 1.10.x and 1.8.x under python 2 and python 3. Comments welcome.