### PR TITLE
Fixed #28280 -- Prevented numberformat.format() from formatting large/tiny floats in scientific notation.

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -28,6 +28,11 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
     sign = ''
     if isinstance(number, Decimal):
         str_number = '{:f}'.format(number)
+    elif isinstance(number, float):
+        # if decimal_pos is not given, render it with sufficient precision
+        precision = decimal_pos or 8
+        fmt = '{{:.{}f}}'.format(precision + 1)  # gives '{:.1f}' if precision=1
+        str_number = fmt.format(number)
     else:
         str_number = str(number)
     if str_number[0] == '-':
@@ -42,6 +47,13 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
         int_part, dec_part = str_number, ''
     if decimal_pos is not None:
         dec_part = dec_part + ('0' * (decimal_pos - len(dec_part)))
+    else:
+        if isinstance(number, (float, int)):
+            # By default, {:f} formatted floats get 9 decimal pos.
+            # Strip trailing zeros that add no extra information.
+            # The second part of the "or" expression emulates how str() renders
+            # a float, i.e. retain a single 0 in the decimal part
+            dec_part = dec_part.rstrip('0') or ('0' if isinstance(number, float) else '')
     if dec_part:
         dec_part = decimal_sep + dec_part
     # grouping

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -50,6 +50,13 @@ class TestNumberFormat(TestCase):
         self.assertEqual(nformat(-2 * int_max, '.'), most_max2.format('-'))
 
     def test_float_numbers(self):
+        self.assertEqual(nformat(0.00000001, '.', decimal_pos=8), '0.00000001')
+        self.assertEqual(nformat(9e-19, '.', decimal_pos=2), '0.00')
+        self.assertEqual(nformat(.00000000000099, '.', decimal_pos=0), '0')
+        self.assertEqual(nformat(1e16, '.', thousand_sep=',', grouping=3, force_grouping=True),
+                         '10,000,000,000,000,000.0')
+        self.assertEqual(nformat(1e16, '.', decimal_pos=2, thousand_sep=',', grouping=3, force_grouping=True),
+                         '10,000,000,000,000,000.00')
         # A float with no fractional part (3.) still results in a ".0" when no
         # deimal_pos is given. Contrast with the Decimal('3.') case in the
         # test_decimal_numbers method, which returns no fractional part.

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -49,6 +49,12 @@ class TestNumberFormat(TestCase):
         self.assertEqual(nformat(-1 - int_max, '.'), most_max.format('-', '9'))
         self.assertEqual(nformat(-2 * int_max, '.'), most_max2.format('-'))
 
+    def test_float_numbers(self):
+        # A float with no fractional part (3.) still results in a ".0" when no
+        # deimal_pos is given. Contrast with the Decimal('3.') case in the
+        # test_decimal_numbers method, which returns no fractional part.
+        self.assertEqual(nformat(3., '.'), '3.0')
+
     def test_decimal_numbers(self):
         self.assertEqual(nformat(Decimal('1234'), '.'), '1234')
         self.assertEqual(nformat(Decimal('1234.2'), '.'), '1234.2')
@@ -57,6 +63,18 @@ class TestNumberFormat(TestCase):
         self.assertEqual(nformat(Decimal('1234'), '.', grouping=2, thousand_sep=',', force_grouping=True), '12,34')
         self.assertEqual(nformat(Decimal('-1234.33'), '.', decimal_pos=1), '-1234.3')
         self.assertEqual(nformat(Decimal('0.00000001'), '.', decimal_pos=8), '0.00000001')
+        self.assertEqual(nformat(Decimal('9e-19'), '.', decimal_pos=2), '0.00')
+        self.assertEqual(nformat(Decimal('.00000000000099'), '.', decimal_pos=0), '0')
+        self.assertEqual(
+            nformat(Decimal('1e16'), '.', thousand_sep=',', grouping=3, force_grouping=True),
+            '10,000,000,000,000,000'
+        )
+        self.assertEqual(
+            nformat(Decimal('1e16'), '.', decimal_pos=2, thousand_sep=',', grouping=3, force_grouping=True),
+            '10,000,000,000,000,000.00'
+        )
+        self.assertEqual(nformat(Decimal('3.'), '.'), '3')
+        self.assertEqual(nformat(Decimal('3.0'), '.'), '3.0')
 
     def test_decimal_subclass(self):
         class EuroDecimal(Decimal):


### PR DESCRIPTION
This fix takes into account float values that gets represented in scientific notation.

Please see https://code.djangoproject.com/ticket/28280