### PR TITLE
Fixed #28241 -- Added dotted path support to module_has_submodule

### DIFF
--- a/django/utils/module_loading.py
+++ b/django/utils/module_loading.py
@@ -70,7 +70,14 @@ def module_has_submodule(package, module_name):
         return False
 
     full_module_name = package_name + '.' + module_name
-    return importlib_find(full_module_name, package_path) is not None
+    try:
+        return importlib_find(full_module_name, package_path) is not None
+    except (ImportError, AttributeError):
+        # When module_name is an invalid dotted path, Python raises ImportError
+        # (or ModuleNotFoundError in Python 3.6+). AttributeError may be raised
+        # if the penultimate part of the path is not a package.
+        # (http://bugs.python.org/issue30436)
+        return False
 
 
 def module_dir(module):

--- a/tests/utils_tests/test_module/child_module/grandchild_module.py
+++ b/tests/utils_tests/test_module/child_module/grandchild_module.py
@@ -1,0 +1,1 @@
+content = 'Grandchild Module'

--- a/tests/utils_tests/test_module_loading.py
+++ b/tests/utils_tests/test_module_loading.py
@@ -48,6 +48,18 @@ class DefaultLoader(unittest.TestCase):
         with self.assertRaises(ImportError):
             import_module('utils_tests.test_no_submodule.anything')
 
+    def test_has_sumbodule_with_dotted_path(self):
+        """Nested module existence can be tested."""
+        test_module = import_module('utils_tests.test_module')
+        # A grandchild that exists.
+        self.assertIs(module_has_submodule(test_module, 'child_module.grandchild_module'), True)
+        # A grandchild that doesn't exist.
+        self.assertIs(module_has_submodule(test_module, 'child_module.no_such_module'), False)
+        # A grandchild whose parent doesn't exist.
+        self.assertIs(module_has_submodule(test_module, 'no_such_module.grandchild_module'), False)
+        # A grandchild whose parent is not a package.
+        self.assertIs(module_has_submodule(test_module, 'good_module.no_such_module'), False)
+
 
 class EggLoader(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
[Ticket 28241](https://code.djangoproject.com/ticket/28241)

Enables module_has_submodule and autodiscover_modules to accept dotted paths.

Replaces #8611 which included support for python 2 (and therefore Django 1.8 to 1.11)

Note: I included an empty __init__.py in the dummy module I added for tests even if unnecessary in python 3 as there are still __init__.py files everywhere.