### PR TITLE
Refs: #28291 - Failing testcase for ArrayField(JSONField())

### DIFF
--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -53,6 +53,17 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.CreateModel(
+            name='JSONArrayModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('field', ArrayField(JSONField(default={}))),
+            ],
+            options={
+                'required_db_vendor': 'postgresql',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
             name='OtherTypesArrayModel',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -51,6 +51,8 @@ class NullableIntegerArrayModel(PostgreSQLModel):
 class CharArrayModel(PostgreSQLModel):
     field = ArrayField(models.CharField(max_length=10))
 
+class JSONArrayModel(PostgreSQLModel):
+    field = ArrayField(JSONField(default=dict))
 
 class DateTimeArrayModel(PostgreSQLModel):
     datetimes = ArrayField(models.DateTimeField())

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -15,8 +15,8 @@ from django.utils import timezone
 from . import PostgreSQLTestCase, PostgreSQLWidgetTestCase
 from .models import (
     ArrayFieldSubclass, CharArrayModel, DateTimeArrayModel, IntegerArrayModel,
-    NestedIntegerArrayModel, NullableIntegerArrayModel, OtherTypesArrayModel,
-    PostgreSQLModel, Tag,
+    JSONArrayModel, NestedIntegerArrayModel, NullableIntegerArrayModel,
+    OtherTypesArrayModel, PostgreSQLModel, Tag,
 )
 
 try:
@@ -53,6 +53,13 @@ class TestSaveLoad(PostgreSQLTestCase):
         self.assertEqual(instance.datetimes, loaded.datetimes)
         self.assertEqual(instance.dates, loaded.dates)
         self.assertEqual(instance.times, loaded.times)
+
+    def test_json(self):
+        instance = JSONArrayModel(field=[{'a': 1 }, {'b': 2}])
+        instance.save()
+        loaded = JSONArrayModel.objects.get()
+        self.assertEqual(instance.field, loaded.field)
+        self.assertEqual(len(loaded.field), 2)
 
     def test_tuples(self):
         instance = IntegerArrayModel(field=(1,))


### PR DESCRIPTION
This PR is just an example failing testcase, and isn't meant to be merged.

Added a failing testcase for #28291.

Using `ArrayField(JSONField())` causes a sql error on saving:
```
psycopg2.ProgrammingError: column "field" is of type jsonb[] but expression is of type text[]
LINE 1: ..."postgres_tests_jsonarraymodel" ("field") VALUES (ARRAY['{"a...
```
