### PR TITLE
Refs #23919 -- Removed support for broken Model.__str__() in Model.__repr__().

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -498,11 +498,7 @@ class Model(metaclass=ModelBase):
         return new
 
     def __repr__(self):
-        try:
-            u = str(self)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            u = '[Bad Unicode data]'
-        return '<%s: %s>' % (self.__class__.__name__, u)
+        return '<%s: %s>' % (self.__class__.__name__, self)
 
     def __str__(self):
         return '%s object' % self.__class__.__name__

--- a/tests/model_regress/models.py
+++ b/tests/model_regress/models.py
@@ -52,14 +52,6 @@ class Worker(models.Model):
         return self.name
 
 
-class BrokenStrMethod(models.Model):
-    name = models.CharField(max_length=7)
-
-    def __str__(self):
-        # Intentionally broken (invalid start byte in byte string).
-        return b'Name\xff: %s'.decode() % self.name
-
-
 class NonAutoPK(models.Model):
     name = models.CharField(max_length=10, primary_key=True)
 

--- a/tests/model_regress/tests.py
+++ b/tests/model_regress/tests.py
@@ -8,8 +8,8 @@ from django.test import TestCase, skipUnlessDBFeature
 from django.utils.timezone import get_fixed_timezone
 
 from .models import (
-    Article, BrokenStrMethod, Department, Event, Model1, Model2, Model3,
-    NonAutoPK, Party, Worker,
+    Article, Department, Event, Model1, Model2, Model3, NonAutoPK, Party,
+    Worker,
 )
 
 
@@ -185,11 +185,6 @@ class ModelTests(TestCase):
         d = Department.objects.create(id=10, name="IT")
         w = Worker.objects.create(department=d, name="Full-time")
         self.assertEqual(str(w), "Full-time")
-
-    def test_broken_unicode(self):
-        # Models with broken __str__() methods have a printable repr().
-        b = BrokenStrMethod.objects.create(name='Jerry')
-        self.assertEqual(repr(b), '<BrokenStrMethod: [Bad Unicode data]>')
 
     @skipUnlessDBFeature("supports_timezones")
     def test_timezones(self):


### PR DESCRIPTION
Returning invalid bytestrings in `__str__()` is unlikely in Python 3.