### PR TITLE
Fixed #27967 -- Fixed KeyError in admin's inline form with inherited non-editable pk.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -337,7 +337,7 @@ class InlineAdminForm(AdminForm):
         # Also search any parents for an auto field. (The pk info is propagated to child
         # models so that does not need to be checked in parents.)
         for parent in self.form._meta.model._meta.get_parent_list():
-            if parent._meta.auto_field:
+            if parent._meta.auto_field or not parent._meta.model._meta.pk.editable:
                 return True
         return False
 

--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -26,3 +26,6 @@ Bugfixes
 
 * Fixed model initialization to set the name of class-based model indexes
   for models that only inherit ``models.Model`` (:ticket:`28282`).
+
+* Fixed crash in admin's inlines when a model has an inherited non-editable
+  primary key (:ticket:`27967`).

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -5,10 +5,10 @@ from .models import (
     Author, BinaryTree, CapoFamiglia, Chapter, ChildModel1, ChildModel2,
     Consigliere, EditablePKBook, ExtraTerrestrial, Fashionista, Holder,
     Holder2, Holder3, Holder4, Inner, Inner2, Inner3, Inner4Stacked,
-    Inner4Tabular, NonAutoPKBook, Novel, ParentModelWithCustomPk, Poll,
-    Profile, ProfileCollection, Question, ReadOnlyInline, ShoppingWeakness,
-    Sighting, SomeChildModel, SomeParentModel, SottoCapo, Title,
-    TitleCollection,
+    Inner4Tabular, NonAutoPKBook, NonAutoPKBookChild, Novel,
+    ParentModelWithCustomPk, Poll, Profile, ProfileCollection, Question,
+    ReadOnlyInline, ShoppingWeakness, Sighting, SomeChildModel,
+    SomeParentModel, SottoCapo, Title, TitleCollection,
 )
 
 site = admin.AdminSite(name="admin")
@@ -20,6 +20,11 @@ class BookInline(admin.TabularInline):
 
 class NonAutoPKBookTabularInline(admin.TabularInline):
     model = NonAutoPKBook
+    classes = ('collapse',)
+
+
+class NonAutoPKBookChildTabularInline(admin.TabularInline):
+    model = NonAutoPKBookChild
     classes = ('collapse',)
 
 
@@ -40,6 +45,7 @@ class AuthorAdmin(admin.ModelAdmin):
     inlines = [
         BookInline, NonAutoPKBookTabularInline, NonAutoPKBookStackedInline,
         EditablePKBookTabularInline, EditablePKBookStackedInline,
+        NonAutoPKBookChildTabularInline,
     ]
 
 

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -56,6 +56,10 @@ class NonAutoPKBook(models.Model):
         super().save(*args, **kwargs)
 
 
+class NonAutoPKBookChild(NonAutoPKBook):
+    pass
+
+
 class EditablePKBook(models.Model):
     manual_pk = models.IntegerField(primary_key=True)
     author = models.ForeignKey(Author, models.CASCADE)

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -355,6 +355,21 @@ class TestInline(TestDataMixin, TestCase):
             html=True
         )
 
+    def test_inline_nonauto_noneditable_inherited_pk(self):
+        response = self.client.get(reverse('admin:admin_inlines_author_add'))
+        self.assertContains(
+            response,
+            '<input id="id_nonautopkbookchild_set-0-nonautopkbook_ptr" '
+            'name="nonautopkbookchild_set-0-nonautopkbook_ptr" type="hidden" />',
+            html=True
+        )
+        self.assertContains(
+            response,
+            '<input id="id_nonautopkbookchild_set-2-nonautopkbook_ptr" '
+            'name="nonautopkbookchild_set-2-nonautopkbook_ptr" type="hidden" />',
+            html=True
+        )
+
     def test_inline_editable_pk(self):
         response = self.client.get(reverse('admin:admin_inlines_author_add'))
         self.assertContains(
@@ -886,7 +901,7 @@ class SeleniumTests(AdminSeleniumTestCase):
         # One field is in a stacked inline, other in a tabular one.
         test_fields = ['#id_nonautopkbook_set-0-title', '#id_nonautopkbook_set-2-0-title']
         show_links = self.selenium.find_elements_by_link_text('SHOW')
-        self.assertEqual(len(show_links), 2)
+        self.assertEqual(len(show_links), 3)
         for show_index, field_name in enumerate(test_fields, 0):
             self.wait_until_invisible(field_name)
             show_links[show_index].click()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27967