### PR TITLE
Fixed #28295 - Removed trailing hyphens from ModelAdmin.prepopulated_fields

### DIFF
--- a/django/contrib/admin/static/admin/js/urlify.js
+++ b/django/contrib/admin/static/admin/js/urlify.js
@@ -172,8 +172,9 @@
         }
         s = s.replace(/^\s+|\s+$/g, '');   // trim leading/trailing spaces
         s = s.replace(/[-\s]+/g, '-');     // convert spaces to hyphens
-        s = s.toLowerCase();               // convert to lowercase
-        return s.substring(0, num_chars);  // trim to first num_chars chars
+        s = s.substring(0, num_chars);     // trim to first num_chars chars
+        s = s.replace(/-+$/g, '');         // trim any trailing hyphens
+        return s.toLowerCase();            // convert to lowercase
     }
     window.URLify = URLify;
 })();

--- a/js_tests/admin/URLify.test.js
+++ b/js_tests/admin/URLify.test.js
@@ -19,3 +19,7 @@ QUnit.test('strip non-URL characters', function(assert) {
 QUnit.test('merge adjacent whitespace', function(assert) {
     assert.strictEqual(URLify('D   silent', 8, true), 'd-silent');
 });
+
+QUnit.test('trim trailing hyphens', function(assert) {
+    assert.strictEqual(URLify('D silent always', 9, true), 'd-silent');
+});


### PR DESCRIPTION
The JavaScript responsible for generating the output of ModelAdmin.prepopulated_fields would sometimes leave a trailing hyphen in the returned string. A single, extra operation was added to urlify.js to ensure that the resulting output will no longer end with a hyphen.