### PR TITLE
Allow complex template structure for related object links

### DIFF
--- a/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -58,7 +58,7 @@
 
     function updateRelatedObjectLinks(triggeringLink) {
         var $this = $(triggeringLink);
-        var siblings = $this.nextAll('.change-related, .delete-related');
+        var siblings = $this.parents('.related-widget-wrapper').find('.change-related, .delete-related');
         if (!siblings.length) {
             return;
         }


### PR DESCRIPTION
When overriding `admin/related_widget_wrapper.html` the Javascript associated to button handling is too restrictive on the DOM structure.
This change allows to have complex siblings as buttons (for a boostrap theme for example).