### PR TITLE
Added JS unit tests for contrib.admin's URLify.js.

### DIFF
--- a/js_tests/admin/URLify.test.js
+++ b/js_tests/admin/URLify.test.js
@@ -1,0 +1,21 @@
+/* global QUnit, URLify */
+/* eslint global-strict: 0, strict: 0 */
+'use strict';
+
+QUnit.module('admin.URLify');
+
+QUnit.test('empty string', function(assert) {
+    assert.strictEqual(URLify('', 8, true), '');
+});
+
+QUnit.test('strip nonessential words', function(assert) {
+    assert.strictEqual(URLify('the D is silent', 8, true), 'd-silent');
+});
+
+QUnit.test('strip non-URL characters', function(assert) {
+    assert.strictEqual(URLify('D#silent@', 7, true), 'dsilent');
+});
+
+QUnit.test('merge adjacent whitespace', function(assert) {
+    assert.strictEqual(URLify('D   silent', 8, true), 'd-silent');
+});

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -43,6 +43,7 @@
 
     <script src="./qunit/qunit.js"></script>
 
+    <script src='../django/contrib/admin/static/admin/js/vendor/xregexp/xregexp.min.js'></script>
     <script src='../django/contrib/admin/static/admin/js/vendor/jquery/jquery.min.js'></script>
     <script src='../django/contrib/admin/static/admin/js/jquery.init.js'></script>
     <script src='./admin/jsi18n-mocks.test.js'></script>
@@ -76,6 +77,7 @@
     <script src='../django/contrib/admin/static/admin/js/collapse.js' data-cover></script>
     <script src='../django/contrib/admin/static/admin/js/prepopulate.js' data-cover></script>
     <script src='../django/contrib/admin/static/admin/js/urlify.js' data-cover></script>
+    <script src='./admin/URLify.test.js'></script>
 
     <div id="id_point_map" style="display:none;">
         <textarea id="id_point" name="point" class="vSerializedField required"


### PR DESCRIPTION
As directed in #8624, this pull request contains a handful of unit tests for contrib.admin's URLify.js. All tests are passing as they cover base behavior of URLify.js which is not altered by the proposed modifications in #8624.

Comment and test name strings have been updated per the code review in #8624 and the test docstring [Coding Style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#python-style).