### PR TITLE
Fixed #28303 -- Prevented localization of attribute values in the DTL attrs.html widget template.

### DIFF
--- a/django/forms/templates/django/forms/widgets/attrs.html
+++ b/django/forms/templates/django/forms/widgets/attrs.html
@@ -1,1 +1,1 @@
-{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value }}"{% endif %}{% endif %}{% endfor %}
+{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -40,3 +40,7 @@ Bugfixes
   context. It's now an empty string (as it is for the original function-based
   ``login()`` view) if the corresponding parameter isn't sent in a request (in
   particular, when the login page is accessed directly) (:ticket:`28229`).
+
+* Prevented attribute values in the ``django/forms/widgets/attrs.html``
+  template from being localized so that numeric attributes (e.g. ``max`` and
+  ``min``) of ``NumberInput`` work correctly (:ticket:`28303`).

--- a/tests/forms_tests/widget_tests/test_numberinput.py
+++ b/tests/forms_tests/widget_tests/test_numberinput.py
@@ -1,0 +1,15 @@
+from django.forms.widgets import NumberInput
+from django.test import override_settings
+
+from .base import WidgetTest
+
+
+class NumberInputTests(WidgetTest):
+
+    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    def test_attrs_not_localized(self):
+        widget = NumberInput(attrs={'max': 12345, 'min': 1234, 'step': 9999})
+        self.check_html(
+            widget, 'name', 'value',
+            '<input type="number" name="name" value="value" max="12345" min="1234" step="9999" />'
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28303