### PR TITLE
Refs #25809 -- Removed BrinIndex.__repr__().

### DIFF
--- a/django/contrib/postgres/indexes.py
+++ b/django/contrib/postgres/indexes.py
@@ -17,16 +17,6 @@ class BrinIndex(Index):
         self.pages_per_range = pages_per_range
         super().__init__(fields, name)
 
-    def __repr__(self):
-        if self.pages_per_range is not None:
-            return '<%(name)s: fields=%(fields)s, pages_per_range=%(pages_per_range)s>' % {
-                'name': self.__class__.__name__,
-                'fields': "'{}'".format(', '.join(self.fields)),
-                'pages_per_range': self.pages_per_range,
-            }
-        else:
-            return super().__repr__()
-
     def deconstruct(self):
         path, args, kwargs = super().deconstruct()
         kwargs['pages_per_range'] = self.pages_per_range

--- a/tests/postgres_tests/test_indexes.py
+++ b/tests/postgres_tests/test_indexes.py
@@ -12,12 +12,6 @@ class BrinIndexTests(PostgreSQLTestCase):
     def test_suffix(self):
         self.assertEqual(BrinIndex.suffix, 'brin')
 
-    def test_repr(self):
-        index = BrinIndex(fields=['title'], pages_per_range=4)
-        another_index = BrinIndex(fields=['title'])
-        self.assertEqual(repr(index), "<BrinIndex: fields='title', pages_per_range=4>")
-        self.assertEqual(repr(another_index), "<BrinIndex: fields='title'>")
-
     def test_not_eq(self):
         index = BrinIndex(fields=['title'])
         index_with_page_range = BrinIndex(fields=['title'], pages_per_range=16)
@@ -57,10 +51,6 @@ class GinIndexTests(PostgreSQLTestCase):
 
     def test_suffix(self):
         self.assertEqual(GinIndex.suffix, 'gin')
-
-    def test_repr(self):
-        index = GinIndex(fields=['title'])
-        self.assertEqual(repr(index), "<GinIndex: fields='title'>")
 
     def test_eq(self):
         index = GinIndex(fields=['title'])


### PR DESCRIPTION
In retrospect, implementing a `__repr__()` for index subclasses doesn't
seem worthwhile.

(discussed in https://github.com/django/django/pull/7950#discussion_r119955225)