### PR TITLE
Fixed #28176 -- Restored the uncasted option value in ChoiceWidget template context.

### DIFF
--- a/django/forms/templates/django/forms/widgets/input.html
+++ b/django/forms/templates/django/forms/widgets/input.html
@@ -1,1 +1,1 @@
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />

--- a/django/forms/templates/django/forms/widgets/select_option.html
+++ b/django/forms/templates/django/forms/widgets/select_option.html
@@ -1,1 +1,1 @@
-<option value="{{ widget.value }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label }}</option>
+<option value="{{ widget.value|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label }}</option>

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -591,7 +591,7 @@ class ChoiceWidget(Widget):
             option_attrs['id'] = self.id_for_label(option_attrs['id'], index)
         return {
             'name': name,
-            'value': str(value),
+            'value': value,
             'label': label,
             'selected': selected,
             'index': index,

--- a/docs/releases/1.11.3.txt
+++ b/docs/releases/1.11.3.txt
@@ -44,3 +44,10 @@ Bugfixes
 * Prevented attribute values in the ``django/forms/widgets/attrs.html``
   template from being localized so that numeric attributes (e.g. ``max`` and
   ``min``) of ``NumberInput`` work correctly (:ticket:`28303`).
+
+* Removed casting of the option value to a string in the template context of
+  the ``CheckboxSelectMultiple``, ``NullBooleanSelect``, ``RadioSelect``,
+  ``SelectMultiple``, and ``Select`` widgets (:ticket:`28176`). In Django
+  1.11.1, casting was added in Python to avoid localization of numeric values
+  in Django templates, but this made some use cases more difficult. Casting is
+  now done in the template using the ``|stringformat:'s'`` filter.

--- a/tests/forms_tests/widget_tests/test_select.py
+++ b/tests/forms_tests/widget_tests/test_select.py
@@ -348,6 +348,12 @@ class SelectTest(WidgetTest):
         )
         self.assertEqual(index, 2)
 
+    def test_optgroups_integer_choices(self):
+        """The option 'value' is the same type as what's in `choices`."""
+        groups = list(self.widget(choices=[[0, 'choice text']]).optgroups('name', ['vhs']))
+        label, options, index = groups[0]
+        self.assertEqual(options[0]['value'], 0)
+
     def test_deepcopy(self):
         """
         __deepcopy__() should copy all attributes properly (#25085).


### PR DESCRIPTION
The first commit is from https://github.com/django/django/pull/8639.
The second commit is the approach John suggested in https://github.com/django/django/pull/8639#issuecomment-308612817.
The third commit reverts parts of the second commit to what I think is a simpler approach.