### PR TITLE
Fixed #28312 -- Fixed incorrect caching of ModelChoiceIterator.__len__().

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1112,7 +1112,7 @@ class ModelChoiceIterator:
             yield self.choice(obj)
 
     def __len__(self):
-        return (len(self.queryset) + (1 if self.field.empty_label is not None else 0))
+        return (len(self.queryset.all()) + (1 if self.field.empty_label is not None else 0))
 
     def choice(self, obj):
         return (self.field.prepare_value(obj), self.field.label_from_instance(obj))

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1997,6 +1997,12 @@ class ModelMultipleChoiceFieldTests(TestCase):
         form = ArticleCategoriesForm(instance=article)
         self.assertCountEqual(form['categories'].value(), [self.c2.slug, self.c3.slug])
 
+    def test_added_fields_gets_counted(self):
+        f = forms.ModelMultipleChoiceField(Category.objects.all())
+        self.assertEqual(len(f.choices), 3)
+        Category.objects.create()
+        self.assertEqual(len(f.choices), 4)
+
 
 class ModelOneToOneFieldTests(TestCase):
     def test_modelform_onetoonefield(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28312