### PR TITLE
Fixed #28322 -- Added dbshell support for client TLS certs on MySQL.

### DIFF
--- a/django/db/backends/mysql/client.py
+++ b/django/db/backends/mysql/client.py
@@ -14,7 +14,9 @@ class DatabaseClient(BaseDatabaseClient):
         passwd = settings_dict['OPTIONS'].get('passwd', settings_dict['PASSWORD'])
         host = settings_dict['OPTIONS'].get('host', settings_dict['HOST'])
         port = settings_dict['OPTIONS'].get('port', settings_dict['PORT'])
-        cert = settings_dict['OPTIONS'].get('ssl', {}).get('ca')
+        server_ca = settings_dict['OPTIONS'].get('ssl', {}).get('ca')
+        client_cert = settings_dict['OPTIONS'].get('ssl', {}).get('cert')
+        client_key = settings_dict['OPTIONS'].get('ssl', {}).get('key')
         defaults_file = settings_dict['OPTIONS'].get('read_default_file')
         # Seems to be no good way to set sql_mode with CLI.
 
@@ -31,8 +33,12 @@ class DatabaseClient(BaseDatabaseClient):
                 args += ["--host=%s" % host]
         if port:
             args += ["--port=%s" % port]
-        if cert:
-            args += ["--ssl-ca=%s" % cert]
+        if server_ca:
+            args += ["--ssl-ca=%s" % server_ca]
+        if client_cert:
+            args += ["--ssl-cert=%s" % client_cert]
+        if client_key:
+            args += ["--ssl-key=%s" % client_key]
         if db:
             args += [db]
         return args

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -210,6 +210,8 @@ Management Commands
 * On Oracle, :djadmin:`inspectdb` can now introspect ``AutoField`` if the
   column is created as an identity column.
 
+* On MySQL, :djadmin:`dbshell` now supports client-side TLS certificates.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/dbshell/test_mysql.py
+++ b/tests/dbshell/test_mysql.py
@@ -59,14 +59,21 @@ class MySqlDbshellCommandTestCase(SimpleTestCase):
     def test_ssl_certificate_is_added(self):
         self.assertEqual(
             ['mysql', '--user=someuser', '--password=somepassword',
-             '--host=somehost', '--port=444', '--ssl-ca=sslca', 'somedbname'],
+             '--host=somehost', '--port=444', '--ssl-ca=sslca',
+             '--ssl-cert=sslcert', '--ssl-key=sslkey', 'somedbname'],
             self.get_command_line_arguments({
                 'NAME': 'somedbname',
                 'USER': 'someuser',
                 'PASSWORD': 'somepassword',
                 'HOST': 'somehost',
                 'PORT': 444,
-                'OPTIONS': {'ssl': {'ca': 'sslca'}},
+                'OPTIONS': {
+                    'ssl': {
+                        'ca': 'sslca',
+                        'cert': 'sslcert',
+                        'key': 'sslkey',
+                    },
+                },
             }))
 
     def get_command_line_arguments(self, connection_settings):


### PR DESCRIPTION
Add support for client-side TLS certificates in the MySQL dbshell
command.

Manually tested that this works with a live MySQL database (Google Cloud SQL).