### PR TITLE
Removed obsolete Query.tables attribute.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -971,7 +971,7 @@ class Subquery(Expression):
         clone.queryset.query = clone.queryset.query.relabeled_clone(change_map)
         clone.queryset.query.external_aliases.update(
             alias for alias in change_map.values()
-            if alias not in clone.queryset.query.tables
+            if alias not in clone.queryset.query.alias_map
         )
         return clone
 

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -19,7 +19,7 @@ class DeleteQuery(Query):
     compiler = 'SQLDeleteCompiler'
 
     def do_query(self, table, where, using):
-        self.tables = (table,)
+        self.alias_map = {table: self.alias_map[table]}
         self.where = where
         cursor = self.get_compiler(using).execute_sql(CURSOR)
         return cursor.rowcount if cursor else 0
@@ -52,8 +52,8 @@ class DeleteQuery(Query):
         innerq.get_initial_alias()
         # The same for our new query.
         self.get_initial_alias()
-        innerq_used_tables = tuple([t for t in innerq.tables if innerq.alias_refcount[t]])
-        if not innerq_used_tables or innerq_used_tables == self.tables:
+        innerq_used_tables = tuple([t for t in innerq.alias_map if innerq.alias_refcount[t]])
+        if not innerq_used_tables or innerq_used_tables == tuple(self.alias_map):
             # There is only the base table in use in the query.
             self.where = innerq.where
         else:

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -272,7 +272,7 @@ class Queries1Tests(TestCase):
         list(q2)
         combined_query = (q1 & q2).order_by('name').query
         self.assertEqual(len([
-            t for t in combined_query.tables if combined_query.alias_refcount[t]
+            t for t in combined_query.alias_map if combined_query.alias_refcount[t]
         ]), 1)
 
     def test_order_by_join_unref(self):
@@ -499,7 +499,7 @@ class Queries1Tests(TestCase):
             qs,
             ['<Item: four>', '<Item: one>', '<Item: three>', '<Item: two>']
         )
-        self.assertEqual(len(qs.query.tables), 1)
+        self.assertEqual(len(qs.query.alias_map), 1)
 
     def test_tickets_2874_3002(self):
         qs = Item.objects.select_related().order_by('note__note', 'name')


### PR DESCRIPTION
As query.alias_map is an OrderedDict, it's not needed any more.

Refs #26522