### PR TITLE
Fixed #27670 -- Prevented shell crash on error in .pythonrc.

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -1,6 +1,7 @@
 import os
 import select
 import sys
+import traceback
 from contextlib import suppress
 
 from django.core.management import BaseCommand, CommandError
@@ -69,9 +70,15 @@ class Command(BaseCommand):
                     continue
                 if not os.path.isfile(pythonrc):
                     continue
-                with suppress(NameError):
-                    with open(pythonrc) as handle:
-                        exec(compile(handle.read(), pythonrc, 'exec'), imported_objects)
+                with open(pythonrc) as handle:
+                    pythonrc_code = handle.read()
+                # Match the behavior of the cpython shell where an error in
+                # PYTHONSTARTUP prints an exception and continues.
+                try:
+                    exec(compile(pythonrc_code, pythonrc, 'exec'), imported_objects)
+                except Exception:
+                    traceback.print_exc()
+
         code.interact(local=imported_objects)
 
     def handle(self, **options):


### PR DESCRIPTION
This more-or-less matches the behaviour of CPython.

There's one unnecessary line from Django's code in the printed
traceback, but eliminating this requires a lot of poking around into the
internals of the traceback module.