### PR TITLE
Fixed #28356 -- Fix serializer DateField/DateTimeField

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1268,8 +1268,8 @@ class DateField(DateTimeCheckMixin, Field):
             val = parse_date(val)
             if val is None:
                 raise exceptions.ValidationError(
-                    self.error_messages['invalid'],
-                    code='invalid',
+                    self.error_messages['invalid_date'],
+                    code='invalid_date',
                     params={'value': original_value}
                 )
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1261,7 +1261,19 @@ class DateField(DateTimeCheckMixin, Field):
 
     def value_to_string(self, obj):
         val = self.value_from_object(obj)
-        return '' if val is None else val.isoformat()
+        if not val:
+            return ""
+        elif isinstance(val, str):
+            original_value = val
+            val = parse_date(val)
+            if val is None:
+                raise exceptions.ValidationError(
+                    self.error_messages['invalid'],
+                    code='invalid',
+                    params={'value': original_value}
+                )
+
+        return val.isoformat()
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.DateField}
@@ -1416,7 +1428,19 @@ class DateTimeField(DateField):
 
     def value_to_string(self, obj):
         val = self.value_from_object(obj)
-        return '' if val is None else val.isoformat()
+        if not val:
+            return ""
+        elif isinstance(val, str):
+            original_value = val
+            val = parse_datetime(val)
+            if val is None:
+                raise exceptions.ValidationError(
+                    self.error_messages['invalid'],
+                    code='invalid',
+                    params={'value': original_value}
+                )
+
+        return val.isoformat()
 
     def formfield(self, **kwargs):
         defaults = {'form_class': forms.DateTimeField}

--- a/tests/serializers/models/base.py
+++ b/tests/serializers/models/base.py
@@ -163,3 +163,18 @@ class ComplexModel(models.Model):
     field1 = models.CharField(max_length=10)
     field2 = models.CharField(max_length=10)
     field3 = models.CharField(max_length=10)
+
+
+class DateTimeFieldSerialization(models.Model):
+    datetime_field1 = models.DateTimeField()
+
+
+class DateFieldSerialization(models.Model):
+    date_field2 = models.DateField()
+
+
+# Fixed #28356 -- Fix serializer DateField/DateTimeField
+
+    # When we serializer one DateTimeField/DateField we need to check if
+    # it was a datetime/date object, if not, try to parse it before and
+    # raise an Exception in case of invalid format.

--- a/tests/serializers/models/base.py
+++ b/tests/serializers/models/base.py
@@ -171,10 +171,3 @@ class DateTimeFieldSerialization(models.Model):
 
 class DateFieldSerialization(models.Model):
     date_field2 = models.DateField()
-
-
-# Fixed #28356 -- Fix serializer DateField/DateTimeField
-
-    # When we serializer one DateTimeField/DateField we need to check if
-    # it was a datetime/date object, if not, try to parse it before and
-    # raise an Exception in case of invalid format.

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -3,7 +3,7 @@ import decimal
 import json
 import re
 
-from django.core import serializers
+from django.core import exceptions, serializers
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -336,3 +336,19 @@ class DateAndDateTimeFieldSerializerTests(SimpleTestCase):
 
         fields = json.loads(serialized_object)[0].get('fields')
         self.assertEqual(fields['date_field2'], fields['date_field2'])
+
+    def test_raise_exception_on_wrong_date_field_serializer(self):
+        random_datetime = datetime.date.today()
+        string_datetime = random_datetime.isoformat()+"a"
+
+        instance = DateFieldSerialization(date_field2=string_datetime)
+        with self.assertRaises(exceptions.ValidationError):
+            serializers.serialize('json', [instance])
+
+    def test_raise_exception_on_wrong_datetime_field_serializer(self):
+        random_datetime = datetime.date.today()
+        string_datetime = random_datetime.isoformat()+"a"
+
+        instance = DateFieldSerialization(date_field2=string_datetime)
+        with self.assertRaises(exceptions.ValidationError):
+            serializers.serialize('json', [instance])

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.utils import isolate_apps
 from django.utils.translation import gettext_lazy, override
 
-from .models import Score
+from .models import Score, DateFieldSerialization, DateTimeFieldSerialization
 from .tests import SerializersTestBase, SerializersTransactionTestBase
 
 
@@ -312,3 +312,27 @@ class DjangoJSONEncoderTests(SimpleTestCase):
             json.dumps({'duration': duration}, cls=DjangoJSONEncoder),
             '{"duration": "P0DT00H00M00S"}'
         )
+
+
+class DateAndDateTimeFieldSerializerTests(SimpleTestCase):
+    def test_datetime_field_serializer(self):
+        random_datetime = datetime.datetime.now()
+        string_datetime = random_datetime.isoformat()
+
+        instance = DateTimeFieldSerialization(datetime_field1=string_datetime)
+
+        serialized_object = serializers.serialize('json', [instance])
+
+        fields = json.loads(serialized_object)[0].get('fields')
+        self.assertEqual(fields['datetime_field1'], fields['datetime_field1'])
+
+    def test_date_field_serializer(self):
+        random_datetime = datetime.datetime.now()
+        string_datetime = random_datetime.isoformat()
+
+        instance = DateFieldSerialization(date_field2=string_datetime)
+
+        serialized_object = serializers.serialize('json', [instance])
+
+        fields = json.loads(serialized_object)[0].get('fields')
+        self.assertEqual(fields['date_field2'], fields['date_field2'])

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -339,7 +339,7 @@ class DateAndDateTimeFieldSerializerTests(SimpleTestCase):
 
     def test_raise_exception_on_wrong_date_field_serializer(self):
         random_datetime = datetime.date.today()
-        string_datetime = random_datetime.isoformat()+"a"
+        string_datetime = random_datetime.isoformat() + "a"
 
         instance = DateFieldSerialization(date_field2=string_datetime)
         with self.assertRaises(exceptions.ValidationError):
@@ -347,7 +347,7 @@ class DateAndDateTimeFieldSerializerTests(SimpleTestCase):
 
     def test_raise_exception_on_wrong_datetime_field_serializer(self):
         random_datetime = datetime.date.today()
-        string_datetime = random_datetime.isoformat()+"a"
+        string_datetime = random_datetime.isoformat() + "a"
 
         instance = DateFieldSerialization(date_field2=string_datetime)
         with self.assertRaises(exceptions.ValidationError):

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.utils import isolate_apps
 from django.utils.translation import gettext_lazy, override
 
-from .models import Score, DateFieldSerialization, DateTimeFieldSerialization
+from .models import DateFieldSerialization, DateTimeFieldSerialization, Score
 from .tests import SerializersTestBase, SerializersTransactionTestBase
 
 
@@ -327,7 +327,7 @@ class DateAndDateTimeFieldSerializerTests(SimpleTestCase):
         self.assertEqual(fields['datetime_field1'], fields['datetime_field1'])
 
     def test_date_field_serializer(self):
-        random_datetime = datetime.datetime.now()
+        random_datetime = datetime.date.today()
         string_datetime = random_datetime.isoformat()
 
         instance = DateFieldSerialization(date_field2=string_datetime)


### PR DESCRIPTION
When we serializer one DateTimeField/DateField we need to check if
it was a datetime/date object, if not, try to parse it before and
raise an Exception in case of invalid format.
https://code.djangoproject.com/ticket/28356