### PR TITLE
[1.11.x] Fixed #28355 -- Fixed widget rendering of non-ASCII date/time formats on Python 2.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -463,7 +463,9 @@ class DateTimeBaseInput(TextInput):
         self.format = format if format else None
 
     def format_value(self, value):
-        return formats.localize_input(value, self.format or formats.get_format(self.format_key)[0])
+        if value is not None:
+            # localize_input() returns str on Python 2.
+            return force_text(formats.localize_input(value, self.format or formats.get_format(self.format_key)[0]))
 
 
 class DateInput(DateTimeBaseInput):

--- a/docs/releases/1.11.4.txt
+++ b/docs/releases/1.11.4.txt
@@ -9,4 +9,6 @@ Django 1.11.4 fixes several bugs in 1.11.3.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in 1.11.3 on Python 2 where non-ASCII ``format`` values
+  for date/time widgets results in an empty ``value`` in the widget's HTML
+  (:ticket:`28355`).

--- a/tests/forms_tests/widget_tests/test_timeinput.py
+++ b/tests/forms_tests/widget_tests/test_timeinput.py
@@ -1,4 +1,9 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
+import sys
 from datetime import time
+from unittest import skipIf
 
 from django.forms import TimeInput
 from django.test import override_settings
@@ -42,6 +47,12 @@ class TimeInputTest(WidgetTest):
         t = time(12, 51, 34, 482548)
         widget = TimeInput(format='%H:%M', attrs={'type': 'time'})
         self.check_html(widget, 'time', t, html='<input type="time" name="time" value="12:51" />')
+
+    # Test fails on Windows due to http://bugs.python.org/issue8304#msg222667
+    @skipIf(sys.platform.startswith('win'), 'Fails with UnicodeEncodeError error on Windows.')
+    def test_non_ascii_format(self):
+        widget = TimeInput(format='τ-%H:%M')
+        self.check_html(widget, 'time', time(10, 10), '<input type="text" name="time" value="\u03c4-10:10" />')
 
     @override_settings(USE_L10N=True)
     @translation.override('de-at')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28355