### PR TITLE
Fix #28359: Redirect requests that do not match SECURE_SSL_HOST

### DIFF
--- a/docs/ref/middleware.txt
+++ b/docs/ref/middleware.txt
@@ -369,6 +369,12 @@ connections to HTTPS.
 If the :setting:`SECURE_SSL_HOST` setting has a value, all redirects will be
 sent to that host instead of the originally-requested host.
 
+.. versionchanged:: 2.0
+
+   Secure requests are also redirected if the originally-requested host
+   does not match the setting. Previously, secure requests were never
+   redirected.
+
 If there are a few pages on your site that should be available over HTTP, and
 not redirected to HTTPS, you can list regular expressions to match those URLs
 in the :setting:`SECURE_REDIRECT_EXEMPT` setting.

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2280,6 +2280,12 @@ to this host rather than the originally-requested host
 (e.g. ``www.example.com``). If :setting:`SECURE_SSL_REDIRECT` is ``False``, this
 setting has no effect.
 
+.. versionchanged:: 2.0
+
+   Secure requests are also redirected if the originally-requested host
+   does not match the setting. Previously, secure requests were never
+   redirected.
+
 .. setting:: SECURE_SSL_REDIRECT
 
 ``SECURE_SSL_REDIRECT``

--- a/tests/middleware/test_security.py
+++ b/tests/middleware/test_security.py
@@ -221,6 +221,10 @@ class SecurityMiddlewareTest(SimpleTestCase):
         self.assertEqual(ret.status_code, 301)
         self.assertEqual(ret["Location"], "https://secure.example.com/some/url")
 
+        ret = self.process_request("get", "/some/url", secure=True, headers={"host": "www.secure.example.com"})
+        self.assertEqual(ret.status_code, 301)
+        self.assertEqual(ret["Location"], "https://secure.example.com/some/url")
+
     @override_settings(SECURE_SSL_REDIRECT=False)
     def test_ssl_redirect_off(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28359