### PR TITLE
Made changes in topic "Saving ForeignKey and ManyToManyField fields"

### DIFF
--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -101,7 +101,7 @@ the field in question. This example updates the ``blog`` attribute of an
 ``Entry`` instance ``entry``, assuming appropriate instances of ``Entry`` and
 ``Blog`` are already saved to the database (so we can retrieve them below)::
 
-    >>> from blog.models import Entry
+    >>> from blog.models import Entry, Blog
     >>> entry = Entry.objects.get(pk=1)
     >>> cheese_blog = Blog.objects.get(name="Cheddar Talk")
     >>> entry.blog = cheese_blog

--- a/docs/topics/db/queries.txt
+++ b/docs/topics/db/queries.txt
@@ -101,7 +101,7 @@ the field in question. This example updates the ``blog`` attribute of an
 ``Entry`` instance ``entry``, assuming appropriate instances of ``Entry`` and
 ``Blog`` are already saved to the database (so we can retrieve them below)::
 
-    >>> from blog.models import Entry, Blog
+    >>> from blog.models import Blog, Entry
     >>> entry = Entry.objects.get(pk=1)
     >>> cheese_blog = Blog.objects.get(name="Cheddar Talk")
     >>> entry.blog = cheese_blog


### PR DESCRIPTION
In topic [Saving ForeignKey and ManyToManyField fields](https://docs.djangoproject.com/en/1.11/topics/db/queries/#saving-foreignkey-and-manytomanyfield-fields) we are using Entry and Blog classes of the model.py ("blog.models") but only importing Entry from blog.models which will give an error after executing 
`cheese_blog = Blog.objects.get(name="Cheddar Talk")`