### PR TITLE
Fixed #28364 -- Removed redundant table joins in get_relations() on Oracle.

### DIFF
--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -105,17 +105,11 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """
         table_name = table_name.upper()
         cursor.execute("""
-    SELECT ta.column_name, tb.table_name, tb.column_name
-    FROM   user_constraints, USER_CONS_COLUMNS ca, USER_CONS_COLUMNS cb,
-           user_tab_cols ta, user_tab_cols tb
+    SELECT ca.column_name, cb.table_name, cb.column_name
+    FROM   user_constraints, USER_CONS_COLUMNS ca, USER_CONS_COLUMNS cb
     WHERE  user_constraints.table_name = %s AND
-           ta.table_name = user_constraints.table_name AND
-           ta.column_name = ca.column_name AND
-           ca.table_name = ta.table_name AND
            user_constraints.constraint_name = ca.constraint_name AND
            user_constraints.r_constraint_name = cb.constraint_name AND
-           cb.table_name = tb.table_name AND
-           cb.column_name = tb.column_name AND
            ca.position = cb.position""", [table_name])
 
         relations = {}


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28364