### PR TITLE
Fixed #28361 -- Fixed possible time-related failure in was_published_recently() tutorial test.

### DIFF
--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -285,7 +285,7 @@ more comprehensively:
         was_published_recently() returns False for questions whose pub_date
         is older than 1 day.
         """
-        time = timezone.now() - datetime.timedelta(days=1)
+        time = timezone.now() - datetime.timedelta(days=1, seconds=1)
         old_question = Question(pub_date=time)
         self.assertIs(old_question.was_published_recently(), False)
 


### PR DESCRIPTION
Make it time independent on all systems, as described here: https://code.djangoproject.com/ticket/28361