### PR TITLE
Fixed #28382 -- Prevented BaseExpression._output_field from being set if _resolve_output_field() fails.

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -44,8 +44,8 @@ class Avg(Aggregate):
     def _resolve_output_field(self):
         source_field = self.get_source_fields()[0]
         if isinstance(source_field, (IntegerField, DecimalField)):
-            self._output_field = FloatField()
-        super()._resolve_output_field()
+            return FloatField()
+        return super()._resolve_output_field()
 
     def as_oracle(self, compiler, connection):
         if self.output_field.get_internal_type() == 'DurationField':

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -965,8 +965,12 @@ class AggregateTestCase(TestCase):
         self.assertEqual(p2, {'avg_price': Approximate(53.39, places=2)})
 
     def test_combine_different_types(self):
-        with self.assertRaisesMessage(FieldError, 'Expression contains mixed types. You must set output_field'):
-            Book.objects.annotate(sums=Sum('rating') + Sum('pages') + Sum('price')).get(pk=self.b4.pk)
+        msg = 'Expression contains mixed types. You must set output_field.'
+        qs = Book.objects.annotate(sums=Sum('rating') + Sum('pages') + Sum('price'))
+        with self.assertRaisesMessage(FieldError, msg):
+            qs.first()
+        with self.assertRaisesMessage(FieldError, msg):
+            qs.first()
 
         b1 = Book.objects.annotate(sums=Sum(F('rating') + F('pages') + F('price'),
                                    output_field=IntegerField())).get(pk=self.b4.pk)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28382