### PR TITLE
Fix #28373 -- Uses the DatabaseWrapper timezone_name instead of 'UTC'

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -45,8 +45,8 @@ class DatabaseOperations(BaseDatabaseOperations):
             return "DATE(%s)" % (field_name)
 
     def _convert_field_to_tz(self, field_name, tzname):
-        if settings.USE_TZ:
-            field_name = "CONVERT_TZ(%s, 'UTC', %%s)" % field_name
+        if settings.USE_TZ and self.connection.timezone_name != tzname:
+            field_name = "CONVERT_TZ(%s, '%s', %%s)" % (field_name, self.connection.timezone_name)
             params = [tzname]
         else:
             params = []


### PR DESCRIPTION
I opened this ticket https://code.djangoproject.com/ticket/28373 (master has a similar fix)

As you can see, datetimes are converted from 'UTC' to the required tz regardless of the database specific TIME_ZONE setting.

It is also my opinion that this conversion is not required if both tz are equal. To be discussed.

I haven't written a test case yet, I mainly wanted to bring this to the experts attention.

