### PR TITLE
Refs #23919 -- Reference only Python 3+ in bash completion utility.

### DIFF
--- a/extras/django_bash_completion
+++ b/extras/django_bash_completion
@@ -43,7 +43,7 @@ _python_django_completion()
 {
     if [[ ${COMP_CWORD} -ge 2 ]]; then
         local PYTHON_EXE=${COMP_WORDS[0]##*/}
-        echo $PYTHON_EXE | egrep "python([2-9]\.[0-9])?" >/dev/null 2>&1
+        echo $PYTHON_EXE | egrep "python([3-9]\.[0-9])?" >/dev/null 2>&1
         if [[ $? == 0 ]]; then
             local PYTHON_SCRIPT=${COMP_WORDS[1]##*/}
             echo $PYTHON_SCRIPT | egrep "manage\.py|django-admin(\.py)?" >/dev/null 2>&1


### PR DESCRIPTION
As Python 2 is not supported anymore, the binary shouldn't be referenced. I was tempted to change the minor version, but I don't think there's a final decision on 3.5 or 3.4 as the least supported minor version.