### PR TITLE
Fixed #28378 -- Fixed union(), and difference() when combining with queryset raising EmptyResultSet exception.

### DIFF
--- a/docs/releases/1.11.4.txt
+++ b/docs/releases/1.11.4.txt
@@ -12,3 +12,6 @@ Bugfixes
 * Fixed a regression in 1.11.3 on Python 2 where non-ASCII ``format`` values
   for date/time widgets results in an empty ``value`` in the widget's HTML
   (:ticket:`28355`).
+
+* Fixed ``QuerySet.union()`` and ``difference()`` when combining with
+  a queryset raising ``EmptyResultSet`` (:ticket:`28378`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -58,18 +58,26 @@ class QuerySetSetOperationTests(TestCase):
     def test_difference_with_empty_qs(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.none()
+        qs3 = Number.objects.filter(pk__in=[])
         self.assertEqual(len(qs1.difference(qs2)), 10)
+        self.assertEqual(len(qs1.difference(qs3)), 10)
         self.assertEqual(len(qs2.difference(qs1)), 0)
+        self.assertEqual(len(qs3.difference(qs1)), 0)
         self.assertEqual(len(qs2.difference(qs2)), 0)
+        self.assertEqual(len(qs3.difference(qs3)), 0)
 
     def test_union_with_empty_qs(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.none()
+        qs3 = Number.objects.filter(pk__in=[])
         self.assertEqual(len(qs1.union(qs2)), 10)
         self.assertEqual(len(qs2.union(qs1)), 10)
+        self.assertEqual(len(qs1.union(qs3)), 10)
+        self.assertEqual(len(qs3.union(qs1)), 10)
         self.assertEqual(len(qs2.union(qs1, qs1, qs1)), 10)
         self.assertEqual(len(qs2.union(qs1, qs1, all=True)), 20)
         self.assertEqual(len(qs2.union(qs2)), 0)
+        self.assertEqual(len(qs3.union(qs3)), 0)
 
     def test_limits(self):
         qs1 = Number.objects.all()

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -46,9 +46,13 @@ class QuerySetSetOperationTests(TestCase):
     def test_intersection_with_empty_qs(self):
         qs1 = Number.objects.all()
         qs2 = Number.objects.none()
+        qs3 = Number.objects.filter(pk__in=[])
         self.assertEqual(len(qs1.intersection(qs2)), 0)
+        self.assertEqual(len(qs1.intersection(qs3)), 0)
         self.assertEqual(len(qs2.intersection(qs1)), 0)
+        self.assertEqual(len(qs3.intersection(qs1)), 0)
         self.assertEqual(len(qs2.intersection(qs2)), 0)
+        self.assertEqual(len(qs3.intersection(qs3)), 0)
 
     @skipUnlessDBFeature('supports_select_difference')
     def test_difference_with_empty_qs(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28378