### PR TITLE
Fixed #28380 -- Handled -1 return value of Spatialite geometry functions on NULL parameters.

### DIFF
--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -36,7 +36,10 @@ class SpatiaLiteDistanceOperator(SpatialOperator):
 
 class SpatialiteNullCheckOperator(SpatialOperator):
     def as_sql(self, connection, lookup, template_params, sql_params):
-        sql_template = '%(func)s(%(lhs)s, %(rhs)s) > 0'
+        if 'rhs' in template_params:
+            sql_template = '%(func)s(%(lhs)s, %(rhs)s) > 0'
+        else:
+            sql_template = '%(func)s(%(lhs)s) > 0'
         template_params.update({'op': self.op, 'func': self.func})
         return sql_template % template_params, sql_params
 

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -34,6 +34,13 @@ class SpatiaLiteDistanceOperator(SpatialOperator):
         return super(SpatiaLiteDistanceOperator, self).as_sql(connection, lookup, template_params, sql_params)
 
 
+class SpatialiteNullCheckOperator(SpatialOperator):
+    def as_sql(self, connection, lookup, template_params, sql_params):
+        sql_template = '%(func)s(%(lhs)s, %(rhs)s) > 0'
+        template_params.update({'op': self.op, 'func': self.func})
+        return sql_template % template_params, sql_params
+
+
 class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
     name = 'spatialite'
     spatialite = True
@@ -72,26 +79,26 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
 
     gis_operators = {
         # Unary predicates
-        'isvalid': SpatialOperator(func='IsValid'),
+        'isvalid': SpatialiteNullCheckOperator(func='IsValid'),
         # Binary predicates
-        'equals': SpatialOperator(func='Equals'),
-        'disjoint': SpatialOperator(func='Disjoint'),
-        'touches': SpatialOperator(func='Touches'),
-        'crosses': SpatialOperator(func='Crosses'),
-        'within': SpatialOperator(func='Within'),
-        'overlaps': SpatialOperator(func='Overlaps'),
-        'contains': SpatialOperator(func='Contains'),
-        'intersects': SpatialOperator(func='Intersects'),
-        'relate': SpatialOperator(func='Relate'),
+        'equals': SpatialiteNullCheckOperator(func='Equals'),
+        'disjoint': SpatialiteNullCheckOperator(func='Disjoint'),
+        'touches': SpatialiteNullCheckOperator(func='Touches'),
+        'crosses': SpatialiteNullCheckOperator(func='Crosses'),
+        'within': SpatialiteNullCheckOperator(func='Within'),
+        'overlaps': SpatialiteNullCheckOperator(func='Overlaps'),
+        'contains': SpatialiteNullCheckOperator(func='Contains'),
+        'intersects': SpatialiteNullCheckOperator(func='Intersects'),
+        'relate': SpatialiteNullCheckOperator(func='Relate'),
         # Returns true if B's bounding box completely contains A's bounding box.
-        'contained': SpatialOperator(func='MbrWithin'),
+        'contained': SpatialiteNullCheckOperator(func='MbrWithin'),
         # Returns true if A's bounding box completely contains B's bounding box.
-        'bbcontains': SpatialOperator(func='MbrContains'),
+        'bbcontains': SpatialiteNullCheckOperator(func='MbrContains'),
         # Returns true if A's bounding box overlaps B's bounding box.
-        'bboverlaps': SpatialOperator(func='MbrOverlaps'),
+        'bboverlaps': SpatialiteNullCheckOperator(func='MbrOverlaps'),
         # These are implemented here as synonyms for Equals
-        'same_as': SpatialOperator(func='Equals'),
-        'exact': SpatialOperator(func='Equals'),
+        'same_as': SpatialiteNullCheckOperator(func='Equals'),
+        'exact': SpatialiteNullCheckOperator(func='Equals'),
         # Distance predicates
         'dwithin': SpatialOperator(func='PtDistWithin'),
         'distance_gt': SpatiaLiteDistanceOperator(func='Distance', op='>'),


### PR DESCRIPTION
Checking return values for some geometry comparison functions as the value `-1` means that one of the passed values was NULL.

Ticket: https://code.djangoproject.com/ticket/28380#ticket