### PR TITLE
Update name of topics/db/queries link on index page

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -87,7 +87,7 @@ manipulating the data of your Web application. Learn more about it below:
   :doc:`Model class <ref/models/class>`
 
 * **QuerySets:**
-  :doc:`Executing queries <topics/db/queries>` |
+  :doc:`Making queries <topics/db/queries>` |
   :doc:`QuerySet method reference <ref/models/querysets>` |
   :doc:`Lookup expressions <ref/models/lookups>`
 


### PR DESCRIPTION
The `<h1>` on `<topics/db/queries>` is "Making queries" but the name of the link on the index page is executing queries. I think the link name should match the `<h1>` it links to.