### PR TITLE
Increasing more length to the name of the group

### DIFF
--- a/django/contrib/auth/models.py
+++ b/django/contrib/auth/models.py
@@ -108,7 +108,7 @@ class Group(models.Model):
     members-only portion of your site, or sending them members-only email
     messages.
     """
-    name = models.CharField(_('name'), max_length=80, unique=True)
+    name = models.CharField(_('name'), max_length=100, unique=True)
     permissions = models.ManyToManyField(
         Permission,
         verbose_name=_('permissions'),


### PR DESCRIPTION
Hello django @django

This pull request only have one change for increasing more length to the name of the group from 80 to 100

This change is for support one name more long

This changed fixed https://github.com/WeblateOrg/weblate/issues/1549


