### PR TITLE
Fixed rendering of form errors in test client login template.

### DIFF
--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-{% if form.has_errors %}
+{% if form.errors %}
 <p>Your username and password didn't match. Please try again.</p>
 {% endif %}
 


### PR DESCRIPTION
Forms don't have a `has_errors` property - this was removed in previous versions of Django.