### PR TITLE
Fixed #28383 -- Made NumPoints GIS function return None for non-LINESTRING geometries on MySQL.

### DIFF
--- a/django/contrib/gis/db/models/functions.py
+++ b/django/contrib/gis/db/models/functions.py
@@ -419,12 +419,6 @@ class NumPoints(GeoFunc):
     output_field_class = IntegerField
     arity = 1
 
-    def as_sql(self, compiler, connection):
-        if self.source_expressions[self.geom_param_pos[0]].output_field.geom_type != 'LINESTRING':
-            if not connection.features.supports_num_points_poly:
-                raise TypeError('NumPoints can only operate on LineString content on this database.')
-        return super().as_sql(compiler, connection)
-
 
 class Perimeter(DistanceResultMixin, OracleToleranceMixin, GeoFunc):
     arity = 1

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -336,9 +336,8 @@ class GISFunctionsTests(TestCase):
         self.assertEqual(qs.first().num_points, 2)
         mpoly_qs = Country.objects.annotate(num_points=functions.NumPoints('mpoly'))
         if not connection.features.supports_num_points_poly:
-            msg = 'NumPoints can only operate on LineString content on this database.'
-            with self.assertRaisesMessage(TypeError, msg):
-                list(mpoly_qs)
+            for c in mpoly_qs:
+                self.assertIsNone(c.num_points)
             return
 
         for c in mpoly_qs:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28383