### PR TITLE
Fixed #28386 -- Made operations within non-atomic migrations honor the operation's atomic flag when migrating backwards.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -254,6 +254,7 @@ answer newbie questions, and generally made Django that much better:
     Esdras Beleza <linux@esdrasbeleza.com>
     Espen Grindhaug <http://grindhaug.org/>
     Eugene Lazutkin <http://lazutkin.com/blog/>
+    Evan Grim <https://github.com/egrim>
     Fabrice Aneche <akh@nobugware.com>
     favo@exoweb.net
     fdr <drfarina@gmail.com>

--- a/tests/migrations/test_migrations_atomic_operation/0001_initial.py
+++ b/tests/migrations/test_migrations_atomic_operation/0001_initial.py
@@ -18,5 +18,5 @@ class Migration(migrations.Migration):
                 ("name", models.CharField(primary_key=True, max_length=255)),
             ],
         ),
-        migrations.RunPython(raise_error, atomic=True),
+        migrations.RunPython(raise_error, reverse_code=raise_error, atomic=True),
     ]

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2009,10 +2009,11 @@ class OperationTests(OperationTestBase):
             Pony.objects.create(pink=1, weight=3.55)
             raise ValueError("Adrian hates ponies.")
 
+        # Verify atomicity when applying.
         atomic_migration = Migration("test", "test_runpythonatomic")
-        atomic_migration.operations = [migrations.RunPython(inner_method)]
+        atomic_migration.operations = [migrations.RunPython(inner_method, reverse_code=inner_method)]
         non_atomic_migration = Migration("test", "test_runpythonatomic")
-        non_atomic_migration.operations = [migrations.RunPython(inner_method, atomic=False)]
+        non_atomic_migration.operations = [migrations.RunPython(inner_method, reverse_code=inner_method, atomic=False)]
         # If we're a fully-transactional database, both versions should rollback
         if connection.features.can_rollback_ddl:
             self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
@@ -2035,11 +2036,33 @@ class OperationTests(OperationTestBase):
                 with connection.schema_editor() as editor:
                     non_atomic_migration.apply(project_state, editor)
             self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 1)
-        # And deconstruction
+        # Reset object count to zero and verify atomicity when unapplying.
+        project_state.apps.get_model("test_runpythonatomic", "Pony").objects.all().delete()
+        # On a fully-transactional database, both versions rollback.
+        if connection.features.can_rollback_ddl:
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
+            with self.assertRaises(ValueError):
+                with connection.schema_editor() as editor:
+                    atomic_migration.unapply(project_state, editor)
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
+            with self.assertRaises(ValueError):
+                with connection.schema_editor() as editor:
+                    non_atomic_migration.unapply(project_state, editor)
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
+        # Otherwise, the non-atomic operation leaves a row there.
+        else:
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
+            with self.assertRaises(ValueError):
+                with connection.schema_editor() as editor:
+                    atomic_migration.unapply(project_state, editor)
+            with self.assertRaises(ValueError):
+                with connection.schema_editor() as editor:
+                    non_atomic_migration.unapply(project_state, editor)
+        # Verify deconstruction.
         definition = non_atomic_migration.operations[0].deconstruct()
         self.assertEqual(definition[0], "RunPython")
         self.assertEqual(definition[1], [])
-        self.assertEqual(sorted(definition[2]), ["atomic", "code"])
+        self.assertEqual(sorted(definition[2]), ["atomic", "code", "reverse_code"])
 
     def test_run_python_related_assignment(self):
         """

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2055,9 +2055,11 @@ class OperationTests(OperationTestBase):
             with self.assertRaises(ValueError):
                 with connection.schema_editor() as editor:
                     atomic_migration.unapply(project_state, editor)
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 0)
             with self.assertRaises(ValueError):
                 with connection.schema_editor() as editor:
                     non_atomic_migration.unapply(project_state, editor)
+            self.assertEqual(project_state.apps.get_model("test_runpythonatomic", "Pony").objects.count(), 1)
         # Verify deconstruction.
         definition = non_atomic_migration.operations[0].deconstruct()
         self.assertEqual(definition[0], "RunPython")


### PR DESCRIPTION
Non-atomic migrations added in [#25833](https://code.djangoproject.com/ticket/25833) (PR #5745) allowed for individual operations to be marked atomic. This works properly in the forward direction but fails when moving backwards.

Ticket for this bug: [#28386](https://code.djangoproject.com/ticket/28386)