### PR TITLE
Fixed #21076 -- Store hashes of session keys in backends

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -478,6 +478,11 @@ SESSION_FILE_PATH = None
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 # Whether to hash the session_key when stored in the backend
 SESSION_STORE_KEY_HASH = True
+# Whether to allow non-hashed session keys to be loaded. Setting this to
+# 'False' bypasses the security benefit of hashing session keys. This
+# should be set to 'True' after moving session keys from unhashed to
+# hashed
+SESSION_REQUIRE_KEY_HASH = False
 
 #########
 # CACHE #

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -476,6 +476,8 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 SESSION_FILE_PATH = None
 # class to serialize session data
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
+# Whether to hash the session_key when stored in the backend
+SESSION_STORE_KEY_HASH = True
 
 #########
 # CACHE #

--- a/django/contrib/sessions/backends/cache.py
+++ b/django/contrib/sessions/backends/cache.py
@@ -19,7 +19,8 @@ class SessionStore(SessionBase):
 
     @property
     def cache_key(self):
-        return self.cache_key_prefix + self._get_or_create_session_key()
+        session_key = self.get_session_key_hash(self._get_or_create_session_key())
+        return self.cache_key_prefix + session_key
 
     def load(self):
         try:
@@ -67,13 +68,15 @@ class SessionStore(SessionBase):
             raise CreateError
 
     def exists(self, session_key):
+        session_key = self.get_session_key_hash(session_key)
         return bool(session_key) and (self.cache_key_prefix + session_key) in self._cache
 
     def delete(self, session_key=None):
+        session_key = self.get_session_key_hash(session_key)
         if session_key is None:
             if self.session_key is None:
                 return
-            session_key = self.session_key
+            session_key = self.get_session_key_hash(self.session_key)
         self._cache.delete(self.cache_key_prefix + session_key)
 
     @classmethod

--- a/django/contrib/sessions/backends/cached_db.py
+++ b/django/contrib/sessions/backends/cached_db.py
@@ -55,8 +55,8 @@ class SessionStore(DBStore):
         return data
 
     def exists(self, session_key):
-        session_key = self.get_session_key_hash(session_key)
-        if session_key and (self.cache_key_prefix + session_key) in self._cache:
+        hashed_session_key = self.get_session_key_hash(session_key)
+        if hashed_session_key and (self.cache_key_prefix + hashed_session_key) in self._cache:
             return True
         return super().exists(session_key)
 

--- a/django/contrib/sessions/backends/db.py
+++ b/django/contrib/sessions/backends/db.py
@@ -30,7 +30,7 @@ class SessionStore(SessionBase):
     def load(self):
         try:
             s = self.model.objects.get(
-                session_key=self.session_key,
+                session_key=self.get_session_key_hash(self.session_key),
                 expire_date__gt=timezone.now()
             )
             return self.decode(s.session_data)
@@ -42,7 +42,7 @@ class SessionStore(SessionBase):
             return {}
 
     def exists(self, session_key):
-        return self.model.objects.filter(session_key=session_key).exists()
+        return self.model.objects.filter(session_key=self.get_session_key_hash(session_key)).exists()
 
     def create(self):
         while True:
@@ -98,7 +98,7 @@ class SessionStore(SessionBase):
                 return
             session_key = self.session_key
         try:
-            self.model.objects.get(session_key=session_key).delete()
+            self.model.objects.get(session_key=self.get_session_key_hash(session_key)).delete()
         except self.model.DoesNotExist:
             pass
 

--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -48,6 +48,8 @@ class SessionStore(SessionBase):
         """
         if session_key is None:
             session_key = self._get_or_create_session_key()
+        else:
+            session_key = self.get_session_key_hash(session_key)
 
         # Make sure we're not vulnerable to directory traversal. Session keys
         # should always be md5s, so they should never contain directory

--- a/django/contrib/sessions/base_session.py
+++ b/django/contrib/sessions/base_session.py
@@ -24,7 +24,7 @@ class BaseSessionManager(models.Manager):
 
 
 class AbstractBaseSession(models.Model):
-    session_key = models.CharField(_('session key'), max_length=40, primary_key=True)
+    session_key = models.CharField(_('session key'), max_length=70, primary_key=True)
     session_data = models.TextField(_('session data'))
     expire_date = models.DateTimeField(_('expire date'), db_index=True)
 

--- a/django/contrib/sessions/migrations/0002_alter_session_key_max_length.py
+++ b/django/contrib/sessions/migrations/0002_alter_session_key_max_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sessions', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='session',
+            name='session_key',
+            field=models.CharField(max_length=70, serialize=False, verbose_name='session key', primary_key=True),
+        ),
+    ]

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3157,6 +3157,19 @@ Whether to save the session key as a one-way hash. You should only set this to
 ``False`` if you have a good reason since it can decrease the security of your
 site.
 
+.. setting:: SESSION_REQUIRE_KEY_HASH
+
+``SESSION_REQUIRE_KEY_HASH``
+------------------------------
+
+Default: ``False``
+
+Whether to require the session key to be stored and retrieved as a one-way
+hash. All security benefits of having :setting:`SESSION_STORE_KEY_HASH` set to
+``True`` will be invalidated if this is set to the default of ``False``.
+However, this default of ``False`` is useful while transitioning to the new
+one-way hashed session storage behavior in order to support legacy sessions.
+
 Sites
 =====
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -3146,6 +3146,17 @@ See :ref:`session_serialization` for details, including a warning regarding
 possible remote code execution when using
 :class:`~django.contrib.sessions.serializers.PickleSerializer`.
 
+.. setting:: SESSION_STORE_KEY_HASH
+
+``SESSION_STORE_KEY_HASH``
+------------------------------
+
+Default: ``True``
+
+Whether to save the session key as a one-way hash. You should only set this to
+``False`` if you have a good reason since it can decrease the security of your
+site.
+
 Sites
 =====
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -138,6 +138,13 @@ Minor features
   session key should be stored as a one-way hash. Only set this to
   False if you have an explicit reason.
 
+* Added :setting:`SESSION_REQUIRE_KEY_HASH` to determine whether the
+  session key must be hashed. This needs to be set to True in order
+  to actually see any security benefit in hashing the session keys
+  in the backend. However, you is useful to set this to False (the
+  current default) so that legacy (non-hashed) sessions still work
+  while transitioning to hashed sessions.
+
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -513,6 +520,13 @@ Miscellaneous
   before querying the backend if you currently access it directly. You can
   disable this behavior by setting :setting:`SESSION_STORE_KEY_HASH` to
   False.
+
+* :setting:`SESSION_REQUIRE_KEY_HASH` now dictates whether a session key
+  must be hashed. This is by default set to False so that legacy
+  (non-hashed) sessions will continue to work when upgrading to 2.0.
+  However, unless :setting:`SESSION_REQUIRE_KEY_HASH` is set to True, an
+  attacker could easily bypass the security benefit of hashing the
+  session keys in the backend.
 
 * The ``SessionAuthenticationMiddleware`` class is removed. It provided no
   functionality since session authentication is unconditionally enabled in

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -119,7 +119,25 @@ Minor features
 :mod:`django.contrib.sessions`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* One-way hashes of the session keys are now stored in the ``db``,
+  ``cached_db``, ``cached`` and ``file`` backends by default. Old
+  sessions should continue to work on your site. As sessions are
+  cycled, your backend will slowly move towards using one-way
+  hashed session_keys. This provides an additional layer of
+  security against compromises of a backend via a backup or
+  read only access.
+
+* The new
+  :meth:`~django.contrib.sessions.backends.base.SessionBase.get_session_key_hash`
+  may be needed if you directly access the session backend. For
+  example::
+
+      Session.objects.get(session_key=get_session_key_hash(session_key))
+
+* Added :setting:`SESSION_STORE_KEY_HASH` to determine whether the
+  session key should be stored as a one-way hash. Only set this to
+  False if you have an explicit reason.
+
 
 :mod:`django.contrib.sitemaps`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -487,6 +505,14 @@ cases such as multiple databases. Feel free to contribute improvements.
 
 Miscellaneous
 -------------
+
+* Session keys are now hashed in the backends (except for signed cookies).
+  This adds a layer of security against some attack vectors like exploiting
+  a backend backup. You may need to pass the sessionid cookie value through
+  :meth:`~django.contrib.sessions.backends.base.SessionBase.get_session_key_hash`
+  before querying the backend if you currently access it directly. You can
+  disable this behavior by setting :setting:`SESSION_STORE_KEY_HASH` to
+  False.
 
 * The ``SessionAuthenticationMiddleware`` class is removed. It provided no
   functionality since session authentication is unconditionally enabled in

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -44,7 +44,11 @@ configured to store session data on your filesystem or in your cache.
 
 One-way hashes of the session_keys will be stored in the backends by
 default. You can override this by changing :setting:`SESSION_STORE_KEY_HASH`
-to False.
+to False. You must also set :setting:`SESSION_REQUIRE_KEY_HASH` to True in
+order to realize the security benefit of this change. However, you will
+probably want to keep :setting:`SESSION_REQUIRE_KEY_HASH` set to False
+until all of your non-hashed session keys have expired so that they
+will continue to be accessible.
 
 Using database-backed sessions
 ------------------------------
@@ -257,7 +261,8 @@ You can edit it multiple times.
       .. versionadded:: 2.0
 
       Returns the hashed version of the session_key or if
-      :setting:`SESSION_STORE_KEY_HASH` is False it will just return the
+      :setting:`SESSION_STORE_KEY_HASH` is False and
+      :setting:`SESSION_REQUIRE_KEY_HASH` is False it will just return the
       session_key. Pass the value of the sessionid cookie through this
       method in order to query the backend directly.
 
@@ -659,6 +664,7 @@ behavior:
 * :setting:`SESSION_SAVE_EVERY_REQUEST`
 * :setting:`SESSION_SERIALIZER`
 * :setting:`SESSION_STORE_KEY_HASH`
+* :setting:`SESSION_REQUIRE_KEY_HASH`
 
 .. _topics-session-security:
 
@@ -682,7 +688,9 @@ session cookies from that site to be sent to ``bad.example.com``.
 
 Changing :setting:`SESSION_STORE_KEY_HASH` to False could allow an attacker
 to takeover a session even if they only had access to a backend backup or
-read-only access to the backend.
+read-only access to the backend. If :setting:`SESSION_REQUIRE_KEY_HASH` is
+set to False, an attacker could trivially bypass the security benefits of
+having :setting:`SESSION_STORE_KEY_HASH` set to True.
 
 Technical details
 =================

--- a/docs/topics/http/sessions.txt
+++ b/docs/topics/http/sessions.txt
@@ -38,6 +38,14 @@ By default, Django stores sessions in your database (using the model
 some setups it's faster to store session data elsewhere, so Django can be
 configured to store session data on your filesystem or in your cache.
 
+.. versionchanged:: 2.0
+
+  The way session keys are stored in the backend was changed.
+
+One-way hashes of the session_keys will be stored in the backends by
+default. You can override this by changing :setting:`SESSION_STORE_KEY_HASH`
+to False.
+
 Using database-backed sessions
 ------------------------------
 
@@ -243,6 +251,15 @@ You can edit it multiple times.
     .. method:: delete_test_cookie()
 
       Deletes the test cookie. Use this to clean up after yourself.
+
+    .. method:: get_session_key_hash(session_key)
+
+      .. versionadded:: 2.0
+
+      Returns the hashed version of the session_key or if
+      :setting:`SESSION_STORE_KEY_HASH` is False it will just return the
+      session_key. Pass the value of the sessionid cookie through this
+      method in order to query the backend directly.
 
     .. method:: set_expiry(value)
 
@@ -481,7 +498,10 @@ Using sessions out of views
       >>> from django.conf import settings
       >>> SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
-An API is available to manipulate session data outside of a view::
+An API is available to manipulate session data outside of a view. Note that you
+must pass the session_key through the
+:meth:`~backends.base.SessionBase.get_session_key_hash` before directly
+querying the session_key field::
 
     >>> from django.contrib.sessions.backends.db import SessionStore
     >>> s = SessionStore()
@@ -489,8 +509,9 @@ An API is available to manipulate session data outside of a view::
     >>> s['last_login'] = 1376587691
     >>> s.create()
     >>> s.session_key
-    '2b1189a188b44ad18c35e113ac6ceead'
-    >>> s = SessionStore(session_key='2b1189a188b44ad18c35e113ac6ceead')
+    'md5$2b1189a188b44ad18c35e113ac6ceead'
+    >>> session_key = get_session_key_hash(s.session_key)
+    >>> s = SessionStore(session_key=session_key)
     >>> s['last_login']
     1376587691
 
@@ -507,7 +528,9 @@ session is just a normal Django model. The ``Session`` model is defined in
 access sessions using the normal Django database API::
 
     >>> from django.contrib.sessions.models import Session
-    >>> s = Session.objects.get(pk='2b1189a188b44ad18c35e113ac6ceead')
+    >>> from django.contrib.sessions import get_session_key_hash
+    >>> pk = get_session_key_hash('md5$2b1189a188b44ad18c35e113ac6ceead')
+    >>> s = Session.objects.get(pk=pk)
     >>> s.expire_date
     datetime.datetime(2005, 8, 20, 13, 35, 12)
 
@@ -635,6 +658,7 @@ behavior:
 * :setting:`SESSION_FILE_PATH`
 * :setting:`SESSION_SAVE_EVERY_REQUEST`
 * :setting:`SESSION_SERIALIZER`
+* :setting:`SESSION_STORE_KEY_HASH`
 
 .. _topics-session-security:
 
@@ -655,6 +679,10 @@ sensitive personal data (e.g. credit card info) into the attackers account.
 Another possible attack would be if ``good.example.com`` sets its
 :setting:`SESSION_COOKIE_DOMAIN` to ``".example.com"`` which would cause
 session cookies from that site to be sent to ``bad.example.com``.
+
+Changing :setting:`SESSION_STORE_KEY_HASH` to False could allow an attacker
+to takeover a session even if they only had access to a backend backup or
+read-only access to the backend.
 
 Technical details
 =================
@@ -719,7 +747,11 @@ including ``django.contrib.sessions`` in :setting:`INSTALLED_APPS`.
 
         Primary key. The field itself may contain up to 40 characters. The
         current implementation generates a 32-character string (a random
-        sequence of digits and lowercase ASCII letters).
+        sequence of digits and lowercase ASCII letters) which is passed
+        through a one-way hashing function before being stored. You will
+        need to pass the value of the sessionid cookie through the
+        :meth:`~backends.base.SessionBase.get_session_key_hash`
+        before directly querying this field.
 
     .. attribute:: session_data
 


### PR DESCRIPTION
Added the ability to store a one-way hash of the session key instead of storing it as plain-text in the backend to improve security. This is particularly beneficial if a malicious actor only gains access to a read-only version of the backend or an unencrypted backend backup. Further discussion can be found on the [django-developers Google group](https://groups.google.com/forum/#!topic/django-developers/XMZXYBGQDZU).

The [Trac ticket](https://code.djangoproject.com/ticket/21076) mentioned the ability to turn this feature off since some installs rely upon shared backend stores to handle authentication across applications. I added the SESSION_STORE_KEY_HASH global setting to allow developers to disable this behavior if desired.

Some design considerations:

- Ensure we don't break current user sessions
- Use a fast hashing algorithm to have minimal performance impact
- Store the hashing function used so that we can change the function used gracefully if needed
- Expose an API method to hash the key
- Support this functionality in all backends (except the cookie backend)

An area of concern:
- If a developer currently accesses a Session through the `objects` manager, they'll need to update their code to hash the key before querying via the `session_key` or `pk` fields. For instance,

```py
Session.objects.get(session_key=session_key)
```
would now need to be:

```py
Session.objects.get(session_key=get_session_key_hash(session_key))
```

Is there a better way to address this shortcoming?