### PR TITLE
Fixed #28174 -- Fixed crash in runserver's autoreload with Python 2 on Windows with non-str environment variables.

### DIFF
--- a/docs/releases/1.11.4.txt
+++ b/docs/releases/1.11.4.txt
@@ -18,3 +18,6 @@ Bugfixes
 
 * Fixed a regression in pickling of ``LazyObject`` on Python 2 when the wrapped
   object doesn't have ``__reduce__()`` (:ticket:`28389`).
+
+* Fixed crash in ``runserver``'s ``autoreload`` with Python 2 on Windows with
+  non-``str`` environment variables (:ticket:`28174`).

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -1,6 +1,9 @@
+from __future__ import unicode_literals
+
 import gettext
 import os
 import shutil
+import sys
 import tempfile
 from importlib import import_module
 
@@ -251,3 +254,17 @@ class ResetTranslationsTests(SimpleTestCase):
         self.assertEqual(trans_real._translations, {})
         self.assertIsNone(trans_real._default)
         self.assertIsInstance(trans_real._active, _thread._local)
+
+
+class TestRestartWithReloader(SimpleTestCase):
+
+    def test_environment(self):
+        """"
+        With Python 2 on Windows, restart_with_reloader() coerces environment
+        variables to str to avoid "TypeError: environment can only contain
+        strings" in Python's subprocess.py.
+        """
+        # With unicode_literals, these values are unicode.
+        os.environ['SPAM'] = 'spam'
+        with mock.patch.object(sys, 'argv', ['-c', 'pass']):
+            autoreload.restart_with_reloader()


### PR DESCRIPTION
Ensure that all environment values are str objects to avoid a TypeError.  

Ticket: https://code.djangoproject.com/ticket/28174