### PR TITLE
Fixed #28316: to_field_name handled properly on ModelChoiceFields

### DIFF
--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -831,6 +831,7 @@ class UniqueTest(TestCase):
     """
     unique/unique_together validation.
     """
+
     def setUp(self):
         self.writer = Writer.objects.create(name='Mike Royko')
 
@@ -1798,6 +1799,40 @@ class ModelChoiceFieldTests(TestCase):
 
         with self.assertNumQueries(2):
             template.render(Context({'form': CategoriesForm()}))
+
+    def test_to_field_name_with_initial_data_different_to_field_from_model(self):
+        """
+        Inventory.parent to_field='barcode' but the form field uses a different
+        to_field_name.
+        """
+        class InventoryForm(forms.ModelForm):
+            parent = forms.ModelChoiceField(Inventory.objects.all(), to_field_name='name')
+
+            class Meta:
+                model = Inventory
+                fields = ['parent']
+
+        apple = Inventory.objects.create(barcode=86, name='Apple')
+        pear = Inventory.objects.create(barcode=22, name='Pear', parent=apple)
+        form = InventoryForm(instance=pear)
+        self.assertEqual(form['parent'].value(), apple.name)
+
+    def test_to_field_name_with_initial_data(self):
+        """
+        Student.character doesn't have to_field but the form field uses
+        to_field_name.
+        """
+        class StudentForm(forms.ModelForm):
+            character = forms.ModelChoiceField(Character.objects.all(), to_field_name='username')
+
+            class Meta:
+                model = Student
+                fields = ['character']
+
+        character = Character.objects.create(username='character', last_action=datetime.datetime.today())
+        student = Student.objects.create(character=character, study='Django')
+        form = StudentForm(instance=student)
+        self.assertEqual(form['character'].value(), character.username)
 
 
 class ModelMultipleChoiceFieldTests(TestCase):


### PR DESCRIPTION
The form `initial` state should also reflect the `to_field_name` on a previously setup `ModelChoiceField`.

Also, please be less OCD on the PEP8 enforced newlines.