### PR TITLE
Fixed #28392 -- Fixed GIS's WKT regex to match large scientific notation numbers.

### DIFF
--- a/django/contrib/gis/geometry/regex.py
+++ b/django/contrib/gis/geometry/regex.py
@@ -8,6 +8,6 @@ wkt_regex = re.compile(r'^(SRID=(?P<srid>\-?\d+);)?'
                        r'(?P<wkt>'
                        r'(?P<type>POINT|LINESTRING|LINEARRING|POLYGON|MULTIPOINT|'
                        r'MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)'
-                       r'[ACEGIMLONPSRUTYZ\d,\.\-\(\) ]+)$',
+                       r'[ACEGIMLONPSRUTYZ\d,\.\-\+\(\) ]+)$',
                        re.I)
 json_regex = re.compile(r'^(\s+)?\{.*}(\s+)?$', re.DOTALL)


### PR DESCRIPTION
The regex filters out large numbers e.g. "SRID=4326;POINT (0.0 1.0e+10)" giving:
ValueError: Problem installing fixture './temp.json': String or unicode input unrecognized as WKT EWKT, and HEXEWKB.

Ticket: https://code.djangoproject.com/ticket/28392