### PR TITLE
Removed unneeded index check in LineString._set_single() as index is already checked in __getitem__().

### DIFF
--- a/django/contrib/gis/geos/linestring.py
+++ b/django/contrib/gis/geos/linestring.py
@@ -122,7 +122,6 @@ class LineString(LinearGeometryMixin, GEOSGeometry):
             raise GEOSException('Geometry resulting from slice deletion was invalid.')
 
     def _set_single(self, index, value):
-        self._checkindex(index)
         self._cs[index] = value
 
     def _checkdim(self, dim):


### PR DESCRIPTION
Unneeded since its introduction in 66e1670efae34d721e374788e4c3f8b5fe5fa481.