### PR TITLE
Fixed #28393 -- Added a helpful exception for invalid AutoField/IntegerField values.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -935,7 +935,14 @@ class AutoField(Field):
         value = super().get_prep_value(value)
         if value is None:
             return None
-        return int(value)
+        try:
+            return int(value)
+        except (ValueError, TypeError) as e:
+            # Provide a more verbose error message for easier debugging
+            raise e.__class__(
+                "Field '{}' expected a number but got {!r}".format(
+                    self.name, value)
+            ) from e
 
     def contribute_to_class(self, cls, name, **kwargs):
         assert not cls._meta.auto_field, "A model can't have more than one AutoField."
@@ -1743,7 +1750,14 @@ class FloatField(Field):
         value = super().get_prep_value(value)
         if value is None:
             return None
-        return float(value)
+        try:
+            return float(value)
+        except (ValueError, TypeError) as e:
+            # Provide a more descriptive message for easier debugging
+            raise e.__class__(
+                "Field '{}' expected a number but got {!r}".format(
+                    self.name, value)
+            ) from e
 
     def get_internal_type(self):
         return "FloatField"
@@ -1815,7 +1829,14 @@ class IntegerField(Field):
         value = super().get_prep_value(value)
         if value is None:
             return None
-        return int(value)
+        try:
+            return int(value)
+        except (ValueError, TypeError) as e:
+            # Provide a more descriptive message for easier debugging
+            raise e.__class__(
+                "Field '{}' expected a number but got {!r}".format(
+                    self.name, value)
+            ) from e
 
     def get_internal_type(self):
         return "IntegerField"


### PR DESCRIPTION
When a large model is updated and saved with invalid values, it produces a traceback deep within the ORM, with no clue which field assignment caused the error. Developers are faced with tracebacks like:

```
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/base.py", line 953, in _do_update
    return filtered._update(values) > 0
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/query.py", line 661, in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1191, in execute_sql
    cursor = super(SQLUpdateCompiler, self).execute_sql(result_type)
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 863, in execute_sql
    sql, params = self.as_sql()
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/sql/compiler.py", line 1157, in as_sql
    val = field.get_db_prep_save(val, connection=self.connection)
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 766, in get_db_prep_save
    prepared=False)
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 758, in get_db_prep_value
    value = self.get_prep_value(value)
  File "/Users/diederik/Sites/virtualenvs/test/lib/python3.6/site-packages/django/db/models/fields/__init__.py", line 1853, in get_prep_value
    self.name, repr(value)
   TypeError: int() argument must be a string, a bytes-like object or a number, not 'tuple'
```

This change displays the field name which makes spotting errors a lot easier.

For example, it shows:

    TypeError: remote_id: expected string or a number, not (39468135737,)

Trac issue: https://code.djangoproject.com/ticket/28393