### PR TITLE
Removed unused enter/exit methods of MySQL's CursorWrapper.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -92,14 +92,6 @@ class CursorWrapper:
     def __iter__(self):
         return iter(self.cursor)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        # Close instead of passing through to avoid backend-specific behavior
-        # (#17671).
-        self.close()
-
 
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = 'mysql'


### PR DESCRIPTION
Unused since their introduction in e1d839237f7ce38ef078b7f09cc3a1aeaacc02f0.