### PR TITLE
Fixed #28407 -- Added inspectdb support for db column comments.

### DIFF
--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -1,6 +1,6 @@
+import collections
 import keyword
 import re
-import collections
 from collections import OrderedDict
 
 from django.core.management.base import BaseCommand, CommandError
@@ -156,7 +156,7 @@ class Command(BaseCommand):
                     if field_type.startswith('ForeignKey('):
                         field_desc += ', models.DO_NOTHING'
 
-                    help_text_real = help_text_format % collections.defaultdict(lambda :'', row._asdict())
+                    help_text_real = help_text_format % collections.defaultdict(lambda: '', row._asdict())
                     if help_text_real.strip():
                         extra_params['help_text'] = help_text_real
 

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -156,7 +156,7 @@ class Command(BaseCommand):
                     if field_type.startswith('ForeignKey('):
                         field_desc += ', models.DO_NOTHING'
 
-                    help_text_real = help_text_format % collections.defaultdict(lambda: '', row._asdict())
+                    help_text_real = help_text_format % collections.defaultdict(lambda: '', {k:v if v is not None else '' for k, v in row._asdict().items()})
                     if help_text_real.strip():
                         extra_params['help_text'] = help_text_real
 

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
                     )
                     if field_type.startswith('ForeignKey('):
                         field_desc += ', models.DO_NOTHING'
-                        
+
                     comment = getattr(row, 'comment', None)
                     if comment:
                         extra_params['help_text'] = comment

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -98,6 +98,10 @@ class Command(BaseCommand):
                     column_name = row[0]
                     is_relation = column_name in relations
 
+                    comment = getattr(row, 'comment', None)
+                    if(comment):
+                        comment_notes.append(comment)
+
                     att_name, params, notes = self.normalize_col_name(
                         column_name, used_column_names, is_relation)
                     extra_params.update(params)

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -23,10 +23,6 @@ class Command(BaseCommand):
             '--database', action='store', dest='database', default=DEFAULT_DB_ALIAS,
             help='Nominates a database to introspect. Defaults to using the "default" database.',
         )
-        parser.add_argument(
-            '--help_text_format', action='store', dest='help_text_format', default='',
-            help='help_text format e.g. "%%(name)s %%(comment)s" ',
-        )
 
     def handle(self, **options):
         try:
@@ -37,7 +33,6 @@ class Command(BaseCommand):
 
     def handle_inspection(self, options):
         connection = connections[options['database']]
-        help_text_format = options['help_text_format']
         # 'table_name_filter' is a stealth option
         table_name_filter = options.get('table_name_filter')
 
@@ -159,10 +154,6 @@ class Command(BaseCommand):
                     )
                     if field_type.startswith('ForeignKey('):
                         field_desc += ', models.DO_NOTHING'
-
-                    help_text_real = help_text_format % collections.defaultdict(lambda: '', {k:v if v is not None else '' for k, v in row._asdict().items()})
-                    if help_text_real.strip():
-                        extra_params['help_text'] = help_text_real
 
                     if extra_params:
                         if not field_desc.endswith('('):

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -1,4 +1,3 @@
-import collections
 import keyword
 import re
 from collections import OrderedDict

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -93,8 +93,9 @@ class Command(BaseCommand):
                     is_relation = column_name in relations
 
                     comment = getattr(row, 'comment', None)
-                    if(comment):
-                        comment_notes.append(comment)
+                    comment = comment.replace('\n', ' ').replace('\r', ' ').strip() if comment is not None else None
+                    if comment:
+                        comment_notes.append('db-comment:%s' % comment)
 
                     att_name, params, notes = self.normalize_col_name(
                         column_name, used_column_names, is_relation)

--- a/django/core/management/commands/inspectdb.py
+++ b/django/core/management/commands/inspectdb.py
@@ -149,6 +149,10 @@ class Command(BaseCommand):
                     )
                     if field_type.startswith('ForeignKey('):
                         field_desc += ', models.DO_NOTHING'
+                        
+                    comment = getattr(row, 'comment', None)
+                    if comment:
+                        extra_params['help_text'] = comment
 
                     if extra_params:
                         if not field_desc.endswith('('):

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -10,8 +10,8 @@ from django.db.models.indexes import Index
 from django.utils.datastructures import OrderedSet
 from django.utils.deprecation import RemovedInDjango21Warning
 
-FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('extra', 'is_unsigned'))
-InfoLine = namedtuple('InfoLine', 'col_name data_type max_len num_prec num_scale extra column_default is_unsigned')
+FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('extra', 'is_unsigned', 'comment'))
+InfoLine = namedtuple('InfoLine', 'col_name data_type max_len num_prec num_scale extra column_default is_unsigned comment')
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
@@ -75,7 +75,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 CASE
                     WHEN column_type LIKE '%% unsigned' THEN 1
                     ELSE 0
-                END AS is_unsigned
+                END AS is_unsigned, column_comment
             FROM information_schema.columns
             WHERE table_name = %s AND table_schema = DATABASE()""", [table_name])
         field_info = {line[0]: InfoLine(*line) for line in cursor.fetchall()}
@@ -100,6 +100,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                         field_info[col_name].column_default,
                         field_info[col_name].extra,
                         field_info[col_name].is_unsigned,
+                        field_info[col_name].comment,
                     )
                 ))
             )

--- a/django/db/backends/mysql/introspection.py
+++ b/django/db/backends/mysql/introspection.py
@@ -11,7 +11,8 @@ from django.utils.datastructures import OrderedSet
 from django.utils.deprecation import RemovedInDjango21Warning
 
 FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('extra', 'is_unsigned', 'comment'))
-InfoLine = namedtuple('InfoLine', 'col_name data_type max_len num_prec num_scale extra column_default is_unsigned comment')
+InfoLine = namedtuple('InfoLine', 'col_name data_type max_len num_prec num_scale '
+                                  'extra column_default is_unsigned comment')
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -8,7 +8,7 @@ from django.db.backends.base.introspection import (
 )
 from django.utils.deprecation import RemovedInDjango21Warning
 
-FieldInfo = namedtuple('FieldInfo', BaseFieldInfo._fields + ('is_autofield','comment'))
+FieldInfo = namedtuple('FieldInfo', BaseFieldInfo._fields + ('is_autofield', 'comment'))
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
@@ -72,7 +72,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 END as is_autofield,
                 cc.comments as comment
             FROM user_tab_cols AS tc
-            LEFT JOIN user_col_comments AS cc ON cc.column_name = tc.column_name AND cc.table_name  = tc.table_name
+            LEFT JOIN user_col_comments AS cc ON cc.column_name = tc.column_name AND cc.table_name = tc.table_name
             WHERE table_name = UPPER(%s)""", [table_name])
         field_map = {
             column: (internal_size, default if default != 'NULL' else None, is_autofield, comment)

--- a/django/db/backends/oracle/introspection.py
+++ b/django/db/backends/oracle/introspection.py
@@ -8,7 +8,7 @@ from django.db.backends.base.introspection import (
 )
 from django.utils.deprecation import RemovedInDjango21Warning
 
-FieldInfo = namedtuple('FieldInfo', BaseFieldInfo._fields + ('is_autofield',))
+FieldInfo = namedtuple('FieldInfo', BaseFieldInfo._fields + ('is_autofield','comment'))
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
@@ -60,21 +60,23 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # user_tab_columns gives data default for columns
         cursor.execute("""
             SELECT
-                column_name,
-                data_default,
+                tc.column_name,
+                tc.data_default,
                 CASE
-                    WHEN char_used IS NULL THEN data_length
-                    ELSE char_length
+                    WHEN tc.char_used IS NULL THEN tc.data_length
+                    ELSE tc.char_length
                 END as internal_size,
                 CASE
-                    WHEN identity_column = 'YES' THEN 1
+                    WHEN tc.identity_column = 'YES' THEN 1
                     ELSE 0
-                END as is_autofield
-            FROM user_tab_cols
+                END as is_autofield,
+                cc.comments as comment
+            FROM user_tab_cols AS tc
+            LEFT JOIN user_col_comments AS cc ON cc.column_name = tc.column_name AND cc.table_name  = tc.table_name
             WHERE table_name = UPPER(%s)""", [table_name])
         field_map = {
-            column: (internal_size, default if default != 'NULL' else None, is_autofield)
-            for column, default, internal_size, is_autofield in cursor.fetchall()
+            column: (internal_size, default if default != 'NULL' else None, is_autofield, comment)
+            for column, default, internal_size, is_autofield, comment in cursor.fetchall()
         }
         self.cache_bust_counter += 1
         cursor.execute("SELECT * FROM {} WHERE ROWNUM < 2 AND {} > 0".format(
@@ -83,14 +85,14 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         description = []
         for desc in cursor.description:
             name = desc[0]
-            internal_size, default, is_autofield = field_map[name]
+            internal_size, default, is_autofield, comment = field_map[name]
             name = name % {}  # cx_Oracle, for some reason, doubles percent signs.
             description.append(FieldInfo(*(
                 (name.lower(),) +
                 desc[1:3] +
                 (internal_size, desc[4] or 0, desc[5] or 0) +
                 desc[6:] +
-                (default, is_autofield)
+                (default, is_autofield, comment)
             )))
         return description
 

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -9,6 +9,7 @@ from django.utils.deprecation import RemovedInDjango21Warning
 
 FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('comment',))
 
+
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     # Maps type codes to Django Field types.
     data_types_reverse = {
@@ -76,20 +77,26 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         cursor.execute("""
              SELECT  col.column_name, col.is_nullable, col.column_default, info.description
                 FROM information_schema.columns AS col
-                LEFT JOIN 
-                  (SELECT c.relname AS table_name, n.nspname AS table_schema, a.attname AS column_name,  d.description AS description
+                LEFT JOIN
+                  (SELECT c.relname AS table_name,
+                          n.nspname AS table_schema,
+                          a.attname AS column_name,
+                          d.description AS description
                   FROM pg_class AS c
                   INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
                   LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
                   LEFT JOIN pg_tablespace AS t ON t.oid = c.reltablespace
                   LEFT JOIN pg_description AS d ON (d.objoid = c.oid AND d.objsubid = a.attnum)
                   WHERE  c.relkind = 'r') AS info
-                ON col.table_name = info.table_name AND col.table_schema = info.table_schema AND col.column_name = info.column_name
+                ON col.table_name = info.table_name
+                    AND col.table_schema = info.table_schema
+                    AND col.column_name = info.column_name
                 WHERE col.table_name = %s""", [table_name])
         field_map = {line[0]: line[1:] for line in cursor.fetchall()}
         cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
         return [
-            FieldInfo(*(line[0:6] + (field_map[line.name][0] == 'YES', field_map[line.name][1], field_map[line.name][2])))
+            FieldInfo(*(line[0:6] + (field_map[line.name][0] == 'YES', field_map[line.name][1],
+                        field_map[line.name][2])))
             for line in cursor.description
         ]
 

--- a/django/db/backends/postgresql/introspection.py
+++ b/django/db/backends/postgresql/introspection.py
@@ -1,4 +1,5 @@
 import warnings
+from collections import namedtuple
 
 from django.db.backends.base.introspection import (
     BaseDatabaseIntrospection, FieldInfo, TableInfo,
@@ -6,6 +7,7 @@ from django.db.backends.base.introspection import (
 from django.db.models.indexes import Index
 from django.utils.deprecation import RemovedInDjango21Warning
 
+FieldInfo = namedtuple('FieldInfo', FieldInfo._fields + ('comment',))
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     # Maps type codes to Django Field types.
@@ -72,13 +74,22 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # As cursor.description does not return reliably the nullable property,
         # we have to query the information_schema (#7783)
         cursor.execute("""
-            SELECT column_name, is_nullable, column_default
-            FROM information_schema.columns
-            WHERE table_name = %s""", [table_name])
+             SELECT  col.column_name, col.is_nullable, col.column_default, info.description
+                FROM information_schema.columns AS col
+                LEFT JOIN 
+                  (SELECT c.relname AS table_name, n.nspname AS table_schema, a.attname AS column_name,  d.description AS description
+                  FROM pg_class AS c
+                  INNER JOIN pg_attribute AS a ON c.oid = a.attrelid
+                  LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+                  LEFT JOIN pg_tablespace AS t ON t.oid = c.reltablespace
+                  LEFT JOIN pg_description AS d ON (d.objoid = c.oid AND d.objsubid = a.attnum)
+                  WHERE  c.relkind = 'r') AS info
+                ON col.table_name = info.table_name AND col.table_schema = info.table_schema AND col.column_name = info.column_name
+                WHERE col.table_name = %s""", [table_name])
         field_map = {line[0]: line[1:] for line in cursor.fetchall()}
         cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
         return [
-            FieldInfo(*(line[0:6] + (field_map[line.name][0] == 'YES', field_map[line.name][1])))
+            FieldInfo(*(line[0:6] + (field_map[line.name][0] == 'YES', field_map[line.name][1], field_map[line.name][2])))
             for line in cursor.description
         ]
 


### PR DESCRIPTION
user can set help_text_format when create model from db by inspectdb .
help_text whill set by help_text_format .
if not set help_text_format models have no help_text param
Updated proposal from https://github.com/django/django/pull/8738.
