### PR TITLE
Fixed 403 link in docs/ref/contrib/gis/install/spatialite.txt.

### DIFF
--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -86,7 +86,7 @@ Get the latest SpatiaLite library source bundle from the
 
         $ ./configure --target=macosx
 
-__ https://www.gaia-gis.it/gaia-sins/libspatialite-sources/
+__ http://www.gaia-gis.it/gaia-sins/libspatialite-sources/
 
 .. _spatialite_macos:
 


### PR DESCRIPTION
https://www.gaia-gis.it/gaia-sins/libspatialite-sources/ = 403 Forbidden