### PR TITLE
Removed unused branch in GISLookup.process_band_indices().

### DIFF
--- a/django/contrib/gis/db/models/lookups.py
+++ b/django/contrib/gis/db/models/lookups.py
@@ -40,10 +40,7 @@ class GISLookup(Lookup):
             self.band_lhs = 1
 
         self.band_rhs = self.rhs[1]
-        if len(self.rhs) == 1:
-            self.rhs = self.rhs[0]
-        else:
-            self.rhs = (self.rhs[0], ) + self.rhs[2:]
+        self.rhs = (self.rhs[0], ) + self.rhs[2:]
 
     def get_db_prep_lookup(self, value, connection):
         # get_db_prep_lookup is called by process_rhs from super class


### PR DESCRIPTION
This branch is unused since `process_band_indices()` is called only with `only_lhs=True` or when `len(self.rhs) > 1`.