### PR TITLE
Removed redundant lookup values in RasterFieldTest.test_all_gis_lookups_with_rasters.

### DIFF
--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -169,16 +169,27 @@ class RasterFieldTest(TransactionTestCase):
                 # Set lookup values for all function based operators.
                 combo_values = [
                     rast, (rast, 0), (rast, 0), (stx_pnt, 0), stx_pnt,
-                    rast, rast, json.loads(JSON_RASTER)
+                    rast, json.loads(JSON_RASTER)
                 ]
             else:
                 # Override band lookup for these, as it's not supported.
                 combo_keys[2] = 'rastprojected__' + name
                 # Set lookup values for all other operators.
-                combo_values = [rast, rast, rast, stx_pnt, stx_pnt, rast, rast, json.loads(JSON_RASTER)]
+                combo_values = [rast, None, rast, stx_pnt, stx_pnt, rast, json.loads(JSON_RASTER)]
 
             # Create query filter combinations.
-            combos = [{x[0]: x[1]} for x in zip(combo_keys, combo_values)]
+            self.assertEqual(
+                len(combo_keys),
+                len(combo_values),
+                'Number of lookup names and values should be the same',
+            )
+            combos = list(x for x in zip(combo_keys, combo_values) if x[1])
+            self.assertEqual(
+                [(n, x) for n, x in enumerate(combos) if x in combos[:n]],
+                [],
+                'There are repeated test lookups',
+            )
+            combos = [{k: v} for k, v in combos]
 
             for combo in combos:
                 # Apply this query filter.


### PR DESCRIPTION
These values produce already tested lookups and prevent another ones from being tested.

I'm not sure if it's really worth to add asserts.