### PR TITLE
Fixed #28418 -- Fixed queryset crash when using a GenericRelation to a proxy model.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -646,6 +646,7 @@ answer newbie questions, and generally made Django that much better:
     pradeep.gowda@gmail.com
     Preston Holmes <preston@ptone.com>
     Preston Timmons <prestontimmons@gmail.com>
+    Rachel Tobin <rmtobin@me.com>
     Rachel Willmer <http://www.willmer.com/kb/>
     Radek Švarz <http://www.svarz.cz/translate/>
     Rajesh Dhawan <rajesh.dhawan@gmail.com>

--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -362,7 +362,7 @@ class GenericRelation(ForeignObject):
         # generating a join to the parent model, then generating joins to the
         # child models.
         path = []
-        opts = self.remote_field.model._meta
+        opts = self.remote_field.model._meta.concrete_model._meta
         parent_opts = opts.get_field(self.object_id_field_name).model._meta
         target = parent_opts.pk
         path.append(PathInfo(self.model._meta, parent_opts, (target,), self.remote_field, True, False))

--- a/docs/releases/1.11.4.txt
+++ b/docs/releases/1.11.4.txt
@@ -35,3 +35,6 @@ Bugfixes
   ``checkbox_name``, ``checkbox_id``, ``is_initial``, ``input_text``,
   ``initial_text``, and ``clear_checkbox_label`` are now attributes of
   ``widget`` rather than appearing in the top-level context.
+
+* Fixed queryset crash when using a ``GenericRelation`` to a proxy model
+  (:ticket:`28418`).

--- a/tests/generic_relations_regress/models.py
+++ b/tests/generic_relations_regress/models.py
@@ -19,9 +19,15 @@ class Link(models.Model):
         return "Link to %s id=%s" % (self.content_type, self.object_id)
 
 
+class LinkProxy(Link):
+    class Meta:
+        proxy = True
+
+
 class Place(models.Model):
     name = models.CharField(max_length=100)
     links = GenericRelation(Link)
+    link_proxy = GenericRelation(LinkProxy)
 
     def __str__(self):
         return "Place: %s" % self.name

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -246,3 +246,8 @@ class GenericRelationTests(TestCase):
     def test_ticket_22982(self):
         place = Place.objects.create(name='My Place')
         self.assertIn('GenericRelatedObjectManager', str(place.links))
+
+    def test_filter_on_related_proxy_model(self):
+        place = Place.objects.create()
+        Link.objects.create(content_object=place)
+        self.assertEqual(Place.objects.get(link_proxy__object_id=place.id), place)


### PR DESCRIPTION
Fixes [#28418](https://code.djangoproject.com/ticket/28418). When building a join path for a field, use the concrete model defined for the field so proxy models do not incorrectly cause an ancestor lookup.