### PR TITLE
Don't rely on the order of dictionary iteration within Func.__repr__

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -533,7 +533,7 @@ class Func(Expression):
         args = self.arg_joiner.join(str(arg) for arg in self.source_expressions)
         extra = dict(self.extra, **self._get_repr_options())
         if extra:
-            extra = ', '.join(str(key) + '=' + str(val) for key, val in extra.items())
+            extra = ', '.join(str(key) + '=' + str(val) for key, val in sorted(extra.items()))
             return "{}({}, {})".format(self.__class__.__name__, args, extra)
         return "{}({})".format(self.__class__.__name__, args)
 


### PR DESCRIPTION
Ref #8759

As per [this comment](https://github.com/django/django/pull/8352#discussion_r128457812), I cannot add tests for the new `filter` argument as the order of the values returned is not always going to be the same.

This MR just sorts by the key for simplicity.