### PR TITLE
Fixed DatabaseFeatures.has_case_insensitive_like on MySQL and Oracle.

### DIFF
--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -32,6 +32,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_select_difference = False
     supports_slicing_ordering_in_compound = True
     supports_index_on_text_field = False
+    has_case_insensitive_like = False
 
     @cached_property
     def _mysql_storage_engine(self):

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -39,3 +39,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # does by uppercasing all identifiers.
     ignores_table_name_case = True
     supports_index_on_text_field = False
+    has_case_insensitive_like = False

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -18,9 +18,7 @@ from django.db.models.functions import (
 )
 from django.db.models.sql import constants
 from django.db.models.sql.datastructures import Join
-from django.test import (
-    SimpleTestCase, TestCase, skipIfDBFeature, skipUnlessDBFeature,
-)
+from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import Approximate
 
 from .models import (
@@ -339,12 +337,14 @@ class BasicExpressionsTests(TestCase):
         queryset = Employee.objects.filter(firstname__iexact=F('lastname'))
         self.assertQuerysetEqual(queryset, ["<Employee: Test test>"])
 
-    @skipIfDBFeature('has_case_insensitive_like')
     def test_ticket_16731_startswith_lookup(self):
         Employee.objects.create(firstname="John", lastname="Doe")
         e2 = Employee.objects.create(firstname="Jack", lastname="Jackson")
         e3 = Employee.objects.create(firstname="Jack", lastname="jackson")
-        self.assertSequenceEqual(Employee.objects.filter(lastname__startswith=F('firstname')), [e2])
+        self.assertSequenceEqual(
+            Employee.objects.filter(lastname__startswith=F('firstname')),
+            [e2, e3] if connection.features.has_case_insensitive_like else [e2]
+        )
         qs = Employee.objects.filter(lastname__istartswith=F('firstname')).order_by('pk')
         self.assertSequenceEqual(qs, [e2, e3])
 


### PR DESCRIPTION
Incorrect since its introduction in 20bab2cf9d02a5c6477d8aac066a635986e0d3f3.