### PR TITLE
Fixed #28420 -- Doc'd 'is' comparison restrictions for User.is_authenticated/anonymous.

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -133,6 +133,16 @@ Attributes
         (representing the currently logged-in user), you should know this
         attribute is ``True`` for any :class:`~models.User` instance.
 
+        .. admonition:: Don't use the ``is`` operator for comparisons!
+
+            To allow the ``is_authenticated`` and ``is_anonymous`` attributes
+            to also work as methods (for backwards compatibility with Django
+            1.9 and older), the attributes are  ``CallableBool`` objects. Thus,
+            until the deprecation period ends in Django 2.0, you can't compare
+            these properties using the ``is`` operator. That is,
+            ``request.user.is_authenticated is True`` always evaluate to
+            ``False``.
+
     .. attribute:: is_anonymous
 
         Read-only attribute which is always ``False``. This is a way of


### PR DESCRIPTION
Added a note to the `django.contrib.auth` documentation to notify users
that `is` comparisons on CallableBool are not allowed. Note was added
to the `is_authenticated` property, as the section for `is_anonymous`
already recommends using `is_authenticated`.