### PR TITLE
Removed unused SpatialOperations.from_wkb.

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -38,7 +38,6 @@ class BaseSpatialOperations:
 
     # Constructors
     from_text = False
-    from_wkb = False
 
     # Default conversion functions for aggregates; will be overridden if implemented
     # for the spatial backend.

--- a/django/contrib/gis/db/backends/mysql/operations.py
+++ b/django/contrib/gis/db/backends/mysql/operations.py
@@ -37,10 +37,6 @@ class MySQLOperations(BaseSpatialOperations, DatabaseOperations):
         return self.geom_func_prefix + 'AsText(%s)'
 
     @cached_property
-    def from_wkb(self):
-        return self.geom_func_prefix + 'GeomFromWKB'
-
-    @cached_property
     def from_text(self):
         return self.geom_func_prefix + 'GeomFromText'
 

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -29,7 +29,6 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
     unionagg = 'GUnion'
 
     from_text = 'GeomFromText'
-    from_wkb = 'GeomFromWKB'
     select = 'AsText(%s)'
 
     gis_operators = {


### PR DESCRIPTION
Unused since its introduction in ff60c5f9de3e8690d1e86f3e9e3f7248a15397c8.