### PR TITLE
Fixed #28440 -- Disabled keep-alive in runserver.

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -135,13 +135,6 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler):
         return super().get_environ()
 
     def handle(self):
-        """Handle multiple requests if necessary."""
-        self.close_connection = 1
-        self.handle_one_request()
-        while not self.close_connection:
-            self.handle_one_request()
-
-    def handle_one_request(self):
         """Copy of WSGIRequestHandler.handle() but with different ServerHandler"""
         self.raw_requestline = self.rfile.readline(65537)
         if len(self.raw_requestline) > 65536:


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/28440)

If you use the built in http.server module and don't send a `content-length` in your response and use `connection: keep-alive` then the server will hang until the client times out.

This MR disables the keep-alive functionality. A better fix might be to detect these conditions and close the connection only if required, but I'm not sure how to do this correctly.

Edit: I think I've found a way...