### PR TITLE
remove lru_cache module

### DIFF
--- a/django/utils/lru_cache.py
+++ b/django/utils/lru_cache.py
@@ -1,5 +1,0 @@
-from functools import lru_cache  # noqa
-
-# Deprecate or remove this module when no supported version of Django still
-# supports Python 2. Until then, keep it to allow pluggable apps to support
-# Python 2 and Python 3 without raising a deprecation warning.


### PR DESCRIPTION
We are not supporting Python 2 anymore, why keep this module?

