### PR TITLE
Refs 23919 -- Add maxsize=None to lru_cache calls

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -80,7 +80,7 @@ def make_password(password, salt=None, hasher='default'):
     return hasher.encode(password, salt)
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_hashers():
     hashers = []
     for hasher_path in settings.PASSWORD_HASHERS:
@@ -93,7 +93,7 @@ def get_hashers():
     return hashers
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_hashers_by_algorithm():
     return {hasher.algorithm: hasher for hasher in get_hashers()}
 

--- a/django/forms/renderers.py
+++ b/django/forms/renderers.py
@@ -16,7 +16,7 @@ except ImportError:
 ROOT = os.path.dirname(__file__)
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_renderer():
     renderer_class = import_string(settings.FORM_RENDERER)
     return renderer_class()

--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -53,7 +53,7 @@ class Engine:
         self.template_builtins = self.get_template_builtins(self.builtins)
 
     @staticmethod
-    @functools.lru_cache()
+    @functools.lru_cache(maxsize=None)
     def get_default():
         """
         Return the first DjangoTemplates backend that's configured, or raise

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -67,7 +67,7 @@ def get_fixed_timezone(offset):
 
 # In order to avoid accessing settings at compile time,
 # wrap the logic in a function and cache the result.
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_timezone():
     """
     Return the default time zone as a tzinfo instance.
@@ -78,6 +78,7 @@ def get_default_timezone():
 
 
 # This function exists for consistency with get_current_timezone_name
+@functools.lru_cache(maxsize=None)
 def get_default_timezone_name():
     """Return the name of the default time zone."""
     return _get_timezone_name(get_default_timezone())

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -400,7 +400,7 @@ def check_for_language(lang_code):
     return False
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_languages():
     """
     Cache of settings.LANGUAGES in an OrderedDict for easy lookups by key.

--- a/django/utils/version.py
+++ b/django/utils/version.py
@@ -58,7 +58,7 @@ def get_docs_version(version=None):
         return '%d.%d' % version[:2]
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_git_changeset():
     """Return a numeric identifier of the latest git changeset.
 

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -93,7 +93,7 @@ def technical_500_response(request, exc_type, exc_value, tb, status_code=500):
         return HttpResponse(html, status=status_code, content_type='text/html')
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=None)
 def get_default_exception_reporter_filter():
     # Instantiate the default filter for the first time and cache it.
     return import_string(settings.DEFAULT_EXCEPTION_REPORTER_FILTER)()


### PR DESCRIPTION
Part of the Python 3 cleanup. Any function with no arguments that's decorated with `lru_cache` should have `maxsize` set to `None`. This is because without it every call requires the acquisition of a lock and more memory. On my machine calls with `maxsize=None` are over twice as fast than calls with no `maxsize` set.

I also noticed that `parse_accept_lang_header` in `trans_real.py` would be good candidate for an `lru_cache`, as long as it could be converted to return a tuple rather than a mutable list.