### PR TITLE
Removed unneeded TruncBase.arity.

### DIFF
--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -148,7 +148,6 @@ ExtractYear.register_lookup(YearLte)
 
 
 class TruncBase(TimezoneMixin, Transform):
-    arity = 1
     kind = None
     tzinfo = None
 


### PR DESCRIPTION
Uneeded since its introduction in 2a4af0ea43512370764303d35bc5309f8abce666.