### PR TITLE
Fixed #28462 -- Changed admin "POSTed bulk-edit data" to use ChangeList qs.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1602,7 +1602,7 @@ class ModelAdmin(BaseModelAdmin):
         # Handle POSTed bulk-edit data.
         if request.method == 'POST' and cl.list_editable and '_save' in request.POST:
             FormSet = self.get_changelist_formset(request)
-            formset = cl.formset = FormSet(request.POST, request.FILES, queryset=self.get_queryset(request))
+            formset = cl.formset = FormSet(request.POST, request.FILES, queryset=cl.get_queryset(request))
             if formset.is_valid():
                 changecount = 0
                 for form in formset.forms:


### PR DESCRIPTION
This was changed in 917cc288a3 to use the model admin queryset, instead
of the ChangeList's `result_list`, but it seems to be more appropriate
to use the ChangeList's queryset here instead, like it is done in
`changelist_view` in general.