### PR TITLE
Fixed #28454 -- Simplify use of Query.setup_joins() by returning a named tuple

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -818,8 +818,8 @@ class SQLCompiler:
                 related_field_name = f.related_query_name()
                 fields_found.add(related_field_name)
 
-                _, _, _, joins, _ = self.query.setup_joins([related_field_name], opts, root_alias)
-                alias = joins[-1]
+                join_info = self.query.setup_joins([related_field_name], opts, root_alias)
+                alias = join_info.joins[-1]
                 from_parent = issubclass(model, opts.model) and model is not opts.model
                 klass_info = {
                     'model': model,


### PR DESCRIPTION
Define a namedtuple to represent the output of the setup_joins
function, then change uses of this function to use the names
declared in the tuple rather than unpacking all values into
local variables.

This has the side effect of making variable names more consistent
throughout the ORM, especially ``field`` vs ``final_field``. It also
changes the behaviour of the ``_setup_joins()`` private function
to return a tuple of the result of ``Query.setup_joins()`` and
the alias to be used.