### PR TITLE
[1.11.x] Fixed #28441 -- Fixed GEOS version parsing with a commit hash at the end.

### DIFF
--- a/django/contrib/gis/geos/libgeos.py
+++ b/django/contrib/gis/geos/libgeos.py
@@ -179,7 +179,7 @@ geos_version = GEOSFuncFactory('GEOSversion', restype=c_char_p)
 # '3.0.0rc4-CAPI-1.3.3', '3.0.0-CAPI-1.4.1', '3.4.0dev-CAPI-1.8.0' or '3.4.0dev-CAPI-1.8.0 r0'
 version_regex = re.compile(
     r'^(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<subminor>\d+))'
-    r'((rc(?P<release_candidate>\d+))|dev)?-CAPI-(?P<capi_version>\d+\.\d+\.\d+)( r\d+)?$'
+    r'((rc(?P<release_candidate>\d+))|dev)?-CAPI-(?P<capi_version>\d+\.\d+\.\d+)( r\d+)?( \w+)?$'
 )
 
 

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -9,4 +9,5 @@ Django 1.11.5 fixes several bugs in 1.11.4.
 Bugfixes
 ========
 
-* ...
+* Fixed GEOS version parsing if the version has a commit hash at the end (new
+  in GEOS 3.6.2) (:ticket:`28441`).

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1278,7 +1278,8 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         versions = [('3.0.0rc4-CAPI-1.3.3', '3.0.0', '1.3.3'),
                     ('3.0.0-CAPI-1.4.1', '3.0.0', '1.4.1'),
                     ('3.4.0dev-CAPI-1.8.0', '3.4.0', '1.8.0'),
-                    ('3.4.0dev-CAPI-1.8.0 r0', '3.4.0', '1.8.0')]
+                    ('3.4.0dev-CAPI-1.8.0 r0', '3.4.0', '1.8.0'),
+                    ('3.6.2-CAPI-1.10.2 4d2925d6', '3.6.2', '1.10.2')]
         for v_init, v_geos, v_capi in versions:
             m = version_regex.match(v_init)
             self.assertTrue(m, msg="Unable to parse the version string '%s'" % v_init)


### PR DESCRIPTION
Less invasive than https://github.com/django/django/pull/8817 so as to minimize the chance of a problem on a stable branch.