### PR TITLE
Refs #28459 -- Improved performance of Model.from_db() when fields are deferred.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -489,9 +489,11 @@ class Model(metaclass=ModelBase):
     @classmethod
     def from_db(cls, db, field_names, values):
         if len(values) != len(cls._meta.concrete_fields):
-            values = list(values)
-            values.reverse()
-            values = [values.pop() if f.attname in field_names else DEFERRED for f in cls._meta.concrete_fields]
+            values_iter = iter(values)
+            values = [
+                next(values_iter) if f.attname in field_names else DEFERRED
+                for f in cls._meta.concrete_fields
+            ]
         new = cls(*values)
         new._state.adding = False
         new._state.db = db


### PR DESCRIPTION
Before:
```
In [3]: %timeit for x in City.objects.only('id'): pass               
1.07 s ± 10.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
In [2]: %timeit for x in City.objects.only('id'): pass
961 ms ± 5.68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

@timgraham, probably I'll create few more PRs to improve QuerySet performance, so I'm not sure if I should create ticket for the each one or shoud I rename [#28459](https://code.djangoproject.com/ticket/28459) to be more general and reference it.