### PR TITLE
Removed unused _combine() node argument from various combinable classes.

### DIFF
--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -36,7 +36,7 @@ class SearchQueryField(Field):
 class SearchVectorCombinable:
     ADD = '||'
 
-    def _combine(self, other, connector, reversed, node=None):
+    def _combine(self, other, connector, reversed):
         if not isinstance(other, SearchVectorCombinable) or not self.config == other.config:
             raise TypeError('SearchVector can only be combined with other SearchVectors')
         if reversed:
@@ -96,7 +96,7 @@ class SearchQueryCombinable:
     BITAND = '&&'
     BITOR = '||'
 
-    def _combine(self, other, connector, reversed, node=None):
+    def _combine(self, other, connector, reversed):
         if not isinstance(other, SearchQueryCombinable):
             raise TypeError(
                 'SearchQuery can only be combined with other SearchQuerys, '
@@ -153,8 +153,8 @@ class SearchQuery(SearchQueryCombinable, Value):
             template = '!!({})'.format(template)
         return template, params
 
-    def _combine(self, other, connector, reversed, node=None):
-        combined = super()._combine(other, connector, reversed, node)
+    def _combine(self, other, connector, reversed):
+        combined = super()._combine(other, connector, reversed)
         combined.output_field = SearchQueryField()
         return combined
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -34,7 +34,7 @@ class Combinable:
     BITLEFTSHIFT = '<<'
     BITRIGHTSHIFT = '>>'
 
-    def _combine(self, other, connector, reversed, node=None):
+    def _combine(self, other, connector, reversed):
         if not hasattr(other, 'resolve_expression'):
             # everything must be resolvable to an expression
             if isinstance(other, datetime.timedelta):


### PR DESCRIPTION
Unused since f59fd15c4928caf3dfcbd50f6ab47be409a43b01 (`Combinable`) and since its introduction in 2d877da85526bad0dad7fd6b1d56b1f924c0116a (`SearchVectorCombinable` / `SearchQueryCombinable` / `SearchQuery`).