### PR TITLE
Refs #28459 -- Improved performance of SQLCompiler.results_iter().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1227,9 +1227,9 @@ class RawQuerySet:
             converters = compiler.get_converters([
                 f.get_col(f.model._meta.db_table) if f else None for f in fields
             ])
+            if converters:
+                query = compiler.apply_converters(query, converters)
             for values in query:
-                if converters:
-                    values = compiler.apply_converters(values, converters)
                 # Associate fields to values
                 model_init_values = [values[pos] for pos in model_init_pos]
                 instance = model_cls.from_db(db, model_init_names, model_init_values)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -464,7 +464,7 @@ class Query:
             result = [None for q in outer_query.annotation_select.items()]
 
         converters = compiler.get_converters(outer_query.annotation_select.values())
-        result = compiler.apply_converters(result, converters)
+        result = next(compiler.apply_converters((result,), converters))
 
         return {
             alias: val


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
In [3]: %timeit for x in City.objects.values_list('id'): pass
74 ms ± 1.45 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
In [2]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values_list('v'): pass
343 ms ± 2.62 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
In [4]: %timeit for x in City.objects.values_list('id'): pass
69.1 ms ± 744 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
In [3]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values_list('v'): pass
264 ms ± 3.26 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```