### PR TITLE
Fixed #15648 -- Allowed QuerySet.values_list() to return a namedtuple.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -626,7 +626,7 @@ You can also refer to fields on related models with reverse relations through
 ``values_list()``
 ~~~~~~~~~~~~~~~~~
 
-.. method:: values_list(*fields, flat=False)
+.. method:: values_list(*fields, flat=False, named=False)
 
 This is similar to ``values()`` except that instead of returning dictionaries,
 it returns tuples when iterated over. Each tuple contains the value from the
@@ -650,6 +650,15 @@ rather than one-tuples. An example should make the difference clearer::
     <QuerySet [1, 2, 3, ...]>
 
 It is an error to pass in ``flat`` when there is more than one field.
+
+You can pass ``named=True`` to get results as a
+:func:`~python:collections.namedtuple`::
+
+    >>> Entry.objects.values_list('id', 'headline', named=True)
+    <QuerySet [Row(id=1, headline='First entry'), ...]>
+
+Using a named tuple may make use of the results more readable, at the expense
+of a small performance penalty for transforming the results into a named tuple.
 
 If you don't pass any values to ``values_list()``, it will return all the
 fields in the model, in the order they were declared.
@@ -687,6 +696,10 @@ not having any author::
 .. versionchanged:: 1.11
 
     Support for expressions in ``*fields`` was added.
+
+.. versionchanged:: 2.0
+
+    The ``named`` parameter was added.
 
 ``dates()``
 ~~~~~~~~~~~

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -291,6 +291,9 @@ Models
 * Added support for expressions in :attr:`Meta.ordering
   <django.db.models.Options.ordering>`.
 
+* The new ``named`` parameter of :meth:`.QuerySet.values_list` allows fetching
+  results as named tuples.
+
 Pagination
 ~~~~~~~~~~
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2248,6 +2248,44 @@ class ValuesQuerysetTests(TestCase):
         with self.assertRaisesMessage(FieldError, msg):
             Tag.objects.values_list('name__foo')
 
+    def test_named_values_list_flat(self):
+        msg = "'flat' and 'named' can't be used together."
+        with self.assertRaisesMessage(TypeError, msg):
+            Number.objects.values_list('num', flat=True, named=True)
+
+    def test_named_values_list_bad_field_name(self):
+        msg = "Type names and field names must be valid identifiers: '1'"
+        with self.assertRaisesMessage(ValueError, msg):
+            Number.objects.extra(select={'1': 'num+1'}).values_list('1', named=True).first()
+
+    def test_named_values_list_with_fields(self):
+        qs = Number.objects.extra(select={'num2': 'num+1'}).annotate(Count('id'))
+        values = qs.values_list('num', 'num2', named=True).first()
+        self.assertEqual(type(values).__name__, 'Row')
+        self.assertEqual(values._fields, ('num', 'num2'))
+        self.assertEqual(values.num, 72)
+        self.assertEqual(values.num2, 73)
+
+    def test_named_values_list_without_fields(self):
+        qs = Number.objects.extra(select={'num2': 'num+1'}).annotate(Count('id'))
+        values = qs.values_list(named=True).first()
+        self.assertEqual(type(values).__name__, 'Row')
+        self.assertEqual(values._fields, ('num2', 'id', 'num', 'id__count'))
+        self.assertEqual(values.num, 72)
+        self.assertEqual(values.num2, 73)
+        self.assertEqual(values.id__count, 1)
+
+    def test_named_values_list_expression_with_default_alias(self):
+        expr = Count('id')
+        values = Number.objects.annotate(id__count1=expr).values_list(expr, 'id__count1', named=True).first()
+        self.assertEqual(values._fields, ('id__count2', 'id__count1'))
+
+    def test_named_values_list_expression(self):
+        expr = F('num') + 1
+        qs = Number.objects.annotate(combinedexpression1=expr).values_list(expr, 'combinedexpression1', named=True)
+        values = qs.first()
+        self.assertEqual(values._fields, ('combinedexpression2', 'combinedexpression1'))
+
 
 class QuerySetSupportsPythonIdioms(TestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/15648

I'm not sure if there is consensus on API, but I decided to push it forward.
I'm not sure also if the current way of naming expressions is OK and if should support expressions with `named=True` at all.