### PR TITLE
Fixed #28471 -- Clarified that Meta.indexes is preferred to index_together.

### DIFF
--- a/docs/ref/models/options.txt
+++ b/docs/ref/models/options.txt
@@ -417,6 +417,12 @@ Django quotes column and table names behind the scenes.
 
 .. attribute:: Options.index_together
 
+    .. admonition:: Use the :attr:`~Options.indexes` option instead.
+
+        The newer :attr:`~Options.indexes` option provides more functionality
+        than ``index_together``. ``index_together`` may be deprecated in the
+        future.
+
     Sets of field names that, taken together, are indexed::
 
         index_together = [


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28471