### PR TITLE
Refs #28459 -- Improved performance of ValuesIterable.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -102,8 +102,9 @@ class ValuesIterable(BaseIterable):
         # extra(select=...) cols are always at the start of the row.
         names = extra_names + field_names + annotation_names
 
+        indexes = range(len(names))
         for row in compiler.results_iter():
-            yield dict(zip(names, row))
+            yield {names[i]: row[i] for i in indexes}
 
 
 class ValuesListIterable(BaseIterable):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
In [6]: %timeit -n 10 for x in City.objects.values('id', 'b'): pass
212 ms ± 4.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
After:
```
In [5]: %timeit for x in City.objects.values('id', 'b'): pass
151 ms ± 850 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```