### PR TITLE
Refs #7070 -- Improved test for extra(), values(), distinct() and ordering() altogether.

### DIFF
--- a/tests/extra_regress/tests.py
+++ b/tests/extra_regress/tests.py
@@ -433,4 +433,5 @@ class ExtraRegressTests(TestCase):
         self.assertSequenceEqual(qs.order_by('-second_extra'), [t2.pk, t1.pk])
         # Note: the extra ordering must appear in select clause, so we get two
         # non-distinct results here (this is on purpose, see #7070).
-        self.assertSequenceEqual(qs.order_by('-second_extra').values_list('first', flat=True), ['a', 'a'])
+        # Extra select doesn't appear in result values.
+        self.assertSequenceEqual(qs.order_by('-second_extra').values_list('first'), [('a',), ('a',)])


### PR DESCRIPTION
Tested that extra select that appears in select clause only because of distinct() and
order_by() doesn't appear in result values.

This assures that slicing is performed here: https://github.com/django/django/blob/master/django/db/models/sql/compiler.py#L1397.

