### PR TITLE
Fixed typo in docs/releases/2.0.txt.

### DIFF
--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -109,7 +109,7 @@ Minor features
   operation.
 
 * :class:`django.contrib.postgres.indexes.GinIndex` now supports the
-  ``fast_update`` and ``gin_pending_list_limit`` parameters.
+  ``fastupdate`` and ``gin_pending_list_limit`` parameters.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
fast_update -> fastupdate

Docs: https://github.com/django/django/blob/831358f23d545b8dba017c6b26bd295ba9f6c17d/django/contrib/postgres/indexes.py#L37