### PR TITLE
Fix argument name in call_command docstring

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -79,8 +79,9 @@ def call_command(command_name, *args, **options):
 
     This is the primary API you should use for calling specific commands.
 
-    `name` may be a string or a command object. Using a string is preferred
-    unless the command object is required for further processing or testing.
+    `command_name` may be a string or a command object. Using a string is
+    preferred unless the command object is required for further processing or
+    testing.
 
     Some examples:
         call_command('migrate')


### PR DESCRIPTION
In `django.core.management.call_command`, the docstring says «`name` may be a string or a command object.» but the argument name is actually `command_name`.