### PR TITLE
Refs #4518 -- Removed handling of empty strings in typecast_decimal().

### DIFF
--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -161,7 +161,7 @@ def typecast_timestamp(s):  # does NOT store time zone information
 
 
 def typecast_decimal(s):
-    if s is None or s == '':
+    if s is None:
         return None
     return decimal.Decimal(s)
 


### PR DESCRIPTION
Reverts 6fc10f50b0c9b877fffcad4893056cb91fa66b4f.
It's not clear if the original change was ever needed, but it seems unneeded now.