### PR TITLE
Fixed #28485 -- Made ExceptionReporter.get_traceback_frames() include frames without source code.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -514,6 +514,7 @@ answer newbie questions, and generally made Django that much better:
     Martin Kosír <martin@martinkosir.net>
     Martin Mahner <http://www.mahner.org/>
     Martin Maney <http://www.chipy.org/Martin_Maney>
+    Martin von Gagern <gagern@google.com>
     Mart Sõmermaa <http://mrts.pri.ee/>
     Marty Alchin <gulopine@gamemusic.org>
     masonsimon+django@gmail.com

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -418,22 +418,26 @@ class ExceptionReporter:
             pre_context_lineno, pre_context, context_line, post_context = self._get_lines_from_file(
                 filename, lineno, 7, loader, module_name,
             )
-            if pre_context_lineno is not None:
-                frames.append({
-                    'exc_cause': explicit_or_implicit_cause(exc_value),
-                    'exc_cause_explicit': getattr(exc_value, '__cause__', True),
-                    'tb': tb,
-                    'type': 'django' if module_name.startswith('django.') else 'user',
-                    'filename': filename,
-                    'function': function,
-                    'lineno': lineno + 1,
-                    'vars': self.filter.get_traceback_frame_variables(self.request, tb.tb_frame),
-                    'id': id(tb),
-                    'pre_context': pre_context,
-                    'context_line': context_line,
-                    'post_context': post_context,
-                    'pre_context_lineno': pre_context_lineno + 1,
-                })
+            if pre_context_lineno is None:
+                pre_context_lineno = lineno
+                pre_context = []
+                context_line = '<source code not available>'
+                post_context = []
+            frames.append({
+                'exc_cause': explicit_or_implicit_cause(exc_value),
+                'exc_cause_explicit': getattr(exc_value, '__cause__', True),
+                'tb': tb,
+                'type': 'django' if module_name.startswith('django.') else 'user',
+                'filename': filename,
+                'function': function,
+                'lineno': lineno + 1,
+                'vars': self.filter.get_traceback_frame_variables(self.request, tb.tb_frame),
+                'id': id(tb),
+                'pre_context': pre_context,
+                'context_line': context_line,
+                'post_context': post_context,
+                'pre_context_lineno': pre_context_lineno + 1,
+            })
 
             # If the traceback for current exception is consumed, try the
             # other exception.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28485

So far we are silently dropping any stack frames that don't offer access to source code snippets, for whatever reason.  Actually having these frames included would be valuable, since they may still contain function names, file names and line numbers.