### PR TITLE
Fixed #18392 -- Defaulted to the utf8mb4 character set for MySQL databases.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -189,7 +189,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_connection_params(self):
         kwargs = {
             'conv': django_conversions,
-            'charset': 'utf8',
+            'charset': 'utf8mb4',
         }
         settings_dict = self.settings_dict
         if settings_dict['USER']:

--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -9,13 +9,11 @@ from .client import DatabaseClient
 class DatabaseCreation(BaseDatabaseCreation):
 
     def sql_table_creation_suffix(self):
-        suffix = []
         test_settings = self.connection.settings_dict['TEST']
-        if test_settings['CHARSET']:
-            suffix.append('CHARACTER SET %s' % test_settings['CHARSET'])
-        if test_settings['COLLATION']:
-            suffix.append('COLLATE %s' % test_settings['COLLATION'])
-        return ' '.join(suffix)
+        return ' '.join([
+            'CHARACTER SET %s' % (test_settings['CHARSET'] or 'utf8mb4'),
+            'COLLATE %s' % (test_settings['COLLATION'] or 'utf8mb4_general_ci'),
+        ])
 
     def _execute_create_test_db(self, cursor, parameters, keepdb=False):
         try:

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -281,10 +281,11 @@ Django supports MySQL 5.6 and higher.
 Django's ``inspectdb`` feature uses the ``information_schema`` database, which
 contains detailed data on all database schemas.
 
-Django expects the database to support Unicode (UTF-8 encoding) and delegates to
-it the task of enforcing transactions and referential integrity. It is important
-to be aware of the fact that the two latter ones aren't actually enforced by
-MySQL when using the MyISAM storage engine, see the next section.
+Django expects the database to support Unicode (UTF-8 encoding, preferably with
+the ``utf8mb4`` character set) and delegates to it the task of enforcing
+transactions and referential integrity. It is important to be aware of the fact
+that the two latter ones aren't actually enforced by MySQL when using the
+MyISAM storage engine, see the next section.
 
 .. _mysql-storage-engines:
 
@@ -362,9 +363,11 @@ Creating your database
 
 You can `create your database`_ using the command-line tools and this SQL::
 
-  CREATE DATABASE <dbname> CHARACTER SET utf8;
+  CREATE DATABASE <dbname> CHARACTER SET utf8mb4;
 
-This ensures all tables and columns will use UTF-8 by default.
+This ensures all tables and columns will use UTF-8 by default. The ``utf8``
+character set is also supported, but then only Unicode characters stored with
+up to three bytes can be stored in the database.
 
 .. _create your database: https://dev.mysql.com/doc/refman/en/create-database.html
 
@@ -383,21 +386,21 @@ the model definition.
 .. _documented thoroughly: https://dev.mysql.com/doc/refman/en/charset.html
 
 By default, with a UTF-8 database, MySQL will use the
-``utf8_general_ci`` collation. This results in all string equality
+``utf8mb4_general_ci`` collation. This results in all string equality
 comparisons being done in a *case-insensitive* manner. That is, ``"Fred"`` and
 ``"freD"`` are considered equal at the database level. If you have a unique
 constraint on a field, it would be illegal to try to insert both ``"aa"`` and
 ``"AA"`` into the same column, since they compare as equal (and, hence,
 non-unique) with the default collation. If you want case-sensitive comparisons
 on a particular column or table, change the column or table to use the
-``utf8_bin`` collation.
+``utf8mb4_bin`` collation.
 
 Please note that according to `MySQL Unicode Character Sets`_, comparisons for
-the ``utf8_general_ci`` collation are faster, but slightly less correct, than
-comparisons for ``utf8_unicode_ci``. If this is acceptable for your application,
-you should use ``utf8_general_ci`` because it is faster. If this is not acceptable
-(for example, if you require German dictionary order), use ``utf8_unicode_ci``
-because it is more accurate.
+the ``utf8mb4_general_ci`` collation are faster, but slightly less correct, than
+comparisons for ``utf8mb4_unicode_ci``. If this is acceptable for your
+application, you should use ``utf8mb4_general_ci`` because it is faster. If this
+is not acceptable (for example, if you require German dictionary order), use
+``utf8mb4_unicode_ci`` because it is more accurate.
 
 .. _MySQL Unicode Character Sets: https://dev.mysql.com/doc/refman/en/charset-unicode-sets.html
 
@@ -407,6 +410,46 @@ because it is more accurate.
     using a case-insensitive collation, a formset with unique field values that
     differ only by case will pass validation, but upon calling ``save()``, an
     ``IntegrityError`` will be raised.
+
+.. _mysql-convert-charset-collation:
+
+Converting the charset and/or collation for an existing database
+----------------------------------------------------------------
+
+You can write migrations to change the character set or the collation of
+existing MySQL databases. Here's an example migration::
+
+    from django.conf import settings
+    from django.db import migrations
+
+    def to_utf8mb4(apps, schema_editor):
+        if not schema_editor.connection.vendor == 'mysql':
+            return
+
+        # Only if you want to change the database default, this doesn't convert any existing columns.
+        db_name = settings.DATABASES['default']['NAME']
+        schema_editor.execute(
+            'ALTER DATABASE %s CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci' % db_name,
+            params=None
+        )
+
+        tables = [
+            apps.get_model("applabel", "Model1")._meta.db_table,
+            apps.get_model("applabel", "Model2")._meta.db_table,
+        ]
+        for table_name in tables:
+            schema_editor.execute(
+                'ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci' % table_name,
+                params=None
+            )
+
+    class Migration(migrations.Migration):
+        dependencies = [
+            ('applabel', '0003_some_previous_migration'),
+        ]
+
+        # Writing a reverse migration is an exercise left to the reader!
+        operations = [migrations.RunPython(to_utf8mb4, migrations.RunPython.noop, atomic=False)]
 
 Connecting to the database
 --------------------------
@@ -442,7 +485,7 @@ Here's a sample configuration which uses a MySQL option file::
     database = NAME
     user = USER
     password = PASSWORD
-    default-character-set = utf8
+    default-character-set = utf8mb4
 
 Several other `MySQLdb connection options`_ may be useful, such as ``ssl``,
 ``init_command``, and ``sql_mode``.
@@ -552,12 +595,14 @@ these methods in no-op's based in the results of such detection.
 Notes on specific fields
 ------------------------
 
-Character fields
-~~~~~~~~~~~~~~~~
+Indexes for character fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Any fields that are stored with ``VARCHAR`` column types have their
-``max_length`` restricted to 255 characters if you are using ``unique=True``
-for the field. This affects :class:`~django.db.models.CharField`,
+On most default MySQL installations, index length is limited to 767 bytes. That
+means that fields stored with ``VARCHAR`` column types will only index the 191
+first characters of the fields. Avoid using ``unique=True`` on fields having
+more than 191 characters, because the unicity will only be checked on the 191
+first characters. This affects :class:`~django.db.models.CharField` and
 :class:`~django.db.models.SlugField`.
 
 ``TextField`` limitations

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -296,6 +296,13 @@ upload handler is used.
 ``FILE_UPLOAD_PERMISSION`` now defaults to ``0o644`` to avoid this
 inconsistency.
 
+MySQL defaults to ``utf8mb4`` character set
+-------------------------------------------
+
+The MySQL backend now uses ``utf8mb4`` as the default character as it allows
+storing the full range of Unicode characters. If needed, :ref:`write a
+migration to convert existing databases <mysql-convert-charset-collation>`.
+
 Miscellaneous
 -------------
 

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -115,7 +115,7 @@ class CustomArticle(models.Model):
 
 
 class ModelWithStringPrimaryKey(models.Model):
-    string_pk = models.CharField(max_length=255, primary_key=True)
+    string_pk = models.CharField(max_length=150, primary_key=True)
 
     def __str__(self):
         return self.string_pk

--- a/tests/auth_tests/models/custom_permissions.py
+++ b/tests/auth_tests/models/custom_permissions.py
@@ -19,7 +19,7 @@ class CustomPermissionsUserManager(CustomUserManager):
 
 with RemoveGroupsAndPermissions():
     class CustomPermissionsUser(AbstractBaseUser, PermissionsMixin):
-        email = models.EmailField(verbose_name='email address', max_length=255, unique=True)
+        email = models.EmailField(verbose_name='email address', max_length=150, unique=True)
         date_of_birth = models.DateField()
 
         custom_objects = CustomPermissionsUserManager()

--- a/tests/auth_tests/models/custom_user.py
+++ b/tests/auth_tests/models/custom_user.py
@@ -34,7 +34,7 @@ class CustomUserManager(BaseUserManager):
 
 
 class CustomUser(AbstractBaseUser):
-    email = models.EmailField(verbose_name='email address', max_length=255, unique=True)
+    email = models.EmailField(verbose_name='email address', max_length=150, unique=True)
     is_active = models.BooleanField(default=True)
     is_admin = models.BooleanField(default=False)
     date_of_birth = models.DateField()
@@ -93,7 +93,7 @@ class RemoveGroupsAndPermissions:
 
 class CustomUserWithoutIsActiveField(AbstractBaseUser):
     username = models.CharField(max_length=150, unique=True)
-    email = models.EmailField(unique=True)
+    email = models.EmailField(max_length=150, unique=True)
 
     objects = UserManager()
 

--- a/tests/auth_tests/models/with_foreign_key.py
+++ b/tests/auth_tests/models/with_foreign_key.py
@@ -3,7 +3,7 @@ from django.db import models
 
 
 class Email(models.Model):
-    email = models.EmailField(verbose_name='email address', max_length=255, unique=True)
+    email = models.EmailField(verbose_name='email address', max_length=150, unique=True)
 
 
 class CustomUserWithFKManager(BaseUserManager):

--- a/tests/get_or_create/models.py
+++ b/tests/get_or_create/models.py
@@ -25,7 +25,7 @@ class Profile(models.Model):
 
 
 class Tag(models.Model):
-    text = models.CharField(max_length=255, unique=True)
+    text = models.CharField(max_length=150, unique=True)
 
 
 class Thing(models.Model):

--- a/tests/model_fields/test_charfield.py
+++ b/tests/model_fields/test_charfield.py
@@ -1,7 +1,5 @@
-from unittest import skipIf
-
 from django.core.exceptions import ValidationError
-from django.db import connection, models
+from django.db import models
 from django.test import SimpleTestCase, TestCase
 
 from .models import Post
@@ -22,7 +20,6 @@ class TestCharField(TestCase):
     def test_lookup_integer_in_charfield(self):
         self.assertEqual(Post.objects.filter(title=9).count(), 0)
 
-    @skipIf(connection.vendor == 'mysql', 'Running on MySQL requires utf8mb4 encoding (#18392)')
     def test_emoji(self):
         p = Post.objects.create(title='Smile 😀', body='Whatever.')
         p.refresh_from_db()

--- a/tests/model_fields/test_textfield.py
+++ b/tests/model_fields/test_textfield.py
@@ -1,7 +1,5 @@
-from unittest import skipIf
-
 from django import forms
-from django.db import connection, models
+from django.db import models
 from django.test import TestCase
 
 from .models import Post
@@ -32,7 +30,6 @@ class TextFieldTests(TestCase):
     def test_lookup_integer_in_textfield(self):
         self.assertEqual(Post.objects.filter(body=24).count(), 0)
 
-    @skipIf(connection.vendor == 'mysql', 'Running on MySQL requires utf8mb4 encoding (#18392)')
     def test_emoji(self):
         p = Post.objects.create(title='Whatever', body='Smile 😀.')
         p.refresh_from_db()

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -9,7 +9,7 @@ new_apps = Apps()
 
 
 class Author(models.Model):
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=150)
     height = models.PositiveIntegerField(null=True, blank=True)
     weight = models.IntegerField(null=True, blank=True)
     uuid = models.UUIDField(null=True)
@@ -147,7 +147,7 @@ class NoteRename(models.Model):
 
 
 class Tag(models.Model):
-    title = models.CharField(max_length=255)
+    title = models.CharField(max_length=150)
     slug = models.SlugField(unique=True)
 
     class Meta:
@@ -155,7 +155,7 @@ class Tag(models.Model):
 
 
 class TagIndexed(models.Model):
-    title = models.CharField(max_length=255)
+    title = models.CharField(max_length=150)
     slug = models.SlugField(unique=True)
 
     class Meta:

--- a/tests/test_client_regress/models.py
+++ b/tests/test_client_regress/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 
 class CustomUser(AbstractBaseUser):
-    email = models.EmailField(verbose_name='email address', max_length=255, unique=True)
+    email = models.EmailField(verbose_name='email address', max_length=150, unique=True)
     custom_objects = BaseUserManager()
 
     USERNAME_FIELD = 'email'


### PR DESCRIPTION
https://code.djangoproject.com/ticket/18392