### PR TITLE
Fixed #23546 -- Added kwargs support for CursorWrapper.callproc() on Oracle.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -240,6 +240,9 @@ class BaseDatabaseFeatures:
     create_test_procedure_without_params_sql = None
     create_test_procedure_with_int_param_sql = None
 
+    # Does the backend support keyword parameters for cursor.callproc()?
+    supports_callproc_kwargs = False
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -54,3 +54,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             V_I := P_I;
         END;
     """
+    supports_callproc_kwargs = True

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -269,6 +269,10 @@ Models
 * The new ``field_name`` parameter of :meth:`.QuerySet.in_bulk` allows fetching
   results based on any unique model field.
 
+* :meth:`.CursorWrapper.callproc()` now takes an optional dictionary of keyword
+  parameters, if the backend supports this feature. Of Django's built-in
+  backends, only Oracle supports it.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -350,10 +350,12 @@ is equivalent to::
 Calling stored procedures
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. method:: CursorWrapper.callproc(procname, params=None)
+.. method:: CursorWrapper.callproc(procname, params=None, kparams=None)
 
-    Calls a database stored procedure with the given name and optional sequence
-    of input parameters.
+    Calls a database stored procedure with the given name. A sequence
+    (``params``) or dictionary (``kparams``) of input parameters may be
+    provided. Most databases don't support ``kparams``. Of Django's built-in
+    backends, only Oracle supports it.
 
     For example, given this stored procedure in an Oracle database:
 
@@ -372,3 +374,7 @@ Calling stored procedures
 
         with connection.cursor() as cursor:
             cursor.callproc('test_procedure', [1, 'test'])
+
+    .. versionchanged:: 2.0
+
+        The ``kparams`` argument was added.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/23546