### PR TITLE
Fixed #28451 -- Restored pre-Django 1.11 Oracle sequence/trigger naming.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -441,6 +441,7 @@ answer newbie questions, and generally made Django that much better:
     Keith Bussell <kbussell@gmail.com>
     Kenneth Love <kennethlove@gmail.com>
     Kent Hauser <kent@khauser.net>
+    Kevin Grinberg <kevin@kevingrinberg.com>
     Kevin Kubasik <kevin@kubasik.net>
     Kevin McConnell <kevin.mcconnell@gmail.com>
     Kieran Holland <http://www.kieranholland.com>

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -518,8 +518,7 @@ END;
         AutoFields that aren't Oracle identity columns.
         """
         name_length = self.max_name_length() - 3
-        sequence_name = '%s_SQ' % strip_quotes(table)
-        return truncate_name(sequence_name, name_length).upper()
+        return '%s_SQ' % truncate_name(strip_quotes(table), name_length).upper()
 
     def _get_sequence_name(self, cursor, table, pk_name):
         cursor.execute("""

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -15,3 +15,11 @@ Bugfixes
 * Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
 
 * Fixed select widget rendering when option values are tuples (:ticket:`28502`).
+
+* Django 1.11 inadvertently changed the sequence and trigger naming scheme on
+  Oracle. This causes errors on INSERTs for some tables if
+  ``'use_returning_into': False`` is in the ``OPTIONS`` part of ``DATABASES``.
+  The pre-11.1 naming scheme is now restored. Unfortunately, it necessarily
+  requires an update to Oracle tables created with Django 1.11.[1-4]. Use the
+  upgrade script in :ticket:`28451` comment 8 to update sequence and trigger
+  names to use the pre-1.11 naming scheme

--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -1,0 +1,11 @@
+import unittest
+
+from django.db import connection
+
+
+@unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
+class OperationsTests(unittest.TestCase):
+
+    def test_sequence_name_truncation(self):
+        seq_name = connection.ops._get_no_autofield_sequence_name('schema_authorwithevenlongee869')
+        self.assertEqual(seq_name, 'SCHEMA_AUTHORWITHEVENLOB0B8_SQ')


### PR DESCRIPTION
Fixed regression introduced in 69b7d4b1 (#27458) that broke sequence
and trigger name generation (relevant when use_returning_into=False).