### PR TITLE
[1.11.x] Fixed #28451 -- Fixed regression in Oracle sequence naming

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -522,13 +522,11 @@ WHEN (new.%(col_name)s IS NULL)
 
     def _get_sequence_name(self, table):
         name_length = self.max_name_length() - 3
-        sequence_name = '%s_SQ' % strip_quotes(table)
-        return truncate_name(sequence_name, name_length).upper()
+        return '%s_SQ' % truncate_name(strip_quotes(table), name_length).upper()
 
     def _get_trigger_name(self, table):
         name_length = self.max_name_length() - 3
-        trigger_name = '%s_TR' % strip_quotes(table)
-        return truncate_name(trigger_name, name_length).upper()
+        return '%s_TR' % truncate_name(strip_quotes(table), name_length).upper()
 
     def bulk_insert_sql(self, fields, placeholder_rows):
         return " UNION ALL ".join(

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -15,3 +15,11 @@ Bugfixes
 * Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
 
 * Fixed select widget rendering when option values are tuples (:ticket:`28502`).
+
+* Django 1.11 inadvertently changed the sequence and trigger naming scheme on
+  Oracle. This causes errors on INSERTs for some tables if
+  ``'use_returning_into': False`` is in the ``OPTIONS`` part of ``DATABASES``.
+  The pre-11.1 naming scheme is now restored. Unfortunately, it necessarily
+  requires an update to Oracle tables created with Django 1.11.[1-4]. Use the
+  upgrade script in :ticket:`28451` comment 8 to update sequence and trigger
+  names to use the pre-1.11 naming scheme

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -128,6 +128,14 @@ class OracleTests(unittest.TestCase):
             cursor.execute(query)
             self.assertEqual(cursor.fetchone()[0], 1)
 
+    def test_sequence_name_truncation(self):
+        seq_name = connection.ops._get_sequence_name('schema_authorwithevenlongee869')
+        self.assertEqual(seq_name, 'SCHEMA_AUTHORWITHEVENLOB0B8_SQ')
+
+    def test_trigger_name_truncation(self):
+        trigger_name = connection.ops._get_trigger_name('schema_authorwithevenlongee869')
+        self.assertEqual(trigger_name, 'SCHEMA_AUTHORWITHEVENLOB0B8_TR')
+
 
 @unittest.skipUnless(connection.vendor == 'sqlite', "Test only for SQLite")
 class SQLiteTests(TestCase):


### PR DESCRIPTION
Backport of 99c7a18f4edf84d3b2bbddd3dfc7c3287bc8fa23 from master,
with additional migration script & release notes.