### PR TITLE
Clarified Concat example in docs.

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -88,8 +88,9 @@ Usage examples::
 Accepts a list of at least two text fields or expressions and returns the
 concatenated text. Each argument must be of a text or char type. If you want
 to concatenate a ``TextField()`` with a ``CharField()``, then be sure to tell
-Django that the ``output_field`` should be a ``TextField()``. This is also
-required when concatenating a ``Value`` as in the example below.
+Django that the ``output_field`` should be a ``TextField()``. Specifying an
+``output_field`` is also required when concatenating a ``Value`` as in the
+example below.
 
 This function will never have a null result. On backends where a null argument
 results in the entire expression being null, Django will ensure that each null
@@ -102,8 +103,11 @@ Usage example::
     >>> from django.db.models.functions import Concat
     >>> Author.objects.create(name='Margaret Smith', goes_by='Maggie')
     >>> author = Author.objects.annotate(
-    ...    screen_name=Concat('name', V(' ('), 'goes_by', V(')'),
-    ...    output_field=CharField())).get()
+    ...     screen_name=Concat(
+    ...         'name', V(' ('), 'goes_by', V(')'),
+    ...         output_field=CharField()
+    ...     )
+    ... ).get()
     >>> print(author.screen_name)
     Margaret Smith (Maggie)
 


### PR DESCRIPTION
Fixed example in documentation:
- Use TextField instead of CharField as it's stated above it should be,
- Readjusted indentation to make clearer the output_field is argument to Concat() and not annotate()
- Use [] instead of () in Values to make it a bit easier to read with less brackets all over the place