### PR TITLE
Fixed typo in documented number of logging filters.

### DIFF
--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -656,7 +656,7 @@ Python logging module.
 Filters
 -------
 
-Django provides two log filters in addition to those provided by the Python
+Django provides some log filters in addition to those provided by the Python
 logging module.
 
 .. class:: CallbackFilter(callback)


### PR DESCRIPTION
Django provides: `CallbackFilter`, `RequireDebugFalse` and `RequireDebugTrue` --> three log filters