### PR TITLE
Serialize Enum migrations by name

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -125,9 +125,9 @@ class EnumSerializer(BaseSerializer):
         enum_class = self.value.__class__
         module = enum_class.__module__
         imports = {"import %s" % module}
-        v_string, v_imports = serializer_factory(self.value.value).serialize()
+        v_string, v_imports = serializer_factory(self.value.name).serialize()
         imports.update(v_imports)
-        return "%s.%s(%s)" % (module, enum_class.__name__, v_string), imports
+        return "%s.%s[%s]" % (module, enum_class.__name__, v_string), imports
 
 
 class FloatSerializer(BaseSimpleSerializer):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -270,17 +270,25 @@ class WriterTests(SimpleTestCase):
             A = 1
             B = 2
 
+        class ComplexEnum(enum.Enum):
+            A = ('a', 'tuple')
+            B = ('imported', 'function', os.path.join)
+
         self.assertSerializedResultEqual(
             TextEnum.A,
-            ("migrations.test_writer.TextEnum('a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.TextEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             BinaryEnum.A,
-            ("migrations.test_writer.BinaryEnum(b'a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.BinaryEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             IntEnum.B,
-            ("migrations.test_writer.IntEnum(2)", {'import migrations.test_writer'})
+            ("migrations.test_writer.IntEnum['B']", {'import migrations.test_writer'})
+        )
+        self.assertSerializedResultEqual(
+            ComplexEnum.B,
+            ("migrations.test_writer.ComplexEnum['B']", {'import migrations.test_writer'})
         )
 
         field = models.CharField(default=TextEnum.B, choices=[(m.value, m) for m in TextEnum])
@@ -288,27 +296,36 @@ class WriterTests(SimpleTestCase):
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "('a-value', migrations.test_writer.TextEnum('a-value')), "
-            "('value-b', migrations.test_writer.TextEnum('value-b'))], "
-            "default=migrations.test_writer.TextEnum('value-b'))"
+            "('a-value', migrations.test_writer.TextEnum['A']), "
+            "('value-b', migrations.test_writer.TextEnum['B'])], "
+            "default=migrations.test_writer.TextEnum['B'])"
         )
         field = models.CharField(default=BinaryEnum.B, choices=[(m.value, m) for m in BinaryEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "(b'a-value', migrations.test_writer.BinaryEnum(b'a-value')), "
-            "(b'value-b', migrations.test_writer.BinaryEnum(b'value-b'))], "
-            "default=migrations.test_writer.BinaryEnum(b'value-b'))"
+            "(b'a-value', migrations.test_writer.BinaryEnum['A']), "
+            "(b'value-b', migrations.test_writer.BinaryEnum['B'])], "
+            "default=migrations.test_writer.BinaryEnum['B'])"
         )
         field = models.IntegerField(default=IntEnum.A, choices=[(m.value, m) for m in IntEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.IntegerField(choices=["
-            "(1, migrations.test_writer.IntEnum(1)), "
-            "(2, migrations.test_writer.IntEnum(2))], "
-            "default=migrations.test_writer.IntEnum(1))"
+            "(1, migrations.test_writer.IntEnum['A']), "
+            "(2, migrations.test_writer.IntEnum['B'])], "
+            "default=migrations.test_writer.IntEnum['A'])"
+        )
+        field = models.CharField(default=ComplexEnum.A, choices=[(m.name, m) for m in ComplexEnum])
+        string = MigrationWriter.serialize(field)[0]
+        self.assertEqual(
+            string,
+            "models.CharField(choices=["
+            "('A', migrations.test_writer.ComplexEnum['A']), "
+            "('B', migrations.test_writer.ComplexEnum['B'])], "
+            "default=migrations.test_writer.ComplexEnum['A'])"
         )
 
     def test_serialize_uuid(self):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -446,10 +446,10 @@ class WriterTests(SimpleTestCase):
         self.serialize_round_trip(validator)
 
         # Test a string regex with flag
-        validator = RegexValidator(r'^[0-9]+$', flags=re.S)
+        validator = RegexValidator(r'^[0-9]+$', flags=re.DOTALL)
         string = MigrationWriter.serialize(validator)[0]
         if PY36:
-            self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag(16))")
+            self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag['DOTALL'])")
         else:
             self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=16)")
         self.serialize_round_trip(validator)


### PR DESCRIPTION
- avoids unnecessary imports if the values are complicated