### PR TITLE
Fixed #28504 -- Refactored alter field method to add hooks and reduce complexity

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -512,6 +512,139 @@ class BaseDatabaseSchemaEditor:
                      old_db_params, new_db_params, strict=False):
         """Perform a "physical" (non-ManyToMany) field update."""
         # Drop any FK constraints, we'll remake them later
+        fks_dropped = self._drop_fk_constraints(model, old_field, strict)
+
+        # Has unique been removed?
+        if old_field.unique and (not new_field.unique or (not old_field.primary_key and new_field.primary_key)):
+            self._drop_unique_constraints(model, old_field, new_field, strict)
+
+        # Drop incoming FK constraints if we're a primary key and things are going
+        # to change.
+        if old_field.primary_key and new_field.primary_key and old_type != new_type:
+            self._drop_pk_fk_constraints(old_field, new_field)
+
+        # Removed an index? (no strict check, as multiple indexes are possible)
+        # Remove indexes if db_index switched to False or a unique constraint
+        # will now be used in lieu of an index. The following lines from the
+        # truth table show all True cases; the rest are False:
+        #
+        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
+        # ------------------------------------------------------------------------------
+        # True               | False            | False              | False
+        # True               | False            | False              | True
+        # True               | False            | True               | True
+        if old_field.db_index and not old_field.unique and (not new_field.db_index or new_field.unique):
+            self._drop_index(model, old_field, new_field)
+
+        # Change check constraints?
+        if old_db_params['check'] != new_db_params['check'] and old_db_params['check']:
+            self._drop_check_constraints(model, old_field, strict)
+
+        # Have they renamed the column?
+        if old_field.column != new_field.column:
+            self._rename_column(model, old_field, new_field, new_type)
+
+        # Next, accumulate actions to do
+
+        old_default = self.effective_default(old_field)
+        new_default = self.effective_default(new_field)
+        needs_database_default = (
+            old_field.null and
+            not new_field.null and
+            old_default != new_default and
+            new_default is not None and
+            not self.skip_default(new_field)
+        )
+
+        (actions,
+            null_actions,
+            post_actions,
+            four_way_default_alteration) = self._build_actions(
+                model,
+                old_field,
+                new_field,
+                old_type,
+                new_type,
+                needs_database_default)
+
+        # Apply those actions
+        for sql, params in actions:
+            self._apply_alter_column(model, sql, params)
+        if four_way_default_alteration:
+            # Update existing rows with default value
+            self.execute(
+                self.sql_update_with_default % {
+                    "table": self.quote_name(model._meta.db_table),
+                    "column": self.quote_name(new_field.column),
+                    "default": "%s",
+                },
+                [new_default],
+            )
+            # Since we didn't run a NOT NULL change before we need to do it
+            # now
+            for sql, params in null_actions:
+                self.execute(
+                    self.sql_alter_column % {
+                        "table": self.quote_name(model._meta.db_table),
+                        "changes": sql,
+                    },
+                    params,
+                )
+        if post_actions:
+            for sql, params in post_actions:
+                self.execute(sql, params)
+
+        # Added a unique?
+        if (not old_field.unique and new_field.unique) or (
+            old_field.primary_key and not new_field.primary_key and new_field.unique
+        ):
+            self._add_unique_constraint(model, new_field)
+
+        # Added an index? Add an index if db_index switched to True or a unique
+        # constraint will no longer be used in lieu of an index. The following
+        # lines from the truth table show all True cases; the rest are False:
+        #
+        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
+        # ------------------------------------------------------------------------------
+        # False              | False            | True               | False
+        # False              | True             | True               | False
+        # True               | True             | True               | False
+        if (not old_field.db_index or old_field.unique) and new_field.db_index and not new_field.unique:
+            self._add_index(model, new_field)
+
+        # Type alteration on primary key? Then we need to alter the column
+        # referring to us.
+        rels_to_update = self._get_rels_to_update(model, old_field, new_field, old_type, new_type, strict)
+
+        # Handle our type alters on the other end of rels from the PK stuff above
+        self._update_relations(model, rels_to_update)
+
+        # Does it have a foreign key?
+        if (new_field.remote_field and
+                (fks_dropped or not old_field.remote_field or not old_field.db_constraint) and
+                new_field.db_constraint):
+            self._add_foreign_key(model, new_field, "_fk_%(to_table)s_%(to_column)s")
+
+        # Rebuild FKs that pointed to us if we previously had to drop them
+        if old_field.primary_key and new_field.primary_key and old_type != new_type:
+            for rel in new_field.model._meta.related_objects:
+                if not rel.many_to_many and rel.field.db_constraint:
+                    self._add_foreign_key(rel.related_model, rel.field, "_fk")
+
+        # Does it have check constraints we need to add?
+        if old_db_params['check'] != new_db_params['check'] and new_db_params['check']:
+            self._add_check_constraints(model, new_field, new_db_params)
+
+        # Drop the default if we need to
+        # (Django usually does not use in-database defaults)
+        if needs_database_default:
+            self._drop_default(model, old_field, new_field)
+
+        # Reset connection if required
+        if self.connection.features.connection_persists_old_columns:
+            self.connection.close()
+
+    def _drop_fk_constraints(self, model, old_field, strict):
         fks_dropped = set()
         if old_field.remote_field and old_field.db_constraint:
             fk_names = self._constraint_names(model, [old_field.column], foreign_key=True)
@@ -524,71 +657,62 @@ class BaseDatabaseSchemaEditor:
             for fk_name in fk_names:
                 fks_dropped.add((old_field.column,))
                 self.execute(self._delete_constraint_sql(self.sql_delete_fk, model, fk_name))
-        # Has unique been removed?
-        if old_field.unique and (not new_field.unique or (not old_field.primary_key and new_field.primary_key)):
-            # Find the unique constraint for this field
-            constraint_names = self._constraint_names(model, [old_field.column], unique=True)
-            if strict and len(constraint_names) != 1:
-                raise ValueError("Found wrong number (%s) of unique constraints for %s.%s" % (
-                    len(constraint_names),
-                    model._meta.db_table,
-                    old_field.column,
-                ))
-            for constraint_name in constraint_names:
-                self.execute(self._delete_constraint_sql(self.sql_delete_unique, model, constraint_name))
-        # Drop incoming FK constraints if we're a primary key and things are going
-        # to change.
-        if old_field.primary_key and new_field.primary_key and old_type != new_type:
-            # '_meta.related_field' also contains M2M reverse fields, these
-            # will be filtered out
-            for _old_rel, new_rel in _related_non_m2m_objects(old_field, new_field):
-                rel_fk_names = self._constraint_names(
-                    new_rel.related_model, [new_rel.field.column], foreign_key=True
-                )
-                for fk_name in rel_fk_names:
-                    self.execute(self._delete_constraint_sql(self.sql_delete_fk, new_rel.related_model, fk_name))
-        # Removed an index? (no strict check, as multiple indexes are possible)
-        # Remove indexes if db_index switched to False or a unique constraint
-        # will now be used in lieu of an index. The following lines from the
-        # truth table show all True cases; the rest are False:
-        #
-        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
-        # ------------------------------------------------------------------------------
-        # True               | False            | False              | False
-        # True               | False            | False              | True
-        # True               | False            | True               | True
-        if old_field.db_index and not old_field.unique and (not new_field.db_index or new_field.unique):
-            # Find the index for this field
-            meta_index_names = {index.name for index in model._meta.indexes}
-            # Retrieve only BTREE indexes since this is what's created with
-            # db_index=True.
-            index_names = self._constraint_names(model, [old_field.column], index=True, type_=Index.suffix)
-            for index_name in index_names:
-                if index_name in meta_index_names:
-                    # The only way to check if an index was created with
-                    # db_index=True or with Index(['field'], name='foo')
-                    # is to look at its name (refs #28053).
-                    continue
-                self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
-        # Change check constraints?
-        if old_db_params['check'] != new_db_params['check'] and old_db_params['check']:
-            constraint_names = self._constraint_names(model, [old_field.column], check=True)
-            if strict and len(constraint_names) != 1:
-                raise ValueError("Found wrong number (%s) of check constraints for %s.%s" % (
-                    len(constraint_names),
-                    model._meta.db_table,
-                    old_field.column,
-                ))
-            for constraint_name in constraint_names:
-                self.execute(self._delete_constraint_sql(self.sql_delete_check, model, constraint_name))
-        # Have they renamed the column?
-        if old_field.column != new_field.column:
-            self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
-            # Rename all references to the renamed column.
-            for sql in self.deferred_sql:
-                if isinstance(sql, Statement):
-                    sql.rename_column_references(model._meta.db_table, old_field.column, new_field.column)
-        # Next, start accumulating actions to do
+            return fks_dropped
+
+    def _drop_unique_constraints(self, model, old_field, new_field, strict):
+        # Find the unique constraint for this field
+        constraint_names = self._constraint_names(model, [old_field.column], unique=True)
+        if strict and len(constraint_names) != 1:
+            raise ValueError("Found wrong number (%s) of unique constraints for %s.%s" % (
+                len(constraint_names),
+                model._meta.db_table,
+                old_field.column,
+            ))
+        for constraint_name in constraint_names:
+            self.execute(self._delete_constraint_sql(self.sql_delete_unique, model, constraint_name))
+
+    def _drop_pk_fk_constraints(self, old_field, new_field):
+        # '_meta.related_field' also contains M2M reverse fields, these
+        # will be filtered out
+        for _old_rel, new_rel in _related_non_m2m_objects(old_field, new_field):
+            rel_fk_names = self._constraint_names(
+                new_rel.related_model, [new_rel.field.column], foreign_key=True
+            )
+            for fk_name in rel_fk_names:
+                self.execute(self._delete_constraint_sql(self.sql_delete_fk, new_rel.related_model, fk_name))
+
+    def _drop_index(self, model, old_field, new_field):
+        meta_index_names = {index.name for index in model._meta.indexes}
+        # Retrieve only BTREE indexes since this is what's created with
+        # db_index=True.
+        index_names = self._constraint_names(model, [old_field.column], index=True, type_=Index.suffix)
+        for index_name in index_names:
+            if index_name in meta_index_names:
+                # The only way to check if an index was created with
+                # db_index=True or with Index(['field'], name='foo')
+                # is to look at its name (refs #28053).
+                continue
+            self.execute(self._delete_constraint_sql(self.sql_delete_index, model, index_name))
+
+    def _drop_check_constraints(self, model, old_field, strict):
+        constraint_names = self._constraint_names(model, [old_field.column], check=True)
+        if strict and len(constraint_names) != 1:
+            raise ValueError("Found wrong number (%s) of check constraints for %s.%s" % (
+                len(constraint_names),
+                model._meta.db_table,
+                old_field.column,
+            ))
+        for constraint_name in constraint_names:
+            self.execute(self._delete_constraint_sql(self.sql_delete_check, model, constraint_name))
+
+    def _rename_column(self, model, old_field, new_field, new_type):
+        self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
+        # Rename all references to the renamed column.
+        for sql in self.deferred_sql:
+            if isinstance(sql, Statement):
+                sql.rename_column_references(model._meta.db_table, old_field.column, new_field.column)
+
+    def _build_actions(self, model, old_field, new_field, old_type, new_type, needs_default=False):
         actions = []
         null_actions = []
         post_actions = []
@@ -603,17 +727,8 @@ class BaseDatabaseSchemaEditor:
         #  2. Update existing NULL rows with new default
         #  3. Replace NULL constraint with NOT NULL
         #  4. Drop the default again.
-        # Default change?
-        old_default = self.effective_default(old_field)
-        new_default = self.effective_default(new_field)
-        needs_database_default = (
-            old_field.null and
-            not new_field.null and
-            old_default != new_default and
-            new_default is not None and
-            not self.skip_default(new_field)
-        )
-        if needs_database_default:
+
+        if needs_default:
             actions.append(self._alter_column_default_sql(model, old_field, new_field))
         # Nullability change?
         if old_field.null != new_field.null:
@@ -625,65 +740,25 @@ class BaseDatabaseSchemaEditor:
             new_field.has_default() and
             (old_field.null and not new_field.null)
         )
+
         if actions or null_actions:
             if not four_way_default_alteration:
                 # If we don't have to do a 4-way default alteration we can
-                # directly run a (NOT) NULL alteration
+                # directly run  (NOT) NULL alteration
                 actions = actions + null_actions
             # Combine actions together if we can (e.g. postgres)
             if self.connection.features.supports_combined_alters and actions:
                 sql, params = tuple(zip(*actions))
                 actions = [(", ".join(sql), sum(params, []))]
-            # Apply those actions
-            for sql, params in actions:
-                self.execute(
-                    self.sql_alter_column % {
-                        "table": self.quote_name(model._meta.db_table),
-                        "changes": sql,
-                    },
-                    params,
-                )
-            if four_way_default_alteration:
-                # Update existing rows with default value
-                self.execute(
-                    self.sql_update_with_default % {
-                        "table": self.quote_name(model._meta.db_table),
-                        "column": self.quote_name(new_field.column),
-                        "default": "%s",
-                    },
-                    [new_default],
-                )
-                # Since we didn't run a NOT NULL change before we need to do it
-                # now
-                for sql, params in null_actions:
-                    self.execute(
-                        self.sql_alter_column % {
-                            "table": self.quote_name(model._meta.db_table),
-                            "changes": sql,
-                        },
-                        params,
-                    )
-        if post_actions:
-            for sql, params in post_actions:
-                self.execute(sql, params)
-        # Added a unique?
-        if (not old_field.unique and new_field.unique) or (
-            old_field.primary_key and not new_field.primary_key and new_field.unique
-        ):
-            self.execute(self._create_unique_sql(model, [new_field.column]))
-        # Added an index? Add an index if db_index switched to True or a unique
-        # constraint will no longer be used in lieu of an index. The following
-        # lines from the truth table show all True cases; the rest are False:
-        #
-        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
-        # ------------------------------------------------------------------------------
-        # False              | False            | True               | False
-        # False              | True             | True               | False
-        # True               | True             | True               | False
-        if (not old_field.db_index or old_field.unique) and new_field.db_index and not new_field.unique:
-            self.execute(self._create_index_sql(model, [new_field]))
-        # Type alteration on primary key? Then we need to alter the column
-        # referring to us.
+        return actions, null_actions, post_actions, four_way_default_alteration
+
+    def _add_unique_constraint(self, model, new_field):
+        self.execute(self._create_unique_sql(model, [new_field.column]))
+
+    def _add_index(self, model, new_field):
+        self.execute(self._create_index_sql(model, [new_field]))
+
+    def _get_rels_to_update(self, model, old_field, new_field, old_type, new_type, strict):
         rels_to_update = []
         if old_field.primary_key and new_field.primary_key and old_type != new_type:
             rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
@@ -694,18 +769,13 @@ class BaseDatabaseSchemaEditor:
             # First, drop the old PK
             self._delete_primary_key(model, strict)
             # Make the new one
-            self.execute(
-                self.sql_create_pk % {
-                    "table": self.quote_name(model._meta.db_table),
-                    "name": self.quote_name(
-                        self._create_index_name(model._meta.db_table, [new_field.column], suffix="_pk")
-                    ),
-                    "columns": self.quote_name(new_field.column),
-                }
-            )
+            self._create_primary_key(model, new_field)
             # Update all referencing columns
             rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
-        # Handle our type alters on the other end of rels from the PK stuff above
+
+        return rels_to_update
+
+    def _update_relations(self, model, rels_to_update):
         for old_rel, new_rel in rels_to_update:
             rel_db_params = new_rel.field.db_parameters(connection=self.connection)
             rel_type = rel_db_params['type']
@@ -721,40 +791,32 @@ class BaseDatabaseSchemaEditor:
             )
             for sql, params in other_actions:
                 self.execute(sql, params)
-        # Does it have a foreign key?
-        if (new_field.remote_field and
-                (fks_dropped or not old_field.remote_field or not old_field.db_constraint) and
-                new_field.db_constraint):
-            self.execute(self._create_fk_sql(model, new_field, "_fk_%(to_table)s_%(to_column)s"))
-        # Rebuild FKs that pointed to us if we previously had to drop them
-        if old_field.primary_key and new_field.primary_key and old_type != new_type:
-            for rel in new_field.model._meta.related_objects:
-                if not rel.many_to_many and rel.field.db_constraint:
-                    self.execute(self._create_fk_sql(rel.related_model, rel.field, "_fk"))
-        # Does it have check constraints we need to add?
-        if old_db_params['check'] != new_db_params['check'] and new_db_params['check']:
-            self.execute(
-                self.sql_create_check % {
-                    "table": self.quote_name(model._meta.db_table),
-                    "name": self.quote_name(
-                        self._create_index_name(model._meta.db_table, [new_field.column], suffix="_check")
-                    ),
-                    "column": self.quote_name(new_field.column),
-                    "check": new_db_params['check'],
-                }
-            )
-        # Drop the default if we need to
-        # (Django usually does not use in-database defaults)
-        if needs_database_default:
-            changes_sql, params = self._alter_column_default_sql(model, old_field, new_field, drop=True)
-            sql = self.sql_alter_column % {
+
+    def _add_foreign_key(self, model, new_field, suffix):
+        self.execute(self._create_fk_sql(model, new_field, suffix))
+
+    def _add_check_constraints(self, model, new_field, new_db_params):
+        self.execute(
+            self.sql_create_check % {
                 "table": self.quote_name(model._meta.db_table),
-                "changes": changes_sql,
+                "name": self.quote_name(
+                    self._create_index_name(model._meta.db_table, [new_field.column], suffix="_check")
+                ),
+                "column": self.quote_name(new_field.column),
+                "check": new_db_params['check'],
             }
-            self.execute(sql, params)
-        # Reset connection if required
-        if self.connection.features.connection_persists_old_columns:
-            self.connection.close()
+        )
+
+    def _drop_default(self, model, old_field, new_field):
+        changes_sql, params = self._alter_column_default_sql(model, old_field, new_field, drop=True)
+        self._apply_alter_column(model, changes_sql, params)
+
+    def _apply_alter_column(self, model, sql, params):
+        sql = self.sql_alter_column % {
+            "table": self.quote_name(model._meta.db_table),
+            "changes": sql,
+        }
+        self.execute(sql, params)
 
     def _alter_column_null_sql(self, model, old_field, new_field):
         """
@@ -1029,6 +1091,17 @@ class BaseDatabaseSchemaEditor:
             ))
         for constraint_name in constraint_names:
             self.execute(self._delete_constraint_sql(self.sql_delete_pk, model, constraint_name))
+
+    def _create_primary_key(self, model, new_field):
+        self.execute(
+            self.sql_create_pk % {
+                "table": self.quote_name(model._meta.db_table),
+                "name": self.quote_name(
+                    self._create_index_name(model._meta.db_table, [new_field.column], suffix="_pk")
+                ),
+                "columns": self.quote_name(new_field.column),
+            }
+        )
 
     def remove_procedure(self, procedure_name, param_types=()):
         sql = self.sql_delete_procedure % {


### PR DESCRIPTION
This adds hooks into the alter field method so backends can override/augment the actions that occur for an alter field schema change. This also reduces the cyclomatic complexity of this method from 84 to 44.