### PR TITLE
Draft of #28005 -- Normalized usage of terms 'argument' and 'parameter' 

### DIFF
--- a/docs/releases/1.0-porting-guide.txt
+++ b/docs/releases/1.0-porting-guide.txt
@@ -41,7 +41,7 @@ Common changes to your models file:
 Rename ``maxlength`` to ``max_length``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Rename your ``maxlength`` argument to ``max_length`` (this was changed to be
+Rename your ``maxlength`` parameter to ``max_length`` (this was changed to be
 consistent with form fields):
 
 Replace ``__str__`` with ``__unicode__``
@@ -53,14 +53,14 @@ make sure you `use Unicode`_ (``u'foo'``) in that method.
 Remove ``prepopulated_from``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Remove the ``prepopulated_from`` argument on model fields. It's no longer valid
+Remove the ``prepopulated_from`` parameter on model fields. It's no longer valid
 and has been moved to the ``ModelAdmin`` class in ``admin.py``. See `the
 admin`_, below, for more details about changes to the admin.
 
 Remove ``core``
 ~~~~~~~~~~~~~~~
 
-Remove the ``core`` argument from your model fields. It is no longer
+Remove the ``core`` parameter from your model fields. It is no longer
 necessary, since the equivalent functionality (part of :ref:`inline editing
 <admin-inlines>`) is handled differently by the admin interface now. You don't
 have to worry about inline editing until you get to `the admin`_ section,
@@ -533,7 +533,7 @@ New (1.0)::
         ...
 
 If you forget to make this change, you will see errors about ``FloatField``
-not taking a ``max_digits`` attribute in ``__init__``, because the new
+not taking a ``max_digits`` parameter in ``__init__``, because the new
 ``FloatField`` takes no precision-related arguments.
 
 If you're using MySQL or PostgreSQL, no further changes are needed. The

--- a/docs/releases/1.1.txt
+++ b/docs/releases/1.1.txt
@@ -141,7 +141,7 @@ and expected.
 Permanent redirects and the ``redirect_to()`` generic view
 ----------------------------------------------------------
 
-Django 1.1 adds a ``permanent`` argument to the
+Django 1.1 adds a ``permanent`` parameter to the
 ``django.views.generic.simple.redirect_to()`` view. This is technically
 backwards-incompatible if you were using the ``redirect_to`` view with a
 format-string key called 'permanent', which is highly unlikely.
@@ -288,7 +288,7 @@ A couple of small -- but highly useful -- improvements have been made to the
 test client:
 
 * The test :class:`Client` now can automatically follow redirects with the
-  ``follow`` argument to :meth:`Client.get` and :meth:`Client.post`. This
+  ``follow`` parameter to :meth:`Client.get` and :meth:`Client.post`. This
   makes testing views that issue redirects simpler.
 
 * It's now easier to get at the template context in the response returned

--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -122,12 +122,12 @@ Minor features
   to prevent an issue where Safari caches redirects and prevents a user from
   being able to log out.
 
-* Added the optional ``backend`` argument to :func:`~django.contrib.auth.login`
+* Added the optional ``backend`` parameter to :func:`~django.contrib.auth.login`
   to allow using it without credentials.
 
 * The new :setting:`LOGOUT_REDIRECT_URL` setting controls the redirect of the
   :func:`~django.contrib.auth.views.logout` view, if the view doesn't get a
-  ``next_page`` argument.
+  ``next_page`` parameter.
 
 * The new ``redirect_authenticated_user`` parameter for the
   :func:`~django.contrib.auth.views.login` view allows redirecting
@@ -365,7 +365,7 @@ Migrations
 
 * Added support for serialization of ``enum.Enum`` objects.
 
-* Added the ``elidable`` argument to the
+* Added the ``elidable`` parameter to the
   :class:`~django.db.migrations.operations.RunSQL` and
   :class:`~django.db.migrations.operations.RunPython` operations to allow them
   to be removed when squashing migrations.
@@ -540,7 +540,7 @@ Database backend API
   ``supports_temporal_subtraction`` database feature flag to ``True`` and
   implement the ``DatabaseOperations.subtract_temporals()`` method. This
   method should return the SQL and parameters required to compute the
-  difference in microseconds between the ``lhs`` and ``rhs`` arguments in the
+  difference in microseconds between the ``lhs`` and ``rhs`` parameters in the
   datatype used to store :class:`~django.db.models.DurationField`.
 
 ``select_related()`` prohibits non-relational fields for nested relations
@@ -1201,7 +1201,7 @@ to remove usage of these features.
 
 * ``django.conf.urls.patterns()`` is removed.
 
-* Support for the ``prefix`` argument to
+* Support for the ``prefix`` parameter to
   ``django.conf.urls.i18n.i18n_patterns()`` is removed.
 
 * ``SimpleTestCase.urls`` is removed.
@@ -1247,11 +1247,11 @@ to remove usage of these features.
   * ``get_all_related_many_to_many_objects()``
   * ``get_all_related_m2m_objects_with_model()``
 
-* The ``error_message`` argument of ``django.forms.RegexField`` is removed.
+* The ``error_message`` parameter of ``django.forms.RegexField`` is removed.
 
 * The ``unordered_list`` filter no longer supports old style lists.
 
-* Support for string ``view`` arguments to ``url()`` is removed.
+* Support for string ``view`` parameters to ``url()`` is removed.
 
 * The backward compatible shim  to rename ``django.forms.Form._has_changed()``
   to ``has_changed()`` is removed.
@@ -1261,7 +1261,7 @@ to remove usage of these features.
 * The ``remove_tags()`` and ``strip_entities()`` functions in
   ``django.utils.html`` is removed.
 
-* The ``is_admin_site`` argument to
+* The ``is_admin_site`` parameter to
   ``django.contrib.auth.views.password_reset()`` is removed.
 
 * ``django.db.models.field.subclassing.SubfieldBase`` is removed.
@@ -1272,7 +1272,7 @@ to remove usage of these features.
   ``django.contrib.admin.helpers.InlineAdminForm`` is removed.
 
 * The backwards compatibility shim to allow ``FormMixin.get_form()`` to be
-  defined with no default value for its ``form_class`` argument is removed.
+  defined with no default value for its ``form_class`` parameter is removed.
 
 * The following settings are removed, and you must upgrade to the
   :setting:`TEMPLATES` setting:
@@ -1336,7 +1336,7 @@ to remove usage of these features.
   removed.
 
 * The backwards compatibility shims to allow ``Storage.get_available_name()``
-  and ``Storage.save()`` to be defined without a ``max_length`` argument are
+  and ``Storage.save()`` to be defined without a ``max_length`` parameter are
   removed.
 
 * Support for the legacy ``%(<foo>)s`` syntax in ``ModelFormMixin.success_url``

--- a/docs/releases/1.11.1.txt
+++ b/docs/releases/1.11.1.txt
@@ -19,7 +19,7 @@ See :ref:`transaction-pooling-server-side-cursors` for more discussion.
 Bugfixes
 ========
 
-* Made migrations respect ``Index``’s ``name`` argument. If you created a
+* Made migrations respect ``Index``’s ``name`` parameter. If you created a
   named index with Django 1.11, ``makemigrations`` will create a migration to
   recreate the index with the correct name (:ticket:`28051`).
 

--- a/docs/releases/1.11.2.txt
+++ b/docs/releases/1.11.2.txt
@@ -30,7 +30,7 @@ Bugfixes
 * Fixed regression causing pickling of model fields to crash (:ticket:`28188`).
 
 * Fixed ``django.contrib.auth.authenticate()`` when multiple authentication
-  backends don't accept a positional ``request`` argument (:ticket:`28207`).
+  backends don't accept a positional ``request`` parameter (:ticket:`28207`).
 
 * Fixed introspection of index field ordering on PostgreSQL (:ticket:`28197`).
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -144,10 +144,10 @@ Minor features
 
 * The ``HttpRequest`` is now passed to :func:`~django.contrib.auth.authenticate`
   which in turn passes it to the authentication backend if it accepts a
-  ``request`` argument.
+  ``request`` parameter.
 
 * The :func:`~django.contrib.auth.signals.user_login_failed` signal now
-  receives a ``request`` argument.
+  receives a ``request`` parameter.
 
 * :class:`~django.contrib.auth.forms.PasswordResetForm` supports custom user
   models that use an email field named something other than ``'email'``.
@@ -202,7 +202,7 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The new ``distinct`` argument for
+* The new ``distinct`` parameter for
   :class:`~django.contrib.postgres.aggregates.StringAgg` determines if
   concatenated values will be distinct.
 
@@ -248,7 +248,7 @@ CSRF
 Database backends
 ~~~~~~~~~~~~~~~~~
 
-* Added the ``skip_locked`` argument to :meth:`.QuerySet.select_for_update()`
+* Added the ``skip_locked`` parameter to :meth:`.QuerySet.select_for_update()`
   on PostgreSQL 9.5+ and Oracle to execute queries with
   ``FOR UPDATE SKIP LOCKED``.
 
@@ -320,7 +320,7 @@ Migrations
 Models
 ~~~~~~
 
-* Added support for callable values in the ``defaults`` argument of
+* Added support for callable values in the ``defaults`` parameter of
   :meth:`QuerySet.update_or_create()
   <django.db.models.query.QuerySet.update_or_create>` and
   :meth:`~django.db.models.query.QuerySet.get_or_create`.
@@ -497,7 +497,7 @@ backends.
   ``TimeField`` truncation. It accepts a ``lookup_type`` and ``field_name``
   arguments and returns the appropriate SQL to truncate the given time field
   ``field_name`` to a time object with only the given specificity. The
-  ``lookup_type`` argument can be either ``'hour'``, ``'minute'``, or
+  ``lookup_type`` parameter can be either ``'hour'``, ``'minute'``, or
   ``'second'``.
 
 * The ``DatabaseOperations.datetime_cast_time_sql()`` method is added to
@@ -635,7 +635,7 @@ Model state changes in migration operations
 To improve the speed of applying migrations, rendering of related models is
 delayed until an operation that needs them (e.g. ``RunPython``). If you have a
 custom operation that works with model classes or model instances from the
-``from_state`` argument in ``database_forwards()`` or ``database_backwards()``,
+``from_state`` parameter in ``database_forwards()`` or ``database_backwards()``,
 you must render model states using the ``clear_delayed_apps_cache()`` method as
 described in :ref:`writing your own migration operation
 <writing-your-own-migration-operation>`.
@@ -736,7 +736,7 @@ Miscellaneous
   models of all applications have been loaded. Previously they only required
   the target application's models to be loaded and thus could return models
   without all their relations set up. If you need the old behavior of
-  ``get_model()``, set the ``require_ready`` argument to ``False``.
+  ``get_model()``, set the ``require_ready`` parameter to ``False``.
 
 * The unused ``BaseCommand.can_import_settings`` attribute is removed.
 
@@ -833,7 +833,7 @@ Miscellaneous
 * ``DatabaseIntrospection.get_indexes()`` is deprecated in favor of
   ``DatabaseIntrospection.get_constraints()``.
 
-* :func:`~django.contrib.auth.authenticate` now passes a ``request`` argument
+* :func:`~django.contrib.auth.authenticate` now passes a ``request`` parameter
   to the ``authenticate()`` method of authentication backends. Support for
   methods that don't accept ``request`` as the first positional argument will
   be removed in Django 2.1.
@@ -854,6 +854,6 @@ Miscellaneous
   create a :data:`~django.conf.urls.handler404` that looks for uppercase
   characters in the URL and redirects to a lowercase equivalent.
 
-* The ``renderer`` argument is added to the :meth:`Widget.render()
+* The ``renderer`` parameter is added to the :meth:`Widget.render()
   <django.forms.Widget.render>` method. Methods that don't accept that argument
   will work through a deprecation period.

--- a/docs/releases/1.2.txt
+++ b/docs/releases/1.2.txt
@@ -496,7 +496,7 @@ connection for which the value is being prepared.
 
 The two new methods exist to differentiate general data-preparation
 requirements from requirements that are database-specific. The
-``prepared`` argument is used to indicate to the database-preparation
+``prepared`` parameter is used to indicate to the database-preparation
 methods whether generic value preparation has been performed. If
 an unprepared (i.e., ``prepared=False``) value is provided to the
 ``get_db_prep_*()`` calls, they should invoke the corresponding
@@ -1024,7 +1024,7 @@ that you always specify ``title_template`` and ``description_template``
 attributes, or provide ``item_title()`` and ``item_description()`` methods.
 
 However, ``LatestEntriesByCategory`` uses the ``get_object()`` method
-with the ``bits`` argument to specify a specific category to show. In
+with the ``bits`` parameter to specify a specific category to show. In
 the new :class:`~django.contrib.syndication.views.Feed` class,
 ``get_object()`` method takes a ``request`` and arguments from the
 URL, so it would look like this::
@@ -1041,7 +1041,7 @@ URL, so it would look like this::
 
 Additionally, the ``get_feed()`` method on ``Feed`` classes now take
 different arguments, which may impact you if you use the ``Feed``
-classes directly. Instead of just taking an optional ``url`` argument,
+classes directly. Instead of just taking an optional ``url`` parameter,
 it now takes two arguments: the object returned by its own
 ``get_object()`` method, and the current ``request`` object.
 

--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -183,7 +183,7 @@ A number of improvements have been made to Django's built-in template tags:
 * The :ttag:`with` tag now allows you to define multiple context
   variables in a single :ttag:`with` block.
 
-* The :ttag:`load` tag now accepts a ``from`` argument, allowing
+* The :ttag:`load` tag now accepts a ``from`` parameter, allowing
   you to load a single tag or filter from a library.
 
 TemplateResponse
@@ -305,7 +305,7 @@ requests. These include:
   debug server error page.
 
 * :meth:`~django.template.Library.simple_tag` now accepts a
-  ``takes_context`` argument, making it easier to write simple
+  ``takes_context`` parameter, making it easier to write simple
   template tags that require access to template context.
 
 * A new :meth:`~django.shortcuts.render()` shortcut -- an alternative

--- a/docs/releases/1.4.txt
+++ b/docs/releases/1.4.txt
@@ -598,7 +598,7 @@ Django 1.4 also includes several smaller improvements worth noting:
 
 .. _JsLex: https://bitbucket.org/ned/jslex
 
-* The :ttag:`trans` template tag now takes an optional ``as`` argument to
+* The :ttag:`trans` template tag now takes an optional ``as`` parameter to
   be able to retrieve a translation string without displaying it but setting
   a template context variable instead.
 

--- a/docs/releases/1.5.txt
+++ b/docs/releases/1.5.txt
@@ -33,7 +33,7 @@ Other notable new features in Django 1.5 include:
 
 * `Support for saving a subset of model's fields`_ -
   :meth:`Model.save() <django.db.models.Model.save()>` now accepts an
-  ``update_fields`` argument, letting you specify which fields are
+  ``update_fields`` parameter, letting you specify which fields are
   written back to the database when you call ``save()``. This can help
   in high-concurrency operations, and can improve performance.
 
@@ -469,7 +469,7 @@ you must convert it to a query string and append it to the ``path`` parameter.
 
 If you were using the ``data`` parameter in a PUT request without a
 ``content_type``, you must encode your data before passing it to the test
-client and set the ``content_type`` argument.
+client and set the ``content_type`` parameter.
 
 .. _simplejson-incompatibilities:
 
@@ -653,7 +653,7 @@ deserializer.
 Formsets default ``max_num``
 ----------------------------
 
-A (default) value of ``None`` for the ``max_num`` argument to a formset factory
+A (default) value of ``None`` for the ``max_num`` parameter to a formset factory
 no longer defaults to allowing any number of forms in the formset. Instead, in
 order to prevent memory-exhaustion attacks, it now defaults to a limit of 1000
 forms. This limit can be raised by explicitly setting a higher value for
@@ -706,7 +706,7 @@ Miscellaneous
   :setting:`INSTALLED_APPS` contains ``django.contrib.sites``.
 
 * :meth:`BoundField.label_tag <django.forms.BoundField.label_tag>` now
-  escapes its ``contents`` argument. To avoid the HTML escaping, use
+  escapes its ``contents`` parameter. To avoid the HTML escaping, use
   :func:`django.utils.safestring.mark_safe` on the argument before passing it.
 
 * Accessing reverse one-to-one relations fetched via

--- a/docs/releases/1.6.txt
+++ b/docs/releases/1.6.txt
@@ -183,7 +183,7 @@ Minor features
   input type with localized numbers in current browsers, Django only uses it
   when numeric fields are not localized.
 
-* The ``number`` argument for :ref:`lazy plural translations
+* The ``number`` parameter for :ref:`lazy plural translations
   <lazy-plural-translations>` can be provided at translation time rather than
   at definition time.
 
@@ -273,7 +273,7 @@ Minor features
     to customize the default fields, see
     :ref:`modelforms-overriding-default-fields` for details.
 
-* The ``choices`` argument to model fields now accepts an iterable of iterables
+* The ``choices`` parameter to model fields now accepts an iterable of iterables
   instead of requiring an iterable of lists or tuples.
 
 * The reason phrase can be customized in HTTP responses using
@@ -298,7 +298,7 @@ Minor features
   :class:`~django.views.generic.base.RedirectView` now support HTTP ``PATCH``
   method.
 
-* ``GenericForeignKey`` now takes an optional ``for_concrete_model`` argument,
+* ``GenericForeignKey`` now takes an optional ``for_concrete_model`` parameter,
   which when set to ``False`` allows the field to reference proxy models. The
   default is ``True`` to retain the old behavior.
 
@@ -782,7 +782,7 @@ You may also want to add the shim to support the old style reset links. Using
 the example above, you would modify the existing url by replacing
 ``django.contrib.auth.views.password_reset_confirm`` with
 ``django.contrib.auth.views.password_reset_confirm_uidb36`` and also remove
-the ``name`` argument so it doesn't conflict with the new url::
+the ``name`` parameter so it doesn't conflict with the new url::
 
     url(r'^reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
         'django.contrib.auth.views.password_reset_confirm_uidb36'),

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -617,7 +617,7 @@ Forms
   option ``"----------"`` will be omitted in this case.
 
 * :class:`~django.forms.MultiValueField` allows optional subfields by setting
-  the ``require_all_fields`` argument to ``False``. The ``required`` attribute
+  the ``require_all_fields`` parameter to ``False``. The ``required`` attribute
   for each individual field will be respected, and a new ``incomplete``
   validation error will be raised when any required fields are empty.
 
@@ -700,7 +700,7 @@ Management Commands
 
 * The new :option:`dumpdata --natural-foreign` and :option:`dumpdata
   --natural-primary` options, and the new ``use_natural_foreign_keys`` and
-  ``use_natural_primary_keys`` arguments for ``serializers.serialize()``, allow
+  ``use_natural_primary_keys`` parameters for ``serializers.serialize()``, allow
   the use of natural primary keys when serializing.
 
 * It is no longer necessary to provide the cache table name or the
@@ -802,7 +802,7 @@ Models
 Signals
 ~~~~~~~
 
-* The ``enter`` argument was added to the
+* The ``enter`` parameter was added to the
   :data:`~django.test.signals.setting_changed` signal.
 
 * The model signals can be now be connected to using a ``str`` of the
@@ -887,7 +887,7 @@ Tests
   :attr:`~django.test.runner.DiscoverRunner.test_runner`, which facilitate
   overriding the way tests are collected and run.
 
-* The ``fetch_redirect_response`` argument was added to
+* The ``fetch_redirect_response`` parameter was added to
   :meth:`~django.test.SimpleTestCase.assertRedirects`. Since the test
   client can't fetch externals URLs, this allows you to use ``assertRedirects``
   with redirects that aren't part of your Django app.
@@ -895,7 +895,7 @@ Tests
 * Correct handling of scheme when making comparisons in
   :meth:`~django.test.SimpleTestCase.assertRedirects`.
 
-* The ``secure`` argument was added to all the request methods of
+* The ``secure`` parameter was added to all the request methods of
   :class:`~django.test.Client`. If ``True``, the request will be made
   through HTTPS.
 
@@ -928,7 +928,7 @@ Validators
   used when compiling a regular expression string.
 
 * :class:`~django.core.validators.URLValidator` now accepts an optional
-  ``schemes`` argument which allows customization of the accepted URI schemes
+  ``schemes`` parameter which allows customization of the accepted URI schemes
   (instead of the defaults ``http(s)`` and ``ftp(s)``).
 
 * :func:`~django.core.validators.validate_email` now accepts addresses with
@@ -1085,8 +1085,8 @@ following changes that take effect immediately:
 * ``get_model`` raises :exc:`LookupError` instead of returning ``None`` when no
   model is found.
 
-* The ``only_installed`` argument of ``get_model`` and ``get_models`` no
-  longer exists, nor does the ``seed_cache`` argument of ``get_model``.
+* The ``only_installed`` parameter of ``get_model`` and ``get_models`` no
+  longer exists, nor does the ``seed_cache`` parameter of ``get_model``.
 
 Management commands and order of :setting:`INSTALLED_APPS`
 ----------------------------------------------------------
@@ -1372,7 +1372,7 @@ Miscellaneous
   you relied on the default field ordering while having fields defined on both
   the current class *and* on a parent ``Form``.
 
-* The ``required`` argument of
+* The ``required`` parameter of
   :class:`~django.forms.SelectDateWidget` has been removed.
   This widget now respects the form field's ``is_required`` attribute like
   other widgets.
@@ -1412,13 +1412,13 @@ Miscellaneous
 
 * ``django.utils.translation.get_language_from_path()`` and
   ``django.utils.translation.trans_real.get_supported_language_variant()``
-  now no longer have a ``supported`` argument.
+  now no longer have a ``supported`` parameter.
 
 * The ``shortcut`` view in ``django.contrib.contenttypes.views`` now supports
   protocol-relative URLs (e.g. ``//example.com``).
 
 * :class:`~django.contrib.contenttypes.fields.GenericRelation` now supports an
-  optional ``related_query_name`` argument. Setting ``related_query_name`` adds
+  optional ``related_query_name`` parameter. Setting ``related_query_name`` adds
   a relation from the related object back to the content type for filtering,
   ordering and other query operations.
 
@@ -1454,7 +1454,7 @@ Miscellaneous
   the default project template (pre-1.7.2 only), a database must be created
   before accessing a page using :djadmin:`runserver`.
 
-* The addition of the ``schemes`` argument to ``URLValidator`` will appear
+* The addition of the ``schemes`` parameter to ``URLValidator`` will appear
   as a backwards-incompatible change if you were previously using a custom
   regular expression to validate schemes. Any scheme not listed in ``schemes``
   will fail validation, even if the regular expression matches the given URL.
@@ -1625,11 +1625,11 @@ Natural key serialization options
 The ``--natural`` and ``-n`` options for :djadmin:`dumpdata` have been
 deprecated. Use :option:`dumpdata --natural-foreign` instead.
 
-Similarly, the ``use_natural_keys`` argument for ``serializers.serialize()``
+Similarly, the ``use_natural_keys`` parameter for ``serializers.serialize()``
 has been deprecated. Use ``use_natural_foreign_keys`` instead.
 
-Merging of ``POST`` and ``GET`` arguments into ``WSGIRequest.REQUEST``
-----------------------------------------------------------------------
+Merging of ``POST`` and ``GET`` parameters into ``WSGIRequest.REQUEST``
+-----------------------------------------------------------------------
 
 It was already strongly suggested that you use ``GET`` and ``POST`` instead of
 ``REQUEST``, because the former are more explicit. The property ``REQUEST`` is

--- a/docs/releases/1.8.3.txt
+++ b/docs/releases/1.8.3.txt
@@ -124,7 +124,7 @@ Bugfixes
 * Fixed ``SimpleTestCase.assertRaisesMessage()`` on Python 2.7.10
   (:ticket:`24903`).
 
-* Provided better backwards compatibility for the ``verbosity`` argument in
+* Provided better backwards compatibility for the ``verbosity`` parameter in
   ``optparse`` management commands by casting it to an integer
   (:ticket:`24769`).
 

--- a/docs/releases/1.8.7.txt
+++ b/docs/releases/1.8.7.txt
@@ -32,7 +32,7 @@ Bugfixes
   ``allow_migrate()`` method to crash (:ticket:`25686`).
 
 * Fixed a regression in 1.8.6 by restoring the ability to use ``Manager``
-  objects for the ``queryset`` argument of ``ModelChoiceField``
+  objects for the ``queryset`` parameter of ``ModelChoiceField``
   (:ticket:`25683`).
 
 * Fixed a regression in 1.8.6 that caused an application with South migrations

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -318,7 +318,7 @@ File Storage
 * :meth:`Storage.get_available_name()
   <django.core.files.storage.Storage.get_available_name>` and
   :meth:`Storage.save() <django.core.files.storage.Storage.save>`
-  now take a ``max_length`` argument to implement storage-level maximum
+  now take a ``max_length`` parameter to implement storage-level maximum
   filename length constraints. Filenames exceeding this argument will get
   truncated. This prevents a database error when appending a unique suffix to a
   long filename that already exists on the storage. See the :ref:`deprecation
@@ -485,7 +485,7 @@ Migrations
 * The migration operations :class:`~django.db.migrations.operations.RunPython`
   and :class:`~django.db.migrations.operations.RunSQL` now call the
   :meth:`allow_migrate` method of database routers. The router can use the
-  newly introduced ``app_label`` and ``hints`` arguments to make a routing
+  newly introduced ``app_label`` and ``hints`` parameters to make a routing
   decision. To take advantage of this feature you need to update the router to
   the new ``allow_migrate`` signature, see the :ref:`deprecation section
   <deprecated-signature-of-allow-migrate>` for more details.
@@ -544,7 +544,7 @@ Signals
   :meth:`Signal.send_robust() <django.dispatch.Signal.send_robust>` now have
   their traceback attached as a ``__traceback__`` attribute.
 
-* The ``environ`` argument, which contains the WSGI environment structure from
+* The ``environ`` parameter, which contains the WSGI environment structure from
   the request, was added to the :data:`~django.core.signals.request_started`
   signal.
 
@@ -587,7 +587,7 @@ Requests and Responses
   :exc:`~django.core.exceptions.SuspiciousOperation`, the response will be
   rendered with a detailed error page.
 
-* The ``query_string`` argument of :class:`~django.http.QueryDict` is now
+* The ``query_string`` parameter of :class:`~django.http.QueryDict` is now
   optional, defaulting to ``None``, so a blank ``QueryDict`` can now be
   instantiated with ``QueryDict()`` instead of ``QueryDict(None)`` or
   ``QueryDict('')``.
@@ -628,7 +628,7 @@ Tests
   and :class:`Client.trace() <django.test.Client.trace>` methods were
   implemented, allowing you to create ``TRACE`` requests in your tests.
 
-* The ``count`` argument was added to
+* The ``count`` parameter was added to
   :meth:`~django.test.SimpleTestCase.assertTemplateUsed`. This allows you to
   assert that a template was rendered a specific number of times.
 
@@ -1026,7 +1026,7 @@ those writing third-party backends in updating their code:
 :mod:`django.contrib.admin`
 ---------------------------
 
-* ``AdminSite`` no longer takes an ``app_name`` argument and its ``app_name``
+* ``AdminSite`` no longer takes an ``app_name`` parameter and its ``app_name``
   attribute has been removed. The application name is always ``admin`` (as
   opposed to the instance name which you can still customize using
   ``AdminSite(name="...")``.
@@ -1247,7 +1247,7 @@ in ``urlpatterns``::
 and Django would magically import ``myapp.views.myview`` internally and turn
 the string into a real function reference. In order to reduce repetition when
 referencing many views from the same module, the ``patterns()`` function takes
-a required initial ``prefix`` argument which is prepended to all
+a required initial ``prefix`` parameter which is prepended to all
 views-as-strings in that set of ``urlpatterns``::
 
     urlpatterns = patterns('myapp.views',
@@ -1320,10 +1320,10 @@ tests has been deprecated and will be removed in Django 1.10. Use
 :func:`@override_settings(ROOT_URLCONF=...) <django.test.override_settings>`
 instead.
 
-``prefix`` argument to :func:`~django.conf.urls.i18n.i18n_patterns`
--------------------------------------------------------------------
+``prefix`` parameter to :func:`~django.conf.urls.i18n.i18n_patterns`
+--------------------------------------------------------------------
 
-Related to the previous item, the ``prefix`` argument to
+Related to the previous item, the ``prefix`` parameter to
 :func:`django.conf.urls.i18n.i18n_patterns` has been deprecated. Simply pass a
 list of :func:`django.conf.urls.url` instances instead.
 
@@ -1341,7 +1341,7 @@ path being reversed to be imported. This behavior has also resulted in a
 `security issue`_. Use :ref:`named URL patterns <naming-url-patterns>`
 for reversing instead.
 
-If you are using :mod:`django.contrib.sitemaps`, add the ``name`` argument to
+If you are using :mod:`django.contrib.sitemaps`, add the ``name`` parameter to
 the ``url`` that references :func:`django.contrib.sitemaps.views.sitemap`::
 
     from django.contrib.sitemaps.views import sitemap
@@ -1430,8 +1430,8 @@ It provided the :ttag:`lorem` template tag which is now included in the
 built-in tags. Simply remove ``'django.contrib.webdesign'`` from
 :setting:`INSTALLED_APPS` and ``{% load webdesign %}`` from your templates.
 
-``error_message`` argument to ``django.forms.RegexField``
----------------------------------------------------------
+``error_message`` parameter to ``django.forms.RegexField``
+----------------------------------------------------------
 
 It provided backwards compatibility for pre-1.0 code, but its functionality is
 redundant. Use ``Field.error_messages['invalid']`` instead.
@@ -1465,8 +1465,8 @@ they are not actually safe.
 The unused and undocumented ``django.utils.html.strip_entities()`` function has
 also been deprecated.
 
-``is_admin_site`` argument to ``django.contrib.auth.views.password_reset()``
-----------------------------------------------------------------------------
+``is_admin_site`` parameter to ``django.contrib.auth.views.password_reset()``
+-----------------------------------------------------------------------------
 
 It's a legacy option that should no longer be necessary.
 
@@ -1503,11 +1503,11 @@ deprecated and will be removed in Django 1.10. Historically, it was used
 to construct the "view on site" URL. This URL is now accessible using the
 ``absolute_url`` attribute of the form.
 
-``django.views.generic.edit.FormMixin.get_form()``’s ``form_class`` argument
-----------------------------------------------------------------------------
+``django.views.generic.edit.FormMixin.get_form()``’s ``form_class`` parameter
+-----------------------------------------------------------------------------
 
 ``FormMixin`` subclasses that override the ``get_form()`` method should make
-sure to provide a default value for the ``form_class`` argument since it's
+sure to provide a default value for the ``form_class`` parameter since it's
 now optional.
 
 Rendering templates loaded by :func:`~django.template.loader.get_template()` with a :class:`~django.template.Context`
@@ -1539,8 +1539,8 @@ response class.
 Check the :doc:`template response API documentation </ref/template-response>`
 for details.
 
-``current_app`` argument of template-related APIs
--------------------------------------------------
+``current_app`` parameter of template-related APIs
+--------------------------------------------------
 
 The following functions and classes will no longer accept a ``current_app``
 parameter to set an URL namespace in Django 1.10:
@@ -1554,8 +1554,8 @@ Set ``request.current_app`` instead, where ``request`` is the first argument
 to these functions or classes. If you're using a plain ``Context``, use a
 ``RequestContext`` instead.
 
-``dictionary`` and ``context_instance`` arguments of rendering functions
-------------------------------------------------------------------------
+``dictionary`` and ``context_instance`` parameters of rendering functions
+-------------------------------------------------------------------------
 
 The following functions will no longer accept the ``dictionary`` and
 ``context_instance`` parameters in Django 1.10:
@@ -1572,8 +1572,8 @@ pass a :class:`dict` in the ``context`` parameter instead. If you're passing a
 :class:`~django.template.RequestContext`, pass the request separately in the
 ``request`` parameter.
 
-``dirs`` argument of template-finding functions
------------------------------------------------
+``dirs`` parameter of template-finding functions
+------------------------------------------------
 
 The following functions will no longer accept a ``dirs`` parameter to override
 ``TEMPLATE_DIRS`` in Django 1.10:
@@ -1601,8 +1601,8 @@ Private API ``django.test.utils.TestTemplateLoader`` is deprecated in favor of
 
 .. _storage-max-length-update:
 
-Support for the ``max_length`` argument on custom ``Storage`` classes
----------------------------------------------------------------------
+Support for the ``max_length`` parameter on custom ``Storage`` classes
+----------------------------------------------------------------------
 
 ``Storage`` subclasses should add ``max_length=None`` as a parameter to
 :meth:`~django.core.files.storage.Storage.get_available_name` and/or
@@ -1620,7 +1620,7 @@ to a function that quoted identifiers for sending to the database. In Django
 ``SQLCompiler`` instance. For backwards-compatibility, calling a
 ``SQLCompiler`` instance performs the same name-quoting that the ``qn``
 function used to. However, this backwards-compatibility shim is immediately
-deprecated: you should rename your ``qn`` arguments to ``compiler``, and call
+deprecated: you should rename your ``qn`` parameters to ``compiler``, and call
 ``compiler.quote_name_unless_alias(...)`` where you previously called
 ``qn(...)``.
 

--- a/docs/releases/1.9.txt
+++ b/docs/releases/1.9.txt
@@ -102,11 +102,11 @@ implementation, though:
   supported.
 
 * The :meth:`~django.contrib.auth.mixins.AccessMixin.handle_no_permission`
-  method does not take a ``request`` argument. The current request is available
+  method does not take a ``request`` parameter. The current request is available
   in ``self.request``.
 
 * The custom ``test_func()`` of :class:`~django.contrib.auth.mixins.UserPassesTestMixin`
-  does not take a ``user`` argument. The current user is available in
+  does not take a ``user`` parameter. The current user is available in
   ``self.request.user``.
 
 * The :attr:`permission_required <django.contrib.auth.mixins.PermissionRequiredMixin>`
@@ -1192,11 +1192,11 @@ versions:
 Its parsing caused bugs with the current syntax, so support for the old syntax
 will be removed in Django 1.10 following an accelerated deprecation.
 
-``ForeignKey`` and ``OneToOneField`` ``on_delete`` argument
------------------------------------------------------------
+``ForeignKey`` and ``OneToOneField`` ``on_delete`` parameter
+------------------------------------------------------------
 
 In order to increase awareness about cascading model deletion, the
-``on_delete`` argument of ``ForeignKey`` and ``OneToOneField`` will be required
+``on_delete`` parameter of ``ForeignKey`` and ``OneToOneField`` will be required
 in Django 2.0.
 
 Update models and existing migrations to explicitly set the argument. Since the
@@ -1237,7 +1237,7 @@ Passing a 3-tuple or an ``app_name`` to :func:`~django.conf.urls.include()`
 ---------------------------------------------------------------------------
 
 The instance namespace part of passing a tuple as an argument to ``include()``
-has been replaced by passing the ``namespace`` argument to ``include()``. For
+has been replaced by passing the ``namespace`` parameter to ``include()``. For
 example::
 
     polls_patterns = [
@@ -1258,10 +1258,10 @@ becomes::
         url(r'^polls/', include(polls_patterns, namespace='author-polls')),
     ]
 
-The ``app_name`` argument to ``include()`` has been replaced by passing a
+The ``app_name`` parameter to ``include()`` has been replaced by passing a
 2-tuple (as above), or passing an object or module with an ``app_name``
 attribute (as below). If the ``app_name`` is set in this new way, the
-``namespace`` argument is no longer required. It will default to the value of
+``namespace`` parameter is no longer required. It will default to the value of
 ``app_name``. For example, the URL patterns in the tutorial are changed from:
 
 .. snippet::
@@ -1339,7 +1339,7 @@ it doesn't provide the legacy GeoIP-Python API compatibility methods.
 Miscellaneous
 -------------
 
-* The ``weak`` argument to ``django.dispatch.signals.Signal.disconnect()`` has
+* The ``weak`` parameter to ``django.dispatch.signals.Signal.disconnect()`` has
   been deprecated as it has no effect.
 
 * The ``check_aggregate_support()`` method of
@@ -1387,7 +1387,7 @@ Miscellaneous
   return value instead.
 
 * The ``enclosure`` keyword argument to ``SyndicationFeed.add_item()`` is
-  deprecated. Use the new ``enclosures`` argument which accepts a list of
+  deprecated. Use the new ``enclosures`` parameter which accepts a list of
   ``Enclosure`` objects instead of a single one.
 
 * The ``django.template.loader.LoaderOrigin`` and
@@ -1462,7 +1462,7 @@ remove usage of these features.
 
 * The ``--natural`` and ``-n`` options for :djadmin:`dumpdata` are removed.
 
-* The ``use_natural_keys`` argument for ``serializers.serialize()`` is removed.
+* The ``use_natural_keys`` parameter for ``serializers.serialize()`` is removed.
 
 * Private API ``django.forms.forms.get_declared_fields()`` is removed.
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -104,7 +104,7 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The new ``distinct`` argument for
+* The new ``distinct`` parameter for
   :class:`~django.contrib.postgres.aggregates.ArrayAgg` determines if
   concatenated values will be distinct.
 
@@ -182,7 +182,7 @@ File Uploads
 Forms
 ~~~~~
 
-* The new ``date_attrs`` and ``time_attrs`` arguments for
+* The new ``date_attrs`` and ``time_attrs`` parameters for
   :class:`~django.forms.SplitDateTimeWidget` and
   :class:`~django.forms.SplitHiddenDateTimeWidget` allow specifying different
   HTML attributes for the ``DateInput`` and ``TimeInput`` (or hidden)
@@ -260,7 +260,7 @@ Models
   :class:`~django.db.models.functions.datetime.Extract` now works with
   :class:`~django.db.models.DurationField`.
 
-* Added the ``of`` argument to :meth:`.QuerySet.select_for_update()`, supported
+* Added the ``of`` parameter to :meth:`.QuerySet.select_for_update()`, supported
   on PostgreSQL and Oracle, to lock only rows from specific tables rather than
   all selected tables. It may be helpful particularly when
   :meth:`~.QuerySet.select_for_update()` is used in conjunction with
@@ -273,7 +273,7 @@ Models
   parameters, if the backend supports this feature. Of Django's built-in
   backends, only Oracle supports it.
 
-* The new ``filter`` argument for built-in aggregates allows :ref:`adding
+* The new ``filter`` parameter for built-in aggregates allows :ref:`adding
   different conditionals <conditional-aggregation>` to multiple aggregations
   over the same fields or relations.
 
@@ -371,7 +371,7 @@ backends.
   ``DatabaseOperations.cast_char_field_without_max_length`` attribute with the
   database data type that will be used in the
   :class:`~django.db.models.functions.Cast` function for a ``CharField`` if the
-  ``max_length`` argument isn't provided.
+  ``max_length`` parameter isn't provided.
 
 Dropped support for Oracle 11.2
 -------------------------------
@@ -561,7 +561,7 @@ Miscellaneous
 
       Book.objects.iterator(chunk_size=100)
 
-* Providing unknown package names in the ``packages`` argument of the
+* Providing unknown package names in the ``packages`` parameter of the
   :class:`~django.views.i18n.JavaScriptCatalog` view now raises ``ValueError``
   instead of passing silently.
 
@@ -593,10 +593,10 @@ Miscellaneous
 Features deprecated in 2.0
 ==========================
 
-``context`` argument of ``Field.from_db_value()`` and ``Expression.convert_value()``
-------------------------------------------------------------------------------------
+``context`` parameter of ``Field.from_db_value()`` and ``Expression.convert_value()``
+-------------------------------------------------------------------------------------
 
-The ``context`` argument of ``Field.from_db_value()`` and
+The ``context`` parameter of ``Field.from_db_value()`` and
 ``Expression.convert_value()`` is unused as it's always an empty dictionary.
 The signature of both methods is now::
 
@@ -640,7 +640,7 @@ in Django 2.0. See :ref:`deprecated-features-1.9` and
 :ref:`deprecated-features-1.10` for details, including how to remove usage of
 these features.
 
-* The ``weak`` argument to ``django.dispatch.signals.Signal.disconnect()`` is
+* The ``weak`` parameter to ``django.dispatch.signals.Signal.disconnect()`` is
   removed.
 
 * ``django.db.backends.base.BaseDatabaseOperations.check_aggregate_support()``
@@ -650,13 +650,13 @@ these features.
 
 * The ``assignment_tag`` helper is removed.
 
-* The ``host`` argument to ``SimpleTestCase.assertsRedirects()`` is removed.
+* The ``host`` parameter to ``SimpleTestCase.assertsRedirects()`` is removed.
   The compatibility layer which allows absolute URLs to be considered equal to
   relative ones when the path is identical is also removed.
 
 * ``Field.rel`` and ``Field.remote_field.to`` are removed.
 
-* The ``on_delete`` argument for ``ForeignKey`` and ``OneToOneField`` are now
+* The ``on_delete`` parameter for ``ForeignKey`` and ``OneToOneField`` are now
   required.
 
 * ``django.db.models.fields.add_lazy_relation()`` is removed.
@@ -682,7 +682,7 @@ these features.
 * The ``load_template`` and ``load_template_sources`` template loader methods
   are removed.
 
-* The ``template_dirs`` argument for template loaders is removed:
+* The ``template_dirs`` parameter for template loaders is removed:
 
   * ``django.template.loaders.base.Loader.get_template()``
   * ``django.template.loaders.cached.Loader.cache_key()``
@@ -698,7 +698,7 @@ these features.
 * The ``mime_type`` attribute of ``django.utils.feedgenerator.Atom1Feed`` and
   ``django.utils.feedgenerator.RssFeed`` is removed.
 
-* The ``app_name`` argument to ``include()`` is removed.
+* The ``app_name`` parameter to ``include()`` is removed.
 
 * Support for passing a 3-tuple (including ``admin.site.urls``) as the first
   argument to ``include()`` is removed.


### PR DESCRIPTION
 Normalized usage of terms 'argument' and 'parameter' on docs