### PR TITLE
BigAutoField as new default in 2.0

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -247,7 +247,7 @@ class BaseDatabaseFeatures:
     # Does the backend support keyword parameters for cursor.callproc()?
     supports_callproc_kwargs = False
 
-    # Does the backend just alias bigint to integter.
+    # Does the backend just alias bigint to integer.
     bigint_is_integer = False
 
     def __init__(self, connection):

--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -247,6 +247,9 @@ class BaseDatabaseFeatures:
     # Does the backend support keyword parameters for cursor.callproc()?
     supports_callproc_kwargs = False
 
+    # Does the backend just alias bigint to integter.
+    bigint_is_integer = False
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -275,7 +275,7 @@ class BaseDatabaseSchemaEditor:
                 definition,
             ))
             # Autoincrement SQL (for backends with post table definition variant)
-            if field.get_internal_type() in ("AutoField", "BigAutoField"):
+            if field.get_internal_type() in ("AutoField", "SmallAutoField", "BigAutoField"):
                 autoinc_sql = self.connection.ops.autoinc_sql(model._meta.db_table, field.column)
                 if autoinc_sql:
                     self.deferred_sql.extend(autoinc_sql)

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -31,6 +31,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_temporal_subtraction = True
     ignores_table_name_case = True
     supports_cast_with_precision = False
+    bigint_is_integer = True
 
     @cached_property
     def uses_savepoints(self):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -895,7 +895,12 @@ class MigrationAutodetector:
             if old_field_dec != new_field_dec:
                 both_m2m = old_field.many_to_many and new_field.many_to_many
                 neither_m2m = not old_field.many_to_many and not new_field.many_to_many
-                if both_m2m or neither_m2m:
+
+                if isinstance(old_field, models.SmallAutoField) and isinstance(new_field, models.BigAutoField):
+                    if not self.questioner.ask_small_to_big_autofield(field_name, model_name):
+                        raise RuntimeError("Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the Django release notes for more information.".format(field_name))
+
+                elif both_m2m or neither_m2m:
                     # Either both fields are m2m or neither is
                     preserve_default = True
                     if (old_field.null and not new_field.null and not new_field.has_default() and

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -920,7 +920,11 @@ class MigrationAutodetector:
 
                 elif isinstance(old_field, models.SmallAutoField) and isinstance(new_field, models.BigAutoField):
                     if not self.questioner.ask_small_to_big_autofield(field_name, model_name):
-                        raise RuntimeError("Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the Django release notes for more information.".format(field_name))
+                        raise RuntimeError(
+                            "Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, "
+                            "please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the "
+                            "Django release notes for more information.".format(field_name)
+                        )
 
                 else:
                     # We cannot alter between m2m and concrete fields

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -895,7 +895,6 @@ class MigrationAutodetector:
             if old_field_dec != new_field_dec:
                 both_m2m = old_field.many_to_many and new_field.many_to_many
                 neither_m2m = not old_field.many_to_many and not new_field.many_to_many
-
                 if both_m2m or neither_m2m:
                     # Either both fields are m2m or neither is
                     preserve_default = True
@@ -921,11 +920,10 @@ class MigrationAutodetector:
                 elif isinstance(old_field, models.SmallAutoField) and isinstance(new_field, models.BigAutoField):
                     if not self.questioner.ask_small_to_big_autofield(field_name, model_name):
                         raise RuntimeError(
-                            "Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, "
-                            "please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the "
-                            "Django release notes for more information.".format(field_name)
+                            'Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, '
+                            'please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the '
+                            'Django release notes for more information.'.format(field_name)
                         )
-
                 else:
                     # We cannot alter between m2m and concrete fields
                     self._generate_removed_field(app_label, model_name, field_name)

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -896,11 +896,7 @@ class MigrationAutodetector:
                 both_m2m = old_field.many_to_many and new_field.many_to_many
                 neither_m2m = not old_field.many_to_many and not new_field.many_to_many
 
-                if isinstance(old_field, models.SmallAutoField) and isinstance(new_field, models.BigAutoField):
-                    if not self.questioner.ask_small_to_big_autofield(field_name, model_name):
-                        raise RuntimeError("Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the Django release notes for more information.".format(field_name))
-
-                elif both_m2m or neither_m2m:
+                if both_m2m or neither_m2m:
                     # Either both fields are m2m or neither is
                     preserve_default = True
                     if (old_field.null and not new_field.null and not new_field.has_default() and
@@ -921,6 +917,11 @@ class MigrationAutodetector:
                             preserve_default=preserve_default,
                         )
                     )
+
+                elif isinstance(old_field, models.SmallAutoField) and isinstance(new_field, models.BigAutoField):
+                    if not self.questioner.ask_small_to_big_autofield(field_name, model_name):
+                        raise RuntimeError("Automatic upgrade to BigAutoField refused. \nIf you do not want to upgrade, please define {0} = models.SmallAutoField in your model definition.\n\nPlease see the Django release notes for more information.".format(field_name))
+
                 else:
                     # We cannot alter between m2m and concrete fields
                     self._generate_removed_field(app_label, model_name, field_name)

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -192,13 +192,13 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
         return self._boolean_input(msg % (model_name, old_name, model_name, new_name,
                                           field_instance.__class__.__name__), False)
 
-
     def ask_small_to_big_autofield(self, field_name, model_name):
-        """Adding an auto_now_add field to a model."""
+        """Upgrading an AutoField to a BigAutoField."""
         if not self.dry_run:
             choice = self._choice_input(
-                "You have upgraded Django, which will change the field {}.{} to a BigAutoField'. "
-                "The database needs to upgrade from int to bigint, which may take a while, if you have a lot of rows ".format(model_name, field_name),
+                "You are changing the field {}.{} from a SmallAutoField to a BigAutofield "
+                "(perhaps as a result of upgrading Django). The database needs to upgrade from int to bigint, "
+                "which may take a while, if you have a lot of rows ".format(model_name, field_name),
                 [
                     "Create upgrade migration (may take a while to apply)",
                     "Quit, and let me specify SmallAutoField in models.py",
@@ -207,7 +207,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
             if choice == 2:
                 return False
             else:
-                return True
+                return choice == 1
         return None
 
     def ask_rename_model(self, old_model_state, new_model_state):

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -79,7 +79,7 @@ class MigrationQuestioner:
         return None
 
     def ask_small_to_big_autofield(self, field_name, model_name):
-        """Upgrading a AutoField to a BigAutoField on a model."""
+        """Upgrading an AutoField to a BigAutoField on a model."""
         return self.defaults.get("ask_small_to_big_autofield", False)
 
 
@@ -201,7 +201,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
                 "The database needs to upgrade from int to bigint, which may take a while, if you have a lot of rows ".format(model_name, field_name),
                 [
                     "Create upgrade migration (may take a while to apply)",
-                    "Quit, and let me specifity SmallAutoField in models.py",
+                    "Quit, and let me specify SmallAutoField in models.py",
                 ]
             )
             if choice == 2:

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -78,6 +78,10 @@ class MigrationQuestioner:
         # None means quit
         return None
 
+    def ask_small_to_big_autofield(self, field_name, model_name):
+        """Upgrading a AutoField to a BigAutoField on a model."""
+        return self.defaults.get("ask_small_to_big_autofield", False)
+
 
 class InteractiveMigrationQuestioner(MigrationQuestioner):
 
@@ -187,6 +191,24 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
         msg = "Did you rename %s.%s to %s.%s (a %s)? [y/N]"
         return self._boolean_input(msg % (model_name, old_name, model_name, new_name,
                                           field_instance.__class__.__name__), False)
+
+
+    def ask_small_to_big_autofield(self, field_name, model_name):
+        """Adding an auto_now_add field to a model."""
+        if not self.dry_run:
+            choice = self._choice_input(
+                "You have upgraded Django, which will change the field {}.{} to a BigAutoField'. "
+                "The database needs to upgrade from int to bigint, which may take a while, if you have a lot of rows ".format(model_name, field_name),
+                [
+                    "Create upgrade migration (may take a while to apply)",
+                    "Quit, and let me specifity SmallAutoField in models.py",
+                ]
+            )
+            if choice == 2:
+                return False
+            else:
+                return True
+        return None
 
     def ask_rename_model(self, old_model_state, new_model_state):
         """Was this model really renamed?"""

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -39,8 +39,8 @@ __all__ = [
     'EmailField', 'Empty', 'Field', 'FieldDoesNotExist', 'FilePathField',
     'FloatField', 'GenericIPAddressField', 'IPAddressField', 'IntegerField',
     'NOT_PROVIDED', 'NullBooleanField', 'PositiveIntegerField',
-    'PositiveSmallIntegerField', 'SlugField', 'SmallIntegerField', 'TextField',
-    'TimeField', 'URLField', 'UUIDField',
+    'PositiveSmallIntegerField', 'SlugField', 'SmallAutoField',
+    'SmallIntegerField', 'TextField', 'TimeField', 'URLField', 'UUIDField',
 ]
 
 
@@ -873,7 +873,7 @@ class Field(RegisterLookupMixin):
         return getattr(obj, self.attname)
 
 
-class AutoField(Field):
+class SmallAutoField(Field):
     description = _("Integer")
 
     empty_strings_allowed = False
@@ -950,7 +950,7 @@ class AutoField(Field):
         return None
 
 
-class BigAutoField(AutoField):
+class BigAutoField(SmallAutoField):
     description = _("Big (8 byte) integer")
 
     def get_internal_type(self):
@@ -958,6 +958,10 @@ class BigAutoField(AutoField):
 
     def rel_db_type(self, connection):
         return BigIntegerField().db_type(connection=connection)
+
+
+# Aliased for backwards compabitbility.
+AutoField = SmallAutoField
 
 
 class BooleanField(Field):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -950,7 +950,7 @@ class SmallAutoField(Field):
         return None
 
 
-# Aliased for backwards compabitbility.
+# Aliased for backwards compatibility.
 AutoField = SmallAutoField
 
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -950,6 +950,10 @@ class SmallAutoField(Field):
         return None
 
 
+# Aliased for backwards compabitbility.
+AutoField = SmallAutoField
+
+
 class BigAutoField(SmallAutoField):
     description = _("Big (8 byte) integer")
 
@@ -958,10 +962,6 @@ class BigAutoField(SmallAutoField):
 
     def rel_db_type(self, connection):
         return BigIntegerField().db_type(connection=connection)
-
-
-# Aliased for backwards compabitbility.
-AutoField = SmallAutoField
 
 
 class BooleanField(Field):

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db import connections
 from django.db.models import Manager
-from django.db.models.fields import AutoField
+from django.db.models.fields import BigAutoField
 from django.db.models.fields.proxy import OrderWrt
 from django.db.models.query_utils import PathInfo
 from django.utils.datastructures import ImmutableList, OrderedSet
@@ -241,7 +241,7 @@ class Options:
                         'Add parent_link=True to %s.' % field,
                     )
             else:
-                auto = AutoField(verbose_name='ID', primary_key=True, auto_created=True)
+                auto = BigAutoField(verbose_name='ID', primary_key=True, auto_created=True)
                 model.add_to_class('id', auto)
 
     def add_manager(self, manager):

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -110,4 +110,4 @@ class OrderedObject(models.Model):
 
 
 class CustomIdUser(models.Model):
-    uuid = models.AutoField(primary_key=True)
+    uuid = models.BigAutoField(primary_key=True)

--- a/tests/admin_scripts/another_app_waiting_migration/migrations/0001_initial.py
+++ b/tests/admin_scripts/another_app_waiting_migration/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Foo',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=255)),
             ],
         ),

--- a/tests/admin_scripts/app_waiting_migration/migrations/0001_initial.py
+++ b/tests/admin_scripts/app_waiting_migration/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Bar',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=255)),
             ],
         ),

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -394,7 +394,7 @@ class DooHickey(models.Model):
 
 
 class Grommet(models.Model):
-    code = models.AutoField(primary_key=True)
+    code = models.BigAutoField(primary_key=True)
     owner = models.ForeignKey(Collector, models.CASCADE)
     name = models.CharField(max_length=100)
 

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3678,8 +3678,8 @@ class AdminInlineTests(TestCase):
         self.assertEqual(Widget.objects.count(), 1)
         self.assertEqual(Widget.objects.all()[0].name, "Widget 1 Updated")
 
-    def test_explicit_autofield_inline(self):
-        "A model with an explicit autofield primary key can be saved as inlines. Regression for #8093"
+    def test_explicit_BigAutoField_inline(self):
+        "A model with an explicit BigAutoField primary key can be saved as inlines. Regression for #8093"
         # First add a new inline
         self.post_data['grommet_set-0-name'] = "Grommet 1"
         collector_url = reverse('admin:admin_views_collector_change', args=(self.collector.pk,))

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -3678,8 +3678,10 @@ class AdminInlineTests(TestCase):
         self.assertEqual(Widget.objects.count(), 1)
         self.assertEqual(Widget.objects.all()[0].name, "Widget 1 Updated")
 
-    def test_explicit_BigAutoField_inline(self):
-        "A model with an explicit BigAutoField primary key can be saved as inlines. Regression for #8093"
+    def test_explicit_bigautofield_inline(self):
+        """A model with an explicit BigAutoField primary key can be
+        saved as inlines. Regression for #8093
+        """
         # First add a new inline
         self.post_data['grommet_set-0-name'] = "Grommet 1"
         collector_url = reverse('admin:admin_views_collector_change', args=(self.collector.pk,))

--- a/tests/aggregation_regress/models.py
+++ b/tests/aggregation_regress/models.py
@@ -59,13 +59,13 @@ class Store(models.Model):
 
 
 class Entries(models.Model):
-    EntryID = models.AutoField(primary_key=True, db_column='Entry ID')
+    EntryID = models.BigAutoField(primary_key=True, db_column='Entry ID')
     Entry = models.CharField(unique=True, max_length=50)
     Exclude = models.BooleanField(default=False)
 
 
 class Clues(models.Model):
-    ID = models.AutoField(primary_key=True)
+    ID = models.BigAutoField(primary_key=True)
     EntryID = models.ForeignKey(Entries, models.CASCADE, verbose_name='Entry', db_column='Entry ID')
     Clue = models.CharField(max_length=150)
 
@@ -73,7 +73,7 @@ class Clues(models.Model):
 class WithManualPK(models.Model):
     # The generic relations regression test needs two different model
     # classes with the same PK value, and there are some (external)
-    # DB backends that don't work nicely when assigning integer to AutoField
+    # DB backends that don't work nicely when assigning integer to BigAutoField
     # column (MSSQL at least).
     id = models.IntegerField(primary_key=True)
 

--- a/tests/backends/models.py
+++ b/tests/backends/models.py
@@ -28,7 +28,7 @@ class SchoolClass(models.Model):
 
 
 class VeryLongModelNameZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ(models.Model):
-    primary_key_is_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.AutoField(primary_key=True)
+    primary_key_is_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.BigAutoField(primary_key=True)
     charfield_is_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.CharField(max_length=100)
     m2m_also_quite_long_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz = models.ManyToManyField(Person, blank=True)
 

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -741,7 +741,7 @@ class ThreadTests(TransactionTestCase):
 
 class MySQLPKZeroTests(TestCase):
     """
-    Zero as id for AutoField should raise exception in MySQL, because MySQL
+    Zero as id for BigAutoField should raise exception in MySQL, because MySQL
     does not allow zero for autoincrement primary key.
     """
     @skipIfDBFeature('allows_auto_pk_0')

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -51,7 +51,7 @@ class ModelInstanceCreationTests(TestCase):
         self.assertEqual(a.headline, 'Third article')
         self.assertEqual(a.pub_date, datetime(2005, 7, 30, 0, 0))
 
-    def test_autofields_generate_different_values_for_each_instance(self):
+    def test_BigAutoFields_generate_different_values_for_each_instance(self):
         a1 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))
         a2 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))
         a3 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))
@@ -74,9 +74,9 @@ class ModelInstanceCreationTests(TestCase):
                 foo='bar',
             )
 
-    def test_can_leave_off_value_for_autofield_and_it_gets_value_on_save(self):
+    def test_can_leave_off_value_for_BigAutoField_and_it_gets_value_on_save(self):
         """
-        You can leave off the value for an AutoField when creating an
+        You can leave off the value for an BigAutoField when creating an
         object, because it'll get filled in automatically when you save().
         """
         a = Article(headline='Article 5', pub_date=datetime(2005, 7, 31))

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -51,7 +51,7 @@ class ModelInstanceCreationTests(TestCase):
         self.assertEqual(a.headline, 'Third article')
         self.assertEqual(a.pub_date, datetime(2005, 7, 30, 0, 0))
 
-    def test_BigAutoFields_generate_different_values_for_each_instance(self):
+    def test_bigautofields_generate_different_values_for_each_instance(self):
         a1 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))
         a2 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))
         a3 = Article.objects.create(headline='First', pub_date=datetime(2005, 7, 30, 0, 0))

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -108,7 +108,7 @@ class BulkCreateTests(TestCase):
         """
         valid_country = Country(name='Germany', iso_two_letter='DE')
         invalid_country = Country(id=0, name='Poland', iso_two_letter='PL')
-        msg = 'The database backend does not accept 0 as a value for BigAutoField.'
+        msg = 'The database backend does not accept 0 as a value for AutoField.'
         with self.assertRaisesMessage(ValueError, msg):
             Country.objects.bulk_create([valid_country, invalid_country])
 

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -103,12 +103,12 @@ class BulkCreateTests(TestCase):
     @skipIfDBFeature('allows_auto_pk_0')
     def test_zero_as_autoval(self):
         """
-        Zero as id for AutoField should raise exception in MySQL, because MySQL
+        Zero as id for BigAutoField should raise exception in MySQL, because MySQL
         does not allow zero for automatic primary key.
         """
         valid_country = Country(name='Germany', iso_two_letter='DE')
         invalid_country = Country(id=0, name='Poland', iso_two_letter='PL')
-        msg = 'The database backend does not accept 0 as a value for AutoField.'
+        msg = 'The database backend does not accept 0 as a value for BigAutoField.'
         with self.assertRaisesMessage(ValueError, msg):
             Country.objects.bulk_create([valid_country, invalid_country])
 

--- a/tests/contenttypes_tests/operations_migrations/0001_initial.py
+++ b/tests/contenttypes_tests/operations_migrations/0001_initial.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             'Foo',
             [
-                ('id', models.AutoField(primary_key=True)),
+                ('id', models.BigAutoField(primary_key=True)),
             ],
         ),
     ]

--- a/tests/custom_columns/models.py
+++ b/tests/custom_columns/models.py
@@ -19,7 +19,7 @@ from django.db import models
 
 
 class Author(models.Model):
-    Author_ID = models.AutoField(primary_key=True, db_column='Author ID')
+    Author_ID = models.BigAutoField(primary_key=True, db_column='Author ID')
     first_name = models.CharField(max_length=30, db_column='firstname')
     last_name = models.CharField(max_length=30, db_column='last')
 
@@ -32,7 +32,7 @@ class Author(models.Model):
 
 
 class Article(models.Model):
-    Article_ID = models.AutoField(primary_key=True, db_column='Article ID')
+    Article_ID = models.BigAutoField(primary_key=True, db_column='Article ID')
     headline = models.CharField(max_length=100)
     authors = models.ManyToManyField(Author, db_table='my_m2m_table')
     primary_author = models.ForeignKey(

--- a/tests/custom_pk/fields.py
+++ b/tests/custom_pk/fields.py
@@ -20,7 +20,7 @@ class MyWrapper:
         return self.value == other
 
 
-class MyAutoField(models.CharField):
+class MyBigAutoField(models.CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 10

--- a/tests/custom_pk/models.py
+++ b/tests/custom_pk/models.py
@@ -7,7 +7,7 @@ this behavior by explicitly adding ``primary_key=True`` to a field.
 
 from django.db import models
 
-from .fields import MyAutoField
+from .fields import MyBigAutoField
 
 
 class Employee(models.Model):
@@ -34,7 +34,7 @@ class Business(models.Model):
 
 
 class Bar(models.Model):
-    id = MyAutoField(primary_key=True, db_index=True)
+    id = MyBigAutoField(primary_key=True, db_index=True)
 
     def __str__(self):
         return repr(self.pk)

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -32,7 +32,7 @@ class FieldDeconstructionTests(SimpleTestCase):
         field = models.AutoField(primary_key=True)
         field.set_attributes_from_name("id")
         name, path, args, kwargs = field.deconstruct()
-        self.assertEqual(path, "django.db.models.AutoField")
+        self.assertEqual(path, "django.db.models.SmallAutoField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"primary_key": True})
 

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -29,10 +29,10 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(name, "author")
 
     def test_auto_field(self):
-        field = models.AutoField(primary_key=True)
+        field = models.BigAutoField(primary_key=True)
         field.set_attributes_from_name("id")
         name, path, args, kwargs = field.deconstruct()
-        self.assertEqual(path, "django.db.models.SmallAutoField")
+        self.assertEqual(path, "django.db.models.BigAutoField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"primary_key": True})
 

--- a/tests/gis_tests/gis_migrations/migrations/0001_initial.py
+++ b/tests/gis_tests/gis_migrations/migrations/0001_initial.py
@@ -5,7 +5,7 @@ ops = [
     migrations.CreateModel(
         name='Neighborhood',
         fields=[
-            ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+            ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ('name', models.CharField(max_length=100, unique=True)),
             ('geom', models.MultiPolygonField(srid=4326)),
         ],
@@ -16,7 +16,7 @@ ops = [
     migrations.CreateModel(
         name='Household',
         fields=[
-            ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+            ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ('neighborhood', models.ForeignKey(
                 'gis_migrations.Neighborhood',
                 models.SET_NULL,
@@ -34,7 +34,7 @@ ops = [
     migrations.CreateModel(
         name='Family',
         fields=[
-            ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+            ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ('name', models.CharField(max_length=100, unique=True)),
         ],
         options={
@@ -54,7 +54,7 @@ if connection.features.supports_raster:
         migrations.CreateModel(
             name='Heatmap',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=100, unique=True)),
                 ('rast', models.fields.RasterField(srid=4326)),
             ],

--- a/tests/gis_tests/gis_migrations/test_operations.py
+++ b/tests/gis_tests/gis_migrations/test_operations.py
@@ -53,7 +53,7 @@ class OperationTestCase(TransactionTestCase):
 
     def set_up_test_model(self, force_raster_creation=False):
         test_fields = [
-            ('id', models.AutoField(primary_key=True)),
+            ('id', models.BigAutoField(primary_key=True)),
             ('name', models.CharField(max_length=100, unique=True)),
             ('geom', fields.MultiPolygonField(srid=4326))
         ]

--- a/tests/inspectdb/models.py
+++ b/tests/inspectdb/models.py
@@ -41,7 +41,7 @@ class SpecialName(models.Model):
 
 
 class ColumnTypes(models.Model):
-    id = models.AutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True)
     big_int_field = models.BigIntegerField()
     bool_field = models.BooleanField(default=False)
     null_bool_field = models.NullBooleanField()

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -75,7 +75,7 @@ class IntrospectionTests(TransactionTestCase):
             desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)
         self.assertEqual(
             [datatype(r[1], r) for r in desc],
-            ['AutoField' if connection.features.can_introspect_autofield else 'IntegerField',
+            ['BigAutoField' if connection.features.can_introspect_autofield else 'IntegerField',
              'CharField', 'CharField', 'CharField',
              'BigIntegerField' if connection.features.can_introspect_big_integer_field else 'IntegerField',
              'BinaryField' if connection.features.can_introspect_binary_field else 'TextField',
@@ -101,7 +101,7 @@ class IntrospectionTests(TransactionTestCase):
         )
 
     @skipUnlessDBFeature('can_introspect_autofield')
-    def test_bigautofield(self):
+    def test_BigAutoField(self):
         with connection.cursor() as cursor:
             desc = connection.introspection.get_table_description(cursor, City._meta.db_table)
         self.assertIn('BigAutoField', [datatype(r[1], r) for r in desc])

--- a/tests/invalid_models_tests/test_custom_fields.py
+++ b/tests/invalid_models_tests/test_custom_fields.py
@@ -7,7 +7,7 @@ from django.test.utils import isolate_apps
 class CustomFieldTest(SimpleTestCase):
 
     def test_none_column(self):
-        class NoColumnField(models.AutoField):
+        class NoColumnField(models.BigAutoField):
             def db_type(self, connection):
                 # None indicates not to create a column in the database.
                 return None

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -8,11 +8,11 @@ from django.utils.timezone import now
 
 
 @isolate_apps('invalid_models_tests')
-class AutoFieldTests(SimpleTestCase):
+class BigAutoFieldTests(SimpleTestCase):
 
     def test_valid_case(self):
         class Model(models.Model):
-            id = models.AutoField(primary_key=True)
+            id = models.BigAutoField(primary_key=True)
 
         field = Model._meta.get_field('id')
         self.assertEqual(field.check(), [])
@@ -20,11 +20,11 @@ class AutoFieldTests(SimpleTestCase):
     def test_primary_key(self):
         # primary_key must be True. Refs #12467.
         class Model(models.Model):
-            field = models.AutoField(primary_key=False)
+            field = models.BigAutoField(primary_key=False)
 
-            # Prevent Django from autocreating `id` AutoField, which would
+            # Prevent Django from autocreating `id` BigAutoField, which would
             # result in an error, because a model must have exactly one
-            # AutoField.
+            # BigAutoField.
             another = models.IntegerField(primary_key=True)
 
         field = Model._meta.get_field('field')

--- a/tests/m2m_regress/models.py
+++ b/tests/m2m_regress/models.py
@@ -48,7 +48,7 @@ class SelfReferChildSibling(SelfRefer):
     pass
 
 
-# Many-to-Many relation between models, where one of the PK's isn't an Autofield
+# Many-to-Many relation between models, where one of the PK's isn't an BigAutoField
 class Line(models.Model):
     name = models.CharField(max_length=100)
 

--- a/tests/m2m_regress/tests.py
+++ b/tests/m2m_regress/tests.py
@@ -56,7 +56,7 @@ class M2MRegressionTests(TestCase):
 
     def test_m2m_pk_field_type(self):
         # Regression for #11311 - The primary key for models in a m2m relation
-        # doesn't have to be an AutoField
+        # doesn't have to be an BigAutoField
 
         w = Worksheet(id='abc')
         w.save()

--- a/tests/m2m_through_regress/models.py
+++ b/tests/m2m_through_regress/models.py
@@ -14,7 +14,7 @@ class Membership(models.Model):
 
 # using custom id column to test ticket #11107
 class UserMembership(models.Model):
-    id = models.AutoField(db_column='usermembership_id', primary_key=True)
+    id = models.BigAutoField(db_column='usermembership_id', primary_key=True)
     user = models.ForeignKey(User, models.CASCADE)
     group = models.ForeignKey('Group', models.CASCADE)
     price = models.IntegerField(default=100)

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -522,7 +522,7 @@ class ManyToOneTests(TestCase):
         self.assertIsNot(c.parent, p)
         self.assertEqual(c.parent, p)
 
-    def test_fk_to_bigautofield(self):
+    def test_fk_to_BigAutoField(self):
         ch = City.objects.create(name='Chicago')
         District.objects.create(city=ch, name='Far South')
         District.objects.create(city=ch, name='North')

--- a/tests/many_to_one/tests.py
+++ b/tests/many_to_one/tests.py
@@ -522,7 +522,7 @@ class ManyToOneTests(TestCase):
         self.assertIsNot(c.parent, p)
         self.assertEqual(c.parent, p)
 
-    def test_fk_to_BigAutoField(self):
+    def test_fk_to_bigautofield(self):
         ch = City.objects.create(name='Chicago')
         District.objects.create(city=ch, name='Far South')
         District.objects.create(city=ch, name='North')

--- a/tests/migrate_signals/custom_migrations/0001_initial.py
+++ b/tests/migrate_signals/custom_migrations/0001_initial.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Signal",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         ),
     ]

--- a/tests/migration_test_data_persistence/migrations/0001_initial.py
+++ b/tests/migration_test_data_persistence/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Book',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('id', models.BigAutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
                 ('title', models.CharField(max_length=100)),
             ],
             options={

--- a/tests/migrations/deprecated_field_migrations/0001_initial.py
+++ b/tests/migrations/deprecated_field_migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IPAddressField',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('ip', models.IPAddressField(null=True, blank=True)),
             ],
         ),

--- a/tests/migrations/migrations_test_apps/alter_fk/author_app/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/alter_fk/author_app/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Author',
             fields=[
-                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=50)),
             ],
         ),

--- a/tests/migrations/migrations_test_apps/alter_fk/book_app/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/alter_fk/book_app/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Book',
             fields=[
-                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=50)),
                 ('author', models.ForeignKey('author_app.Author', models.CASCADE)),
             ],

--- a/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0001_initial.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0002_conflicting_second.py
+++ b/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0002_conflicting_second.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Something",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         )
     ]

--- a/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0002_second.py
+++ b/tests/migrations/migrations_test_apps/conflicting_app_with_dependencies/migrations/0002_second.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         )
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='A1',
             fields=[
-                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0002_a2.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0002_a2.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='A2',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('id', models.BigAutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0003_a3.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0003_a3.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='A3',
             fields=[
-                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('id', models.BigAutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
                 ('b2', models.ForeignKey('lookuperror_b.B2', models.CASCADE)),
                 ('c2', models.ForeignKey('lookuperror_c.C2', models.CASCADE)),
             ],

--- a/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0004_a4.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_a/migrations/0004_a4.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='A4',
             fields=[
-                ('id', models.AutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
+                ('id', models.BigAutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='B1',
             fields=[
-                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('id', models.BigAutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0002_b2.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0002_b2.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='B2',
             fields=[
-                ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
+                ('id', models.BigAutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('a1', models.ForeignKey('lookuperror_a.A1', models.CASCADE)),
             ],
         ),

--- a/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0003_b3.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_b/migrations/0003_b3.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='B3',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='C1',
             fields=[
-                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0002_c2.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0002_c2.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='C2',
             fields=[
-                ('id', models.AutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
+                ('id', models.BigAutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
                 ('a1', models.ForeignKey('lookuperror_a.A1', models.CASCADE)),
             ],
         ),

--- a/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0003_c3.py
+++ b/tests/migrations/migrations_test_apps/lookuperror_c/migrations/0003_c3.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='C3',
             fields=[
-                ('id', models.AutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
+                ('id', models.BigAutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
             ],
         ),
     ]

--- a/tests/migrations/migrations_test_apps/migrated_app/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/migrated_app/migrations/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/migrations_test_apps/migrated_unapplied_app/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/migrated_unapplied_app/migrations/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "OtherAuthor",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),

--- a/tests/migrations/migrations_test_apps/migrated_unapplied_app/models.py
+++ b/tests/migrations/migrations_test_apps/migrated_unapplied_app/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 
 class OtherAuthor(models.Model):
-    id = models.AutoField(primary_key=True)
+    id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=255)
     slug = models.SlugField(null=True)
     age = models.IntegerField(default=0)

--- a/tests/migrations/migrations_test_apps/mutate_state_a/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/mutate_state_a/migrations/0001_initial.py
@@ -12,7 +12,8 @@ class Migration(migrations.Migration):
             migrations.CreateModel(
                 name='A',
                 fields=[
-                    ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                    ('id', models.BigAutoField(
+                        serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ],
             ),
         ])

--- a/tests/migrations/migrations_test_apps/mutate_state_a/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/mutate_state_a/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
             migrations.CreateModel(
                 name='A',
                 fields=[
-                    ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                    ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ],
             ),
         ])

--- a/tests/migrations/migrations_test_apps/mutate_state_b/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/mutate_state_b/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
             migrations.CreateModel(
                 name='B',
                 fields=[
-                    ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                    ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ],
             ),
         ])

--- a/tests/migrations/migrations_test_apps/mutate_state_b/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/mutate_state_b/migrations/0001_initial.py
@@ -11,7 +11,8 @@ class Migration(migrations.Migration):
             migrations.CreateModel(
                 name='B',
                 fields=[
-                    ('id', models.BigAutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                    ('id', models.BigAutoField(
+                        serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
                 ],
             ),
         ])

--- a/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0001_initial.py
+++ b/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0002_conflicting_second.py
+++ b/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0002_conflicting_second.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Something",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         )
 

--- a/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0002_second.py
+++ b/tests/migrations/migrations_test_apps/unspecified_app_with_conflict/migrations/0002_second.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         )
 

--- a/tests/migrations/test_add_many_to_many_field_initial/0001_initial.py
+++ b/tests/migrations/test_add_many_to_many_field_initial/0001_initial.py
@@ -12,13 +12,13 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Project',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
             ],
         ),
         migrations.CreateModel(
             name='Task',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
             ],
         ),
         migrations.AddField(

--- a/tests/migrations/test_auto_now_add/0001_initial.py
+++ b/tests/migrations/test_auto_now_add/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Entry',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('title', models.CharField(max_length=255)),
             ],
         ),

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -40,99 +40,99 @@ class AutodetectorTests(TestCase):
     Tests the migration autodetector.
     """
 
-    author_empty = ModelState("testapp", "Author", [("id", models.AutoField(primary_key=True))])
+    author_empty = ModelState("testapp", "Author", [("id", models.BigAutoField(primary_key=True))])
     author_name = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
     ])
     author_name_null = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, null=True)),
     ])
     author_name_longer = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=400)),
     ])
     author_name_renamed = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("names", models.CharField(max_length=200)),
     ])
     author_name_default = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default='Ada Lovelace')),
     ])
     author_dates_of_birth_auto_now = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("date_of_birth", models.DateField(auto_now=True)),
         ("date_time_of_birth", models.DateTimeField(auto_now=True)),
         ("time_of_birth", models.TimeField(auto_now=True)),
     ])
     author_dates_of_birth_auto_now_add = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("date_of_birth", models.DateField(auto_now_add=True)),
         ("date_time_of_birth", models.DateTimeField(auto_now_add=True)),
         ("time_of_birth", models.TimeField(auto_now_add=True)),
     ])
     author_name_deconstructible_1 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject())),
     ])
     author_name_deconstructible_2 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject())),
     ])
     author_name_deconstructible_3 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=models.IntegerField())),
     ])
     author_name_deconstructible_4 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=models.IntegerField())),
     ])
     author_name_deconstructible_list_1 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=[DeconstructibleObject(), 123])),
     ])
     author_name_deconstructible_list_2 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=[DeconstructibleObject(), 123])),
     ])
     author_name_deconstructible_list_3 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=[DeconstructibleObject(), 999])),
     ])
     author_name_deconstructible_tuple_1 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=(DeconstructibleObject(), 123))),
     ])
     author_name_deconstructible_tuple_2 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=(DeconstructibleObject(), 123))),
     ])
     author_name_deconstructible_tuple_3 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=(DeconstructibleObject(), 999))),
     ])
     author_name_deconstructible_dict_1 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default={
             'item': DeconstructibleObject(), 'otheritem': 123
         })),
     ])
     author_name_deconstructible_dict_2 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default={
             'item': DeconstructibleObject(), 'otheritem': 123
         })),
     ])
     author_name_deconstructible_dict_3 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default={
             'item': DeconstructibleObject(), 'otheritem': 999
         })),
     ])
     author_name_nested_deconstructible_1 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2'),),
@@ -141,7 +141,7 @@ class AutodetectorTests(TestCase):
         ))),
     ])
     author_name_nested_deconstructible_2 = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2'),),
@@ -150,7 +150,7 @@ class AutodetectorTests(TestCase):
         ))),
     ])
     author_name_nested_deconstructible_changed_arg = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2-changed'),),
@@ -159,7 +159,7 @@ class AutodetectorTests(TestCase):
         ))),
     ])
     author_name_nested_deconstructible_extra_arg = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2'),),
@@ -169,7 +169,7 @@ class AutodetectorTests(TestCase):
         ))),
     ])
     author_name_nested_deconstructible_changed_kwarg = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2'),),
@@ -178,7 +178,7 @@ class AutodetectorTests(TestCase):
         ))),
     ])
     author_name_nested_deconstructible_extra_kwarg = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, default=DeconstructibleObject(
             DeconstructibleObject(1),
             (DeconstructibleObject('t1'), DeconstructibleObject('t2'),),
@@ -189,47 +189,47 @@ class AutodetectorTests(TestCase):
     ])
     author_custom_pk = ModelState("testapp", "Author", [("pk_field", models.IntegerField(primary_key=True))])
     author_with_biography_non_blank = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField()),
         ("biography", models.TextField()),
     ])
     author_with_biography_blank = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(blank=True)),
         ("biography", models.TextField(blank=True)),
     ])
     author_with_book = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("book", models.ForeignKey("otherapp.Book", models.CASCADE)),
     ])
     author_with_book_order_wrt = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("book", models.ForeignKey("otherapp.Book", models.CASCADE)),
     ], options={"order_with_respect_to": "book"})
     author_renamed_with_book = ModelState("testapp", "Writer", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("book", models.ForeignKey("otherapp.Book", models.CASCADE)),
     ])
     author_with_publisher_string = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("publisher_name", models.CharField(max_length=200)),
     ])
     author_with_publisher = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("publisher", models.ForeignKey("testapp.Publisher", models.CASCADE)),
     ])
     author_with_user = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("user", models.ForeignKey("auth.User", models.CASCADE)),
     ])
     author_with_custom_user = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
         ("user", models.ForeignKey("thirdapp.CustomUser", models.CASCADE)),
     ])
@@ -244,148 +244,148 @@ class AutodetectorTests(TestCase):
     author_proxy_proxy = ModelState("testapp", "AAuthorProxyProxy", [], {"proxy": True}, ("testapp.authorproxy", ))
     author_unmanaged = ModelState("testapp", "AuthorUnmanaged", [], {"managed": False}, ("testapp.author", ))
     author_unmanaged_managed = ModelState("testapp", "AuthorUnmanaged", [], {}, ("testapp.author", ))
-    author_unmanaged_default_pk = ModelState("testapp", "Author", [("id", models.AutoField(primary_key=True))])
+    author_unmanaged_default_pk = ModelState("testapp", "Author", [("id", models.BigAutoField(primary_key=True))])
     author_unmanaged_custom_pk = ModelState("testapp", "Author", [
         ("pk_field", models.IntegerField(primary_key=True)),
     ])
     author_with_m2m = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher")),
     ])
     author_with_m2m_blank = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher", blank=True)),
     ])
     author_with_m2m_through = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher", through="testapp.Contract")),
     ])
     author_with_renamed_m2m_through = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher", through="testapp.Deal")),
     ])
     author_with_former_m2m = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("publishers", models.CharField(max_length=100)),
     ])
     author_with_options = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], {
         "permissions": [('can_hire', 'Can hire')],
         "verbose_name": "Authi",
     })
     author_with_db_table_options = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], {"db_table": "author_one"})
     author_with_new_db_table_options = ModelState("testapp", "Author", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], {"db_table": "author_two"})
     author_renamed_with_db_table_options = ModelState("testapp", "NewAuthor", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], {"db_table": "author_one"})
     author_renamed_with_new_db_table_options = ModelState("testapp", "NewAuthor", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], {"db_table": "author_three"})
     contract = ModelState("testapp", "Contract", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("publisher", models.ForeignKey("testapp.Publisher", models.CASCADE)),
     ])
     contract_renamed = ModelState("testapp", "Deal", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("publisher", models.ForeignKey("testapp.Publisher", models.CASCADE)),
     ])
     publisher = ModelState("testapp", "Publisher", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("name", models.CharField(max_length=100)),
     ])
     publisher_with_author = ModelState("testapp", "Publisher", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("name", models.CharField(max_length=100)),
     ])
     publisher_with_aardvark_author = ModelState("testapp", "Publisher", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Aardvark", models.CASCADE)),
         ("name", models.CharField(max_length=100)),
     ])
     publisher_with_book = ModelState("testapp", "Publisher", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("otherapp.Book", models.CASCADE)),
         ("name", models.CharField(max_length=100)),
     ])
     other_pony = ModelState("otherapp", "Pony", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ])
     other_pony_food = ModelState("otherapp", "Pony", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
     ], managers=[
         ('food_qs', FoodQuerySet.as_manager()),
         ('food_mgr', FoodManager('a', 'b')),
         ('food_mgr_kwargs', FoodManager('x', 'y', 3, 4)),
     ])
-    other_stable = ModelState("otherapp", "Stable", [("id", models.AutoField(primary_key=True))])
-    third_thing = ModelState("thirdapp", "Thing", [("id", models.AutoField(primary_key=True))])
+    other_stable = ModelState("otherapp", "Stable", [("id", models.BigAutoField(primary_key=True))])
+    third_thing = ModelState("thirdapp", "Thing", [("id", models.BigAutoField(primary_key=True))])
     book = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ])
     book_proxy_fk = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("thirdapp.AuthorProxy", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ])
     book_proxy_proxy_fk = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.AAuthorProxyProxy", models.CASCADE)),
     ])
     book_migrations_fk = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("migrations.UnmigratedModel", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ])
     book_with_no_author = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("title", models.CharField(max_length=200)),
     ])
     book_with_author_renamed = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Writer", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ])
     book_with_field_and_author_renamed = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("writer", models.ForeignKey("testapp.Writer", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ])
     book_with_multiple_authors = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("authors", models.ManyToManyField("testapp.Author")),
         ("title", models.CharField(max_length=200)),
     ])
     book_with_multiple_authors_through_attribution = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("authors", models.ManyToManyField("testapp.Author", through="otherapp.Attribution")),
         ("title", models.CharField(max_length=200)),
     ])
     book_indexes = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ], {
         "indexes": [models.Index(fields=["author", "title"], name="book_title_author_idx")],
     })
     book_unordered_indexes = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ], {
         "indexes": [models.Index(fields=["title", "author"], name="book_author_title_idx")],
     })
     book_foo_together = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ], {
@@ -393,7 +393,7 @@ class AutodetectorTests(TestCase):
         "unique_together": {("author", "title")},
     })
     book_foo_together_2 = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
     ], {
@@ -401,7 +401,7 @@ class AutodetectorTests(TestCase):
         "unique_together": {("title", "author")},
     })
     book_foo_together_3 = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("newfield", models.IntegerField()),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
@@ -410,7 +410,7 @@ class AutodetectorTests(TestCase):
         "unique_together": {("title", "newfield")},
     })
     book_foo_together_4 = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("newfield2", models.IntegerField()),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("title", models.CharField(max_length=200)),
@@ -419,31 +419,31 @@ class AutodetectorTests(TestCase):
         "unique_together": {("title", "newfield2")},
     })
     attribution = ModelState("otherapp", "Attribution", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
         ("book", models.ForeignKey("otherapp.Book", models.CASCADE)),
     ])
     edition = ModelState("thirdapp", "Edition", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("book", models.ForeignKey("otherapp.Book", models.CASCADE)),
     ])
     custom_user = ModelState("thirdapp", "CustomUser", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("username", models.CharField(max_length=255)),
     ], bases=(AbstractBaseUser, ))
     custom_user_no_inherit = ModelState("thirdapp", "CustomUser", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("username", models.CharField(max_length=255)),
     ])
-    aardvark = ModelState("thirdapp", "Aardvark", [("id", models.AutoField(primary_key=True))])
-    aardvark_testapp = ModelState("testapp", "Aardvark", [("id", models.AutoField(primary_key=True))])
+    aardvark = ModelState("thirdapp", "Aardvark", [("id", models.BigAutoField(primary_key=True))])
+    aardvark_testapp = ModelState("testapp", "Aardvark", [("id", models.BigAutoField(primary_key=True))])
     aardvark_based_on_author = ModelState("testapp", "Aardvark", [], bases=("testapp.Author", ))
     aardvark_pk_fk_author = ModelState("testapp", "Aardvark", [
         ("id", models.OneToOneField("testapp.Author", models.CASCADE, primary_key=True)),
     ])
-    knight = ModelState("eggs", "Knight", [("id", models.AutoField(primary_key=True))])
+    knight = ModelState("eggs", "Knight", [("id", models.BigAutoField(primary_key=True))])
     rabbit = ModelState("eggs", "Rabbit", [
-        ("id", models.AutoField(primary_key=True)),
+        ("id", models.BigAutoField(primary_key=True)),
         ("knight", models.ForeignKey("eggs.Knight", models.CASCADE)),
         ("parent", models.ForeignKey("eggs.Rabbit", models.CASCADE)),
     ], {
@@ -729,11 +729,11 @@ class AutodetectorTests(TestCase):
 
         # An unchanged partial reference.
         before = [ModelState("testapp", "Author", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("file", models.FileField(max_length=200, upload_to=content_file_name('file'))),
         ])]
         after = [ModelState("testapp", "Author", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("file", models.FileField(max_length=200, upload_to=content_file_name('file'))),
         ])]
         changes = self.get_changes(before, after)
@@ -741,7 +741,7 @@ class AutodetectorTests(TestCase):
 
         # A changed partial reference.
         args_changed = [ModelState("testapp", "Author", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("file", models.FileField(max_length=200, upload_to=content_file_name('other-file'))),
         ])]
         changes = self.get_changes(before, args_changed)
@@ -758,7 +758,7 @@ class AutodetectorTests(TestCase):
         )
 
         kwargs_changed = [ModelState("testapp", "Author", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("file", models.FileField(max_length=200, upload_to=content_file_name('file', spam='eggs'))),
         ])]
         changes = self.get_changes(before, kwargs_changed)
@@ -878,20 +878,20 @@ class AutodetectorTests(TestCase):
         """
         before = [
             ModelState("testapp", "EntityA", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             ModelState("testapp", "EntityB", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("some_label", models.CharField(max_length=255)),
                 ("entity_a", models.ForeignKey("testapp.EntityA", models.CASCADE)),
             ]),
         ]
         after = [
             ModelState("testapp", "EntityA", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             ModelState("testapp", "RenamedEntityB", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("entity_a", models.ForeignKey("testapp.EntityA", models.CASCADE)),
                 ("some_label", models.CharField(max_length=255)),
             ]),
@@ -1075,7 +1075,7 @@ class AutodetectorTests(TestCase):
 
     def test_identical_regex_doesnt_alter(self):
         from_state = ModelState(
-            "testapp", "model", [("id", models.AutoField(primary_key=True, validators=[
+            "testapp", "model", [("id", models.BigAutoField(primary_key=True, validators=[
                 RegexValidator(
                     re.compile('^[-a-zA-Z0-9_]+\\Z'),
                     "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
@@ -1084,7 +1084,7 @@ class AutodetectorTests(TestCase):
             ]))]
         )
         to_state = ModelState(
-            "testapp", "model", [("id", models.AutoField(primary_key=True, validators=[validate_slug]))]
+            "testapp", "model", [("id", models.BigAutoField(primary_key=True, validators=[validate_slug]))]
         )
         changes = self.get_changes([from_state], [to_state])
         # Right number/type of migrations?
@@ -1092,7 +1092,7 @@ class AutodetectorTests(TestCase):
 
     def test_different_regex_does_alter(self):
         from_state = ModelState(
-            "testapp", "model", [("id", models.AutoField(primary_key=True, validators=[
+            "testapp", "model", [("id", models.BigAutoField(primary_key=True, validators=[
                 RegexValidator(
                     re.compile('^[a-z]+\\Z', 32),
                     "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
@@ -1101,7 +1101,7 @@ class AutodetectorTests(TestCase):
             ]))]
         )
         to_state = ModelState(
-            "testapp", "model", [("id", models.AutoField(primary_key=True, validators=[validate_slug]))]
+            "testapp", "model", [("id", models.BigAutoField(primary_key=True, validators=[validate_slug]))]
         )
         changes = self.get_changes([from_state], [to_state])
         self.assertNumberMigrations(changes, "testapp", 1)
@@ -1113,11 +1113,11 @@ class AutodetectorTests(TestCase):
         """
         # Explicitly testing for not specified, since this is the case after
         # a CreateModel operation w/o any definition on the original model
-        model_state_not_specified = ModelState("a", "model", [("id", models.AutoField(primary_key=True))])
+        model_state_not_specified = ModelState("a", "model", [("id", models.BigAutoField(primary_key=True))])
         # Explicitly testing for None, since this was the issue in #23452 after
         # a AlterFooTogether operation with e.g. () as value
         model_state_none = ModelState("a", "model", [
-            ("id", models.AutoField(primary_key=True))
+            ("id", models.BigAutoField(primary_key=True))
         ], {
             "index_together": None,
             "unique_together": None,
@@ -1125,7 +1125,7 @@ class AutodetectorTests(TestCase):
         # Explicitly testing for the empty set, since we now always have sets.
         # During removal (('col1', 'col2'),) --> () this becomes set([])
         model_state_empty = ModelState("a", "model", [
-            ("id", models.AutoField(primary_key=True))
+            ("id", models.BigAutoField(primary_key=True))
         ], {
             "index_together": set(),
             "unique_together": set(),
@@ -1155,7 +1155,7 @@ class AutodetectorTests(TestCase):
     def test_create_model_with_indexes(self):
         """Test creation of new model with indexes already defined."""
         author = ModelState('otherapp', 'Author', [
-            ('id', models.AutoField(primary_key=True)),
+            ('id', models.BigAutoField(primary_key=True)),
             ('name', models.CharField(max_length=200)),
         ], {'indexes': [models.Index(fields=['name'], name='create_model_with_indexes_idx')]})
         changes = self.get_changes([], [author])
@@ -1266,11 +1266,11 @@ class AutodetectorTests(TestCase):
 
     def test_create_model_and_unique_together(self):
         author = ModelState("otherapp", "Author", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("name", models.CharField(max_length=200)),
         ])
         book_with_author = ModelState("otherapp", "Book", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("author", models.ForeignKey("otherapp.Author", models.CASCADE)),
             ("title", models.CharField(max_length=200)),
         ], {
@@ -1607,7 +1607,7 @@ class AutodetectorTests(TestCase):
             "testapp",
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(
                     max_length=200,
                     # IntegerField intentionally not instantiated.
@@ -1902,8 +1902,8 @@ class AutodetectorTests(TestCase):
 
     def test_multiple_bases(self):
         """#23956 - Inheriting models doesn't move *_ptr fields into AddField operations."""
-        A = ModelState("app", "A", [("a_id", models.AutoField(primary_key=True))])
-        B = ModelState("app", "B", [("b_id", models.AutoField(primary_key=True))])
+        A = ModelState("app", "A", [("a_id", models.BigAutoField(primary_key=True))])
+        B = ModelState("app", "B", [("b_id", models.BigAutoField(primary_key=True))])
         C = ModelState("app", "C", [], bases=("app.A", "app.B"))
         D = ModelState("app", "D", [], bases=("app.A", "app.B"))
         E = ModelState("app", "E", [], bases=("app.A", "app.B"))
@@ -2009,18 +2009,18 @@ class AutodetectorTests(TestCase):
         before AddField and not become unsolvable.
         """
         address = ModelState("a", "Address", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("country", models.ForeignKey("b.DeliveryCountry", models.CASCADE)),
         ])
         person = ModelState("a", "Person", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
         ])
         apackage = ModelState("b", "APackage", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
             ("person", models.ForeignKey("a.Person", models.CASCADE)),
         ])
         country = ModelState("b", "DeliveryCountry", [
-            ("id", models.AutoField(primary_key=True)),
+            ("id", models.BigAutoField(primary_key=True)),
         ])
         changes = self.get_changes([], [address, person, apackage, country])
         # Right number/type of migrations?
@@ -2038,12 +2038,12 @@ class AutodetectorTests(TestCase):
         """
         with isolate_lru_cache(apps.get_swappable_settings_name):
             tenant = ModelState("a", "Tenant", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("primary_address", models.ForeignKey("b.Address", models.CASCADE))],
                 bases=(AbstractBaseUser, )
             )
             address = ModelState("b", "Address", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("tenant", models.ForeignKey(settings.AUTH_USER_MODEL, models.CASCADE)),
             ])
             changes = self.get_changes([], [address, tenant])
@@ -2068,11 +2068,11 @@ class AutodetectorTests(TestCase):
         """
         with isolate_lru_cache(apps.get_swappable_settings_name):
             address = ModelState("a", "Address", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("tenant", models.ForeignKey(settings.AUTH_USER_MODEL, models.CASCADE)),
             ])
             tenant = ModelState("b", "Tenant", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("primary_address", models.ForeignKey("a.Address", models.CASCADE))],
                 bases=(AbstractBaseUser, )
             )
@@ -2096,7 +2096,7 @@ class AutodetectorTests(TestCase):
         """
         with isolate_lru_cache(apps.get_swappable_settings_name):
             person = ModelState("a", "Person", [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("parent1", models.ForeignKey(settings.AUTH_USER_MODEL, models.CASCADE, related_name='children'))
             ])
             changes = self.get_changes([], [person])

--- a/tests/migrations/test_migrations/0001_initial.py
+++ b/tests/migrations/test_migrations/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         ),

--- a/tests/migrations/test_migrations/0002_second.py
+++ b/tests/migrations/test_migrations/0002_second.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_conflict/0001_initial.py
+++ b/tests/migrations/test_migrations_conflict/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/test_migrations_conflict/0002_conflicting_second.py
+++ b/tests/migrations/test_migrations_conflict/0002_conflicting_second.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Something",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
         )
 

--- a/tests/migrations/test_migrations_conflict/0002_second.py
+++ b/tests/migrations/test_migrations_conflict/0002_second.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_custom_user/0001_initial.py
+++ b/tests/migrations/test_migrations_custom_user/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
             ],
         ),
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey(settings.AUTH_USER_MODEL, models.CASCADE, to_field="id")),
             ],
         )

--- a/tests/migrations/test_migrations_fake_split_initial/0001_initial.py
+++ b/tests/migrations/test_migrations_fake_split_initial/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         ),

--- a/tests/migrations/test_migrations_fake_split_initial/0002_second.py
+++ b/tests/migrations/test_migrations_fake_split_initial/0002_second.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         ),

--- a/tests/migrations/test_migrations_first/second.py
+++ b/tests/migrations/test_migrations_first/second.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_first/thefirst.py
+++ b/tests/migrations/test_migrations_first/thefirst.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/test_migrations_initial_false/0001_not_initial.py
+++ b/tests/migrations/test_migrations_initial_false/0001_not_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         ),

--- a/tests/migrations/test_migrations_no_ancestor/0001_initial.py
+++ b/tests/migrations/test_migrations_no_ancestor/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/test_migrations_no_ancestor/0002_conflicting_second.py
+++ b/tests/migrations/test_migrations_no_ancestor/0002_conflicting_second.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_no_ancestor/0002_second.py
+++ b/tests/migrations/test_migrations_no_ancestor/0002_second.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_no_changes/0001_initial.py
+++ b/tests/migrations/test_migrations_no_changes/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/test_migrations_no_changes/0002_second.py
+++ b/tests/migrations/test_migrations_no_changes/0002_second.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_no_changes/0003_third.py
+++ b/tests/migrations/test_migrations_no_changes/0003_third.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ModelWithCustomBase',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ],
             options={},
             bases=(models.Model,),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UnmigratedModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ],
             options={},
             bases=(models.Model,),

--- a/tests/migrations/test_migrations_no_default/0001_initial.py
+++ b/tests/migrations/test_migrations_no_default/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SillyModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('silly_field', models.BooleanField(default=False)),
             ],
             options={

--- a/tests/migrations/test_migrations_run_before/0001_initial.py
+++ b/tests/migrations/test_migrations_run_before/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Salamander",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("size", models.IntegerField(default=0)),
                 ("silly_field", models.BooleanField(default=False)),
             ],

--- a/tests/migrations/test_migrations_run_before/0002_second.py
+++ b/tests/migrations/test_migrations_run_before/0002_second.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_run_before/0003_third.py
+++ b/tests/migrations/test_migrations_run_before/0003_third.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),

--- a/tests/migrations/test_migrations_squashed/0001_initial.py
+++ b/tests/migrations/test_migrations_squashed/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Tribble",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("fluffy", models.BooleanField(default=True)),
             ],
         )

--- a/tests/migrations/test_migrations_squashed/0001_squashed_0002.py
+++ b/tests/migrations/test_migrations_squashed/0001_squashed_0002.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         ),

--- a/tests/migrations/test_migrations_squashed/0002_second.py
+++ b/tests/migrations/test_migrations_squashed/0002_second.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("author", models.ForeignKey("migrations.Author", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_migrations_unmigdep/0001_initial.py
+++ b/tests/migrations/test_migrations_unmigdep/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("user", models.ForeignKey("auth.User", models.SET_NULL, null=True)),
             ],
         )

--- a/tests/migrations/test_multidb.py
+++ b/tests/migrations/test_multidb.py
@@ -53,7 +53,7 @@ class MultiDBOperationTests(OperationTestBase):
         """
         operation = migrations.CreateModel(
             "Pony",
-            [("id", models.AutoField(primary_key=True))],
+            [("id", models.BigAutoField(primary_key=True))],
         )
         # Test the state alteration
         project_state = ProjectState()

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1310,7 +1310,7 @@ class OperationTests(OperationTestBase):
                     if c.name == "pony_id"
                 ][0]
 
-            # Sqlite only allows primary keys of type integer, however, this is allows bigints.
+            # Sqlite only allows primary keys of type integer, however, this allows bigints.
             if connection.features.bigint_is_integer and id_type == 'integer':
                 self.assertIn(fk_type, ['integer', 'bigint'])
             else:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1294,7 +1294,8 @@ class OperationTests(OperationTestBase):
         operation = migrations.AlterField("Pony", "id", models.FloatField(primary_key=True))
         new_state = project_state.clone()
         operation.state_forwards("test_alflpkfk", new_state)
-        self.assertIsInstance(project_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.BigAutoField)
+        self.assertIsInstance(
+            project_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.BigAutoField)
         self.assertIsInstance(new_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.FloatField)
 
         def assertIdTypeEqualsFkType():
@@ -1789,7 +1790,8 @@ class OperationTests(OperationTestBase):
             "DELETE FROM i_love_ponies WHERE special_thing LIKE '%%Ponies%%';"
             "DROP TABLE i_love_ponies",
 
-            state_operations=[migrations.CreateModel("SomethingElse", [("id", models.BigAutoField(primary_key=True))])],
+            state_operations=[migrations.CreateModel("SomethingElse", [
+                ("id", models.BigAutoField(primary_key=True))])],
         )
         self.assertEqual(operation.describe(), "Raw SQL operation")
         # Test the state alteration

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -90,7 +90,7 @@ class OperationTestBase(MigrationTestBase):
         operations = [migrations.CreateModel(
             "Pony",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("pink", models.IntegerField(default=3)),
                 ("weight", models.FloatField()),
             ],
@@ -110,21 +110,21 @@ class OperationTestBase(MigrationTestBase):
             operations.append(migrations.CreateModel(
                 "Stable",
                 [
-                    ("id", models.AutoField(primary_key=True)),
+                    ("id", models.BigAutoField(primary_key=True)),
                 ]
             ))
         if third_model:
             operations.append(migrations.CreateModel(
                 "Van",
                 [
-                    ("id", models.AutoField(primary_key=True)),
+                    ("id", models.BigAutoField(primary_key=True)),
                 ]
             ))
         if related_model:
             operations.append(migrations.CreateModel(
                 "Rider",
                 [
-                    ("id", models.AutoField(primary_key=True)),
+                    ("id", models.BigAutoField(primary_key=True)),
                     ("pony", models.ForeignKey("Pony", models.CASCADE)),
                     ("friend", models.ForeignKey("self", models.CASCADE))
                 ],
@@ -157,7 +157,7 @@ class OperationTestBase(MigrationTestBase):
             operations.append(migrations.CreateModel(
                 "Food",
                 fields=[
-                    ("id", models.AutoField(primary_key=True)),
+                    ("id", models.BigAutoField(primary_key=True)),
                 ],
                 managers=[
                     ("food_qs", FoodQuerySet.as_manager()),
@@ -184,7 +184,7 @@ class OperationTests(OperationTestBase):
         operation = migrations.CreateModel(
             "Pony",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("pink", models.IntegerField(default=1)),
             ],
         )
@@ -219,7 +219,7 @@ class OperationTests(OperationTestBase):
             migrations.CreateModel(
                 "Pony",
                 [
-                    ("id", models.AutoField(primary_key=True)),
+                    ("id", models.BigAutoField(primary_key=True)),
                     ("pink", models.TextField()),
                     ("pink", models.IntegerField(default=1)),
                 ],
@@ -292,14 +292,14 @@ class OperationTests(OperationTestBase):
         operation1 = migrations.CreateModel(
             "Pony",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("pink", models.IntegerField(default=1)),
             ],
         )
         operation2 = migrations.CreateModel(
             "Rider",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("number", models.IntegerField(default=1)),
                 ("pony", models.ForeignKey("test_crmoua.Pony", models.CASCADE)),
             ],
@@ -336,7 +336,7 @@ class OperationTests(OperationTestBase):
         operation = migrations.CreateModel(
             "Stable",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("ponies", models.ManyToManyField("Pony", related_name="stables"))
             ]
         )
@@ -471,7 +471,7 @@ class OperationTests(OperationTestBase):
         operation = migrations.CreateModel(
             "Food",
             fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
             managers=[
                 ("food_qs", FoodQuerySet.as_manager()),
@@ -690,7 +690,7 @@ class OperationTests(OperationTestBase):
 
         project_state = self.apply_operations(app_label, ProjectState(), operations=[
             migrations.CreateModel("ReflexivePony", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("ponies", models.ManyToManyField("self")),
             ]),
         ])
@@ -705,10 +705,10 @@ class OperationTests(OperationTestBase):
         app_label = "test_rename_model_with_m2m"
         project_state = self.apply_operations(app_label, ProjectState(), operations=[
             migrations.CreateModel("Rider", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             migrations.CreateModel("Pony", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("riders", models.ManyToManyField("Rider")),
             ]),
         ])
@@ -734,10 +734,10 @@ class OperationTests(OperationTestBase):
         app_label = "test_rename_m2m_target_model"
         project_state = self.apply_operations(app_label, ProjectState(), operations=[
             migrations.CreateModel("Rider", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             migrations.CreateModel("Pony", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("riders", models.ManyToManyField("Rider")),
             ]),
         ])
@@ -763,13 +763,13 @@ class OperationTests(OperationTestBase):
         app_label = "test_rename_through"
         project_state = self.apply_operations(app_label, ProjectState(), operations=[
             migrations.CreateModel("Rider", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             migrations.CreateModel("Pony", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ]),
             migrations.CreateModel("PonyRider", fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("rider", models.ForeignKey("test_rename_through.Rider", models.CASCADE)),
                 ("pony", models.ForeignKey("test_rename_through.Pony", models.CASCADE)),
             ]),
@@ -1275,7 +1275,7 @@ class OperationTests(OperationTestBase):
         operation = migrations.AlterField("Pony", "id", models.IntegerField(primary_key=True))
         new_state = project_state.clone()
         operation.state_forwards("test_alflpk", new_state)
-        self.assertIsInstance(project_state.models["test_alflpk", "pony"].get_field_by_name("id"), models.AutoField)
+        self.assertIsInstance(project_state.models["test_alflpk", "pony"].get_field_by_name("id"), models.BigAutoField)
         self.assertIsInstance(new_state.models["test_alflpk", "pony"].get_field_by_name("id"), models.IntegerField)
         # Test the database alteration
         with connection.schema_editor() as editor:
@@ -1294,7 +1294,7 @@ class OperationTests(OperationTestBase):
         operation = migrations.AlterField("Pony", "id", models.FloatField(primary_key=True))
         new_state = project_state.clone()
         operation.state_forwards("test_alflpkfk", new_state)
-        self.assertIsInstance(project_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.AutoField)
+        self.assertIsInstance(project_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.BigAutoField)
         self.assertIsInstance(new_state.models["test_alflpkfk", "pony"].get_field_by_name("id"), models.FloatField)
 
         def assertIdTypeEqualsFkType():
@@ -1309,7 +1309,13 @@ class OperationTests(OperationTestBase):
                     for c in connection.introspection.get_table_description(cursor, "test_alflpkfk_rider")
                     if c.name == "pony_id"
                 ][0]
-            self.assertEqual(id_type, fk_type)
+
+            # Sqlite only allows primary keys of type integer, however, this is allows bigints.
+            if connection.features.bigint_is_integer and id_type == 'integer':
+                self.assertIn(fk_type, ['integer', 'bigint'])
+            else:
+                self.assertEqual(id_type, fk_type)
+
             self.assertEqual(id_null, fk_null)
 
         assertIdTypeEqualsFkType()
@@ -1721,7 +1727,7 @@ class OperationTests(OperationTestBase):
         create_operation = migrations.CreateModel(
             name="Rider",
             fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("pony", models.ForeignKey("Pony", models.CASCADE)),
             ],
         )
@@ -1783,7 +1789,7 @@ class OperationTests(OperationTestBase):
             "DELETE FROM i_love_ponies WHERE special_thing LIKE '%%Ponies%%';"
             "DROP TABLE i_love_ponies",
 
-            state_operations=[migrations.CreateModel("SomethingElse", [("id", models.AutoField(primary_key=True))])],
+            state_operations=[migrations.CreateModel("SomethingElse", [("id", models.BigAutoField(primary_key=True))])],
         )
         self.assertEqual(operation.describe(), "Raw SQL operation")
         # Test the state alteration
@@ -2081,7 +2087,7 @@ class OperationTests(OperationTestBase):
         create_author = migrations.CreateModel(
             "Author",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=100)),
             ],
             options={},
@@ -2089,7 +2095,7 @@ class OperationTests(OperationTestBase):
         create_book = migrations.CreateModel(
             "Book",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("title", models.CharField(max_length=100)),
                 ("author", models.ForeignKey("test_authors.Author", models.CASCADE))
             ],
@@ -2123,7 +2129,7 @@ class OperationTests(OperationTestBase):
             create_old_man.state_forwards("test_books", new_state)
             create_old_man.database_forwards("test_books", editor, project_state, new_state)
 
-    def test_model_with_bigautofield(self):
+    def test_model_with_BigAutoField(self):
         """
         A model with BigAutoField can be created.
         """
@@ -2175,9 +2181,9 @@ class OperationTests(OperationTestBase):
             fill_data.state_forwards("fill_data", new_state)
             fill_data.database_forwards("fill_data", editor, project_state, new_state)
 
-    def test_autofield_foreignfield_growth(self):
+    def test_BigAutoField_foreignfield_growth(self):
         """
-        A field may be migrated from AutoField to BigAutoField.
+        A field may be migrated from BigAutoField to BigAutoField.
         """
         def create_initial_data(models, schema_editor):
             Article = models.get_model("test_article", "Article")
@@ -2196,7 +2202,7 @@ class OperationTests(OperationTestBase):
         create_blog = migrations.CreateModel(
             "Blog",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=100)),
             ],
             options={},
@@ -2204,7 +2210,7 @@ class OperationTests(OperationTestBase):
         create_article = migrations.CreateModel(
             "Article",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("blog", models.ForeignKey(to="test_blog.Blog", on_delete=models.CASCADE)),
                 ("name", models.CharField(max_length=100)),
                 ("data", models.TextField(default="")),
@@ -2283,7 +2289,7 @@ class OperationTests(OperationTestBase):
             "CREATE TABLE i_love_ponies (id int, special_thing int);",
             "DROP TABLE i_love_ponies;"
         )
-        state_operation = migrations.CreateModel("SomethingElse", [("id", models.AutoField(primary_key=True))])
+        state_operation = migrations.CreateModel("SomethingElse", [("id", models.BigAutoField(primary_key=True))])
         operation = migrations.SeparateDatabaseAndState(
             state_operations=[state_operation],
             database_operations=[database_operation]
@@ -2322,34 +2328,34 @@ class OperationTests(OperationTestBase):
         database_operations = [
             migrations.CreateModel(
                 "ILovePonies",
-                [("id", models.AutoField(primary_key=True))],
+                [("id", models.BigAutoField(primary_key=True))],
                 options={"db_table": "iloveponies"},
             ),
             migrations.CreateModel(
                 "ILoveMorePonies",
-                # We use IntegerField and not AutoField because
+                # We use IntegerField and not BigAutoField because
                 # the model is going to be deleted immediately
-                # and with an AutoField this fails on Oracle
+                # and with an BigAutoField this fails on Oracle
                 [("id", models.IntegerField(primary_key=True))],
                 options={"db_table": "ilovemoreponies"},
             ),
             migrations.DeleteModel("ILoveMorePonies"),
             migrations.CreateModel(
                 "ILoveEvenMorePonies",
-                [("id", models.AutoField(primary_key=True))],
+                [("id", models.BigAutoField(primary_key=True))],
                 options={"db_table": "iloveevenmoreponies"},
             ),
         ]
         state_operations = [
             migrations.CreateModel(
                 "SomethingElse",
-                [("id", models.AutoField(primary_key=True))],
+                [("id", models.BigAutoField(primary_key=True))],
                 options={"db_table": "somethingelse"},
             ),
             migrations.DeleteModel("SomethingElse"),
             migrations.CreateModel(
                 "SomethingCompletelyDifferent",
-                [("id", models.AutoField(primary_key=True))],
+                [("id", models.BigAutoField(primary_key=True))],
                 options={"db_table": "somethingcompletelydifferent"},
             ),
         ]
@@ -2407,7 +2413,7 @@ class SwappableOperationTests(OperationTestBase):
         operation = migrations.CreateModel(
             "Pony",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("pink", models.IntegerField(default=1)),
             ],
             options={

--- a/tests/migrations/test_state.py
+++ b/tests/migrations/test_state.py
@@ -324,7 +324,7 @@ class StateTests(SimpleTestCase):
             app_label="migrations",
             name="Tag",
             fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=100)),
                 ("hidden", models.BooleanField()),
             ],
@@ -353,7 +353,7 @@ class StateTests(SimpleTestCase):
             app_label="migrations",
             name="Food",
             fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
             ],
             managers=[
                 # The ordering we really want is objects, mgr1, mgr2
@@ -693,7 +693,7 @@ class StateTests(SimpleTestCase):
             "migrations",
             "Tag",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=100)),
                 ("hidden", models.BooleanField()),
             ],
@@ -714,7 +714,7 @@ class StateTests(SimpleTestCase):
             "migrations",
             "Tag",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=99)),
                 ("hidden", models.BooleanField()),
             ],
@@ -873,7 +873,7 @@ class StateTests(SimpleTestCase):
             app_label="migrations",
             name="Tag",
             fields=[
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("hidden", models.BooleanField()),
             ],
             managers=[

--- a/tests/migrations2/test_migrations_2/0001_initial.py
+++ b/tests/migrations2/test_migrations_2/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "OtherAuthor",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),

--- a/tests/migrations2/test_migrations_2_first/0001_initial.py
+++ b/tests/migrations2/test_migrations_2_first/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "OtherAuthor",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),

--- a/tests/migrations2/test_migrations_2_first/0002_second.py
+++ b/tests/migrations2/test_migrations_2_first/0002_second.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "Bookstore",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
             ],

--- a/tests/migrations2/test_migrations_2_no_deps/0001_initial.py
+++ b/tests/migrations2/test_migrations_2_no_deps/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             "OtherAuthor",
             [
-                ("id", models.AutoField(primary_key=True)),
+                ("id", models.BigAutoField(primary_key=True)),
                 ("name", models.CharField(max_length=255)),
                 ("slug", models.SlugField(null=True)),
                 ("age", models.IntegerField(default=0)),

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -158,7 +158,7 @@ class RenamedField(models.Model):
 
 
 class VerboseNameField(models.Model):
-    id = models.AutoField("verbose pk", primary_key=True)
+    id = models.BigAutoField("verbose pk", primary_key=True)
     field1 = models.BigIntegerField("verbose field1")
     field2 = models.BooleanField("verbose field2", default=False)
     field3 = models.CharField("verbose field3", max_length=10)

--- a/tests/model_fields/test_promises.py
+++ b/tests/model_fields/test_promises.py
@@ -2,11 +2,11 @@ import datetime
 from decimal import Decimal
 
 from django.db.models.fields import (
-    BigAutoField, BinaryField, BooleanField, CharField, DateField, DateTimeField,
-    DecimalField, EmailField, FilePathField, FloatField, GenericIPAddressField,
-    IntegerField, IPAddressField, NullBooleanField, PositiveIntegerField,
-    PositiveSmallIntegerField, SmallIntegerField, SlugField, TextField,
-    TimeField, URLField,
+    BigAutoField, BinaryField, BooleanField, CharField, DateField,
+    DateTimeField, DecimalField, EmailField, FilePathField,
+    FloatField, GenericIPAddressField, IntegerField, IPAddressField,
+    NullBooleanField, PositiveIntegerField, PositiveSmallIntegerField,
+    SlugField, SmallIntegerField, TextField, TimeField, URLField
 )
 from django.db.models.fields.files import FileField, ImageField
 from django.test import SimpleTestCase

--- a/tests/model_fields/test_promises.py
+++ b/tests/model_fields/test_promises.py
@@ -2,7 +2,7 @@ import datetime
 from decimal import Decimal
 
 from django.db.models.fields import (
-    AutoField, BinaryField, BooleanField, CharField, DateField, DateTimeField,
+    BigAutoField, BinaryField, BooleanField, CharField, DateField, DateTimeField,
     DecimalField, EmailField, FilePathField, FloatField, GenericIPAddressField,
     IntegerField, IPAddressField, NullBooleanField, PositiveIntegerField,
     PositiveSmallIntegerField, SlugField, SmallIntegerField, TextField,
@@ -15,9 +15,9 @@ from django.utils.functional import lazy
 
 class PromiseTest(SimpleTestCase):
 
-    def test_AutoField(self):
+    def test_BigAutoField(self):
         lazy_func = lazy(lambda: 1, int)
-        self.assertIsInstance(AutoField(primary_key=True).get_prep_value(lazy_func()), int)
+        self.assertIsInstance(BigAutoField(primary_key=True).get_prep_value(lazy_func()), int)
 
     def test_BinaryField(self):
         lazy_func = lazy(lambda: b'', bytes)

--- a/tests/model_fields/test_promises.py
+++ b/tests/model_fields/test_promises.py
@@ -3,10 +3,10 @@ from decimal import Decimal
 
 from django.db.models.fields import (
     BigAutoField, BinaryField, BooleanField, CharField, DateField,
-    DateTimeField, DecimalField, EmailField, FilePathField,
-    FloatField, GenericIPAddressField, IntegerField, IPAddressField,
-    NullBooleanField, PositiveIntegerField, PositiveSmallIntegerField,
-    SlugField, SmallIntegerField, TextField, TimeField, URLField
+    DateTimeField, DecimalField, EmailField, FilePathField, FloatField,
+    GenericIPAddressField, IntegerField, IPAddressField, NullBooleanField,
+    PositiveIntegerField, PositiveSmallIntegerField, SlugField,
+    SmallIntegerField, TextField, TimeField, URLField,
 )
 from django.db.models.fields.files import FileField, ImageField
 from django.test import SimpleTestCase

--- a/tests/model_fields/test_promises.py
+++ b/tests/model_fields/test_promises.py
@@ -5,7 +5,7 @@ from django.db.models.fields import (
     BigAutoField, BinaryField, BooleanField, CharField, DateField, DateTimeField,
     DecimalField, EmailField, FilePathField, FloatField, GenericIPAddressField,
     IntegerField, IPAddressField, NullBooleanField, PositiveIntegerField,
-    PositiveSmallIntegerField, SlugField, SmallIntegerField, TextField,
+    PositiveSmallIntegerField, SmallIntegerField, SlugField, TextField,
     TimeField, URLField,
 )
 from django.db.models.fields.files import FileField, ImageField

--- a/tests/model_formsets/models.py
+++ b/tests/model_formsets/models.py
@@ -97,7 +97,7 @@ class Place(models.Model):
 
 
 class Owner(models.Model):
-    auto_id = models.AutoField(primary_key=True)
+    auto_id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=100)
     place = models.ForeignKey(Place, models.CASCADE)
 

--- a/tests/model_formsets/test_uuid.py
+++ b/tests/model_formsets/test_uuid.py
@@ -41,7 +41,7 @@ class InlineFormsetTests(TestCase):
         """
         #24958 - Variant of test_inlineformset_factory_nulls_default_pks for
         the case of a parent object with a UUID primary key and a child object
-        with an AutoField primary key.
+        with an BigAutoField primary key.
         """
         FormSet = inlineformset_factory(UUIDPKParent, AutoPKChildOfUUIDPKParent, fields='__all__')
         formset = FormSet()
@@ -50,7 +50,7 @@ class InlineFormsetTests(TestCase):
     def test_inlineformset_factory_nulls_default_pks_auto_parent_uuid_child(self):
         """
         #24958 - Variant of test_inlineformset_factory_nulls_default_pks for
-        the case of a parent object with an AutoField primary key and a child
+        the case of a parent object with an BigAutoField primary key and a child
         object with a UUID primary key.
         """
         FormSet = inlineformset_factory(AutoPKParent, UUIDPKChildOfAutoPKParent, fields='__all__')

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -791,7 +791,7 @@ class ModelFormsetTest(TestCase):
 
     def test_inline_formsets_with_multi_table_inheritance(self):
         # Test inline formsets where the inline-edited object uses multi-table
-        # inheritance, thus has a non AutoField yet auto-created primary key.
+        # inheritance, thus has a non BigAutoField yet auto-created primary key.
 
         AuthorBooksFormSet3 = inlineformset_factory(Author, AlternateBook, can_delete=False, extra=1, fields="__all__")
         author = Author.objects.create(pk=1, name='Charles Baudelaire')
@@ -1045,7 +1045,7 @@ class ModelFormsetTest(TestCase):
             '<input id="id_form-0-some_field" type="text" name="form-0-some_field" maxlength="100" /></p>'
         )
 
-        # Custom primary keys with ForeignKey, OneToOneField and AutoField ############
+        # Custom primary keys with ForeignKey, OneToOneField and BigAutoField ############
 
         place = Place.objects.create(pk=1, name='Giordanos', city='Chicago')
 

--- a/tests/model_inheritance/test_abstract_inheritance.py
+++ b/tests/model_inheritance/test_abstract_inheritance.py
@@ -331,21 +331,21 @@ class AbstractInheritanceTests(TestCase):
 
         self.assertEqual(
             fields(model1),
-            [('id', models.AutoField), ('name', models.CharField), ('age', models.IntegerField)]
+            [('id', models.BigAutoField), ('name', models.CharField), ('age', models.IntegerField)]
         )
 
-        self.assertEqual(fields(model2), [('id', models.AutoField), ('name', models.CharField)])
+        self.assertEqual(fields(model2), [('id', models.BigAutoField), ('name', models.CharField)])
         self.assertEqual(getattr(model2, 'age'), 2)
 
-        self.assertEqual(fields(model3), [('id', models.AutoField), ('name', models.CharField)])
+        self.assertEqual(fields(model3), [('id', models.BigAutoField), ('name', models.CharField)])
 
-        self.assertEqual(fields(model4), [('id', models.AutoField), ('name', models.CharField)])
+        self.assertEqual(fields(model4), [('id', models.BigAutoField), ('name', models.CharField)])
         self.assertEqual(getattr(model4, 'age'), 2)
 
         self.assertEqual(
             fields(model5),
             [
-                ('id', models.AutoField), ('foo', models.IntegerField),
+                ('id', models.BigAutoField), ('foo', models.IntegerField),
                 ('concretemodel_ptr', models.OneToOneField),
                 ('age', models.SmallIntegerField), ('concretemodel2_ptr', models.OneToOneField),
                 ('name', models.CharField),

--- a/tests/model_inheritance_regress/models.py
+++ b/tests/model_inheritance_regress/models.py
@@ -40,7 +40,7 @@ class ParkingLot(Place):
 
 class ParkingLot3(Place):
     # The parent_link connector need not be the pk on the model.
-    primary_key = models.AutoField(primary_key=True)
+    primary_key = models.BigAutoField(primary_key=True)
     parent = models.OneToOneField(Place, models.CASCADE, parent_link=True)
 
 
@@ -216,13 +216,13 @@ class User(models.Model):
 
 
 class Profile(User):
-    profile_id = models.AutoField(primary_key=True)
+    profile_id = models.BigAutoField(primary_key=True)
     extra = models.CharField(max_length=30, blank=True)
 
 
 # Check concrete + concrete -> concrete -> concrete
 class Politician(models.Model):
-    politician_id = models.AutoField(primary_key=True)
+    politician_id = models.BigAutoField(primary_key=True)
     title = models.CharField(max_length=50)
 
 

--- a/tests/model_meta/test_removedindjango21.py
+++ b/tests/model_meta/test_removedindjango21.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase
 from .models import Person
 
 
-class HasAutoFieldTests(SimpleTestCase):
+class HasBigAutoFieldTests(SimpleTestCase):
 
     def test_get_warns(self):
         with warnings.catch_warnings(record=True) as warns:

--- a/tests/model_regress/models.py
+++ b/tests/model_regress/models.py
@@ -23,8 +23,8 @@ class Article(models.Model):
 
 
 class Movie(models.Model):
-    # Test models with non-default primary keys / AutoFields #5218
-    movie_id = models.AutoField(primary_key=True)
+    # Test models with non-default primary keys / BigAutoFields #5218
+    movie_id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=60)
 
 

--- a/tests/postgres_tests/array_default_migrations/0001_initial.py
+++ b/tests/postgres_tests/array_default_migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IntegerArrayDefaultModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', django.contrib.postgres.fields.ArrayField(models.IntegerField(), size=None)),
             ],
             options={

--- a/tests/postgres_tests/array_index_migrations/0001_initial.py
+++ b/tests/postgres_tests/array_index_migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CharTextArrayIndexModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('char', django.contrib.postgres.fields.ArrayField(
                     models.CharField(max_length=10), db_index=True, size=100)
                  ),

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CharArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', ArrayField(models.CharField(max_length=10), size=None)),
             ],
             options={
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='DateTimeArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('datetimes', ArrayField(models.DateTimeField(), size=None)),
                 ('dates', ArrayField(models.DateField(), size=None)),
                 ('times', ArrayField(models.TimeField(), size=None)),
@@ -43,7 +43,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='HStoreModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', HStoreField(blank=True, null=True)),
                 ('array_field', ArrayField(HStoreField(), null=True)),
             ],
@@ -55,7 +55,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='OtherTypesArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('ips', ArrayField(models.GenericIPAddressField(), size=None)),
                 ('uuids', ArrayField(models.UUIDField(), size=None)),
                 ('decimals', ArrayField(models.DecimalField(max_digits=5, decimal_places=2), size=None)),
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='IntegerArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', ArrayField(models.IntegerField(), size=None)),
             ],
             options={
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='NestedIntegerArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', ArrayField(ArrayField(models.IntegerField(), size=None), size=None)),
             ],
             options={
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='NullableIntegerArrayModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', ArrayField(models.IntegerField(), size=None, null=True, blank=True)),
             ],
             options={
@@ -102,7 +102,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CharFieldModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', models.CharField(max_length=16)),
             ],
             options=None,
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TextFieldModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', models.TextField()),
             ],
             options=None,
@@ -120,7 +120,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Scene',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('scene', models.CharField(max_length=255)),
                 ('setting', models.CharField(max_length=255)),
             ],
@@ -130,7 +130,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Character',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=255)),
             ],
             options=None,
@@ -152,7 +152,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Line',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('scene', models.ForeignKey('postgres_tests.Scene', on_delete=models.SET_NULL)),
                 ('character', models.ForeignKey('postgres_tests.Character', on_delete=models.SET_NULL)),
                 ('dialogue', models.TextField(blank=True, null=True)),
@@ -167,7 +167,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='AggregateTestModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('boolean_field', models.NullBooleanField()),
                 ('char_field', models.CharField(max_length=30, blank=True)),
                 ('integer_field', models.IntegerField(null=True)),
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='StatTestModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('int1', models.IntegerField()),
                 ('int2', models.IntegerField()),
                 ('related_field', models.ForeignKey(
@@ -189,21 +189,21 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='NowTestModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('when', models.DateTimeField(null=True, default=None)),
             ]
         ),
         migrations.CreateModel(
             name='UUIDTestModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('uuid', models.UUIDField(default=None, null=True)),
             ]
         ),
         migrations.CreateModel(
             name='RangesModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('ints', IntegerRangeField(null=True, blank=True)),
                 ('bigints', BigIntegerRangeField(null=True, blank=True)),
                 ('floats', FloatRangeField(null=True, blank=True)),
@@ -237,7 +237,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='JSONModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('field', JSONField(null=True, blank=True)),
                 ('field_custom', JSONField(null=True, blank=True, encoder=DjangoJSONEncoder)),
             ],

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -624,13 +624,13 @@ class StaffUser(BaseUser):
 
 
 class Ticket21203Parent(models.Model):
-    parentid = models.AutoField(primary_key=True)
+    parentid = models.BigAutoField(primary_key=True)
     parent_bool = models.BooleanField(default=True)
     created = models.DateTimeField(auto_now=True)
 
 
 class Ticket21203Child(models.Model):
-    childid = models.AutoField(primary_key=True)
+    childid = models.BigAutoField(primary_key=True)
     parent = models.ForeignKey(Ticket21203Parent, models.CASCADE)
 
 

--- a/tests/raw_query/models.py
+++ b/tests/raw_query/models.py
@@ -33,7 +33,7 @@ class Coffee(models.Model):
 
 
 class MixedCaseIDColumn(models.Model):
-    id = models.AutoField(primary_key=True, db_column='MiXeD_CaSe_Id')
+    id = models.BigAutoField(primary_key=True, db_column='MiXeD_CaSe_Id')
 
 
 class Reviewer(models.Model):

--- a/tests/schema/models.py
+++ b/tests/schema/models.py
@@ -200,7 +200,7 @@ class UniqueTest(models.Model):
 
 
 class Node(models.Model):
-    node_id = models.AutoField(primary_key=True)
+    node_id = models.BigAutoField(primary_key=True)
     parent = models.ForeignKey('self', models.CASCADE, null=True, blank=True)
 
     class Meta:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -12,7 +12,7 @@ from django.db.models.deletion import CASCADE, PROTECT
 from django.db.models.fields import (
     BigAutoField, BigIntegerField, BinaryField, BooleanField, CharField,
     DateField, DateTimeField, IntegerField, PositiveIntegerField, SlugField,
-    TextField, TimeField,
+    SmallAutoField, TextField, TimeField,
 )
 from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
@@ -1054,16 +1054,16 @@ class SchemaTests(TransactionTestCase):
         Author.objects.create(name='Foo')
         Author.objects.create(name='Bar')
 
-    def test_alter_int_pk_to_BigAutoField_pk(self):
+    def test_alter_int_pk_to_SmallAutoField_pk(self):
         """
         Should be able to rename an IntegerField(primary_key=True) to
-        BigAutoField(primary_key=True).
+        SmallAutoField(primary_key=True).
         """
         with connection.schema_editor() as editor:
             editor.create_model(IntegerPK)
 
         old_field = IntegerPK._meta.get_field('i')
-        new_field = BigAutoField(primary_key=True)
+        new_field = SmallAutoField(primary_key=True)
         new_field.model = IntegerPK
         new_field.set_attributes_from_name('i')
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1070,7 +1070,7 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.alter_field(IntegerPK, old_field, new_field, strict=True)
 
-    def test_alter_int_pk_to_BigAutoField_pk(self):
+    def test_alter_int_pk_to_bigautofield_pk(self):
         """
         Should be able to rename an IntegerField(primary_key=True) to
         BigAutoField(primary_key=True).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -10,7 +10,7 @@ from django.db import (
 from django.db.models import Model
 from django.db.models.deletion import CASCADE, PROTECT
 from django.db.models.fields import (
-    AutoField, BigAutoField, BigIntegerField, BinaryField, BooleanField,
+    BigAutoField, BigAutoField, BigIntegerField, BinaryField, BooleanField,
     CharField, DateField, DateTimeField, IntegerField, PositiveIntegerField,
     SlugField, TextField, TimeField,
 )
@@ -579,7 +579,7 @@ class SchemaTests(TransactionTestCase):
         # Create the table
         with connection.schema_editor() as editor:
             editor.create_model(Author)
-        # Change AutoField to IntegerField
+        # Change BigAutoField to IntegerField
         old_field = Author._meta.get_field('id')
         new_field = IntegerField(primary_key=True)
         new_field.set_attributes_from_name('id')
@@ -591,7 +591,7 @@ class SchemaTests(TransactionTestCase):
         # Create the table
         with connection.schema_editor() as editor:
             editor.create_model(Author)
-        # Change AutoField to CharField
+        # Change BigAutoField to CharField
         old_field = Author._meta.get_field('id')
         new_field = CharField(primary_key=True, max_length=50)
         new_field.set_attributes_from_name('id')
@@ -1044,7 +1044,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Author)
 
         old_field = Author._meta.get_field("id")
-        new_field = AutoField(primary_key=True)
+        new_field = BigAutoField(primary_key=True)
         new_field.set_attributes_from_name("id")
         new_field.model = Author
         with connection.schema_editor() as editor:
@@ -1054,23 +1054,23 @@ class SchemaTests(TransactionTestCase):
         Author.objects.create(name='Foo')
         Author.objects.create(name='Bar')
 
-    def test_alter_int_pk_to_autofield_pk(self):
+    def test_alter_int_pk_to_BigAutoField_pk(self):
         """
         Should be able to rename an IntegerField(primary_key=True) to
-        AutoField(primary_key=True).
+        BigAutoField(primary_key=True).
         """
         with connection.schema_editor() as editor:
             editor.create_model(IntegerPK)
 
         old_field = IntegerPK._meta.get_field('i')
-        new_field = AutoField(primary_key=True)
+        new_field = BigAutoField(primary_key=True)
         new_field.model = IntegerPK
         new_field.set_attributes_from_name('i')
 
         with connection.schema_editor() as editor:
             editor.alter_field(IntegerPK, old_field, new_field, strict=True)
 
-    def test_alter_int_pk_to_bigautofield_pk(self):
+    def test_alter_int_pk_to_BigAutoField_pk(self):
         """
         Should be able to rename an IntegerField(primary_key=True) to
         BigAutoField(primary_key=True).
@@ -2307,7 +2307,7 @@ class SchemaTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.create_model(Node)
         old_field = Node._meta.get_field('node_id')
-        new_field = AutoField(primary_key=True)
+        new_field = BigAutoField(primary_key=True)
         new_field.set_attributes_from_name('id')
         with connection.schema_editor() as editor:
             editor.alter_field(Node, old_field, new_field, strict=True)

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -801,7 +801,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Book)
         # Ensure the field is right to begin with
         columns = self.column_classes(Book)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         self.assertForeignKeyExists(Book, 'author_id', 'schema_author')
         # Alter the FK
         old_field = Book._meta.get_field("author")
@@ -811,7 +811,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Book, old_field, new_field, strict=True)
         # Ensure the field is right afterwards
         columns = self.column_classes(Book)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         self.assertForeignKeyExists(Book, 'author_id', 'schema_author')
 
     @skipUnlessDBFeature('supports_foreign_keys')
@@ -857,7 +857,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(BookWithO2O)
         # Ensure the field is right to begin with
         columns = self.column_classes(BookWithO2O)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         # Ensure the field is unique
         author = Author.objects.create(name="Joe")
         BookWithO2O.objects.create(author=author, title="Django 1", pub_date=datetime.datetime.now())
@@ -873,7 +873,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(BookWithO2O, old_field, new_field, strict=True)
         # Ensure the field is right afterwards
         columns = self.column_classes(Book)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         # Ensure the field is not unique anymore
         Book.objects.create(author=author, title="Django 1", pub_date=datetime.datetime.now())
         Book.objects.create(author=author, title="Django 2", pub_date=datetime.datetime.now())
@@ -890,7 +890,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(Book)
         # Ensure the field is right to begin with
         columns = self.column_classes(Book)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         # Ensure the field is not unique
         author = Author.objects.create(name="Joe")
         Book.objects.create(author=author, title="Django 1", pub_date=datetime.datetime.now())
@@ -905,7 +905,7 @@ class SchemaTests(TransactionTestCase):
             editor.alter_field(Book, old_field, new_field, strict=True)
         # Ensure the field is right afterwards
         columns = self.column_classes(BookWithO2O)
-        self.assertEqual(columns['author_id'][0], "IntegerField")
+        self.assertEqual(columns['author_id'][0], "BigIntegerField")
         # Ensure the field is unique now
         BookWithO2O.objects.create(author=author, title="Django 1", pub_date=datetime.datetime.now())
         with self.assertRaises(IntegrityError):
@@ -1188,7 +1188,7 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(LocalBookWithM2M)
         # Ensure there is now an m2m table there
         columns = self.column_classes(LocalBookWithM2M._meta.get_field("tags").remote_field.through)
-        self.assertEqual(columns['tagm2mtest_id'][0], "IntegerField")
+        self.assertEqual(columns['tagm2mtest_id'][0], "BigIntegerField")
 
     def test_m2m_create(self):
         self._test_m2m_create(ManyToManyField)
@@ -1227,8 +1227,8 @@ class SchemaTests(TransactionTestCase):
             editor.create_model(LocalBookWithM2MThrough)
         # Ensure there is now an m2m table there
         columns = self.column_classes(LocalTagThrough)
-        self.assertEqual(columns['book_id'][0], "IntegerField")
-        self.assertEqual(columns['tag_id'][0], "IntegerField")
+        self.assertEqual(columns['book_id'][0], "BigIntegerField")
+        self.assertEqual(columns['tag_id'][0], "BigIntegerField")
 
     def test_m2m_create_through(self):
         self._test_m2m_create_through(ManyToManyField)
@@ -1267,7 +1267,7 @@ class SchemaTests(TransactionTestCase):
             editor.add_field(LocalAuthorWithM2M, new_field)
         # Ensure there is now an m2m table there
         columns = self.column_classes(new_field.remote_field.through)
-        self.assertEqual(columns['tagm2mtest_id'][0], "IntegerField")
+        self.assertEqual(columns['tagm2mtest_id'][0], "BigIntegerField")
 
         # "Alter" the field. This should not rename the DB table to itself.
         with connection.schema_editor() as editor:

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -1054,7 +1054,7 @@ class SchemaTests(TransactionTestCase):
         Author.objects.create(name='Foo')
         Author.objects.create(name='Bar')
 
-    def test_alter_int_pk_to_SmallAutoField_pk(self):
+    def test_alter_int_pk_to_small_authfield_pk(self):
         """
         Should be able to rename an IntegerField(primary_key=True) to
         SmallAutoField(primary_key=True).

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -10,9 +10,9 @@ from django.db import (
 from django.db.models import Model
 from django.db.models.deletion import CASCADE, PROTECT
 from django.db.models.fields import (
-    BigAutoField, BigAutoField, BigIntegerField, BinaryField, BooleanField,
-    CharField, DateField, DateTimeField, IntegerField, PositiveIntegerField,
-    SlugField, TextField, TimeField,
+    BigAutoField, BigIntegerField, BinaryField, BooleanField, CharField,
+    DateField, DateTimeField, IntegerField, PositiveIntegerField, SlugField,
+    TextField, TimeField,
 )
 from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,

--- a/tests/select_related_onetoone/models.py
+++ b/tests/select_related_onetoone/models.py
@@ -64,7 +64,7 @@ class Parent1(models.Model):
 
 class Parent2(models.Model):
     # Avoid having two "id" fields in the Child1 subclass
-    id2 = models.AutoField(primary_key=True)
+    id2 = models.BigAutoField(primary_key=True)
     name2 = models.CharField(max_length=50)
 
     def __str__(self):

--- a/tests/sites_framework/migrations/0001_initial.py
+++ b/tests/sites_framework/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='CustomArticle',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=50)),
                 ('places_this_article_should_appear', models.ForeignKey('sites.Site', models.CASCADE)),
             ],
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ExclusiveArticle',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=50)),
                 ('site', models.ForeignKey('sites.Site', models.CASCADE)),
             ],
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SyndicatedArticle',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(max_length=50)),
                 ('sites', models.ManyToManyField('sites.Site')),
             ],

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -331,7 +331,7 @@ class AutoIncrementResetTest(TransactionTestCase):
     """
     Here we test creating the same model two times in different test methods,
     and check that both times they get "1" as their PK value. That is, we test
-    that AutoField values start from 1 for each transactional test case.
+    that BigAutoField values start from 1 for each transactional test case.
     """
 
     available_apps = ['test_runner']

--- a/tests/validation/models.py
+++ b/tests/validation/models.py
@@ -121,13 +121,13 @@ class GenericIPAddrUnpackUniqueTest(models.Model):
     generic_v4unpack_ip = models.GenericIPAddressField(null=True, blank=True, unique=True, unpack_ipv4=True)
 
 
-# A model can't have multiple AutoFields
+# A model can't have multiple BigAutoFields
 # Refs #12467.
 assertion_error = None
 try:
-    class MultipleAutoFields(models.Model):
-        auto1 = models.AutoField(primary_key=True)
-        auto2 = models.AutoField(primary_key=True)
+    class MultipleBigAutoFields(models.Model):
+        auto1 = models.BigAutoField(primary_key=True)
+        auto2 = models.BigAutoField(primary_key=True)
 except AssertionError as exc:
     assertion_error = exc
 assert str(assertion_error) == "A model can't have more than one AutoField."

--- a/tests/validation/test_error_messages.py
+++ b/tests/validation/test_error_messages.py
@@ -11,8 +11,8 @@ class ValidationMessagesTest(TestCase):
             field.clean(value, None)
         self.assertEqual(cm.exception.messages, expected)
 
-    def test_autofield_field_raises_error_message(self):
-        f = models.AutoField(primary_key=True)
+    def test_BigAutoField_field_raises_error_message(self):
+        f = models.BigAutoField(primary_key=True)
         self._test_validation_messages(f, 'fõo', ["'fõo' value must be an integer."])
 
     def test_integer_field_raises_error_message(self):


### PR DESCRIPTION
This pull request uses bigints (`BigAutoField`) as the new default for auto created primary keys in Django applications. 

- New applications will use `BigAutoField` by default, instead of `AutoField`. 
- `SmallAutoField` is introduced, and `AutoField` is aliased to it, for later deprecation. 
- Migration path is to warn about the expensive migration, and guide the user to hardcode their models to the new `SmallAutoField`, if desired (and to the release notes). 

Discussed at length with @andrewgodwin, and paired with him on this. 

Tests are all passing locally. 