### PR TITLE
Fixed #27515 -- Made AuthenticationForm's username field use the max_length from the model field.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -478,6 +478,7 @@ answer newbie questions, and generally made Django that much better:
     Loïc Bistuer <loic.bistuer@sixmedia.com>
     Lowe Thiderman <lowe.thiderman@gmail.com>
     Luan Pablo <luanpab@gmail.com>
+    Lucas Connors <http://www.revolutiontech.ca>
     Luciano Ramalho
     Ludvig Ericson <ludvig.ericson@gmail.com>
     Luis C. Berrocal <luis.berrocal.1942@gmail.com>

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -155,10 +155,7 @@ class AuthenticationForm(forms.Form):
     Base class for authenticating users. Extend this to get a form that accepts
     username/password logins.
     """
-    username = UsernameField(
-        max_length=254,
-        widget=forms.TextInput(attrs={'autofocus': True}),
-    )
+    username = UsernameField(widget=forms.TextInput(attrs={'autofocus': True}))
     password = forms.CharField(
         label=_("Password"),
         strip=False,
@@ -182,8 +179,9 @@ class AuthenticationForm(forms.Form):
         self.user_cache = None
         super().__init__(*args, **kwargs)
 
-        # Set the label for the "username" field.
+        # Set the max length and label for the "username" field.
         self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)
+        self.fields['username'].max_length = self.username_field.max_length or 254
         if self.fields['username'].label is None:
             self.fields['username'].label = capfirst(self.username_field.verbose_name)
 

--- a/tests/auth_tests/models/with_custom_email_field.py
+++ b/tests/auth_tests/models/with_custom_email_field.py
@@ -19,5 +19,6 @@ class CustomEmailField(AbstractBaseUser):
     is_active = models.BooleanField(default=True)
 
     EMAIL_FIELD = 'email_address'
+    USERNAME_FIELD = 'username'
 
     objects = CustomEmailFieldUserManager()

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -377,6 +377,19 @@ class AuthenticationFormTest(TestDataMixin, TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(form.non_field_errors(), [])
 
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomEmailField')
+    def test_username_field_max_length_matches_user_model(self):
+        self.assertEqual(CustomEmailField._meta.get_field('username').max_length, 255)
+        data = {
+            'username': 'u' * 255,
+            'password': 'pwd',
+            'email': 'test@example.com',
+        }
+        CustomEmailField.objects.create_user(**data)
+        form = AuthenticationForm(None, data)
+        self.assertEqual(form.fields['username'].max_length, 255)
+        self.assertEqual(form.errors, {})
+
     @override_settings(AUTH_USER_MODEL='auth_tests.IntegerUsernameUser')
     def test_username_field_max_length_defaults_to_254(self):
         self.assertIsNone(IntegerUsernameUser._meta.get_field('username').max_length)


### PR DESCRIPTION
so that `max_length` respects the max length of the user model being used, rather than using a hardcoded value of 254.

Thanks Ramin Farajpour Cami for reporting.