### PR TITLE
Fixed #28050 - Added template path to TemplateSyntaxError exception.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -441,6 +441,7 @@ answer newbie questions, and generally made Django that much better:
     Keith Bussell <kbussell@gmail.com>
     Kenneth Love <kennethlove@gmail.com>
     Kent Hauser <kent@khauser.net>
+    Kevin Grinberg <kevin@kevingrinberg.com>
     Kevin Kubasik <kevin@kubasik.net>
     Kevin McConnell <kevin.mcconnell@gmail.com>
     Kieran Holland <http://www.kieranholland.com>

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -627,8 +627,8 @@ class ModelAdmin(BaseModelAdmin):
         exclude = exclude or None
 
         # Remove declared form fields which are in readonly_fields.
-        new_attrs = OrderedDict(
-            (f, None) for f in readonly_fields
+        new_attrs = OrderedDict.fromkeys(
+            f for f in readonly_fields
             if f in self.form.declared_fields
         )
         form = type(self.form.__name__, (self.form,), new_attrs)

--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -169,7 +169,7 @@ class AdminSite:
         """
         Get all the enabled actions as an iterable of (name, func).
         """
-        return iter(self._actions.items())
+        return self._actions.items()
 
     @property
     def empty_value_display(self):

--- a/django/contrib/auth/views.py
+++ b/django/contrib/auth/views.py
@@ -133,6 +133,10 @@ class LogoutView(SuccessURLAllowedHostsMixin, TemplateView):
             return HttpResponseRedirect(next_page)
         return super().dispatch(request, *args, **kwargs)
 
+    def post(self, request, *args, **kwargs):
+        """Logout may be done via POST."""
+        return self.get(request, *args, **kwargs)
+
     def get_next_page(self):
         if self.next_page is not None:
             next_page = resolve_url(self.next_page)

--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                                 len(objs),
                                 obj_type._meta.label,
                             ))
-                        content_type_display = '\n'.join(ct_info)
+                    content_type_display = '\n'.join(ct_info)
                     self.stdout.write("""Some content types in your database are stale and can be deleted.
 Any objects that depend on these content types will also be deleted.
 The content types and dependent objects that would be deleted are:

--- a/django/contrib/gis/db/backends/mysql/features.py
+++ b/django/contrib/gis/db/backends/mysql/features.py
@@ -2,6 +2,7 @@ from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.mysql.features import (
     DatabaseFeatures as MySQLDatabaseFeatures,
 )
+from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
@@ -14,3 +15,7 @@ class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
     supports_real_shape_operations = False
     supports_null_geometries = False
     supports_num_points_poly = False
+
+    @cached_property
+    def supports_empty_geometry_collection(self):
+        return self.connection.mysql_version >= (5, 7, 5)

--- a/django/contrib/gis/db/backends/spatialite/operations.py
+++ b/django/contrib/gis/db/backends/spatialite/operations.py
@@ -17,6 +17,12 @@ from django.utils.functional import cached_property
 from django.utils.version import get_version_tuple
 
 
+class SpatialiteNullCheckOperator(SpatialOperator):
+    def as_sql(self, connection, lookup, template_params, sql_params):
+        sql, params = super().as_sql(connection, lookup, template_params, sql_params)
+        return '%s > 0' % sql, params
+
+
 class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
     name = 'spatialite'
     spatialite = True
@@ -33,15 +39,15 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
 
     gis_operators = {
         # Binary predicates
-        'equals': SpatialOperator(func='Equals'),
-        'disjoint': SpatialOperator(func='Disjoint'),
-        'touches': SpatialOperator(func='Touches'),
-        'crosses': SpatialOperator(func='Crosses'),
-        'within': SpatialOperator(func='Within'),
-        'overlaps': SpatialOperator(func='Overlaps'),
-        'contains': SpatialOperator(func='Contains'),
-        'intersects': SpatialOperator(func='Intersects'),
-        'relate': SpatialOperator(func='Relate'),
+        'equals': SpatialiteNullCheckOperator(func='Equals'),
+        'disjoint': SpatialiteNullCheckOperator(func='Disjoint'),
+        'touches': SpatialiteNullCheckOperator(func='Touches'),
+        'crosses': SpatialiteNullCheckOperator(func='Crosses'),
+        'within': SpatialiteNullCheckOperator(func='Within'),
+        'overlaps': SpatialiteNullCheckOperator(func='Overlaps'),
+        'contains': SpatialiteNullCheckOperator(func='Contains'),
+        'intersects': SpatialiteNullCheckOperator(func='Intersects'),
+        'relate': SpatialiteNullCheckOperator(func='Relate'),
         # Returns true if B's bounding box completely contains A's bounding box.
         'contained': SpatialOperator(func='MbrWithin'),
         # Returns true if A's bounding box completely contains B's bounding box.
@@ -49,8 +55,8 @@ class SpatiaLiteOperations(BaseSpatialOperations, DatabaseOperations):
         # Returns true if A's bounding box overlaps B's bounding box.
         'bboverlaps': SpatialOperator(func='MbrOverlaps'),
         # These are implemented here as synonyms for Equals
-        'same_as': SpatialOperator(func='Equals'),
-        'exact': SpatialOperator(func='Equals'),
+        'same_as': SpatialiteNullCheckOperator(func='Equals'),
+        'exact': SpatialiteNullCheckOperator(func='Equals'),
         # Distance predicates
         'dwithin': SpatialOperator(func='PtDistWithin'),
     }

--- a/django/contrib/gis/geoip2/base.py
+++ b/django/contrib/gis/geoip2/base.py
@@ -33,7 +33,7 @@ class GeoIP2:
     MODE_FILE = 4
     # Load database into memory. Pure Python.
     MODE_MEMORY = 8
-    cache_options = {opt: None for opt in (0, 1, 2, 4, 8)}
+    cache_options = frozenset((MODE_AUTO, MODE_MMAP_EXT, MODE_MMAP, MODE_FILE, MODE_MEMORY))
 
     # Paths to the city & country binary databases.
     _city_file = ''

--- a/django/contrib/gis/geos/collections.py
+++ b/django/contrib/gis/geos/collections.py
@@ -34,7 +34,7 @@ class GeometryCollection(GEOSGeometry):
         self._check_allowed(init_geoms)
 
         # Creating the geometry pointer array.
-        collection = self._create_collection(len(init_geoms), iter(init_geoms))
+        collection = self._create_collection(len(init_geoms), init_geoms)
         super().__init__(collection, **kwargs)
 
     def __iter__(self):

--- a/django/contrib/gis/geos/mutable_list.py
+++ b/django/contrib/gis/geos/mutable_list.py
@@ -252,14 +252,13 @@ class ListMixin:
     def _set_slice(self, index, values):
         "Assign values to a slice of the object"
         try:
-            iter(values)
+            valueList = list(values)
         except TypeError:
             raise TypeError('can only assign an iterable to a slice')
 
-        self._check_allowed(values)
+        self._check_allowed(valueList)
 
         origLen = len(self)
-        valueList = list(values)
         start, stop, step = index.indices(origLen)
 
         # CAREFUL: index.step and step are not the same!

--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -21,6 +21,11 @@ class StaticFilesHandler(WSGIHandler):
         self.base_url = urlparse(self.get_base_url())
         super().__init__()
 
+    def load_middleware(self):
+        # Middleware are already loaded for self.application; no need to reload
+        # them for self.
+        pass
+
     def get_base_url(self):
         utils.check_settings()
         return settings.STATIC_URL

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -21,8 +21,8 @@ class Tags:
 class CheckRegistry:
 
     def __init__(self):
-        self.registered_checks = []
-        self.deployment_checks = []
+        self.registered_checks = set()
+        self.deployment_checks = set()
 
     def register(self, check=None, *tags, **kwargs):
         """
@@ -44,11 +44,8 @@ class CheckRegistry:
 
         def inner(check):
             check.tags = tags
-            if kwargs['deploy']:
-                if check not in self.deployment_checks:
-                    self.deployment_checks.append(check)
-            elif check not in self.registered_checks:
-                self.registered_checks.append(check)
+            checks = self.deployment_checks if kwargs['deploy'] else self.registered_checks
+            checks.add(check)
             return check
 
         if callable(check):

--- a/django/core/checks/registry.py
+++ b/django/core/checks/registry.py
@@ -66,13 +66,11 @@ class CheckRegistry:
         checks = self.get_checks(include_deployment_checks)
 
         if tags is not None:
-            checks = [check for check in checks
-                      if hasattr(check, 'tags') and not set(check.tags).isdisjoint(tags)]
+            checks = [check for check in checks if not set(check.tags).isdisjoint(tags)]
         else:
             # By default, 'database'-tagged checks are not run as they do more
             # than mere static code analysis.
-            checks = [check for check in checks
-                      if not hasattr(check, 'tags') or Tags.database not in check.tags]
+            checks = [check for check in checks if Tags.database not in check.tags]
 
         for check in checks:
             new_errors = check(app_configs=app_configs)
@@ -88,7 +86,6 @@ class CheckRegistry:
     def tags_available(self, deployment_checks=False):
         return set(chain.from_iterable(
             check.tags for check in self.get_checks(deployment_checks)
-            if hasattr(check, 'tags')
         ))
 
     def get_checks(self, include_deployment_checks=False):

--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -87,8 +87,8 @@ class Command(BaseCommand):
         if len(app_labels) == 0:
             if primary_keys:
                 raise CommandError("You can only use --pks option with one model")
-            app_list = OrderedDict(
-                (app_config, None) for app_config in apps.get_app_configs()
+            app_list = OrderedDict.fromkeys(
+                app_config for app_config in apps.get_app_configs()
                 if app_config.models_module is not None and app_config not in excluded_apps
             )
         else:

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -518,8 +518,7 @@ END;
         AutoFields that aren't Oracle identity columns.
         """
         name_length = self.max_name_length() - 3
-        sequence_name = '%s_SQ' % strip_quotes(table)
-        return truncate_name(sequence_name, name_length).upper()
+        return '%s_SQ' % truncate_name(strip_quotes(table), name_length).upper()
 
     def _get_sequence_name(self, cursor, table, pk_name):
         cursor.execute("""

--- a/django/db/backends/postgresql_psycopg2/version.py
+++ b/django/db/backends/postgresql_psycopg2/version.py
@@ -1,1 +1,0 @@
-from ..postgresql.version import *  # NOQA

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -128,34 +128,34 @@ class MigrationAutodetector:
         # proxy models and ignoring unmigrated apps.
         self.old_apps = self.from_state.concrete_apps
         self.new_apps = self.to_state.apps
-        self.old_model_keys = []
-        self.old_proxy_keys = []
-        self.old_unmanaged_keys = []
-        self.new_model_keys = []
-        self.new_proxy_keys = []
-        self.new_unmanaged_keys = []
-        for al, mn in sorted(self.from_state.models):
+        self.old_model_keys = set()
+        self.old_proxy_keys = set()
+        self.old_unmanaged_keys = set()
+        self.new_model_keys = set()
+        self.new_proxy_keys = set()
+        self.new_unmanaged_keys = set()
+        for al, mn in self.from_state.models:
             model = self.old_apps.get_model(al, mn)
             if not model._meta.managed:
-                self.old_unmanaged_keys.append((al, mn))
+                self.old_unmanaged_keys.add((al, mn))
             elif al not in self.from_state.real_apps:
                 if model._meta.proxy:
-                    self.old_proxy_keys.append((al, mn))
+                    self.old_proxy_keys.add((al, mn))
                 else:
-                    self.old_model_keys.append((al, mn))
+                    self.old_model_keys.add((al, mn))
 
-        for al, mn in sorted(self.to_state.models):
+        for al, mn in self.to_state.models:
             model = self.new_apps.get_model(al, mn)
             if not model._meta.managed:
-                self.new_unmanaged_keys.append((al, mn))
+                self.new_unmanaged_keys.add((al, mn))
             elif (
                 al not in self.from_state.real_apps or
                 (convert_apps and al in convert_apps)
             ):
                 if model._meta.proxy:
-                    self.new_proxy_keys.append((al, mn))
+                    self.new_proxy_keys.add((al, mn))
                 else:
-                    self.new_model_keys.append((al, mn))
+                    self.new_model_keys.add((al, mn))
 
         # Renames have to come first
         self.generate_renamed_models()
@@ -201,18 +201,23 @@ class MigrationAutodetector:
         in the old state so dependencies can be made from the through model
         deletion to the field that uses it.
         """
-        self.kept_model_keys = set(self.old_model_keys).intersection(self.new_model_keys)
-        self.kept_proxy_keys = set(self.old_proxy_keys).intersection(self.new_proxy_keys)
-        self.kept_unmanaged_keys = set(self.old_unmanaged_keys).intersection(self.new_unmanaged_keys)
+        self.kept_model_keys = self.old_model_keys & self.new_model_keys
+        self.kept_proxy_keys = self.old_proxy_keys & self.new_proxy_keys
+        self.kept_unmanaged_keys = self.old_unmanaged_keys & self.new_unmanaged_keys
         self.through_users = {}
-        self.old_field_keys = set()
-        self.new_field_keys = set()
-        for app_label, model_name in sorted(self.kept_model_keys):
-            old_model_name = self.renamed_models.get((app_label, model_name), model_name)
-            old_model_state = self.from_state.models[app_label, old_model_name]
-            new_model_state = self.to_state.models[app_label, model_name]
-            self.old_field_keys.update((app_label, model_name, x) for x, y in old_model_state.fields)
-            self.new_field_keys.update((app_label, model_name, x) for x, y in new_model_state.fields)
+        self.old_field_keys = {
+            (app_label, model_name, x)
+            for app_label, model_name in self.kept_model_keys
+            for x, y in self.from_state.models[
+                app_label,
+                self.renamed_models.get((app_label, model_name), model_name)
+            ].fields
+        }
+        self.new_field_keys = {
+            (app_label, model_name, x)
+            for app_label, model_name in self.kept_model_keys
+            for x, y in self.to_state.models[app_label, model_name].fields
+        }
 
     def _generate_through_model_map(self):
         """Through model map generation."""
@@ -451,12 +456,12 @@ class MigrationAutodetector:
         """
         self.renamed_models = {}
         self.renamed_models_rel = {}
-        added_models = set(self.new_model_keys).difference(self.old_model_keys)
+        added_models = self.new_model_keys - self.old_model_keys
         for app_label, model_name in sorted(added_models):
             model_state = self.to_state.models[app_label, model_name]
             model_fields_def = self.only_relation_agnostic_fields(model_state.fields)
 
-            removed_models = set(self.old_model_keys).difference(self.new_model_keys)
+            removed_models = self.old_model_keys - self.new_model_keys
             for rem_app_label, rem_model_name in removed_models:
                 if rem_app_label == app_label:
                     rem_model_state = self.from_state.models[rem_app_label, rem_model_name]
@@ -477,7 +482,7 @@ class MigrationAutodetector:
                                 model_state.name,
                             )
                             self.old_model_keys.remove((rem_app_label, rem_model_name))
-                            self.old_model_keys.append((app_label, model_name))
+                            self.old_model_keys.add((app_label, model_name))
                             break
 
     def generate_created_models(self):
@@ -490,9 +495,9 @@ class MigrationAutodetector:
         Defer any model options that refer to collections of fields that might
         be deferred (e.g. unique_together, index_together).
         """
-        old_keys = set(self.old_model_keys).union(self.old_unmanaged_keys)
-        added_models = set(self.new_model_keys) - old_keys
-        added_unmanaged_models = set(self.new_unmanaged_keys) - old_keys
+        old_keys = self.old_model_keys | self.old_unmanaged_keys
+        added_models = self.new_model_keys - old_keys
+        added_unmanaged_models = self.new_unmanaged_keys - old_keys
         all_added_models = chain(
             sorted(added_models, key=self.swappable_first_key, reverse=True),
             sorted(added_unmanaged_models, key=self.swappable_first_key, reverse=True)
@@ -642,7 +647,7 @@ class MigrationAutodetector:
         models it's safe to skip all the pointless field stuff and just chuck
         out an operation.
         """
-        added = set(self.new_proxy_keys).difference(self.old_proxy_keys)
+        added = self.new_proxy_keys - self.old_proxy_keys
         for app_label, model_name in sorted(added):
             model_state = self.to_state.models[app_label, model_name]
             assert model_state.options.get("proxy")
@@ -679,9 +684,9 @@ class MigrationAutodetector:
         Also bring forward removal of any model options that refer to
         collections of fields - the inverse of generate_created_models().
         """
-        new_keys = set(self.new_model_keys).union(self.new_unmanaged_keys)
-        deleted_models = set(self.old_model_keys) - new_keys
-        deleted_unmanaged_models = set(self.old_unmanaged_keys) - new_keys
+        new_keys = self.new_model_keys | self.new_unmanaged_keys
+        deleted_models = self.old_model_keys - new_keys
+        deleted_unmanaged_models = self.old_unmanaged_keys - new_keys
         all_deleted_models = chain(sorted(deleted_models), sorted(deleted_unmanaged_models))
         for app_label, model_name in all_deleted_models:
             model_state = self.from_state.models[app_label, model_name]
@@ -764,7 +769,7 @@ class MigrationAutodetector:
 
     def generate_deleted_proxies(self):
         """Make DeleteModel options for proxy models."""
-        deleted = set(self.old_proxy_keys).difference(self.new_proxy_keys)
+        deleted = self.old_proxy_keys - self.new_proxy_keys
         for app_label, model_name in sorted(deleted):
             model_state = self.from_state.models[app_label, model_name]
             assert model_state.options.get("proxy")
@@ -868,7 +873,7 @@ class MigrationAutodetector:
         Make AlterField operations, or possibly RemovedField/AddField if alter
         isn's possible.
         """
-        for app_label, model_name, field_name in sorted(self.old_field_keys.intersection(self.new_field_keys)):
+        for app_label, model_name, field_name in sorted(self.old_field_keys & self.new_field_keys):
             # Did the field change?
             old_model_name = self.renamed_models.get((app_label, model_name), model_name)
             old_field_name = self.renamed_fields.get((app_label, model_name, field_name), field_name)
@@ -988,19 +993,17 @@ class MigrationAutodetector:
             new_model_state = self.to_state.models[app_label, model_name]
 
             # We run the old version through the field renames to account for those
-            old_value = old_model_state.options.get(option_name) or set()
-            if old_value:
-                old_value = {
-                    tuple(
-                        self.renamed_fields.get((app_label, model_name, n), n)
-                        for n in unique
-                    )
-                    for unique in old_value
-                }
+            old_value = old_model_state.options.get(option_name)
+            old_value = {
+                tuple(
+                    self.renamed_fields.get((app_label, model_name, n), n)
+                    for n in unique
+                )
+                for unique in old_value
+            } if old_value else set()
 
-            new_value = new_model_state.options.get(option_name) or set()
-            if new_value:
-                new_value = set(new_value)
+            new_value = new_model_state.options.get(option_name)
+            new_value = set(new_value) if new_value else set()
 
             if old_value != new_value:
                 dependencies = []
@@ -1026,7 +1029,7 @@ class MigrationAutodetector:
         self._generate_altered_foo_together(operations.AlterIndexTogether)
 
     def generate_altered_db_table(self):
-        models_to_check = self.kept_model_keys.union(self.kept_proxy_keys).union(self.kept_unmanaged_keys)
+        models_to_check = self.kept_model_keys.union(self.kept_proxy_keys, self.kept_unmanaged_keys)
         for app_label, model_name in sorted(models_to_check):
             old_model_name = self.renamed_models.get((app_label, model_name), model_name)
             old_model_state = self.from_state.models[app_label, old_model_name]
@@ -1049,15 +1052,12 @@ class MigrationAutodetector:
         migrations needs them).
         """
         models_to_check = self.kept_model_keys.union(
-            self.kept_proxy_keys
-        ).union(
-            self.kept_unmanaged_keys
-        ).union(
+            self.kept_proxy_keys,
+            self.kept_unmanaged_keys,
             # unmanaged converted to managed
-            set(self.old_unmanaged_keys).intersection(self.new_model_keys)
-        ).union(
+            self.old_unmanaged_keys & self.new_model_keys,
             # managed converted to unmanaged
-            set(self.old_model_keys).intersection(self.new_unmanaged_keys)
+            self.old_model_keys & self.new_unmanaged_keys,
         )
 
         for app_label, model_name in sorted(models_to_check):
@@ -1189,8 +1189,7 @@ class MigrationAutodetector:
         old_required_apps = None
         while old_required_apps != required_apps:
             old_required_apps = set(required_apps)
-            for app_label in list(required_apps):
-                required_apps.update(app_dependencies.get(app_label, set()))
+            required_apps.update(*[app_dependencies.get(app_label, ()) for app_label in required_apps])
         # Remove all migrations that aren't needed
         for app_label in list(changes):
             if app_label not in required_apps:

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -63,8 +63,6 @@ and two directions (forward and reverse) for a total of six combinations.
    ``ReverseManyToManyDescriptor``, use ``ManyToManyDescriptor`` instead.
 """
 
-from operator import attrgetter
-
 from django.db import connections, router, transaction
 from django.db.models import Q, signals
 from django.db.models.query import QuerySet
@@ -334,11 +332,8 @@ class ReverseOneToOneDescriptor:
             queryset = self.get_queryset()
         queryset._add_hints(instance=instances[0])
 
-        rel_obj_attr = attrgetter(self.related.field.attname)
-
-        def instance_attr(obj):
-            return obj.pk
-
+        rel_obj_attr = self.related.field.get_local_related_value
+        instance_attr = self.related.field.get_foreign_related_value
         instances_dict = {instance_attr(inst): inst for inst in instances}
         query = {'%s__in' % self.related.field.name: instances}
         queryset = queryset.filter(**query)

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -51,7 +51,7 @@ def normalize_together(option_together):
             return ()
         if not isinstance(option_together, (tuple, list)):
             raise TypeError
-        first_element = next(iter(option_together))
+        first_element = option_together[0]
         if not isinstance(first_element, (tuple, list)):
             option_together = (option_together,)
         # Normalize everything to tuples

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -119,7 +119,6 @@ class ValuesListIterable(BaseIterable):
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
 
-        results = compiler.results_iter()
         if queryset._fields:
             field_names = list(query.values_select)
             extra_names = list(query.extra_select)
@@ -133,8 +132,8 @@ class ValuesListIterable(BaseIterable):
                 # Reorder according to fields.
                 index_map = {name: idx for idx, name in enumerate(names)}
                 rowfactory = operator.itemgetter(*[index_map[f] for f in fields])
-                results = map(rowfactory, results)
-        return results
+                return map(rowfactory, compiler.results_iter())
+        return compiler.results_iter(tuple_expected=True)
 
 
 class FlatValuesListIterable(BaseIterable):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -942,16 +942,15 @@ class SQLCompiler:
     def apply_converters(self, rows, converters):
         connection = self.connection
         converters = list(converters.items())
-        for row in rows:
-            row = list(row)
+        for row in map(list, rows):
             for pos, (convs, expression) in converters:
                 value = row[pos]
                 for converter in convs:
                     value = converter(value, expression, connection)
                 row[pos] = value
-            yield tuple(row)
+            yield row
 
-    def results_iter(self, results=None):
+    def results_iter(self, results=None, tuple_expected=False):
         """Return an iterator over the results from executing this query."""
         if results is None:
             results = self.execute_sql(MULTI)
@@ -960,6 +959,8 @@ class SQLCompiler:
         rows = chain.from_iterable(results)
         if converters:
             rows = self.apply_converters(rows, converters)
+            if tuple_expected:
+                rows = map(tuple, rows)
         return rows
 
     def has_results(self):

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -345,7 +345,7 @@ class HttpRequest:
         yield from self
 
     def readlines(self):
-        return list(iter(self))
+        return list(self)
 
 
 class QueryDict(MultiValueDict):

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -320,7 +320,7 @@ class Token:
 
     def split_contents(self):
         split = []
-        bits = iter(smart_split(self.contents))
+        bits = smart_split(self.contents)
         for bit in bits:
             # Handle translation-marked template pieces
             if bit.startswith(('_("', "_('")):

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -198,7 +198,7 @@ class Template:
             return parser.parse()
         except Exception as e:
             if self.origin.name != UNKNOWN_SOURCE:
-                template_path = "Template : %s, " % self.origin.name
+                template_path = "Template: %s, " % self.origin.name
                 e.args = (template_path + e.args[0],)
             if self.engine.debug:
                 e.template_debug = self.get_exception_info(e, e.token)

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -197,6 +197,9 @@ class Template:
         try:
             return parser.parse()
         except Exception as e:
+            if self.origin.name != UNKNOWN_SOURCE:
+                template_path = "Template : %s, " % self.origin.name
+                e.args = (template_path + e.args[0],)
             if self.engine.debug:
                 e.template_debug = self.get_exception_info(e, e.token)
             raise

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -223,9 +223,9 @@ def stringformat(value, arg):
     See https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
     for documentation of Python string formatting.
     """
+    if isinstance(value, tuple):
+        value = str(value)
     try:
-        if isinstance(value, tuple):
-            return ('%' + str(arg)) % str(value)
         return ("%" + str(arg)) % value
     except (ValueError, TypeError):
         return ""

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -224,6 +224,8 @@ def stringformat(value, arg):
     for documentation of Python string formatting.
     """
     try:
+        if isinstance(value, tuple):
+            return ('%' + str(arg)) % str(value)
         return ("%" + str(arg)) % value
     except (ValueError, TypeError):
         return ""

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -499,10 +499,14 @@ class override_system_checks(TestContextDecorator):
 
     def enable(self):
         self.old_checks = self.registry.registered_checks
-        self.registry.registered_checks = self.new_checks
+        self.registry.registered_checks = []
+        for check in self.new_checks:
+            self.registry.register(check, *getattr(check, 'tags', ()))
         self.old_deployment_checks = self.registry.deployment_checks
         if self.deployment_checks is not None:
-            self.registry.deployment_checks = self.deployment_checks
+            self.registry.deployment_checks = []
+            for check in self.deployment_checks:
+                self.registry.register(check, *getattr(check, 'tags', ()), deploy=True)
 
     def disable(self):
         self.registry.registered_checks = self.old_checks

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -499,12 +499,12 @@ class override_system_checks(TestContextDecorator):
 
     def enable(self):
         self.old_checks = self.registry.registered_checks
-        self.registry.registered_checks = []
+        self.registry.registered_checks = set()
         for check in self.new_checks:
             self.registry.register(check, *getattr(check, 'tags', ()))
         self.old_deployment_checks = self.registry.deployment_checks
         if self.deployment_checks is not None:
-            self.registry.deployment_checks = []
+            self.registry.deployment_checks = set()
             for check in self.deployment_checks:
                 self.registry.register(check, *getattr(check, 'tags', ()), deploy=True)
 

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -10,7 +10,7 @@ class OrderedSet:
     """
 
     def __init__(self, iterable=None):
-        self.dict = OrderedDict(((x, None) for x in iterable) if iterable else [])
+        self.dict = OrderedDict.fromkeys(iterable or ())
 
     def add(self, item):
         self.dict[item] = None

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -279,7 +279,7 @@ class JavaScriptCatalog(View):
         trans_cat = self.translation._catalog
         trans_fallback_cat = self.translation._fallback._catalog if self.translation._fallback else {}
         seen_keys = set()
-        for key, value in itertools.chain(iter(trans_cat.items()), iter(trans_fallback_cat.items())):
+        for key, value in itertools.chain(trans_cat.items(), trans_fallback_cat.items()):
             if key == '' or key in seen_keys:
                 continue
             if isinstance(key, str):

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -363,7 +363,7 @@
       <header class="u-clearfix">
           <div class="logo">
             <a href="https://www.djangoproject.com/" target="_blank" rel="noopener">
-              <h2>Django</h2>
+              <h2>django</h2>
             </a>
           </div>
           <div class="release-notes">

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -190,7 +190,6 @@
 {% if template_info %}
 <div id="template">
    <h2>Error during template rendering</h2>
-   <p>In template <code>{{ template_info.name }}</code>, error at line <strong>{{ template_info.line }}</strong></p>
    <h3>{{ template_info.message }}</h3>
    <table class="source{% if template_info.top %} cut-top{% endif %}
       {% if template_info.bottom != template_info.total %} cut-bottom{% endif %}">

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -19,7 +19,7 @@ Bugfixes
 * Django 1.11 inadvertently changed the sequence and trigger naming scheme on
   Oracle. This causes errors on INSERTs for some tables if
   ``'use_returning_into': False`` is in the ``OPTIONS`` part of ``DATABASES``.
-  The pre-11.1 naming scheme is now restored. Unfortunately, it necessarily
+  The pre-1.11 naming scheme is now restored. Unfortunately, it necessarily
   requires an update to Oracle tables created with Django 1.11.[1-4]. Use the
   upgrade script in :ticket:`28451` comment 8 to update sequence and trigger
-  names to use the pre-1.11 naming scheme
+  names to use the pre-1.11 naming scheme.

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -12,7 +12,7 @@ Bugfixes
 * Fixed GEOS version parsing if the version has a commit hash at the end (new
   in GEOS 3.6.2) (:ticket:`28441`).
 
-* Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
+* Added compatibility for ``cx_Oracle`` 6 (:ticket:`28498`).
 
 * Fixed select widget rendering when option values are tuples (:ticket:`28502`).
 

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -13,3 +13,5 @@ Bugfixes
   in GEOS 3.6.2) (:ticket:`28441`).
 
 * Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
+
+* Fixed select widget rendering when option values are tuples (:ticket:`28502`).

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -15,3 +15,11 @@ Bugfixes
 * Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
 
 * Fixed select widget rendering when option values are tuples (:ticket:`28502`).
+
+* Django 1.11 inadvertently changed the sequence and trigger naming scheme on
+  Oracle. This causes errors on INSERTs for some tables if
+  ``'use_returning_into': False`` is in the ``OPTIONS`` part of ``DATABASES``.
+  The pre-11.1 naming scheme is now restored. Unfortunately, it necessarily
+  requires an update to Oracle tables created with Django 1.11.[1-4]. Use the
+  upgrade script in :ticket:`28451` comment 8 to update sequence and trigger
+  names to use the pre-1.11 naming scheme

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -23,3 +23,6 @@ Bugfixes
   requires an update to Oracle tables created with Django 1.11.[1-4]. Use the
   upgrade script in :ticket:`28451` comment 8 to update sequence and trigger
   names to use the pre-1.11 naming scheme.
+
+* Added POST request support to ``LogoutView``, for equivalence with the
+  function-based ``logout()`` view (:ticket:`28513`).

--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1442,11 +1442,11 @@ Old :tfilter:`unordered_list` syntax
 An older (pre-1.0), more restrictive and verbose input format for the
 :tfilter:`unordered_list` template filter has been deprecated::
 
-    ``['States', [['Kansas', [['Lawrence', []], ['Topeka', []]]], ['Illinois', []]]]``
+    ['States', [['Kansas', [['Lawrence', []], ['Topeka', []]]], ['Illinois', []]]]
 
 Using the new syntax, this becomes::
 
-    ``['States', ['Kansas', ['Lawrence', 'Topeka'], 'Illinois']]``
+    ['States', ['Kansas', ['Lawrence', 'Topeka'], 'Illinois']]
 
 ``django.forms.Field._has_changed()``
 -------------------------------------

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -456,8 +456,8 @@ Django provides several built-in loggers.
 ``django``
 ~~~~~~~~~~
 
-``django`` is the catch-all logger. No messages are posted directly to
-this logger.
+The catch-all logger for messages in the  ``django`` hierarchy. No messages are
+posted using this name but instead using one of the loggers below.
 
 .. _django-request-logger:
 
@@ -734,18 +734,19 @@ By default, Django configures the following logging:
 
 When :setting:`DEBUG` is ``True``:
 
-* The ``django`` catch-all logger sends all messages at the ``INFO`` level or
-  higher to the console.
+* The ``django`` logger sends messages in the ``django`` hierarchy (except
+  ``django.server``) at the ``INFO`` level or higher to the console.
 
 When :setting:`DEBUG` is ``False``:
 
-* The ``django`` logger send messages with ``ERROR`` or ``CRITICAL`` level to
+* The ``django`` logger sends messages in the ``django`` hierarchy (except
+  ``django.server``)  with ``ERROR`` or ``CRITICAL`` level to
   :class:`AdminEmailHandler`.
 
 Independent of the value of :setting:`DEBUG`:
 
-* The :ref:`django-server-logger` logger sends all messages at the ``INFO``
-  level or higher to the console.
+* The :ref:`django-server-logger` logger sends messages at the ``INFO`` level
+  or higher to the console.
 
 See also :ref:`Configuring logging <configuring-logging>` to learn how you can
 complement or replace this default logging configuration.

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -656,7 +656,7 @@ Python logging module.
 Filters
 -------
 
-Django provides two log filters in addition to those provided by the Python
+Django provides some log filters in addition to those provided by the Python
 logging module.
 
 .. class:: CallbackFilter(callback)

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -343,3 +343,10 @@ the :setting:`PASSWORD_HASHERS` setting to a faster hashing algorithm::
 
 Don't forget to also include in :setting:`PASSWORD_HASHERS` any hashing
 algorithm used in fixtures, if any.
+
+Preserving the test database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :option:`test --keepdb` option preserves the test database between test
+runs. It skips the create and destroy actions which can greatly decrease the
+time to run tests.

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -5,7 +5,7 @@ from django.contrib.admin.models import LogEntry
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.templatetags.admin_list import pagination
 from django.contrib.admin.tests import AdminSeleniumTestCase
-from django.contrib.admin.views.main import ALL_VAR, SEARCH_VAR, ChangeList
+from django.contrib.admin.views.main import ALL_VAR, SEARCH_VAR
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.template import Context, Template
@@ -30,22 +30,15 @@ from .models import (
 )
 
 
-def get_changelist_args(modeladmin, **kwargs):
-    m = modeladmin
-    args = (
-        kwargs.pop('list_display', m.list_display),
-        kwargs.pop('list_display_links', m.list_display_links),
-        kwargs.pop('list_filter', m.list_filter),
-        kwargs.pop('date_hierarchy', m.date_hierarchy),
-        kwargs.pop('search_fields', m.search_fields),
-        kwargs.pop('list_select_related', m.list_select_related),
-        kwargs.pop('list_per_page', m.list_per_page),
-        kwargs.pop('list_max_show_all', m.list_max_show_all),
-        kwargs.pop('list_editable', m.list_editable),
-        m,
-    )
-    assert not kwargs, "Unexpected kwarg %s" % kwargs
-    return args
+def build_tbody_html(pk, href, extra_fields):
+    return (
+        '<tbody><tr class="row1">'
+        '<td class="action-checkbox">'
+        '<input type="checkbox" name="_selected_action" value="{}" '
+        'class="action-select" /></td>'
+        '<th class="field-name"><a href="{}">name</a></th>'
+        '{}</tr></tbody>'
+    ).format(pk, href, extra_fields)
 
 
 @override_settings(ROOT_URLCONF="admin_changelist.urls")
@@ -69,29 +62,20 @@ class ChangeListTests(TestCase):
         """
         m = ChildAdmin(Child, custom_site)
         request = self.factory.get('/child/')
-        cl = ChangeList(
-            request, Child,
-            *get_changelist_args(m, list_select_related=m.get_list_select_related(request))
-        )
+        cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.query.select_related, {'parent': {}})
 
     def test_select_related_as_tuple(self):
         ia = InvitationAdmin(Invitation, custom_site)
         request = self.factory.get('/invitation/')
-        cl = ChangeList(
-            request, Child,
-            *get_changelist_args(ia, list_select_related=ia.get_list_select_related(request))
-        )
+        cl = ia.get_changelist_instance(request)
         self.assertEqual(cl.queryset.query.select_related, {'player': {}})
 
     def test_select_related_as_empty_tuple(self):
         ia = InvitationAdmin(Invitation, custom_site)
         ia.list_select_related = ()
         request = self.factory.get('/invitation/')
-        cl = ChangeList(
-            request, Child,
-            *get_changelist_args(ia, list_select_related=ia.get_list_select_related(request))
-        )
+        cl = ia.get_changelist_instance(request)
         self.assertIs(cl.queryset.query.select_related, False)
 
     def test_get_select_related_custom_method(self):
@@ -103,10 +87,7 @@ class ChangeListTests(TestCase):
 
         ia = GetListSelectRelatedAdmin(Invitation, custom_site)
         request = self.factory.get('/invitation/')
-        cl = ChangeList(
-            request, Child,
-            *get_changelist_args(ia, list_select_related=ia.get_list_select_related(request))
-        )
+        cl = ia.get_changelist_instance(request)
         self.assertEqual(cl.queryset.query.select_related, {'player': {}, 'band': {}})
 
     def test_result_list_empty_changelist_value(self):
@@ -117,16 +98,13 @@ class ChangeListTests(TestCase):
         new_child = Child.objects.create(name='name', parent=None)
         request = self.factory.get('/child/')
         m = ChildAdmin(Child, custom_site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.formset = None
         template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
         context = Context({'cl': cl})
         table_output = template.render(context)
         link = reverse('admin:admin_changelist_child_change', args=(new_child.id,))
-        row_html = (
-            '<tbody><tr class="row1"><th class="field-name"><a href="%s">name</a></th>'
-            '<td class="field-parent nowrap">-</td></tr></tbody>' % link
-        )
+        row_html = build_tbody_html(new_child.id, link, '<td class="field-parent nowrap">-</td>')
         self.assertNotEqual(table_output.find(row_html), -1, 'Failed to find expected row element: %s' % table_output)
 
     def test_result_list_set_empty_value_display_on_admin_site(self):
@@ -138,16 +116,13 @@ class ChangeListTests(TestCase):
         # Set a new empty display value on AdminSite.
         admin.site.empty_value_display = '???'
         m = ChildAdmin(Child, admin.site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.formset = None
         template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
         context = Context({'cl': cl})
         table_output = template.render(context)
         link = reverse('admin:admin_changelist_child_change', args=(new_child.id,))
-        row_html = (
-            '<tbody><tr class="row1"><th class="field-name"><a href="%s">name</a></th>'
-            '<td class="field-parent nowrap">???</td></tr></tbody>' % link
-        )
+        row_html = build_tbody_html(new_child.id, link, '<td class="field-parent nowrap">???</td>')
         self.assertNotEqual(table_output.find(row_html), -1, 'Failed to find expected row element: %s' % table_output)
 
     def test_result_list_set_empty_value_display_in_model_admin(self):
@@ -157,15 +132,17 @@ class ChangeListTests(TestCase):
         new_child = Child.objects.create(name='name', parent=None)
         request = self.factory.get('/child/')
         m = EmptyValueChildAdmin(Child, admin.site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.formset = None
         template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
         context = Context({'cl': cl})
         table_output = template.render(context)
         link = reverse('admin:admin_changelist_child_change', args=(new_child.id,))
-        row_html = (
-            '<tbody><tr class="row1"><th class="field-name"><a href="%s">name</a></th>'
-            '<td class="field-age_display">&amp;dagger;</td><td class="field-age">-empty-</td></tr></tbody>' % link
+        row_html = build_tbody_html(
+            new_child.id,
+            link,
+            '<td class="field-age_display">&amp;dagger;</td>'
+            '<td class="field-age">-empty-</td>'
         )
         self.assertNotEqual(table_output.find(row_html), -1, 'Failed to find expected row element: %s' % table_output)
 
@@ -178,16 +155,13 @@ class ChangeListTests(TestCase):
         new_child = Child.objects.create(name='name', parent=new_parent)
         request = self.factory.get('/child/')
         m = ChildAdmin(Child, custom_site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.formset = None
         template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
         context = Context({'cl': cl})
         table_output = template.render(context)
         link = reverse('admin:admin_changelist_child_change', args=(new_child.id,))
-        row_html = (
-            '<tbody><tr class="row1"><th class="field-name"><a href="%s">name</a></th>'
-            '<td class="field-parent nowrap">%s</td></tr></tbody>' % (link, new_parent)
-        )
+        row_html = build_tbody_html(new_child.id, link, '<td class="field-parent nowrap">%s</td>' % new_parent)
         self.assertNotEqual(table_output.find(row_html), -1, 'Failed to find expected row element: %s' % table_output)
 
     def test_result_list_editable_html(self):
@@ -208,7 +182,7 @@ class ChangeListTests(TestCase):
         m.list_display = ['id', 'name', 'parent']
         m.list_display_links = ['id']
         m.list_editable = ['name']
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         FormSet = m.get_changelist_formset(request)
         cl.formset = FormSet(queryset=cl.result_list)
         template = Template('{% load admin_list %}{% spaceless %}{% result_list cl %}{% endspaceless %}')
@@ -248,7 +222,7 @@ class ChangeListTests(TestCase):
         m.list_display_links = ['id']
         m.list_editable = ['name']
         with self.assertRaises(IncorrectLookupParameters):
-            ChangeList(request, Child, *get_changelist_args(m))
+            m.get_changelist_instance(request)
 
     def test_custom_paginator(self):
         new_parent = Parent.objects.create(name='parent')
@@ -258,7 +232,7 @@ class ChangeListTests(TestCase):
         request = self.factory.get('/child/')
         m = CustomPaginationAdmin(Child, custom_site)
 
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
         self.assertIsInstance(cl.paginator, CustomPaginator)
 
@@ -276,7 +250,7 @@ class ChangeListTests(TestCase):
         m = BandAdmin(Band, custom_site)
         request = self.factory.get('/band/', data={'genres': blues.pk})
 
-        cl = ChangeList(request, Band, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
 
         # There's only one Group instance
@@ -295,7 +269,7 @@ class ChangeListTests(TestCase):
         m = GroupAdmin(Group, custom_site)
         request = self.factory.get('/group/', data={'members': lead.pk})
 
-        cl = ChangeList(request, Group, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
 
         # There's only one Group instance
@@ -316,7 +290,7 @@ class ChangeListTests(TestCase):
         m = ConcertAdmin(Concert, custom_site)
         request = self.factory.get('/concert/', data={'group__members': lead.pk})
 
-        cl = ChangeList(request, Concert, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
 
         # There's only one Concert instance
@@ -336,7 +310,7 @@ class ChangeListTests(TestCase):
         m = QuartetAdmin(Quartet, custom_site)
         request = self.factory.get('/quartet/', data={'members': lead.pk})
 
-        cl = ChangeList(request, Quartet, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
 
         # There's only one Quartet instance
@@ -356,7 +330,7 @@ class ChangeListTests(TestCase):
         m = ChordsBandAdmin(ChordsBand, custom_site)
         request = self.factory.get('/chordsband/', data={'members': lead.pk})
 
-        cl = ChangeList(request, ChordsBand, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
 
         # There's only one ChordsBand instance
@@ -375,7 +349,7 @@ class ChangeListTests(TestCase):
         m = ParentAdmin(Parent, custom_site)
         request = self.factory.get('/parent/', data={'child__name': 'Daniel'})
 
-        cl = ChangeList(request, Parent, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         # Make sure distinct() was called
         self.assertEqual(cl.queryset.count(), 1)
 
@@ -391,7 +365,7 @@ class ChangeListTests(TestCase):
         m = ParentAdmin(Parent, custom_site)
         request = self.factory.get('/parent/', data={SEARCH_VAR: 'daniel'})
 
-        cl = ChangeList(request, Parent, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         # Make sure distinct() was called
         self.assertEqual(cl.queryset.count(), 1)
 
@@ -410,7 +384,7 @@ class ChangeListTests(TestCase):
         m = ConcertAdmin(Concert, custom_site)
         request = self.factory.get('/concert/', data={SEARCH_VAR: 'vox'})
 
-        cl = ChangeList(request, Concert, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         # There's only one Concert instance
         self.assertEqual(cl.queryset.count(), 1)
 
@@ -422,11 +396,11 @@ class ChangeListTests(TestCase):
         m.search_fields = ['group__pk']
 
         request = self.factory.get('/concert/', data={SEARCH_VAR: band.pk})
-        cl = ChangeList(request, Concert, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 1)
 
         request = self.factory.get('/concert/', data={SEARCH_VAR: band.pk + 5})
-        cl = ChangeList(request, Concert, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 0)
 
     def test_no_distinct_for_m2m_in_list_filter_without_params(self):
@@ -437,12 +411,12 @@ class ChangeListTests(TestCase):
         m = BandAdmin(Band, custom_site)
         for lookup_params in ({}, {'name': 'test'}):
             request = self.factory.get('/band/', lookup_params)
-            cl = ChangeList(request, Band, *get_changelist_args(m))
+            cl = m.get_changelist_instance(request)
             self.assertFalse(cl.queryset.query.distinct)
 
         # A ManyToManyField in params does have distinct applied.
         request = self.factory.get('/band/', {'genres': '0'})
-        cl = ChangeList(request, Band, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         self.assertTrue(cl.queryset.query.distinct)
 
     def test_pagination(self):
@@ -459,14 +433,14 @@ class ChangeListTests(TestCase):
 
         # Test default queryset
         m = ChildAdmin(Child, custom_site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 60)
         self.assertEqual(cl.paginator.count, 60)
         self.assertEqual(list(cl.paginator.page_range), [1, 2, 3, 4, 5, 6])
 
         # Test custom queryset
         m = FilteredChildAdmin(Child, custom_site)
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         self.assertEqual(cl.queryset.count(), 30)
         self.assertEqual(cl.paginator.count, 30)
         self.assertEqual(list(cl.paginator.page_range), [1, 2, 3])
@@ -538,7 +512,7 @@ class ChangeListTests(TestCase):
         m = ChildAdmin(Child, custom_site)
         m.list_max_show_all = 200
         # 200 is the max we'll pass to ChangeList
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
         self.assertEqual(len(cl.result_list), 60)
 
@@ -547,7 +521,7 @@ class ChangeListTests(TestCase):
         m = ChildAdmin(Child, custom_site)
         m.list_max_show_all = 30
         # 30 is the max we'll pass to ChangeList for this test
-        cl = ChangeList(request, Child, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         cl.get_results(request)
         self.assertEqual(len(cl.result_list), 10)
 
@@ -792,7 +766,7 @@ class ChangeListTests(TestCase):
         # instantiating and setting up ChangeList object
         m = GroupAdmin(Group, custom_site)
         request = self.factory.get('/group/')
-        cl = ChangeList(request, Group, *get_changelist_args(m))
+        cl = m.get_changelist_instance(request)
         per_page = cl.list_per_page = 10
 
         for page_num, objects_count, expected_page_range in [

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -922,6 +922,12 @@ class LogoutTest(AuthViewsTestCase):
         self.assertContains(response, 'Logged out')
         self.confirm_logged_out()
 
+    def test_logout_with_post(self):
+        self.login()
+        response = self.client.post('/logout/')
+        self.assertContains(response, 'Logged out')
+        self.confirm_logged_out()
+
     def test_14377(self):
         # Bug 14377
         self.login()

--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -1,0 +1,11 @@
+import unittest
+
+from django.db import connection
+
+
+@unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
+class OperationsTests(unittest.TestCase):
+
+    def test_sequence_name_truncation(self):
+        seq_name = connection.ops._get_no_autofield_sequence_name('schema_authorwithevenlongee869')
+        self.assertEqual(seq_name, 'SCHEMA_AUTHORWITHEVENLOB0B8_SQ')

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -248,7 +248,7 @@ class GISFunctionsTests(TestCase):
         geom = Point(5, 23, srid=4326)
         qs = Country.objects.annotate(inter=functions.Intersection('mpoly', geom))
         for c in qs:
-            if spatialite or (mysql and not connection.ops.uses_invalid_empty_geometry_collection) or oracle:
+            if spatialite or (mysql and not connection.features.supports_empty_geometry_collection) or oracle:
                 # When the intersection is empty, some databases return None.
                 expected = None
             else:

--- a/tests/gis_tests/geoapp/tests.py
+++ b/tests/gis_tests/geoapp/tests.py
@@ -403,6 +403,27 @@ class GeoLookupTest(TestCase):
         State.objects.filter(name='Northern Mariana Islands').update(poly=None)
         self.assertIsNone(State.objects.get(name='Northern Mariana Islands').poly)
 
+    @skipUnlessDBFeature('supports_null_geometries', 'supports_crosses_lookup', 'supports_relate_lookup')
+    def test_null_geometries_excluded_in_lookups(self):
+        """NULL features are excluded in spatial lookup functions."""
+        null = State.objects.create(name='NULL', poly=None)
+        queries = [
+            ('equals', Point(1, 1)),
+            ('disjoint', Point(1, 1)),
+            ('touches', Point(1, 1)),
+            ('crosses', LineString((0, 0), (1, 1), (5, 5))),
+            ('within', Point(1, 1)),
+            ('overlaps', LineString((0, 0), (1, 1), (5, 5))),
+            ('contains', LineString((0, 0), (1, 1), (5, 5))),
+            ('intersects', LineString((0, 0), (1, 1), (5, 5))),
+            ('relate', (Point(1, 1), 'T*T***FF*')),
+            ('same_as', Point(1, 1)),
+            ('exact', Point(1, 1)),
+        ]
+        for lookup, geom in queries:
+            with self.subTest(lookup=lookup):
+                self.assertNotIn(null, State.objects.filter(**{'poly__%s' % lookup: geom}))
+
     @skipUnlessDBFeature("supports_relate_lookup")
     def test_relate_lookup(self):
         "Testing the 'relate' lookup type."

--- a/tests/prefetch_related/models.py
+++ b/tests/prefetch_related/models.py
@@ -65,7 +65,12 @@ class BookWithYear(Book):
 
 
 class Bio(models.Model):
-    author = models.OneToOneField(Author, models.CASCADE)
+    author = models.OneToOneField(
+        Author,
+        models.CASCADE,
+        primary_key=True,
+        to_field='name',
+    )
     books = models.ManyToManyField(Book, blank=True)
 
 

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -81,6 +81,23 @@ class PrefetchRelatedTests(TestCase):
             with self.assertRaises(BookWithYear.DoesNotExist):
                 book.bookwithyear
 
+    def test_onetoone_reverse_with_to_field_pk(self):
+        """
+        A model (Bio) with a OneToOneField primary key (author) that references
+        a non-pk field (name) on the related model (Author) is prefetchable.
+        """
+        Bio.objects.bulk_create([
+            Bio(author=self.author1),
+            Bio(author=self.author2),
+            Bio(author=self.author3),
+        ])
+        authors = Author.objects.filter(
+            name__in=[self.author1, self.author2, self.author3],
+        ).prefetch_related('bio')
+        with self.assertNumQueries(2):
+            for author in authors:
+                self.assertEqual(author.name, author.bio.author.name)
+
     def test_survives_clone(self):
         with self.assertNumQueries(2):
             [list(b.first_time_authors.all())

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -11,7 +11,9 @@ from admin_scripts.tests import AdminScriptTestCase
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
-from django.contrib.staticfiles.management.commands import collectstatic
+from django.contrib.staticfiles.management.commands import (
+    collectstatic, runserver,
+)
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.test import override_settings
@@ -32,6 +34,15 @@ class TestNoFilesCreated:
         Make sure no files were create in the destination directory.
         """
         self.assertEqual(os.listdir(settings.STATIC_ROOT), [])
+
+
+class TestRunserver(StaticFilesTestCase):
+    @override_settings(MIDDLEWARE=['django.middleware.common.CommonMiddleware'])
+    def test_middleware_loaded_only_once(self):
+        command = runserver.Command()
+        with mock.patch('django.middleware.common.CommonMiddleware') as mocked:
+            command.get_handler(use_static_handler=True, insecure_serving=True)
+            self.assertEqual(mocked.call_count, 1)
 
 
 class TestFindStatic(TestDefaults, CollectionTestCase):

--- a/tests/template_tests/filter_tests/test_stringformat.py
+++ b/tests/template_tests/filter_tests/test_stringformat.py
@@ -29,6 +29,11 @@ class FunctionTests(SimpleTestCase):
 
     def test_format(self):
         self.assertEqual(stringformat(1, '03d'), '001')
+        self.assertEqual(stringformat([1, None], 's'), '[1, None]')
+        self.assertEqual(stringformat({1, 2}, 's'), '{1, 2}')
+        self.assertEqual(stringformat({1: 2, 2: 3}, 's'), '{1: 2, 2: 3}')
 
     def test_invalid(self):
         self.assertEqual(stringformat(1, 'z'), '')
+        self.assertEqual(stringformat(object(), 'd'), '')
+        self.assertEqual(stringformat(None, 'd'), '')

--- a/tests/template_tests/filter_tests/test_stringformat.py
+++ b/tests/template_tests/filter_tests/test_stringformat.py
@@ -39,3 +39,4 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(stringformat(1, 'z'), '')
         self.assertEqual(stringformat(object(), 'd'), '')
         self.assertEqual(stringformat(None, 'd'), '')
+        self.assertEqual(stringformat((1, 2, 3), 'd'), '')

--- a/tests/template_tests/filter_tests/test_stringformat.py
+++ b/tests/template_tests/filter_tests/test_stringformat.py
@@ -30,6 +30,8 @@ class FunctionTests(SimpleTestCase):
     def test_format(self):
         self.assertEqual(stringformat(1, '03d'), '001')
         self.assertEqual(stringformat([1, None], 's'), '[1, None]')
+        self.assertEqual(stringformat((1, 2, 3), 's'), '(1, 2, 3)')
+        self.assertEqual(stringformat((1,), 's'), '(1,)')
         self.assertEqual(stringformat({1, 2}, 's'), '{1, 2}')
         self.assertEqual(stringformat({1: 2, 2: 3}, 's'), '{1: 2, 2: 3}')
 

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -670,7 +670,7 @@ class PlainTextReportTests(SimpleTestCase):
         self.assertIn(
             'Template error:\n'
             'In template %(path)s, error at line 2\n'
-            '   \'cycle\' tag requires at least two arguments\n'
+            '   Template : %(path)s, \'cycle\' tag requires at least two arguments\n'
             '   1 : Template with error:\n'
             '   2 :  {%% cycle %%} \n'
             '   3 : ' % {'path': templ_path},

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -670,7 +670,7 @@ class PlainTextReportTests(SimpleTestCase):
         self.assertIn(
             'Template error:\n'
             'In template %(path)s, error at line 2\n'
-            '   Template : %(path)s, \'cycle\' tag requires at least two arguments\n'
+            '   Template: %(path)s, \'cycle\' tag requires at least two arguments\n'
             '   1 : Template with error:\n'
             '   2 :  {%% cycle %%} \n'
             '   3 : ' % {'path': templ_path},


### PR DESCRIPTION
Adjust template exception test to account for template path. 

Here's an example technical_500.html render with the duplication removed:

<img width="1603" alt="template-syntax-error" src="https://user-images.githubusercontent.com/17954825/29437395-1fd4d8e8-8365-11e7-8d00-8acd200fb69b.png">
Remove redundant template path and line number in technical_500.html.