### PR TITLE
Refs #28459 -- Improved performance of SQLCompiler.apply_converters().

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -118,7 +118,6 @@ class ValuesListIterable(BaseIterable):
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
 
-        results = compiler.results_iter()
         if queryset._fields:
             field_names = list(query.values_select)
             extra_names = list(query.extra_select)
@@ -132,8 +131,8 @@ class ValuesListIterable(BaseIterable):
                 # Reorder according to fields.
                 index_map = {name: idx for idx, name in enumerate(names)}
                 rowfactory = operator.itemgetter(*[index_map[f] for f in fields])
-                results = map(rowfactory, results)
-        return results
+                return map(rowfactory, compiler.results_iter())
+        return compiler.results_iter(tuple_expected=True)
 
 
 class FlatValuesListIterable(BaseIterable):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -942,16 +942,15 @@ class SQLCompiler:
     def apply_converters(self, rows, converters):
         connection = self.connection
         converters = list(converters.items())
-        for row in rows:
-            row = list(row)
+        for row in map(list, rows):
             for pos, (convs, expression) in converters:
                 value = row[pos]
                 for converter in convs:
                     value = converter(value, expression, connection)
                 row[pos] = value
-            yield tuple(row)
+            yield row
 
-    def results_iter(self, results=None):
+    def results_iter(self, results=None, tuple_expected=False):
         """Return an iterator over the results from executing this query."""
         if results is None:
             results = self.execute_sql(MULTI)
@@ -960,6 +959,8 @@ class SQLCompiler:
         rows = chain.from_iterable(results)
         if converters:
             rows = self.apply_converters(rows, converters)
+            if tuple_expected:
+                rows = map(tuple, rows)
         return rows
 
     def has_results(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
In [3]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values_list('v'): pass
176 ms ± 725 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
In [6]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values('v'): pass
257 ms ± 2.18 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
In [3]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values_list('v'): pass
170 ms ± 1.25 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
In [5]: %timeit for x in City.objects.annotate(v=models.Value(1, output_field=models.IntegerField())).values('v'): pass
224 ms ± 1.88 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```