### PR TITLE
Use dict.update in django/db/backends/mysql/base.py:data_types

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -128,7 +128,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     @cached_property
     def data_types(self):
         if self.features.supports_microsecond_precision:
-            return dict(self._data_types, DateTimeField='datetime(6)', TimeField='time(6)')
+            return self._data_types.update({'DateTimeField': 'datetime(6)', 'TimeField': 'time(6)'})
         else:
             return self._data_types
 


### PR DESCRIPTION
A fairly rudimentary way of testing this was just copying the `_data_types` variable, and running `timeit` on both ways.

After:
```
In [5]: %timeit _data_types.update({'DateTimeField': 'datetime(6)', 'TimeField': 'time(6)'})
233 ns ± 6.68 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Before:
```
In [8]: %timeit dict(_data_types, DateTimeField='datetime(6)', TimeField='time(6)')
760 ns ± 10.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```