### PR TITLE
Fixed #28367 -- Doc'd how to override management commands.

### DIFF
--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -181,6 +181,24 @@ Testing
 Information on how to test custom management commands can be found in the
 :ref:`testing docs <topics-testing-management-commands>`.
 
+Overriding commands
+===================
+
+Django registers the built-in commands and then searches for commands in
+:setting:`INSTALLED_APPS` in reverse. During the search, if a command name
+duplicates an already registered command, the newly discovered command
+overrides the first.
+
+In other words, to override a command, the new command must have the same name
+and its app must be before the overridden command's app in
+:setting:`INSTALLED_APPS`.
+
+Management commands from third-party apps that have been unintentionally
+overridden can be made available under a new name by creating a new command in
+one of your project's apps (ordered before the third-party app in
+:setting:`INSTALLED_APPS`) which imports the ``Command`` of the overridden
+command.
+
 Command objects
 ===============
 


### PR DESCRIPTION
Included ``warning`` block as there is currently no notification if duplicate management command modules exist.