### PR TITLE
Refs #23919 - Remove Jython and pypy workarounds

### DIFF
--- a/django/core/management/templates.py
+++ b/django/core/management/templates.py
@@ -5,7 +5,6 @@ import posixpath
 import re
 import shutil
 import stat
-import sys
 import tempfile
 from importlib import import_module
 from os import path
@@ -335,9 +334,6 @@ class TemplateCommand(BaseCommand):
         Make sure that the file is writeable.
         Useful if our source is read-only.
         """
-        if sys.platform.startswith('java'):
-            # On Jython there is no os.access()
-            return
         if not os.access(filename, os.W_OK):
             st = os.stat(filename)
             new_permissions = stat.S_IMODE(st.st_mode) | stat.S_IWUSR

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -298,24 +298,13 @@ def python_reloader(main_func, args, kwargs):
                 sys.exit(exit_code)
 
 
-def jython_reloader(main_func, args, kwargs):
-    from _systemrestart import SystemRestart
-    _thread.start_new_thread(main_func, args)
-    while True:
-        if code_changed():
-            raise SystemRestart
-        time.sleep(1)
-
-
 def main(main_func, args=None, kwargs=None):
     if args is None:
         args = ()
     if kwargs is None:
         kwargs = {}
-    if sys.platform.startswith('java'):
-        reloader = jython_reloader
-    else:
-        reloader = python_reloader
+
+    reloader = python_reloader
 
     wrapped_main_func = check_errors(main_func)
     reloader(wrapped_main_func, args, kwargs)

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -94,12 +94,6 @@ class AdminScriptTestCase(unittest.TestCase):
         else:
             os.remove(full_name)
 
-        # Also try to remove the compiled file; if it exists, it could
-        # mess up later tests that depend upon the .py file not existing
-        with suppress(OSError):
-            if sys.platform.startswith('java'):
-                # Jython produces module$py.class files
-                os.remove(re.sub(r'\.py$', '$py.class', full_name))
         # Also remove a __pycache__ directory, if it exists
         cache_name = os.path.join(self.test_dir, '__pycache__')
         if os.path.isdir(cache_name):
@@ -130,10 +124,7 @@ class AdminScriptTestCase(unittest.TestCase):
 
         # Define a temporary environment for the subprocess
         test_environ = os.environ.copy()
-        if sys.platform.startswith('java'):
-            python_path_var_name = 'JYTHONPATH'
-        else:
-            python_path_var_name = 'PYTHONPATH'
+        python_path_var_name = 'PYTHONPATH'
 
         old_cwd = os.getcwd()
 

--- a/tests/dispatch/tests.py
+++ b/tests/dispatch/tests.py
@@ -1,6 +1,4 @@
 import gc
-import sys
-import time
 import weakref
 from types import TracebackType
 
@@ -8,21 +6,9 @@ from django.dispatch import Signal, receiver
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
-if sys.platform.startswith('java'):
-    def garbage_collect():
-        # Some JVM GCs will execute finalizers in a different thread, meaning
-        # we need to wait for that to complete before we go on looking for the
-        # effects of that.
-        gc.collect()
-        time.sleep(0.1)
-elif hasattr(sys, "pypy_version_info"):
-    def garbage_collect():
-        # Collecting weakreferences can take two collections on PyPy.
-        gc.collect()
-        gc.collect()
-else:
-    def garbage_collect():
-        gc.collect()
+
+def garbage_collect():
+    gc.collect()
 
 
 def receiver_1_arg(val, **kwargs):


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/23919)

Seeing as Django currently doesn't support Jython or PyPy we should perhaps also remove references them to from the documentation?