### PR TITLE
Removed redundant backticks in docs/releases/1.8.txt

### DIFF
--- a/docs/releases/1.8.txt
+++ b/docs/releases/1.8.txt
@@ -1442,11 +1442,11 @@ Old :tfilter:`unordered_list` syntax
 An older (pre-1.0), more restrictive and verbose input format for the
 :tfilter:`unordered_list` template filter has been deprecated::
 
-    ``['States', [['Kansas', [['Lawrence', []], ['Topeka', []]]], ['Illinois', []]]]``
+    ['States', [['Kansas', [['Lawrence', []], ['Topeka', []]]], ['Illinois', []]]]
 
 Using the new syntax, this becomes::
 
-    ``['States', ['Kansas', ['Lawrence', 'Topeka'], 'Illinois']]``
+    ['States', ['Kansas', ['Lawrence', 'Topeka'], 'Illinois']]
 
 ``django.forms.Field._has_changed()``
 -------------------------------------


### PR DESCRIPTION
I noticed this while porting a project to Django 1.8. You can see the rendered version at https://docs.djangoproject.com/en/1.8/releases/1.8/#old-unordered-list-syntax