### PR TITLE
Removed postgresql_psycopg2.version.

### DIFF
--- a/django/db/backends/postgresql_psycopg2/version.py
+++ b/django/db/backends/postgresql_psycopg2/version.py
@@ -1,1 +1,0 @@
-from ..postgresql.version import *  # NOQA


### PR DESCRIPTION
`postgresql.version` doesn't exist since 29ea9714ee23525000dd8bdb7a9aafb2147de8c7.