### PR TITLE
Django -> django when styled as a logo with font.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -363,7 +363,7 @@
       <header class="u-clearfix">
           <div class="logo">
             <a href="https://www.djangoproject.com/" target="_blank" rel="noopener">
-              <h2>Django</h2>
+              <h2>django</h2>
             </a>
           </div>
           <div class="release-notes">


### PR DESCRIPTION
This was pointed out at DjangoCon US.

Not creating a Trac ticket as this is a "typo fix or trivial documentation change."