### PR TITLE
[1.11.x] Fixed #28498 -- Added support for cx_Oracle 6.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -200,9 +200,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                              settings_dict['PASSWORD'], dsn)
 
     def get_connection_params(self):
-        conn_params = self.settings_dict['OPTIONS'].copy()
-        if 'use_returning_into' in conn_params:
-            del conn_params['use_returning_into']
+        # Specify encoding to support unicode in DSN.
+        conn_params = {'encoding': 'UTF-8', 'nencoding': 'UTF-8'}
+        user_params = self.settings_dict['OPTIONS'].copy()
+        if 'use_returning_into' in user_params:
+            del user_params['use_returning_into']
+        conn_params.update(user_params)
         return conn_params
 
     def get_new_connection(self, conn_params):
@@ -359,6 +362,8 @@ class OracleParam(object):
         elif string_size > 4000:
             # Mark any string param greater than 4000 characters as a CLOB.
             self.input_size = Database.CLOB
+        elif isinstance(param, decimal.Decimal):
+            self.input_size = Database.NUMBER
         else:
             self.input_size = None
 

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -12,6 +12,6 @@ Bugfixes
 * Fixed GEOS version parsing if the version has a commit hash at the end (new
   in GEOS 3.6.2) (:ticket:`28441`).
 
-* Fixed test database creation with ``cx_Oracle`` 6 (:ticket:`28498`).
+* Added compatibility for ``cx_Oracle`` 6 (:ticket:`28498`).
 
 * Fixed select widget rendering when option values are tuples (:ticket:`28502`).

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -117,6 +117,14 @@ class OracleTests(unittest.TestCase):
         connection.ensure_connection()
         self.assertEqual(connection.connection.encoding, "UTF-8")
         self.assertEqual(connection.connection.nencoding, "UTF-8")
+        # Client encoding may be changed in OPTIONS.
+        new_connection = connection.copy()
+        new_connection.settings_dict['OPTIONS']['encoding'] = 'ISO-8859-2'
+        new_connection.settings_dict['OPTIONS']['nencoding'] = 'ASCII'
+        new_connection.ensure_connection()
+        self.assertEqual(new_connection.connection.encoding, 'ISO-8859-2')
+        self.assertEqual(new_connection.connection.nencoding, 'ASCII')
+        new_connection.close()
 
     def test_order_of_nls_parameters(self):
         # an 'almost right' datetime should work with configured


### PR DESCRIPTION
- Fixed implicit `Decimal` to `float` conversion when `input_size` is not specified for `Decimal` parameters (fixes `db_functions.tests.FunctionTests.test_greatest_decimal_filter`, `db_functions.tests.FunctionTests.test_least_decimal_filter`, `expressions_case.tests.CaseExpressionTests.test_update_decimal` failures on Python 2).
- Used `encoding`, `nencoding` parameters of `cx_Oracle.connect()` to specify `CHAR` and `NCHAR` encoding (fixes `backends.tests.BackendTestCase.test_unicode_password` failures on Python 2).