### PR TITLE
Fixed bad indent in remove_stale_contenttypes.

### DIFF
--- a/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
+++ b/django/contrib/contenttypes/management/commands/remove_stale_contenttypes.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                                 len(objs),
                                 obj_type._meta.label,
                             ))
-                        content_type_display = '\n'.join(ct_info)
+                    content_type_display = '\n'.join(ct_info)
                     self.stdout.write("""Some content types in your database are stale and can be deleted.
 Any objects that depend on these content types will also be deleted.
 The content types and dependent objects that would be deleted are:


### PR DESCRIPTION
It is unnecessary for ``content_type_display`` to be constructed from ``ct_info`` in every loop iteration.