### PR TITLE
Fixed #28518 -- Improved performance of loading geometries from DB.

### DIFF
--- a/django/contrib/gis/db/backends/mysql/features.py
+++ b/django/contrib/gis/db/backends/mysql/features.py
@@ -2,6 +2,7 @@ from django.contrib.gis.db.backends.base.features import BaseSpatialFeatures
 from django.db.backends.mysql.features import (
     DatabaseFeatures as MySQLDatabaseFeatures,
 )
+from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
@@ -14,3 +15,7 @@ class DatabaseFeatures(BaseSpatialFeatures, MySQLDatabaseFeatures):
     supports_real_shape_operations = False
     supports_null_geometries = False
     supports_num_points_poly = False
+
+    @cached_property
+    def supports_empty_geometry_collection(self):
+        return self.connection.mysql_version >= (5, 7, 5)

--- a/tests/gis_tests/geoapp/test_functions.py
+++ b/tests/gis_tests/geoapp/test_functions.py
@@ -248,7 +248,7 @@ class GISFunctionsTests(TestCase):
         geom = Point(5, 23, srid=4326)
         qs = Country.objects.annotate(inter=functions.Intersection('mpoly', geom))
         for c in qs:
-            if spatialite or (mysql and not connection.ops.uses_invalid_empty_geometry_collection) or oracle:
+            if spatialite or (mysql and not connection.features.supports_empty_geometry_collection) or oracle:
                 # When the intersection is empty, some databases return None.
                 expected = None
             else:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28518

Before:
```
In [2]: %timeit for x in City.objects.values_list('point')[:1000]: pass
64.4 ms ± 644 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
After:
```
In [3]: %timeit for x in City.objects.values_list('point')[:1000]: pass
49.8 ms ± 957 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Benchmarks are provided for PostgreSQL, will provide them for other backends if needed.