### PR TITLE
Fixed #27796 -- Prevented middleware being loaded twice with runserver

### DIFF
--- a/django/contrib/staticfiles/handlers.py
+++ b/django/contrib/staticfiles/handlers.py
@@ -21,6 +21,11 @@ class StaticFilesHandler(WSGIHandler):
         self.base_url = urlparse(self.get_base_url())
         super().__init__()
 
+    def load_middleware(self):
+        # Middleware are already loaded for self.application; no need to reload
+        # them for self.
+        pass
+
     def get_base_url(self):
         utils.check_settings()
         return settings.STATIC_URL

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -11,7 +11,9 @@ from admin_scripts.tests import AdminScriptTestCase
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
-from django.contrib.staticfiles.management.commands import collectstatic
+from django.contrib.staticfiles.management.commands import (
+    collectstatic, runserver,
+)
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.test import override_settings
@@ -32,6 +34,15 @@ class TestNoFilesCreated:
         Make sure no files were create in the destination directory.
         """
         self.assertEqual(os.listdir(settings.STATIC_ROOT), [])
+
+
+class TestRunserver(StaticFilesTestCase):
+    @override_settings(MIDDLEWARE=['django.middleware.common.CommonMiddleware'])
+    def test_middleware_loaded_only_once(self):
+        command = runserver.Command()
+        with mock.patch('django.middleware.common.CommonMiddleware') as mocked:
+            command.get_handler(use_static_handler=True, insecure_serving=True)
+            self.assertEqual(mocked.call_count, 1)
 
 
 class TestFindStatic(TestDefaults, CollectionTestCase):


### PR DESCRIPTION
Thanks Tim Graham for the review.