### PR TITLE
[1.11.x] Fixed #28487 -- Fixed force_bytes() decoding of non-unicode strings.

### DIFF
--- a/django/utils/encoding.py
+++ b/django/utils/encoding.py
@@ -121,7 +121,7 @@ def force_bytes(s, encoding='utf-8', strings_only=False, errors='strict'):
         if encoding == 'utf-8':
             return s
         else:
-            return s.decode('utf-8', errors).encode(encoding, errors)
+            return s.decode(encoding, errors).encode('utf-8', errors)
     if strings_only and is_protected_type(s):
         return s
     if isinstance(s, six.memoryview):

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -26,3 +26,6 @@ Bugfixes
 
 * Added POST request support to ``LogoutView``, for equivalence with the
   function-based ``logout()`` view (:ticket:`28513`).
+
+* Fixed ``UnicodeDecodeError`` raised when ``force_bytes`` decodes
+  strings encoded with character encodings other than UTF-8 (:ticket: `28487`).

--- a/tests/utils_tests/test_encoding.py
+++ b/tests/utils_tests/test_encoding.py
@@ -34,6 +34,19 @@ class TestEncodingUtils(unittest.TestCase):
         s = SimpleLazyObject(lambda: 'x')
         self.assertTrue(issubclass(type(force_text(s)), six.text_type))
 
+    def test_force_bytes(self):
+        """
+        Verify that force_bytes handles UTF-8 and non-UTF-8 encodings properly.
+        """
+        s = b'\xc6u vi komprenas?'
+        if six.PY3:
+            u = 'Ĉu vi komprenas?'
+        else:
+            u = 'Ĉu vi komprenas?'.encode('utf-8')
+        self.assertEqual(force_bytes(u).decode('utf-8'), u)
+        self.assertEqual(force_bytes(u, encoding='utf-8').decode('utf-8'), u)
+        self.assertEqual(force_bytes(s, encoding='latin3').decode('utf-8'), u)
+
     def test_force_bytes_exception(self):
         """
         force_bytes knows how to convert to bytes an exception


### PR DESCRIPTION
No different than the patch from @jjkalucki, but I added an appropriate regression test.
https://code.djangoproject.com/ticket/28487