### PR TITLE
Added Media.__repr__().

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -52,6 +52,9 @@ class Media:
         self._css = css
         self._js = js
 
+    def __repr__(self):
+        return 'Media(css=%r, js=%r)' % (self._css, self._js)
+
     def __str__(self):
         return self.render()
 

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -25,6 +25,11 @@ class FormsMediaTestCase(SimpleTestCase):
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
         )
+        self.assertEqual(
+            repr(m),
+            "Media(css={'all': ('path/to/css1', '/path/to/css2')}, "
+            "js=('/path/to/js1', 'http://media.other.com/path/to/js2', 'https://secure.other.com/path/to/js3'))"
+        )
 
         class Foo:
             css = {


### PR DESCRIPTION
This makes it easier to debug MediaOrderConflictWarnings.