### PR TITLE
[1.11.x] Fixed #28487 -- Fixed runserver crash with non-Unicode system encodings on Python 2 + Windows.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -40,7 +40,7 @@ from django.conf import settings
 from django.core.signals import request_finished
 from django.utils import six
 from django.utils._os import npath
-from django.utils.encoding import force_bytes, get_system_encoding
+from django.utils.encoding import get_system_encoding
 from django.utils.six.moves import _thread as thread
 
 # This import does nothing, but it's necessary to avoid some race conditions
@@ -290,8 +290,8 @@ def restart_with_reloader():
             # Environment variables on Python 2 + Windows must be str.
             encoding = get_system_encoding()
             for key in new_environ.keys():
-                str_key = force_bytes(key, encoding=encoding)
-                str_value = force_bytes(new_environ[key], encoding=encoding)
+                str_key = key.decode(encoding).encode('utf-8')
+                str_value = new_environ[key].decode(encoding).encode('utf-8')
                 del new_environ[key]
                 new_environ[str_key] = str_value
         new_environ["RUN_MAIN"] = 'true'

--- a/docs/releases/1.11.5.txt
+++ b/docs/releases/1.11.5.txt
@@ -32,3 +32,6 @@ Bugfixes
 
 * Fixed a regression where ``SelectDateWidget`` localized the years in the
   select box (:ticket:`28530`).
+
+* Fixed a regression in 1.11.4 where ``runserver`` crashed with non-Unicode
+  system encodings on Python 2 + Windows (:ticket:`28487`).


### PR DESCRIPTION
Here is a better, far more conservative fix.

I've replaced the `force_bytes` call with a decode/encode chain that does the inverse of `force_bytes`, which is what was intended originally when I understood the encoding parameter to be a source encoding.

The unit test I've added is a bit contrived.  It tests that the reencoding is occurring correctly, but a bytestring can't actually be inserted into the environment without getting deep into the weeds of Windows internals.   I think the test I have here covers what needs to be covered, but I am open to suggestions on how it could be improved.
