### PR TITLE
Fixed #28549 -- Fixed QuerySet.defer() with super and subclass fields.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -649,7 +649,7 @@ class Query:
             # models.
             workset = {}
             for model, values in seen.items():
-                for field in model._meta.fields:
+                for field in model._meta.local_fields:
                     if field in values:
                         continue
                     m = field.model._meta.concrete_model

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -188,6 +188,11 @@ class BigChildDeferTests(AssertionMixin, TestCase):
         self.assertEqual(obj.value, "foo")
         self.assertEqual(obj.other, "bar")
 
+    def test_defer_subclass_both(self):
+        # Deferring fields from both superclass and subclass works.
+        obj = BigChild.objects.defer("other", "value").get(name="b1")
+        self.assert_delayed(obj, 2)
+
     def test_only_baseclass_when_subclass_has_added_field(self):
         # You can retrieve a single field on a baseclass
         obj = BigChild.objects.only("name").get(name="b1")


### PR DESCRIPTION
Previously, deferring on multiple fields (in different classes) did not
properly omit the superclass' defered field; we were iterating the
fields from SubClass._meta.fields as well as SuperClass._meta.fields,
and only deferred one of those.

Changed to iterate .local_fields only, so we do the correct filtering.

Thanks to Simon Charette for the suggested fix.