### PR TITLE
Fixed #28546 -- Fixed translation's to_locale() with langauge subtags.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -58,21 +58,27 @@ def reset_cache(**kwargs):
 
 
 def to_locale(language, to_lower=False):
-    """
-    Turn a language name (en-us) into a locale name (en_US). If 'to_lower' is
-    True, the last component is lower-cased (en_us).
-    """
-    p = language.find('-')
-    if p >= 0:
-        if to_lower:
-            return language[:p].lower() + '_' + language[p + 1:].lower()
+    lang_code = ''
+    parts = language.split('-')
+
+    if to_lower:
+        lang_code = parts[0] + '_' + '-'.join(parts[1:])
+    # If languge code is only the country code return lower
+    elif len(parts) == 1:
+        lang_code = language.lower()
+    # languge code is long form
+    elif len(parts) > 1:
+        lang_code += parts[0] + '_'
+        # language code format 'sr-latn-x-informal'
+        if len(parts[1]) > 2:
+            parts[1] = parts[1].title()
+        # language code format 'nl-nl-x-informal'
         else:
-            # Get correct locale for sr-latn
-            if len(language[p + 1:]) > 2:
-                return language[:p].lower() + '_' + language[p + 1].upper() + language[p + 2:].lower()
-            return language[:p].lower() + '_' + language[p + 1:].upper()
-    else:
-        return language.lower()
+            parts[1] = parts[1].upper()
+
+        lang_code += '-'.join(parts[1:])
+
+    return lang_code
 
 
 def to_language(locale):

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -259,8 +259,18 @@ class TranslationTests(SimpleTestCase):
             self.assertEqual('Catalan Win\nEOF\n', gettext('Win\r\nEOF\r\n'))
 
     def test_to_locale(self):
-        self.assertEqual(to_locale('en-us'), 'en_US')
-        self.assertEqual(to_locale('sr-lat'), 'sr_Lat')
+        tests = (
+            ('EN', 'en'),
+            ('en-us', 'en_US'),
+            # A language with > 2 characters after the dash.
+            ('sr-latn', 'sr_Latn'),
+            # Language with private use subtag (x-informal).
+            ('nl-nl-x-informal', 'nl_NL-x-informal'),
+            ('sr-latn-x-informal', 'sr_Latn-x-informal'),
+        )
+        for lang, output in tests:
+            with self.subTest(lang=lang):
+                self.assertEqual(to_locale(lang), output)
 
     def test_to_language(self):
         self.assertEqual(trans_real.to_language('en_US'), 'en-us')


### PR DESCRIPTION
Added statement to check for subtags and return correct formatting. The statement to get correct locale with 'sr-latn' did not allow the subtags to be formatted properly. I added an if statement to catch the subtags.
I also added to the 'to_locale' test to check for proper subtag formatting.
https://code.djangoproject.com/ticket/28546