### PR TITLE
Fixed #28500 -- Fixed crash in FileBasedCache._is_expired() if the cache file is empty.

### DIFF
--- a/django/core/cache/backends/filebased.py
+++ b/django/core/cache/backends/filebased.py
@@ -116,7 +116,10 @@ class FileBasedCache(BaseCache):
         """
         Take an open cache file `f` and delete it if it's expired.
         """
-        exp = pickle.load(f)
+        try:
+            exp = pickle.load(f)
+        except EOFError:
+            exp = 0  # An empty file is considered expired.
         if exp is not None and exp < time.time():
             f.close()  # On Windows a file has to be closed before deleting
             self._delete(f.name)

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1366,6 +1366,13 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
             with self.assertRaises(IOError):
                 cache.get('foo')
 
+    def test_empty_cache_file_considered_expired(self):
+        cache_file = cache._key_to_file('foo')
+        with open(cache_file, 'wb') as fh:
+            fh.write(b'')
+        with open(cache_file, 'rb') as fh:
+            self.assertIs(cache._is_expired(fh), True)
+
 
 @override_settings(CACHES={
     'default': {


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28500