### PR TITLE
Suggested LoginView rather than @login_required as an alternative to authenticate().

### DIFF
--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -142,9 +142,8 @@ Authenticating users
         example, it's used by the
         :class:`~django.contrib.auth.middleware.RemoteUserMiddleware`. Unless
         you are writing your own authentication system, you probably won't use
-        this. Rather if you are looking for a way to limit access to logged in
-        users, see the :func:`~django.contrib.auth.decorators.login_required`
-        decorator.
+        this. Rather if you're looking for a way to login a user, use the
+        :class:`~django.contrib.auth.views.LoginView`.
 
 .. _topic-authorization:
 


### PR DESCRIPTION
This note was added in 1.8, but doesn't seem to have ever been true. `authenticate` is the main way to check a set of credentials, as recommended under "How to log a user in" further down this page. `login_required` isn't at all comparable and doesn't replace it in any way whatsoever.