### PR TITLE
Fixed #28559 -- Removed obsolete OGRException.

### DIFF
--- a/django/contrib/gis/gdal/__init__.py
+++ b/django/contrib/gis/gdal/__init__.py
@@ -29,7 +29,7 @@ from django.contrib.gis.gdal.datasource import DataSource
 from django.contrib.gis.gdal.driver import Driver
 from django.contrib.gis.gdal.envelope import Envelope
 from django.contrib.gis.gdal.error import (
-    GDALException, OGRException, OGRIndexError, SRSException, check_err,
+    GDALException, OGRIndexError, SRSException, check_err,
 )
 from django.contrib.gis.gdal.geometries import OGRGeometry
 from django.contrib.gis.gdal.geomtype import OGRGeomType
@@ -41,7 +41,7 @@ from django.contrib.gis.gdal.srs import CoordTransform, SpatialReference
 
 __all__ = (
     'Driver', 'DataSource', 'CoordTransform', 'Envelope', 'GDALException',
-    'GDALRaster', 'GDAL_VERSION', 'OGRException', 'OGRGeometry', 'OGRGeomType',
-    'OGRIndexError', 'SpatialReference', 'SRSException',
-    'check_err', 'gdal_version', 'gdal_full_version',
+    'GDALRaster', 'GDAL_VERSION', 'OGRGeometry', 'OGRGeomType',
+    'OGRIndexError', 'SpatialReference', 'SRSException', 'check_err',
+    'gdal_version', 'gdal_full_version',
 )

--- a/django/contrib/gis/gdal/error.py
+++ b/django/contrib/gis/gdal/error.py
@@ -10,10 +10,6 @@ class GDALException(Exception):
     pass
 
 
-# Legacy name
-OGRException = GDALException
-
-
 class SRSException(Exception):
     pass
 

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -588,6 +588,9 @@ Miscellaneous
   the relative order of elements in each list <form-media-asset-order>`.
   ``MediaOrderConflictWarning`` is issued if the order can't be preserved.
 
+* ``django.contrib.gis.gdal.OGRException`` is removed. It's been an alias for
+  ``GDALException`` since Django 1.8.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0


### PR DESCRIPTION
Ticket [#28559](https://code.djangoproject.com/ticket/28559).

This was kept for backwards compatibility when merged with ``GDALException`` for Django 1.8 where the release notes said it "should not be used any longer". It is also undocumented. Removal with a major version bump to 2.0 would be a good time to clean this up.