### PR TITLE
Fixed typo in docs/releases/1.10.txt

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -225,7 +225,7 @@ Minor features
   not worry about whether or not the ``staticfiles`` app is installed.
 
 * You can :ref:`more easily customize <customize-staticfiles-ignore-patterns>`
-  the ``collectstatic --ignore_patterns`` option with a custom ``AppConfig``.
+  the ``collectstatic --ignore`` option with a custom ``AppConfig``.
 
 Cache
 ~~~~~


### PR DESCRIPTION
The 'collectstatic' command doesn't have an option named '--ignore_patterns'.
It should be '--ignore' instead.