### PR TITLE
Fixed class name in docs/releases/1.10.txt

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -225,7 +225,7 @@ Minor features
   not worry about whether or not the ``staticfiles`` app is installed.
 
 * You can :ref:`more easily customize <customize-staticfiles-ignore-patterns>`
-  the ``collectstatic --ignore_patterns`` option with a custom ``AppConfig``.
+  the ``collectstatic --ignore`` option with a custom ``AppConfig``.
 
 Cache
 ~~~~~
@@ -450,7 +450,7 @@ Requests and Responses
   :meth:`~django.http.HttpResponse.seekable()` to make an instance a
   stream-like object and allow wrapping it with :py:class:`io.TextIOWrapper`.
 
-* Added the :attr:`HttpResponse.content_type
+* Added the :attr:`HttpRequest.content_type
   <django.http.HttpRequest.content_type>` and
   :attr:`~django.http.HttpRequest.content_params` attributes which are
   parsed from the ``CONTENT_TYPE`` header.


### PR DESCRIPTION
The 'content_type' and 'content_params' attributes were added
to the 'HttpRequest' class.

See 6f1318734f0f3b6e62b782b0251a4e676e542e0b for details.