### PR TITLE
Removed redundant white-space in docs/releases/1.10.txt

### DIFF
--- a/docs/releases/1.10.txt
+++ b/docs/releases/1.10.txt
@@ -908,7 +908,7 @@ Miscellaneous
   a new :meth:`.AbstractBaseUser.clean` method.
 
 * Private API ``django.forms.models.model_to_dict()`` returns a queryset rather
-  than a list of primary keys for ``ManyToManyField``\s .
+  than a list of primary keys for ``ManyToManyField``\s.
 
 * If ``django.contrib.staticfiles`` is
   installed, the :ttag:`static`  template tag uses the ``staticfiles`` storage


### PR DESCRIPTION
I noticed this while porting a project to Django 1.10:

![screenshot from 2017-09-04 15 19 23](https://user-images.githubusercontent.com/26338/30026196-82c0386c-9184-11e7-8a81-1a9482a54657.png)

I've built docs locally to test the change.