### PR TITLE
Fixed #28561 -- Removed inaccurate docs about QuerySet.order_by() and joins.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -311,15 +311,6 @@ identical to::
 
     Entry.objects.order_by('blog__name')
 
-It is also possible to order a queryset by a related field, without incurring
-the cost of a JOIN, by referring to the ``_id`` of the related field::
-
-    # No Join
-    Entry.objects.order_by('blog_id')
-
-    # Join
-    Entry.objects.order_by('blog__id')
-
 You can also order by :doc:`query expressions </ref/models/expressions>` by
 calling ``asc()`` or ``desc()`` on the expression::
 


### PR DESCRIPTION
As of ccbba98131ace3beb43790c65e8f4eee94e9631c, both examples don't use a join.