### PR TITLE
Fixed #28501 -- Fixed the problem "python -m django runserver" crashes.

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -280,8 +280,15 @@ def reloader_thread():
 
 
 def restart_with_reloader():
+    import django.__main__
     while True:
-        args = [sys.executable] + ['-W%s' % o for o in sys.warnoptions] + sys.argv
+        args = [sys.executable] + ['-W%s' % o for o in sys.warnoptions]
+        if sys.argv[0] == django.__main__.__file__:
+            # The server was started with `python -m django runserver`.
+            args += ['-m', 'django']
+            args += sys.argv[1:]
+        else:
+            args += sys.argv
         new_environ = os.environ.copy()
         new_environ["RUN_MAIN"] = 'true'
         exit_code = subprocess.call(args, env=new_environ)

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -277,3 +277,12 @@ class RestartWithReloaderTests(SimpleTestCase):
         autoreload.restart_with_reloader()
         self.assertEqual(mock_call.call_count, 1)
         self.assertEqual(mock_call.call_args[0][0], [self.executable, '-Wall'] + argv)
+
+    def test_python_m_django(self):
+        main = '/usr/lib/pythonX.Y/site-packages/django/__main__.py'
+        argv = [main, 'runserver']
+        mock_call = self.patch_autoreload(argv)
+        with mock.patch('django.__main__.__file__', main):
+            autoreload.restart_with_reloader()
+            self.assertEqual(mock_call.call_count, 1)
+            self.assertEqual(mock_call.call_args[0][0], [self.executable, '-Wall', '-m', 'django'] + argv[1:])


### PR DESCRIPTION
Fixed the problem that "python -m django runserver" crashes when autoreloader is enabled.

https://code.djangoproject.com/ticket/28501