### PR TITLE
Fixed reference to JavaScriptCatalog view in documentation.

### DIFF
--- a/docs/releases/1.3.txt
+++ b/docs/releases/1.3.txt
@@ -583,8 +583,8 @@ domain):
   translations shipped with applications by using the :setting:`LOCALE_PATHS`
   setting is now possible for this domain too. These translations have higher
   precedence than the translations of Python packages passed to the
-  :ref:`javascript_catalog view <javascript_catalog-view>`.  Paths listed first
-  have higher precedence than the ones listed later.
+  ``javascript_catalog()`` view. Paths listed first have higher precedence than
+  the ones listed later.
 
 * Translations under the ``locale`` subdirectory of the *project directory*
   have never been taken in account for JavaScript translations and remain in

--- a/docs/releases/1.7.txt
+++ b/docs/releases/1.7.txt
@@ -1742,7 +1742,7 @@ will be removed in Django 1.9. You can simply remove the
 --------------------------------------
 
 ``javascript_quote()`` was an undocumented function present in ``django.utils.text``.
-It was used internally in the :ref:`javascript_catalog view <javascript_catalog-view>`
+It was used internally in the ``javascript_catalog()`` view
 whose implementation was changed to make use of ``json.dumps()`` instead.
 If you were relying on this function to provide safe output from untrusted
 strings, you should use ``django.utils.html.escapejs`` or the

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -960,8 +960,6 @@ The main solution to these problems is the following ``JavaScriptCatalog`` view,
 which generates a JavaScript code library with functions that mimic the
 ``gettext`` interface, plus an array of translation strings.
 
-.. _javascript_catalog-view:
-
 The ``JavaScriptCatalog`` view
 ------------------------------
 
@@ -2071,9 +2069,8 @@ translations for the same literal:
 .. seealso::
 
     The translations for literals included in JavaScript assets are looked up
-    following a similar but not identical algorithm. See the
-    :ref:`javascript_catalog view documentation <javascript_catalog-view>` for
-    more details.
+    following a similar but not identical algorithm. See
+    :class:`.JavaScriptCatalog` for more details.
 
 In all cases the name of the directory containing the translation is expected to
 be named using :term:`locale name` notation. E.g. ``de``, ``pt_BR``, ``es_AR``,


### PR DESCRIPTION
`javascript_catalog` was removed in Django 2.