### PR TITLE
Refs #28010 -- Allowed reverse related fields in select_for_update(of=(...)).

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -910,7 +910,10 @@ class SQLCompiler:
                     path = []
                     yield 'self'
                 else:
-                    path = parent_path + [klass_info['field'].name]
+                    field = klass_info['field']
+                    if klass_info['reverse']:
+                        field = field.remote_field
+                    path = parent_path + [field.name]
                     yield LOOKUP_SEP.join(path)
                 queue.extend(
                     (path, klass_info)
@@ -923,7 +926,10 @@ class SQLCompiler:
             klass_info = self.klass_info
             for part in parts:
                 for related_klass_info in klass_info.get('related_klass_infos', []):
-                    if related_klass_info['field'].name == part:
+                    field = related_klass_info['field']
+                    if related_klass_info['reverse']:
+                        field = field.remote_field
+                    if field.name == part:
                         klass_info = related_klass_info
                         break
                 else:

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1628,6 +1628,12 @@ specify the related objects you want to lock in ``select_for_update(of=(...))``
 using the same fields syntax as :meth:`select_related`. Use the value ``'self'``
 to refer to the queryset's model.
 
+It is not possible to use ``select_for_update()`` when selecting nullable
+related objects. If you know that the related objects are not null, you can
+overcome this problem by excluding null values. For example::
+
+    entries = Person.objects.select_for_update().exclude(hometown=None)
+
 Currently, the ``postgresql``, ``oracle``, and ``mysql`` database
 backends support ``select_for_update()``. However, MySQL doesn't support the
 ``nowait``, ``skip_locked``, and ``of`` arguments.

--- a/tests/select_for_update/models.py
+++ b/tests/select_for_update/models.py
@@ -14,3 +14,7 @@ class Person(models.Model):
     name = models.CharField(max_length=30)
     born = models.ForeignKey(City, models.CASCADE, related_name='+')
     died = models.ForeignKey(City, models.CASCADE, related_name='+')
+
+
+class PersonProfile(models.Model):
+    person = models.OneToOneField(Person, models.CASCADE, related_name='profile')

--- a/tests/select_for_update/tests.py
+++ b/tests/select_for_update/tests.py
@@ -15,7 +15,7 @@ from django.test import (
 )
 from django.test.utils import CaptureQueriesContext
 
-from .models import City, Country, Person
+from .models import City, Country, Person, PersonProfile
 
 
 class SelectForUpdateTests(TransactionTestCase):
@@ -30,6 +30,7 @@ class SelectForUpdateTests(TransactionTestCase):
         self.city1 = City.objects.create(name='Liberchies', country=self.country1)
         self.city2 = City.objects.create(name='Samois-sur-Seine', country=self.country2)
         self.person = Person.objects.create(name='Reinhardt', born=self.city1, died=self.city2)
+        self.person_profile = PersonProfile.objects.create(person=self.person)
 
         # We need another database connection in transaction to test that one
         # connection issuing a SELECT ... FOR UPDATE will block.
@@ -225,13 +226,29 @@ class SelectForUpdateTests(TransactionTestCase):
         msg = (
             'Invalid field name(s) given in select_for_update(of=(...)): %s. '
             'Only relational fields followed in the query are allowed. '
-            'Choices are: self, born.'
+            'Choices are: self, born, profile.'
         )
         for name in ['born__country', 'died', 'died__country']:
             with self.subTest(name=name):
                 with self.assertRaisesMessage(FieldError, msg % name):
                     with transaction.atomic():
-                        Person.objects.select_related('born').select_for_update(of=(name,)).get()
+                        Person.objects.select_related(
+                            'born', 'profile',
+                        ).exclude(profile=None).select_for_update(of=(name,)).get()
+
+    @skipUnlessDBFeature('has_select_for_update', 'has_select_for_update_of')
+    def test_reverse_one_to_one_of_arguments_are_allowed(self):
+        """
+        It is allowed to include reverse OneToOne fields in of=(...).
+
+        NULLs must be excluded because LEFT JOIN is not allowed in SELECT FOR
+        UPDATE.
+        """
+        with transaction.atomic():
+            person = Person.objects.select_related(
+                'profile',
+            ).exclude(profile=None).select_for_update(of=('profile',)).get()
+            person.profile
 
     @skipUnlessDBFeature('has_select_for_update')
     def test_for_update_after_from(self):


### PR DESCRIPTION
Previously, reverse related fields (OneToOneFields in this case) were
not matched correctly and thus effectively excluded, even though they
are allowed in select_related().

Reverse OneToOne fields are normally followed using a LEFT JOIN, which
are not allowed in SELECT FOR UPDATE. Thus, in order to use this
support, it is necessary to force an INNER JOIN, as is demonstrated in
the test.

Thanks to Adam Chidlow for the report and suggested fix.