### PR TITLE
Fixed #28574 -- Add Queryset.explain() method

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -250,8 +250,20 @@ class BaseDatabaseFeatures:
     # Convert CharField results from bytes to str in database functions.
     db_functions_convert_bytes_to_str = False
 
+    # What formats does the backend EXPLAIN syntax support?
+    supported_explain_formats = set()
+
+    # Does DatabaseOperations.explain_query_prefix() raise ValueError if
+    # unknown kwargs are passed to QuerySet.explain()?
+    validates_explain_options = True
+
     def __init__(self, connection):
         self.connection = connection
+
+    @cached_property
+    def supports_explaining_query_execution(self):
+        """Does this backend support explaining query execution?"""
+        return self.connection.ops.explain_prefix is not None
 
     @cached_property
     def supports_transactions(self):

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -49,6 +49,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         END;
     """
     db_functions_convert_bytes_to_str = True
+    # Alias MySQL's TRADITIONAL to TEXT for consistency with other backends.
+    supported_explain_formats = {'JSON', 'TEXT', 'TRADITIONAL'}
 
     @cached_property
     def _mysql_storage_engine(self):
@@ -80,6 +82,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     @cached_property
     def supports_over_clause(self):
         return self.connection.mysql_version >= (8, 0, 2)
+
+    @cached_property
+    def needs_explain_extended(self):
+        # EXTENDED is deprecated (and not required) in 5.7 and removed in 8.0.
+        return self.connection.mysql_version < (5, 7)
 
     @cached_property
     def supports_transactions(self):

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -50,6 +50,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     $$ LANGUAGE plpgsql;"""
     supports_over_clause = True
     supports_aggregate_filter_clause = True
+    supported_explain_formats = {'JSON', 'TEXT', 'XML', 'YAML'}
+    validates_explain_options = False  # A query will error on invalid options.
 
     @cached_property
     def is_postgresql_9_5(self):

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -7,6 +7,7 @@ from django.db.backends.base.operations import BaseDatabaseOperations
 
 class DatabaseOperations(BaseDatabaseOperations):
     cast_char_field_without_max_length = 'varchar'
+    explain_prefix = 'EXPLAIN'
 
     def unification_cast_sql(self, output_field):
         internal_type = output_field.get_internal_type()
@@ -258,3 +259,17 @@ class DatabaseOperations(BaseDatabaseOperations):
                 'and FOLLOWING.'
             )
         return start_, end_
+
+    def explain_query_prefix(self, format=None, **options):
+        prefix = super().explain_query_prefix(format)
+        extra = {}
+        if format:
+            extra['FORMAT'] = format
+        if options:
+            extra.update({
+                name.upper(): 'true' if value else 'false'
+                for name, value in options.items()
+            })
+        if extra:
+            prefix += ' (%s)' % ', '.join('%s %s' % i for i in extra.items())
+        return prefix

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -19,6 +19,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         'DateField': 'TEXT',
         'DateTimeField': 'TEXT',
     }
+    explain_prefix = 'EXPLAIN QUERY PLAN'
 
     def bulk_batch_size(self, fields, objs):
         """

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -717,6 +717,9 @@ class QuerySet:
         prefetch_related_objects(self._result_cache, *self._prefetch_related_lookups)
         self._prefetch_done = True
 
+    def explain(self, *, format=None, **options):
+        return self.query.explain(using=self.db, format=format, **options)
+
     ##################################################
     # PUBLIC METHODS THAT RETURN A QUERYSET SUBCLASS #
     ##################################################

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -223,6 +223,10 @@ class Query:
 
         self._filtered_relations = {}
 
+        self.explain_query = False
+        self.explain_format = None
+        self.explain_options = {}
+
     @property
     def extra(self):
         if self._extra is None:
@@ -510,6 +514,14 @@ class Query:
         q.set_limits(high=1)
         compiler = q.get_compiler(using=using)
         return compiler.has_results()
+
+    def explain(self, using, format=None, **options):
+        q = self.clone()
+        q.explain_query = True
+        q.explain_format = format
+        q.explain_options = options
+        compiler = q.get_compiler(using=using)
+        return '\n'.join(compiler.explain_query())
 
     def combine(self, rhs, connector):
         """

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2476,6 +2476,49 @@ Class method that returns an instance of :class:`~django.db.models.Manager`
 with a copy of the ``QuerySet``’s methods. See
 :ref:`create-manager-with-queryset-methods` for more details.
 
+``explain()``
+~~~~~~~~~~~~~
+
+.. versionadded:: 2.1
+
+.. method:: explain(format=None, **options)
+
+Returns a string of the ``QuerySet``’s execution plan, which details how the
+database would execute the query, including any indexes or joins that would be
+used. Knowing these details may help you improve the performance of slow
+queries.
+
+For example, when using PostgreSQL::
+
+    >>> print(Blog.objects.filter(title='My Blog').explain())
+    Seq Scan on blog  (cost=0.00..35.50 rows=10 width=12)
+      Filter: (title = 'My Blog'::bpchar)
+
+The output differs significantly between databases.
+
+``explain()`` is supported by all built-in database backends except Oracle
+because an implementation there isn't straightforward.
+
+The ``format`` parameter changes the output format from the databases's default,
+usually text-based. PostgreSQL supports ``'TEXT'``, ``'JSON'``, ``'YAML'``, and
+``'XML'``. MySQL supports ``'TEXT'`` (also called ``'TRADITIONAL'``) and
+``'JSON'``.
+
+Some databases accept flags that can return more information about the query.
+Pass these flags as keyword arguments. For example, when using PostgreSQL::
+
+    >>> print(Blog.objects.filter(title='My Blog').explain(verbose=True))
+    Seq Scan on public.blog  (cost=0.00..35.50 rows=10 width=12) (actual time=0.004..0.004 rows=10 loops=1)
+      Output: id, title
+      Filter: (blog.title = 'My Blog'::bpchar)
+    Planning time: 0.064 ms
+    Execution time: 0.058 ms
+
+On some databases, flags may cause the query to be executed which could have
+adverse effects on your database. For example, PostgreSQL's ``ANALYZE`` flag
+could result in changes to data if there are triggers or if a function is
+called, even for a ``SELECT`` query.
+
 .. _field-lookups:
 
 ``Field`` lookups

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -236,6 +236,9 @@ Models
   encouraged instead of :class:`~django.db.models.NullBooleanField`, which will
   likely be deprecated in the future.
 
+* The new :meth:`.QuerySet.explain` method displays the database's execution
+  plan of a queryset's query.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -555,6 +555,7 @@ class ManagerTest(SimpleTestCase):
         'only',
         'using',
         'exists',
+        'explain',
         '_insert',
         '_update',
         'raw',

--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -1,0 +1,99 @@
+import unittest
+
+from django.db import NotSupportedError, connection, transaction
+from django.db.models import Count
+from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+from django.test.utils import CaptureQueriesContext
+
+from .models import Tag
+
+
+@skipUnlessDBFeature('supports_explaining_query_execution')
+class ExplainTests(TestCase):
+
+    def test_basic(self):
+        querysets = [
+            Tag.objects.filter(name='test'),
+            Tag.objects.filter(name='test').select_related('parent'),
+            Tag.objects.filter(name='test').prefetch_related('children'),
+            Tag.objects.filter(name='test').annotate(Count('children')),
+            Tag.objects.filter(name='test').values_list('name'),
+            Tag.objects.order_by().union(Tag.objects.order_by().filter(name='test')),
+            Tag.objects.all().select_for_update().filter(name='test'),
+        ]
+        supported_formats = connection.features.supported_explain_formats
+        all_formats = (None,) + tuple(supported_formats) + tuple(f.lower() for f in supported_formats)
+        for idx, queryset in enumerate(querysets):
+            for format in all_formats:
+                with self.subTest(format=format, queryset=idx):
+                    if connection.vendor == 'mysql':
+                        # This does a query and caches the result.
+                        connection.features.needs_explain_extended
+                    with self.assertNumQueries(1), CaptureQueriesContext(connection) as captured_queries:
+                        result = queryset.explain(format=format)
+                        self.assertTrue(captured_queries[0]['sql'].startswith(connection.ops.explain_prefix))
+                        self.assertIsInstance(result, str)
+                        self.assertTrue(result)
+
+    @skipUnlessDBFeature('validates_explain_options')
+    def test_unknown_options(self):
+        with self.assertRaisesMessage(ValueError, 'Unknown options: test, test2'):
+            Tag.objects.all().explain(test=1, test2=1)
+
+    def test_unknown_format(self):
+        msg = 'DOES NOT EXIST is not a recognized format.'
+        if connection.features.supported_explain_formats:
+            msg += ' Allowed formats: %s' % ', '.join(sorted(connection.features.supported_explain_formats))
+        with self.assertRaisesMessage(ValueError, msg):
+            Tag.objects.all().explain(format='does not exist')
+
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL specific')
+    def test_postgres_options(self):
+        qs = Tag.objects.filter(name='test')
+        test_options = [
+            {'COSTS': False, 'BUFFERS': True, 'ANALYZE': True},
+            {'costs': False, 'buffers': True, 'analyze': True},
+            {'verbose': True, 'timing': True, 'analyze': True},
+            {'verbose': False, 'timing': False, 'analyze': True},
+        ]
+        if connection.pg_version >= 100000:
+            test_options.append({'summary': True})
+        for options in test_options:
+            with self.subTest(**options), transaction.atomic():
+                with CaptureQueriesContext(connection) as captured_queries:
+                    qs.explain(format='text', **options)
+                self.assertEqual(len(captured_queries), 1)
+                for name, value in options.items():
+                    option = '{} {}'.format(name.upper(), 'true' if value else 'false')
+                    self.assertIn(option, captured_queries[0]['sql'])
+
+    @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL specific')
+    def test_mysql_text_to_traditional(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            Tag.objects.filter(name='test').explain(format='text')
+        self.assertEqual(len(captured_queries), 1)
+        self.assertIn('FORMAT=TRADITIONAL', captured_queries[0]['sql'])
+
+    @unittest.skipUnless(connection.vendor == 'mysql', 'MySQL < 5.7 specific')
+    def test_mysql_extended(self):
+        # Inner skip to avoid module level query for MySQL version.
+        if not connection.features.needs_explain_extended:
+            raise unittest.SkipTest('MySQL < 5.7 specific')
+        qs = Tag.objects.filter(name='test')
+        with CaptureQueriesContext(connection) as captured_queries:
+            qs.explain(format='json')
+        self.assertEqual(len(captured_queries), 1)
+        self.assertNotIn('EXTENDED', captured_queries[0]['sql'])
+        with CaptureQueriesContext(connection) as captured_queries:
+            qs.explain(format='text')
+        self.assertEqual(len(captured_queries), 1)
+        self.assertNotIn('EXTENDED', captured_queries[0]['sql'])
+
+
+@skipIfDBFeature('supports_explaining_query_execution')
+class ExplainUnsupportedTests(TestCase):
+
+    def test_message(self):
+        msg = 'This backend does not support explaining query execution.'
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            Tag.objects.filter(name='test').explain()

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -20,6 +20,14 @@ from django.test.utils import get_runner
 from django.utils.deprecation import RemovedInDjango30Warning
 from django.utils.log import DEFAULT_LOGGING
 
+try:
+    import MySQLdb
+except ImportError:
+    pass
+else:
+    # Ignore informational warnings from QuerySet.explain().
+    warnings.filterwarnings('ignore', '\(1003, *', category=MySQLdb.Warning)
+
 # Make deprecation warnings errors to ensure no usage of deprecated features.
 warnings.simplefilter("error", RemovedInDjango30Warning)
 # Make runtime warning errors to ensure no usage of error prone patterns.


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/28574)

```python
>> qs = Tag.objects.filter(name='test').all()
>> print(qs.explain())
Seq Scan on queries_tag  (cost=0.00..23.00 rows=5 width=50)
  Filter: ((name)::text = 'test'::text)
>> print(qs.explain(verbose=True))
Seq Scan on public.queries_tag  (cost=0.00..23.00 rows=5 width=50) (actual time=0.054..0.054 rows=0 loops=1)
  Output: id, name, parent_id, category_id
  Filter: ((queries_tag.name)::text = 'test'::text)
  Rows Removed by Filter: 5
Planning time: 0.382 ms
Execution time: 0.189 ms
>> print(qs.explain(verbose=True, format='json'))
[{'Execution Time': 0.177, 'Triggers': [], 'Planning Time': 0.419, 'Plan': {'Actual Loops': 1, 'Filter': "((queries_tag.name)::text = 'test'::text)", 'Node Type': 'Seq Scan', 'Rows Removed by Filter': 5, 'Alias': 'queries_tag', 'Output': ['id', 'name', 'parent_id', 'category_id'], 'Actual Startup Time': 0.067, 'Actual Total Time': 0.067, 'Relation Name': 'queries_tag', 'Parallel Aware': False, 'Plan Rows': 5, 'Plan Width': 50, 'Actual Rows': 0, 'Total Cost': 23.0, 'Schema': 'public', 'Startup Cost': 0.0}}]
```

I need to add docs, but I hope the general implementation is OK with regards to modifying the `operations` and `features` db-backend files, and their interaction with the compiler/queryset/query etc.