### PR TITLE
Fixed #28392 -- Fixed GIS's WKT regex to match large scientific notation numbers.

### DIFF
--- a/django/contrib/gis/geometry/regex.py
+++ b/django/contrib/gis/geometry/regex.py
@@ -8,6 +8,6 @@ wkt_regex = re.compile(r'^(SRID=(?P<srid>\-?\d+);)?'
                        r'(?P<wkt>'
                        r'(?P<type>POINT|LINESTRING|LINEARRING|POLYGON|MULTIPOINT|'
                        r'MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)'
-                       r'[ACEGIMLONPSRUTYZ\d,\.\-\(\) ]+)$',
+                       r'[ACEGIMLONPSRUTYZ\d,\.\-\+\(\) ]+)$',
                        re.I)
 json_regex = re.compile(r'^(\s+)?\{.*}(\s+)?$', re.DOTALL)

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -1337,6 +1337,9 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
         with self.assertRaisesMessage(ValueError, msg):
             GEOSGeometry.from_ewkt('SRID=WGS84;POINT(1 1)')
 
+    def test_fromstr_scientific_wkt(self):
+        self.assertEqual(GEOSGeometry('POINT(1.0e-1 1.0e+1)'), Point(.1, 10))
+
     def test_normalize(self):
         g = MultiPoint(Point(0, 0), Point(2, 2), Point(1, 1))
         self.assertIsNone(g.normalize())


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28392

Thanks Greg Larmore for report and initial patch.