### PR TITLE
Fixed #28570 -- Avoided setting SRID in GEOSGeometry.clone().

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -613,7 +613,7 @@ class GEOSGeometryBase(GEOSBase):
 
     def clone(self):
         "Clone this Geometry."
-        return GEOSGeometry(capi.geom_clone(self.ptr), srid=self.srid)
+        return GEOSGeometry(capi.geom_clone(self.ptr))
 
 
 class LinearGeometryMixin:

--- a/docs/ref/contrib/gis/install/geolibs.txt
+++ b/docs/ref/contrib/gis/install/geolibs.txt
@@ -8,7 +8,7 @@ geospatial libraries:
 ========================  ====================================  ================================  ===================================
 Program                   Description                           Required                          Supported Versions
 ========================  ====================================  ================================  ===================================
-:doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.5, 3.4, 3.3
+:doc:`GEOS <../geos>`     Geometry Engine Open Source           Yes                               3.5, 3.4
 `PROJ.4`_                 Cartographic Projections library      Yes (PostgreSQL and SQLite only)  4.9, 4.8, 4.7, 4.6, 4.5, 4.4
 :doc:`GDAL <../gdal>`     Geospatial Data Abstraction Library   Yes                               2.2, 2.1, 2.0, 1.11, 1.10, 1.9
 :doc:`GeoIP <../geoip2>`  IP-based geolocation library          No                                2
@@ -26,7 +26,6 @@ totally fine with GeoDjango. Your mileage may vary.
 
 ..
     Libs release dates:
-    GEOS 3.3.0 2011-05-30
     GEOS 3.4.0 2013-08-11
     GEOS 3.5.0 2015-08-15
     GDAL 1.9.0 2012-01-03

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -617,6 +617,8 @@ Miscellaneous
 * ``django.contrib.gis.gdal.OGRException`` is removed. It's been an alias for
   ``GDALException`` since Django 1.8.
 
+* Support for GEOS 3.3.x is dropped.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28570

This requires at least GEOS 3.3.1, I think it's OK to set it as minimum version, but I'm not sure if change `3.3` to `3.3.1` here https://github.com/django/django/blob/a599ae6018f748f66e774604d12989911ea09d33/docs/ref/contrib/gis/install/geolibs.txt#L11
would look good. Actually I think we could fully drop support for 3.3.