### PR TITLE
Added Test case for ticket #28567

### DIFF
--- a/tests/i18n/i18n_unprefixed_urls.py
+++ b/tests/i18n/i18n_unprefixed_urls.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+# ==============================================================================
+#
+#       File Name : unprefixed_urls.py
+#
+#       Purpose :
+#
+#       Creation Date : Sun 10 Sep 2017 10:35:45 PM EEST
+#
+#       Last Modified : Sun 10 Sep 2017 11:30:47 PM EEST
+#
+#       Developer : rara_tiru  | email: tantiras@yandex.com
+#
+# ==============================================================================
+
+from django.conf.urls import url
+from django.conf.urls import include
+from django.conf.urls.i18n import i18n_patterns
+from django.utils.translation import gettext_lazy as _
+from django.http import HttpResponse
+from django.contrib import admin
+
+urlpatterns = [
+    url(r'^i18n/', include('django.conf.urls.i18n')),
+]
+
+urlpatterns += i18n_patterns(
+    url(r'^admin/', admin.site.urls),
+    prefix_default_language=False,
+)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1491,6 +1491,46 @@ class UnprefixedDefaultLanguageTests(SimpleTestCase):
         response = self.client.get('/nonexistent/')
         self.assertEqual(response.status_code, 404)
 
+@override_settings(
+    USE_I18N=True,
+    LANGUAGES=[
+        ('en', 'English'),
+        ('fr', 'French'),
+    ],
+    MIDDLEWARE=[
+        'django.middleware.locale.LocaleMiddleware',
+        'django.middleware.common.CommonMiddleware',
+    ],
+    ROOT_URLCONF='i18n.i18n_unprefixed_urls',
+    LANGUAGE_CODE='en',
+)
+class UnprefixedI18nSetLang(TestCase):
+    def test_en2fr(self):
+        response = self.client.post(
+            '/i18n/setlang/',
+            data={'language': 'fr'},
+            HTTP_REFERER='/admin/',
+            follow=False,
+        )
+        self.assertEqual(
+            response.url,
+            '/fr/admin/',
+            'Setlang did not change from unprefixed English to French admin'
+        )
+
+    def test_fr2en(self):
+        response = self.client.post(
+            '/i18n/setlang/',
+            data={'language': 'en'},
+            HTTP_REFERER='/fr/admin/',
+            follow=False,
+        )
+        self.assertEqual(
+            response.url,
+            '/admin/',
+            'Setlang did not change from French to unprefixed English admin',
+            )
+
 
 @override_settings(
     USE_I18N=True,


### PR DESCRIPTION
[#28567](https://code.djangoproject.com/ticket/28567)

Setlang will not redirect to `/admin/` if `prefix_default_language=False`