### PR TITLE
[1.11.x] Fixed #27895 -- Fixed test client response.json crash with non-ASCII characters on Python 2.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -697,7 +697,7 @@ class Client(RequestFactory):
                     'Content-Type header is "{0}", not "application/json"'
                     .format(response.get('Content-Type'))
                 )
-            response._json = json.loads(response.content.decode(), **extra)
+            response._json = json.loads(response.content.decode('utf-8'), **extra)
         return response._json
 
     def _handle_redirects(self, response, **extra):

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1233,6 +1233,10 @@ class RequestMethodStringDataTests(SimpleTestCase):
         response = self.client.get('/json_response/')
         self.assertIs(response.json(), response.json())
 
+    def test_unicode_json(self):
+        response = self.client.get('/unicode_json_response/')
+        self.assertEqual(response.json(), {'峠': 'とうげ tōge "mountain pass"'})
+
     def test_json_wrong_header(self):
         response = self.client.get('/body/')
         msg = 'Content-Type header is "text/html; charset=utf-8", not "application/json"'

--- a/tests/test_client_regress/urls.py
+++ b/tests/test_client_regress/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     url(r'^check_unicode/$', views.return_unicode),
     url(r'^check_binary/$', views.return_undecodable_binary),
     url(r'^json_response/$', views.return_json_response),
+    url(r'^unicode_json_response/$', views.return_unicode_json_response),
     url(r'^parse_unicode_json/$', views.return_json_file),
     url(r'^check_headers/$', views.check_headers),
     url(r'^check_headers_redirect/$', RedirectView.as_view(url='/check_headers/')),

--- a/tests/test_client_regress/views.py
+++ b/tests/test_client_regress/views.py
@@ -1,3 +1,5 @@
+# -*- coding:utf-8 -*-
+
 import json
 
 from django.conf import settings
@@ -109,6 +111,13 @@ def return_json_response(request):
     content_type = request.GET.get('content_type')
     kwargs = {'content_type': content_type} if content_type else {}
     return JsonResponse({'key': 'value'}, **kwargs)
+
+
+def return_unicode_json_response(request):
+    content_type = request.GET.get('content_type')
+    kwargs = {'content_type': content_type} if content_type else {}
+    kwargs['json_dumps_params'] = {'ensure_ascii': False}
+    return JsonResponse({'峠': 'とうげ tōge "mountain pass"'}, **kwargs)
 
 
 def return_json_file(request):


### PR DESCRIPTION
Based on Aniruddha Maru's patch (ticket #27895).