### PR TITLE
Fixed #28575 - Added a custom metaclass for exceptions to ensure they are pickleable

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -348,7 +348,7 @@ class ParallelTestSuite(unittest.TestSuite):
         - make tracebacks picklable with tblib, if available
 
         Even with tblib, errors may still occur for dynamically created
-        exception classes such Model.DoesNotExist which cannot be unpickled.
+        exception classes.
         """
         counter = multiprocessing.Value(ctypes.c_int, 0)
         pool = multiprocessing.Pool(

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -52,6 +52,15 @@ class PickleabilityTestCase(TestCase):
         self.assertEqual(original.__class__, unpickled.__class__)
         self.assertEqual(original.args, unpickled.args)
 
+    def test_can_pickle_doesnotexist_class(self):
+        """
+        #28575 - Verifies the dynamically created DoesNotExist attribute can be pickled
+        """
+        self.assertEqual(
+            pickle.loads(pickle.dumps(Event.DoesNotExist)),
+            Event.DoesNotExist
+        )
+
     def test_manager_pickle(self):
         pickle.loads(pickle.dumps(Happening.objects))
 


### PR DESCRIPTION
This adds a custom metaclass for dynamically created exceptions attached to models on creation. It also adds a pickling function and registers it with the pickler dispatch table for the custom metaclass.