### PR TITLE
Fixed #28575 -- Added a qualified name to dynamic exceptions in models

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -64,6 +64,8 @@ def subclass_exception(name, parents, module, attached_to=None):
 
         class_dict['__reduce__'] = __reduce__
         class_dict['__setstate__'] = __setstate__
+        if attached_to:
+            class_dict['__qualname__'] = '%s.%s' % (attached_to.__qualname__, name)
 
     return type(name, parents, class_dict)
 

--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -350,7 +350,7 @@ class ParallelTestSuite(unittest.TestSuite):
         - make tracebacks picklable with tblib, if available
 
         Even with tblib, errors may still occur for dynamically created
-        exception classes such Model.DoesNotExist which cannot be unpickled.
+        exception classes which cannot be unpickled.
         """
         counter = multiprocessing.Value(ctypes.c_int, 0)
         pool = multiprocessing.Pool(

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -47,6 +47,14 @@ class PickleabilityTestCase(TestCase):
         self.assertEqual(original.__class__, unpickled.__class__)
         self.assertEqual(original.args, unpickled.args)
 
+    def test_doesnotexist_class(self):
+        klass = Event.DoesNotExist
+        self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
+
+    def test_multipleobjectsreturned_class(self):
+        klass = Event.MultipleObjectsReturned
+        self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
+
     def test_manager_pickle(self):
         pickle.loads(pickle.dumps(Happening.objects))
 


### PR DESCRIPTION
This adds a custom metaclass for dynamically created exceptions attached to models on creation. It also adds a pickling function and registers it with the pickler dispatch table for the custom metaclass.