### PR TITLE
Fixed #29007 -- Fixed DecimalValidator crash on NaN, SNan, Inf, and Infinity values.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -391,6 +391,7 @@ class DecimalValidator:
     expected, otherwise raise ValidationError.
     """
     messages = {
+        'invalid': _('Enter a number.'),
         'max_digits': ngettext_lazy(
             'Ensure that there are no more than %(max)s digit in total.',
             'Ensure that there are no more than %(max)s digits in total.',
@@ -414,6 +415,8 @@ class DecimalValidator:
 
     def __call__(self, value):
         digit_tuple, exponent = value.as_tuple()[1:]
+        if exponent in {'F', 'n', 'N'}:
+            raise ValidationError(self.messages['invalid'])
         if exponent >= 0:
             # A positive exponent adds that many trailing zeros.
             digits = len(digit_tuple) + exponent

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -271,6 +271,14 @@ TEST_DATA = [
     (DecimalValidator(max_digits=5, decimal_places=2), Decimal('7304E-3'), ValidationError),
     (DecimalValidator(max_digits=5, decimal_places=5), Decimal('70E-5'), None),
     (DecimalValidator(max_digits=5, decimal_places=5), Decimal('70E-6'), ValidationError),
+    # 'Enter a number.' errors
+    *[
+        (DecimalValidator(decimal_places=2, max_digits=10), Decimal(value), ValidationError)
+        for value in (
+            'NaN', '-NaN', '+NaN', 'sNaN', '-sNaN', '+sNaN',
+            'Inf', '-Inf', '+Inf', 'Infinity', '-Infinity', '-Infinity',
+        )
+    ],
 
     (validate_image_file_extension, ContentFile('contents', name='file.jpg'), None),
     (validate_image_file_extension, ContentFile('contents', name='file.png'), None),


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29007