### PR TITLE
Fixed #28601 -- Prevented cache.get_or_set() from caching None if default is a callable that returns None.

### DIFF
--- a/django/core/cache/backends/base.py
+++ b/django/core/cache/backends/base.py
@@ -155,13 +155,15 @@ class BaseCache:
         Return the value of the key stored or retrieved.
         """
         val = self.get(key, version=version)
-        if val is None and default is not None:
+        if val is None:
             if callable(default):
                 default = default()
-            self.add(key, default, timeout=timeout, version=version)
-            # Fetch the value again to avoid a race condition if another caller
-            # added a value between the first get() and the add() above.
-            return self.get(key, default, version=version)
+            if default is not None:
+                self.add(key, default, timeout=timeout, version=version)
+                # Fetch the value again to avoid a race condition if another
+                # caller added a value between the first get() and the add()
+                # above.
+                return self.get(key, default, version=version)
         return val
 
     def has_key(self, key, version=None):

--- a/docs/releases/1.11.7.txt
+++ b/docs/releases/1.11.7.txt
@@ -9,4 +9,5 @@ Django 1.11.7 fixes several bugs in 1.11.6.
 Bugfixes
 ========
 
-* ...
+* Prevented ``cache.get_or_set()`` from caching ``None`` if the ``default``
+  argument is a callable that returns ``None`` (:ticket:`28601`).

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -924,6 +924,11 @@ class BaseCacheTests:
         self.assertEqual(cache.get_or_set('mykey', my_callable), 'value')
         self.assertEqual(cache.get_or_set('mykey', my_callable()), 'value')
 
+    def test_get_or_set_callable_returning_none(self):
+        self.assertIsNone(cache.get_or_set('mykey', lambda: None))
+        # Previous get_or_set() doesn't store None in the cache.
+        self.assertEqual(cache.get('mykey', 'default'), 'default')
+
     def test_get_or_set_version(self):
         msg = "get_or_set() missing 1 required positional argument: 'default'"
         cache.get_or_set('brian', 1979, version=2)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28601

In 82be474 the change was made to allow None as a default value passed to
BaseCache.get_or_set. In case the default value of None is used, it is not
stored in the cache. This still left open the possibility that default could
be a callable that *returns* None, in which case it *would* be stored in the
cache.

    # This scenario works as expected.
    cache.get_or_set('foo', None)  # None
    cache.get_or_set('foo', 5)  # 5
    cache.get('foo')  # 5

    # This scenario seems wrong.
    cache.get_or_set('bar', lambda: None)  # None
    cache.get_or_set('bar', 5)  # None :(
    cache.get('bar')  # None :(

This change updates the logic for BaseCache.get_or_set so that if default is
None or *returns* None, the default value is not cached.