### PR TITLE
Refs #8408 -- Added EstimatedCountPaginator.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -377,6 +377,7 @@ answer newbie questions, and generally made Django that much better:
     Jeremy Carbaugh <jcarbaugh@gmail.com>
     Jeremy Dunck <jdunck@gmail.com>
     Jeremy Lainé <jeremy.laine@m4x.org>
+    Jerome Leclanche <jerome@leclan.ch>
     Jesse Young <adunar@gmail.com>
     jhenry <jhenry@theonion.com>
     Jim Dalton <jim.dalton@gmail.com>

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -308,6 +308,8 @@ Pagination
 * Added :meth:`Paginator.get_page() <django.core.paginator.Paginator.get_page>`
   to provide the documented pattern of handling invalid page numbers.
 
+* Added :class:`~django.core.paginators.EstimatedCountPaginator`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
**RFC, please discuss**

This PR implements a paginator which takes advantage of Postgres and mysql's ability to estimate the amount of rows in a table.
Even as early as 1 million rows, SQL count operations can become slow and the Django administration unexplicably slows down. It becomes unusable within a couple of magnitudes.
This is basically a different way to approach [8408](https://code.djangoproject.com/ticket/8408), which has a `no_count` PR in #8858.

Notes:

* Only postgres and mysql are supported; I have no idea how to do it with other engines (and I don't think it's necessary, this is best-effort after all).
* MySQL is completely untested. I rewrote a postgres version I'm currently using in production.
* Estimations can be off by a lot! I've seen discrepancies of up to 3-4% on postgres.
* This is obviously only meant to be used on QuerySets. It will fail gracefully if given a non-queryset object though.
* No tests/docs yet (and I would welcome help writing those). I'd like input on whether this is an acceptable approach to be merged first.
* Is `django.core.paginator` an ok place for this to live? It's where I would expect it, but the module doesn't do db stuff in general.