### PR TITLE
Removed unneeded StdDev.convert_value() and Variance.convert_value().

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -151,11 +151,6 @@ class StdDev(Aggregate):
         options = super()._get_repr_options()
         return dict(options, sample=self.function == 'STDDEV_SAMP')
 
-    def convert_value(self, value, expression, connection):
-        if value is None:
-            return value
-        return float(value)
-
 
 class Sum(Aggregate):
     function = 'SUM'
@@ -181,8 +176,3 @@ class Variance(Aggregate):
     def _get_repr_options(self):
         options = super()._get_repr_options()
         return dict(options, sample=self.function == 'VAR_SAMP')
-
-    def convert_value(self, value, expression, connection):
-        if value is None:
-            return value
-        return float(value)


### PR DESCRIPTION
This seems unneeded since its introduction in f59fd15c4928caf3dfcbd50f6ab47be409a43b01.