### PR TITLE
Fixed #28608 -- Allowed UserCreationForm and UserChangeForm to work with custom user models.

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -7,7 +7,6 @@ from django.contrib.auth import (
 from django.contrib.auth.hashers import (
     UNUSABLE_PASSWORD_PREFIX, identify_hasher,
 )
-from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMultiAlternatives
@@ -83,7 +82,7 @@ class UserCreationForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = ("username",)
         field_classes = {'username': UsernameField}
 
@@ -132,7 +131,7 @@ class UserChangeForm(forms.ModelForm):
     )
 
     class Meta:
-        model = User
+        model = UserModel
         fields = '__all__'
         field_classes = {'username': UsernameField}
 

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -840,6 +840,9 @@ The following forms are compatible with any subclass of
 * :class:`~django.contrib.auth.forms.SetPasswordForm`
 * :class:`~django.contrib.auth.forms.PasswordChangeForm`
 * :class:`~django.contrib.auth.forms.AdminPasswordChangeForm`
+* :class:`~django.contrib.auth.forms.UserCreationForm`
+* :class:`~django.contrib.auth.forms.UserChangeForm`
+
 
 The following forms make assumptions about the user model and can be used as-is
 if those assumptions are met:
@@ -850,24 +853,6 @@ if those assumptions are met:
   default) that can be used to identify the user and a boolean field named
   ``is_active`` to prevent password resets for inactive users.
 
-Finally, the following forms are tied to
-:class:`~django.contrib.auth.models.User` and need to be rewritten or extended
-to work with a custom user model:
-
-* :class:`~django.contrib.auth.forms.UserCreationForm`
-* :class:`~django.contrib.auth.forms.UserChangeForm`
-
-If your custom user model is a simple subclass of ``AbstractUser``, then you
-can extend these forms in this manner::
-
-    from django.contrib.auth.forms import UserCreationForm
-    from myapp.models import CustomUser
-
-    class CustomUserCreationForm(UserCreationForm):
-
-        class Meta(UserCreationForm.Meta):
-            model = CustomUser
-            fields = UserCreationForm.Meta.fields + ('custom_field',)
 
 Custom users and :mod:`django.contrib.admin`
 --------------------------------------------


### PR DESCRIPTION
fixes https://code.djangoproject.com/ticket/28608#no1