### PR TITLE
[1.11.x] Fixed #28609 -- Add REQUEST_URI to dev server

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -132,7 +132,9 @@ class WSGIRequestHandler(simple_server.WSGIRequestHandler, object):
             if '_' in k:
                 del self.headers[k]
 
-        return super(WSGIRequestHandler, self).get_environ()
+        environ = super(WSGIRequestHandler, self).get_environ()
+        environ[str("REQUEST_URI")] = self.path
+        return environ
 
     def handle(self):
         """Copy of WSGIRequestHandler, but with different ServerHandler"""


### PR DESCRIPTION
Pass original request URI in the environment from the development server
WSGIRequestHandler so that WSGI middleware which need access it can be
applied in WSGI_APPLICATION.