### PR TITLE
bug#28198. Fixed logic that set default value for deferred fields

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -419,6 +419,7 @@ class Model(metaclass=ModelBase):
             # without changing the logic.
             for val, field in zip(args, fields_iter):
                 if val is _DEFERRED:
+                    _setattr(self, field.attname, field.default)
                     continue
                 _setattr(self, field.attname, val)
         else:
@@ -426,6 +427,7 @@ class Model(metaclass=ModelBase):
             fields_iter = iter(opts.fields)
             for val, field in zip(args, fields_iter):
                 if val is _DEFERRED:
+                    _setattr(self, field.attname, field.default)
                     continue
                 _setattr(self, field.attname, val)
                 kwargs.pop(field.name, None)


### PR DESCRIPTION
All deferred fields were skipped during model initialization process, even they have default value 