### PR TITLE
Refs #28334 -- Fixed crash in hstore/citext oid caching when testing.

### DIFF
--- a/django/contrib/postgres/signals.py
+++ b/django/contrib/postgres/signals.py
@@ -5,6 +5,7 @@ from psycopg2 import ProgrammingError
 from psycopg2.extras import register_hstore
 
 from django.db import connections
+from django.db.backends.base.base import NO_DB_ALIAS
 
 
 @functools.lru_cache()
@@ -34,7 +35,7 @@ def get_citext_oids(connection_alias):
 
 
 def register_type_handlers(connection, **kwargs):
-    if connection.vendor != 'postgresql':
+    if connection.vendor != 'postgresql' or connection.alias == NO_DB_ALIAS:
         return
 
     try:

--- a/tests/postgres_tests/test_signals.py
+++ b/tests/postgres_tests/test_signals.py
@@ -3,7 +3,9 @@ from django.db import connection
 from . import PostgreSQLTestCase
 
 try:
-    from django.contrib.postgres.signals import get_hstore_oids, get_citext_oids
+    from django.contrib.postgres.signals import (
+        get_citext_oids, get_hstore_oids, register_type_handlers,
+    )
 except ImportError:
     pass  # pyscogp2 isn't installed.
 
@@ -31,3 +33,7 @@ class OIDTests(PostgreSQLTestCase):
     def test_citext_values(self):
         oids = get_citext_oids(connection.alias)
         self.assertOIDs(oids)
+
+    def test_register_type_handlers_no_db(self):
+        """Registering type handlers for the nodb connection does nothing."""
+        register_type_handlers(connection._nodb_connection)


### PR DESCRIPTION
Reported in https://github.com/django/django/pull/8686#issuecomment-330273596.