### PR TITLE
Fixed #28617 -- Made ogrinspect output pep8 compliant

### DIFF
--- a/django/contrib/gis/management/commands/ogrinspect.py
+++ b/django/contrib/gis/management/commands/ogrinspect.py
@@ -124,10 +124,10 @@ class Command(BaseCommand):
             # This extra legwork is so that the dictionary definition comes
             # out in the same order as the fields in the model definition.
             rev_mapping = {v: k for k, v in mapping_dict.items()}
-            output.extend(['', '# Auto-generated `LayerMapping` dictionary for %s model' % model_name,
+            output.extend(['', '', '# Auto-generated `LayerMapping` dictionary for %s model' % model_name,
                            '%s_mapping = {' % model_name.lower()])
-            output.extend("    '%s' : '%s'," % (
+            output.extend("    '%s': '%s'," % (
                 rev_mapping[ogr_fld], ogr_fld) for ogr_fld in ds[options['layer_key']].fields
             )
-            output.extend(["    '%s' : '%s'," % (options['geom_name'], mapping_dict[options['geom_name']]), '}'])
+            output.extend(["    '%s': '%s'," % (options['geom_name'], mapping_dict[options['geom_name']]), '}'])
         return '\n'.join(output) + '\n'

--- a/django/contrib/gis/utils/ogrinspect.py
+++ b/django/contrib/gis/utils/ogrinspect.py
@@ -169,6 +169,7 @@ def _ogrinspect(data_source, model_name, geom_name='geom', layer_key=0, srid=Non
         yield '# This is an auto-generated Django model module created by ogrinspect.'
         yield 'from django.contrib.gis.db import models'
         yield ''
+        yield ''
 
     yield 'class %s(models.Model):' % model_name
 

--- a/tests/gis_tests/inspectapp/tests.py
+++ b/tests/gis_tests/inspectapp/tests.py
@@ -70,6 +70,7 @@ class OGRInspectTest(TestCase):
             '# This is an auto-generated Django model module created by ogrinspect.',
             'from django.contrib.gis.db import models',
             '',
+            '',
             'class MyModel(models.Model):',
             '    float = models.FloatField()',
             '    int = models.{}()'.format('BigIntegerField' if GDAL_VERSION >= (2, 0) else 'FloatField'),
@@ -95,6 +96,7 @@ class OGRInspectTest(TestCase):
         expected = [
             '# This is an auto-generated Django model module created by ogrinspect.',
             'from django.contrib.gis.db import models',
+            '',
             '',
             'class City(models.Model):',
             '    name = models.CharField(max_length=80)',
@@ -126,6 +128,7 @@ class OGRInspectTest(TestCase):
             '# This is an auto-generated Django model module created by ogrinspect.\n'
             'from django.contrib.gis.db import models\n'
             '\n'
+            '\n'
             'class Measurement(models.Model):\n'
         ))
 
@@ -147,6 +150,24 @@ class OGRInspectTest(TestCase):
         call_command('ogrinspect', shp_file, 'City', stdout=out)
         output = out.getvalue()
         self.assertIn('class City(models.Model):', output)
+
+    def test_mapping_option(self):
+        expected = (
+            "    geom = models.PointField(srid=-1)\n"
+            "\n"
+            "\n"
+            "# Auto-generated `LayerMapping` dictionary for City model\n"
+            "city_mapping = {\n"
+            "    'name': 'Name',\n"
+            "    'population': 'Population',\n"
+            "    'density': 'Density',\n"
+            "    'created': 'Created',\n"
+            "    'geom': 'POINT',\n"
+            "}\n")
+        shp_file = os.path.join(TEST_DATA, 'cities', 'cities.shp')
+        out = StringIO()
+        call_command('ogrinspect', shp_file, '--mapping', 'City', stdout=out)
+        self.assertIn(expected, out.getvalue())
 
 
 def get_ogr_db_string():


### PR DESCRIPTION
This PR fixes some E305 and E203 violations in the output of the `ogrinspect` command. It also adds a test for the `--mapping` option.