### PR TITLE
Fixed #28508 -- Changed the foreground colors to black on error pages

### DIFF
--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -23,7 +23,7 @@ CSRF_FAILURE_TEMPLATE = """
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font:small sans-serif; background:#eee; }
+    body { font:small sans-serif; background:#eee; color:#000; }
     body>div { border-bottom:1px solid #ddd; }
     h1 { font-weight:normal; margin-bottom:.4em; }
     h1 span { font-size:60%; color:#666; font-weight:normal; }

--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -8,7 +8,7 @@
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }
     body * * { padding:0; }
-    body { font:small sans-serif; background:#eee; }
+    body { font:small sans-serif; background:#eee; color:#000; }
     body>div { border-bottom:1px solid #ddd; }
     h1 { font-weight:normal; margin-bottom:.4em; }
     h1 span { font-size:60%; color:#666; font-weight:normal; }


### PR DESCRIPTION
Fixes:
https://code.djangoproject.com/ticket/28508