### PR TITLE
Fixed #27846 -- clear all cached reverse relationships on refresh_from_db()

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -627,6 +627,12 @@ class Model(metaclass=ModelBase):
                 related_val = None if rel_instance is None else getattr(rel_instance, field.target_field.attname)
                 if local_val != related_val or (local_val is None and related_val is None):
                     field.delete_cached_value(self)
+
+        # Clear cached relations.
+        for field in self._meta.related_objects:
+            if field.is_cached(self):
+                field.delete_cached_value(self)
+
         self._state.db = db_instance._state.db
 
     def serializable_value(self, field_name):

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -17,6 +17,10 @@ class Article(models.Model):
         return self.headline
 
 
+class FeaturedArticle(models.Model):
+    article = models.OneToOneField(Article, models.CASCADE, related_name='featured')
+
+
 class ArticleSelectOnSave(Article):
     class Meta:
         proxy = True

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -10,7 +10,7 @@ from django.test import (
 )
 from django.utils.translation import gettext_lazy
 
-from .models import Article, ArticleSelectOnSave, SelfRef
+from .models import Article, ArticleSelectOnSave, FeaturedArticle, SelfRef
 
 
 class ModelInstanceCreationTests(TestCase):
@@ -711,3 +711,14 @@ class ModelRefreshTests(TestCase):
         a = Article.objects.create(pub_date=datetime.now())
         with self.assertNumQueries(0):
             a.refresh_from_db(fields=[])
+
+    def test_refresh_clears_reverse_related(self):
+        """refresh_from_db() clear cached reverse relations."""
+        article = Article.objects.create(
+            headline='Parrot programs in Python',
+            pub_date=datetime(2005, 7, 28),
+        )
+        self.assertFalse(hasattr(article, 'featured'))
+        FeaturedArticle.objects.create(article_id=article.pk)
+        article.refresh_from_db()
+        self.assertTrue(hasattr(article, 'featured'))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27846