### PR TITLE
[RFC] admin: changeform view: handle ValidationErrors

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1488,15 +1488,20 @@ class ModelAdmin(BaseModelAdmin):
                 new_object = form.instance
             formsets, inline_instances = self._create_formsets(request, new_object, change=not add)
             if all_valid(formsets) and form_validated:
-                self.save_model(request, new_object, form, not add)
-                self.save_related(request, form, formsets, not add)
-                change_message = self.construct_change_message(request, form, formsets, add)
-                if add:
-                    self.log_addition(request, new_object, change_message)
-                    return self.response_add(request, new_object)
+                try:
+                    self.save_model(request, new_object, form, not add)
+                    self.save_related(request, form, formsets, not add)
+                except ValidationError as e:
+                    form.add_error(None, e)
+                    form_validated = False
                 else:
-                    self.log_change(request, new_object, change_message)
-                    return self.response_change(request, new_object)
+                    change_message = self.construct_change_message(request, form, formsets, add)
+                    if add:
+                        self.log_addition(request, new_object, change_message)
+                        return self.response_add(request, new_object)
+                    else:
+                        self.log_change(request, new_object, change_message)
+                        return self.response_change(request, new_object)
             else:
                 form_validated = False
         else:


### PR DESCRIPTION
This patch handles ValidationErrors coming from `save_model` or
`save_related`.

This is useful for e.g. django-fsm, where a transition method might
throw this.
An alternative approach would be to hook into the form's validation
(`is_valid`), but this is not as straight forward and it seems like a
good behavior to handle ValidationErrors here, instead of letting them
bubble up and typically causing a 500 for the admin page.

Ref: https://github.com/kmmbvnr/django-fsm/issues/120

TODO:
- [x] ticket (https://code.djangoproject.com/ticket/28619)
- [ ] (fix?) tests