### PR TITLE
Fixed #28642 -- Add LRU cache to parse_accept_lang_header

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -509,25 +509,26 @@ def get_language_from_request(request, check_path=False):
         return settings.LANGUAGE_CODE
 
 
+@functools.lru_cache(maxsize=1000)
 def parse_accept_lang_header(lang_string):
     """
     Parse the lang_string, which is the body of an HTTP Accept-Language
-    header, and return a list of (lang, q-value), ordered by 'q' values.
+    header, and return a tuple of (lang, q-value), ordered by 'q' values.
 
-    Return an empty list if there are any format errors in lang_string.
+    Return an empty tuple if there are any format errors in lang_string.
     """
     result = []
     pieces = accept_language_re.split(lang_string.lower())
     if pieces[-1]:
-        return []
+        return tuple()
     for i in range(0, len(pieces) - 1, 3):
         first, lang, priority = pieces[i:i + 3]
         if first:
-            return []
+            return tuple()
         if priority:
             priority = float(priority)
         else:
             priority = 1.0
         result.append((lang, priority))
     result.sort(key=lambda k: k[1], reverse=True)
-    return result
+    return tuple(result)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1133,7 +1133,7 @@ class MiscTests(SimpleTestCase):
         ]
         for value, expected in tests:
             with self.subTest(value=value):
-                self.assertEqual(trans_real.parse_accept_lang_header(value), expected)
+                self.assertEqual(trans_real.parse_accept_lang_header(value), tuple(expected))
 
     def test_parse_literal_http_header(self):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28642#ticket

`parse_accept_lang_header` seems to be an ideal candidate for an `lru_cache`.