### PR TITLE
Fixed #18620 -- Made ContentTypes shortcut view prefer current site if available.

### DIFF
--- a/tests/contenttypes_tests/models.py
+++ b/tests/contenttypes_tests/models.py
@@ -128,3 +128,11 @@ class ModelWithNullFKToSite(models.Model):
 
     def get_absolute_url(self):
         return '/title/%s/' % quote(self.title)
+
+
+class ModelWithM2MToSite(models.Model):
+    title = models.CharField(max_length=200)
+    sites = models.ManyToManyField(Site)
+
+    def get_absolute_url(self):
+        return '/title/%s/' % quote(self.title)

--- a/tests/contenttypes_tests/test_views.py
+++ b/tests/contenttypes_tests/test_views.py
@@ -106,13 +106,15 @@ class ContentTypesViewsTests(TestCase):
         obj = ModelWithNullFKToSite.objects.create(title='title')
         url = '/shortcut/%s/%s/' % (ContentType.objects.get_for_model(ModelWithNullFKToSite).id, obj.pk)
         response = self.client.get(url)
-        self.assertRedirects(response, '%s' % obj.get_absolute_url(), fetch_redirect_response=False)
+        expected_url = 'http://testserver%s' % obj.get_absolute_url()
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     @mock.patch('django.apps.apps.get_model')
     def test_shortcut_view_with_site_m2m(self, get_model):
         """
-        When the object has a ManyToManyField to Site, redirect to the
-        domain of the first site found in the m2m relationship.
+        When the object has a ManyToManyField to Site, redirect to the current
+        site if it's attached to the object or to the domain of the first site
+        found in the m2m relationship.
         """
         get_model.side_effect = lambda *args, **kwargs: MockSite if args[0] == 'sites.Site' else ModelWithM2MToSite
 
@@ -136,6 +138,23 @@ class ContentTypesViewsTests(TestCase):
             # Redirects to the domain of the first Site found in the m2m
             # relationship (ordering is arbitrary).
             response = self.client.get('/shortcut/%s/%s/' % (ct.pk, site_3_obj.pk))
+            self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+        obj_with_sites = ModelWithM2MToSite.objects.create(title='Linked to Current Site')
+        obj_with_sites.sites.set(MockSite.objects.all())
+        shortcut_url = '/shortcut/%s/%s/' % (ct.pk, obj_with_sites.pk)
+        expected_url = 'http://example2.com%s' % obj_with_sites.get_absolute_url()
+
+        with self.settings(SITE_ID=2):
+            # Redirects to the domain of the Site matching the current site's
+            # domain.
+            response = self.client.get(shortcut_url)
+            self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+        with self.settings(SITE_ID=None, ALLOWED_HOSTS=['example2.com']):
+            # Redirects to the domain of the Site matching the request's host
+            # header.
+            response = self.client.get(shortcut_url, SERVER_NAME='example2.com')
             self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/18620

Initial patch: https://github.com/django/django/pull/203/

I had to adapt an existing test because the proposed solution will always use an absolute url if one is available. The previous solution would always use one only if the sites framework was not installed.