### PR TITLE
Fixed #28198 -- Prevented model attributes from overriding deferred fields.

### DIFF
--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -14,6 +14,7 @@ class Primary(models.Model):
     name = models.CharField(max_length=50)
     value = models.CharField(max_length=50)
     related = models.ForeignKey(Secondary, models.CASCADE)
+    other = True
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Attributes from parent classes will not overload attributes in child classes. During model creation process, attributes which are dublicated in parent and child classes will be removed. That attributes will restored for all parent classes after model creation process