### PR TITLE
Refs #28593 -- Made URLResolver._populate() more resilient to signal interrupts.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -398,12 +398,12 @@ class URLResolver:
         # thread-local variable.
         if getattr(self._local, 'populating', False):
             return
-        self._local.populating = True
-        lookups = MultiValueDict()
-        namespaces = {}
-        apps = {}
-        language_code = get_language()
         try:
+            self._local.populating = True
+            lookups = MultiValueDict()
+            namespaces = {}
+            apps = {}
+            language_code = get_language()
             for url_pattern in reversed(self.url_patterns):
                 p_pattern = url_pattern.pattern.regex.pattern
                 if p_pattern.startswith('^'):


### PR DESCRIPTION
The _populate() method sets a flag to prevent infinite recursion in case a
urlconf includes itself. The flag is a threadlocal to [avoid a race
condition][1] where one thread sets the flag and another checks it, then
proceeds to access data that's supposed to be populated (e.g. _reverse_dict)
but isn't yet.

The potential still exists for a thread to set the threadlocal, then be
interrupted by a signal such as SIGALRM and raise before resetting the
threadlocal flag. In this scenario, subsequent calls to _populate() in the
same thread will short-circuit erroneously.

The bulk of the method was already wrapped in a try/finally in df41b5a, but
since a signal interrupt can occur at any line executed by the interpreter,
this moves up the try to ensure threadlocal gets reset.

[1]: https://groups.google.com/d/msg/django-developers/D_bIeinKHjE/4NmVQUJqAgAJ