### PR TITLE
Removed unused eof argument to BoundaryIter._find_boundary().

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -519,7 +519,7 @@ class BoundaryIter:
             raise StopIteration()
 
         chunk = b''.join(chunks)
-        boundary = self._find_boundary(chunk, len(chunk) < self._rollback)
+        boundary = self._find_boundary(chunk)
 
         if boundary:
             end, next = boundary
@@ -537,7 +537,7 @@ class BoundaryIter:
                 stream.unget(chunk[-rollback:])
                 return chunk[:-rollback]
 
-    def _find_boundary(self, data, eof=False):
+    def _find_boundary(self, data):
         """
         Find a multipart boundary in data.
 


### PR DESCRIPTION
Unused since its introduction in d725cc9734272f867d41f7236235c28b3931a1b2.