### PR TITLE
Refs #28535 -- Add rebase option in makemigrations command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -576,6 +576,7 @@ answer newbie questions, and generally made Django that much better:
     Martin von Gagern <gagern@google.com>
     Mart Sõmermaa <http://mrts.pri.ee/>
     Marty Alchin <gulopine@gamemusic.org>
+    Masashi Shibata <m.shibata1020@gmail.com>
     masonsimon+django@gmail.com
     Massimiliano Ravelli <massimiliano.ravelli@gmail.com>
     Massimo Scamarcia <massimo.scamarcia@gmail.com>

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -75,6 +75,10 @@ class MigrationQuestioner:
         """Do you really want to merge these migrations?"""
         return self.defaults.get("ask_merge", False)
 
+    def ask_rebase(self, app_label):
+        """Do you really want to rebase these migrations?"""
+        return self.defaults.get("ask_rebase", False)
+
     def ask_auto_now_add_addition(self, field_name, model_name):
         """Adding an auto_now_add field to a model."""
         # None means quit
@@ -201,6 +205,14 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
             "\nMerging will only work if the operations printed above do not conflict\n" +
             "with each other (working on different fields or models)\n" +
             "Do you want to merge these migration branches? [y/N]",
+            False,
+        )
+
+    def ask_rebase(self, app_label):
+        return self._boolean_input(
+            "\nRebasing will only work if the operations printed above do not conflict\n" +
+            "with each other (working on different fields or models)\n" +
+            "Do you want to rebase these migration branches? [y/N]",
             False,
         )
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -768,7 +768,15 @@ the complete migrations files that would be written.
 
 .. django-admin-option:: --merge
 
-Enables fixing of migration conflicts.
+Fixes migration conflicts by generating a single new migration file while
+retaining the original conflicting files.
+
+.. django-admin-option:: --rebase
+
+.. versionadded:: 3.1
+
+Fixes migration conflicts by deleting a conflicting migration and reapplying
+it to a new migration.
 
 .. django-admin-option:: --name NAME, -n NAME
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -201,6 +201,8 @@ Migrations
 
 * Migrations are now loaded also from directories without ``__init__.py``
   files.
+* The new :option:`makemigrations --rebase` fixes migration conflicts by
+  deleting a conflicting migration and reapplying it to a new migration.
 
 Models
 ~~~~~~

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -318,6 +318,26 @@ new migrations until it's fixed. When using multiple databases, you can use the
 <topics-db-multi-db-routing>` to control which databases
 :djadmin:`makemigrations` checks for consistent history.
 
+Solving migration conflicts
+---------------------------
+
+If you develop using multiple branches on VCS, there may be conflicts with your
+migrations files. In that case, you can choose from the following solutions.
+
+* Run :djadmin:`makemigrations` command with ``--merge`` option.
+* Run :djadmin:`makemigrations` command with ``--rebase`` option.
+* Delete one of the conflicting migration files, and execute the
+  :djadmin:`makemigrations` command again.
+
+The first solution using the ``--merge`` flag when executing :djadmin:`makemigrations`
+command generates a merged migration file while retaining the original conflicting migration.
+If you want to avoid retaining the conflicting migration file, you can select the
+``--rebase`` option. By adding this option, conflicting migration commits are
+reapplied and are prepended to the next one.  The conflicting migration file is deleted.
+However, this option cannot specify which conflicting migration commits are reapplied.
+If you want to specify the migrations, please delete the one that you wish to reapply,
+and execute command again.
+
 Adding migrations to apps
 =========================
 


### PR DESCRIPTION
Hi! I added `--rebase` option for `makemigrations` command.
Usage is like this:

```
$ ls snippets/migrations/
0001_initial.py            0002_snippet_created_at.py 0002_snippet_updated_at.py __init__.py
$ python manage.py makemigrations --rebase -v 3
Rebasing snippets
  Branch 0002_snippet_updated_at
    - Add field updated_at to snippet
  Branch 0002_snippet_created_at
    - Add field created_at to snippet

Rebasing will only work if the operations printed above do not conflict
with each other (working on different fields or models)
Do you want to rebase these migration branches? [y/N] y

Created new rebase migrations:
  - /Users/a14737/PycharmProjects/django-book/tutorial/blog/snippets/migrations/0003_snippet_created_at.py
$ ls snippets/migrations/
0001_initial.py            0002_snippet_updated_at.py 0003_snippet_created_at.py __init__.py
```

Ticket URL is https://code.djangoproject.com/ticket/28535.
Thanks.