### PR TITLE
Clarified StrIndex docs example.

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -259,10 +259,9 @@ Usage example::
     >>> Author.objects.create(name='Margaret Smith')
     >>> Author.objects.create(name='Smith, Margaret')
     >>> Author.objects.create(name='Margaret Jackson')
-    >>> authors = Author.objects.annotate(
+    >>> Author.objects.filter(name='Margaret Jackson').annotate(
     ...     smith_index=StrIndex('name', V('Smith'))
-    ... ).order_by('smith_index')
-    >>> authors.first().smith_index
+    ... ).get().smith_index
     0
     >>> authors = Author.objects.annotate(
     ...    smith_index=StrIndex('name', V('Smith'))


### PR DESCRIPTION
StrIndex code example in database-functions.txt now shows the name of the first author for explicitly show that the first author does not have "Smith".