### PR TITLE
Refs #28248 -- Clarified the precision of PASSWORD_RESET_TIMEOUT_DAYS.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -41,7 +41,11 @@ class PasswordResetTokenGenerator:
         if not constant_time_compare(self._make_token_with_timestamp(user, ts), token):
             return False
 
-        # Check the timestamp is within limit
+        # Check the timestamp is within limit. Timestamps are rounded to
+        # midnight (server time) providing a resolution of only 1 day. If a
+        # link is generated 5 minutes before midnight and used 6 minutes later,
+        # that counts as 1 day. Therefore, PASSWORD_RESET_TIMEOUT_DAYS = 1 means
+        # "at least 1 day, could be up to 2."
         if (self._num_days(self._today()) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS:
             return False
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2807,8 +2807,10 @@ the URL in two places (``settings`` and URLconf).
 
 Default: ``3``
 
-The number of days a password reset link is valid for. Used by the
-:mod:`django.contrib.auth` password reset mechanism.
+The minimum number of days a password reset link is valid for. Depending on
+when the link is generated, it will be valid for up to a day longer.
+
+Used by the :class:`~django.contrib.auth.views.PasswordResetConfirmView`.
 
 .. setting:: PASSWORD_HASHERS
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28248