### PR TITLE
Added a test for pbkdf2 default digest algorithm.

### DIFF
--- a/tests/utils_tests/test_crypto.py
+++ b/tests/utils_tests/test_crypto.py
@@ -140,3 +140,7 @@ class TestUtilsCryptoPBKDF2(unittest.TestCase):
             result = pbkdf2(**vector['args'])
             self.assertEqual(binascii.hexlify(result).decode('ascii'),
                              vector['result'])
+
+    def test_default_hmac_alg(self):
+        kwargs = {'password': b'password', 'salt': b'salt', 'iterations': 1, 'dklen': 20}
+        self.assertEqual(pbkdf2(**kwargs), hashlib.pbkdf2_hmac(hash_name=hashlib.sha256().name, **kwargs))


### PR DESCRIPTION
I'm not sure if `called_once_with` is the preferred way, or if this is also fine. I checked the coverage report, and got a hit for the fallback `digest` algorithm.