### PR TITLE
Fixed #28635 -- Fixed admin's preserved filters if the URL contains non-ASCII characters.

### DIFF
--- a/django/contrib/admin/templatetags/admin_urls.py
+++ b/django/contrib/admin/templatetags/admin_urls.py
@@ -1,4 +1,4 @@
-from urllib.parse import parse_qsl, urlparse, urlunparse
+from urllib.parse import parse_qsl, unquote, urlparse, urlunparse
 
 from django import template
 from django.contrib.admin.utils import quote
@@ -30,7 +30,7 @@ def add_preserved_filters(context, url, popup=False, to_field=None):
     if opts and preserved_filters:
         preserved_filters = dict(parse_qsl(preserved_filters))
 
-        match_url = '/%s' % url.partition(get_script_prefix())[2]
+        match_url = '/%s' % unquote(url).partition(get_script_prefix())[2]
         try:
             match = resolve(match_url)
         except Resolver404:

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -5641,19 +5641,14 @@ class AdminKeepChangeListFiltersTests(TestCase):
             'preserved_filters': self.get_preserved_filters_querystring(),
             'opts': User._meta,
         }
-
-        url = reverse('admin:auth_user_changelist', current_app=self.admin_site.name)
-        self.assertURLEqual(
-            self.get_changelist_url(),
-            add_preserved_filters(context, url),
-        )
-
-        with override_script_prefix('/prefix/'):
-            url = reverse('admin:auth_user_changelist', current_app=self.admin_site.name)
-            self.assertURLEqual(
-                self.get_changelist_url(),
-                add_preserved_filters(context, url),
-            )
+        prefixes = ('', '/prefix/', '/後台/')
+        for prefix in prefixes:
+            with self.subTest(prefix=prefix), override_script_prefix(prefix):
+                url = reverse('admin:auth_user_changelist', current_app=self.admin_site.name)
+                self.assertURLEqual(
+                    self.get_changelist_url(),
+                    add_preserved_filters(context, url),
+                )
 
 
 class NamespacedAdminKeepChangeListFiltersTests(AdminKeepChangeListFiltersTests):


### PR DESCRIPTION
The ticket is [#28635](https://code.djangoproject.com/ticket/28635)