### PR TITLE
Completed test coverage for default filters

### DIFF
--- a/tests/template_tests/filter_tests/test_date.py
+++ b/tests/template_tests/filter_tests/test_date.py
@@ -80,5 +80,9 @@ class FunctionTests(SimpleTestCase):
     def test_date(self):
         self.assertEqual(date(datetime(2005, 12, 29), "d F Y"), '29 December 2005')
 
+    def test_no_args(self):
+        self.assertEqual(date(''), '')
+        self.assertEqual(date(None), '')
+
     def test_escape_characters(self):
         self.assertEqual(date(datetime(2005, 12, 29), r'jS \o\f F'), '29th of December')

--- a/tests/template_tests/filter_tests/test_last.py
+++ b/tests/template_tests/filter_tests/test_last.py
@@ -15,3 +15,8 @@ class LastTests(SimpleTestCase):
     def test_last02(self):
         output = self.engine.render_to_string('last02', {"a": ["x", "a&b"], "b": ["x", mark_safe("a&b")]})
         self.assertEqual(output, "a&b a&b")
+
+    @setup({'empty_list': '{% autoescape off %}{{ a|last }}{% endautoescape %}'})
+    def test_empty_list(self):
+        output = self.engine.render_to_string('empty_list', {"a": []})
+        self.assertEqual(output, '')

--- a/tests/template_tests/filter_tests/test_pluralize.py
+++ b/tests/template_tests/filter_tests/test_pluralize.py
@@ -33,3 +33,10 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(pluralize(0, 'y,ies'), 'ies')
         self.assertEqual(pluralize(2, 'y,ies'), 'ies')
         self.assertEqual(pluralize(0, 'y,ies,error'), '')
+
+    def test_no_len_type(self):
+        self.assertEqual(pluralize(object(), 'y,es'), 'y')
+        self.assertEqual(pluralize(object(), 'es'), '')
+
+    def test_value_error(self):
+        self.assertEqual(pluralize('', 'y,es'), 'y')

--- a/tests/template_tests/filter_tests/test_slice.py
+++ b/tests/template_tests/filter_tests/test_slice.py
@@ -37,3 +37,7 @@ class FunctionTests(SimpleTestCase):
 
     def test_range_step(self):
         self.assertEqual(slice_filter('abcdefg', '0::2'), 'aceg')
+
+    def test_fail_silently(self):
+        obj = object()
+        self.assertEqual(slice_filter(obj, '0::2'), obj)

--- a/tests/template_tests/filter_tests/test_time.py
+++ b/tests/template_tests/filter_tests/test_time.py
@@ -58,6 +58,10 @@ class TimeTests(TimezoneTestCase):
 
 class FunctionTests(SimpleTestCase):
 
+    def test_no_args(self):
+        self.assertEqual(time_filter(''), '')
+        self.assertEqual(time_filter(None), '')
+
     def test_inputs(self):
         self.assertEqual(time_filter(time(13), 'h'), '01')
         self.assertEqual(time_filter(time(0), 'h'), '12')

--- a/tests/template_tests/filter_tests/test_timesince.py
+++ b/tests/template_tests/filter_tests/test_timesince.py
@@ -131,5 +131,8 @@ class FunctionTests(SimpleTestCase):
     def test_since_now(self):
         self.assertEqual(timesince_filter(datetime.now() - timedelta(1)), '1\xa0day')
 
+    def test_no_args(self):
+        self.assertEqual(timesince_filter(None), '')
+
     def test_explicit_date(self):
         self.assertEqual(timesince_filter(datetime(2005, 12, 29), datetime(2005, 12, 30)), '1\xa0day')

--- a/tests/template_tests/filter_tests/test_timeuntil.py
+++ b/tests/template_tests/filter_tests/test_timeuntil.py
@@ -97,11 +97,24 @@ class TimeuntilTests(TimezoneTestCase):
         output = self.engine.render_to_string('timeuntil14', {'a': self.today, 'b': self.today - timedelta(hours=24)})
         self.assertEqual(output, '1\xa0day')
 
+    @setup({'timeuntil15': '{{ a|timeuntil:b }}'})
+    def test_naive_aware_type_error(self):
+        output = self.engine.render_to_string('timeuntil15', {'a': self.now, 'b': self.now_tz_i})
+        self.assertEqual(output, '')
+
+    @setup({'timeuntil16': '{{ a|timeuntil:b }}'})
+    def test_aware_naive_type_error(self):
+        output = self.engine.render_to_string('timeuntil16', {'a': self.now_tz_i, 'b': self.now})
+        self.assertEqual(output, '')
+
 
 class FunctionTests(SimpleTestCase):
 
     def test_until_now(self):
         self.assertEqual(timeuntil_filter(datetime.now() + timedelta(1, 1)), '1\xa0day')
+
+    def test_no_args(self):
+        self.assertEqual(timeuntil_filter(None), '')
 
     def test_explicit_date(self):
         self.assertEqual(timeuntil_filter(datetime(2005, 12, 30), datetime(2005, 12, 29)), '1\xa0day')

--- a/tests/template_tests/filter_tests/test_truncatechars.py
+++ b/tests/template_tests/filter_tests/test_truncatechars.py
@@ -14,3 +14,8 @@ class TruncatecharsTests(SimpleTestCase):
     def test_truncatechars02(self):
         output = self.engine.render_to_string('truncatechars02', {'a': 'Testing'})
         self.assertEqual(output, 'Testing')
+
+    @setup({'truncatechars03': "{{ a|truncatechars:'e' }}"})
+    def test_fail_silently_incorrect_arg(self):
+        output = self.engine.render_to_string('truncatechars03', {'a': 'Testing, testing'})
+        self.assertEqual(output, 'Testing, testing')

--- a/tests/template_tests/filter_tests/test_truncatechars_html.py
+++ b/tests/template_tests/filter_tests/test_truncatechars_html.py
@@ -30,3 +30,7 @@ class FunctionTests(SimpleTestCase):
 
     def test_truncate_something(self):
         self.assertEqual(truncatechars_html('a<b>b</b>c', 3), 'a<b>b</b>c')
+
+    def test_invalid_arg(self):
+        html = '<p>one <a href="#">two - three <br>four</a> five</p>'
+        self.assertEqual(truncatechars_html(html, 'a'), html)

--- a/tests/template_tests/filter_tests/test_truncatewords_html.py
+++ b/tests/template_tests/filter_tests/test_truncatewords_html.py
@@ -39,3 +39,6 @@ class FunctionTests(SimpleTestCase):
             truncatewords_html('<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo est&aacute;?</i>', 3),
             '<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo ...</i>',
         )
+
+    def test_invalid_arg(self):
+        self.assertEqual(truncatewords_html('<p>string</p>', 'a'), '<p>string</p>')

--- a/tests/template_tests/filter_tests/test_yesno.py
+++ b/tests/template_tests/filter_tests/test_yesno.py
@@ -24,3 +24,8 @@ class FunctionTests(SimpleTestCase):
 
     def test_none_three_arguments(self):
         self.assertEqual(yesno(None, 'certainly,get out of town,perhaps'), 'perhaps')
+
+    def test_invalid_value(self):
+        self.assertIs(yesno(True, 'yes'), True)
+        self.assertIs(yesno(False, 'yes'), False)
+        self.assertIsNone(yesno(None, 'yes'))


### PR DESCRIPTION
There's a still a miss for `join` for the silent fallback (I couldn't find something that'd match), and a partial miss `if args` in `stringfilter`.