### PR TITLE
Fixed #28600 -- Added prefetch_related() support to RawQuerySet.

### DIFF
--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -239,6 +239,8 @@ Models
 * The new :meth:`.QuerySet.explain` method displays the database's execution
   plan of a queryset's query.
 
+*  :meth:`.QuerySet.raw` now supports :meth:`~.QuerySet.prefetch_related`.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR adds

- Results caching support in `RawQuerySet`
- Prefetch related support in `RawQuerySet`

Ticket: https://code.djangoproject.com/ticket/28600