### PR TITLE
Refs #28628 -- abolished use of '\d' in regexes

### DIFF
--- a/django/contrib/gis/db/backends/postgis/operations.py
+++ b/django/contrib/gis/db/backends/postgis/operations.py
@@ -341,7 +341,7 @@ class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
         Return the version of PROJ.4 used by PostGIS as a tuple of the
         major, minor, and subminor release numbers.
         """
-        proj_regex = re.compile(r'(\d+)\.(\d+)\.(\d+)')
+        proj_regex = re.compile(r'([0-9]+)\.([0-9]+)\.([0-9]+)')
         proj_ver_str = self.postgis_proj_version()
         m = proj_regex.search(proj_ver_str)
         if m:

--- a/django/contrib/gis/gdal/libgdal.py
+++ b/django/contrib/gis/gdal/libgdal.py
@@ -84,7 +84,7 @@ def gdal_full_version():
     return _version_info('')
 
 
-version_regex = re.compile(r'^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<subminor>\d+))?')
+version_regex = re.compile(r'^(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(\.(?P<subminor>[0-9]+))?')
 
 
 def gdal_version_info():

--- a/django/contrib/gis/geometry.py
+++ b/django/contrib/gis/geometry.py
@@ -4,10 +4,10 @@ import re
 # to prevent potentially malicious input from reaching the underlying C
 # library.  Not a substitute for good Web security programming practices.
 hex_regex = re.compile(r'^[0-9A-F]+$', re.I)
-wkt_regex = re.compile(r'^(SRID=(?P<srid>\-?\d+);)?'
+wkt_regex = re.compile(r'^(SRID=(?P<srid>\-?[0-9]+);)?'
                        r'(?P<wkt>'
                        r'(?P<type>POINT|LINESTRING|LINEARRING|POLYGON|MULTIPOINT|'
                        r'MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)'
-                       r'[ACEGIMLONPSRUTYZ\d,\.\-\+\(\) ]+)$',
+                       r'[ACEGIMLONPSRUTYZ[0-9],\.\-\+\(\) ]+)$',
                        re.I)
 json_regex = re.compile(r'^(\s+)?\{.*}(\s+)?$', re.DOTALL)

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -113,7 +113,7 @@ class GEOSGeometryBase(GEOSBase):
         parts = ewkt.split(b';', 1)
         if len(parts) == 2:
             srid_part, wkt = parts
-            match = re.match(b'SRID=(?P<srid>\-?\d+)', srid_part)
+            match = re.match(b'SRID=(?P<srid>\-?[0-9]+)', srid_part)
             if not match:
                 raise ValueError('EWKT has invalid SRID part.')
             srid = int(match.group('srid'))

--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -45,7 +45,7 @@ def intcomma(value, use_l10n=True):
         else:
             return number_format(value, force_grouping=True)
     orig = str(value)
-    new = re.sub(r"^(-?\d+)(\d{3})", r'\g<1>,\g<2>', orig)
+    new = re.sub(r"^(-?[0-9]+)([0-9]{3})", r'\g<1>,\g<2>', orig)
     if orig == new:
         return new
     else:

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -399,7 +399,7 @@ class Command(BaseCommand):
             ['xgettext', '--version'],
             stdout_encoding=DEFAULT_LOCALE_ENCODING,
         )
-        m = re.search(r'(\d+)\.(\d+)\.?(\d+)?', out)
+        m = re.search(r'([0-9]+)\.([0-9]+)\.?([0-9]+)?', out)
         if m:
             return tuple(int(d) for d in m.groups() if d is not None)
         else:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -75,7 +75,7 @@ class URLValidator(RegexValidator):
     ul = '\u00a1-\uffff'  # unicode letters range (must not be a raw string)
 
     # IP patterns
-    ipv4_re = r'(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}'
+    ipv4_re = r'(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])){3}'
     ipv6_re = r'\[[0-9a-f:\.]+\]'  # (simple regex, validated later)
 
     # Host patterns
@@ -96,7 +96,7 @@ class URLValidator(RegexValidator):
         r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
         r'(?:\S+(?::\S*)?@)?'  # user:pass authentication
         r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
-        r'(?::\d{2,5})?'  # port
+        r'(?::[0-9]{2,5})?'  # port
         r'(?:[/?#][^\s]*)?'  # resource path
         r'\Z', re.IGNORECASE)
     message = _('Enter a valid URL.')
@@ -133,7 +133,7 @@ class URLValidator(RegexValidator):
                 raise
         else:
             # Now verify IPv6 in the netloc part
-            host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', urlsplit(value).netloc)
+            host_match = re.search(r'^\[(.+)\](?::[0-9]{2,5})?$', urlsplit(value).netloc)
             if host_match:
                 potential_ip = host_match.groups()[0]
                 try:
@@ -150,7 +150,7 @@ class URLValidator(RegexValidator):
 
 
 integer_validator = RegexValidator(
-    _lazy_re_compile(r'^-?\d+\Z'),
+    _lazy_re_compile(r'^-?[0-9]+\Z'),
     message=_('Enter a valid integer.'),
     code='invalid',
 )
@@ -293,7 +293,7 @@ def ip_address_validators(protocol, unpack_ipv4):
 
 
 def int_list_validator(sep=',', message=None, code='invalid', allow_negative=False):
-    regexp = _lazy_re_compile(r'^%(neg)s\d+(?:%(sep)s%(neg)s\d+)*\Z' % {
+    regexp = _lazy_re_compile(r'^%(neg)s[0-9]+(?:%(sep)s%(neg)s[0-9]+)*\Z' % {
         'neg': '(-)?' if allow_negative else '',
         'sep': re.escape(sep),
     })

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -46,7 +46,7 @@ django_conversions.update({
 
 # This should match the numerical portion of the version numbers (we can treat
 # versions like 5.0.24 and 5.0.24a as the same).
-server_version_re = re.compile(r'(\d{1,2})\.(\d{1,2})\.(\d{1,2})')
+server_version_re = re.compile(r'([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})')
 
 
 class CursorWrapper:

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -5,7 +5,7 @@ from django.db.backends.base.introspection import (
 )
 from django.db.models.indexes import Index
 
-field_size_re = re.compile(r'^\s*(?:var)?char\s*\(\s*(\d+)\s*\)\s*$')
+field_size_re = re.compile(r'^\s*(?:var)?char\s*\(\s*([0-9]+)\s*\)\s*$')
 
 
 def get_field_size(name):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1230,7 +1230,7 @@ class MigrationAutodetector:
         Given a migration name, try to extract a number from the beginning of
         it. If no number is found, return None.
         """
-        match = re.match(r'^\d+', name)
+        match = re.match(r'^[0-9]+', name)
         if match:
             return int(match.group())
         return None

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -167,7 +167,7 @@ class MigrationWriter:
         # for comments
         migration_imports = set()
         for line in list(imports):
-            if re.match(r"^import (.*)\.\d+[^\s]*$", line):
+            if re.match(r"^import (.*)\.[0-9]+[^\s]*$", line):
                 migration_imports.add(line.split("import")[1].strip())
                 imports.remove(line)
                 self.needs_manual_porting = True

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -922,7 +922,7 @@ class SelectDateWidget(Widget):
     template_name = 'django/forms/widgets/select_date.html'
     input_type = 'select'
     select_widget = Select
-    date_re = re.compile(r'(\d{4}|0)-(\d\d?)-(\d\d?)$')
+    date_re = re.compile(r'([0-9]{4}|0)-([0-9][0-9]?)-([0-9][0-9]?)$')
 
     def __init__(self, attrs=None, years=None, months=None, empty_label=None):
         self.attrs = attrs or {}

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -18,7 +18,7 @@ from django.utils.encoding import escape_uri_path, force_bytes, iri_to_uri
 from django.utils.http import is_same_domain, limited_parse_qsl
 
 RAISE_ERROR = object()
-host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:\d+)?$")
+host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
 
 
 class UnreadablePostError(IOError):

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -235,7 +235,7 @@ def stringformat(value, arg):
 def title(value):
     """Convert a string into titlecase."""
     t = re.sub("([a-z])'([A-Z])", lambda m: m.group(0).lower(), value.title())
-    return re.sub(r"\d([A-Z])", lambda m: m.group(0).lower(), t)
+    return re.sub(r"[0-9]([A-Z])", lambda m: m.group(0).lower(), t)
 
 
 @register.filter(is_safe=True)

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -31,7 +31,7 @@ __all__ = ('Client', 'RedirectCycleError', 'RequestFactory', 'encode_file', 'enc
 
 BOUNDARY = 'BoUnDaRyStRiNg'
 MULTIPART_CONTENT = 'multipart/form-data; boundary=%s' % BOUNDARY
-CONTENT_TYPE_RE = re.compile(r'.*; charset=([\w\d-]+);?')
+CONTENT_TYPE_RE = re.compile(r'.*; charset=([\w[0-9]-]+);?')
 # JSON Vendor Tree spec: https://tools.ietf.org/html/rfc6838#section-3.2
 JSON_CONTENT_TYPE_RE = re.compile(r'^application\/(vnd\..+\+)?json')
 

--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -11,28 +11,28 @@ import re
 from django.utils.timezone import get_fixed_timezone, utc
 
 date_re = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$'
+    r'(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})$'
 )
 
 time_re = re.compile(
-    r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{1,2})'
+    r'(?::(?P<second>[0-9]{1,2})(?:\.(?P<microsecond>[0-9]{1,6})[0-9]{0,6})?)?'
 )
 
 datetime_re = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
-    r'[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
-    r'(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
+    r'(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})'
+    r'[T ](?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{1,2})'
+    r'(?::(?P<second>[0-9]{1,2})(?:\.(?P<microsecond>[0-9]{1,6})[0-9]{0,6})?)?'
+    r'(?P<tzinfo>Z|[+-][0-9]{2}(?::?[0-9]{2})?)?$'
 )
 
 standard_duration_re = re.compile(
     r'^'
-    r'(?:(?P<days>-?\d+) (days?, )?)?'
-    r'((?:(?P<hours>-?\d+):)(?=\d+:\d+))?'
-    r'(?:(?P<minutes>-?\d+):)?'
-    r'(?P<seconds>-?\d+)'
-    r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
+    r'(?:(?P<days>-?[0-9]+) (days?, )?)?'
+    r'((?:(?P<hours>-?[0-9]+):)(?=[0-9]+:[0-9]+))?'
+    r'(?:(?P<minutes>-?[0-9]+):)?'
+    r'(?P<seconds>-?[0-9]+)'
+    r'(?:\.(?P<microseconds>[0-9]{1,6})[0-9]{0,6})?'
     r'$'
 )
 
@@ -41,11 +41,11 @@ standard_duration_re = re.compile(
 iso8601_duration_re = re.compile(
     r'^(?P<sign>[-+]?)'
     r'P'
-    r'(?:(?P<days>\d+(.\d+)?)D)?'
+    r'(?:(?P<days>[0-9]+(.[0-9]+)?)D)?'
     r'(?:T'
-    r'(?:(?P<hours>\d+(.\d+)?)H)?'
-    r'(?:(?P<minutes>\d+(.\d+)?)M)?'
-    r'(?:(?P<seconds>\d+(.\d+)?)S)?'
+    r'(?:(?P<hours>[0-9]+(.[0-9]+)?)H)?'
+    r'(?:(?P<minutes>[0-9]+(.[0-9]+)?)M)?'
+    r'(?:(?P<seconds>[0-9]+(.[0-9]+)?)S)?'
     r')?'
     r'$'
 )
@@ -55,12 +55,12 @@ iso8601_duration_re = re.compile(
 # aren't accepted.
 postgres_interval_re = re.compile(
     r'^'
-    r'(?:(?P<days>-?\d+) (days? ?))?'
+    r'(?:(?P<days>-?[0-9]+) (days? ?))?'
     r'(?:(?P<sign>[-+])?'
-    r'(?P<hours>\d+):'
-    r'(?P<minutes>\d\d):'
-    r'(?P<seconds>\d\d)'
-    r'(?:\.(?P<microseconds>\d{1,6}))?'
+    r'(?P<hours>[0-9]+):'
+    r'(?P<minutes>[0-9][0-9]):'
+    r'(?P<seconds>[0-9][0-9])'
+    r'(?:\.(?P<microseconds>[0-9]{1,6}))?'
     r')?$'
 )
 

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -24,7 +24,7 @@ WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('[', ']'), ('&lt;', '&gt;'), ('
 # List of possible strings used for bullets in bulleted lists.
 DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']
 
-unencoded_ampersands_re = re.compile(r'&(?!(\w+|#\d+);)')
+unencoded_ampersands_re = re.compile(r'&(?!(\w+|#[0-9]+);)')
 word_split_re = re.compile(r'''([\s<>"']+)''')
 simple_url_re = re.compile(r'^https?://\[?\w', re.IGNORECASE)
 simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)($|/.*)$', re.IGNORECASE)

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -27,12 +27,12 @@ ETAG_MATCH = re.compile(r'''
 ''', re.X)
 
 MONTHS = 'jan feb mar apr may jun jul aug sep oct nov dec'.split()
-__D = r'(?P<day>\d{2})'
-__D2 = r'(?P<day>[ \d]\d)'
+__D = r'(?P<day>[0-9]{2})'
+__D2 = r'(?P<day>[ [0-9]][0-9])'
 __M = r'(?P<mon>\w{3})'
-__Y = r'(?P<year>\d{4})'
-__Y2 = r'(?P<year>\d{2})'
-__T = r'(?P<hour>\d{2}):(?P<min>\d{2}):(?P<sec>\d{2})'
+__Y = r'(?P<year>[0-9]{4})'
+__Y2 = r'(?P<year>[0-9]{2})'
+__T = r'(?P<hour>[0-9]{2}):(?P<min>[0-9]{2}):(?P<sec>[0-9]{2})'
 RFC1123_DATE = re.compile(r'^\w{3}, %s %s %s %s GMT$' % (__D, __M, __Y, __T))
 RFC850_DATE = re.compile(r'^\w{6,9}, %s-%s-%s %s GMT$' % (__D, __M, __Y2, __T))
 ASCTIME_DATE = re.compile(r'^\w{3} %s %s %s %s$' % (__M, __D2, __T, __Y))

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -246,7 +246,7 @@ class JavaScriptCatalog(View):
         Return the number of plurals for this catalog language, or 2 if no
         plural string is available.
         """
-        match = re.search(r'nplurals=\s*(\d+)', self._plural_string or '')
+        match = re.search(r'nplurals=\s*([0-9]+)', self._plural_string or '')
         if match:
             return int(match.groups()[0])
         return 2


### PR DESCRIPTION
Replaced the '\d' with [0-9] in regular expressions to avoid errors
due to different python versions (Python 3 matches '\d' with any
character with unicode category. Thanks James Bennett to report.