### PR TITLE
Fixed #28622 -- Allowed specifying password reset token expiration in number of seconds.

### DIFF
--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -12,7 +12,6 @@ class PasswordResetTokenGenerator:
     """
     key_salt = "django.contrib.auth.tokens.PasswordResetTokenGenerator"
     secret = settings.SECRET_KEY
-    timeout_type = 'SECONDS' if hasattr(settings, 'PASSWORD_RESET_TIMEOUT') else 'DAYS'
 
     def make_token(self, user):
         """

--- a/django/contrib/auth/tokens.py
+++ b/django/contrib/auth/tokens.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 
 from django.conf import settings
 from django.utils.crypto import constant_time_compare, salted_hmac

--- a/tests/auth_tests/test_tokens.py
+++ b/tests/auth_tests/test_tokens.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import User


### PR DESCRIPTION
can set PASSWORD_RESET_TIMEOUT using seconds, so it can be expired within a day.

changing making token to use seconds instead of days. 

It should be backward compatible, because PASSWORD_RESET_TIMEOUT_DAYS can still be used. Old tokens generated should be checked without problems.