### PR TITLE
Fixed #28636 -- Added optional parameter support_all_languages in translation

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -197,12 +197,12 @@ def to_locale(language):
     return _trans.to_locale(language)
 
 
-def get_language_from_request(request, check_path=False):
-    return _trans.get_language_from_request(request, check_path)
+def get_language_from_request(request, check_path=False, support_all_languages=False):
+    return _trans.get_language_from_request(request, check_path, support_all_languages)
 
 
-def get_language_from_path(path):
-    return _trans.get_language_from_path(path)
+def get_language_from_path(path, support_all_languages=False):
+    return _trans.get_language_from_path(path, support_all_languages)
 
 
 def templatize(src, **kwargs):

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1192,6 +1192,37 @@ class MiscTests(SimpleTestCase):
     @override_settings(
         LANGUAGES=[
             ('en', 'English'),
+            ('de', 'German'),
+        ]
+    )
+    def test_parse_literal_http_header_support_all(self):
+        """
+        Here we test that we parse a literal HTTP header correctly when
+        support_all_languages=True
+        """
+        g = get_language_from_request
+        r = self.rf.get('/')
+        r.COOKIES = {}
+        r.META = {'HTTP_ACCEPT_LANGUAGE': 'en'}
+        self.assertEqual('en', g(r))
+        self.assertEqual('en', g(r, support_all_languages=True))
+
+        r.META = {'HTTP_ACCEPT_LANGUAGE': 'de'}
+        self.assertEqual('de', g(r))
+        self.assertEqual('de', g(r, support_all_languages=True))
+
+        # From here support_all_languages=True should lead to another output
+        r.META = {'HTTP_ACCEPT_LANGUAGE': 'es'}
+        self.assertEqual('en', g(r))
+        self.assertEqual('es', g(r, support_all_languages=True))
+
+        r.META = {'HTTP_ACCEPT_LANGUAGE': 'pl'}
+        self.assertEqual('en', g(r))
+        self.assertEqual('pl', g(r, support_all_languages=True))
+
+    @override_settings(
+        LANGUAGES=[
+            ('en', 'English'),
             ('zh-hans', 'Simplified Chinese'),
             ('zh-hant', 'Traditional Chinese'),
         ]


### PR DESCRIPTION
Modification in order to be able to get a user's language preference that's listed in django's available languages (`LANG_INFO`) rather than in `settings.LANGUAGES`.