### PR TITLE
Fixed #28596 -- Fixed QuerySet.bulk_create() and cascade deletion crash on Oracle when using more than 65535 parameters.

### DIFF
--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -55,3 +55,4 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     """
     supports_callproc_kwargs = True
     supports_over_clause = True
+    max_query_params = 2**16 - 1

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -553,3 +553,9 @@ END;
             rhs_sql, rhs_params = rhs
             return "NUMTODSINTERVAL(%s - %s, 'DAY')" % (lhs_sql, rhs_sql), lhs_params + rhs_params
         return super().subtract_temporals(internal_type, lhs, rhs)
+
+    def bulk_batch_size(self, fields, objs):
+        """Oracle restricts the number of parameters in a query."""
+        if fields:
+            return self.connection.features.max_query_params // len(fields)
+        return len(objs)

--- a/tests/backends/oracle/test_operations.py
+++ b/tests/backends/oracle/test_operations.py
@@ -9,3 +9,17 @@ class OperationsTests(unittest.TestCase):
     def test_sequence_name_truncation(self):
         seq_name = connection.ops._get_no_autofield_sequence_name('schema_authorwithevenlongee869')
         self.assertEqual(seq_name, 'SCHEMA_AUTHORWITHEVENLOB0B8_SQ')
+
+    def test_bulk_batch_size(self):
+        # Oracle restricts the number of parameters in a query.
+        objects = range(2**16)
+        self.assertEqual(connection.ops.bulk_batch_size([], objects), len(objects))
+        # Each field is a parameter for each object.
+        self.assertEqual(
+            connection.ops.bulk_batch_size(['id'], objects),
+            connection.features.max_query_params,
+        )
+        self.assertEqual(
+            connection.ops.bulk_batch_size(['id', 'other'], objects),
+            connection.features.max_query_params // 2,
+        )


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28596