### PR TITLE
Fixed #28628 --Replaced '\d' in regexes with [0-9] for more strict matching.

### DIFF
--- a/django/contrib/humanize/templatetags/humanize.py
+++ b/django/contrib/humanize/templatetags/humanize.py
@@ -45,7 +45,7 @@ def intcomma(value, use_l10n=True):
         else:
             return number_format(value, force_grouping=True)
     orig = str(value)
-    new = re.sub(r"^(-?\d+)(\d{3})", r'\g<1>,\g<2>', orig)
+    new = re.sub(r"^(-?[0-9]+)([0-9]{3})", r'\g<1>,\g<2>', orig)
     if orig == new:
         return new
     else:

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -399,7 +399,7 @@ class Command(BaseCommand):
             ['xgettext', '--version'],
             stdout_encoding=DEFAULT_LOCALE_ENCODING,
         )
-        m = re.search(r'(\d+)\.(\d+)\.?(\d+)?', out)
+        m = re.search(r'([0-9]+)\.([0-9]+)\.?([0-9]+)?', out)
         if m:
             return tuple(int(d) for d in m.groups() if d is not None)
         else:

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -75,7 +75,7 @@ class URLValidator(RegexValidator):
     ul = '\u00a1-\uffff'  # unicode letters range (must not be a raw string)
 
     # IP patterns
-    ipv4_re = r'(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}'
+    ipv4_re = r'(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]?[0-9])){3}'
     ipv6_re = r'\[[0-9a-f:\.]+\]'  # (simple regex, validated later)
 
     # Host patterns
@@ -96,7 +96,7 @@ class URLValidator(RegexValidator):
         r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
         r'(?:\S+(?::\S*)?@)?'  # user:pass authentication
         r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
-        r'(?::\d{2,5})?'  # port
+        r'(?::[0-9]{2,5})?'  # port
         r'(?:[/?#][^\s]*)?'  # resource path
         r'\Z', re.IGNORECASE)
     message = _('Enter a valid URL.')
@@ -133,7 +133,7 @@ class URLValidator(RegexValidator):
                 raise
         else:
             # Now verify IPv6 in the netloc part
-            host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', urlsplit(value).netloc)
+            host_match = re.search(r'^\[(.+)\](?::[0-9]{2,5})?$', urlsplit(value).netloc)
             if host_match:
                 potential_ip = host_match.groups()[0]
                 try:
@@ -150,7 +150,7 @@ class URLValidator(RegexValidator):
 
 
 integer_validator = RegexValidator(
-    _lazy_re_compile(r'^-?\d+\Z'),
+    _lazy_re_compile(r'^-?[0-9]+\Z'),
     message=_('Enter a valid integer.'),
     code='invalid',
 )
@@ -293,7 +293,7 @@ def ip_address_validators(protocol, unpack_ipv4):
 
 
 def int_list_validator(sep=',', message=None, code='invalid', allow_negative=False):
-    regexp = _lazy_re_compile(r'^%(neg)s\d+(?:%(sep)s%(neg)s\d+)*\Z' % {
+    regexp = _lazy_re_compile(r'^%(neg)s[0-9]+(?:%(sep)s%(neg)s[0-9]+)*\Z' % {
         'neg': '(-)?' if allow_negative else '',
         'sep': re.escape(sep),
     })

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -46,7 +46,7 @@ django_conversions.update({
 
 # This should match the numerical portion of the version numbers (we can treat
 # versions like 5.0.24 and 5.0.24a as the same).
-server_version_re = re.compile(r'(\d{1,2})\.(\d{1,2})\.(\d{1,2})')
+server_version_re = re.compile(r'([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})')
 
 
 class CursorWrapper:

--- a/django/db/backends/sqlite3/introspection.py
+++ b/django/db/backends/sqlite3/introspection.py
@@ -5,7 +5,7 @@ from django.db.backends.base.introspection import (
 )
 from django.db.models.indexes import Index
 
-field_size_re = re.compile(r'^\s*(?:var)?char\s*\(\s*(\d+)\s*\)\s*$')
+field_size_re = re.compile(r'^\s*(?:var)?char\s*\(\s*([0-9]+)\s*\)\s*$')
 
 
 def get_field_size(name):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1230,7 +1230,7 @@ class MigrationAutodetector:
         Given a migration name, try to extract a number from the beginning of
         it. If no number is found, return None.
         """
-        match = re.match(r'^\d+', name)
+        match = re.match(r'^[0-9]+', name)
         if match:
             return int(match.group())
         return None

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -167,7 +167,7 @@ class MigrationWriter:
         # for comments
         migration_imports = set()
         for line in list(imports):
-            if re.match(r"^import (.*)\.\d+[^\s]*$", line):
+            if re.match(r"^import (.*)\.[0-9]+[^\s]*$", line):
                 migration_imports.add(line.split("import")[1].strip())
                 imports.remove(line)
                 self.needs_manual_porting = True

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -922,7 +922,7 @@ class SelectDateWidget(Widget):
     template_name = 'django/forms/widgets/select_date.html'
     input_type = 'select'
     select_widget = Select
-    date_re = re.compile(r'(\d{4}|0)-(\d\d?)-(\d\d?)$')
+    date_re = re.compile(r'([0-9]{4}|0)-([0-9][0-9]?)-([0-9][0-9]?)$')
 
     def __init__(self, attrs=None, years=None, months=None, empty_label=None):
         self.attrs = attrs or {}

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -235,7 +235,7 @@ def stringformat(value, arg):
 def title(value):
     """Convert a string into titlecase."""
     t = re.sub("([a-z])'([A-Z])", lambda m: m.group(0).lower(), value.title())
-    return re.sub(r"\d([A-Z])", lambda m: m.group(0).lower(), t)
+    return re.sub(r"[0-9]([A-Z])", lambda m: m.group(0).lower(), t)
 
 
 @register.filter(is_safe=True)

--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -11,28 +11,28 @@ import re
 from django.utils.timezone import get_fixed_timezone, utc
 
 date_re = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$'
+    r'(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})$'
 )
 
 time_re = re.compile(
-    r'(?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
+    r'(?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{1,2})'
+    r'(?::(?P<second>[0-9]{1,2})(?:\.(?P<microsecond>[0-9]{1,6})[0-9]{0,6})?)?'
 )
 
 datetime_re = re.compile(
-    r'(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})'
-    r'[T ](?P<hour>\d{1,2}):(?P<minute>\d{1,2})'
-    r'(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?'
-    r'(?P<tzinfo>Z|[+-]\d{2}(?::?\d{2})?)?$'
+    r'(?P<year>[0-9]{4})-(?P<month>[0-9]{1,2})-(?P<day>[0-9]{1,2})'
+    r'[T ](?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{1,2})'
+    r'(?::(?P<second>[0-9]{1,2})(?:\.(?P<microsecond>[0-9]{1,6})[0-9]{0,6})?)?'
+    r'(?P<tzinfo>Z|[+-][0-9]{2}(?::?[0-9]{2})?)?$'
 )
 
 standard_duration_re = re.compile(
     r'^'
-    r'(?:(?P<days>-?\d+) (days?, )?)?'
-    r'((?:(?P<hours>-?\d+):)(?=\d+:\d+))?'
-    r'(?:(?P<minutes>-?\d+):)?'
-    r'(?P<seconds>-?\d+)'
-    r'(?:\.(?P<microseconds>\d{1,6})\d{0,6})?'
+    r'(?:(?P<days>-?[0-9]+) (days?, )?)?'
+    r'((?:(?P<hours>-?[0-9]+):)(?=[0-9]+:[0-9]+))?'
+    r'(?:(?P<minutes>-?[0-9]+):)?'
+    r'(?P<seconds>-?[0-9]+)'
+    r'(?:\.(?P<microseconds>[0-9]{1,6})[0-9]{0,6})?'
     r'$'
 )
 
@@ -41,11 +41,11 @@ standard_duration_re = re.compile(
 iso8601_duration_re = re.compile(
     r'^(?P<sign>[-+]?)'
     r'P'
-    r'(?:(?P<days>\d+(.\d+)?)D)?'
+    r'(?:(?P<days>[0-9]+(.[0-9]+)?)D)?'
     r'(?:T'
-    r'(?:(?P<hours>\d+(.\d+)?)H)?'
-    r'(?:(?P<minutes>\d+(.\d+)?)M)?'
-    r'(?:(?P<seconds>\d+(.\d+)?)S)?'
+    r'(?:(?P<hours>[0-9]+(.[0-9]+)?)H)?'
+    r'(?:(?P<minutes>[0-9]+(.[0-9]+)?)M)?'
+    r'(?:(?P<seconds>[0-9]+(.[0-9]+)?)S)?'
     r')?'
     r'$'
 )
@@ -55,12 +55,12 @@ iso8601_duration_re = re.compile(
 # aren't accepted.
 postgres_interval_re = re.compile(
     r'^'
-    r'(?:(?P<days>-?\d+) (days? ?))?'
+    r'(?:(?P<days>-?[0-9]+) (days? ?))?'
     r'(?:(?P<sign>[-+])?'
-    r'(?P<hours>\d+):'
-    r'(?P<minutes>\d\d):'
-    r'(?P<seconds>\d\d)'
-    r'(?:\.(?P<microseconds>\d{1,6}))?'
+    r'(?P<hours>[0-9]+):'
+    r'(?P<minutes>[0-9][0-9]):'
+    r'(?P<seconds>[0-9][0-9])'
+    r'(?:\.(?P<microseconds>[0-9]{1,6}))?'
     r')?$'
 )
 

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -24,7 +24,7 @@ WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('[', ']'), ('&lt;', '&gt;'), ('
 # List of possible strings used for bullets in bulleted lists.
 DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']
 
-unencoded_ampersands_re = re.compile(r'&(?!(\w+|#\d+);)')
+unencoded_ampersands_re = re.compile(r'&(?!(\w+|#[0-9]+);)')
 word_split_re = re.compile(r'''([\s<>"']+)''')
 simple_url_re = re.compile(r'^https?://\[?\w', re.IGNORECASE)
 simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)($|/.*)$', re.IGNORECASE)

--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -246,7 +246,7 @@ class JavaScriptCatalog(View):
         Return the number of plurals for this catalog language, or 2 if no
         plural string is available.
         """
-        match = re.search(r'nplurals=\s*(\d+)', self._plural_string or '')
+        match = re.search(r'nplurals=\s*([0-9]+)', self._plural_string or '')
         if match:
             return int(match.groups()[0])
         return 2


### PR DESCRIPTION
In Python2 and Python3 '\d' in regular expression matches to different patterns. To avoid errors, '\d' was replaced with [0-9].