### PR TITLE
Utils(autoreload): check if stdin exists before using it

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -251,7 +251,7 @@ def raise_last_exception():
 def ensure_echo_on():
     if termios:
         fd = sys.stdin
-        if fd.isatty():
+        if fd is not None and fd.isatty():
             attr_list = termios.tcgetattr(fd)
             if not attr_list[3] & termios.ECHO:
                 attr_list[3] |= termios.ECHO


### PR DESCRIPTION
It could happen that the django process runs in some environment where the stdin has been closed before launching the child. Without this check the process crashes because the stdin is None

This is the error I get for instance:
```
  File "/~/.virtualenvs/my/lib/python3.6/site-packages/django/utils/autoreload.py", line 256, in ensure_echo_on
    if fd.isatty():
AttributeError: 'NoneType' object has no attribute 'isatty'
```
