### PR TITLE
Refs #24254 -- Removed unnecessary a SQL AS clause in SQLCompiler.as_sql().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -559,7 +559,7 @@ class SQLCompiler:
                         subselect, subparams = select_clone.as_sql(self, self.connection)
                         sub_selects.append(subselect)
                         sub_params.extend(subparams)
-                return 'SELECT %s FROM (%s) AS subquery' % (
+                return 'SELECT %s FROM (%s) subquery' % (
                     ', '.join(sub_selects),
                     ' '.join(result),
                 ), sub_params + params


### PR DESCRIPTION
Aliasing table with SQL `AS` clause is incorrect on Oracle and unnecessary on other backends. Currently this code is unreachable on Oracle, but will use it after #9204.