### PR TITLE
Fixed #27392 -- Remove "Tests that", "Ensures that", etc. from test docstings

### DIFF
--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -57,8 +57,8 @@ class ChangeListTests(TestCase):
 
     def test_select_related_preserved(self):
         """
-        Regression test for #10348: ChangeList.get_queryset() shouldn't
-        overwrite a custom select_related provided by ModelAdmin.get_queryset().
+        ChangeList.get_queryset() shouldn't overwrite a custom select_related
+        provided by ModelAdmin.get_queryset() (#10348).
         """
         m = ChildAdmin(Child, custom_site)
         request = self.factory.get('/child/')


### PR DESCRIPTION
I am re-working on this [PR 8648](https://github.com/django/django/pull/8648).