### PR TITLE
Fixed a race condition problem in migrations howto.

### DIFF
--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -86,16 +86,23 @@ the respective field according to your needs.
   arguments (choose an appropriate default for the type of the field you're
   adding).
 
-* Run the :djadmin:`makemigrations` command. This should generate a migration
-  with an ``AddField`` operation.
+* Change the parameter ``unique=True`` to ``null=True`` temporarily-
 
-* Generate two empty migration files for the same app by running
-  ``makemigrations myapp --empty`` twice. We've renamed the migration files to
+* Run the :djadmin:`makemigrations` command. This should generate a migration
+  with an ``AddField`` operation and will create the intermediary
+  null field and defer creating the unique constraint until we've populated
+  unique values on all the rows.
+
+* Generate an empty migration file for the same app by running
+  ``makemigrations myapp --empty``. We've renamed the migration files to
   give them meaningful names in the examples below.
 
-* Copy the ``AddField`` operation from the auto-generated migration (the first
-  of the three new files) to the last migration, change ``AddField`` to
-  ``AlterField``, and add imports of ``uuid`` and ``models``. For example:
+* Revert the added parameter ``null=True`` back to ``unique=True``.
+
+* Run the :djadmin:`makemigrations` command. This should generate a migration
+  with an ``AlterField`` operation.
+
+* The last migration file looks similar to this:
 
   .. snippet::
     :filename: 0006_remove_uuid_null.py
@@ -118,8 +125,7 @@ the respective field according to your needs.
             ),
         ]
 
-* Edit the first migration file. The generated migration class should look
-  similar to this:
+* The first migration file looks similar to this:
 
   .. snippet::
     :filename: 0004_add_uuid_field.py
@@ -134,15 +140,11 @@ the respective field according to your needs.
             migrations.AddField(
                 model_name='mymodel',
                 name='uuid',
-                field=models.UUIDField(default=uuid.uuid4, unique=True),
+                field=models.UUIDField(default=uuid.uuid4, null=True),
             ),
         ]
 
-  Change ``unique=True`` to ``null=True`` -- this will create the intermediary
-  null field and defer creating the unique constraint until we've populated
-  unique values on all the rows.
-
-* In the first empty migration file, add a
+* In the empty migration file, add a
   :class:`~django.db.migrations.operations.RunPython` or
   :class:`~django.db.migrations.operations.RunSQL` operation to generate a
   unique value (UUID in the example) for each existing row. Also add an import

--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -157,7 +157,7 @@ the respective field according to your needs.
 
     def gen_uuid(apps, schema_editor):
         MyModel = apps.get_model('myapp', 'MyModel')
-        for row in MyModel.objects.all():
+        for row in MyModel.objects.filter(uuid__isnull=True):
             row.uuid = uuid.uuid4()
             row.save(update_fields=['uuid'])
 
@@ -175,8 +175,11 @@ the respective field according to your needs.
 * Now you can apply the migrations as usual with the :djadmin:`migrate` command.
 
   Note there is a race condition if you allow objects to be created while this
-  migration is running. Objects created after the ``AddField`` and before
-  ``RunPython`` will have their original ``uuid``’s overwritten.
+  migration is running. The filter ``uuid__isnull=True`` helps to not overwrite
+  the original ``uuid`` of objects created after the ``AddField`` and before
+  ``RunPython``. If an object with a null field is created after ``RunPython``
+  before ``AlterField`` it can be fixed by reverting ``RunPython`` and running
+  it again that is fast and it only updates the new object.
 
 .. _non-atomic-migrations:
 


### PR DESCRIPTION
edited howto chapter "Migrations that add unique fields", how they are split to 3 migrations.

* The first commit will fix the mentioned race condition. It is also more similar to a normal migration  that only value `None` is replaced by the default value, not overwritten if an existing field is migrated to `null=False`.

* The second commit requires a discussion if it should be also applied:
  + pros: This method is easier memorable, linear without jumping back and forth. Model migrations are created automatically. Only the data migration is edited.
  - cons: It the problem was recognized late, this method requires to delete the migration file, not to edit it. That is controversial.

    > If you have created an invalid migration yet for that field then remove it. It will be replaced by three smaller migrations.

  The migrations are finally the same, only the steps differs.
  Number of non empty lines in howto is the same, but most of it is descriptive now and can be massively simplified, eventually by removing the two file snippets that are created automatically now.

My texts require language adjustment, please.