### PR TITLE
Fixed #28690 django.utils.http.parse_http_date two digit year check is incorrect

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -164,7 +164,19 @@ def parse_http_date(date):
     try:
         year = int(m.group('year'))
         if year < 100:
-            if year < 70:
+            # RFC 850 does not mention this, but in RFC 7231 (and there's something similar in RFC 2822),
+            # there's the following quote:
+            # Recipients of a timestamp value in rfc850-date format, which uses a
+            # two-digit year, MUST interpret a timestamp that appears to be more
+            # than 50 years in the future as representing the most recent year in
+            # the past that had the same last two digits.
+            # E.g., in 2018
+            #  06-Nov-67 is 06-Nov-2067
+            #  06-Nov-68 is 06-Nov-2068
+            #  06-Nov-69 is 06-Nov-1969
+            #  06-Nov-70 is 06-Nov-1970
+            current_year = datetime.date.today().year - 2000  # 2018 -> 18
+            if year <= current_year + 50:
                 year += 2000
             else:
                 year += 1900

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -268,6 +268,18 @@ class HttpDateProcessingTests(unittest.TestCase):
         parsed = parse_http_date('Sunday, 06-Nov-94 08:49:37 GMT')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))
 
+    def test_parsing_rfc850_year_50(self):
+        year = datetime.now().year % 100
+        dates = (
+            ('Monday, 31-Dec-18 08:49:37 GMT', datetime(2018, 12, 31, 8, 49, 37)),
+            ('Tuesday, 31-Dec-%s 08:49:37 GMT' % (year + 50), datetime(2000 + year + 50, 12, 31, 8, 49, 37)),
+            ('Wednesday, 31-Dec-%s 18:49:37 GMT' % (year + 51), datetime(1900 + year + 51, 12, 31, 18, 49, 37)),
+        )
+        for rfc850str, rfc850date in dates:
+            with self.subTest(string=rfc850str, date=rfc850date):
+                parsed = parse_http_date(rfc850str)
+                self.assertEqual(datetime.utcfromtimestamp(parsed), rfc850date)
+
     def test_parsing_asctime(self):
         parsed = parse_http_date('Sun Nov  6 08:49:37 1994')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28690  