### PR TITLE
Fixed #28685 -- Added buttom margin to fix flotation issue

### DIFF
--- a/django/contrib/admin/static/admin/css/autocomplete.css
+++ b/django/contrib/admin/static/admin/css/autocomplete.css
@@ -122,8 +122,7 @@ select.admin-autocomplete {
     cursor: pointer;
     float: right;
     font-weight: bold;
-    margin-top: 5px;
-    margin-right: 10px;
+    margin: 5px;
 }
 
 .select2-container--admin-autocomplete .select2-selection--multiple .select2-selection__choice {


### PR DESCRIPTION
The CSS class `x` to clear the multi select2 input did have a
different hight than the selected options. This resulted in a
floation error, where an option could be oddly displaced.

This patch also decresed the horizontal margin.