### PR TITLE
Fixed #28688 -- Made admin's URLify.js skip removal of English words if non-ASCII chars are present.

### DIFF
--- a/django/contrib/admin/static/admin/js/urlify.js
+++ b/django/contrib/admin/static/admin/js/urlify.js
@@ -155,13 +155,19 @@
         if (!allowUnicode) {
             s = downcode(s);
         }
-        var removelist = [
-            "a", "an", "as", "at", "before", "but", "by", "for", "from", "is",
-            "in", "into", "like", "of", "off", "on", "onto", "per", "since",
-            "than", "the", "this", "that", "to", "up", "via", "with"
-        ];
-        var r = new RegExp('\\b(' + removelist.join('|') + ')\\b', 'gi');
-        s = s.replace(r, '');
+        var hasUnicodeChars = /[^\u0000-\u007f]/.test(s);
+        // Remove English words only if the string contains ASCII (English)
+        // characters.
+        if (!hasUnicodeChars) {
+            var removeList = [
+                "a", "an", "as", "at", "before", "but", "by", "for", "from",
+                "is", "in", "into", "like", "of", "off", "on", "onto", "per",
+                "since", "than", "the", "this", "that", "to", "up", "via",
+                "with"
+            ];
+            var r = new RegExp('\\b(' + removeList.join('|') + ')\\b', 'gi');
+            s = s.replace(r, '');
+        }
         // if downcode doesn't hit, the char will be stripped here
         if (allowUnicode) {
             // Keep Unicode letters including both lowercase and uppercase

--- a/js_tests/admin/URLify.test.js
+++ b/js_tests/admin/URLify.test.js
@@ -23,3 +23,8 @@ QUnit.test('merge adjacent whitespace', function(assert) {
 QUnit.test('trim trailing hyphens', function(assert) {
     assert.strictEqual(URLify('D silent always', 9, true), 'd-silent');
 });
+
+QUnit.test('do not remove English words if the string contains non-ASCII', function(assert) {
+    // If removing English words wasn't skipped, the last 'a' would be removed.
+    assert.strictEqual(URLify('Kaupa-miða', 255, true), 'kaupa-miða');
+});


### PR DESCRIPTION
As suggested in a comment of the ticket https://code.djangoproject.com/ticket/28688, I've implemented a solution where the remove word list in urlify.js is simply skipped if the string contains a unicode character.