### PR TITLE
Refs #24031 -- Added test for Case and When constructor arguments.

### DIFF
--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -8,7 +8,7 @@ from django.core.exceptions import FieldError
 from django.db import models
 from django.db.models import F, Max, Min, Q, Sum, Value
 from django.db.models.expressions import Case, When
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from .models import CaseTestModel, Client, FKCaseTestModel, O2OCaseTestModel
 
@@ -1287,3 +1287,17 @@ class CaseDocumentationExamples(TestCase):
             [('Jack Black', 'P')],
             transform=attrgetter('name', 'account_type')
         )
+
+
+class CaseWhenTests(SimpleTestCase):
+    def test_only_when_arguments(self):
+        msg = 'Positional arguments must all be When objects.'
+        with self.assertRaisesMessage(TypeError, msg):
+            Case(When(Q(pk__in=[])), object())
+
+    def test_invalid_when_constructor_args(self):
+        msg = '__init__() takes either a Q object or lookups as keyword arguments'
+        with self.assertRaisesMessage(TypeError, msg):
+            When(condition=object())
+        with self.assertRaisesMessage(TypeError, msg):
+            When()


### PR DESCRIPTION
I'm not sure `Case.copy` is needed anymore; I don't get any test failures if I delete it. Experiments with bisecting weren't really fruitful to find out when it became obsolete.

`Case` with only a default argument is supported, and there's currently no test coverage for it. I think it'd be better to raise a `ValueError` for this in the constructor.