### PR TITLE
Fix invalid field reference in "choices"

### DIFF
--- a/docs/topics/db/models.txt
+++ b/docs/topics/db/models.txt
@@ -170,10 +170,11 @@ ones:
         )
 
     The first element in each tuple is the value that will be stored in the
-    database. The second element will be displayed by the default form widget
-    or in a :class:`~django.forms.ModelChoiceField`. Given a model instance,
-    the display value for a choices field can be accessed using the
-    ``get_FOO_display()`` method. For example::
+    database. The second element is displayed by the field's form widget.
+
+    Given a model instance, the display value for a field with ``choices`` can
+    be accessed using the :meth:`~django.db.models.Model.get_FOO_display`
+    method. For example::
 
         from django.db import models
 


### PR DESCRIPTION
In the topics/db/models document Field options, the second element of choices is shown using ModelChoiceField.
Since choices uses ChoiceField, ModelChoiceField has been modified to ChoiceField.