### PR TITLE
Fixed #28703 -- Deterministically construct the URL regex for admin's app_index view.

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -274,7 +274,7 @@ class AdminSite:
         # If there were ModelAdmins registered, we should have a list of app
         # labels for which we need to allow access to the app_index view,
         if valid_app_labels:
-            regex = r'^(?P<app_label>' + '|'.join(valid_app_labels) + ')/$'
+            regex = r'^(?P<app_label>' + '|'.join(sorted(valid_app_labels)) + ')/$'
             urlpatterns += [
                 re_path(regex, wrap(self.app_index), name='app_list'),
             ]

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -43,6 +43,32 @@ class ModelAdminTests(TestCase):
         )
         self.site = AdminSite()
 
+    def test_model_pattern_sorted(self):
+        class Agent(models.Model):
+            class Meta:
+                app_label = 'agent'
+
+        class Booking(models.Model):
+            class Meta:
+                app_label = 'booking'
+
+        class CoverBand(models.Model):
+            class Meta:
+                app_label = 'coverband'
+
+        def find_app_label():
+            urls = self.site.get_urls()
+            for url in urls:
+                if '<app_label>' in str(url.pattern):
+                    return str(url.pattern)
+
+        self.site.register(Booking)
+        self.assertIn('booking', find_app_label())
+        self.site.register(CoverBand)
+        self.assertIn('booking|coverband', find_app_label())
+        self.site.register(Agent)
+        self.assertIn('agent|booking|coverband', find_app_label())
+
     def test_modeladmin_str(self):
         ma = ModelAdmin(Band, self.site)
         self.assertEqual(str(ma), 'modeladmin.ModelAdmin')


### PR DESCRIPTION
It is possible to query the endpoints that your Django app provides.

    from django.core import urlresolvers
    urlresolvers.get_resolver()

One can then walk that tree to enumerate each of the regex patterns that went into constructing it.

The regex pattern that is constructed for an endpoint is not stable. For instance, in my project I have seen it construct each of the following:

^admin/^(?P<app_label>social_django|authtoken|queues|jobs|files|users|clusters|appps|auth|vdcs)/$
^admin/^(?P<app_label>social_django|auth|users|vdcs|appps|jobs|queues|authtoken|clusters|files)/$
^admin/^(?P<app_label>authtoken|appps|social_django|clusters|users|queues|jobs|vdcs|auth|files)/$
^admin/^(?P<app_label>authtoken|appps|social_django|clusters|users|queues|vdcs|jobs|auth|files)/$

This precludes the use of patterns in unit tests.

Make the construction of the patterns stable so that subsequent walks of the tree will be consistent.