### PR TITLE
Refs #28440 -- Fixed server connection closing test on macOS.

### DIFF
--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -70,7 +70,8 @@ class LiveServerViews(LiveServerBase):
             conn.request('GET', '/example_view/', headers={'Connection': 'keep-alive'})
             response = conn.getresponse().read()
             conn.request('GET', '/example_view/', headers={'Connection': 'close'})
-            with self.assertRaises(RemoteDisconnected, msg='Server did not close the connection'):
+            # macOS may give ConnectionResetError.
+            with self.assertRaises((RemoteDisconnected, ConnectionResetError)):
                 try:
                     conn.getresponse()
                 except ConnectionAbortedError:


### PR DESCRIPTION
Re: https://groups.google.com/d/msg/django-developers/zsfgCudRnFI/KrZKkj0dBAAJ

On MacOS w/ Python 3.5 it does indeed throw RemoteDisconnected. Given the strange non-deterministic issue on Windows and the different exceptions thrown varying by platform and python version perhaps we could just remove this test. As I understand it we always close the connection in the dev server after a request, so it's perhaps a bit odd to have a test for something that is the default and we don't implement.