### PR TITLE
Improved performance of utils.html.escape().

### DIFF
--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import operator
 from functools import total_ordering, wraps
 
@@ -189,7 +190,7 @@ def keep_lazy(*resultclasses):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            for arg in list(args) + list(kwargs.values()):
+            for arg in itertools.chain(args, kwargs.values()):
                 if isinstance(arg, Promise):
                     break
             else:

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -30,6 +30,14 @@ simple_url_re = re.compile(r'^https?://\[?\w', re.IGNORECASE)
 simple_url_2_re = re.compile(r'^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)($|/.*)$', re.IGNORECASE)
 simple_email_re = re.compile(r'^\S+@\S+\.\S+$')
 
+_html_escapes = {
+    ord('&'): '&amp;',
+    ord('<'): '&lt;',
+    ord('>'): '&gt;',
+    ord('"'): '&quot;',
+    ord("'"): '&#39;',
+}
+
 
 @keep_lazy(str, SafeText)
 def escape(text):
@@ -41,10 +49,7 @@ def escape(text):
     This may result in double-escaping. If this is a concern, use
     conditional_escape() instead.
     """
-    return mark_safe(
-        str(text).replace('&', '&amp;').replace('<', '&lt;')
-        .replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#39;')
-    )
+    return mark_safe(str(text).translate(_html_escapes))
 
 
 _js_escapes = {


### PR DESCRIPTION
There is no ticket for this, I can make one if needed. I'm not sure about the procedure for general speed improvements.

I saw some small performance gains that could be made with the `escape` function. Using multiple `replace` calls adds function call overhead, as well as creating up to 4 intermediate strings that are not used and just garbage collected. Using `itertools.chain` in `keep_lazy` means we don't have to construct two lists from `args` and `kwargs`, concatenate them into a third list and then just iterate over them.

All this adds up to a whopping ~1 µs speed gain per call!