### PR TITLE
Fixed #28575 -- Made RelatedObjectDoesNotExist classes pickable.

### DIFF
--- a/tests/queryset_pickle/models.py
+++ b/tests/queryset_pickle/models.py
@@ -45,6 +45,7 @@ class Happening(models.Model):
     name = models.CharField(blank=True, max_length=100, default="test")
     number1 = models.IntegerField(blank=True, default=standalone_number)
     number2 = models.IntegerField(blank=True, default=Numbers.get_static_number)
+    event = models.OneToOneField(Event, models.CASCADE, null=True)
 
 
 class Container:

--- a/tests/queryset_pickle/tests.py
+++ b/tests/queryset_pickle/tests.py
@@ -55,6 +55,18 @@ class PickleabilityTestCase(TestCase):
         klass = Event.MultipleObjectsReturned
         self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
 
+    def test_forward_relatedobjectdoesnotexist_class(self):
+        # ForwardManyToOneDescriptor
+        klass = Event.group.RelatedObjectDoesNotExist
+        self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
+        # ForwardOneToOneDescriptor
+        klass = Happening.event.RelatedObjectDoesNotExist
+        self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
+
+    def test_reverse_one_to_one_relatedobjectdoesnotexist_class(self):
+        klass = Event.happening.RelatedObjectDoesNotExist
+        self.assertIs(pickle.loads(pickle.dumps(klass)), klass)
+
     def test_manager_pickle(self):
         pickle.loads(pickle.dumps(Happening.objects))
 


### PR DESCRIPTION
This ended up easier than I thought @timgraham, sorry for stealing the remaining work from you @rmtobin!