### PR TITLE
Fixed #28711 -- Fixed unordered_list template filter with lazy translations.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -1,6 +1,7 @@
 """Default variable filters."""
 import random as random_module
 import re
+import types
 from decimal import ROUND_HALF_UP, Context, Decimal, InvalidOperation
 from functools import wraps
 from operator import itemgetter
@@ -615,7 +616,7 @@ def unordered_list(value, autoescape=True):
                 except StopIteration:
                     yield item, None
                     break
-                if not isinstance(next_item, str):
+                if isinstance(next_item, (list, tuple, types.GeneratorType)):
                     try:
                         iter(next_item)
                     except TypeError:

--- a/tests/template_tests/filter_tests/test_unordered_list.py
+++ b/tests/template_tests/filter_tests/test_unordered_list.py
@@ -1,6 +1,7 @@
 from django.template.defaultfilters import unordered_list
 from django.test import SimpleTestCase
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy
 
 from ..utils import setup
 
@@ -37,6 +38,12 @@ class FunctionTests(SimpleTestCase):
 
     def test_list(self):
         self.assertEqual(unordered_list(['item 1', 'item 2']), '\t<li>item 1</li>\n\t<li>item 2</li>')
+
+    def test_list_gettext(self):
+        self.assertEqual(
+            unordered_list(['item 1', ugettext_lazy('item 2')]),
+            '\t<li>item 1</li>\n\t<li>item 2</li>'
+        )
 
     def test_nested(self):
         self.assertEqual(


### PR DESCRIPTION
I wasn't sure how to check for "is it a `str` or a lazy `str`", so I reverted the `isinstance` check to what it was before https://github.com/django/django/commit/b3660d28f3422a33a84de7a7ccad404b3135a1a8, with the addition of an explicit check for generator expressions.

If someone can suggest a better way to check for stringy values, I'm happy to implement it.