### PR TITLE
Refs #19295 -- Doc'd that ManifestStaticFilesStorage doesn't work with runserver --insecure.

### DIFF
--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -222,8 +222,10 @@ setting is ``False``. By using this you acknowledge the fact that it's
 **grossly inefficient** and probably **insecure**. This is only intended for
 local development, should **never be used in production** and is only
 available if the :doc:`staticfiles </ref/contrib/staticfiles>` app is
-in your project's :setting:`INSTALLED_APPS` setting. :djadmin:`runserver`
+in your project's :setting:`INSTALLED_APPS` setting.
+
 ``--insecure`` doesn't work with
+:class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage` or
 :class:`~django.contrib.staticfiles.storage.CachedStaticFilesStorage`.
 
 Example usage::


### PR DESCRIPTION
Clarify that `runserver --insecure` doesn't work with either `ManifestStaticFilesStorage` or `CachedStaticFilesStorage`.