### PR TITLE
Corrected messages middleware comment grammar

### DIFF
--- a/django/contrib/messages/middleware.py
+++ b/django/contrib/messages/middleware.py
@@ -15,8 +15,7 @@ class MessageMiddleware(MiddlewareMixin):
         """
         Update the storage backend (i.e., save the messages).
 
-        If not all messages could not be stored and ``DEBUG`` is ``True``,
-        raise ValueError.
+        Raise ValueError if not all messages could be stored and DEBUG is True.
         """
         # A higher middleware layer may return a request which does not contain
         # messages storage, so make no assumption that it will be there.


### PR DESCRIPTION
Minor edit of the grammar in a comment on the messages middleware. Too many uses of the word 'not'.