### PR TITLE
Fixed #28636 -- Allowed customizing of translation fallback

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -47,7 +47,7 @@ USE_TZ = False
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-# Translation fallback for any language except LANGUAGE_CODE.
+# Translation fallback for any language except LANGUAGE_CODE and English.
 # Set this as fallback for unsupported languages and missing translations.
 LANGUAGE_FALLBACK = LANGUAGE_CODE
 

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -47,6 +47,10 @@ USE_TZ = False
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
+# Language code for translation fallback, which is LANGUAGE_CODE by default.
+# Set this as fallback for unsupported languages and missing translations.
+LANGUAGE_FALLBACK = LANGUAGE_CODE
+
 # Languages we provide translations for, out of the box.
 LANGUAGES = [
     ('af', gettext_noop('Afrikaans')),

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -47,7 +47,7 @@ USE_TZ = False
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-# Language code for translation fallback, which is LANGUAGE_CODE by default.
+# Translation fallback for any language except LANGUAGE_CODE.
 # Set this as fallback for unsupported languages and missing translations.
 LANGUAGE_FALLBACK = LANGUAGE_CODE
 

--- a/django/middleware/locale.py
+++ b/django/middleware/locale.py
@@ -21,7 +21,7 @@ class LocaleMiddleware(MiddlewareMixin):
         language = translation.get_language_from_request(request, check_path=i18n_patterns_used)
         language_from_path = translation.get_language_from_path(request.path_info)
         if not language_from_path and i18n_patterns_used and not prefixed_default_language:
-            language = settings.LANGUAGE_CODE
+            language = translation.get_fallback()
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
 

--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -189,6 +189,10 @@ def get_language_bidi():
     return _trans.get_language_bidi()
 
 
+def get_fallback():
+    return _trans.get_fallback()
+
+
 def check_for_language(lang_code):
     return _trans.check_for_language(lang_code)
 

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -179,11 +179,11 @@ class DjangoTranslation(gettext_module.GNUTranslations):
     def _add_fallback(self, localedirs=None):
         """Set the GNUTranslations() fallback with the default language."""
         fallback = get_fallback()
-        # Don't set a fallback for any default language variant or any English variant
-        # (as it's empty, so it'll ALWAYS fall back to the default language)
-        # If the language and fallback are the same, there's no need for adding a fallback.
-        if self.__language == fallback or self.__language.startswith(
-                settings.LANGUAGE_CODE[0:2]) or self.__language.startswith('en'):
+        # Don't set a fallback for the default language or any English variant
+        # (as it's empty, so it'll ALWAYS fall back to the fallback language).
+        # If the language is the same, there's no need for adding the fallback.
+        if self.__language == fallback or settings.LANGUAGE_CODE.startswith(
+                self.__language) or self.__language.startswith('en'):
             return
         if self.domain == 'django':
             # Get from cache

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1706,12 +1706,9 @@ It serves two purposes:
 
 * If the locale middleware isn't in use, it decides which translation is served
   to all users.
-* If the locale middleware is active, it provides a fallback language in case the
-  user's preferred language can't be determined or is not supported by the
-  website. It also provides the fallback translation when a translation for a
-  given literal doesn't exist for the user's preferred language.
-
-See :ref:`how-django-discovers-language-preference` for more details.
+* If the locale middleware is active, it provides the default fallback language
+  for unsupported languages and missing literal translations, in case
+  :setting:`LANGUAGE_FALLBACK` has not been changed.
 
 .. _list of language identifiers: http://www.i18nguy.com/unicode/language-identifiers.html
 
@@ -1778,6 +1775,43 @@ and reliable option to perform the switch is to change the language cookie name
 permanently (via the :setting:`LANGUAGE_COOKIE_NAME` setting), and to add
 a middleware that copies the value from the old cookie to a new one and then
 deletes the one.
+
+.. setting:: LANGUAGE_FALLBACK
+
+``LANGUAGE_FALLBACK``
+---------------------
+
+Default: ``LANGUAGE_CODE``
+
+A string determing the fallback language in case the user’s preferred language
+can’t be determined or is not supported by the website. It also provides the
+fallback translation when a translation for a given literal doesn’t exist for
+the user’s preferred language.
+
+Just like with :setting:`LANGUAGE_CODE` the string should be in standard
+:term:`language ID format <language code>`. The ``LocaleMiddleware`` must be
+active for the setting to have any effect.
+
+Note that :setting:`LANGUAGE_FALLBACK` has no effect on translation, when
+either :setting:`LANGUAGE_CODE` or an English variant is determined as the
+user’s preferred language. This has following reasons:
+
+* Django's built-in translations do not define values for English variants,
+  because the original strings are already written in English. Adding a
+  fallback for English would therefore result in a lot of unintended
+  fallback cases.
+* For similar reasons adding a fallback language could also result in
+  unintended fallbacks in case the language of original strings is the same
+  as your language code. Without restriction on :setting:`LANGUAGE_CODE`, a
+  user with this as preferred language would receive texts in the defined
+  fallback language, except redundant translations for the base language are
+  maintained (which is not recommended). For example, a German user would
+  get English texts for a site with German as the language code and original
+  strings written in German, if :setting:`LANGUAGE_FALLBACK` is set to
+  English.
+
+See :ref:`how-django-discovers-language-preference` and
+:ref:`using-a-non-english-base-language` for more details.
 
 .. setting:: LANGUAGES
 
@@ -3354,6 +3388,7 @@ Globalization (``i18n``/``l10n``)
 * :setting:`LANGUAGE_COOKIE_DOMAIN`
 * :setting:`LANGUAGE_COOKIE_NAME`
 * :setting:`LANGUAGE_COOKIE_PATH`
+* :setting:`LANGUAGE_FALLBACK`
 * :setting:`LANGUAGES`
 * :setting:`LOCALE_PATHS`
 * :setting:`MONTH_DAY_FORMAT`

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -1925,9 +1925,7 @@ Behind the scenes, Django has a very flexible model of deciding which language
 should be used -- installation-wide, for a particular user, or both.
 
 To set an installation-wide language preference, set :setting:`LANGUAGE_CODE`.
-Django uses this language as the default translation -- the final attempt if no
-better matching translation is found through one of the methods employed by the
-locale middleware (see below).
+Django uses this language as the default translation.
 
 If all you want is to run Django with your native language all you need to do
 is set :setting:`LANGUAGE_CODE` and make sure the corresponding :term:`message
@@ -1937,6 +1935,12 @@ If you want to let each individual user specify which language they
 prefer, then you also need to use the ``LocaleMiddleware``.
 ``LocaleMiddleware`` enables language selection based on data from the request.
 It customizes content for each user.
+
+If additionally you want to have a translation fallback for foreign languages
+in case of unsupported languages or missing translations, set
+:setting:`LANGUAGE_FALLBACK`. This is the final attempt if no better matching
+translation is found through one of the methods employed by the locale
+middleware.
 
 To use ``LocaleMiddleware``, add ``'django.middleware.locale.LocaleMiddleware'``
 to your :setting:`MIDDLEWARE` setting. Because middleware order matters, follow
@@ -1981,7 +1985,7 @@ following this algorithm:
   prefer, in order by priority. Django tries each language in the header
   until it finds one with available translations.
 
-* Failing that, it uses the global :setting:`LANGUAGE_CODE` setting.
+* Failing that, it uses the global :setting:`LANGUAGE_FALLBACK` setting.
 
 .. _locale-middleware-notes:
 
@@ -2096,6 +2100,8 @@ You can also run :djadmin:`django-admin compilemessages
 --settings=path.to.settings <compilemessages>` to make the compiler process all
 the directories in your :setting:`LOCALE_PATHS` setting.
 
+.. _using-a-non-english-base-language:
+
 Using a non-English base language
 ---------------------------------
 
@@ -2109,7 +2115,14 @@ aware of certain limitations:
   English.
 
 * When an English variant is activated and English strings are missing, the
-  fallback language will not be the :setting:`LANGUAGE_CODE` of the project,
+  fallback language will not be the :setting:`LANGUAGE_FALLBACK` of the project,
   but the original strings. For example, an English user visiting a site with
-  Spanish as the default language and original strings written in Russian will
+  Spanish as the fallback language and original strings written in Russian will
   fallback to Russian, not to Spanish.
+
+If your project has a non-English base language, then consider using it for
+:setting:`LANGUAGE_CODE` unless there are good reasons not to do so. This will
+avoid possible confusion regarding the aforementioned point, because if
+:setting:`LANGUAGE_CODE` is determined as the user’s preferred language, then
+:setting:`LANGUAGE_FALLBACK` will not be active. This results in having your
+base language as fallback for your language code.


### PR DESCRIPTION
Introduction of a new setting LANGUAGE_FALLBACK, which allows controlling the fallback language of Django's translation module (set to LANGUAGE_CODE by default, for backward compatibility reasons).

Thanks Claude Paroz for the analysis and Dhia Abbasi for the good ideas.