### PR TITLE
Refs #28010 -- Allowed reverse related fields in SELECT FOR UPDATE .. OF

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -783,6 +783,7 @@ class SQLCompiler:
             klass_info = {
                 'model': f.remote_field.model,
                 'field': f,
+                'reverse': False,
                 'local_setter': f.set_cached_value,
                 'remote_setter': f.remote_field.set_cached_value if f.unique else lambda x, y: None,
                 'from_parent': False,
@@ -821,6 +822,7 @@ class SQLCompiler:
                 klass_info = {
                     'model': model,
                     'field': f,
+                    'reverse': True,
                     'local_setter': f.remote_field.set_cached_value,
                     'remote_setter': f.set_cached_value,
                     'from_parent': from_parent,
@@ -858,6 +860,7 @@ class SQLCompiler:
                     klass_info = {
                         'model': model,
                         'field': f,
+                        'reverse': True,
                         'local_setter': local_setter,
                         'remote_setter': remote_setter,
                         'from_parent': from_parent,
@@ -905,7 +908,10 @@ class SQLCompiler:
                     path = []
                     yield 'self'
                 else:
-                    path = parent_path + [klass_info['field'].name]
+                    field = klass_info['field']
+                    if klass_info['reverse']:
+                        field = field.remote_field
+                    path = parent_path + [field.name]
                     yield LOOKUP_SEP.join(path)
                 queue.extend(
                     (path, klass_info)
@@ -918,7 +924,10 @@ class SQLCompiler:
             klass_info = self.klass_info
             for part in parts:
                 for related_klass_info in klass_info.get('related_klass_infos', []):
-                    if related_klass_info['field'].name == part:
+                    field = related_klass_info['field']
+                    if related_klass_info['reverse']:
+                        field = field.remote_field
+                    if field.name == part:
                         klass_info = related_klass_info
                         break
                 else:

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1628,6 +1628,19 @@ specify the related objects you want to lock in ``select_for_update(of=(...))``
 using the same fields syntax as :meth:`select_related`. Use the value ``'self'``
 to refer to the queryset's model.
 
+You can't use ``select_for_update()`` on nullable relations::
+
+    >>> Person.objects.select_related('hometown').select_for_update()
+    Traceback (most recent call last):
+    ...
+    django.db.utils.NotSupportedError: FOR UPDATE cannot be applied to the nullable side of an outer join
+
+To avoid that restriction, you can exclude null objects if you don't care about
+them::
+
+    >>> Person.objects.select_related('hometown').select_for_update().exclude(hometown=None)
+    <QuerySet [<Person: ...)>, ...]>
+
 Currently, the ``postgresql``, ``oracle``, and ``mysql`` database
 backends support ``select_for_update()``. However, MySQL doesn't support the
 ``nowait``, ``skip_locked``, and ``of`` arguments.

--- a/tests/select_for_update/models.py
+++ b/tests/select_for_update/models.py
@@ -14,3 +14,7 @@ class Person(models.Model):
     name = models.CharField(max_length=30)
     born = models.ForeignKey(City, models.CASCADE, related_name='+')
     died = models.ForeignKey(City, models.CASCADE, related_name='+')
+
+
+class PersonProfile(models.Model):
+    person = models.OneToOneField(Person, models.CASCADE, related_name='profile')


### PR DESCRIPTION
This is a continuation of Ran Benita's (@bluetech) pull request #9043.

It adds back the 'reverse' key required to `klass_info` that removed in #9081, and also adds a unit test to make sure the two features can work together.