### PR TITLE
Fixed #28719 -- Added a helpful exception if MultipleObjectTemplateResponseMixin doesn't generate any template names.

### DIFF
--- a/django/views/generic/list.py
+++ b/django/views/generic/list.py
@@ -181,7 +181,13 @@ class MultipleObjectTemplateResponseMixin(TemplateResponseMixin):
         if hasattr(self.object_list, 'model'):
             opts = self.object_list.model._meta
             names.append("%s/%s%s.html" % (opts.app_label, opts.model_name, self.template_name_suffix))
-
+        elif not names:
+            raise ImproperlyConfigured(
+                "%(cls)s requires either a 'template_name' attribute "
+                "or a get_queryset() method that returns a QuerySet." % {
+                    'cls': self.__class__.__name__,
+                }
+            )
         return names
 
 

--- a/tests/generic_views/test_list.py
+++ b/tests/generic_views/test_list.py
@@ -207,6 +207,14 @@ class ListViewTests(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             self.client.get('/list/authors/invalid/')
 
+    def test_invalid_get_queryset(self):
+        msg = (
+            "AuthorListGetQuerysetReturnsNone requires either a 'template_name' "
+            "attribute or a get_queryset() method that returns a QuerySet."
+        )
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            self.client.get('/list/authors/get_queryset/')
+
     def test_paginated_list_view_does_not_load_entire_table(self):
         # Regression test for #17535
         self._make_authors(3)

--- a/tests/generic_views/urls.py
+++ b/tests/generic_views/urls.py
@@ -133,6 +133,10 @@ urlpatterns = [
     path('list/authors/dupe_context_object_name/', views.AuthorList.as_view(context_object_name='object_list')),
     path('list/authors/invalid/', views.AuthorList.as_view(queryset=None)),
     path(
+        'list/authors/get_queryset/',
+        views.AuthorListGetQuerysetReturnsNone.as_view(),
+    ),
+    path(
         'list/authors/paginated/custom_class/',
         views.AuthorList.as_view(paginate_by=5, paginator_class=views.CustomPaginator),
     ),

--- a/tests/generic_views/views.py
+++ b/tests/generic_views/views.py
@@ -66,6 +66,11 @@ class AuthorList(generic.ListView):
     queryset = Author.objects.all()
 
 
+class AuthorListGetQuerysetReturnsNone(AuthorList):
+    def get_queryset(self):
+        return None
+
+
 class BookList(generic.ListView):
     model = Book
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28719