### PR TITLE
Ticket#23816. Implemented 'default_deferred_fields'

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -32,7 +32,7 @@ DEFAULT_NAMES = (
     'auto_created', 'index_together', 'apps', 'default_permissions',
     'select_on_save', 'default_related_name', 'required_db_features',
     'required_db_vendor', 'base_manager_name', 'default_manager_name',
-    'indexes',
+    'indexes', 'default_deferred_fields',
 )
 
 

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -44,3 +44,16 @@ class RefreshPrimaryProxy(Primary):
             if fields.intersection(deferred_fields):
                 fields = fields.union(deferred_fields)
         super().refresh_from_db(using, fields, **kwargs)
+
+
+class User(models.Model):
+    username = models.CharField(max_length=50)
+
+
+class Publication(models.Model):
+    title = models.CharField(max_length=240, default="Test Title")
+    text = models.TextField(default="Test text")
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    class Meta:
+        default_deferred_fields = ('title', 'user')

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from .models import (
     BigChild, Child, ChildProxy, Primary, RefreshPrimaryProxy, Secondary,
-)
+    User, Publication)
 
 
 class AssertionMixin:
@@ -271,3 +271,16 @@ class TestDefer2(AssertionMixin, TestCase):
             # access of any of them.
             self.assertEqual(rf2.name, 'new foo')
             self.assertEqual(rf2.value, 'new bar')
+
+    def test_defaul_defer_fields(self):
+        u = User.objects.create()
+        p = Publication()
+        p.user = u
+        p.save()
+        p = Publication.objects.get()
+        publication = Publication.objects.defer('text').get()
+        self.assertEqual(len(p.get_deferred_fields()), 2)
+        self.assertEqual(len(publication.get_deferred_fields()), 3)
+        self.assertEqual(p.user, u)
+        self.assertEqual(publication.text, "Test text")
+        self.assertEqual(p.title, "Test Title")


### PR DESCRIPTION
Implemented new feature that allow to define fields which will be deferred for reading. 
The `default_deferred_fields` property must be defined in the model's meta-class and contains a tuple of fields. The fields from this list will be marked as `deferred` before executing query 
Example:
```
class Sub(Super):
    is_super = models.BooleanField(default=False)
    len = models.IntegerField(default=2)

    class Meta:
        default_deferred_fields = ('is_super',)
```
