### PR TITLE
Ticket 23816  Implemented  default deferred fields

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -129,6 +129,7 @@ class Field(RegisterLookupMixin):
         return _('Field of type: %(field_type)s') % {
             'field_type': self.__class__.__name__
         }
+
     description = property(_description)
 
     def __init__(self, verbose_name=None, name=None, primary_key=False,
@@ -137,7 +138,7 @@ class Field(RegisterLookupMixin):
                  serialize=True, unique_for_date=None, unique_for_month=None,
                  unique_for_year=None, choices=None, help_text='', db_column=None,
                  db_tablespace=None, auto_created=False, validators=(),
-                 error_messages=None):
+                 error_messages=None, defer=False):
         self.name = name
         self.verbose_name = verbose_name  # May be set by set_attributes_from_name
         self._verbose_name = verbose_name  # Store original for deconstruction
@@ -148,6 +149,7 @@ class Field(RegisterLookupMixin):
         self.is_relation = self.remote_field is not None
         self.default = default
         self.editable = editable
+        self.defer = defer
         self.serialize = serialize
         self.unique_for_date = unique_for_date
         self.unique_for_month = unique_for_month
@@ -251,7 +253,7 @@ class Field(RegisterLookupMixin):
                     )
                 ]
             elif any(isinstance(choice, str) or
-                     not is_iterable(choice) or len(choice) != 2
+                         not is_iterable(choice) or len(choice) != 2
                      for choice in self.choices):
                 return [
                     checks.Error(
@@ -800,20 +802,20 @@ class Field(RegisterLookupMixin):
                     break
 
         first_choice = (blank_choice if include_blank and
-                        not blank_defined else [])
+                                        not blank_defined else [])
         if self.choices:
             return first_choice + choices
         rel_model = self.remote_field.model
         limit_choices_to = limit_choices_to or self.get_limit_choices_to()
         if hasattr(self.remote_field, 'get_related_field'):
             lst = [(getattr(x, self.remote_field.get_related_field().attname),
-                   smart_text(x))
+                    smart_text(x))
                    for x in rel_model._default_manager.complex_filter(
-                       limit_choices_to)]
+                    limit_choices_to)]
         else:
             lst = [(x.pk, smart_text(x))
                    for x in rel_model._default_manager.complex_filter(
-                       limit_choices_to)]
+                    limit_choices_to)]
         return first_choice + lst
 
     def value_to_string(self, obj):
@@ -832,6 +834,7 @@ class Field(RegisterLookupMixin):
             else:
                 flat.append((choice, value))
         return flat
+
     flatchoices = property(_get_flatchoices)
 
     def save_form_data(self, instance, data):
@@ -1057,7 +1060,7 @@ class CharField(Field):
                 )
             ]
         elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool) or
-                self.max_length <= 0):
+                      self.max_length <= 0):
             return [
                 checks.Error(
                     "'max_length' must be a positive integer.",
@@ -1114,7 +1117,6 @@ class CommaSeparatedIntegerField(CharField):
 
 
 class DateTimeCheckMixin:
-
     def check(self, **kwargs):
         errors = super().check(**kwargs)
         errors.extend(self._check_mutually_exclusive_options())
@@ -2023,7 +2025,6 @@ class NullBooleanField(Field):
 
 
 class PositiveIntegerRelDbTypeMixin:
-
     def rel_db_type(self, connection):
         """
         Return the data type that a related field pointing to this field should

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -138,7 +138,7 @@ class Field(RegisterLookupMixin):
                  serialize=True, unique_for_date=None, unique_for_month=None,
                  unique_for_year=None, choices=None, help_text='', db_column=None,
                  db_tablespace=None, auto_created=False, validators=(),
-                 error_messages=None, defer=False):
+                 error_messages=None, defer=False, ):
         self.name = name
         self.verbose_name = verbose_name  # May be set by set_attributes_from_name
         self._verbose_name = verbose_name  # Store original for deconstruction
@@ -252,9 +252,9 @@ class Field(RegisterLookupMixin):
                         id='fields.E004',
                     )
                 ]
-            elif any(isinstance(choice, str) or
-                         not is_iterable(choice) or len(choice) != 2
-                     for choice in self.choices):
+            elif any(
+                    isinstance(choice, str) or not is_iterable(choice) or len(choice) != 2 for choice in
+                    self.choices):
                 return [
                     checks.Error(
                         "'choices' must be an iterable containing "
@@ -801,21 +801,16 @@ class Field(RegisterLookupMixin):
                     blank_defined = True
                     break
 
-        first_choice = (blank_choice if include_blank and
-                                        not blank_defined else [])
+        first_choice = (blank_choice if include_blank and not blank_defined else [])
         if self.choices:
             return first_choice + choices
         rel_model = self.remote_field.model
         limit_choices_to = limit_choices_to or self.get_limit_choices_to()
         if hasattr(self.remote_field, 'get_related_field'):
-            lst = [(getattr(x, self.remote_field.get_related_field().attname),
-                    smart_text(x))
-                   for x in rel_model._default_manager.complex_filter(
-                    limit_choices_to)]
+            lst = [(getattr(x, self.remote_field.get_related_field().attname), smart_text(x)) for x in
+                   rel_model._default_manager.complex_filter(limit_choices_to)]
         else:
-            lst = [(x.pk, smart_text(x))
-                   for x in rel_model._default_manager.complex_filter(
-                    limit_choices_to)]
+            lst = [(x.pk, smart_text(x)) for x in rel_model._default_manager.complex_filter(limit_choices_to)]
         return first_choice + lst
 
     def value_to_string(self, obj):
@@ -1059,8 +1054,7 @@ class CharField(Field):
                     id='fields.E120',
                 )
             ]
-        elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool) or
-                      self.max_length <= 0):
+        elif (not isinstance(self.max_length, int) or isinstance(self.max_length, bool) or self.max_length <= 0):
             return [
                 checks.Error(
                     "'max_length' must be a positive integer.",

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1192,9 +1192,10 @@ class QuerySet:
     def _merge_sanity_check(self, other):
         """Check that two QuerySet classes may be merged."""
         if self._fields is not None and (
-                        set(self.query.values_select) != set(other.query.values_select) or
-                        set(self.query.extra_select) != set(other.query.extra_select) or
-                    set(self.query.annotation_select) != set(other.query.annotation_select)):
+            set(self.query.values_select) != set(other.query.values_select) or
+            set(self.query.extra_select) != set(other.query.extra_select) or
+            set(self.query.annotation_select) != set(other.query.annotation_select)
+        ):
             raise TypeError(
                 "Merging '%s' classes must involve the same values in each case."
                 % self.__class__.__name__
@@ -1301,9 +1302,11 @@ class RawQuerySet:
                 raise InvalidQuery('Raw query must include the primary key')
             model_cls = self.model
             fields = [self.model_fields.get(c) for c in self.columns]
-            converters = compiler.get_converters([
-                                                     f.get_col(f.model._meta.db_table) if f else None for f in fields
-                                                     ])
+            converters = compiler.get_converters(
+                [
+                    f.get_col(f.model._meta.db_table) if f else None for f in fields
+                ]
+            )
             if converters:
                 query = compiler.apply_converters(query, converters)
             for values in query:
@@ -1638,7 +1641,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     additional_lookups = [
         copy.copy(additional_lookup) for additional_lookup
         in getattr(rel_qs, '_prefetch_related_lookups', ())
-        ]
+    ]
     if additional_lookups:
         # Don't need to clone because the manager should have given us a fresh
         # instance, so we access an internal instead of using public interface
@@ -1752,7 +1755,7 @@ class RelatedPopulator:
             self.cols_end = select_fields[-1] + 1
             self.init_list = [
                 f[0].target.attname for f in select[self.cols_start:self.cols_end]
-                ]
+            ]
             self.reorder_for_init = None
         else:
             attname_indexes = {select[idx][0].target.attname: idx for idx in select_fields}

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -189,6 +189,9 @@ class QuerySet:
         self._sticky_filter = False
         self._for_write = False
         self._prefetch_related_lookups = ()
+        self._prefetch_deferred_fields = ()
+        if model is not None:
+            self._prefetch_deferred_fields = [x.attname for x in model._meta.fields if x.defer]
         self._prefetch_done = False
         self._known_related_objects = {}  # {rel_field: {pk: rel_obj}}
         self._iterable_class = ModelIterable
@@ -200,6 +203,7 @@ class QuerySet:
         manager = Manager.from_queryset(cls)()
         manager._built_with_as_manager = True
         return manager
+
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
 
@@ -673,6 +677,7 @@ class QuerySet:
         query. No signals are sent and there is no protection for cascades.
         """
         return sql.DeleteQuery(self.model).delete_qs(self, using)
+
     _raw_delete.alters_data = True
 
     def update(self, **kwargs):
@@ -691,6 +696,7 @@ class QuerySet:
             rows = query.get_compiler(self.db).execute_sql(CURSOR)
         self._result_cache = None
         return rows
+
     update.alters_data = True
 
     def _update(self, values):
@@ -706,6 +712,7 @@ class QuerySet:
         query.add_update_fields(values)
         self._result_cache = None
         return query.get_compiler(self.db).execute_sql(CURSOR)
+
     _update.alters_data = True
     _update.queryset_only = False
 
@@ -1109,6 +1116,7 @@ class QuerySet:
         query = sql.InsertQuery(self.model)
         query.insert_values(fields, objs, raw=raw)
         return query.get_compiler(using=using).execute_sql(return_id)
+
     _insert.alters_data = True
     _insert.queryset_only = False
 
@@ -1158,6 +1166,7 @@ class QuerySet:
         c._known_related_objects = self._known_related_objects
         c._iterable_class = self._iterable_class
         c._fields = self._fields
+        c.query.add_deferred_loading(self._prefetch_deferred_fields)
         return c
 
     def _fetch_all(self):
@@ -1183,9 +1192,9 @@ class QuerySet:
     def _merge_sanity_check(self, other):
         """Check that two QuerySet classes may be merged."""
         if self._fields is not None and (
-                set(self.query.values_select) != set(other.query.values_select) or
-                set(self.query.extra_select) != set(other.query.extra_select) or
-                set(self.query.annotation_select) != set(other.query.annotation_select)):
+                        set(self.query.values_select) != set(other.query.values_select) or
+                        set(self.query.extra_select) != set(other.query.extra_select) or
+                    set(self.query.annotation_select) != set(other.query.annotation_select)):
             raise TypeError(
                 "Merging '%s' classes must involve the same values in each case."
                 % self.__class__.__name__
@@ -1206,6 +1215,7 @@ class QuerySet:
         query = self.query.resolve_expression(*args, **kwargs)
         query._db = self._db
         return query
+
     resolve_expression.queryset_only = True
 
     def _add_hints(self, **hints):
@@ -1255,6 +1265,7 @@ class RawQuerySet:
     Provide an iterator which converts the results of raw SQL queries into
     annotated model instances.
     """
+
     def __init__(self, raw_query, model=None, query=None, params=None,
                  translations=None, using=None, hints=None):
         self.raw_query = raw_query
@@ -1291,8 +1302,8 @@ class RawQuerySet:
             model_cls = self.model
             fields = [self.model_fields.get(c) for c in self.columns]
             converters = compiler.get_converters([
-                f.get_col(f.model._meta.db_table) if f else None for f in fields
-            ])
+                                                     f.get_col(f.model._meta.db_table) if f else None for f in fields
+                                                     ])
             if converters:
                 query = compiler.apply_converters(query, converters)
             for values in query:
@@ -1431,7 +1442,7 @@ def prefetch_related_objects(model_instances, *related_lookups):
     # We need to be able to dynamically add to the list of prefetch_related
     # lookups that we look up (see below).  So we need some book keeping to
     # ensure we don't do duplicate work.
-    done_queries = {}    # dictionary of things like 'foo__bar': [results]
+    done_queries = {}  # dictionary of things like 'foo__bar': [results]
 
     auto_lookups = set()  # we add to this as we go through.
     followed_descriptors = set()  # recursion protection
@@ -1627,7 +1638,7 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     additional_lookups = [
         copy.copy(additional_lookup) for additional_lookup
         in getattr(rel_qs, '_prefetch_related_lookups', ())
-    ]
+        ]
     if additional_lookups:
         # Don't need to clone because the manager should have given us a fresh
         # instance, so we access an internal instead of using public interface
@@ -1708,6 +1719,7 @@ class RelatedPopulator:
     method gets row and from_obj as input and populates the select_related()
     model instance.
     """
+
     def __init__(self, klass_info, select, db):
         self.db = db
         # Pre-compute needed attributes. The attributes are:
@@ -1740,7 +1752,7 @@ class RelatedPopulator:
             self.cols_end = select_fields[-1] + 1
             self.init_list = [
                 f[0].target.attname for f in select[self.cols_start:self.cols_end]
-            ]
+                ]
             self.reorder_for_init = None
         else:
             attname_indexes = {select[idx][0].target.attname: idx for idx in select_fields}

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -44,3 +44,13 @@ class RefreshPrimaryProxy(Primary):
             if fields.intersection(deferred_fields):
                 fields = fields.union(deferred_fields)
         super().refresh_from_db(using, fields, **kwargs)
+
+
+class User(models.Model):
+    username = models.CharField(max_length=50)
+
+
+class Publication(models.Model):
+    title = models.CharField(max_length=240, default="Test Title", defer=True)
+    text = models.TextField(default="Test text")
+    user = models.ForeignKey(User, on_delete=models.CASCADE, defer=True)

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -2,8 +2,9 @@ from django.db.models.query_utils import InvalidQuery
 from django.test import TestCase
 
 from .models import (
-    BigChild, Child, ChildProxy, Primary, RefreshPrimaryProxy, Secondary,
-    User, Publication)
+    BigChild, Child, ChildProxy, Primary, Publication, RefreshPrimaryProxy,
+    Secondary, User,
+)
 
 
 class AssertionMixin:

--- a/tests/defer/tests.py
+++ b/tests/defer/tests.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from .models import (
     BigChild, Child, ChildProxy, Primary, RefreshPrimaryProxy, Secondary,
-)
+    User, Publication)
 
 
 class AssertionMixin:
@@ -271,3 +271,16 @@ class TestDefer2(AssertionMixin, TestCase):
             # access of any of them.
             self.assertEqual(rf2.name, 'new foo')
             self.assertEqual(rf2.value, 'new bar')
+
+    def test_defaul_defer_fields(self):
+        u = User.objects.create()
+        p = Publication()
+        p.user = u
+        p.save()
+        p = Publication.objects.get()
+        publication = Publication.objects.defer('text').get()
+        self.assertEqual(len(p.get_deferred_fields()), 2)
+        self.assertEqual(len(publication.get_deferred_fields()), 3)
+        self.assertEqual(p.user, u)
+        self.assertEqual(publication.text, "Test text")
+        self.assertEqual(p.title, "Test Title")


### PR DESCRIPTION
Implemented new feature that allow to define fields which will be deferred for reading. 
Added new parameter to fields - "defer". By default this param is equal False.Before executing query the fields which have `defer=True` will be marked as `deferred` 
Example:
```
class Sub(Super):
    is_super = models.BooleanField(default=False, defer=True)
    len = models.IntegerField(default=2)
```
This logic is equal to `Sub.objects.defer("is_super").get()`