### PR TITLE
Removed reimports in various code.

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -65,8 +65,6 @@ class Command(BaseCommand):
         return get_internal_wsgi_application()
 
     def handle(self, *args, **options):
-        from django.conf import settings
-
         if not settings.DEBUG and not settings.ALLOWED_HOSTS:
             raise CommandError('You must set settings.ALLOWED_HOSTS if DEBUG is False.')
 

--- a/django/core/management/commands/test.py
+++ b/django/core/management/commands/test.py
@@ -50,9 +50,6 @@ class Command(BaseCommand):
             test_runner_class.add_arguments(parser)
 
     def handle(self, *test_labels, **options):
-        from django.conf import settings
-        from django.test.utils import get_runner
-
         TestRunner = get_runner(settings, options['testrunner'])
 
         test_runner = TestRunner(**options)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -63,7 +63,6 @@ class ResolverMatch:
 @functools.lru_cache(maxsize=None)
 def get_resolver(urlconf=None):
     if urlconf is None:
-        from django.conf import settings
         urlconf = settings.ROOT_URLCONF
     return URLResolver(RegexPattern(r'^/'), urlconf)
 


### PR DESCRIPTION
Unused since 578ac17f814f21648484a1d846413398e92f8808, 046ffa483ed63faae7b31e7e2cf618f88a3312ba, and 95ca01f9995ef72c6bbe9bba477781b46cf573b4.