### PR TITLE
Flake8 comprehensions

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -520,11 +520,11 @@ def parse_accept_lang_header(lang_string):
     result = []
     pieces = accept_language_re.split(lang_string.lower())
     if pieces[-1]:
-        return tuple()
+        return ()
     for i in range(0, len(pieces) - 1, 3):
         first, lang, priority = pieces[i:i + 3]
         if first:
-            return tuple()
+            return ()
         if priority:
             priority = float(priority)
         else:

--- a/tests/gis_tests/rasterapp/test_rasterfield.py
+++ b/tests/gis_tests/rasterapp/test_rasterfield.py
@@ -127,11 +127,11 @@ class RasterFieldTest(TransactionTestCase):
         stx_pnt = GEOSGeometry('POINT (-95.370401017314293 29.704867409475465)', 4326)
         stx_pnt.transform(3086)
 
-        lookups = list(
+        lookups = [
             (name, lookup)
             for name, lookup in BaseSpatialField.get_lookups().items()
             if issubclass(lookup, GISLookup)
-        )
+        ]
         self.assertNotEqual(lookups, [], 'No lookups found')
         # Loop through all the GIS lookups.
         for name, lookup in lookups:
@@ -185,7 +185,7 @@ class RasterFieldTest(TransactionTestCase):
                 len(combo_values),
                 'Number of lookup names and values should be the same',
             )
-            combos = list(x for x in zip(combo_keys, combo_values) if x[1])
+            combos = [x for x in zip(combo_keys, combo_values) if x[1]]
             self.assertEqual(
                 [(n, x) for n, x in enumerate(combos) if x in combos[:n]],
                 [],


### PR DESCRIPTION
The `tuple()` construct is about 5-6 slower than `()`. I don't know the speedup for list-comprehensions, but it should also be somewhat faster.

The warnings are found by flake8-comprehensions, C407 is ignored, I tried to replace it and broke the tests. I think it was discussed previously if this should be included as part of the flake8 test. https://github.com/django/django/commit/0d74c41981687598d3fa0a7eb9712ce4c387ca19 replaced the dict-calls with a literal.