### PR TITLE
Allow update operations on slices

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -680,8 +680,11 @@ class QuerySet:
         Update all elements in the current QuerySet, setting all the given
         fields to the appropriate values.
         """
-        assert self.query.can_filter(), \
-            "Cannot update a query once a slice has been taken."
+
+        if not self.query.can_filter():
+            return self.query.model.objects.filter(
+                pk__in=list(self.values_list('pk', flat=True))).update(**kwargs)
+        
         self._for_write = True
         query = self.query.chain(sql.UpdateQuery)
         query.add_update_values(kwargs)

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -684,7 +684,7 @@ class QuerySet:
         if not self.query.can_filter():
             return self.query.model.objects.filter(
                 pk__in=list(self.values_list('pk', flat=True))).update(**kwargs)
-        
+
         self._for_write = True
         query = self.query.chain(sql.UpdateQuery)
         query.add_update_values(kwargs)

--- a/tests/update/tests.py
+++ b/tests/update/tests.py
@@ -118,14 +118,12 @@ class AdvancedTests(TestCase):
         resp = DataPoint.objects.values('value').distinct()
         self.assertEqual(list(resp), [{'value': 'thing'}])
 
-    def test_update_slice_fail(self):
+    def test_update_slice(self):
         """
-        We do not support update on already sliced query sets.
+        Ensure that updates on slices return the correct result count
         """
         method = DataPoint.objects.all()[:2].update
-        msg = 'Cannot update a query once a slice has been taken.'
-        with self.assertRaisesMessage(AssertionError, msg):
-            method(another_value='another thing')
+        self.assertEqual(2, method(another_value='another thing'))
 
     def test_update_respects_to_field(self):
         """


### PR DESCRIPTION
Implemented for convenience, this will run as two queries as it needs to fetch the pk's from the original filter, and then uses those to perform the update in the second query.