### PR TITLE
Fixed #28718 -- Allowed password reset if a user's current password doesn't use an enabled hasher.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -6,7 +6,7 @@ import unicodedata
 
 from django.contrib.auth import password_validation
 from django.contrib.auth.hashers import (
-    check_password, is_password_usable, make_password,
+    check_password, is_password_disabled, is_password_usable, make_password,
 )
 from django.db import models
 from django.utils.crypto import get_random_string, salted_hmac
@@ -116,6 +116,9 @@ class AbstractBaseUser(models.Model):
 
     def has_usable_password(self):
         return is_password_usable(self.password)
+
+    def has_disabled_password(self):
+        return is_password_disabled(self.password)
 
     def get_session_auth_hash(self):
         """

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -255,14 +255,14 @@ class PasswordResetForm(forms.Form):
         """Given an email, return matching user(s) who should receive a reset.
 
         This allows subclasses to more easily customize the default policies
-        that prevent inactive users and users with unusable passwords from
+        that prevent inactive users and users with disabled passwords from
         resetting their password.
         """
         active_users = UserModel._default_manager.filter(**{
             '%s__iexact' % UserModel.get_email_field_name(): email,
             'is_active': True,
         })
-        return (u for u in active_users if u.has_usable_password())
+        return (u for u in active_users if not u.has_disabled_password())
 
     def save(self, domain_override=None,
              subject_template_name='registration/password_reset_subject.txt',

--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -21,8 +21,12 @@ UNUSABLE_PASSWORD_PREFIX = '!'  # This will never be a valid encoded hash
 UNUSABLE_PASSWORD_SUFFIX_LENGTH = 40  # number of random chars to add after UNUSABLE_PASSWORD_PREFIX
 
 
+def is_password_disabled(password):
+    return password.startswith(UNUSABLE_PASSWORD_PREFIX)
+
+
 def is_password_usable(encoded):
-    if encoded is None or encoded.startswith(UNUSABLE_PASSWORD_PREFIX):
+    if encoded is None or is_password_disabled(encoded):
         return False
     try:
         identify_hasher(encoded)

--- a/tests/auth_tests/test_basic.py
+++ b/tests/auth_tests/test_basic.py
@@ -14,6 +14,7 @@ class BasicTestCase(TestCase):
         "Users can be created and can set their password"
         u = User.objects.create_user('testuser', 'test@example.com', 'testpw')
         self.assertTrue(u.has_usable_password())
+        self.assertIs(u.has_disabled_password(), False)
         self.assertFalse(u.check_password('bad'))
         self.assertTrue(u.check_password('testpw'))
 
@@ -22,10 +23,12 @@ class BasicTestCase(TestCase):
         u.save()
         self.assertFalse(u.check_password('testpw'))
         self.assertFalse(u.has_usable_password())
+        self.assertIs(u.has_disabled_password(), True)
         u.set_password('testpw')
         self.assertTrue(u.check_password('testpw'))
         u.set_password(None)
         self.assertFalse(u.has_usable_password())
+        self.assertIs(u.has_disabled_password(), True)
 
         # Check username getter
         self.assertEqual(u.get_username(), 'testuser')
@@ -40,6 +43,7 @@ class BasicTestCase(TestCase):
         # Check API-based user creation with no password
         u2 = User.objects.create_user('testuser2', 'test2@example.com')
         self.assertFalse(u2.has_usable_password())
+        self.assertIs(u.has_disabled_password(), True)
 
     def test_unicode_username(self):
         User.objects.create_user('jörg')

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -817,6 +817,19 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
         form.save()
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_disabled_password(self):
+        user = User.objects.create_user('testuser', 'test@example.com', 'test')
+        data = {"email": "test@example.com"}
+        form = PasswordResetForm(data)
+        self.assertTrue(form.is_valid())
+        user.password = 'unknown hasher'
+        user.save()
+        form = PasswordResetForm(data)
+        # The form itself is valid, but no email is sent
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(len(mail.outbox), 1)
+
     def test_save_plaintext_email(self):
         """
         Test the PasswordResetForm.save() method with no html_email_template_name


### PR DESCRIPTION
[#28718](https://code.djangoproject.com/ticket/28718)

> Currently the built in django password reset system requires that you have an active account and that your password can be compared to by an enabled hasher. 
I think that this is in error, as you are about to reset the password to something new (hence resetting it) and the standard process of password resetting requires an email confirmation. I can see no way in which this is able to be abused by a malicious 3rd party. If I'm mistaken here then feel free to correct me.
I propose that the system is changed to just require that the user is active and that their password is not marked disabled as per the UNUSABLE_PASSWORD_PREFIX.