### PR TITLE
Fixed #28734  -- Added --password option to createsuperuser management command.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1495,6 +1495,10 @@ using the ``--username`` and ``--email`` arguments on the command
 line. If either of those is not supplied, ``createsuperuser`` will prompt for
 it when running interactively.
 
+.. django-admin-option:: --password PASSWORD
+
+Specifies the password of superuser.
+
 .. django-admin-option:: --database DATABASE
 
 Specifies the database into which the superuser object will be saved.

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -602,6 +602,93 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
 
         test(self)
 
+    def test_password_argument(self):
+
+        """createsuperuser --password."""
+        new_io = StringIO()
+
+        def test(self):
+            call_command(
+                'createsuperuser',
+                username='joe1234567890',
+                password='joe1234',
+                email='joe@somewhere.org',
+                stdin=MockTTY(),
+                stdout=new_io,
+                stderr=new_io,
+            )
+            command_output = new_io.getvalue().strip()
+            self.assertEqual(command_output, 'Superuser created successfully.')
+            u = User._default_manager.get(username='joe1234567890')
+            self.assertEqual(u.email, 'joe@somewhere.org')
+            self.assertTrue(u.has_usable_password())
+            self.assertTrue(u.check_password('joe1234'))
+
+        test(self)
+
+    def test_invalid_password_argument(self):
+
+        """createsuperuser --password with invalid password."""
+        new_io = StringIO()
+
+        def test(self):
+            with self.assertRaisesMessage(CommandError, 'This password is entirely numeric.'):
+                call_command(
+                    'createsuperuser',
+                    username='joe1234567890',
+                    password='1234',
+                    stdin=MockTTY(),
+                    stdout=new_io,
+                    stderr=new_io,
+                )
+
+        test(self)
+
+    def test_non_intractive_password_argument(self):
+
+        """createsuperuser --password --noinput."""
+        new_io = StringIO()
+
+        def test(self):
+            call_command(
+                'createsuperuser',
+                interactive=False,
+                username='joe1234567890',
+                email='joe@somewhere.org',
+                password='joe1234',
+                stdin=MockTTY(),
+                stdout=new_io,
+                stderr=new_io,
+            )
+            command_output = new_io.getvalue().strip()
+            self.assertEqual(command_output, 'Superuser created successfully.')
+            u = User._default_manager.get(username='joe1234567890')
+            self.assertEqual(u.email, 'joe@somewhere.org')
+            self.assertTrue(u.has_usable_password())
+            self.assertTrue(u.check_password('joe1234'))
+
+        test(self)
+
+    def test_non_intractive_invalid_password_argument(self):
+
+        """createsuperuser --password --noinput with invalid password."""
+        new_io = StringIO()
+
+        def test(self):
+            with self.assertRaisesMessage(CommandError, 'This password is entirely numeric.'):
+                call_command(
+                    'createsuperuser',
+                    interactive=False,
+                    username='joe1234567890',
+                    email='joe@somewhere.org',
+                    password='1234',
+                    stdin=MockTTY(),
+                    stdout=new_io,
+                    stderr=new_io,
+                )
+
+        test(self)
+
     def test_validation_mismatched_passwords(self):
         """
         Creation should fail if the user enters mismatched passwords.


### PR DESCRIPTION
Add `--password` option to createsuperuser management command.
it is a useful option when you want to create superuser in non intractive mode. for example when you want to create a default superuser with a default password. 
https://code.djangoproject.com/ticket/28734