### PR TITLE
Add --interface-opts argument to "manage.py shell"

### DIFF
--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -2,6 +2,7 @@ import os
 import select
 import sys
 import traceback
+import shlex
 
 from django.core.management import BaseCommand, CommandError
 from django.utils.datastructures import OrderedSet
@@ -30,14 +31,26 @@ class Command(BaseCommand):
             '-c', '--command', dest='command',
             help='Instead of opening an interactive shell, run a command as Django and exit.',
         )
+        parser.add_argument(
+            '--interface-opts', dest='interface_opts',
+            help='Provide additional command-line options to the interactive interpreter, if it is not "python".',
+        )
 
     def ipython(self, options):
         from IPython import start_ipython
-        start_ipython(argv=[])
+        interface_opts = options['interface_opts']
+        if interface_opts is None:
+            start_ipython()
+        else:
+            start_ipython(argv=shlex.split(interface_opts))
 
     def bpython(self, options):
         import bpython
-        bpython.embed()
+        interface_opts = options['interface_opts']
+        if interface_opts is None:
+            bpython.embed()
+        else:
+            bpython.embed(args=shlex.split(interface_opts))
 
     def python(self, options):
         import code

--- a/django/core/management/commands/shell.py
+++ b/django/core/management/commands/shell.py
@@ -1,8 +1,8 @@
 import os
 import select
+import shlex
 import sys
 import traceback
-import shlex
 
 from django.core.management import BaseCommand, CommandError
 from django.utils.datastructures import OrderedSet


### PR DESCRIPTION
This PR adds a command-line argument to `manage.py shell` called "--interface-opts", which enables users to provide a string of additional command-line options to be passed along to the interactive interpreter when the interpreter is not "python".

For example, to start ipython with a classic prompt, with no "confirm-on-exit" behavior:
`python manage.py shell --interface ipython --interface-opts '--no-confirm-exit --simple-prompt --classic'`

Open to feedback and suggestions.