### PR TITLE
Fixed #28735 -- Fixed typo in django/views/templates/default_urlconf.html.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -390,7 +390,7 @@
           </svg>
         </div>
         <h2>{% trans "The install worked successfully! Congratulations!" %}</h2>
-        <p>{% blocktrans %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and have not configured any URLs.{% endblocktrans %}</p>
+        <p>{% blocktrans %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktrans %}</p>
       </main>
       <footer class="u-clearfix">
         <a href="https://docs.djangoproject.com/en/{{ version }}/" target="_blank" rel="noopener">


### PR DESCRIPTION
Per https://code.djangoproject.com/ticket/28735