### PR TITLE
Fixed #28739 -- Fixed get_fixed_timezone() for negative timedeltas.

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -58,7 +58,7 @@ utc = pytz.utc
 def get_fixed_timezone(offset):
     """Return a tzinfo instance with a fixed offset from UTC."""
     if isinstance(offset, timedelta):
-        offset = offset.seconds // 60
+        offset = offset.total_seconds() // 60
     sign = '-' if offset < 0 else '+'
     hhmm = '%02d%02d' % divmod(abs(offset), 60)
     name = sign + hhmm

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -194,5 +194,9 @@ class TimezoneTests(SimpleTestCase):
         delta = datetime.timedelta(hours=1)
         self.assertEqual(timezone.get_fixed_timezone(delta).utcoffset(''), delta)
 
+    def test_fixedoffset_negative_timedelta(self):
+        delta = datetime.timedelta(hours=-2)
+        self.assertEqual(timezone.get_fixed_timezone(delta).utcoffset(''), delta)
+
     def test_fixedoffset_pickle(self):
         self.assertEqual(pickle.loads(pickle.dumps(timezone.FixedOffset(0, 'tzname'))).tzname(''), 'tzname')


### PR DESCRIPTION
(Fix requires Python 3.2+ or 2.7+; should be suitable 
for any Django version as far back as 1.8.)