### PR TITLE
Fixed #28740 -- Added 'continent_code' and 'continent_name' in GeoIP2.city() dict.

### DIFF
--- a/django/contrib/gis/geoip2/resources.py
+++ b/django/contrib/gis/geoip2/resources.py
@@ -1,6 +1,8 @@
 def City(response):
     return {
         'city': response.city.name,
+        'continent_code': response.continent.code,
+        'continent_name': response.continent.name,
         'country_code': response.country.iso_code,
         'country_name': response.country.name,
         'dma_code': response.location.metro_code,

--- a/docs/ref/contrib/gis/geoip2.txt
+++ b/docs/ref/contrib/gis/geoip2.txt
@@ -33,6 +33,8 @@ Here is an example of its usage::
     {'country_code': 'US', 'country_name': 'United States'}
     >>> g.city('72.14.207.99')
     {'city': 'Mountain View',
+    'continent_code': 'NA',
+    'continent_name': 'North America',
     'country_code': 'US',
     'country_name': 'United States',
     'dma_code': 807,

--- a/tests/gis_tests/test_geoip2.py
+++ b/tests/gis_tests/test_geoip2.py
@@ -115,6 +115,8 @@ class GeoIPTest(unittest.TestCase):
 
             # City information dictionary.
             d = g.city(query)
+            self.assertEqual('NA', d['continent_code'])
+            self.assertEqual('North America', d['continent_name'])
             self.assertEqual('US', d['country_code'])
             self.assertEqual('Houston', d['city'])
             self.assertEqual('TX', d['region'])


### PR DESCRIPTION
Maxmind data supplies continent information as part of both the free and paid database sets, and has for a very long time.

This isn't accessible from the GeoIP2 city dict, despite it being available.