### PR TITLE
Refs #28457 -- Updated the colors of the 'Congrats' page for WCAG AA compliance.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -25,7 +25,7 @@
           a {
             background-color: transparent;
             -webkit-text-decoration-skip: objects;
-            color: #20AA76;
+            color: #19865C;
             text-decoration: none;
           }
           img {
@@ -221,7 +221,7 @@
             line-height: 20px;
             max-width: 390px;
             margin: 15px auto 0;
-            color: gray;
+            color: #747755;
           }
           .next-step {
             max-width: 120px;
@@ -274,14 +274,14 @@
             margin-right: 10px;
           }
           .option h4 {
-            color: #20AA76;
+            color: #19865C;
             font-size: 19px;
           }
           .option p {
             font-weight: 300;
             font-size: 15px;
             padding-top: 3px;
-            color: #8f8f8f;
+            color: #757575;
           }
           @media (max-width: 996px) {
             body, footer {


### PR DESCRIPTION
First: the new "It works" page is great. Love the design, the messaging, the whole thing. Fantastic. I noticed, however, that it does not meet WCAG accessibility standards in regards to contrast. These values are as close to the original as I could get while reaching WCAG AA compliance.

Also, I didn't touch it here, since it was a bit out-of-scope, but I think .next-step and .next-step H5 are no longer needed in the CSS.