### PR TITLE
Fixed #29734 -- Added option to sort message strings for translations by msgid.

### DIFF
--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -273,6 +273,10 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
+            '--sort-output', action='store_true', dest='sort_output',
+            help="Sort message strings by msgid",
+        )
+        parser.add_argument(
             '--no-obsolete', action='store_true',
             help="Remove obsolete message strings.",
         )
@@ -317,6 +321,11 @@ class Command(BaseCommand):
             self.msguniq_options = self.msguniq_options[:] + [arg_add_location]
             self.msgattrib_options = self.msgattrib_options[:] + [arg_add_location]
             self.xgettext_options = self.xgettext_options[:] + [arg_add_location]
+        if options['sort_output']:
+            self.msgmerge_options = self.msgmerge_options[:] + ['--sort-output']
+            self.msguniq_options = self.msguniq_options[:] + ['--sort-output']
+            self.msgattrib_options = self.msgattrib_options[:] + ['--sort-output']
+            self.xgettext_options = self.xgettext_options[:] + ['--sort-output']
 
         self.no_obsolete = options['no_obsolete']
         self.keep_pot = options['keep_pot']

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -699,6 +699,13 @@ is:
 
 Requires ``gettext`` 0.19 or newer.
 
+.. django-admin-option:: --sort-output
+
+.. versionadded:: 2.2
+
+Sort messages in language files. This can make diff of language files
+more manageable, at the cost of losing some of the messages' context.
+
 .. django-admin-option:: --keep-pot
 
 Prevents deleting the temporary ``.pot`` files generated before creating the

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -170,7 +170,8 @@ Internationalization
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :option:`makemessages --sort-output` option sort messages
+  in PO files.
 
 Migrations
 ~~~~~~~~~~


### PR DESCRIPTION
Ticket [#29734](https://code.djangoproject.com/ticket/29734)