### PR TITLE
Fixed #14218 -- Added iteration behavior to Paginator.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -34,6 +34,10 @@ class Paginator:
         self.orphans = int(orphans)
         self.allow_empty_first_page = allow_empty_first_page
 
+    def __iter__(self):
+        for page_number in self.page_range:
+            yield self.page(page_number)
+
     def validate_number(self, number):
         """Validate the given 1-based page number."""
         try:

--- a/docs/ref/paginator.txt
+++ b/docs/ref/paginator.txt
@@ -14,6 +14,13 @@ classes live in :source:`django/core/paginator.py`.
 
 .. class:: Paginator(object_list, per_page, orphans=0, allow_empty_first_page=True)
 
+    A paginator acts like a sequence of :class:`Page` when using ``len()`` or
+    iterating it directly.
+
+    .. versionchanged:: 3.1
+
+        Support for iterating over ``Paginator`` was added.
+
 .. attribute:: Paginator.object_list
 
     Required. A list, tuple, ``QuerySet``, or other sliceable object with a
@@ -98,8 +105,8 @@ Attributes
 ``Page`` class
 ==============
 
-You usually won't construct ``Page`` objects by hand -- you'll get them using
-:meth:`Paginator.page`.
+You usually won't construct ``Page`` objects by hand -- you'll get them by
+iterating :class:`Paginator`, or by using :meth:`Paginator.page`.
 
 .. class:: Page(object_list, number, paginator)
 

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -162,6 +162,11 @@ Models
 
 * ...
 
+Pagination
+~~~~~~~~~~
+
+* Support for iterating over ``Paginator`` was added.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -297,6 +297,13 @@ class PaginationTests(SimpleTestCase):
         with self.assertRaises(EmptyPage):
             paginator.get_page(1)
 
+    def test_paginator_iteration(self):
+        paginator = Paginator([1, 2, 3], 2)
+        page_iterator = iter(paginator)
+        for page, expected in enumerate(([1, 2], [3]), start=1):
+            with self.subTest(page=page):
+                self.assertEqual(expected, list(next(page_iterator)))
+
 
 class ModelPaginationTests(TestCase):
     """


### PR DESCRIPTION
## Fixes
No open ticket.

## Motivation
I went to use the `Paginator` in a context where I just wanted batches of objects out of a queryset, rather than needing to get a particular page out of the queryset. I ended up expressing it like this:
```python
paginator = Paginator(queryset, 200)
for page_number in paginator.page_range:
  do_stuff_to(paginator.page(page_number))
```
This seemed clumsy, so I went looking to see if there was an `__iter__` method on `Paginator`, which there wasn't. Given that it's a small amount of code and a simple change, I implemented it.