### PR TITLE
Fixed #28749 -- Added subquery support for PostgreSQL’s ArrayField 'in' lookup

### DIFF
--- a/django/contrib/postgres/fields/array.py
+++ b/django/contrib/postgres/fields/array.py
@@ -242,6 +242,9 @@ class ArrayLenTransform(Transform):
 class ArrayInLookup(In):
     def get_prep_lookup(self):
         values = super().get_prep_lookup()
+        if hasattr(self.rhs, '_prepare'):
+            # Subqueries don't need further preparation.
+            return values
         # In.process_rhs() expects values to be hashable, so convert lists
         # to tuples.
         prepared_values = []

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -176,6 +176,15 @@ class TestQuerying(PostgreSQLTestCase):
             self.objs[:2]
         )
 
+    def test_in_subquery(self):
+        IntegerArrayModel.objects.create(field=[2, 3])
+        self.assertSequenceEqual(
+            NullableIntegerArrayModel.objects.filter(
+                field__in=IntegerArrayModel.objects.all().values_list('field', flat=True)
+            ),
+            self.objs[2:3]
+        )
+
     @unittest.expectedFailure
     def test_in_including_F_object(self):
         # This test asserts that Array objects passed to filters can be


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28749#ticket