### PR TITLE
Refs #21927 -- Removed docs for include()'s instance_namespace parameter.

### DIFF
--- a/docs/ref/urls.txt
+++ b/docs/ref/urls.txt
@@ -105,8 +105,6 @@ The ``view``, ``kwargs`` and ``name`` arguments are the same as for
     :arg pattern_list: Iterable of :func:`~django.urls.path` and/or :func:`~django.urls.re_path` instances.
     :arg app_namespace: Application namespace for the URL entries being included
     :type app_namespace: string
-    :arg instance_namespace: Instance namespace for the URL entries being included
-    :type instance_namespace: string
 
 See :ref:`including-other-urlconfs` and :ref:`namespaces-and-include`.
 


### PR DESCRIPTION
This parameter and the associated 3-tuple pattern were removed in https://github.com/django/django/commit/ad393beeb71e8774e4bf9ad842b97022e50f1231 .