### PR TITLE
Fixed #28742 -- Fixed AttributeError crash when assigning None to cached reverse relations.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -428,13 +428,10 @@ class ReverseOneToOneDescriptor:
 
         if value is None:
             # Update the cached related instance (if any) & clear the cache.
-            try:
-                # Following the example above, this would be the cached
-                # ``restaurant`` instance (if any).
-                rel_obj = self.related.get_cached_value(instance)
-            except KeyError:
-                pass
-            else:
+            # Following the example above, this would be the cached
+            # ``restaurant`` instance (if any).
+            rel_obj = self.related.get_cached_value(instance, default=None)
+            if rel_obj is not None:
                 # Remove the ``restaurant`` instance from the ``place``
                 # instance cache.
                 self.related.delete_cached_value(instance)

--- a/tests/one_to_one/tests.py
+++ b/tests/one_to_one/tests.py
@@ -196,6 +196,15 @@ class OneToOneTests(TestCase):
         # UndergroundBar.
         p.undergroundbar = None
 
+    def test_assign_none_to_null_cached_reverse_relation(self):
+        p = Place.objects.get(name='Demon Dogs')
+        # Prime the relation's cache with a value of None.
+        with self.assertRaises(Place.undergroundbar.RelatedObjectDoesNotExist):
+            getattr(p, 'undergroundbar')
+        # Assigning None works if there isn't a related UndergroundBar and the
+        # reverse cache has a value of None.
+        p.undergroundbar = None
+
     def test_related_object_cache(self):
         """ Regression test for #6886 (the related-object cache) """
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28742