### PR TITLE
Fixed #28750 -- Allowed models to define Meta.manager_inheritance_from_future for backwards compatibility.

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -33,6 +33,8 @@ DEFAULT_NAMES = (
     'select_on_save', 'default_related_name', 'required_db_features',
     'required_db_vendor', 'base_manager_name', 'default_manager_name',
     'indexes',
+    # For backwards compatibility with Django 1.11. RemovedInDjango30Warning
+    'manager_inheritance_from_future',
 )
 
 

--- a/tests/model_meta/test_manager_inheritance_from_future.py
+++ b/tests/model_meta/test_manager_inheritance_from_future.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+
+@isolate_apps('model_meta')
+class TestManagerInheritanceFromFuture(SimpleTestCase):
+    def test_defined(self):
+        """
+        Meta.manager_inheritance_from_future can be defined for backwards
+        compatibility with Django 1.11.
+        """
+        class FuturisticModel(models.Model):
+            class Meta:
+                manager_inheritance_from_future = True  # No error raised.


### PR DESCRIPTION
For the sake of easier backward compatibility to Django 1.11, this restores the `manager_inheritance_from_future` option of `Model.Meta`.

This addresses https://code.djangoproject.com/ticket/28750.

~To encourage its removal, it now raises a `RemovedInDjango30Warning`. This wasn't discussed on the ticket. If I've made a mistake there, I'll be happy to correct it.~ *Reverted.*