### PR TITLE
Fixed #28645 -- AuthenticationForm's inactive user error isn't raised when using ModelBackend

### DIFF
--- a/django/contrib/admin/forms.py
+++ b/django/contrib/admin/forms.py
@@ -7,16 +7,18 @@ class AdminAuthenticationForm(AuthenticationForm):
     """
     A custom authentication form used in the admin app.
     """
-    error_messages = {
+    error_messages = dict(AuthenticationForm.error_messages)
+    error_messages.update({
         'invalid_login': _(
             "Please enter the correct %(username)s and password for a staff "
             "account. Note that both fields may be case-sensitive."
         ),
-    }
+    })
     required_css_class = 'required'
 
     def confirm_login_allowed(self, user):
-        if not user.is_active or not user.is_staff:
+        super().confirm_login_allowed(user)
+        if not user.is_staff:
             raise forms.ValidationError(
                 self.error_messages['invalid_login'],
                 code='invalid_login',

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -192,6 +192,15 @@ class AuthenticationForm(forms.Form):
         if username is not None and password:
             self.user_cache = authenticate(self.request, username=username, password=password)
             if self.user_cache is None:
+                # An authentication backend may reject inactive users. Check
+                # if the user exists and is inactive, and raise the 'inactive'
+                # error if so.
+                try:
+                    self.user_cache = UserModel._default_manager.get_by_natural_key(username)
+                except UserModel.DoesNotExist:
+                    pass
+                else:
+                    self.confirm_login_allowed(self.user_cache)
                 raise self.get_invalid_login_error()
             else:
                 self.confirm_login_allowed(self.user_cache)

--- a/docs/releases/1.11.8.txt
+++ b/docs/releases/1.11.8.txt
@@ -9,4 +9,5 @@ Django 1.11.8 fixes several bugs in 1.11.7.
 Bugfixes
 ========
 
-* ...
+* Reallowed, following a regression in Django 1.10, ``AuthenticationForm`` to
+  raise the inactive user error when using ``ModelBackend`` (:ticket:`28645`).

--- a/tests/admin_views/test_forms.py
+++ b/tests/admin_views/test_forms.py
@@ -1,0 +1,17 @@
+from django.contrib.admin.forms import AdminAuthenticationForm
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class AdminAuthenticationFormTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_user(username='inactive', password='password', is_active=False)
+
+    def test_inactive_user(self):
+        data = {
+            'username': 'inactive',
+            'password': 'password',
+        }
+        form = AdminAuthenticationForm(None, data)
+        self.assertEqual(form.non_field_errors(), ['This account is inactive.'])

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -262,9 +262,6 @@ class UserCreationFormTest(TestDataMixin, TestCase):
         )
 
 
-# To verify that the login form rejects inactive users, use an authentication
-# backend that allows them.
-@override_settings(AUTHENTICATION_BACKENDS=['django.contrib.auth.backends.AllowAllUsersModelBackend'])
 class AuthenticationFormTest(TestDataMixin, TestCase):
 
     def test_invalid_username(self):
@@ -323,6 +320,8 @@ class AuthenticationFormTest(TestDataMixin, TestCase):
             self.assertFalse(form.is_valid())
             self.assertEqual(form.non_field_errors(), [str(form.error_messages['inactive'])])
 
+    # Use an authentication backend that allows inactive users.
+    @override_settings(AUTHENTICATION_BACKENDS=['django.contrib.auth.backends.AllowAllUsersModelBackend'])
     def test_custom_login_allowed_policy(self):
         # The user is inactive, but our custom form policy allows them to log in.
         data = {


### PR DESCRIPTION
[Ticket 28645
](https://code.djangoproject.com/ticket/28645)

[Ticket 28751](https://code.djangoproject.com/ticket/28751) is related to ticket 28645, so I make a second commit for ticket 28751 in this pull request.