### PR TITLE
Fixed #23816 -- Allowed specifying default defered fields in model Meta.

### DIFF
--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -32,7 +32,7 @@ DEFAULT_NAMES = (
     'auto_created', 'index_together', 'apps', 'default_permissions',
     'select_on_save', 'default_related_name', 'required_db_features',
     'required_db_vendor', 'base_manager_name', 'default_manager_name',
-    'indexes',
+    'indexes', 'deffer_fields',
     # For backwards compatibility with Django 1.11. RemovedInDjango30Warning
     'manager_inheritance_from_future',
 )

--- a/tests/defer/models.py
+++ b/tests/defer/models.py
@@ -44,3 +44,16 @@ class RefreshPrimaryProxy(Primary):
             if fields.intersection(deferred_fields):
                 fields = fields.union(deferred_fields)
         super().refresh_from_db(using, fields, **kwargs)
+
+
+class User(models.Model):
+    username = models.CharField(max_length=50)
+
+
+class Publication(models.Model):
+    title = models.CharField(max_length=240, default="Test Title")
+    text = models.TextField(default="Test text")
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    class Meta:
+        deffer_fields = ('title', 'user')


### PR DESCRIPTION
Implemented new feature that allow to define fields which will be deferred for reading.
Added new parameter to fields - "defer". By default this param is equal False.Before executing query the fields which have defer=True will be marked as deferred
Example:
```
class Sub(Super):
    is_super = models.BooleanField(default=False, defer=True)
    len = models.IntegerField(default=2)
```

This logic is equal to Sub.objects.defer("is_super").get()