### PR TITLE
Fixed #28760 -- Removed DummyCache's unnecessary get/set/delete_many().

### DIFF
--- a/django/core/cache/backends/dummy.py
+++ b/django/core/cache/backends/dummy.py
@@ -25,19 +25,10 @@ class DummyCache(BaseCache):
         key = self.make_key(key, version=version)
         self.validate_key(key)
 
-    def get_many(self, keys, version=None):
-        return {}
-
     def has_key(self, key, version=None):
         key = self.make_key(key, version=version)
         self.validate_key(key)
         return False
-
-    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
-        return []
-
-    def delete_many(self, keys, version=None):
-        pass
 
     def clear(self):
         pass


### PR DESCRIPTION
Realized that `DummyCache.set_many` wasn't updated for the returning the list of failing keys. Looking closer I realized its `*_many` implementations were unnecessary as the `BaseCache` implementation will suffice, and it ends up doing key validation by calling the underlying single methods.

I added tests that fail until this change is made.