### PR TITLE
Fixed #28758 -- Fixed RangeMax/MinValueValidators crash with infinite ranges.

### DIFF
--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -69,11 +69,11 @@ class KeysValidator:
 
 class RangeMaxValueValidator(MaxValueValidator):
     def compare(self, a, b):
-        return a.upper > b
+        return a.upper is None or a.upper > b
     message = _('Ensure that this range is completely less than or equal to %(limit_value)s.')
 
 
 class RangeMinValueValidator(MinValueValidator):
     def compare(self, a, b):
-        return a.lower < b
+        return a.lower is None or a.lower < b
     message = _('Ensure that this range is completely greater than or equal to %(limit_value)s.')

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -408,18 +408,24 @@ class TestValidators(PostgreSQLTestCase):
     def test_max(self):
         validator = RangeMaxValueValidator(5)
         validator(NumericRange(0, 5))
+        msg = 'Ensure that this range is completely less than or equal to 5.'
         with self.assertRaises(exceptions.ValidationError) as cm:
             validator(NumericRange(0, 10))
-        self.assertEqual(cm.exception.messages[0], 'Ensure that this range is completely less than or equal to 5.')
+        self.assertEqual(cm.exception.messages[0], msg)
         self.assertEqual(cm.exception.code, 'max_value')
+        with self.assertRaisesMessage(exceptions.ValidationError, msg):
+            validator(NumericRange(0, None))  # an unbound range
 
     def test_min(self):
         validator = RangeMinValueValidator(5)
         validator(NumericRange(10, 15))
+        msg = 'Ensure that this range is completely greater than or equal to 5.'
         with self.assertRaises(exceptions.ValidationError) as cm:
             validator(NumericRange(0, 10))
-        self.assertEqual(cm.exception.messages[0], 'Ensure that this range is completely greater than or equal to 5.')
+        self.assertEqual(cm.exception.messages[0], msg)
         self.assertEqual(cm.exception.code, 'min_value')
+        with self.assertRaisesMessage(exceptions.ValidationError, msg):
+            validator(NumericRange(None, 10))  # an unbound range
 
 
 class TestFormField(PostgreSQLTestCase):


### PR DESCRIPTION
* Specify range type in existing validators test definitions
* Add `NumericRange` min/max validator tests for infinite ranges
* Add `DateRange` min/max validator tests inc. for infinite ranges

Full description given at https://code.djangoproject.com/ticket/28758.