### PR TITLE
Fixed #28763 -- Allow SessionStore's to be easily overridden to make dynamic the session cookie age

### DIFF
--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -198,6 +198,9 @@ class SessionBase:
 
     _session = property(_get_session)
 
+    def _get_session_cookie_age(self):
+        return settings.SESSION_COOKIE_AGE
+
     def get_expiry_age(self, **kwargs):
         """Get the number of seconds until the session expires.
 
@@ -217,7 +220,7 @@ class SessionBase:
             expiry = self.get('_session_expiry')
 
         if not expiry:   # Checks both None and 0 cases
-            return settings.SESSION_COOKIE_AGE
+            return self._get_session_cookie_age()
         if not isinstance(expiry, datetime):
             return expiry
         delta = expiry - modification
@@ -242,7 +245,7 @@ class SessionBase:
         if isinstance(expiry, datetime):
             return expiry
         if not expiry:   # Checks both None and 0 cases
-            expiry = settings.SESSION_COOKIE_AGE
+            expiry = self._get_session_cookie_age()
         return modification + timedelta(seconds=expiry)
 
     def set_expiry(self, value):

--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -75,7 +75,7 @@ class SessionStore(SessionBase):
         """
         expiry = session_data.get('_session_expiry')
         if not expiry:
-            expiry = self._last_modification() + datetime.timedelta(seconds=settings.SESSION_COOKIE_AGE)
+            expiry = self._last_modification() + datetime.timedelta(seconds=self._get_session_cookie_age())
         return expiry
 
     def load(self):

--- a/django/contrib/sessions/backends/signed_cookies.py
+++ b/django/contrib/sessions/backends/signed_cookies.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.sessions.backends.base import SessionBase
 from django.core import signing
 

--- a/django/contrib/sessions/backends/signed_cookies.py
+++ b/django/contrib/sessions/backends/signed_cookies.py
@@ -16,7 +16,7 @@ class SessionStore(SessionBase):
                 self.session_key,
                 serializer=self.serializer,
                 # This doesn't handle non-default expiry dates, see #19201
-                max_age=settings.SESSION_COOKIE_AGE,
+                max_age=self._get_session_cookie_age(),
                 salt='django.contrib.sessions.backends.signed_cookies',
             )
         except Exception:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28763