### PR TITLE
Refs #17448, #28632 -- Fixes related to usage of raw SQL with GIS.

### DIFF
--- a/django/contrib/gis/db/backends/base/operations.py
+++ b/django/contrib/gis/db/backends/base/operations.py
@@ -17,7 +17,7 @@ class BaseSpatialOperations:
     spatial_version = None
 
     # How the geometry column should be selected.
-    select = None
+    select = '%s'
 
     @cached_property
     def select_extent(self):

--- a/django/contrib/gis/db/models/fields.py
+++ b/django/contrib/gis/db/models/fields.py
@@ -266,8 +266,7 @@ class GeometryField(BaseSpatialField):
         of the spatial backend. For example, Oracle and MySQL require custom
         selection formats in order to retrieve geometries in OGC WKB.
         """
-        select = compiler.connection.ops.select
-        return select % sql if select else sql, params
+        return compiler.connection.ops.select % sql, params
 
 
 # The OpenGIS Geometry Type Fields

--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -645,16 +645,21 @@ of abstraction::
 
 __ http://spatialreference.org/ref/epsg/32140/
 
+.. _gis-raw-sql:
+
 .. admonition:: Raw queries
 
-    When using :doc:`raw queries </topics/db/sql>`, you should generally wrap
-    your geometry fields with the ``asText()`` SQL function (or ``ST_AsText``
-    for PostGIS) so that the field value will be recognized by GEOS::
+    When using :doc:`raw queries </topics/db/sql>`, you must wrap your geometry
+    fields so that the field value can be recognized by GEOS::
 
-        City.objects.raw('SELECT id, name, asText(point) from myapp_city')
+        from django.db import connection
+        # or if you're querying a non-default database:
+        from django.db import connections
+        connection = connections['your_gis_db_alias']
 
-    This is not absolutely required by PostGIS, but generally you should only
-    use raw queries when you know exactly what you are doing.
+        City.objects.raw('SELECT id, name, %s as point from myapp_city' % (connection.ops.select % 'point'))
+
+    You should only use raw queries when you know exactly what you're doing.
 
 Lazy Geometries
 ---------------

--- a/docs/releases/2.0.txt
+++ b/docs/releases/2.0.txt
@@ -611,6 +611,11 @@ Miscellaneous
 
 * Support for GEOS 3.3.x is dropped.
 
+* The way data is selected for ``GeometryField`` is changed to improve
+  performance, and in raw SQL queries, those fields must now be wrapped in
+  ``connection.ops.select``. See the :ref:`Raw queries note<gis-raw-sql>` in
+  the GIS tutorial for an example.
+
 .. _deprecated-features-2.0:
 
 Features deprecated in 2.0


### PR DESCRIPTION
https://code.djangoproject.com/ticket/17448
https://code.djangoproject.com/ticket/28632

@claudep, I'm not sure if I should restore possibility to select geometry fields without select formatting on Postgres, because it's slower than selecting as `bytea` by 10%.