### PR TITLE
Clarified error message if sqlplarse isn't installed.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -300,7 +300,7 @@ class BaseDatabaseOperations:
             import sqlparse
         except ImportError:
             raise ImproperlyConfigured(
-                "sqlparse is required if you don't split your SQL "
+                "The sqlparse package is required if you don't split your SQL "
                 "statements manually."
             )
         else:


### PR DESCRIPTION
I was unclear that sqlparse was a package that I needed to install (since it raises ImproperlyConfigured and not ImportError) until I did some web searches. Added "package" to error message to clarify it so people can look on PyPI.

I apologize if this pull request is out of order - I looked at the contributor guidelines and it seemed like it was within the range of requests that can be done without a ticket.