### PR TITLE
Fixed #28785 -- Made makemigrations print a warning if a migration file is deleted.

### DIFF
--- a/django/db/migrations/exceptions.py
+++ b/django/db/migrations/exceptions.py
@@ -52,3 +52,8 @@ class MigrationSchemaMissing(DatabaseError):
 
 class InvalidMigrationPlan(ValueError):
     pass
+
+
+class InconsistentMigrationFileHistory(Exception):
+    """An applied migration file has been deleted"""
+    pass


### PR DESCRIPTION
This change would provide a fix for ticket 28785
See the ticket for more details.
Scenario:
1. App is migrated
2. Delete all the migrations file
3. Create migrations using `manage.py makemigrations`
4. Apply migrations using `manage.py migrate` 

At step 4 this will print no change and nothing will happen but we should've updated the django_migrations table and reflect the warning log.

Error message would something like as below,

WARNING: Inconsistent migrations
   App 'CoreApp':
        '0002_room_me'

 