### PR TITLE
Fixes #28782, WIP: Template variable lookup on non-mappings with a __getitem__ method.

### DIFF
--- a/django/contrib/gis/geos/coordseq.py
+++ b/django/contrib/gis/geos/coordseq.py
@@ -9,7 +9,13 @@ from django.contrib.gis.geos import prototypes as capi
 from django.contrib.gis.geos.base import GEOSBase
 from django.contrib.gis.geos.error import GEOSException
 from django.contrib.gis.geos.libgeos import CS_PTR
-from django.contrib.gis.shortcuts import numpy
+from django.utils.typing import NUMPY_IS_AVAILABLE
+
+if NUMPY_IS_AVAILABLE:
+    import numpy
+    COORDINATE_SEQUENCE_TYPES = (tuple, list, numpy.ndarray)
+else:
+    COORDINATE_SEQUENCE_TYPES = (tuple, list)
 
 
 class GEOSCoordSeq(GEOSBase):
@@ -45,9 +51,7 @@ class GEOSCoordSeq(GEOSBase):
     def __setitem__(self, index, value):
         "Set the coordinate sequence value at the given index."
         # Checking the input value
-        if isinstance(value, (list, tuple)):
-            pass
-        elif numpy and isinstance(value, numpy.ndarray):
+        if isinstance(value, COORDINATE_SEQUENCE_TYPES):
             pass
         else:
             raise TypeError('Must set coordinate with a sequence (list, tuple, or numpy array).')

--- a/django/contrib/gis/geos/linestring.py
+++ b/django/contrib/gis/geos/linestring.py
@@ -3,7 +3,13 @@ from django.contrib.gis.geos.coordseq import GEOSCoordSeq
 from django.contrib.gis.geos.error import GEOSException
 from django.contrib.gis.geos.geometry import GEOSGeometry, LinearGeometryMixin
 from django.contrib.gis.geos.point import Point
-from django.contrib.gis.shortcuts import numpy
+from django.utils.typing import NUMPY_IS_AVAILABLE
+
+if NUMPY_IS_AVAILABLE:
+    import numpy
+    LINESTRING_TYPES = (tuple, list, numpy.ndarray)
+else:
+    LINESTRING_TYPES = (tuple, list)
 
 
 class LineString(LinearGeometryMixin, GEOSGeometry):
@@ -29,7 +35,7 @@ class LineString(LinearGeometryMixin, GEOSGeometry):
         else:
             coords = args
 
-        if not (isinstance(coords, (tuple, list)) or numpy and isinstance(coords, numpy.ndarray)):
+        if not isinstance(coords, LINESTRING_TYPES):
             raise TypeError('Invalid initialization input for LineStrings.')
 
         # If SRID was passed in with the keyword arguments
@@ -141,7 +147,7 @@ class LineString(LinearGeometryMixin, GEOSGeometry):
         Return a numpy array if possible.
         """
         lst = [func(i) for i in range(len(self))]
-        if numpy:
+        if NUMPY_IS_AVAILABLE:
             return numpy.array(lst)  # ARRRR!
         else:
             return lst

--- a/django/contrib/gis/shortcuts.py
+++ b/django/contrib/gis/shortcuts.py
@@ -5,15 +5,9 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.template import loader
 
-# NumPy supported?
-try:
-    import numpy
-except ImportError:
-    numpy = False
-
 
 def compress_kml(kml):
-    "Return compressed KMZ from the given KML string."
+    """ Return compressed KMZ from the given KML string. """
     kmz = BytesIO()
     with zipfile.ZipFile(kmz, 'a', zipfile.ZIP_DEFLATED) as zf:
         zf.writestr('doc.kml', kml.encode(settings.DEFAULT_CHARSET))
@@ -22,7 +16,7 @@ def compress_kml(kml):
 
 
 def render_to_kml(*args, **kwargs):
-    "Render the response as KML (using the correct MIME type)."
+    """ Render the response as KML (using the correct MIME type). """
     return HttpResponse(
         loader.render_to_string(*args, **kwargs),
         content_type='application/vnd.google-earth.kml+xml',
@@ -30,10 +24,7 @@ def render_to_kml(*args, **kwargs):
 
 
 def render_to_kmz(*args, **kwargs):
-    """
-    Compress the KML content and return as KMZ (using the correct
-    MIME type).
-    """
+    """ Compress the KML content and return as KMZ (using the correct MIME type). """
     return HttpResponse(
         compress_kml(loader.render_to_string(*args, **kwargs)),
         content_type='application/vnd.google-earth.kmz',

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -49,14 +49,15 @@ times with multiple contexts)
 '<html></html>'
 """
 
-from collections.abc import Mapping
-from inspect import Signature
 import logging
 import re
+from collections.abc import Mapping
+from inspect import Signature
 
 from django.template.context import (  # NOQA: imported for backwards compatibility
     BaseContext, Context, ContextPopException, RequestContext,
 )
+from django.template.exceptions import TemplateSyntaxError
 from django.utils.formats import localize
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import SafeData, mark_safe
@@ -66,9 +67,6 @@ from django.utils.text import (
 from django.utils.timezone import template_localtime
 from django.utils.translation import gettext_lazy, pgettext_lazy
 from django.utils.typing import Sequence
-
-from django.template.exceptions import TemplateSyntaxError
-
 
 TOKEN_TEXT = 0
 TOKEN_VAR = 1

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -849,7 +849,8 @@ class Variable:
                 "Failed lookup for key [{token}] in {current!r}".format(token=token, current=lookup_context)
             )
 
-        def mapping_lookup():
+        # Mapping lookup
+        if isinstance(lookup_context, (Mapping, BaseContext)):
             # a string key is preferred
             if token in lookup_context:
                 return lookup_context[token]
@@ -858,22 +859,9 @@ class Variable:
                 return lookup_context[int(token)]
             doesnt_exist()
 
-        # TODO simplify when BaseContext is a ChainMap
-        # Context lookup
-        if isinstance(lookup_context, BaseContext):
-            try:
-                return mapping_lookup()
-            except VariableDoesNotExist:
-                pass
-            # Don't return class attributes
-            if hasattr(lookup_context.__class__, token):
-                doesnt_exist()
-        # Mapping lookup
-        elif isinstance(lookup_context, Mapping):
-            return mapping_lookup()
-
-        # Attribute lookup
-        if token in dir(lookup_context):
+        # Attribute lookup, but not for attributes of a context object's class
+        if token in dir(lookup_context) and \
+                not (isinstance(lookup_context, BaseContext) and token in dir(lookup_context.__class__)):
             return getattr(lookup_context, token)
 
         # Index lookup

--- a/django/utils/typing.py
+++ b/django/utils/typing.py
@@ -1,0 +1,20 @@
+""" This module contains type definitions and information about type availability. """
+
+from collections.abc import Sequence
+
+try:
+    import numpy
+except ImportError:
+    NUMPY_IS_AVAILABLE = False
+else:
+    NUMPY_IS_AVAILABLE = True
+
+
+if NUMPY_IS_AVAILABLE:
+    # make ndarray instances identifiable as Sequence
+    # see also https://github.com/numpy/numpy/issues/2776
+    Sequence.register(numpy.ndarray)
+
+
+__all__ = ['NUMPY_IS_AVAILABLE', Sequence.__name__
+           ]

--- a/docs/internals/contributing/writing-code/unit-tests.txt
+++ b/docs/internals/contributing/writing-code/unit-tests.txt
@@ -185,6 +185,10 @@ internationalization, type::
 How do you find out the names of individual tests? Look in ``tests/`` — each
 directory name there is the name of a test.
 
+Similarly this can be done with tox::
+
+   $ tox -e py3 generic_relations i18n
+
 If you just want to run a particular class of tests, you can specify a list of
 paths to individual test classes. For example, to run the ``TranslationTests``
 of the ``i18n`` module, type::

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -211,6 +211,22 @@ class ContextTests(SimpleTestCase):
         self.assertEqual(len(c.dicts), 3)
         self.assertEqual(c.dicts[-1]['a'], 2)
 
+    def test_item_lookup_on_non_mapping_type(self):
+        class HunkyDory:
+            def __getitem__(self, item):
+                if item == 'kooks':
+                    return 'undesired'
+                raise AttributeError
+
+            @property
+            def kooks(self):
+                return 'desired'
+
+        self.assertEqual(
+            Variable('hunky_dory.kooks').resolve({'hunky_dory': HunkyDory()}),
+            'desired'
+        )
+
 
 class RequestContextTests(SimpleTestCase):
 
@@ -231,7 +247,7 @@ class RequestContextTests(SimpleTestCase):
 
     def test_stack_size(self):
         """
-        #7116 -- Optimize RequetsContext construction
+        #7116 -- Optimize RequestContext construction
         """
         request = RequestFactory().get('/')
         ctx = RequestContext(request, {})


### PR DESCRIPTION
see [#28782](https://code.djangoproject.com/ticket/28782) regarding the initial problem.

the solution comes among other changes:

- introduces a `utils.typing`
  - see bd3fdf7f0feba86ab99f3e4830b56df432e55e7d's commit message for rationale
  - the registration of a `numpy.ndarray` as `Sequence` is essential here
- i couldn't resist to get rid of calls to deprecated functions in `inspect` (0b325977ee7867b024efc452c97637e89e2d46d0)
  - i could move that to another pr and amend a modernization of the remaining use within the project

so far, this implementation works against all test in `template_tests`, i'll look into the other tests if the approach is approved.

i also looked into a refactoring that bases `template.context.BaseContext` on `collections.ChainMap` and it looks promising regarding a simpler code. but this would require more effort for which i have no time atm and isn't necessary in the scope here. however, i'd highly recommend to modernize this part.