### PR TITLE
Fixed #28755 -- Made check_for_language() include apps' locale directories.

### DIFF
--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -377,7 +377,12 @@ def all_locale_paths():
     """
     globalpath = os.path.join(
         os.path.dirname(sys.modules[settings.__module__].__file__), 'locale')
-    return [globalpath] + list(settings.LOCALE_PATHS)
+    app_paths = []
+    for app_config in apps.get_app_configs():
+        locale_path = os.path.join(app_config.path, 'locale')
+        if os.path.exists(locale_path):
+            app_paths.append(locale_path)
+    return [globalpath] + list(settings.LOCALE_PATHS) + app_paths
 
 
 @functools.lru_cache(maxsize=1000)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -4,11 +4,14 @@ import gettext as gettext_module
 import os
 import pickle
 import re
+import tempfile
 from contextlib import contextmanager
 from importlib import import_module
 from threading import local
+from unittest import mock
 
 from django import forms
+from django.apps import AppConfig
 from django.conf import settings
 from django.conf.locale import LANG_INFO
 from django.conf.urls.i18n import i18n_patterns
@@ -38,6 +41,11 @@ here = os.path.dirname(os.path.abspath(__file__))
 extended_locale_paths = settings.LOCALE_PATHS + [
     os.path.join(here, 'other', 'locale'),
 ]
+
+
+class AppModuleStub:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
 
 
 @contextmanager
@@ -1644,6 +1652,15 @@ class NonDjangoLanguageTests(SimpleTestCase):
     def test_non_django_language(self):
         self.assertEqual(get_language(), 'xxx')
         self.assertEqual(gettext("year"), "reay")
+
+    @override_settings(USE_I18N=True)
+    def test_check_for_langauge(self):
+        with tempfile.TemporaryDirectory() as app_dir:
+            os.makedirs(os.path.join(app_dir, 'locale', 'dummy_Lang', 'LC_MESSAGES'))
+            open(os.path.join(app_dir, 'locale', 'dummy_Lang', 'LC_MESSAGES', 'django.mo'), 'w').close()
+            app_config = AppConfig('dummy_app', AppModuleStub(__path__=[app_dir]))
+            with mock.patch('django.apps.apps.get_app_configs', return_value=[app_config]):
+                self.assertIs(check_for_language('dummy-lang'), True)
 
     @override_settings(
         USE_I18N=True,


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28755