### PR TITLE
Fixed #28794 -- Fixed tx_isolation deprecation warning on MySQL 5.7.20+.

### DIFF
--- a/tests/backends/mysql/tests.py
+++ b/tests/backends/mysql/tests.py
@@ -38,7 +38,7 @@ class IsolationLevelTests(TestCase):
     @staticmethod
     def get_isolation_level(connection):
         with connection.cursor() as cursor:
-            cursor.execute("SELECT @@session.tx_isolation")
+            cursor.execute("SELECT @@session.%s" % connection.transaction_isolation_variable)
             return cursor.fetchone()[0]
 
     def test_auto_is_null_auto_config(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28794

I checked locally that `backends.mysql.tests.IsolationLevelTests` passes on MySQL 5.7.20.