### PR TITLE
Fixed #29945 -- Moved contrib.postgres uninstallation logic to the app config.

### DIFF
--- a/tests/postgres_tests/__init__.py
+++ b/tests/postgres_tests/__init__.py
@@ -3,19 +3,12 @@ import unittest
 from forms_tests.widget_tests.base import WidgetTest
 
 from django.db import connection
-from django.db.backends.signals import connection_created
 from django.test import TestCase, modify_settings
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
 class PostgreSQLTestCase(TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        # No need to keep that signal overhead for non PostgreSQL-related tests.
-        from django.contrib.postgres.signals import register_type_handlers
-
-        connection_created.disconnect(register_type_handlers)
-        super().tearDownClass()
+    pass
 
 
 @unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")

--- a/tests/postgres_tests/test_apps.py
+++ b/tests/postgres_tests/test_apps.py
@@ -1,0 +1,13 @@
+from django.db.backends.signals import connection_created
+from django.test.utils import modify_settings
+
+from . import PostgreSQLTestCase
+
+
+class PostgresConfigTests(PostgreSQLTestCase):
+    def test_register_type_handlers_connection(self):
+        from django.contrib.postgres.signals import register_type_handlers
+        self.assertNotIn(register_type_handlers, connection_created._live_receivers(None))
+        with modify_settings(INSTALLED_APPS={'append': 'django.contrib.postgres'}):
+            self.assertIn(register_type_handlers, connection_created._live_receivers(None))
+        self.assertNotIn(register_type_handlers, connection_created._live_receivers(None))


### PR DESCRIPTION
As discussed in https://github.com/django/django/pull/9291#issuecomment-344451163.