### PR TITLE
Fixed #27629 -- Fixed bug where allow_relation() is never called

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -763,6 +763,7 @@ answer newbie questions, and generally made Django that much better:
     Stanislaus Madueke
     Stanislav Karpov <work@stkrp.ru>
     starrynight <cmorgh@gmail.com>
+    Stefan R. Filipek
     Stefane Fermgier <sf@fermigier.com>
     Stefano Rivera <stefano@rivera.za.net>
     Stéphane Raimbault <stephane.raimbault@gmail.com>

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -205,11 +205,10 @@ class ForwardManyToOneDescriptor:
         elif value is not None:
             if instance._state.db is None:
                 instance._state.db = router.db_for_write(instance.__class__, instance=value)
-            elif value._state.db is None:
+            if value._state.db is None:
                 value._state.db = router.db_for_write(value.__class__, instance=instance)
-            elif value._state.db is not None and instance._state.db is not None:
-                if not router.allow_relation(value, instance):
-                    raise ValueError('Cannot assign "%r": the current database router prevents this relation.' % value)
+            if not router.allow_relation(value, instance):
+                raise ValueError('Cannot assign "%r": the current database router prevents this relation.' % value)
 
         remote_field = self.field.remote_field
         # If we're setting the value of a OneToOneField to None, we need to clear
@@ -451,11 +450,10 @@ class ReverseOneToOneDescriptor:
         else:
             if instance._state.db is None:
                 instance._state.db = router.db_for_write(instance.__class__, instance=value)
-            elif value._state.db is None:
+            if value._state.db is None:
                 value._state.db = router.db_for_write(value.__class__, instance=instance)
-            elif value._state.db is not None and instance._state.db is not None:
-                if not router.allow_relation(value, instance):
-                    raise ValueError('Cannot assign "%r": the current database router prevents this relation.' % value)
+            if not router.allow_relation(value, instance):
+                raise ValueError('Cannot assign "%r": the current database router prevents this relation.' % value)
 
             related_pk = tuple(getattr(instance, field.attname) for field in self.related.field.foreign_related_fields)
             # Set the value of the related field to the value of the related object's related field

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -415,6 +415,9 @@ Miscellaneous
 * ``QuerySet.raw()`` now caches its results like regular querysets. Use
   ``iterator()`` if you don't want caching.
 
+* The database router :meth:`allow_relation` method is called in more cases.
+  Improperly written routers may need to be updated accordingly.
+
 .. _deprecated-features-2.1:
 
 Features deprecated in 2.1

--- a/tests/gis_tests/layermap/tests.py
+++ b/tests/gis_tests/layermap/tests.py
@@ -319,7 +319,10 @@ class OtherRouter:
         return self.db_for_read(model, **hints)
 
     def allow_relation(self, obj1, obj2, **hints):
-        return None
+        # ContentType objects are created during a post-migrate signal while
+        # performing fixture teardown using the default database alias and
+        # don't abide by the database specified by this router.
+        return True
 
     def allow_migrate(self, db, app_label, **hints):
         return True


### PR DESCRIPTION
Modified the behavior surrounding router.allow_relation checks within
the related_descriptors module. It will now always resolve the
instance and value database if needed and then always call the
relation check.

https://code.djangoproject.com/ticket/27629