### PR TITLE
Fixed #28791 -- Allowed commands that don't require settings to work if the DJANGO_SETTINGS_MODULE doesn't exist.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -317,6 +317,8 @@ class ManagementUtility:
             settings.INSTALLED_APPS
         except ImproperlyConfigured as exc:
             self.settings_exception = exc
+        except ImportError as exc:
+            self.settings_exception = exc
 
         if settings.configured:
             # Start the auto-reloading dev server even if the code is broken.

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -236,6 +236,16 @@ class DjangoAdminNoSettings(AdminScriptTestCase):
         self.assertNoOutput(out)
         self.assertOutput(err, "No module named '?bad_settings'?", regex=True)
 
+    def test_commands_with_invalid_settings(self):
+        """"
+        Commands that don't require settings succeed if the settings file
+        doesn't exist.
+        """
+        args = ['startproject']
+        out, err = self.run_django_admin(args, settings_file='bad_settings')
+        self.assertNoOutput(out)
+        self.assertOutput(err, "You must provide a project name", regex=True)
+
 
 class DjangoAdminDefaultSettings(AdminScriptTestCase):
     """A series of tests for django-admin.py when using a settings.py file that


### PR DESCRIPTION
This is a fix for https://code.djangoproject.com/ticket/28791
Safely catching for ImportError and ModuleNotFoundError. Now the core commands are being executed normally. I ran the tests.
Please let me know if I should make more changes.