### PR TITLE
Clarify where the list of admins is read from

### DIFF
--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -48,14 +48,13 @@ of the case of the actual model class name.
 Default: ``[]`` (Empty list)
 
 A list of all the people who get code error notifications. When
-``DEBUG=False`` and a view raises an exception, Django will email these people
-with the full exception information. Each item in the list should be a tuple
-of (Full name, email address). Example::
+:setting:`DEBUG=False <DEBUG>` and :class:`~django.utils.log.AdminEmailHandler`
+is configured in :setting:`LOGGING` (done by default), Django emails these
+people the details of exceptions raised in the request/response cycle.
+
+Each item in the list should be a tuple of (Full name, email address). Example::
 
     [('John', 'john@example.com'), ('Mary', 'mary@example.com')]
-
-Note that Django will email *all* of these people whenever an error happens.
-See :doc:`/howto/error-reporting` for more information.
 
 .. setting:: ALLOWED_HOSTS
 

--- a/docs/topics/logging.txt
+++ b/docs/topics/logging.txt
@@ -379,13 +379,13 @@ This logging configuration does the following things:
 
 * Defines two handlers:
 
-  * ``console``, a StreamHandler, which will print any ``INFO``
-    (or higher) message to stderr. This handler uses the ``simple`` output
-    format.
+  * ``console``, a :class:`~logging.StreamHandler`, which prints any ``INFO``
+    (or higher) message to ``sys.stderr``. This handler uses the ``simple``
+    output format.
 
-  * ``mail_admins``, an AdminEmailHandler, which will email any
-    ``ERROR`` (or higher) message to the site admins. This handler uses
-    the ``special`` filter.
+  * ``mail_admins``, an :class:`AdminEmailHandler`, which emails any ``ERROR``
+    (or higher) message to the site :setting:`ADMINS`. This handler uses the
+    ``special`` filter.
 
 * Configures three loggers:
 
@@ -587,7 +587,7 @@ Python logging module.
 
 .. class:: AdminEmailHandler(include_html=False, email_backend=None)
 
-    This handler sends an email to the site admins for each log
+    This handler sends an email to the site :setting:`ADMINS` for each log
     message it receives.
 
     If the log record contains a ``request`` attribute, the full details


### PR DESCRIPTION
For some reason I assumed that the admins were the _super users_, not a setting, and was confused that my logger did not work. I ended up finding help here: https://stackoverflow.com/a/18136491/867720

For your consideration. Thanks!

(Whoops, my commit message is terribly phrased...)