### PR TITLE
Fixed #28731 -- Error message for empty Q() in When expression

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -818,6 +818,8 @@ class When(Expression):
             condition, lookups = Q(**lookups), None
         if condition is None or not getattr(condition, 'conditional', False) or lookups:
             raise TypeError("__init__() takes either a Q object or lookups as keyword arguments")
+        if isinstance(condition, Q) and not condition:
+            raise ValueError("An empty Q() can't be used as a When() condition.")
         super().__init__(output_field=None)
         self.condition = condition
         self.result = self._parse_expressions(then)[0]

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -1301,3 +1301,8 @@ class CaseWhenTests(SimpleTestCase):
             When(condition=object())
         with self.assertRaisesMessage(TypeError, msg):
             When()
+
+    def test_empty_q_object(self):
+        msg = "An empty Q() can't be used as a When() condition."
+        with self.assertRaisesMessage(ValueError, msg):
+            When(Q(), then=Value(True))


### PR DESCRIPTION
Creating a Case(When(...)) expression that has an empty Q() object now
leads to an explicit exception message rather than hitting invalid SQL.