### PR TITLE
Fixed #28834 -- Followed ancestor links on field cache lookup failure.

### DIFF
--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -178,6 +178,7 @@ class GrandParent(models.Model):
     first_name = models.CharField(max_length=80)
     last_name = models.CharField(max_length=80)
     email = models.EmailField(unique=True)
+    place = models.ForeignKey(Place, models.CASCADE, null=True, related_name='+')
 
     class Meta:
         unique_together = ('first_name', 'last_name')

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -368,6 +368,22 @@ class ModelInheritanceDataTests(TestCase):
         self.assertEqual(qs[1].italianrestaurant.name, 'Ristorante Miron')
         self.assertEqual(qs[1].italianrestaurant.rating, 4)
 
+    def test_parent_cache_reuse(self):
+        place = Place.objects.create()
+        GrandChild.objects.create(place=place)
+        grand_parent = GrandParent.objects.latest('pk')
+        with self.assertNumQueries(1):
+            self.assertEqual(grand_parent.place, place)
+        parent = grand_parent.parent
+        with self.assertNumQueries(0):
+            self.assertEqual(parent.place, place)
+        child = parent.child
+        with self.assertNumQueries(0):
+            self.assertEqual(child.place, place)
+        grandchild = child.grandchild
+        with self.assertNumQueries(0):
+            self.assertEqual(grandchild.place, place)
+
     def test_update_query_counts(self):
         """
         Update queries do not generate unnecessary queries (#18304).

--- a/tests/select_related_onetoone/tests.py
+++ b/tests/select_related_onetoone/tests.py
@@ -82,7 +82,7 @@ class ReverseSelectRelatedTestCase(TestCase):
             stat = UserStat.objects.select_related('user', 'advanceduserstat').get(posts=200)
             self.assertEqual(stat.advanceduserstat.posts, 200)
             self.assertEqual(stat.user.username, 'bob')
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             self.assertEqual(stat.advanceduserstat.user.username, 'bob')
 
     def test_nullable_relation(self):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28834