### PR TITLE
Fixed #28848 -- Fixed NULLS FIRST emulation with filtered subquery.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1106,6 +1106,7 @@ class OrderBy(BaseExpression):
         }
         placeholders.update(extra_context)
         template = template or self.template
+        params *= template.count('%(expression)s')
         return (template % placeholders).rstrip(), params
 
     def as_sqlite(self, compiler, connection):

--- a/docs/releases/1.11.8.txt
+++ b/docs/releases/1.11.8.txt
@@ -21,3 +21,6 @@ Bugfixes
 
 * Made ``QuerySet.iterator()`` use server-side cursors on PostgreSQL after
   ``values()`` and ``values_list()`` (:ticket:`28817`).
+
+* Fixed crash on SQLite and MySQL when ordering by a filtered subquery that
+  uses ``nulls_first`` or ``nulls_last`` (:ticket:`28848`).


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/28848

I'm sure there are more elegant solutions than the use of ``.count()``, but as far as I see they'd all 
* require quite a lot duplicate code in as_mysql and as_sqlite
* or are in theory backwards-incompatible because they require a new keyword argument to as_sql that currently takes arbitrary keyword arguments as additional context

Happy for feedback!