### PR TITLE
[1.11.x] Fixed #28404 -- Shows empty_value_display in case of empty string in …

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -407,7 +407,7 @@ def display_for_field(value, field, empty_value_display):
     # before the general null test.
     elif isinstance(field, models.BooleanField) or isinstance(field, models.NullBooleanField):
         return _boolean_icon(value)
-    elif value is None:
+    elif value is None or isinstance(value, str) and value == '':
         return empty_value_display
     elif isinstance(field, models.DateTimeField):
         return formats.localize(timezone.template_localtime(value))
@@ -428,7 +428,7 @@ def display_for_value(value, empty_value_display, boolean=False):
 
     if boolean:
         return _boolean_icon(value)
-    elif value is None:
+    elif value is None or isinstance(value, str) and value == '':
         return empty_value_display
     elif isinstance(value, datetime.datetime):
         return formats.localize(timezone.template_localtime(value))

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -202,6 +202,13 @@ class UtilsTests(SimpleTestCase):
         display_value = display_for_value([1, 2, 'buckle', 'my', 'shoe'], self.empty_value)
         self.assertEqual(display_value, '1, 2, buckle, my, shoe')
 
+    def test_empty_values_display_for_value(self):
+        display_value = display_for_value("", self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
+        display_value = display_for_value(None, self.empty_value)
+        self.assertEqual(display_value, self.empty_value)
+
     def test_label_for_field(self):
         """
         Tests for label_for_field


### PR DESCRIPTION
…Django admin