### PR TITLE
Remove unnecessary list comprehensions in django.db.models.sql module

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -803,8 +803,8 @@ class Query:
         # "group by" and "where".
         self.where.relabel_aliases(change_map)
         if isinstance(self.group_by, tuple):
-            self.group_by = tuple([col.relabeled_clone(change_map) for col in self.group_by])
-        self.select = tuple([col.relabeled_clone(change_map) for col in self.select])
+            self.group_by = tuple(col.relabeled_clone(change_map) for col in self.group_by)
+        self.select = tuple(col.relabeled_clone(change_map) for col in self.select)
         if self._annotations:
             self._annotations = OrderedDict(
                 (key, col.relabeled_clone(change_map)) for key, col in self._annotations.items())

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -52,7 +52,7 @@ class DeleteQuery(Query):
         innerq.get_initial_alias()
         # The same for our new query.
         self.get_initial_alias()
-        innerq_used_tables = tuple([t for t in innerq.alias_map if innerq.alias_refcount[t]])
+        innerq_used_tables = tuple(t for t in innerq.alias_map if innerq.alias_refcount[t])
         if not innerq_used_tables or innerq_used_tables == tuple(self.alias_map):
             # There is only the base table in use in the query.
             self.where = innerq.where


### PR DESCRIPTION
Tuple accepts a generator, and using a list comprehension is wasteful here.

FYI there is an amazing flake8 plugin called `flake8-comprehensions` that can detect when you should be using a comprehension and when it's wasteful. These are the only instances it found in Django currently.