### PR TITLE
[1.11.x] Fixed #28856 -- Fixed an issue with caching of coerced gfk pointing to mti model.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -230,9 +230,16 @@ class GenericForeignKey(object):
         except AttributeError:
             rel_obj = None
         else:
-            if rel_obj and (ct_id != self.get_content_type(obj=rel_obj, using=instance._state.db).id or
-                            rel_obj._meta.pk.to_python(pk_val) != rel_obj._get_pk_val()):
-                rel_obj = None
+            if rel_obj:
+                if ct_id != self.get_content_type(obj=rel_obj, using=instance._state.db).id:
+                    rel_obj = None
+                else:
+                    pk = rel_obj._meta.pk
+                    # If the primary key is a remote field, use the referenced
+                    # field's to_python().
+                    pk_to_python = pk.target_field.to_python if pk.remote_field else pk.to_python
+                    if pk_to_python(pk_val) != rel_obj._get_pk_val():
+                        rel_obj = None
 
         if rel_obj is not None:
             return rel_obj

--- a/docs/releases/1.11.8.txt
+++ b/docs/releases/1.11.8.txt
@@ -27,3 +27,6 @@ Bugfixes
 
 * Made query lookups for ``CICharField``, ``CIEmailField``, and ``CITextField``
   use a ``citext`` cast (:ticket:`28702`).
+
+* Fixed a regression in caching of a ``GenericForeignKey`` when the referenced
+  model instance uses multi-table inheritance (:ticket:`28856`).

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -48,6 +48,12 @@ class GenericRelationTests(TestCase):
         TextLink.objects.create(content_object=oddrel)
         oddrel.delete()
 
+    def test_coerce_object_id_remote_field_cache_persistence(self):
+        restaurant = Restaurant.objects.create()
+        CharLink.objects.create(content_object=restaurant)
+        charlink = CharLink.objects.latest('pk')
+        self.assertIs(charlink.content_object, charlink.content_object)
+
     def test_q_object_or(self):
         """
         SQL query parameters for generic relations are properly


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28856

See #9395 for the patch against master.