### PR TITLE
Fixed #28866 -- Made InlineAdminFormSet include InlineModelAdmin's Media before its formset's Media.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -304,7 +304,7 @@ class InlineAdminFormSet:
 
     @property
     def media(self):
-        media = self.formset.media + self.opts.media
+        media = self.opts.media + self.formset.media
         for fs in self:
             media = media + fs.media
         return media

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib import admin
+from django.db import models
 
 from .models import (
     Author, BinaryTree, CapoFamiglia, Chapter, ChildModel1, ChildModel2,
@@ -73,8 +74,16 @@ class InnerInline2(admin.StackedInline):
         js = ('my_awesome_inline_scripts.js',)
 
 
+class CustomNumberWidget(forms.NumberInput):
+    class Media:
+        js = ('custom_number.js',)
+
+
 class InnerInline3(admin.StackedInline):
     model = Inner3
+    formfield_overrides = {
+        models.IntegerField: {'widget': CustomNumberWidget},
+    }
 
     class Media:
         js = ('my_awesome_inline_scripts.js',)

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -453,6 +453,16 @@ class TestInlineMedia(TestDataMixin, TestCase):
         Inner3(dummy=42, holder=holder).save()
         change_url = reverse('admin:admin_inlines_holder3_change', args=(holder.id,))
         response = self.client.get(change_url)
+        self.assertEqual(
+            response.context['inline_admin_formsets'][0].media._js,
+            [
+                'admin/js/vendor/jquery/jquery.min.js',
+                'admin/js/jquery.init.js',
+                'admin/js/inlines.min.js',
+                'my_awesome_inline_scripts.js',
+                'custom_number.js',
+            ]
+        )
         self.assertContains(response, 'my_awesome_inline_scripts.js')
 
     def test_all_inline_media(self):


### PR DESCRIPTION
This provides better backwards compatibility following refs #28377.
https://code.djangoproject.com/ticket/28866