### PR TITLE
Fixed #28748: Made CharField choices' check stricter.

### DIFF
--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -149,6 +149,21 @@ class CharFieldTests(TestCase):
             ),
         ])
 
+    def test_non_iterable_choices_two_letters(self):
+        """Two letters isn't a valid choice pair."""
+        class Model(models.Model):
+            field = models.CharField(max_length=10, choices=['ab'])
+
+        field = Model._meta.get_field('field')
+        self.assertEqual(field.check(), [
+            Error(
+                "'choices' must be an iterable containing (actual value, "
+                "human readable name) tuples.",
+                obj=field,
+                id='fields.E005',
+            ),
+        ])
+
     def test_iterable_of_iterable_choices(self):
         class ThingItem:
             def __init__(self, value, display):
@@ -182,6 +197,18 @@ class CharFieldTests(TestCase):
                 id='fields.E005',
             ),
         ])
+
+    def test_choices_named_group(self):
+        class Model(models.Model):
+            field = models.CharField(
+                max_length=10, choices=[
+                    ['knights', [['L', 'Lancelot'], ['G', 'Galahad']]],
+                    ['wizards', [['T', 'Tim the Enchanter']]],
+                    ['R', 'Random character'],
+                ],
+            )
+
+        self.assertEqual(Model._meta.get_field('field').check(), [])
 
     def test_bad_db_index_value(self):
         class Model(models.Model):

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -210,6 +210,44 @@ class CharFieldTests(TestCase):
 
         self.assertEqual(Model._meta.get_field('field').check(), [])
 
+    def test_choices_named_group_non_pairs(self):
+        class Model(models.Model):
+            field = models.CharField(
+                max_length=10,
+                choices=[['knights', [['L', 'Lancelot', 'Du Lac']]]],
+            )
+
+        field = Model._meta.get_field('field')
+        self.assertEqual(field.check(), [
+            Error(
+                "'choices' must be an iterable containing (actual value, "
+                "human readable name) tuples.",
+                obj=field,
+                id='fields.E005',
+            ),
+        ])
+
+    def test_choices_named_group_bad_structure(self):
+        class Model(models.Model):
+            field = models.CharField(
+                max_length=10, choices=[
+                    ['knights', [
+                        ['Noble', [['G', 'Galahad']]],
+                        ['Combative', [['L', 'Lancelot']]],
+                    ]],
+                ],
+            )
+
+        field = Model._meta.get_field('field')
+        self.assertEqual(field.check(), [
+            Error(
+                "'choices' must be an iterable containing (actual value, "
+                "human readable name) tuples.",
+                obj=field,
+                id='fields.E005',
+            ),
+        ])
+
     def test_bad_db_index_value(self):
         class Model(models.Model):
             field = models.CharField(max_length=10, db_index='bad')


### PR DESCRIPTION
A malformed choices structure would pass the Django system checks, but trigger an exception when attempting to migrate the field.
```python
class Model(models.Model):
    field = models.CharField(max_length=1, [
        'knights', [
            ['G', 'Galahad'],
            ['L', 'Lancelot', 'Du Lac'],
        ],
    ])
```


Ticket: https://code.djangoproject.com/ticket/28748