### PR TITLE
Fixed #28874 -- Prevented double escaping of errors on hidden fields

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -199,8 +199,7 @@ class BaseForm:
         for name, field in self.fields.items():
             html_class_attr = ''
             bf = self[name]
-            # Escape and cache in local variable.
-            bf_errors = self.error_class([conditional_escape(error) for error in bf.errors])
+            bf_errors = self.error_class(bf.errors)
             if bf.is_hidden:
                 if bf_errors:
                     top_errors.extend(

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -3398,6 +3398,27 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 <div class="errorlist"><div class="error">This field is required.</div></div>
 <p>Comment: <input type="text" name="comment" required /></p>""")
 
+    def test_error_escaping(self):
+        class TestForm(Form):
+            hidden = CharField(widget=HiddenInput(), required=False)
+            visible = CharField()
+
+            def clean_hidden(self):
+                raise ValidationError('Foo & "bar"!')
+
+            clean_visible = clean_hidden
+
+        form = TestForm({'hidden': 'a', 'visible': 'b'})
+        form.is_valid()
+        self.assertHTMLEqual(
+            form.as_ul(),
+            '<li><ul class="errorlist nonfield"><li>(Hidden field hidden) Foo &amp; &quot;bar&quot;!</li></ul></li>'
+            '<li><ul class="errorlist"><li>Foo &amp; &quot;bar&quot;!</li></ul>'
+            '<label for="id_visible">Visible:</label> '
+            '<input type="text" name="visible" value="b" id="id_visible" required />'
+            '<input type="hidden" name="hidden" value="a" id="id_hidden" /></li>'
+        )
+
     def test_baseform_repr(self):
         """
         BaseForm.__repr__() should contain some basic information about the


### PR DESCRIPTION
This PR should also be backported to 1.11 and 2.0.
If I understood everything correctly, I should create separate PRs for this, is it right? 

https://code.djangoproject.com/ticket/28874