### PR TITLE
Fixed #28878 -- Added python_requires in setup.py and a warning for older pips that don't recognize it.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -845,6 +845,7 @@ answer newbie questions, and generally made Django that much better:
     ymasuda@ethercube.com
     Yoong Kang Lim <yoongkang.lim@gmail.com>
     Yusuke Miyazaki <miyazaki.dev@gmail.com>
+    Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
     Zachary Voase <zacharyvoase@gmail.com>
     Zach Liu <zachliu@gmail.com>
     Zach Thompson <zthompson47@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,35 @@ from distutils.sysconfig import get_python_lib
 
 from setuptools import find_packages, setup
 
+CURRENT_PYTHON = sys.version_info[:2]
+REQUIRED_PYTHON = (3, 5)
+
+# This check and everything above must remain compatible with Python 2.7.
+if CURRENT_PYTHON < REQUIRED_PYTHON:
+    sys.stderr.write("""
+==========================
+Unsupported Python version
+==========================
+
+This version of Django requires Python {}.{}, but you're trying to
+install it on Python {}.{}.
+
+This may be because you are using a version of pip that doesn't
+understand the python_requires classifier. Make sure you
+have pip >= 9.0 and setuptools >= 24.2, then try again:
+
+    $ python -m pip install --upgrade pip setuptools
+    $ python -m pip install django
+
+This will install the latest version of Django which works on your
+version of Python. If you can't upgrade your pip (or Python), request
+an older version of Django:
+
+    $ python -m pip install "django<2"
+""".format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
+    sys.exit(1)
+
+
 # Warn if we are installing over top of an existing installation. This can
 # cause issues where files that were deleted from a more recent Django are
 # still present in site-packages. See #18115.
@@ -35,6 +64,7 @@ version = __import__('django').get_version()
 setup(
     name='Django',
     version=version,
+    python_requires='>={}.{}'.format(*REQUIRED_PYTHON),
     url='https://www.djangoproject.com/',
     author='Django Software Foundation',
     author_email='foundation@djangoproject.com',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28878

- Added the "python_requires" key to setup(), so pip knows not to try installing on incompatible Pythons.
- Added a more useful error for users with an old version of pip, which does not know about python_requires.

Note that this patch is against Django 2.1 - when backported, `python_requires` should instead be set to `>=3.4` so Django 2.0 can be installed on that version.

Having this or a similar patch in a released version will give Python2 users with old pip a useful error on `pip install django`, and that's the best we can do for them.  However, for upgrading pip to be useful, we also need to set the `python_requires` metadata on Django 2.0.0 - probably a job for @timgraham?