### PR TITLE
setuptools metadata for required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'django-admin = django.core.management:execute_from_command_line',
     ]},
     install_requires=['pytz'],
+    python_requires=">=3.5",
     extras_require={
         "bcrypt": ["bcrypt"],
         "argon2": ["argon2-cffi >= 16.1.0"],


### PR DESCRIPTION
The Django 2.0 .tar.gz sdist  was released to PyPI without the **Requires Python** metadata necessary to prevent pip from downloading it on Python 2.7 interpreter.  Brace yourselves for thousands of users complaining that `pip install django` breaks with an `ImportError` in `functools`.  

This fixes master, but you may want to update the existing 2.0 distribution with the metadata for ">=3.4" as well.  