### PR TITLE
Fixed #28883 -- Fixed regex for uuid url converter to support upper case as per RFC4122

### DIFF
--- a/django/urls/converters.py
+++ b/django/urls/converters.py
@@ -24,7 +24,7 @@ class StringConverter:
 
 
 class UUIDConverter:
-    regex = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+    regex = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
     def to_python(self, value):
         return uuid.UUID(value)


### PR DESCRIPTION
Fix for bug #28883:
https://code.djangoproject.com/ticket/28883