### PR TITLE
Fixed #28890 -- Fixed whitespace regression in multiwidget rendering.

### DIFF
--- a/django/forms/jinja2/django/forms/widgets/multiwidget.html
+++ b/django/forms/jinja2/django/forms/widgets/multiwidget.html
@@ -1,1 +1,1 @@
-{% for widget in widget.subwidgets %}{% include widget.template_name %}{% endfor %}
+{% for widget in widget.subwidgets -%}{% include widget.template_name %}{%- endfor %}

--- a/django/forms/templates/django/forms/widgets/multiwidget.html
+++ b/django/forms/templates/django/forms/widgets/multiwidget.html
@@ -1,1 +1,1 @@
-{% for widget in widget.subwidgets %}{% include widget.template_name %}{% endfor %}
+{% spaceless %}{% for widget in widget.subwidgets %}{% include widget.template_name %}{% endfor %}{% endspaceless %}

--- a/docs/releases/1.11.9.txt
+++ b/docs/releases/1.11.9.txt
@@ -9,4 +9,5 @@ Django 1.11.9 fixes several bugs in 1.11.8.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 1.11 that added newlines between ``MultiWidget``'s
+  subwidgets (:ticket:`28890`).

--- a/docs/releases/2.0.1.txt
+++ b/docs/releases/2.0.1.txt
@@ -9,4 +9,5 @@ Django 2.0.1 fixes several bugs in 2.0.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 1.11 that added newlines between ``MultiWidget``'s
+  subwidgets (:ticket:`28890`).

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -166,6 +166,13 @@ class MultiWidgetTest(WidgetTest):
             """
         ))
 
+    def test_no_whitespace_between_widgets(self):
+        widget = MyMultiWidget(widgets=(TextInput, TextInput()))
+        self.check_html(widget, 'code', None, html=(
+            '<input type="text" name="code_0" />'
+            '<input type="text" name="code_1" />'
+        ), strict=True)
+
     def test_deepcopy(self):
         """
         MultiWidget should define __deepcopy__() (#12048).


### PR DESCRIPTION
Ticket [#28890](https://code.djangoproject.com/ticket/28890).