### PR TITLE
Fixed #28894 -- Fixed functools.partial() serialization for migrations.

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -165,7 +165,7 @@ class FunctoolsPartialSerializer(BaseSerializer):
         # Serialize functools.partial() arguments
         func_string, func_imports = serializer_factory(self.value.func).serialize()
         args_string, args_imports = serializer_factory(self.value.args).serialize()
-        keywords_string, keywords_imports = serializer_factory(self.value.keywords).serialize()
+        keywords_string, keywords_imports = serializer_factory(self.value.keywords or {}).serialize()
         # Add any imports needed by arguments
         imports.update(func_imports)
         imports.update(args_imports)

--- a/docs/releases/1.11.9.txt
+++ b/docs/releases/1.11.9.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 1.11 that added newlines between ``MultiWidget``'s
   subwidgets (:ticket:`28890`).
+
+* Fixed invalid migrations caused by the ``functool.partial()`` ``keywords``
+  attribute not being serialized to a dictionary in some versions of Python.
+  (:ticket:`28894`).

--- a/docs/releases/2.0.1.txt
+++ b/docs/releases/2.0.1.txt
@@ -11,3 +11,7 @@ Bugfixes
 
 * Fixed a regression in Django 1.11 that added newlines between ``MultiWidget``'s
   subwidgets (:ticket:`28890`).
+
+* Fixed invalid migrations caused by the ``functool.partial()`` ``keywords``
+  attribute not being serialized to a dictionary in some versions of Python.
+  (:ticket:`28894`).

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -520,6 +520,14 @@ class WriterTests(SimpleTestCase):
         self.assertEqual(result.args, value.args)
         self.assertEqual(result.keywords, value.keywords)
 
+    def test_serialize_functools_partial_keywords_argument(self):
+        value = mock.Mock(spec=functools.partial, func=int, args=('123',), keywords=None)
+        result = self.serialize_round_trip(value)
+        self.assertEqual(result.func, value.func)
+        self.assertEqual(result.args, value.args)
+        self.assertEqual(result.keywords, {})
+        self.assertNotEqual(result.keywords, None)
+
     def test_simple_migration(self):
         """
         Tests serializing a simple migration.


### PR DESCRIPTION
Ticket [#28894](https://code.djangoproject.com/ticket/28894).

