### PR TITLE
Fixed #28883 -- Doc'd that the uuid URL path converter matches only lowercase letters

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -127,7 +127,7 @@ The following path converters are available by default:
   plus the hyphen and underscore characters. For example,
   ``building-your-1st-django-site``.
 
-* ``uuid`` - Matches a formatted UUID. For example,
+* ``uuid`` - Matches a formatted UUID (letters must be lowercase). For example,
   ``075194d3-6885-417e-a8a8-6c931e272f00``. Returns a :class:`~uuid.UUID`
   instance.
 


### PR DESCRIPTION
.https://code.djangoproject.com/ticket/28883