### PR TITLE
Fix PT-BR translation error

### DIFF
--- a/django/conf/locale/pt_BR/LC_MESSAGES/django.po
+++ b/django/conf/locale/pt_BR/LC_MESSAGES/django.po
@@ -764,10 +764,10 @@ msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
 msgid_plural ""
 "Ensure this filename has at most %(max)d characters (it has %(length)d)."
 msgstr[0] ""
-"Certifique-se de que o arquivo tenha no máximo %(max)d caractere (ele possui "
+"Certifique-se de que o nome do arquivo tenha no máximo %(max)d caractere (ele possui "
 "%(length)d)."
 msgstr[1] ""
-"Certifique-se de que o arquivo tenha no máximo %(max)d caracteres (ele "
+"Certifique-se de que o nome do arquivo tenha no máximo %(max)d caracteres (ele "
 "possui %(length)d)."
 
 #: forms/fields.py:571


### PR DESCRIPTION
The word `'filename'` was incorrectly translated as `arquivo` instead of `nome do arquivo`. This produced a confusing error message when the user tries to upload a file whose name exceeds the limit.

I fixed the stable/1.7.x branch, but this change should be cherry picked on later versions too. Please, consider doing so as soon as possible.

Thanks!

update: The error messages on isort, docs, flake8, pull-request-javascript, and pull-requests-trusty seem to be unrelated to this change.