### PR TITLE
[1.11.x] Refs #28856 -- Fixed caching of a GenericForeignKey pointing to a model that uses more than one level of MTI.

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -237,7 +237,15 @@ class GenericForeignKey(object):
                     pk = rel_obj._meta.pk
                     # If the primary key is a remote field, use the referenced
                     # field's to_python().
-                    pk_to_python = pk.target_field.to_python if pk.remote_field else pk.to_python
+                    to_python_field = pk
+                    # Out of an abundance of caution, avoid infinite loops.
+                    seen = {to_python_field}
+                    while to_python_field.remote_field:
+                        to_python_field = to_python_field.target_field
+                        if to_python_field in seen:
+                            break
+                        seen.add(to_python_field)
+                    pk_to_python = to_python_field.to_python
                     if pk_to_python(pk_val) != rel_obj._get_pk_val():
                         rel_obj = None
 

--- a/docs/releases/1.11.9.txt
+++ b/docs/releases/1.11.9.txt
@@ -17,3 +17,7 @@ Bugfixes
 
 * Fixed incorrect foreign key constraint name for models with quoted
   ``db_table`` (:ticket:`28876`).
+
+* Fixed a regression in caching of a ``GenericForeignKey`` when the referenced
+  model instance uses more than one level of multi-table inheritance
+  (:ticket:`28856`).

--- a/tests/generic_relations_regress/models.py
+++ b/tests/generic_relations_regress/models.py
@@ -43,6 +43,12 @@ class Restaurant(Place):
 
 
 @python_2_unicode_compatible
+class Cafe(Restaurant):
+    def __str__(self):
+        return "Cafe: %s" % self.name
+
+
+@python_2_unicode_compatible
 class Address(models.Model):
     street = models.CharField(max_length=80)
     city = models.CharField(max_length=50)

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -5,9 +5,10 @@ from django.forms.models import modelform_factory
 from django.test import TestCase, skipIfDBFeature
 
 from .models import (
-    A, Address, B, Board, C, CharLink, Company, Contact, Content, D, Developer,
-    Guild, HasLinkThing, Link, Node, Note, OddRelation1, OddRelation2,
-    Organization, Person, Place, Related, Restaurant, Tag, Team, TextLink,
+    A, Address, B, Board, C, Cafe, CharLink, Company, Contact, Content, D,
+    Developer, Guild, HasLinkThing, Link, Node, Note, OddRelation1,
+    OddRelation2, Organization, Person, Place, Related, Restaurant, Tag, Team,
+    TextLink,
 )
 
 
@@ -51,6 +52,11 @@ class GenericRelationTests(TestCase):
     def test_coerce_object_id_remote_field_cache_persistence(self):
         restaurant = Restaurant.objects.create()
         CharLink.objects.create(content_object=restaurant)
+        charlink = CharLink.objects.latest('pk')
+        self.assertIs(charlink.content_object, charlink.content_object)
+        # If the model (Cafe) uses more than one level of multi-table inheritance.
+        cafe = Cafe.objects.create()
+        CharLink.objects.create(content_object=cafe)
         charlink = CharLink.objects.latest('pk')
         self.assertIs(charlink.content_object, charlink.content_object)
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28856