### PR TITLE
Update trove classifiers to indicate Python 3 Only.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Internet :: WWW/HTTP :: WSGI',


### PR DESCRIPTION
Now that Django 2.0+ only supports Python 3 we can categorise it as such on PyPI.