### PR TITLE
Fixed #28646 -- Postgres migration fails with error '_like index already exists'

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2566,6 +2566,39 @@ class SwappableOperationTests(OperationTestBase):
             operation.database_forwards('test_rminigsw', editor, project_state, new_state)
             operation.database_backwards('test_rminigsw', editor, new_state, project_state)
 
+    def test_change_primary_key(self):
+        """Regression test for #28646."""
+        operation1 = migrations.CreateModel(
+            'SimpleModel',
+            [
+                ("field1", models.SlugField(max_length=20, primary_key=True)),
+                ("field2", models.SlugField(max_length=20)),
+            ],
+        )
+        operation2 = migrations.AlterField(
+            "SimpleModel",
+            "field1",
+            models.SlugField(max_length=20, primary_key=False),
+        )
+        operation3 = migrations.AlterField(
+            "SimpleModel",
+            "field2",
+            models.SlugField(max_length=20, primary_key=True),
+        )
+
+        project_state = ProjectState()
+
+        with connection.schema_editor() as editor:
+            new_state = project_state.clone()
+            operation1.state_forwards("migrtest", new_state)
+            operation1.database_forwards("migrtest", editor, project_state, new_state)
+            project_state, new_state = new_state, new_state.clone()
+            operation2.state_forwards("migrtest", new_state)
+            operation2.database_forwards("migrtest", editor, project_state, new_state)
+            project_state, new_state = new_state, new_state.clone()
+            operation3.state_forwards("migrtest", new_state)
+            operation3.database_forwards("migrtest", editor, project_state, new_state)
+
 
 class TestCreateModel(SimpleTestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28646