### PR TITLE
Fixed #28905 - Added optional dependencies to extra_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'memcached': ['python3-memcached'],
         'numpy': ['numpy'],
         'mysql': ['mysqlclient>=1.3.7'],
-        'oracle': ['Oracle'],
+        'oracle': ['cx_Oracle>=5.2'],
         'images': ['Pillow'],
         'postgresql': ['psycopg2>=2.5.4'],
         'pylibmc': ['pylibmc; sys.platform != "win32"'],

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'bcrypt': ['bcrypt'],
         'gis': [
             'geoip2',
-            'numpy'
+            'numpy',
         ],
         'geoip': ['geoip2'],
         'jinja2': ['Jinja2>=2.9.2'],

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,26 @@ setup(
     ]},
     install_requires=['pytz'],
     extras_require={
-        "bcrypt": ["bcrypt"],
-        "argon2": ["argon2-cffi >= 16.1.0"],
+        'admindocs': ['docutils'],
+        'argon2': ['argon2_cffi>=16.1.0'],
+        'bcrypt': ['bcrypt'],
+        'gis': [
+            'geoip2',
+            'numpy'
+        ],
+        'geoip': ['geoip2'],
+        'jinja2': ['Jinja2>=2.9.2'],
+        'memcached': ['python3-memcached'],
+        'numpy': ['numpy'],
+        'mysql': ['mysqlclient>=1.3.7'],
+        'oracle': ['Oracle'],
+        'images': ['Pillow'],
+        'postgresql': ['psycopg2>=2.5.4'],
+        'pylibmc': ['pylibmc; sys.platform != "win32"'],
+        'sqlparse': ['sqlparse'],
+        'selenium': ['selenium'],
+        'test-parallel': ['tblib'],
+        'yaml': ['PyYAML'],
     },
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28905

Make it easier to install Django including optional dependencies (like pyscopg2, Pillow etc.) with the correct minimum version by using, i.e.:

    pip install Django[postgresql,images]