### PR TITLE
Refs #23919 -- Prefer use of super().__init__(...)

### DIFF
--- a/django/contrib/gis/gdal/raster/band.py
+++ b/django/contrib/gis/gdal/raster/band.py
@@ -242,7 +242,7 @@ class GDALBand(GDALRasterBase):
 class BandList(list):
     def __init__(self, source):
         self.source = source
-        list.__init__(self)
+        super().__init__()
 
     def __iter__(self):
         for idx in range(1, len(self) + 1):

--- a/django/contrib/gis/gdal/raster/source.py
+++ b/django/contrib/gis/gdal/raster/source.py
@@ -31,7 +31,7 @@ class TransformPoint(list):
     def __init__(self, raster, prop):
         x = raster.geotransform[self.indices[prop][0]]
         y = raster.geotransform[self.indices[prop][1]]
-        list.__init__(self, [x, y])
+        super().__init__([x, y])
         self._raster = raster
         self._prop = prop
 

--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -31,7 +31,7 @@ class Options:
 
 class BaseDatabaseCache(BaseCache):
     def __init__(self, table, params):
-        BaseCache.__init__(self, params)
+        super().__init__(params)
         self._table = table
 
         class CacheEntry:

--- a/django/core/cache/backends/dummy.py
+++ b/django/core/cache/backends/dummy.py
@@ -5,7 +5,7 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
 
 class DummyCache(BaseCache):
     def __init__(self, host, *args, **kwargs):
-        BaseCache.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)

--- a/django/core/cache/backends/locmem.py
+++ b/django/core/cache/backends/locmem.py
@@ -21,7 +21,7 @@ def dummy():
 
 class LocMemCache(BaseCache):
     def __init__(self, name, params):
-        BaseCache.__init__(self, params)
+        super().__init__(params)
         self._cache = _caches.setdefault(name, {})
         self._expire_info = _expire_info.setdefault(name, {})
         self._lock = _locks.setdefault(name, RWLock())

--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -332,7 +332,7 @@ class Command(BaseCommand):
 class SingleZipReader(zipfile.ZipFile):
 
     def __init__(self, *args, **kwargs):
-        zipfile.ZipFile.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         if len(self.namelist()) != 1:
             raise ValueError("Zip-compressed fixtures must contain one file.")
 

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -308,7 +308,7 @@ class DefusedExpatParser(_ExpatParser):
     Forbid DTDs, external entity references
     """
     def __init__(self, *args, **kwargs):
-        _ExpatParser.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setFeature(handler.feature_external_ges, False)
         self.setFeature(handler.feature_external_pes, False)
 

--- a/django/test/html.py
+++ b/django/test/html.py
@@ -148,7 +148,7 @@ class Parser(HTMLParser):
     )
 
     def __init__(self):
-        HTMLParser.__init__(self, convert_charrefs=False)
+        super().__init__(convert_charrefs=False)
         self.root = RootElement()
         self.open_tags = []
         self.element_positions = {}

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -136,7 +136,7 @@ def linebreaks(value, autoescape=False):
 
 class MLStripper(HTMLParser):
     def __init__(self):
-        HTMLParser.__init__(self, convert_charrefs=False)
+        super().__init__(convert_charrefs=False)
         self.reset()
         self.fed = []
 

--- a/django/utils/log.py
+++ b/django/utils/log.py
@@ -82,7 +82,7 @@ class AdminEmailHandler(logging.Handler):
     """
 
     def __init__(self, include_html=False, email_backend=None):
-        logging.Handler.__init__(self)
+        super().__init__()
         self.include_html = include_html
         self.email_backend = email_backend
 


### PR DESCRIPTION
Python 3 dropped support for old-style classes so we should be able to use super() in more cases.