### PR TITLE
Fixed leaky logger in NonDjangoTemplatesDebugViewTests.

### DIFF
--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -250,7 +250,7 @@ class DebugViewQueriesAllowedTests(SimpleTestCase):
         'BACKEND': 'django.template.backends.dummy.TemplateStrings',
     }],
 )
-class NonDjangoTemplatesDebugViewTests(SimpleTestCase):
+class NonDjangoTemplatesDebugViewTests(LoggingCaptureMixin, SimpleTestCase):
 
     def test_400(self):
         # When DEBUG=True, technical_500_template() is called.


### PR DESCRIPTION
```
...................................................................................Forbidden (Permission denied): /raises403/
Not Found: /raises404/
................ss.................................................................................................................
```