### PR TITLE
Fixed #28903 - Changed license-file key to license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,4 +17,4 @@ multi_line_output = 5
 not_skip = __init__.py
 
 [metadata]
-license-file = LICENSE
+license_file = LICENSE


### PR DESCRIPTION
https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file