### PR TITLE
Refs #27849 -- Removed empty Q() hack in filtered Aggregate.as_sql().

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -4,7 +4,6 @@ Classes to represent the definitions of aggregate functions.
 from django.core.exceptions import FieldError
 from django.db.models.expressions import Case, Func, Star, When
 from django.db.models.fields import DecimalField, FloatField, IntegerField
-from django.db.models.query_utils import Q
 
 __all__ = [
     'Aggregate', 'Avg', 'Count', 'Max', 'Min', 'StdDev', 'Sum', 'Variance',
@@ -72,9 +71,8 @@ class Aggregate(Func):
             else:
                 copy = self.copy()
                 copy.filter = None
-                condition = When(Q())
                 source_expressions = copy.get_source_expressions()
-                condition.set_source_expressions([self.filter, source_expressions[0]])
+                condition = When(self.filter, then=source_expressions[0])
                 copy.set_source_expressions([Case(condition)] + source_expressions[1:])
                 return super(Aggregate, copy).as_sql(compiler, connection, **extra_context)
         return super().as_sql(compiler, connection, **extra_context)

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -817,7 +817,7 @@ class When(Expression):
     def __init__(self, condition=None, then=None, **lookups):
         if lookups and condition is None:
             condition, lookups = Q(**lookups), None
-        if condition is None or not isinstance(condition, Q) or lookups:
+        if condition is None or not getattr(condition, 'conditional', False) or lookups:
             raise TypeError("__init__() takes either a Q object or lookups as keyword arguments")
         super().__init__(output_field=None)
         self.condition = condition

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -53,6 +53,7 @@ class Q(tree.Node):
     AND = 'AND'
     OR = 'OR'
     default = AND
+    conditional = True
 
     def __init__(self, *args, **kwargs):
         connector = kwargs.pop('_connector', None)

--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -27,6 +27,7 @@ class WhereNode(tree.Node):
     """
     default = AND
     resolved = False
+    conditional = True
 
     def split_having(self, negated=False):
         """


### PR DESCRIPTION
This required allowing WhereNode to be provided as When(condition).

This was made possible by cf12257db23fa248c89a3da3f718aa01a50ca659.