### PR TITLE
Fixed #28898 -- Corrected admin check to allow a OneToOneField in ModelAdmin.autocomplete_fields.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -689,6 +689,7 @@ answer newbie questions, and generally made Django that much better:
     Robert Wittams
     Rob Hudson <http://rob.cogit8.org/>
     Robin Munn <http://www.geekforgod.com/>
+    Rodrigo Pinheiro Marques de Araújo <fenrrir@gmail.com>
     Romain Garrigues <romain.garrigues.cs@gmail.com>
     Ronny Haryanto <http://ronny.haryan.to/>
     Ross Poulton <ross@rossp.org>

--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -104,7 +104,7 @@ class BaseModelAdminChecks:
         except FieldDoesNotExist:
             return refer_to_missing_field(field=field_name, option=label, model=model, obj=obj, id='admin.E037')
         else:
-            if not (field.many_to_many or field.many_to_one):
+            if not field.many_to_many and not isinstance(field, models.ForeignKey):
                 return must_be(
                     'a foreign key or a many-to-many field',
                     option=label, obj=obj, id='admin.E038'

--- a/docs/releases/2.0.1.txt
+++ b/docs/releases/2.0.1.txt
@@ -23,3 +23,6 @@ Bugfixes
   (:ticket:`28856`).
 
 * Reallowed filtering a queryset with ``GeometryField=None`` (:ticket:`28896`).
+
+* Corrected admin check to allow a ``OneToOneField`` in
+  ``ModelAdmin.autocomplete_fields`` (:ticket:`28898`).

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -6,7 +6,9 @@ from django.core.checks import Error
 from django.forms.models import BaseModelFormSet
 from django.test import SimpleTestCase
 
-from .models import Band, Song, ValidationTestInlineModel, ValidationTestModel
+from .models import (
+    Band, Song, User, ValidationTestInlineModel, ValidationTestModel,
+)
 
 
 class CheckTestCase(SimpleTestCase):
@@ -1243,3 +1245,14 @@ class AutocompleteFieldsTests(CheckTestCase):
         site = AdminSite()
         site.register(Band, SearchFieldsAdmin)
         self.assertIsValid(AutocompleteAdmin, Song, admin_site=site)
+
+    def test_autocomplete_is_onetoone(self):
+        class UserAdmin(ModelAdmin):
+            search_fields = ('name', )
+
+        class Admin(ModelAdmin):
+            autocomplete_fields = ('best_friend', )
+
+        site = AdminSite()
+        site.register(User, UserAdmin)
+        self.assertIsValid(Admin, ValidationTestModel, admin_site=site)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28898