### PR TITLE
Fixed #28727 -- Fixed Cast crash on SQlite when casting a Python date/datetime to Date/DateTimeField.

### DIFF
--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -14,6 +14,10 @@ from django.utils.duration import duration_string
 
 class DatabaseOperations(BaseDatabaseOperations):
     cast_char_field_without_max_length = 'text'
+    cast_data_types = {
+        'DateField': 'TEXT',
+        'DateTimeField': 'TEXT',
+    }
 
     def bulk_batch_size(self, fields, objs):
         """


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28727