### PR TITLE
Fixed #28933 -- Improved the efficiency of ModelAdmin.date_hierarchy queries.

### DIFF
--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -16,6 +16,7 @@ class CustomPaginator(Paginator):
 
 
 class EventAdmin(admin.ModelAdmin):
+    date_hierarchy = 'date'
     list_display = ['event_date_func']
 
     def event_date_func(self, event):

--- a/tests/admin_changelist/test_date_hierarchy.py
+++ b/tests/admin_changelist/test_date_hierarchy.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+from django.contrib.admin.options import IncorrectLookupParameters
+from django.test import RequestFactory, TestCase
+from django.utils.timezone import make_aware
+
+from .admin import EventAdmin, site as custom_site
+from .models import Event
+
+
+class DateHierarchyTests(TestCase):
+    factory = RequestFactory()
+
+    def assertDateParams(self, query, expected_from_date, expected_to_date):
+        query = {'date__%s' % field: val for field, val in query.items()}
+        request = self.factory.get('/', query)
+        changelist = EventAdmin(Event, custom_site).get_changelist_instance(request)
+        _, _, lookup_params, _ = changelist.get_filters(request)
+        self.assertEqual(lookup_params['date__gte'], expected_from_date)
+        self.assertEqual(lookup_params['date__lt'], expected_to_date)
+
+    def test_bounded_params(self):
+        tests = (
+            ({'year': 2017}, datetime(2017, 1, 1), datetime(2018, 1, 1)),
+            ({'year': 2017, 'month': 2}, datetime(2017, 2, 1), datetime(2017, 3, 1)),
+            ({'year': 2017, 'month': 12}, datetime(2017, 12, 1), datetime(2018, 1, 1)),
+            ({'year': 2017, 'month': 12, 'day': 15}, datetime(2017, 12, 15), datetime(2017, 12, 16)),
+            ({'year': 2017, 'month': 12, 'day': 31}, datetime(2017, 12, 31), datetime(2018, 1, 1)),
+            ({'year': 2017, 'month': 2, 'day': 28}, datetime(2017, 2, 28), datetime(2017, 3, 1)),
+        )
+        for query, expected_from_date, expected_to_date in tests:
+            with self.subTest(query=query):
+                self.assertDateParams(query, expected_from_date, expected_to_date)
+
+    def test_bounded_params_with_time_zone(self):
+        with self.settings(USE_TZ=True, TIME_ZONE='Asia/Jerusalem'):
+            self.assertDateParams(
+                {'year': 2017, 'month': 2, 'day': 28},
+                make_aware(datetime(2017, 2, 28)),
+                make_aware(datetime(2017, 3, 1)),
+            )
+
+    def test_invalid_params(self):
+        tests = (
+            {'year': 'x'},
+            {'year': 2017, 'month': 'x'},
+            {'year': 2017, 'month': 12, 'day': 'x'},
+            {'year': 2017, 'month': 13},
+            {'year': 2017, 'month': 12, 'day': 32},
+            {'year': 2017, 'month': 0},
+            {'year': 2017, 'month': 12, 'day': 0},
+        )
+        for invalid_query in tests:
+            with self.subTest(query=invalid_query), self.assertRaises(IncorrectLookupParameters):
+                self.assertDateParams(invalid_query, None, None)


### PR DESCRIPTION
[Ticket](https://code.djangoproject.com/ticket/28933#ticket)

The predicate generated by date_hierarchy makes it very difficult for databases to optimize the query.

The following date hierarchy:
```
/admin/app/model?created__year=2017&created__month=12&created__day=16
```

Will generate the following where clause (PostgreSql):
```
WHERE created between '2017-01-01' and '2017-31-12' and EXTRACT('month', created) = 12 and EXTRACT('day', created) = 16
```

The query above will not be able to utilize range based indexes on the date hierarchy column - on big tables this has a significant performance impact.

The current implementation of date hierarchy is relying on the "default" filtering mechinizem used by Django Admin. **I propose implementing custom filtering for Django Admin that will better utilize it's hierarchical nature and make it more database "friendly".**

Instead of the query above the date hierarchy would generate the following predicates for different levels of the heirarchy:
```
/admin/app/model?created__year=2017&created__month=12&created__day=16 
WHERE created >= '2017-12-16' and created < '2017-12-17'
```
```
/admin/app/model?created__year=2017&created__month=12
WHERE created >= '2017-12-01' and created < '2018-01-01'
```
```
/admin/app/model?created__year=2017
WHERE created >= '2017-01-01' and created < '2018-01-01'
```

Please let me know if this is acceptable.