### PR TITLE
Fixed #28934 -- Prevented Cast from truncating microseconds on Oracle.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -350,6 +350,8 @@ class OracleParam:
         elif string_size > 4000:
             # Mark any string param greater than 4000 characters as a CLOB.
             self.input_size = Database.CLOB
+        elif isinstance(param, datetime.datetime):
+            self.input_size = Database.TIMESTAMP
         else:
             self.input_size = None
 

--- a/tests/db_functions/test_cast.py
+++ b/tests/db_functions/test_cast.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.db import connection, models
+from django.db import models
 from django.db.models.expressions import Value
 from django.db.models.functions import Cast
 from django.test import TestCase, ignore_warnings, skipUnlessDBFeature
@@ -51,9 +51,6 @@ class CastTests(TestCase):
 
     def test_cast_from_python_to_datetime(self):
         now = datetime.datetime.now()
-        if connection.vendor == 'oracle':
-            # Workaround until #28934 is fixed.
-            now = now.replace(microsecond=0)
         dates = Author.objects.annotate(cast_datetime=Cast(now, models.DateTimeField()))
         self.assertEqual(dates.get().cast_datetime, now)
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28934

`test_cast_from_python_to_datetime` should fail on SQLite (see https://github.com/django/django/pull/9460).