### PR TITLE
Fixed #28938 -- Clarified Python compatibility in tutorial

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -23,12 +23,12 @@ in a shell prompt (indicated by the $ prefix):
 If Django is installed, you should see the version of your installation. If it
 isn't, you'll get an error telling "No module named django".
 
-This tutorial is written for Django |version| and Python 3.5 or later. If the
-Django version doesn't match, you can refer to the tutorial for your version
-of Django by using the version switcher at the bottom right corner of this
-page, or update Django to the newest version. If you are still using Python
-2.7, you will need to adjust the code samples slightly, as described in
-comments.
+This tutorial is written for Django |version|, which supports Python 3.5 and
+later. If the Django version doesn't match, you can refer to the tutorial for
+your version of Django by using the version switcher at the bottom right corner
+of this page, or update Django to the newest version. If you're using an older
+version of Python, check :ref:`faq-python-version-support` to find a compatible
+version of Django.
 
 See :doc:`How to install Django </topics/install>` for advice on how to remove
 older versions of Django and install a newer one.


### PR DESCRIPTION
Made it clear that uses of Python 3.4 and older must use another
version of Django.