### PR TITLE
Fixed #28947 -- Fixed crash when coercing a translatable URL pattern to str.

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -182,7 +182,7 @@ class RegexPattern(CheckURLMixin):
             )
 
     def __str__(self):
-        return self._regex
+        return str(self._regex)
 
 
 _PATH_PARAMETER_COMPONENT_RE = re.compile(
@@ -270,7 +270,7 @@ class RoutePattern(CheckURLMixin):
         return re.compile(_route_to_regex(route, self._is_endpoint)[0])
 
     def __str__(self):
-        return self._route
+        return str(self._route)
 
 
 class LocalePrefixPattern:

--- a/docs/releases/2.0.1.txt
+++ b/docs/releases/2.0.1.txt
@@ -31,3 +31,6 @@ Bugfixes
   trailing zeros in the fractional part truncated (:ticket:`28915`).
 
 * Fixed crash in the ``testserver`` command startup (:ticket:`28941`).
+
+* Fixed crash when coercing a translatable URL pattern to ``str``
+  (:ticket:`28947`).

--- a/tests/urlpatterns/test_resolvers.py
+++ b/tests/urlpatterns/test_resolvers.py
@@ -1,0 +1,15 @@
+from django.test import SimpleTestCase
+from django.urls.resolvers import RegexPattern, RoutePattern
+from django.utils.translation import gettext_lazy as _
+
+
+class RegexPatternTests(SimpleTestCase):
+
+    def test_str(self):
+        self.assertEqual(str(RegexPattern(_('^translated/$'))), '^translated/$')
+
+
+class RoutePatternTests(SimpleTestCase):
+
+    def test_str(self):
+        self.assertEqual(str(RoutePattern(_('translated/'))), 'translated/')


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/28947

I'm unsure where to put regression tests for those, any recommendations?