### PR TITLE
Refs #28459 -- Improved performance of loading DecimalField on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -39,7 +39,6 @@ Database.register_converter("date", decoder(parse_date))
 Database.register_converter("datetime", decoder(parse_datetime))
 Database.register_converter("timestamp", decoder(parse_datetime))
 Database.register_converter("TIMESTAMP", decoder(parse_datetime))
-Database.register_converter("decimal", decoder(decimal.Decimal))
 
 Database.register_adapter(decimal.Decimal, backend_utils.rev_typecast_decimal)
 

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1560,20 +1560,6 @@ class DecimalField(Field):
                 params={'value': value},
             )
 
-    def format_number(self, value):
-        """
-        Format a number into a string with the requisite number of digits and
-        decimal places.
-        """
-        # Method moved to django.db.backends.utils.
-        #
-        # It is preserved because it is used by the oracle backend
-        # (django.db.backends.oracle.query), and also for
-        # backwards-compatibility with any external code which may have used
-        # this method.
-        from django.db.backends import utils
-        return utils.format_number(value, self.max_digits, self.decimal_places)
-
     def get_db_prep_save(self, value, connection):
         return connection.ops.adapt_decimalfield_value(self.to_python(value), self.max_digits, self.decimal_places)
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
In [2]: %timeit for x in DecimalModel.objects.values_list('d'): pass
128 ms ± 531 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit for x in DecimalModel.objects.values_list(models.F('d') + 1): pass
39.5 ms ± 542 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After:
```
In [2]: %timeit for x in DecimalModel.objects.values_list('d'): pass
31.8 ms ± 490 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit for x in DecimalModel.objects.values_list(models.F('d') + 1): pass
20.3 ms ± 579 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```