### PR TITLE
Refs #28459 -- Improved performance of loading DurationField on SQLite and MySQL.

### DIFF
--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import NotSupportedError, transaction
 from django.db.backends import utils
 from django.utils import timezone
-from django.utils.dateparse import parse_duration
 from django.utils.encoding import force_text
 
 
@@ -568,9 +567,7 @@ class BaseDatabaseOperations:
 
     def convert_durationfield_value(self, value, expression, connection):
         if value is not None:
-            value = str(decimal.Decimal(value) / decimal.Decimal(1000000))
-            value = parse_duration(value)
-        return value
+            return datetime.timedelta(0, 0, value)
 
     def check_expression_support(self, expression):
         """

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -94,6 +94,12 @@ class Avg(Aggregate):
             return FloatField()
         return super()._resolve_output_field()
 
+    def as_mysql(self, compiler, connection):
+        sql, params = super().as_sql(compiler, connection)
+        if self.output_field.get_internal_type() == 'DurationField':
+            sql = 'CAST(%s as SIGNED)' % sql
+        return sql, params
+
     def as_oracle(self, compiler, connection):
         if self.output_field.get_internal_type() == 'DurationField':
             expression = self.get_source_expressions()[0]
@@ -152,6 +158,12 @@ class StdDev(Aggregate):
 class Sum(Aggregate):
     function = 'SUM'
     name = 'Sum'
+
+    def as_mysql(self, compiler, connection):
+        sql, params = super().as_sql(compiler, connection)
+        if self.output_field.get_internal_type() == 'DurationField':
+            sql = 'CAST(%s as SIGNED)' % sql
+        return sql, params
 
     def as_oracle(self, compiler, connection):
         if self.output_field.get_internal_type() == 'DurationField':


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
%timeit for x in DurationModel.objects.values_list('d'): pass
168 ms ± 678 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
After:
```
%timeit for x in DurationModel.objects.values_list('d'): pass
23.1 ms ± 243 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```