### PR TITLE
Deleted unused order_by-variable assignment in QuerySet._earliest_or_…

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -562,7 +562,6 @@ class QuerySet:
         if fields and field_name is not None:
             raise ValueError('Cannot use both positional arguments and the field_name keyword argument.')
 
-        order_by = None
         if field_name is not None:
             warnings.warn(
                 'The field_name keyword argument to earliest() and latest() '


### PR DESCRIPTION
…latest

All three branches re-assign it. Seems to have been unused since its introduction in ad4a8acdb55a80a6a6dec60724b22abed0025399