### PR TITLE
Fixed #28966 -- Doc'd that the uuid URL path converter requires dashes.

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -127,9 +127,10 @@ The following path converters are available by default:
   plus the hyphen and underscore characters. For example,
   ``building-your-1st-django-site``.
 
-* ``uuid`` - Matches a formatted UUID (letters must be lowercase). For example,
-  ``075194d3-6885-417e-a8a8-6c931e272f00``. Returns a :class:`~uuid.UUID`
-  instance.
+* ``uuid`` - Matches a formatted UUID. To prevent multiple URLs from mapping to
+  the same page, dashes must be included and letters must be lowercase. For
+  example, ``075194d3-6885-417e-a8a8-6c931e272f00``. Returns a
+  :class:`~uuid.UUID` instance.
 
 * ``path`` - Matches any non-empty string, including the path separator,
   ``'/'``. This allows you to match against a complete URL path rather than


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28966