### PR TITLE
Fixed #28117 -- Added a helpful message in loaddata when psycopg2 can't load a fixture due to NUL(0x00) characters.

### DIFF
--- a/django/core/management/commands/loaddata.py
+++ b/django/core/management/commands/loaddata.py
@@ -180,7 +180,8 @@ class Command(BaseCommand):
                                     '\rProcessed %i object(s).' % loaded_objects_in_fixture,
                                     ending=''
                                 )
-                        except (DatabaseError, IntegrityError) as e:
+                        # psycopg2 raises ValueError if data contains NUL chars.
+                        except (DatabaseError, IntegrityError, ValueError) as e:
                             e.args = ("Could not load %(app_label)s.%(object_name)s(pk=%(pk)s): %(error_msg)s" % {
                                 'app_label': obj.object._meta.app_label,
                                 'object_name': obj.object._meta.object_name,

--- a/tests/fixtures/fixtures/null_character_in_field_value.json
+++ b/tests/fixtures/fixtures/null_character_in_field_value.json
@@ -1,0 +1,10 @@
+[
+    {
+        "pk": "2",
+        "model": "fixtures.article",
+        "fields": {
+            "headline": "Poker has no place on ESPN\u0000",
+            "pub_date": "2006-06-16 12:00:00"
+        }
+    }
+]

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -571,6 +571,15 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
             management.call_command('loaddata', 'invalid.json', verbosity=0)
             self.assertIn("Could not load fixtures.Article(pk=1):", cm.exception.args[0])
 
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'psycopg2 prohibits null characters in data.')
+    def test_loaddata_null_characters_on_postgresql(self):
+        msg = (
+            'Could not load fixtures.Article(pk=2): '
+            'A string literal cannot contain NUL (0x00) characters.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            management.call_command('loaddata', 'null_character_in_field_value.json')
+
     def test_loaddata_app_option(self):
         with self.assertRaisesMessage(CommandError, "No fixture named 'db_fixture_1' found."):
             management.call_command('loaddata', 'db_fixture_1', verbosity=0, app_label="someotherapp")


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28117