### PR TITLE
Fixed #24754 -- Added support for per-app permissions (not tied to a model)

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -53,8 +53,8 @@ class ModelBackend:
                 perms = Permission.objects.all()
             else:
                 perms = getattr(self, '_get_%s_permissions' % from_name)(user_obj)
-            perms = perms.values_list('content_type__app_label', 'codename').order_by()
-            setattr(user_obj, perm_cache_name, {"%s.%s" % (ct, name) for ct, name in perms})
+            perms = perms.values_list('content_type__app_label', 'app_label', 'codename').order_by()
+            setattr(user_obj, perm_cache_name, {"%s.%s" % (ct or app_label, name) for ct, app_label, name in perms})
         return getattr(user_obj, perm_cache_name)
 
     def get_user_permissions(self, user_obj, obj=None):

--- a/django/contrib/auth/migrations/0010_alter_permission_content_type_null.py
+++ b/django/contrib/auth/migrations/0010_alter_permission_content_type_null.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0009_alter_user_last_name_max_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='permission',
+            name='content_type',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE,
+                                    to='contenttypes.ContentType', verbose_name='content type'),
+        ),
+        migrations.AddField(
+            model_name='permission',
+            name='app_label',
+            field=models.CharField(max_length=100, blank=True, default=''),
+        ),
+    ]

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -351,12 +351,16 @@ fields:
 
     .. attribute:: content_type
 
-        Required. A reference to the ``django_content_type`` database table,
+	Optional. A reference to the ``django_content_type`` database table,
         which contains a record for each installed model.
 
     .. attribute:: codename
 
         Required. 100 characters or fewer. Example: ``'can_vote'``.
+
+    .. attribute:: app_label
+
+       Optional. 100 characters or fewer. Example: ``'myapp'``.
 
 Methods
 -------

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -48,6 +48,10 @@ Minor features
 * :djadmin:`createsuperuser` now gives a prompt to allow bypassing the
   :setting:`AUTH_PASSWORD_VALIDATORS` checks.
 
+* The :attr:`.Permission.content_type` field is now nullable.
+
+* A new field :attr:`.Permission.app_label` has been added.
+
 :mod:`django.contrib.contenttypes`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/auth_tests/custom_perms/__init__.py
+++ b/tests/auth_tests/custom_perms/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'auth_tests.custom_perms.apps.CustomAppConfig'

--- a/tests/auth_tests/custom_perms/apps.py
+++ b/tests/auth_tests/custom_perms/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class CustomAppConfig(AppConfig):
+    name = 'auth_tests.custom_perms'
+    permissions = [
+        ('can_haz', 'Can haz cheeseburger.'),
+    ]


### PR DESCRIPTION
- Allow Permission.content_type to be Null
- Add settings.GLOBAL_PERMS as a list of permission details
- Update a few places to handle ContentType being None.
