### PR TITLE
[WIP] Fixes 28975 -- Allows to skip create extension statement for postgis

### DIFF
--- a/django/contrib/gis/db/backends/postgis/base.py
+++ b/django/contrib/gis/db/backends/postgis/base.py
@@ -21,6 +21,12 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
 
     def prepare_database(self):
         super().prepare_database()
-        # Check that postgis extension is installed.
         with self.cursor() as cursor:
+            cursor.execute(
+                """SELECT installed_version
+                FROM pg_available_extensions
+                WHERE name ='postgis';"""
+            )
+            if cursor.fetchone()[0]:
+                return
             cursor.execute("CREATE EXTENSION IF NOT EXISTS postgis")

--- a/docs/ref/contrib/gis/install/postgis.txt
+++ b/docs/ref/contrib/gis/install/postgis.txt
@@ -37,8 +37,11 @@ functionality::
     > CREATE EXTENSION postgis;
 
 The database user must be a superuser in order to run
-``CREATE EXTENSION postgis;``. The command is run during the :djadmin:`migrate`
-process. An alternative is to use a migration operation in your project::
+``CREATE EXTENSION postgis;`` which is run during the :djadmin:`migrate`
+process. However if the extension already exists it wont create it
+during this process, hence the database user does not need superuser
+status to proceed. An alternative is to use a migration operation
+in your project::
 
     from django.contrib.postgres.operations import CreateExtension
     from django.db import migrations

--- a/tests/gis_tests/test_postgis_extension.py
+++ b/tests/gis_tests/test_postgis_extension.py
@@ -1,0 +1,75 @@
+import unittest
+
+from django.db import connection
+from django.test import TestCase
+
+
+@unittest.skipUnless(connection.vendor == 'postgresql', "PostgreSQL specific tests")
+class TestsPostGISCreateExtension(TestCase):
+
+    def setUp(self):
+        """
+        Make extension is not available initially
+        """
+        new_connection = connection.copy()
+        try:
+            with new_connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT installed_version FROM
+                    pg_available_extensions WHERE name = 'postgis';
+                    """
+                )
+                if cursor.fetchone()[0] is not None:
+                    cursor.execute("""DROP EXTENSION postgis CASCADE;""")
+        finally:
+            new_connection.close()
+
+    def test_extension_is_created(self):
+        """
+        Create PostGIS extension
+        if it does not exists.
+        """
+        new_connection = connection.copy()
+        try:
+            with new_connection.cursor() as cursor:
+                cursor.execute(
+                    """SELECT installed_version
+                    FROM pg_available_extensions
+                    WHERE name ='postgis';"""
+                )
+                self.assertIsNone(cursor.fetchone()[0])
+                new_connection.prepare_database()
+                cursor.execute(
+                    """SELECT installed_version
+                    FROM pg_available_extensions
+                    WHERE name ='postgis';"""
+                )
+                self.assertTrue(cursor.fetchone()[0])
+                new_connection.close()
+        finally:
+            new_connection.close()
+
+    def test_extension_is_not_created(self):
+        """
+        Dont create PostGIS extension
+        if it exists.
+        """
+        new_connection = connection.copy()
+        try:
+            with new_connection.cursor() as cursor:
+                cursor.execute(
+                    """SELECT installed_version
+                    FROM pg_available_extensions
+                    WHERE name ='postgis';"""
+                )
+                new_connection.prepare_database()
+                cursor.execute(
+                    """SELECT installed_version
+                    FROM pg_available_extensions
+                    WHERE name ='postgis';"""
+                )
+                self.assertTrue(cursor.fetchone()[0])
+        finally:
+            new_connection.prepare_database()
+            new_connection.close()


### PR DESCRIPTION
Background: https://code.djangoproject.com/ticket/28975

This patch check for the result of `SELECT installed_version FROM pg_available_extensions WHERE name ='postgis';` - if it returns something, the function simply returns since we dont want to create the extension then - however if it doesnt return anything the expected behaivor of autocreating the extension is executed.

Allows for a bit more freedom when running the migration with a non-superuser db user. However it will still raise:
```
django.db.utils.ProgrammingError: permission denied to create extension "postgis"
HINT:  Must be superuser to create this extension.
```

..if the extension does not exist, and the user is not a superuser.

* [x] logic
* [x] docs
* [ ] tests
* [ ] ready to merge
