### PR TITLE
Fixed #28986 -- Prevented boolean values in admin list display from being formatted with thousand separator.

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -418,6 +418,8 @@ def display_for_value(value, empty_value_display, boolean=False):
         return _boolean_icon(value)
     elif value is None:
         return empty_value_display
+    elif isinstance(value, bool):
+        return str(value)
     elif isinstance(value, datetime.datetime):
         return formats.localize(timezone.template_localtime(value))
     elif isinstance(value, (datetime.date, datetime.time)):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -210,6 +210,8 @@ class UtilsTests(SimpleTestCase):
             display_for_value(False, '', boolean=True),
             '<img src="/static/admin/img/icon-no.svg" alt="False" />'
         )
+        self.assertEqual(display_for_value(True, ''), 'True')
+        self.assertEqual(display_for_value(False, ''), 'False')
 
     def test_label_for_field(self):
         """

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -200,6 +200,17 @@ class UtilsTests(SimpleTestCase):
         display_value = display_for_value([1, 2, 'buckle', 'my', 'shoe'], self.empty_value)
         self.assertEqual(display_value, '1, 2, buckle, my, shoe')
 
+    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    def test_list_display_for_value_boolean(self):
+        self.assertEqual(
+            display_for_value(True, '', boolean=True),
+            '<img src="/static/admin/img/icon-yes.svg" alt="True" />'
+        )
+        self.assertEqual(
+            display_for_value(False, '', boolean=True),
+            '<img src="/static/admin/img/icon-no.svg" alt="False" />'
+        )
+
     def test_label_for_field(self):
         """
         Tests for label_for_field


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28986