### PR TITLE
Documenation: include example of get_FOO_display for choices

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -123,6 +123,12 @@ define a suitably-named constant for each value::
         def is_upperclass(self):
             return self.year_in_school in (self.JUNIOR, self.SENIOR)
 
+        def full_and_short_display(self):
+            return '{} ({})'.format(
+                self.get_year_in_school_display(),
+                self.year_in_school,
+            )
+
 Though you can define a choices list outside of a model class and then
 refer to it, defining the choices and names for each choice inside the
 model class keeps all of that information with the class that uses it,


### PR DESCRIPTION
It is easy to miss in the middle of the paragraph below the examples. With this, we show how, then explain why.