### PR TITLE
Fixed #28859 -- Made Oracle backend raise DatabaseError if "no data found" exception is hidden by the Oracle OCI library.

### DIFF
--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -2,6 +2,10 @@ import unittest
 
 from django.db import connection
 from django.db.models.fields import BooleanField, NullBooleanField
+from django.db.utils import DatabaseError
+from django.test import TransactionTestCase
+
+from ..models import Square
 
 
 @unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
@@ -61,3 +65,32 @@ class Tests(unittest.TestCase):
             with self.subTest(field=field):
                 field.set_attributes_from_name('is_nice')
                 self.assertIn('"IS_NICE" IN (0,1)', field.db_check(connection))
+
+
+@unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
+class HiddenNoDataFoundExceptionTest(TransactionTestCase):
+    available_apps = ['backends']
+
+    def test_hidden_no_data_found_exception(self):
+        # "ORA-1403: no data found" exception is hidden by Oracle OCI library
+        # when an INSERT statement is used with a RETURNING clause (see #28859).
+        with connection.cursor() as cursor:
+            # Create trigger that raises "ORA-1403: no data found".
+            cursor.execute("""
+                CREATE OR REPLACE TRIGGER "TRG_NO_DATA_FOUND"
+                AFTER INSERT ON "BACKENDS_SQUARE"
+                FOR EACH ROW
+                BEGIN
+                    RAISE NO_DATA_FOUND;
+                END;
+            """)
+        try:
+            with self.assertRaisesMessage(DatabaseError, (
+                'The database did not return a new row id. Probably "ORA-1403: '
+                'no data found" was raised internally but was hidden by the '
+                'Oracle OCI library (see https://code.djangoproject.com/ticket/28859).'
+            )):
+                Square.objects.create(root=2, square=4)
+        finally:
+            with connection.cursor() as cursor:
+                cursor.execute('DROP TRIGGER "TRG_NO_DATA_FOUND"')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28859