### PR TITLE
Refs #28459 -- Improved performance of duration expressions on SQLite.

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -1,6 +1,7 @@
 """
 SQLite3 backend for the sqlite3 module in the standard library.
 """
+import datetime
 import decimal
 import math
 import re
@@ -14,7 +15,7 @@ from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils import timezone
-from django.utils.dateparse import parse_datetime, parse_duration, parse_time
+from django.utils.dateparse import parse_datetime, parse_time
 from django.utils.duration import duration_microseconds
 
 from .client import DatabaseClient                          # isort:skip
@@ -426,20 +427,11 @@ def _sqlite_format_dtdelta(conn, lhs, rhs):
     """
     LHS and RHS can be either:
     - An integer number of microseconds
-    - A string representing a timedelta object
     - A string representing a datetime
     """
     try:
-        if isinstance(lhs, int):
-            lhs = str(decimal.Decimal(lhs) / decimal.Decimal(1000000))
-        real_lhs = parse_duration(lhs)
-        if real_lhs is None:
-            real_lhs = backend_utils.typecast_timestamp(lhs)
-        if isinstance(rhs, int):
-            rhs = str(decimal.Decimal(rhs) / decimal.Decimal(1000000))
-        real_rhs = parse_duration(rhs)
-        if real_rhs is None:
-            real_rhs = backend_utils.typecast_timestamp(rhs)
+        real_lhs = datetime.timedelta(0, 0, lhs) if isinstance(lhs, int) else backend_utils.typecast_timestamp(lhs)
+        real_rhs = datetime.timedelta(0, 0, rhs) if isinstance(rhs, int) else backend_utils.typecast_timestamp(rhs)
         if conn.strip() == '+':
             out = real_lhs + real_rhs
         else:

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -10,7 +10,7 @@ from django.db.models import aggregates, fields
 from django.db.models.expressions import Col
 from django.utils import timezone
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
-from django.utils.duration import duration_string
+from django.utils.duration import duration_microseconds
 
 
 class DatabaseOperations(BaseDatabaseOperations):
@@ -63,7 +63,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "django_date_extract('%s', %s)" % (lookup_type.lower(), field_name)
 
     def date_interval_sql(self, timedelta):
-        return "'%s'" % duration_string(timedelta)
+        return str(duration_microseconds(timedelta))
 
     def format_for_duration_arithmetic(self, sql):
         """Do nothing since formatting is handled in the custom function."""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28459

Before:
```
%timeit for x in Date.objects.annotate(d=models.ExpressionWrapper(models.F('date') + models.F('duration'), models.DateTimeField())).values_list('d'): pass
591 ms ± 21.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
%timeit for x in Date.objects.annotate(d=models.ExpressionWrapper(models.F('date') + models.F('duration'), models.DateTimeField())).values_list('d'): pass
390 ms ± 2.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```