### PR TITLE
Refs #17476 -- Removed obsolete simplification of timezone names in cache key generation.

### DIFF
--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -24,7 +24,7 @@ import time
 from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpResponse, HttpResponseNotModified
-from django.utils.encoding import force_bytes, force_text, iri_to_uri
+from django.utils.encoding import force_bytes, iri_to_uri
 from django.utils.http import (
     http_date, parse_etags, parse_http_date_safe, quote_etag,
 )
@@ -297,9 +297,7 @@ def _i18n_cache_key_suffix(request, cache_key):
     if settings.USE_TZ:
         # The datetime module doesn't restrict the output of tzname().
         # Windows is known to use non-standard, locale-dependent names.
-        # User-defined tzinfo classes may return absolutely anything.
-        # Hence this paranoid conversion to create a valid cache key.
-        tz_name = force_text(get_current_timezone_name(), errors='ignore')
+        tz_name = get_current_timezone_name()
         cache_key += '.%s' % tz_name.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
     return cache_key
 

--- a/django/utils/cache.py
+++ b/django/utils/cache.py
@@ -295,10 +295,7 @@ def _i18n_cache_key_suffix(request, cache_key):
         # which in turn can also fall back to settings.LANGUAGE_CODE
         cache_key += '.%s' % getattr(request, 'LANGUAGE_CODE', get_language())
     if settings.USE_TZ:
-        # The datetime module doesn't restrict the output of tzname().
-        # Windows is known to use non-standard, locale-dependent names.
-        tz_name = get_current_timezone_name()
-        cache_key += '.%s' % tz_name.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
+        cache_key += '.%s' % get_current_timezone_name()
     return cache_key
 
 

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -98,12 +98,7 @@ def get_current_timezone_name():
 
 def _get_timezone_name(timezone):
     """Return the name of ``timezone``."""
-    try:
-        # for pytz timezones
-        return timezone.zone
-    except AttributeError:
-        # for regular tzinfo objects
-        return timezone.tzname(None)
+    return timezone.tzname(None)
 
 # Timezone selection functions.
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1,7 +1,6 @@
 # Unit tests for cache framework
 # Uses whatever cache backend is set in the test settings file.
 import copy
-import datetime
 import io
 import os
 import pickle
@@ -1856,10 +1855,7 @@ class CacheI18nTest(TestCase):
     @override_settings(USE_I18N=False, USE_L10N=False, USE_TZ=True)
     def test_cache_key_i18n_timezone(self):
         request = self.factory.get(self.path)
-        # This is tightly coupled to the implementation,
-        # but it's the most straightforward way to test the key.
         tz = timezone.get_current_timezone_name()
-        tz = tz.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
         response = HttpResponse()
         key = learn_cache_key(request, response)
         self.assertIn(tz, key, "Cache keys should include the time zone name when time zones are active")
@@ -1871,23 +1867,10 @@ class CacheI18nTest(TestCase):
         request = self.factory.get(self.path)
         lang = translation.get_language()
         tz = timezone.get_current_timezone_name()
-        tz = tz.encode('ascii', 'ignore').decode('ascii').replace(' ', '_')
         response = HttpResponse()
         key = learn_cache_key(request, response)
         self.assertNotIn(lang, key, "Cache keys shouldn't include the language name when i18n isn't active")
         self.assertNotIn(tz, key, "Cache keys shouldn't include the time zone name when i18n isn't active")
-
-    @override_settings(USE_I18N=False, USE_L10N=False, USE_TZ=True)
-    def test_cache_key_with_non_ascii_tzname(self):
-        # Timezone-dependent cache keys should use ASCII characters only
-        # (#17476).
-        request = self.factory.get(self.path)
-        response = HttpResponse()
-        with timezone.override(datetime.timezone(datetime.timedelta(), 'Hora estándar de Argentina')):
-            self.assertIn(
-                'Hora_estndar_de_Argentina', learn_cache_key(request, response),
-                "Cache keys should include the time zone name when time zones are active"
-            )
 
     @override_settings(
         CACHE_MIDDLEWARE_KEY_PREFIX="test",


### PR DESCRIPTION
`tzname()` of correctly implemented `tzinfo` subclass must return string: https://docs.python.org/3/library/datetime.html#datetime.tzinfo.tzname.

```
In [190]: class CustomTZ(datetime.tzinfo):
     ...:     def tzname(self, dt):
     ...:         return b'bytes'
     ...: 

In [191]: datetime.datetime(1, 1, 1, tzinfo=CustomTZ()).tzname()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-191-1f9927218b78> in <module>()
----> 1 datetime.datetime(1, 1, 1, tzinfo=CustomTZ()).tzname()

TypeError: tzinfo.tzname() must return None or a string, not 'bytes'
```
Reverted 3367913c3db97a15b64f03646ac2c4486a77376f and more.