### PR TITLE
Fixed #28016 -- Made createsuperuser validate --username input.

### DIFF
--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -657,6 +657,34 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
 
         test(self)
 
+    def test_existing_username_non_interactive(self):
+        """Creation fails if the username already exists."""
+        User.objects.create(username='janet')
+        new_io = StringIO()
+
+        with self.assertRaisesMessage(CommandError, "Error: That Username is already taken."):
+            call_command(
+                'createsuperuser',
+                username='janet',
+                email='',
+                interactive=False,
+                stdout=new_io,
+            )
+
+    def test_existing_username_interactive(self):
+        """Creation fails if the username already exists."""
+        User.objects.create(username='janet')
+        new_io = StringIO()
+
+        with self.assertRaisesMessage(CommandError, "Error: That Username is already taken."):
+            call_command(
+                'createsuperuser',
+                username='janet',
+                email='',
+                interactive=False,
+                stdout=new_io,
+            )
+
     def test_validation_mismatched_passwords(self):
         """
         Creation should fail if the user enters mismatched passwords.


### PR DESCRIPTION
when I create the superuser with `--username` and the user already exists, command results in: 
`django.db.utils.IntegrityError: UNIQUE constraint failed: auth_user.username`
and there is no username uniqueness checking in this state. and same behavior when I create the superuser with `--username` and `--noinput`.