### PR TITLE
Fixed #29001 -- Prevented hstore/citext support from being dropped in low memory situations.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -26,7 +26,7 @@ class PostgresConfig(AppConfig):
                 })
                 if conn.connection is not None:
                     register_type_handlers(conn)
-        connection_created.connect(register_type_handlers)
+        connection_created.connect(register_type_handlers, weak=False)
         CharField.register_lookup(Unaccent)
         TextField.register_lookup(Unaccent)
         CharField.register_lookup(SearchLookup)


### PR DESCRIPTION
The postgres hstore integration breaks if this weakref is ever garbage collected.
https://code.djangoproject.com/ticket/29001