### PR TITLE
Fixed #29002 -- Corrected cached template loader docs about when it's automatically enabled.

### DIFF
--- a/docs/ref/templates/api.txt
+++ b/docs/ref/templates/api.txt
@@ -908,8 +908,10 @@ loaders that come with Django:
     ``Template`` in memory. The cached ``Template`` instance is returned for
     subsequent requests to load the same template.
 
-    This loader is automatically enabled if :setting:`DEBUG` is ``False`` and
-    :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified.
+    This loader is automatically enabled if :setting:`OPTIONS['loaders']
+    <TEMPLATES-OPTIONS>` isn't specified and :setting:`OPTIONS['debug']
+    <TEMPLATES-OPTIONS>` is ``False`` (the latter option defaults to the value
+    of :setting:`DEBUG`).
 
     You can also enable template caching with some custom template loaders
     using settings like this::

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -698,8 +698,9 @@ Miscellaneous
   1.0) is removed.
 
 * The :class:`cached template loader <django.template.loaders.cached.Loader>`
-  is now enabled if :setting:`DEBUG` is ``False`` and
-  :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't specified. This could
+  is now enabled if :setting:`OPTIONS['loaders'] <TEMPLATES-OPTIONS>` isn't
+  specified and :setting:`OPTIONS['debug'] <TEMPLATES-OPTIONS>` is ``False``
+  (the latter option defaults to the value of :setting:`DEBUG`). This could
   be backwards-incompatible if you have some :ref:`template tags that aren't
   thread safe <template_tag_thread_safety>`.
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29002