### PR TITLE
Fixed #28960 -- Added GEOSGeometry.buffer_with_style().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -752,6 +752,7 @@ answer newbie questions, and generally made Django that much better:
     Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
     Stanislas Guerra <stan@slashdev.me>
     Stanislaus Madueke
+    Stanislav Karpov <work@stkrp.ru>
     starrynight <cmorgh@gmail.com>
     Stefane Fermgier <sf@fermigier.com>
     Stefano Rivera <stefano@rivera.za.net>

--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -499,6 +499,18 @@ class GEOSGeometryBase(GEOSBase):
         """
         return self._topology(capi.geos_buffer(self.ptr, width, quadsegs))
 
+    def buffer_with_style(self, width, quadsegs=8, end_cap_style=1, join_style=1, mitre_limit=5.0):
+        """
+        Same as buffer() but allows customizing the style of the buffer.
+
+        End cap style can be round (1), flat (2), or square (3).
+        Join style can be round (1), mitre (2), or bevel (3).
+        Mitre ratio limit only affects mitered join style.
+        """
+        return self._topology(
+            capi.geos_bufferwithstyle(self.ptr, width, quadsegs, end_cap_style, join_style, mitre_limit),
+        )
+
     @property
     def centroid(self):
         """

--- a/django/contrib/gis/geos/prototypes/topology.py
+++ b/django/contrib/gis/geos/prototypes/topology.py
@@ -21,6 +21,7 @@ class Topology(GEOSFuncFactory):
 # Topology Routines
 geos_boundary = Topology('GEOSBoundary')
 geos_buffer = Topology('GEOSBuffer', argtypes=[GEOM_PTR, c_double, c_int])
+geos_bufferwithstyle = Topology('GEOSBufferWithStyle', argtypes=[GEOM_PTR, c_double, c_int, c_int, c_int, c_double])
 geos_centroid = Topology('GEOSGetCentroid')
 geos_convexhull = Topology('GEOSConvexHull')
 geos_difference = Topology('GEOSDifference', argtypes=[GEOM_PTR, GEOM_PTR])

--- a/docs/ref/contrib/gis/geos.txt
+++ b/docs/ref/contrib/gis/geos.txt
@@ -496,6 +496,16 @@ Topological Methods
     optional ``quadsegs`` keyword sets the number of segments used to
     approximate a quarter circle (defaults is 8).
 
+.. method:: GEOSGeometry.buffer_with_style(width, quadsegs=8, end_cap_style=1, join_style=1, mitre_limit=5.0)
+
+    .. versionadded:: 2.1
+
+    Same as :meth:`buffer`, but allows customizing the style of the buffer.
+
+    * ``end_cap_style`` can be round (``1``), flat (``2``), or square (``3``).
+    * ``join_style`` can be round (``1``), mitre (``2``), or bevel (``3``).
+    * Mitre ratio limit (``mitre_limit``) only affects mitered join style.
+
 .. method:: GEOSGeometry.difference(other)
 
     Returns a :class:`GEOSGeometry` representing the points making up this

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -70,7 +70,9 @@ Minor features
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :meth:`.GEOSGeometry.buffer_with_style` method is a version of
+  :meth:`~.GEOSGeometry.buffer` that allows customizing the style of the
+  buffer.
 
 :mod:`django.contrib.messages`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -407,6 +407,7 @@ minified
 minify
 mis
 misconfiguration
+mitre
 mixin
 mixins
 modelforms

--- a/tests/gis_tests/data/geometries.json
+++ b/tests/gis_tests/data/geometries.json
@@ -78,6 +78,24 @@
        "width": 2.0, "quadsegs": 8
       }
   ],
+  "buffer_with_style_geoms": [
+      {"wkt": "POINT (0 0)",
+       "buffer_wkt": "POLYGON EMPTY",
+       "width": 5.0, "end_cap_style": 2, "join_style": 2
+      },
+      {"wkt": "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))",
+       "buffer_wkt": "POLYGON ((-2 -2, -2 12, 12 12, 12 -2, -2 -2))",
+       "width": 2.0, "end_cap_style": 2, "join_style": 2
+      },
+      {"wkt": "LINESTRING (0 0, 10 0)",
+       "buffer_wkt": "POLYGON ((10 2, 10 -2, 0 -2, 0 2, 10 2))",
+       "width": 2.0, "end_cap_style": 2, "join_style": 2
+      },
+      {"wkt": "LINESTRING (0 0, 10 0, 10 10, 0 10)",
+       "buffer_wkt": "POLYGON ((8 2, 8 8, 0 8, 0 12, 12 12, 12 -2, 0 -2, 0 2, 8 2))",
+       "width": 2.0, "end_cap_style": 2, "join_style": 2
+      }
+  ],
   "relate_geoms": [
       {"wkt_a": "MULTIPOINT(80 70, 20 20, 200 170, 140 120)",
        "wkt_b": "MULTIPOINT(80 170, 140 120, 200 80, 80 70)",


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/28960

Possible improvement, for which I could not find a place:
```
/// End cap styles
enum EndCapStyle {

    /// Specifies a round line buffer end cap style.
    CAP_ROUND=1,

    /// Specifies a flat line buffer end cap style.
    CAP_FLAT=2,

    /// Specifies a square line buffer end cap style.
    CAP_SQUARE=3
};

/// Join styles
enum JoinStyle {
    
    /// Specifies a round join style.
    JOIN_ROUND=1,
    
    /// Specifies a mitre join style.
    JOIN_MITRE=2,
    
    /// Specifies a bevel join style.
    JOIN_BEVEL=3
};
```
Source: https://github.com/OSGeo/geos/blob/master/include/geos/operation/buffer/BufferParameters.h#L62