### PR TITLE
Fixed #28638 -- Made allowed_hosts a required argument of is_safe_url().

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -282,7 +282,7 @@ def is_same_domain(host, pattern):
     )
 
 
-def is_safe_url(url, allowed_hosts=None, require_https=False):
+def is_safe_url(url, allowed_hosts, require_https=False):
     """
     Return ``True`` if the url is a safe redirection (i.e. it doesn't point to
     a different host and uses a safe scheme).

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -245,6 +245,9 @@ Miscellaneous
   This change should be merely cosmetic except perhaps for antiquated browsers
   that don't parse the new format.
 
+* ``allowed_hosts`` is now a required argument of private API
+  ``django.utils.http.is_safe_url()``.
+
 .. _deprecated-features-2.1:
 
 Features deprecated in 2.1

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -161,9 +161,9 @@ class IsSafeURLTests(unittest.TestCase):
 
     def test_no_allowed_hosts(self):
         # A path without host is allowed.
-        self.assertIs(is_safe_url('/confirm/me@example.com'), True)
+        self.assertIs(is_safe_url('/confirm/me@example.com', allowed_hosts=None), True)
         # Basic auth without host is not allowed.
-        self.assertIs(is_safe_url(r'http://testserver\@example.com'), False)
+        self.assertIs(is_safe_url(r'http://testserver\@example.com', allowed_hosts=None), False)
 
     def test_secure_param_https_urls(self):
         secure_urls = (


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28638