### PR TITLE
Fixed #29006 -- Fixed DecimalField.clean() crash on sNaN values.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -351,7 +351,7 @@ class DecimalField(IntegerField):
         super().validate(value)
         if value in self.empty_values:
             return
-        if not math.isfinite(value):
+        if value.is_nan() or not math.isfinite(value):
             raise ValidationError(self.error_messages['invalid'], code='invalid')
 
     def widget_attrs(self, widget):

--- a/tests/forms_tests/field_tests/test_decimalfield.py
+++ b/tests/forms_tests/field_tests/test_decimalfield.py
@@ -51,6 +51,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = DecimalField(max_digits=4, decimal_places=2)
         values = (
             '-NaN', 'NaN', '+NaN',
+            '-sNaN', 'sNaN', '+sNaN',
             '-Inf', 'Inf', '+Inf',
             '-Infinity', 'Infinity', '+Infinity',
             'a', 'łąść', '1.0a', '--0.12',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29006