### PR TITLE
Removed unused query log clearing in bulk_create tests.

### DIFF
--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -121,11 +121,9 @@ class BulkCreateTests(TestCase):
         self.assertEqual(Restaurant.objects.count(), 2)
 
     def test_large_batch(self):
-        with override_settings(DEBUG=True):
-            connection.queries_log.clear()
-            TwoFields.objects.bulk_create([
-                TwoFields(f1=i, f2=i + 1) for i in range(0, 1001)
-            ])
+        TwoFields.objects.bulk_create([
+            TwoFields(f1=i, f2=i + 1) for i in range(0, 1001)
+        ])
         self.assertEqual(TwoFields.objects.count(), 1001)
         self.assertEqual(
             TwoFields.objects.filter(f1__gte=450, f1__lte=550).count(),
@@ -154,11 +152,10 @@ class BulkCreateTests(TestCase):
         Test inserting a large batch with objects having primary key set
         mixed together with objects without PK set.
         """
-        with override_settings(DEBUG=True):
-            connection.queries_log.clear()
-            TwoFields.objects.bulk_create([
-                TwoFields(id=i if i % 2 == 0 else None, f1=i, f2=i + 1)
-                for i in range(100000, 101000)])
+        TwoFields.objects.bulk_create([
+            TwoFields(id=i if i % 2 == 0 else None, f1=i, f2=i + 1)
+            for i in range(100000, 101000)
+        ])
         self.assertEqual(TwoFields.objects.count(), 1000)
         # We can't assume much about the ID's created, except that the above
         # created IDs must exist.


### PR DESCRIPTION
Left over after 32ac067a6ddca465cd94fc7ee35bfe54a675979b.