### PR TITLE
Fixed #28881 -- Documented that CommonPasswordValidator assumes lowercase

### DIFF
--- a/docs/topics/auth/passwords.txt
+++ b/docs/topics/auth/passwords.txt
@@ -550,13 +550,14 @@ Django includes four validators:
 
 .. class:: CommonPasswordValidator(password_list_path=DEFAULT_PASSWORD_LIST_PATH)
 
-    Validates whether the password is not a common password. By default, this
-    checks against a list of 1000 common password created by
-    `Mark Burnett <https://web.archive.org/web/20150315154609/https://xato.net/passwords/more-top-worst-passwords/>`_.
+    Validates whether the password is not a common password. This converts the
+    password to lowercase (to do a case-insensitive comparison) and checks it
+    against a list of 1000 common password created by `Mark Burnett
+    <https://web.archive.org/web/20150315154609/https://xato.net/passwords/more-top-worst-passwords/>`_.
 
     The ``password_list_path`` can be set to the path of a custom file of
-    common passwords. This file should contain one password per line and
-    may be plain text or gzipped.
+    common passwords. This file should contain one lowercase password per line
+    and may be plain text or gzipped.
 
 .. class:: NumericPasswordValidator()
 


### PR DESCRIPTION
Ticket: #28881 
Refs #9414 
Documented in Django's documentation that CommonPasswordValidator assumes reference set of common passwords to be in lowercase. Custom files of common passwords should be preprocessed to lowercase. 