### PR TITLE
Removed unnecessary .replace(microsecond=0) in SplitDateTimeWidget.

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -888,7 +888,7 @@ class SplitDateTimeWidget(MultiWidget):
     def decompress(self, value):
         if value:
             value = to_current_timezone(value)
-            return [value.date(), value.time().replace(microsecond=0)]
+            return [value.date(), value.time()]
         return [None, None]
 
 

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -359,7 +359,7 @@ foundation for custom widgets.
 
                 def decompress(self, value):
                     if value:
-                        return [value.date(), value.time().replace(microsecond=0)]
+                        return [value.date(), value.time()]
                     return [None, None]
 
         .. tip::


### PR DESCRIPTION
The microseconds are handled by the `TimeInput` subwidget.