### PR TITLE
Removed passing default argument of current TZ to make_aware/make_naive.

### DIFF
--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -174,6 +174,5 @@ def to_current_timezone(value):
     to naive datetimes in the current time zone for display.
     """
     if settings.USE_TZ and value is not None and timezone.is_aware(value):
-        current_timezone = timezone.get_current_timezone()
-        return timezone.make_naive(value, current_timezone)
+        return timezone.make_naive(value)
     return value

--- a/django/views/generic/dates.py
+++ b/django/views/generic/dates.py
@@ -267,7 +267,7 @@ class DateMixin:
         if self.uses_datetime_field:
             value = datetime.datetime.combine(value, datetime.time.min)
             if settings.USE_TZ:
-                value = timezone.make_aware(value, timezone.get_current_timezone())
+                value = timezone.make_aware(value)
         return value
 
     def _make_single_date_lookup(self, date):

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -100,7 +100,7 @@ class TestRangeContainsLookup(PostgreSQLTestCase):
             datetime.datetime(year=2016, month=2, day=2),
         ]
         cls.aware_timestamps = [
-            timezone.make_aware(timestamp, timezone.get_current_timezone())
+            timezone.make_aware(timestamp)
             for timestamp in cls.timestamps
         ]
         cls.dates = [


### PR DESCRIPTION
When the `timezone` argument is not passed `make_aware()`/`make_naive()`, it defaults to `get_current_timezone()`. Simplify the calling code by relying on this default.

There were additional case that I did not alter because the calling code would reuse the `get_current_timezone()` value.