### PR TITLE
Added exception raise when form_class not defined in FormMixin

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -24,6 +24,10 @@ class FormMixin(ContextMixin):
 
     def get_form_class(self):
         """Return the form class to use."""
+        if not self.form_class:
+            raise ImproperlyConfigured(
+                "'form_class' is not defined. Provide either a definition of "
+                "'form_class' or an implementation of 'get_form_class()'")
         return self.form_class
 
     def get_form(self, form_class=None):


### PR DESCRIPTION
Not having a form_class defined in FormView and parents will cause an Exception with a nonsensical error message and trace about NoneType not being callable.

This will check if form_class is defined, and raise ImproperlyConfigured Exception with a accurate error message for the user to define form_class or override get_form_class()