### PR TITLE
Fixed #29015 -- Added an exception if the PostgreSQL database name is too long.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -149,6 +149,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             raise ImproperlyConfigured(
                 "settings.DATABASES is improperly configured. "
                 "Please supply the NAME value.")
+        if len(settings_dict['NAME'] or '') > self.ops.max_name_length():
+            raise ImproperlyConfigured(
+                'Database names longer than %d characters are not supported by '
+                'PostgreSQL. Supply a shorter NAME in settings.DATABASES.'
+                % self.ops.max_name_length()
+            )
         conn_params = {
             'database': settings_dict['NAME'] or 'postgres',
             **settings_dict['OPTIONS'],


### PR DESCRIPTION
PostgreSQL imposes a limit of 63 bytes for all identifiers by default.
Added a 'NotSupportedError' if the NAME value in settings.DATABASES
is longer than 63 characters.
Uses 'len' method instead of 'sys.getsizeof' for getting the size.