### PR TITLE
Removed leftover text from the makemigrations docs.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -751,9 +751,6 @@ Enables fixing of migration conflicts.
 
 Allows naming the generated migration(s) instead of using a generated name.
 
-Makes ``makemigrations`` exit with error code 1 when no migrations are created
-(or would have been created, if combined with ``--dry-run``).
-
 .. django-admin-option:: --check
 
 Makes ``makemigrations`` exit with a non-zero status when model changes without


### PR DESCRIPTION
This text should have been removed in the following commit:
e0910dcc9283cd8f782cb97836c291f6f395f3f0