### PR TITLE
Short circuit get_all_permissions if the user is_superuser

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -82,13 +82,17 @@ class ModelBackend:
         return user_obj._perm_cache
 
     def has_perm(self, user_obj, perm, obj=None):
-        return user_obj.is_active and perm in self.get_all_permissions(user_obj, obj)
+        if not user_obj.is_active:
+            return False
+        return user_obj.is_superuser or perm in self.get_all_permissions(user_obj, obj)
 
     def has_module_perms(self, user_obj, app_label):
         """
         Return True if user_obj has any permissions in the given app_label.
         """
-        return user_obj.is_active and any(
+        if not user_obj.is_active:
+            return False
+        return user_obj.is_superuser or any(
             perm[:perm.index('.')] == app_label
             for perm in self.get_all_permissions(user_obj)
         )


### PR DESCRIPTION
The **_has_perm_** and **_has_module_perms_** methods should not need to **_get_all_permissions_** for a user if they are a superuser. If the developer needs a list of all the permissions, the **_get_permissions_** method still returns a list of all the permissions.