### PR TITLE
Fixed #25790 -- Added option to disable column sort in admin changelist.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -111,6 +111,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
     formfield_overrides = {}
     readonly_fields = ()
     ordering = None
+    sortable_by = None
     view_on_site = True
     show_full_result_count = True
     checks_class = BaseModelAdminChecks
@@ -504,6 +505,9 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         """
         return request.user.has_module_perms(self.opts.app_label)
 
+    def get_sortable_by(self, request):
+        return self.sortable_by or self.get_list_display(request)
+
 
 class ModelAdmin(BaseModelAdmin):
     """Encapsulate all admin options and functionality for a given model."""
@@ -688,6 +692,7 @@ class ModelAdmin(BaseModelAdmin):
         # Add the action checkboxes if any actions are available.
         if self.get_actions(request):
             list_display = ['action_checkbox'] + list(list_display)
+        sortable_by = self.get_sortable_by(request)
         ChangeList = self.get_changelist(request)
         return ChangeList(
             request,
@@ -702,6 +707,7 @@ class ModelAdmin(BaseModelAdmin):
             self.list_max_show_all,
             self.list_editable,
             self,
+            sortable_by
         )
 
     def get_object(self, request, object_id, from_field=None):

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -506,7 +506,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         return request.user.has_module_perms(self.opts.app_label)
 
     def get_sortable_by(self, request):
-        return self.sortable_by or self.get_list_display(request)
+        return self.sortable_by if self.sortable_by is not None else self.get_list_display(request)
 
 
 class ModelAdmin(BaseModelAdmin):

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -100,6 +100,7 @@ def result_headers(cl):
             model_admin=cl.model_admin,
             return_attr=True
         )
+        is_field_sortable = not cl.sortable_by or field_name in cl.sortable_by
         if attr:
             field_name = _coerce_field_name(field_name, i)
             # Potentially not sortable
@@ -115,13 +116,16 @@ def result_headers(cl):
 
             admin_order_field = getattr(attr, "admin_order_field", None)
             if not admin_order_field:
-                # Not sortable
-                yield {
-                    "text": text,
-                    "class_attrib": format_html(' class="column-{}"', field_name),
-                    "sortable": False,
-                }
-                continue
+                is_field_sortable = False
+
+        if not is_field_sortable:
+            # Not sortable
+            yield {
+                "text": text,
+                "class_attrib": format_html(' class="column-{}"', field_name),
+                "sortable": False,
+            }
+            continue
 
         # OK, it is sortable if we got this far
         th_classes = ['sortable', 'column-{}'.format(field_name)]

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -100,7 +100,7 @@ def result_headers(cl):
             model_admin=cl.model_admin,
             return_attr=True
         )
-        is_field_sortable = not cl.sortable_by or field_name in cl.sortable_by
+        is_field_sortable = cl.sortable_by is None or field_name in cl.sortable_by
         if attr:
             field_name = _coerce_field_name(field_name, i)
             # Potentially not sortable

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -35,7 +35,7 @@ IGNORED_PARAMS = (
 class ChangeList:
     def __init__(self, request, model, list_display, list_display_links,
                  list_filter, date_hierarchy, search_fields, list_select_related,
-                 list_per_page, list_max_show_all, list_editable, model_admin):
+                 list_per_page, list_max_show_all, list_editable, model_admin, sortable_by):
         self.model = model
         self.opts = model._meta
         self.lookup_opts = self.opts
@@ -50,6 +50,7 @@ class ChangeList:
         self.list_max_show_all = list_max_show_all
         self.model_admin = model_admin
         self.preserved_filters = model_admin.get_preserved_filters(request)
+        self.sortable_by = sortable_by
 
         # Get search parameters from the query string.
         try:

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1289,17 +1289,38 @@ subclass::
 
 .. attribute:: ModelAdmin.sortable_by
 
-    .. versionadded:: 1.10
+    .. versionadded:: 2.1
 
-    By default, Django admin allows to sort by all model fields and callables,
-    that have ``admin_order_field`` property set. However, you might want to
-    disable interactive sorting for any of them.
+    By default, the change list page allows users to interactively sort it by
+    all model fields (and callables that have the ``admin_order_field`` property
+    set) specified by :attr:`list_display`. However, you might want to disable
+    interactive sorting for any/all of them.
 
-    ``sortable_by`` is a list of fields and callables you would like to be
-    available for sorting in the changelist header.
+    With ``sortable_by`` you can specify a subset of these items. Set
+    ``sortable_by`` to a collection of these same items and they will be
+    available to sort by.
 
-    If you need to specify this list dynamically - you can implement a
-    :meth:`~ModelAdmin.get_sortable_by` method.
+    You can disable customization of such ordering by specifying an empty
+    collection.
+
+    If you need to specify this list dynamically you can implement a
+    :meth:`~ModelAdmin.get_sortable_by` method instead.
+
+    Example::
+
+        class Person(models.Model):
+            first_name = models.CharField(max_length=50)
+            last_name = models.CharField(max_length=50)
+            age = models.PositiveIntegerField()
+            ssn = models.CharField('SSN', max_length=11)
+
+            def full_name(self):
+                  return self.first_name + ' ' + self.last_name
+            full_name.admin_order_field = 'last_name'
+
+        class PersonAdmin(admin.ModelAdmin):
+            list_display = ('full_name', 'age', 'ssn')
+            sortable_by = ('full_name', 'age')
 
 .. attribute:: ModelAdmin.view_on_site
 
@@ -1488,19 +1509,25 @@ templates used by the :class:`ModelAdmin` views:
 
 .. method:: ModelAdmin.get_sortable_by(request)
 
-    .. versionadded:: 1.10
+    .. versionadded:: 2.1
 
-    The ``get_sortable_by`` method is given the ``HttpRequest`` and is expected
-    to return a list or tuple of field names that will be available for the
-    interactive ordering in changelist header. If :attr:`sortable_by` is not
-    set, it returns field names from :meth:`get_list_display` method. You
-    could exclude one or more fields from ordering by overriding this
-    method::
+    The ``get_sortable_by`` method is passed the ``HttpRequest`` and is expected
+    to return a collection of field names that will be available to users for
+    interactive customization of the change list page ordering.
+
+    Its default implementation returns :attr:`sortable_by` if it's set,
+    otherwise it simply defers to :meth:`get_list_display`.
+
+    Just like with :attr:`sortable_by` you can disable customization of such
+    ordering by returning an empty collection.
+
+    For example, you could exclude one or more fields from ordering by
+    overriding this method like this::
 
         class PersonAdmin(admin.ModelAdmin):
 
             def get_sortable_by(self, request):
-                return set(self.get_list_display(request)) - {'rank'}
+                return {*self.get_list_display(request)} - {'rank'}
 
 .. method:: ModelAdmin.save_related(request, form, formsets, change)
 

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1287,6 +1287,20 @@ subclass::
     a full count on the table which can be expensive if the table contains a
     large number of rows.
 
+.. attribute:: ModelAdmin.sortable_by
+
+    .. versionadded:: 1.10
+
+    By default, Django admin allows to sort by all model fields and callables,
+    that have ``admin_order_field`` property set. However, you might want to
+    disable interactive sorting for any of them.
+
+    ``sortable_by`` is a list of fields and callables you would like to be
+    available for sorting in the changelist header.
+
+    If you need to specify this list dynamically - you can implement a
+    :meth:`~ModelAdmin.get_sortable_by` method.
+
 .. attribute:: ModelAdmin.view_on_site
 
     Set ``view_on_site`` to control whether or not to display the "View on site" link.
@@ -1471,6 +1485,22 @@ templates used by the :class:`ModelAdmin` views:
     ('name', '=age')`` which results in a string comparison for the numeric
     field, for example ``... OR UPPER("polls_choice"."votes"::text) = UPPER('4')``
     on PostgreSQL.
+
+.. method:: ModelAdmin.get_sortable_by(request)
+
+    .. versionadded:: 1.10
+
+    The ``get_sortable_by`` method is given the ``HttpRequest`` and is expected
+    to return a list or tuple of field names that will be available for the
+    interactive ordering in changelist header. If :attr:`sortable_by` is not
+    set, it returns field names from :meth:`get_list_display` method. You
+    could exclude one or more fields from ordering by overriding this
+    method::
+
+        class PersonAdmin(admin.ModelAdmin):
+
+            def get_sortable_by(self, request):
+                return set(self.get_list_display(request)) - {'rank'}
 
 .. method:: ModelAdmin.save_related(request, form, formsets, change)
 

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -40,6 +40,11 @@ Minor features
 * The new :meth:`.ModelAdmin.delete_queryset` method allows customizing the
   deletion process of the "delete selected objects" action.
 
+* New :attr:`.ModelAdmin.sortable_by` option and
+  :meth:`.ModelAdmin.get_sortable_by` method allow limiting the number of
+  columns users can manipulate interactively to reorder the model instances
+  grid in the change list page.
+
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -109,6 +109,7 @@ class ArticleAdmin(admin.ModelAdmin):
             'fields': ('date', 'section', 'sub_section')
         })
     )
+    sortable_by = ('date', callable_year)
 
     def changelist_view(self, request):
         return super().changelist_view(request, extra_context={'extra_var': 'Hello!'})

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -1070,3 +1070,43 @@ site2.register(Person, save_as_continue=False)
 site7 = admin.AdminSite(name="admin7")
 site7.register(Article, ArticleAdmin2)
 site7.register(Section)
+
+
+# Used to test *order_by functionality
+class ArticleAdmin6(admin.ModelAdmin):
+    list_display = (
+        'content', 'date', callable_year, 'model_year', 'modeladmin_year',
+        'model_year_reversed', 'section'
+    )
+    sortable_by = ('date', callable_year)
+
+    def modeladmin_year(self, obj):
+        return obj.date.year
+    modeladmin_year.admin_order_field = 'date'
+
+
+class ActorAdmin6(admin.ModelAdmin):
+    list_display = ('name', 'age')
+    sortable_by = ('name',)
+
+    def get_sortable_by(self, request):
+        return ('age',)
+
+
+class ChapterAdmin6(admin.ModelAdmin):
+    list_display = ('title', 'book')
+    sortable_by = ()
+
+
+class ColorAdmin6(admin.ModelAdmin):
+    list_display = ('value',)
+
+    def get_sortable_by(self, request):
+        return ()
+
+
+site6 = admin.AdminSite(name="admin6")
+site6.register(Article, ArticleAdmin6)
+site6.register(Actor, ActorAdmin6)
+site6.register(Chapter, ChapterAdmin6)
+site6.register(Color, ColorAdmin6)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -131,6 +131,7 @@ class AdminViewBasicTestCase(TestCase):
         cls.chap4 = Chapter.objects.create(title='Chapter 2', content='[ insert contents here ]', book=cls.b2)
         cls.cx1 = ChapterXtra1.objects.create(chap=cls.chap1, xtra='ChapterXtra1 1')
         cls.cx2 = ChapterXtra1.objects.create(chap=cls.chap3, xtra='ChapterXtra1 2')
+        Actor.objects.create(name="Palin", age=27)
 
         # Post data for edit inline
         cls.inline_post_data = {
@@ -930,19 +931,33 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertContains(response, 'question__expires__month=10')
         self.assertContains(response, 'question__expires__year=2016')
 
-    def test_sortable_by(self):
+    def test_sortable_by_columns_subset(self):
         expected_sortable_fields = ('date', 'callable_year')
         expected_not_sortable_fields = (
-            'content', 'model_year', 'modeladmin_year',
-            'model_year_reversed', 'section', 'lambda8'
+            'content', 'model_year', 'modeladmin_year', 'model_year_reversed', 'section'
         )
-
-        response = self.client.get(reverse('admin:admin_views_article_changelist'))
+        response = self.client.get(reverse('admin6:admin_views_article_changelist'))
         for field_name in expected_sortable_fields:
             self.assertContains(response, '<th scope="col"  class="sortable column-%s">' % field_name)
-
         for field_name in expected_not_sortable_fields:
             self.assertContains(response, '<th scope="col"  class="column-%s">' % field_name)
+
+    def test_get_sortable_by_columns_subset(self):
+        response = self.client.get(reverse('admin6:admin_views_actor_changelist'))
+        self.assertContains(response, '<th scope="col"  class="sortable column-age">')
+        self.assertContains(response, '<th scope="col"  class="column-name">')
+
+    def test_sortable_by_no_column(self):
+        expected_not_sortable_fields = ('title', 'book')
+        response = self.client.get(reverse('admin6:admin_views_chapter_changelist'))
+        for field_name in expected_not_sortable_fields:
+            self.assertContains(response, '<th scope="col"  class="column-%s">' % field_name)
+        self.assertNotContains(response, '<th scope="col"  class="sortable column')
+
+    def test_get_sortable_by_no_column(self):
+        response = self.client.get(reverse('admin6:admin_views_color_changelist'))
+        self.assertContains(response, '<th scope="col"  class="column-value">')
+        self.assertNotContains(response, '<th scope="col"  class="sortable column')
 
 
 @override_settings(TEMPLATES=[{

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -930,6 +930,20 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertContains(response, 'question__expires__month=10')
         self.assertContains(response, 'question__expires__year=2016')
 
+    def test_sortable_by(self):
+        expected_sortable_fields = ('date', 'callable_year')
+        expected_not_sortable_fields = (
+            'content', 'model_year', 'modeladmin_year',
+            'model_year_reversed', 'section', 'lambda8'
+        )
+
+        response = self.client.get(reverse('admin:admin_views_article_changelist'))
+        for field_name in expected_sortable_fields:
+            self.assertContains(response, '<th scope="col"  class="sortable column-%s">' % field_name)
+
+        for field_name in expected_not_sortable_fields:
+            self.assertContains(response, '<th scope="col"  class="column-%s">' % field_name)
+
 
 @override_settings(TEMPLATES=[{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tests/admin_views/urls.py
+++ b/tests/admin_views/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     url(r'^test_admin/admin8/', (admin.site.get_urls(), 'admin', 'admin-extra-context'), {'extra_context': {}}),
     url(r'^test_admin/has_permission_admin/', custom_has_permission_admin.site.urls),
     url(r'^test_admin/autocomplete_admin/', autocomplete_site.urls),
+    url(r'^test_admin/admin6/', admin.site6.urls),
 ]


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/25790

Updates #9538, which [Jenkins was failing running old code](https://github.com/django/django/pull/9538#issuecomment-359206852). Not at all sure why. Can't reproduce locally. Thus, seeing what happens with a fresh PR. 

Needs to be squashed. (Can we do that when merging?) 
Commit message: 

```
Fixed #25790 -- Added option to disable column sort in admin changelist.
```