### PR TITLE
Fixed #29055 -- Doc'd that escapejs doesn't make template literals safe.

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1618,8 +1618,8 @@ For example, you can apply ``escape`` to fields when :ttag:`autoescape` is off::
 ------------
 
 Escapes characters for use in JavaScript strings. This does *not* make the
-string safe for use in HTML, but does protect you from syntax errors when using
-templates to generate JavaScript/JSON.
+string safe for use in HTML or JavaScript template literals, but does protect
+you from syntax errors when using templates to generate JavaScript/JSON.
 
 For example::
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29055