### PR TITLE
Fixed #29054 -- Fixed a regression where a queryset that annotates with geometry objects crashes.

### DIFF
--- a/django/contrib/gis/geos/geometry.py
+++ b/django/contrib/gis/geos/geometry.py
@@ -144,6 +144,9 @@ class GEOSGeometryBase(GEOSBase):
                 return False
         return isinstance(other, GEOSGeometry) and self.srid == other.srid and self.equals_exact(other)
 
+    def __hash__(self):
+        return hash((self.srid, self.wkt))
+
     # ### Geometry set-like operations ###
     # Thanks to Sean Gillies for inspiration:
     #  http://lists.gispython.org/pipermail/community/2007-July/001034.html

--- a/docs/releases/2.0.2.txt
+++ b/docs/releases/2.0.2.txt
@@ -17,3 +17,6 @@ Bugfixes
 
 * Fixed regression in the use of ``QuerySet.values_list(..., flat=True)``
   followed by ``annotate()`` (:ticket:`29067`).
+
+* Fixed a regression where a queryset that annotates with geometry objects
+  crashes (:ticket:`29054`).

--- a/tests/gis_tests/geos_tests/test_geos.py
+++ b/tests/gis_tests/geos_tests/test_geos.py
@@ -187,6 +187,22 @@ class GEOSTest(SimpleTestCase, TestDataMixin):
             self.assertNotEqual(g, {'foo': 'bar'})
             self.assertNotEqual(g, False)
 
+    def test_hash(self):
+        point_1 = Point(5, 23)
+        point_2 = Point(5, 23, srid=4326)
+        point_3 = Point(5, 23, srid=32632)
+        multipoint_1 = MultiPoint(point_1, srid=4326)
+        multipoint_2 = MultiPoint(point_2)
+        multipoint_3 = MultiPoint(point_3)
+        self.assertNotEqual(hash(point_1), hash(point_2))
+        self.assertNotEqual(hash(point_1), hash(point_3))
+        self.assertNotEqual(hash(point_2), hash(point_3))
+        self.assertNotEqual(hash(multipoint_1), hash(multipoint_2))
+        self.assertEqual(hash(multipoint_2), hash(multipoint_3))
+        self.assertNotEqual(hash(multipoint_1), hash(point_1))
+        self.assertNotEqual(hash(multipoint_2), hash(point_2))
+        self.assertNotEqual(hash(multipoint_3), hash(point_3))
+
     def test_eq_with_srid(self):
         "Testing non-equivalence with different srids."
         p0 = Point(5, 23)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29054

Regression in 19b2dfd1bfe7fd716dd3d8bfa5f972070d83b42f.