### PR TITLE
Fixed #29090 -- Updated Hungarian time formats to use ':' instead of '.'.

### DIFF
--- a/django/conf/locale/hu/formats.py
+++ b/django/conf/locale/hu/formats.py
@@ -3,12 +3,12 @@
 # The *_FORMAT strings use the Django date format syntax,
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
 DATE_FORMAT = 'Y. F j.'
-TIME_FORMAT = 'G.i'
-DATETIME_FORMAT = 'Y. F j. G.i'
+TIME_FORMAT = 'G:i'
+DATETIME_FORMAT = 'Y. F j. G:i'
 YEAR_MONTH_FORMAT = 'Y. F'
 MONTH_DAY_FORMAT = 'F j.'
 SHORT_DATE_FORMAT = 'Y.m.d.'
-SHORT_DATETIME_FORMAT = 'Y.m.d. G.i'
+SHORT_DATETIME_FORMAT = 'Y.m.d. G:i'
 FIRST_DAY_OF_WEEK = 1  # Monday
 
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,
@@ -17,13 +17,13 @@ DATE_INPUT_FORMATS = [
     '%Y.%m.%d.',  # '2006.10.25.'
 ]
 TIME_INPUT_FORMATS = [
-    '%H.%M.%S',  # '14.30.59'
-    '%H.%M',    # '14.30'
+    '%H:%M:%S',  # '14:30:59'
+    '%H:%M',    # '14:30'
 ]
 DATETIME_INPUT_FORMATS = [
-    '%Y.%m.%d. %H.%M.%S',   # '2006.10.25. 14.30.59'
-    '%Y.%m.%d. %H.%M.%S.%f',  # '2006.10.25. 14.30.59.000200'
-    '%Y.%m.%d. %H.%M',      # '2006.10.25. 14.30'
+    '%Y.%m.%d. %H:%M:%S',   # '2006.10.25. 14:30:59'
+    '%Y.%m.%d. %H:%M:%S.%f',  # '2006.10.25. 14:30:59.000200'
+    '%Y.%m.%d. %H:%M',      # '2006.10.25. 14:30'
     '%Y.%m.%d.',            # '2006.10.25.'
 ]
 DECIMAL_SEPARATOR = ','

--- a/django/conf/locale/hu/formats.py
+++ b/django/conf/locale/hu/formats.py
@@ -3,12 +3,12 @@
 # The *_FORMAT strings use the Django date format syntax,
 # see http://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
 DATE_FORMAT = 'Y. F j.'
-TIME_FORMAT = 'G:i'
-DATETIME_FORMAT = 'Y. F j. G:i'
+TIME_FORMAT = 'H:i'
+DATETIME_FORMAT = 'Y. F j. H:i'
 YEAR_MONTH_FORMAT = 'Y. F'
 MONTH_DAY_FORMAT = 'F j.'
 SHORT_DATE_FORMAT = 'Y.m.d.'
-SHORT_DATETIME_FORMAT = 'Y.m.d. G:i'
+SHORT_DATETIME_FORMAT = 'Y.m.d. H:i'
 FIRST_DAY_OF_WEEK = 1  # Monday
 
 # The *_INPUT_FORMATS strings use the Python strftime format syntax,


### PR DESCRIPTION
It's about time notation in Hungary, we use officially ':' instead of '.' among hour, minute and second. Also added the leading zeroes to hour. This one is not official, just some standardization. 
I can't provide tests yet, but probably some expert eyes are enough to check.