### PR TITLE
Fixed #29091 -- Fixed makemigrations crash if migration directory doesn't have __init__.py.

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -48,7 +48,7 @@ class MigrationQuestioner:
             elif hasattr(migrations_module, "__path__"):
                 if len(migrations_module.__path__) > 1:
                     return False
-                filenames = os.listdir(migrations_module.__path__[0])
+                filenames = os.listdir(list(migrations_module.__path__)[0])
             return not any(x.endswith(".py") for x in filenames if x != "__init__.py")
 
     def ask_not_null_addition(self, field_name, model_name):

--- a/docs/releases/2.0.2.txt
+++ b/docs/releases/2.0.2.txt
@@ -24,3 +24,6 @@ Bugfixes
 * Fixed a regression where ``contrib.auth.authenticate()`` crashes if an
   authentication backend doesn't accept ``request`` and a later one does
   (:ticket:`29071`).
+
+* Fixed a regression where ``makemigrations`` crashes if a migrations directory
+  doesn't have an ``__init__.py`` file (:ticket:`29091`).

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -853,6 +853,13 @@ class MakeMigrationsTests(MigrationTestBase):
             call_command("makemigrations", stdout=out)
         self.assertIn("0001_initial.py", out.getvalue())
 
+    def test_makemigrations_no_init(self):
+        """Migration directories without an __init__.py file are allowed."""
+        out = io.StringIO()
+        with self.temporary_migration_module(module='migrations.test_migrations_no_init'):
+            call_command('makemigrations', stdout=out)
+        self.assertIn('0001_initial.py', out.getvalue())
+
     def test_makemigrations_migrations_announce(self):
         """
         makemigrations announces the migration at the default verbosity level.


### PR DESCRIPTION
Regression in aadd3aeb2ba3153e35bd805c80c901f289a6f333.
https://code.djangoproject.com/ticket/29091