### PR TITLE
Refs #27795 -- Replaced force_text() usage in django.core.management

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -14,7 +14,6 @@ from django.core.management.base import (
 )
 from django.core.management.color import color_style
 from django.utils import autoreload
-from django.utils.encoding import force_text
 
 
 def find_commands(management_dir):
@@ -117,7 +116,7 @@ def call_command(command_name, *args, **options):
         for s_opt in parser._actions if s_opt.option_strings
     }
     arg_options = {opt_mapping.get(key, key): value for key, value in options.items()}
-    defaults = parser.parse_args(args=[force_text(a) for a in args])
+    defaults = parser.parse_args(args=[str(a) for a in args])
     defaults = dict(defaults._get_kwargs(), **arg_options)
     # Raise an error if any unknown options were passed.
     stealth_options = set(command.base_stealth_options + command.stealth_options)

--- a/django/core/management/utils.py
+++ b/django/core/management/utils.py
@@ -3,7 +3,7 @@ from subprocess import PIPE, Popen
 
 from django.apps import apps as installed_apps
 from django.utils.crypto import get_random_string
-from django.utils.encoding import DEFAULT_LOCALE_ENCODING, force_text
+from django.utils.encoding import DEFAULT_LOCALE_ENCODING
 
 from .base import CommandError
 
@@ -20,8 +20,8 @@ def popen_wrapper(args, os_err_exc_type=CommandError, stdout_encoding='utf-8'):
         raise os_err_exc_type('Error executing %s' % args[0]) from err
     output, errors = p.communicate()
     return (
-        force_text(output, stdout_encoding, strings_only=True, errors='strict'),
-        force_text(errors, DEFAULT_LOCALE_ENCODING, strings_only=True, errors='replace'),
+        output.decode(stdout_encoding),
+        errors.decode(DEFAULT_LOCALE_ENCODING, errors='replace'),
         p.returncode
     )
 


### PR DESCRIPTION
As `Popen.communicate()` always returns bytes, replace with explicit calls to `.decode()`.

Coerce all values using `str()` before passing to `ArgumentParser.parse_args()`.

https://code.djangoproject.com/ticket/27795