### PR TITLE
[doc] Backend Config section in GIS Installation

### DIFF
--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -89,6 +89,12 @@ Database installation
     postgis
     spatialite
 
+:setting:`DATABASES` configuration
+----------------------------------
+
+Set the :setting:`ENGINE <DATABASE-ENGINE>` setting to one of the :ref:`spatial
+backends <spatial-backends>`.
+
 Add ``django.contrib.gis`` to :setting:`INSTALLED_APPS`
 -------------------------------------------------------
 


### PR DESCRIPTION
Add Backeng Configuration section in the Installation documentation of GeoDjango (as suggested by @timgraham)