### PR TITLE
Fixed #29094 -- Fixed crash when entering an invalid uuid in ModelAdmin.raw_id_fields.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -6,6 +6,7 @@ import json
 
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db.models.deletion import CASCADE
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
@@ -183,7 +184,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
         key = self.rel.get_related_field().name
         try:
             obj = self.rel.model._default_manager.using(self.db).get(**{key: value})
-        except (ValueError, self.rel.model.DoesNotExist):
+        except (ValueError, self.rel.model.DoesNotExist, ValidationError):
             return '', ''
 
         try:

--- a/docs/releases/1.11.10.txt
+++ b/docs/releases/1.11.10.txt
@@ -15,3 +15,6 @@ Bugfixes
 * Fixed a regression where ``contrib.auth.authenticate()`` crashes if an
   authentication backend doesn't accept ``request`` and a later one does
   (:ticket:`29071`).
+
+* Fixed crash when entering an invalid uuid in ``ModelAdmin.raw_id_fields``
+  (:ticket:`29094`).

--- a/docs/releases/2.0.2.txt
+++ b/docs/releases/2.0.2.txt
@@ -27,3 +27,6 @@ Bugfixes
 
 * Fixed a regression where ``makemigrations`` crashes if a migrations directory
   doesn't have an ``__init__.py`` file (:ticket:`29091`).
+
+* Fixed crash when entering an invalid uuid in ``ModelAdmin.raw_id_fields``
+  (:ticket:`29094`).

--- a/tests/admin_widgets/models.py
+++ b/tests/admin_widgets/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.auth.models import User
 from django.db import models
 
@@ -92,6 +94,7 @@ class CarTire(models.Model):
 
 
 class Honeycomb(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     location = models.CharField(max_length=20)
 
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -14,7 +14,7 @@ from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.auth.models import User
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.db.models import CharField, DateField, DateTimeField
+from django.db.models import CharField, DateField, DateTimeField, UUIDField
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import translation
@@ -247,6 +247,12 @@ class AdminForeignKeyRawIdWidget(TestDataMixin, TestCase):
         lookup1 = widgets.url_params_from_lookup_dict({'myfield': my_callable})
         lookup2 = widgets.url_params_from_lookup_dict({'myfield': my_callable()})
         self.assertEqual(lookup1, lookup2)
+
+    def test_label_and_url_for_value_invalid_uuid(self):
+        field = Bee._meta.get_field('honeycomb')
+        self.assertIsInstance(field.target_field, UUIDField)
+        widget = widgets.ForeignKeyRawIdWidget(field.remote_field, admin.site)
+        self.assertEqual(widget.label_and_url_for_value('invalid-uuid'), ('', ''))
 
 
 class FilteredSelectMultipleWidgetTest(SimpleTestCase):


### PR DESCRIPTION
Regression in 2f9861d823620da7ecb291a8f005f53da12b1e89.
https://code.djangoproject.com/ticket/29094