### PR TITLE
Fixed #29069 -- Ensure static file serving sends the request_finished signal

### DIFF
--- a/django/core/servers/basehttp.py
+++ b/django/core/servers/basehttp.py
@@ -15,6 +15,7 @@ from wsgiref import simple_server
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.wsgi import get_wsgi_application
+from django.http import FileResponse
 from django.utils.module_loading import import_string
 
 __all__ = ('WSGIServer', 'WSGIRequestHandler')
@@ -79,6 +80,7 @@ class ThreadedWSGIServer(socketserver.ThreadingMixIn, WSGIServer):
 
 class ServerHandler(simple_server.ServerHandler):
     http_version = '1.1'
+    wsgi_file_wrapper = FileResponse
 
     def handle_error(self):
         # Ignore broken pipe errors, otherwise pass on


### PR DESCRIPTION
Ticket: https://code.djangoproject.com/ticket/29069

This is just exploring what a fix would look like, and seeing if all the tests pass with the proposed changes. There could be wider implications of this, so not sure if we really should do this or not.