### PR TITLE
Refs #28814 -- Imported from collections.abc to fix Python 3.7 deprecation warning.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import warnings
 from math import ceil
 
@@ -127,7 +127,7 @@ class Paginator:
 QuerySetPaginator = Paginator   # For backwards-compatibility.
 
 
-class Page(collections.Sequence):
+class Page(collections.abc.Sequence):
 
     def __init__(self, object_list, number, paginator):
         self.object_list = object_list

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -1,5 +1,5 @@
 import builtins
-import collections
+import collections.abc
 import datetime
 import decimal
 import enum
@@ -341,7 +341,7 @@ def serializer_factory(value):
         return FunctoolsPartialSerializer(value)
     if isinstance(value, (types.FunctionType, types.BuiltinFunctionType, types.MethodType)):
         return FunctionTypeSerializer(value)
-    if isinstance(value, collections.Iterable):
+    if isinstance(value, collections.abc.Iterable):
         return IterableSerializer(value)
     if isinstance(value, (COMPILED_REGEX_TYPE, RegexObject)):
         return RegexSerializer(value)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import copy
 import datetime
 import decimal
@@ -152,7 +152,7 @@ class Field(RegisterLookupMixin):
         self.unique_for_date = unique_for_date
         self.unique_for_month = unique_for_month
         self.unique_for_year = unique_for_year
-        if isinstance(choices, collections.Iterator):
+        if isinstance(choices, collections.abc.Iterator):
             choices = list(choices)
         self.choices = choices or []
         self.help_text = help_text
@@ -463,7 +463,7 @@ class Field(RegisterLookupMixin):
         for name, default in possibles.items():
             value = getattr(self, attr_overrides.get(name, name))
             # Unroll anything iterable for choices into a concrete list
-            if name == "choices" and isinstance(value, collections.Iterable):
+            if name == "choices" and isinstance(value, collections.abc.Iterable):
                 value = list(value)
             # Do correct kind of comparison
             if name in equals_comparison:

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -6,7 +6,8 @@ themselves do not have to (and could be backed by things other than SQL
 databases). The abstraction barrier only works one way: this module has to know
 all about the internals of models in order to get the information it needs.
 """
-from collections import Counter, Iterator, Mapping, OrderedDict, namedtuple
+from collections import Counter, OrderedDict, namedtuple
+from collections.abc import Iterator, Mapping
 from itertools import chain, count, product
 from string import ascii_uppercase
 

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from datetime import datetime
 from math import ceil
 from operator import attrgetter
@@ -99,7 +99,7 @@ class LookupTests(TestCase):
     def test_iterator(self):
         # Each QuerySet gets iterator(), which is a generator that "lazily"
         # returns results using database-level iteration.
-        self.assertIsInstance(Article.objects.iterator(), collections.Iterator)
+        self.assertIsInstance(Article.objects.iterator(), collections.abc.Iterator)
 
         self.assertQuerysetEqual(
             Article.objects.iterator(),


### PR DESCRIPTION
In Python 3.7, there is a warning that the abstract bases in collections.abc will no longer be accessible through the regular collections module in Python 3.8.
https://bugs.python.org/issue25988