### PR TITLE
Fixed #29106 -- Made DiscoverRunner display selected test tags.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -522,6 +522,11 @@ class DiscoverRunner:
             suite.addTest(test)
 
         if self.tags or self.exclude_tags:
+            if self.verbosity >= 2:
+                if self.tags:
+                    print('Including test tag(s): %s.' % ', '.join(sorted(self.tags)))
+                if self.exclude_tags:
+                    print('Excluding test tag(s): %s.' % ', '.join(sorted(self.exclude_tags)))
             suite = filter_tests_by_tags(suite, self.tags, self.exclude_tags)
         suite = reorder_suite(suite, self.reorder_by, self.reverse)
 

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -5,6 +5,7 @@ from unittest import TestSuite, TextTestRunner, defaultTestLoader
 
 from django.test import TestCase
 from django.test.runner import DiscoverRunner
+from django.test.utils import captured_stdout
 
 
 @contextmanager
@@ -210,3 +211,15 @@ class DiscoverRunnerTest(TestCase):
         self.assertEqual(count_tests(tags=['foo'], exclude_tags=['bar']), 2)
         self.assertEqual(count_tests(tags=['foo'], exclude_tags=['bar', 'baz']), 1)
         self.assertEqual(count_tests(exclude_tags=['foo']), 0)
+
+    def test_included_tags_displayed(self):
+        runner = DiscoverRunner(tags=['foo', 'bar'], verbosity=2)
+        with captured_stdout() as stdout:
+            runner.build_suite(['test_runner_apps.tagged.tests'])
+            self.assertIn('Including test tag(s): bar, foo.\n', stdout.getvalue())
+
+    def test_excluded_tags_displayed(self):
+        runner = DiscoverRunner(exclude_tags=['foo', 'bar'], verbosity=3)
+        with captured_stdout() as stdout:
+            runner.build_suite(['test_runner_apps.tagged.tests'])
+            self.assertIn('Excluding test tag(s): bar, foo.\n', stdout.getvalue())


### PR DESCRIPTION
Fixed #29106 -- manage.py test displays tags that are in use

Ticket: https://code.djangoproject.com/ticket/29106

I was writing test for this, but wasn't sure how do I grab something that is printed on console. Neither I was able to attach a debugger (as can be done in py.test) when the test fails in unittest. If someone can provide me a pointer, I'll take this forward.