### PR TITLE
Refs #28814 -- Fixed migrations crash with namespace packages on Python 3.7.

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -84,8 +84,9 @@ class MigrationLoader:
                     continue
                 raise
             else:
-                # PY3 will happily import empty dirs as namespaces.
-                if not hasattr(module, '__file__'):
+                # Empty directories are namespaces.
+                # getattr() needed on PY36 and older (replace w/attribute access).
+                if getattr(module, '__file__', None) is None:
                     self.unmigrated_apps.add(app_config.label)
                     continue
                 # Module is not a package (e.g. migrations.py).

--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -43,7 +43,8 @@ class MigrationQuestioner:
         except ImportError:
             return self.defaults.get("ask_initial", False)
         else:
-            if hasattr(migrations_module, "__file__"):
+            # getattr() needed on PY36 and older (replace with attribute access).
+            if getattr(migrations_module, "__file__", None):
                 filenames = os.listdir(os.path.dirname(migrations_module.__file__))
             elif hasattr(migrations_module, "__path__"):
                 if len(migrations_module.__path__) > 1:


### PR DESCRIPTION
Due to https://bugs.python.org/issue32303.