### PR TITLE
Fixed #29115 -- Allow rendering of admin forms with Jinja2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -397,6 +397,7 @@ answer newbie questions, and generally made Django that much better:
     Joel Heenan <joelh-django@planetjoel.com>
     Joel Watts <joel@joelwatts.com>
     Joe Topjian <http://joe.terrarum.net/geek/code/python/django/>
+    Joey Wilhelm <tarkatronic@gmail.com>
     Johan C. Stöver <johan@nilling.nl>
     Johann Queuniet <johann.queuniet@adh.naellia.eu>
     john@calixto.net

--- a/django/contrib/admin/jinja2/admin/widgets/clearable_file_input.html
+++ b/django/contrib/admin/jinja2/admin/widgets/clearable_file_input.html
@@ -1,0 +1,6 @@
+{% if widget.is_initial %}<p class="file-upload">{{ widget.initial_text }}: <a href="{{ widget.value.url }}">{{ widget.value }}</a>{% if not widget.required %}
+<span class="clearable-file-input">
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}<br>
+{{ widget.input_text }}:{% endif %}
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% if widget.is_initial %}</p>{% endif %}

--- a/django/contrib/admin/jinja2/admin/widgets/foreign_key_raw_id.html
+++ b/django/contrib/admin/jinja2/admin/widgets/foreign_key_raw_id.html
@@ -1,0 +1,1 @@
+{% include 'django/forms/widgets/input.html' %}{% if related_url %}<a href="{{ related_url }}" class="related-lookup" id="lookup_id_{{ widget.name }}" title="{{ link_title }}"></a>{% endif %}{% if link_label %}&nbsp;<strong>{% if link_url %}<a href="{{ link_url }}">{% endif %}{{ link_label }}{% if link_url %}</a>{% endif %}</strong>{% endif %}

--- a/django/contrib/admin/jinja2/admin/widgets/many_to_many_raw_id.html
+++ b/django/contrib/admin/jinja2/admin/widgets/many_to_many_raw_id.html
@@ -1,0 +1,1 @@
+{% include 'admin/widgets/foreign_key_raw_id.html' %}

--- a/django/contrib/admin/jinja2/admin/widgets/radio.html
+++ b/django/contrib/admin/jinja2/admin/widgets/radio.html
@@ -1,0 +1,1 @@
+{% include "django/forms/widgets/multiple_input.html" %}

--- a/django/contrib/admin/jinja2/admin/widgets/related_widget_wrapper.html
+++ b/django/contrib/admin/jinja2/admin/widgets/related_widget_wrapper.html
@@ -1,0 +1,26 @@
+<div class="related-widget-wrapper">
+    {{ rendered_widget }}
+    {% block links %}
+        {% if can_change_related %}
+        <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
+            data-href-template="{{ change_related_template_url }}?{{ url_params }}"
+            title="{% trans %}Change selected {{ model }}{% endtrans %}">
+            <img src="{{ static('admin/img/icon-changelink.svg') }}" alt="{% trans %}Change{% endtrans %}">
+        </a>
+        {% endif %}
+        {% if can_add_related %}
+        <a class="related-widget-wrapper-link add-related" id="add_id_{{ name }}"
+            href="{{ add_related_url }}?{{ url_params }}"
+            title="{% trans %}Add another {{ model }}{% endtrans %}">
+            <img src="{{ static('admin/img/icon-addlink.svg') }}" alt="{% trans %}Add{% endtrans %}">
+        </a>
+        {% endif %}
+        {% if can_delete_related %}
+        <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
+            data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
+            title="{% trans %}Delete selected {{ model }}{% endtrans %}">
+            <img src="{{ static('admin/img/icon-deletelink.svg') }}" alt="{% trans %}Delete{% endtrans %}">
+        </a>
+        {% endif %}
+    {% endblock %}
+</div>

--- a/django/contrib/admin/jinja2/admin/widgets/split_datetime.html
+++ b/django/contrib/admin/jinja2/admin/widgets/split_datetime.html
@@ -1,0 +1,4 @@
+<p class="datetime">
+  {{ date_label }} {% with widget=widget.subwidgets.0 %}{% include widget.template_name %}{% endwith %}<br>
+  {{ time_label }} {% with widget=widget.subwidgets.1 %}{% include widget.template_name %}{% endwith %}
+</p>

--- a/django/contrib/admin/jinja2/admin/widgets/url.html
+++ b/django/contrib/admin/jinja2/admin/widgets/url.html
@@ -1,0 +1,1 @@
+{% if widget.value %}<p class="url">{{ current_label }} <a href="{{ widget.href }}">{{ widget.value }}</a><br>{{ change_label }} {% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.value %}</p>{% endif %}

--- a/docs/ref/forms/renderers.txt
+++ b/docs/ref/forms/renderers.txt
@@ -70,9 +70,7 @@ apps can provide templates in a ``jinja2`` directory.
 
 To use this backend, all the widgets in your project and its third-party apps
 must have Jinja2 templates. Unless you provide your own Jinja2 templates for
-widgets that don't have any, you can't use this renderer. For example,
-:mod:`django.contrib.admin` doesn't include Jinja2 templates for its widgets
-due to their usage of Django template tags.
+widgets that don't have any, you can't use this renderer.
 
 ``TemplatesSetting``
 --------------------

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -149,7 +149,8 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The admin site will now render properly when the :setting:`FORM_RENDERER` is
+  configured to use Jinja2.
 
 Generic Views
 ~~~~~~~~~~~~~
@@ -212,6 +213,8 @@ Templates
 
 * The new :tfilter:`json_script` filter safely outputs a Python object as JSON,
   wrapped in a ``<script>`` tag, ready for use with JavaScript.
+* Added a default environment to the Jinja2 backend, which provides static,
+  url, and i18n-related functionality.
 
 Tests
 ~~~~~

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -395,15 +395,18 @@ look for templates in the ``jinja2`` subdirectory of installed applications.
 
 The most important entry in :setting:`OPTIONS <TEMPLATES-OPTIONS>` is
 ``'environment'``. It's a dotted Python path to a callable returning a Jinja2
-environment. It defaults to ``'jinja2.Environment'``. Django invokes that
-callable and passes other options as keyword arguments. Furthermore, Django
-adds defaults that differ from Jinja2's for a few options:
+environment. It defaults to
+``'django.template.backends.jinja2.default_environment'``. Django invokes that
+callable and passes other options as keyword arguments.
+
+Furthermore, Django adds defaults that differ from Jinja2's for a few options:
 
 * ``'autoescape'``: ``True``
 * ``'loader'``: a loader configured for :setting:`DIRS <TEMPLATES-DIRS>` and
   :setting:`APP_DIRS <TEMPLATES-APP_DIRS>`
 * ``'auto_reload'``: ``settings.DEBUG``
 * ``'undefined'``: ``DebugUndefined if settings.DEBUG else Undefined``
+* ``'extensions'``: ``['jinja2.ext.i18n']``
 
 ``Jinja2`` engines also accept the following :setting:`OPTIONS
 <TEMPLATES-OPTIONS>`:
@@ -441,13 +444,19 @@ adds defaults that differ from Jinja2's for a few options:
     Unless all of these conditions are met, passing a function to the template is
     simpler and more in line with the design of Jinja2.
 
-The default configuration is purposefully kept to a minimum. If a template is
-rendered with a request (e.g. when using :py:func:`~django.shortcuts.render`),
-the ``Jinja2`` backend adds the globals ``request``, ``csrf_input``, and
-``csrf_token`` to the context. Apart from that, this backend doesn't create a
-Django-flavored environment. It doesn't know about Django filters and tags.
-In order to use Django-specific APIs, you must configure them into the
-environment.
+The default configuration is purposefully kept to a minimum. Out of the box,
+it will provide access to a ``url`` function, which is an alias to
+:py:func:`django.urls.reverse`, and i18n functionality via the Jinja2
+`i18n extension`_. If :py:mod:`django.contrib.staticfiles` is
+installed, a ``static`` function will also be provided from the ``url()``
+method of the :setting:`STATICFILES_STORAGE`.
+
+If a template is rendered with a request (e.g. when using
+:py:func:`~django.shortcuts.render`), the ``Jinja2`` backend adds the globals
+``request``, ``csrf_input``, and ``csrf_token`` to the context. Apart from
+that, this backend doesn't create a Django-flavored environment. It doesn't
+know about Django filters and tags. In order to use Django-specific APIs, you
+must configure them into the environment.
 
 For example, you can create ``myproject/jinja2.py`` with this content::
 
@@ -482,6 +491,35 @@ or filter in Django templates can be achieved simply by calling a function in
 Jinja2 templates, as shown in the example above. Jinja2's global namespace
 removes the need for template context processors. The Django template language
 doesn't have an equivalent of Jinja2 tests.
+
+Additionally, Jinja2 does not have i18n enabled by default, unlike the Django
+Template Language. If you wish to use this functionality in your Jinja2 templates,
+you just enable and activate the `i18n extension`_ in your environment. This can
+be done utilizing Django's built-in translation methods. Building on the example
+environment above, your environment file would then look like::
+
+    from django.contrib.staticfiles.storage import staticfiles_storage
+    from django.urls import reverse
+    from django.utils.translation import gettext, ngettext
+
+    from jinja2 import Environment
+
+
+    def environment(**options):
+        env = Environment(extensions=['jinja2.ext.i18n'], **options)
+        env.install_gettext_callables(gettext, ngettext)
+        env.globals.update({
+            'static': staticfiles_storage.url,
+            'url': reverse,
+        })
+        return env
+
+Then you could have translated text in your template, in addition to the aforementioned
+global functions:
+
+.. code-block:: html+jinja
+
+    <a href="{{ url('admin:index') }}">{% trans %}Administration{% endtrans %}</a>
 
 Custom backends
 ---------------
@@ -828,3 +866,4 @@ Implementing a custom context processor is as simple as defining a function.
 .. _Jinja2: http://jinja.pocoo.org/
 .. _DEP 182: https://github.com/django/deps/blob/master/final/0182-multiple-template-engines.rst
 .. _Django Debug Toolbar: https://github.com/jazzband/django-debug-toolbar
+.. _i18n extension: http://jinja.pocoo.org/docs/latest/extensions/#i18n-extension

--- a/docs/topics/templates.txt
+++ b/docs/topics/templates.txt
@@ -444,39 +444,21 @@ Furthermore, Django adds defaults that differ from Jinja2's for a few options:
     Unless all of these conditions are met, passing a function to the template is
     simpler and more in line with the design of Jinja2.
 
-The default configuration is purposefully kept to a minimum. Out of the box,
-it will provide access to a ``url`` function, which is an alias to
-:py:func:`django.urls.reverse`, and i18n functionality via the Jinja2
-`i18n extension`_. If :py:mod:`django.contrib.staticfiles` is
-installed, a ``static`` function will also be provided from the ``url()``
-method of the :setting:`STATICFILES_STORAGE`.
-
 If a template is rendered with a request (e.g. when using
 :py:func:`~django.shortcuts.render`), the ``Jinja2`` backend adds the globals
 ``request``, ``csrf_input``, and ``csrf_token`` to the context. Apart from
-that, this backend doesn't create a Django-flavored environment. It doesn't
+that, this backend does not create a Django-flavored environment. It doesn't
 know about Django filters and tags. In order to use Django-specific APIs, you
 must configure them into the environment.
 
-For example, you can create ``myproject/jinja2.py`` with this content::
+The default ``'django.template.backends.jinja2.default_environment'``
+environment adds some minimal helpers: it gives access to a ``url`` function,
+which is an alias to :py:func:`django.urls.reverse`, i18n functionality via the
+Jinja2 `i18n extension`_, and, if :py:mod:`django.contrib.staticfiles` is
+installed, a ``static`` function will also be provided from the ``url()``
+method of the :setting:`STATICFILES_STORAGE`.
 
-    from django.contrib.staticfiles.storage import staticfiles_storage
-    from django.urls import reverse
-
-    from jinja2 import Environment
-
-
-    def environment(**options):
-        env = Environment(**options)
-        env.globals.update({
-            'static': staticfiles_storage.url,
-            'url': reverse,
-        })
-        return env
-
-and set the ``'environment'`` option to ``'myproject.jinja2.environment'``.
-
-Then you could use the following constructs in Jinja2 templates:
+This allows you to use the following constructs in Jinja2 templates:
 
 .. code-block:: html+jinja
 
@@ -484,19 +466,10 @@ Then you could use the following constructs in Jinja2 templates:
 
     <a href="{{ url('admin:index') }}">Administration</a>
 
-The concepts of tags and filters exist both in the Django template language
-and in Jinja2 but they're used differently. Since Jinja2 supports passing
-arguments to callables in templates, many features that require a template tag
-or filter in Django templates can be achieved simply by calling a function in
-Jinja2 templates, as shown in the example above. Jinja2's global namespace
-removes the need for template context processors. The Django template language
-doesn't have an equivalent of Jinja2 tests.
+    <a href="{{ url('admin:index') }}">{% trans %}Administration{% endtrans %}</a>
 
-Additionally, Jinja2 does not have i18n enabled by default, unlike the Django
-Template Language. If you wish to use this functionality in your Jinja2 templates,
-you just enable and activate the `i18n extension`_ in your environment. This can
-be done utilizing Django's built-in translation methods. Building on the example
-environment above, your environment file would then look like::
+
+For example, you can create ``myproject/jinja2.py`` with this content::
 
     from django.contrib.staticfiles.storage import staticfiles_storage
     from django.urls import reverse
@@ -514,12 +487,15 @@ environment above, your environment file would then look like::
         })
         return env
 
-Then you could have translated text in your template, in addition to the aforementioned
-global functions:
+and set the ``'environment'`` option to ``'myproject.jinja2.environment'``.
 
-.. code-block:: html+jinja
-
-    <a href="{{ url('admin:index') }}">{% trans %}Administration{% endtrans %}</a>
+The concepts of tags and filters exist both in the Django template language
+and in Jinja2 but they're used differently. Since Jinja2 supports passing
+arguments to callables in templates, many features that require a template tag
+or filter in Django templates can be achieved simply by calling a function in
+Jinja2 templates, as shown in the example above. Jinja2's global namespace
+removes the need for template context processors. The Django template language
+doesn't have an equivalent of Jinja2 tests.
 
 Custom backends
 ---------------

--- a/tests/forms_tests/widget_tests/base.py
+++ b/tests/forms_tests/widget_tests/base.py
@@ -7,7 +7,7 @@ except ImportError:
     jinja2 = None
 
 
-class WidgetTest(SimpleTestCase):
+class Jinja2TestMixin:
     beatles = (('J', 'John'), ('P', 'Paul'), ('G', 'George'), ('R', 'Ringo'))
 
     @classmethod
@@ -26,3 +26,7 @@ class WidgetTest(SimpleTestCase):
 
         output = widget.render(name, value, attrs=attrs, renderer=self.django_renderer, **kwargs)
         assertEqual(output, html)
+
+
+class WidgetTest(Jinja2TestMixin, SimpleTestCase):
+    pass


### PR DESCRIPTION
This is for the ticket: https://code.djangoproject.com/ticket/29115

This enables users to set `FORM_RENDERER = 'django.forms.renderers.Jinja2'`, and have a working admin out of the box.

As a side effect, users will get a more usable Jinja2 environment by default, due to a new default environment for the Jinja2 backend which provides the `static` and `url` functions (taken directly from the documentation) along with i18n functionality.

The one part I had trouble figuring out was exactly what tests to add. The new `django.template.backends.jinja2.default_environment` gets automatically tested by means of the pre-existing Jinja2 tests, but the admin Jinja2 templates do not get directly tested. Any help in figuring this out would be greatly appreciated!