### PR TITLE
Fixed #29116 -- Fixed OpenLayersWidget deserialization ignoring the widget map's SRID.

### DIFF
--- a/django/contrib/gis/forms/fields.py
+++ b/django/contrib/gis/forms/fields.py
@@ -35,9 +35,14 @@ class GeometryField(forms.Field):
             return None
 
         if not isinstance(value, GEOSGeometry):
-            try:
-                value = GEOSGeometry(value)
-            except (GEOSException, ValueError, TypeError):
+            if hasattr(self.widget, 'deserialize'):
+                value = self.widget.deserialize(value)
+            else:
+                try:
+                    value = GEOSGeometry(value)
+                except (GEOSException, ValueError, TypeError):
+                    value = None
+            if value is None:
                 raise forms.ValidationError(self.error_messages['invalid_geom'], code='invalid_geom')
 
         # Try to set the srid

--- a/django/contrib/gis/forms/widgets.py
+++ b/django/contrib/gis/forms/widgets.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.gis import gdal
+from django.contrib.gis.geometry import json_regex
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 from django.forms.widgets import Widget
 from django.utils import translation
@@ -36,7 +37,7 @@ class BaseGeometryWidget(Widget):
     def deserialize(self, value):
         try:
             return GEOSGeometry(value)
-        except (GEOSException, ValueError) as err:
+        except (GEOSException, ValueError, TypeError) as err:
             logger.error("Error creating geometry from value '%s' (%s)", value, err)
         return None
 
@@ -90,6 +91,13 @@ class OpenLayersWidget(BaseGeometryWidget):
 
     def serialize(self, value):
         return value.json if value else ''
+
+    def deserialize(self, value):
+        geom = super().deserialize(value)
+        # GeoJSON assumes WGS84 (4326). Use the map's SRID instead.
+        if geom and json_regex.match(value) and self.map_srid != 4326:
+            geom.srid = self.map_srid
+        return geom
 
 
 class OSMWidget(OpenLayersWidget):

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -29,3 +29,6 @@ Bugfixes
 * Fixed a regression in Django 1.11 where an empty choice could be initially
   selected for the ``SelectMultiple`` and ``CheckboxSelectMultiple`` widgets
   (:ticket:`29273`).
+
+* Fixed a regression in Django 2.0 where ``OpenLayersWidget`` deserialization
+  ignored the widget map's SRID and assumed 4326 (WGS84) (:ticket:`29116`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29116