### PR TITLE
Renamed the allow_sliced_subqueries database feature to allow_sliced_subqueries_with_in.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -32,7 +32,7 @@ class BaseDatabaseFeatures:
     # If True, don't use integer foreign keys referring to, e.g., positive
     # integer primary keys.
     related_fields_match_type = False
-    allow_sliced_subqueries = True
+    allow_sliced_subqueries_with_in = True
     has_select_for_update = False
     has_select_for_update_nowait = False
     has_select_for_update_skip_locked = False

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -7,7 +7,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     update_can_self_select = False
     allows_group_by_pk = True
     related_fields_match_type = True
-    allow_sliced_subqueries = False
+    # MySQL doesn't support sliced subqueries with IN/ALL/ANY/SOME.
+    allow_sliced_subqueries_with_in = False
     has_select_for_update = True
     has_select_for_update_nowait = False
     supports_forward_references = False

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -230,6 +230,9 @@ Database backend API
   feature are changed from :exc:`NotImplementedError` to
   :exc:`django.db.NotSupportedError`.
 
+* Renamed the ``allow_sliced_subqueries`` database feature flag to
+  ``allow_sliced_subqueries_with_in``.
+
 :mod:`django.contrib.gis`
 -------------------------
 

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2028,7 +2028,7 @@ class QuerysetOrderedTests(unittest.TestCase):
         self.assertIs(qs.order_by('num_notes').ordered, True)
 
 
-@skipUnlessDBFeature('allow_sliced_subqueries')
+@skipUnlessDBFeature('allow_sliced_subqueries_with_in')
 class SubqueryTests(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
After 0899d583bdb140910698d00d17f5f1abc8774b07, this database feature is false only on MySQL, which doesn't support sliced subqueries only with `IN/ALL/ANY/SOME`.