### PR TITLE
Fixed #29118 -- Fixed crash with QuerySet.order_by(Exists(...)).

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1041,11 +1041,11 @@ class Exists(Subquery):
     def __invert__(self):
         return type(self)(self.queryset, negated=(not self.negated), **self.extra)
 
-    def resolve_expression(self, query=None, **kwargs):
+    def resolve_expression(self, query=None, *args, **kwargs):
         # As a performance optimization, remove ordering since EXISTS doesn't
         # care about it, just whether or not a row matches.
         self.queryset = self.queryset.order_by()
-        return super().resolve_expression(query, **kwargs)
+        return super().resolve_expression(query, *args, **kwargs)
 
     def as_sql(self, compiler, connection, template=None, **extra_context):
         sql, params = super().as_sql(compiler, connection, template, **extra_context)

--- a/docs/releases/2.0.3.txt
+++ b/docs/releases/2.0.3.txt
@@ -15,3 +15,5 @@ Bugfixes
 * Prioritized the datetime and time input formats without ``%f`` for the Thai
   locale to fix the admin time picker widget displaying "undefined"
   (:ticket:`29109`).
+
+* Fixed crash with ``QuerySet.order_by(Exists(...))`` (:ticket:`29118`).


### PR DESCRIPTION
The `resolve_expression` method in `BaseExpression` supports both calls with keyword arguments and positional arguments in practice. This commit makes sure the Exists class supports positional arguments.

(EDIT: Filed a ticket on [trac](https://code.djangoproject.com/ticket/29118#ticket))