### PR TITLE
Removed unnecessary psycopg2-binary version from requirements.

### DIFF
--- a/tests/requirements/postgres.txt
+++ b/tests/requirements/postgres.txt
@@ -1,1 +1,1 @@
-psycopg2-binary>=2.5.4
+psycopg2-binary


### PR DESCRIPTION
`psycopg2-binary` version starts with 2.7.3.2.