### PR TITLE
Fixed #29103 -- Fixed SchemaEditor.quote_value() for unicode strings on MySQL.

### DIFF
--- a/django/db/backends/mysql/schema.py
+++ b/django/db/backends/mysql/schema.py
@@ -25,9 +25,11 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     sql_delete_pk = "ALTER TABLE %(table)s DROP PRIMARY KEY"
 
     def quote_value(self, value):
-        # Inner import to allow module to fail to load gracefully
-        import MySQLdb.converters
-        return MySQLdb.escape(value, MySQLdb.converters.conversions)
+        self.connection.ensure_connection()
+        quoted = self.connection.connection.escape(value, self.connection.connection.encoders)
+        if isinstance(value, str):
+            quoted = quoted.decode()
+        return quoted
 
     def _is_limited_data_type(self, field):
         db_type = field.db_type(self.connection)

--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -1,0 +1,18 @@
+import unittest
+
+from django.db import connection
+from django.test import TestCase
+
+
+@unittest.skipUnless(connection.vendor == 'mysql', 'MySQL tests')
+class SchemaEditorTests(TestCase):
+    def test_quote_value(self):
+        editor = connection.schema_editor()
+        tested_values = [
+            (42, '42'),
+            (1.754, '1.754'),
+            (False, '0'),
+        ]
+        for value, expected in tested_values:
+            with self.subTest(value=value):
+                self.assertEqual(editor.quote_value(value), expected)

--- a/tests/backends/mysql/test_schema.py
+++ b/tests/backends/mysql/test_schema.py
@@ -9,6 +9,7 @@ class SchemaEditorTests(TestCase):
     def test_quote_value(self):
         editor = connection.schema_editor()
         tested_values = [
+            ('string', "'string'"),
             (42, '42'),
             (1.754, '1.754'),
             (False, '0'),

--- a/tests/schema/test_logging.py
+++ b/tests/schema/test_logging.py
@@ -1,9 +1,9 @@
 from django.db import connection
-from django.test import SimpleTestCase
+from django.test import TestCase
 from django.test.utils import patch_logger
 
 
-class SchemaLoggerTests(SimpleTestCase):
+class SchemaLoggerTests(TestCase):
 
     def test_extra_args(self):
         editor = connection.schema_editor(collect_sql=True)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29103