### PR TITLE
Refs #27795 -- Removed force_bytes() in django.test.client where possible.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -310,7 +310,7 @@ class RequestFactory:
                 charset = match.group(1)
             else:
                 charset = settings.DEFAULT_CHARSET
-            return force_bytes(data, encoding=charset)
+            return data.encode(charset)
 
     def _encode_json(self, data, content_type):
         """
@@ -409,7 +409,7 @@ class RequestFactory:
         # If QUERY_STRING is absent or empty, we want to extract it from the URL.
         if not r.get('QUERY_STRING'):
             # WSGI requires latin-1 encoded strings. See get_path_info().
-            query_string = force_bytes(parsed[4]).decode('iso-8859-1')
+            query_string = parsed[4].encode().decode('iso-8859-1')
             r['QUERY_STRING'] = query_string
         return self.request(**r)
 


### PR DESCRIPTION
The regression test in the first commit fails if `.encode().decode('iso-8859-1')` is removed.

The `data = force_bytes(data, settings.DEFAULT_CHARSET)` line was added in e73838b6ddcc7b37c03f9eee04fa6e6a283fedb3. I'm not sure that it's useless but no tests are failing.