### PR TITLE
Translation improved for Latvian Language

### DIFF
--- a/django/conf/locale/ru/LC_MESSAGES/django.po
+++ b/django/conf/locale/ru/LC_MESSAGES/django.po
@@ -193,7 +193,7 @@ msgid "Lithuanian"
 msgstr "Литовский"
 
 msgid "Latvian"
-msgstr "Латвийский"
+msgstr "Латышский"
 
 msgid "Macedonian"
 msgstr "Македонский"


### PR DESCRIPTION
Латвийский - made in Latvia as a country, Латышский - Latvian language