### PR TITLE
Fixed #22449 -- Colorized output of test results

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -853,6 +853,7 @@ answer newbie questions, and generally made Django that much better:
     ye7cakf02@sneakemail.com
     ymasuda@ethercube.com
     Yoong Kang Lim <yoongkang.lim@gmail.com>
+    Yuri Shikanov <dizballanze@gmail.com>
     Yusuke Miyazaki <miyazaki.dev@gmail.com>
     Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
     Zachary Voase <zacharyvoase@gmail.com>

--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -8,6 +8,8 @@ import sys
 
 from django.utils import termcolors
 
+TERMINATOR = '\x1b[{}m'.format(termcolors.RESET)
+
 
 def supports_color():
     """
@@ -23,7 +25,9 @@ def supports_color():
 
 
 class Style:
-    pass
+
+    def is_dark(self):
+        return getattr(self, 'base_palette', None) == termcolors.DARK_PALETTE
 
 
 def make_style(config_string=''):
@@ -35,7 +39,7 @@ def make_style(config_string=''):
 
     style = Style()
 
-    color_settings = termcolors.parse_color_setting(config_string)
+    base_palette, color_settings = termcolors.parse_color_setting(config_string)
 
     # The nocolor palette has all available roles.
     # Use that palette as the basis for populating
@@ -52,6 +56,8 @@ def make_style(config_string=''):
     # For backwards compatibility,
     # set style for ERROR_OUTPUT == ERROR
     style.ERROR_OUTPUT = style.ERROR
+
+    style.base_palette = base_palette
 
     return style
 

--- a/django/utils/termcolors.py
+++ b/django/utils/termcolors.py
@@ -91,6 +91,12 @@ PALETTES = {
         'HTTP_SERVER_ERROR': {},
         'MIGRATE_HEADING': {},
         'MIGRATE_LABEL': {},
+        'TEST_SUCCESS': {},
+        'TEST_FAIL': {},
+        'TEST_ERROR': {},
+        'TEST_EXPECTED_FAILURE': {},
+        'TEST_UNEXPECTED_SUCCESS': {},
+        'TEST_INFO': {},
     },
     DARK_PALETTE: {
         'ERROR': {'fg': 'red', 'opts': ('bold',)},
@@ -110,6 +116,12 @@ PALETTES = {
         'HTTP_SERVER_ERROR': {'fg': 'magenta', 'opts': ('bold',)},
         'MIGRATE_HEADING': {'fg': 'cyan', 'opts': ('bold',)},
         'MIGRATE_LABEL': {'opts': ('bold',)},
+        'TEST_SUCCESS': {'opts': ('noreset',), 'fg': 'green'},
+        'TEST_FAIL': {'opts': ('noreset', 'bold'), 'fg': 'red'},
+        'TEST_ERROR': {'opts': ('noreset', 'bold'), 'fg': 'magenta'},
+        'TEST_EXPECTED_FAILURE': {'opts': ('noreset',), 'fg': 'green'},
+        'TEST_UNEXPECTED_SUCCESS': {'opts': ('noreset', 'bold'), 'fg': 'red'},
+        'TEST_INFO': {'opts': ('bold',), 'fg': 'white'},
     },
     LIGHT_PALETTE: {
         'ERROR': {'fg': 'red', 'opts': ('bold',)},
@@ -129,6 +141,12 @@ PALETTES = {
         'HTTP_SERVER_ERROR': {'fg': 'magenta', 'opts': ('bold',)},
         'MIGRATE_HEADING': {'fg': 'cyan', 'opts': ('bold',)},
         'MIGRATE_LABEL': {'opts': ('bold',)},
+        'TEST_SUCCESS': {'opts': ('noreset',), 'fg': 'green'},
+        'TEST_FAIL': {'opts': ('noreset',), 'fg': 'red'},
+        'TEST_ERROR': {'opts': ('noreset',), 'fg': 'magenta'},
+        'TEST_EXPECTED_FAILURE': {'opts': ('noreset',), 'fg': 'green'},
+        'TEST_UNEXPECTED_SUCCESS': {'opts': ('noreset', 'bold'), 'fg': 'red'},
+        'TEST_INFO': {'opts': ('bold',), 'fg': 'black'},
     }
 }
 DEFAULT_PALETTE = DARK_PALETTE
@@ -136,6 +154,7 @@ DEFAULT_PALETTE = DARK_PALETTE
 
 def parse_color_setting(config_string):
     """Parse a DJANGO_COLORS environment variable to produce the system palette
+    Returns tuple with name of the base palette that was used and the system palette
 
     The general form of a palette definition is:
 
@@ -166,8 +185,9 @@ def parse_color_setting(config_string):
         'bold', 'underscore', 'blink', 'reverse', 'conceal', 'noreset'
     """
     if not config_string:
-        return PALETTES[DEFAULT_PALETTE]
+        return (DEFAULT_PALETTE, PALETTES[DEFAULT_PALETTE])
 
+    base_palette = NOCOLOR_PALETTE
     # Split the color configuration into parts
     parts = config_string.lower().split(';')
     palette = PALETTES[NOCOLOR_PALETTE].copy()
@@ -175,6 +195,7 @@ def parse_color_setting(config_string):
         if part in PALETTES:
             # A default palette has been specified
             palette.update(PALETTES[part])
+            base_palette = part
         elif '=' in part:
             # Process a palette defining string
             definition = {}
@@ -211,5 +232,5 @@ def parse_color_setting(config_string):
 
     # If there are no colors specified, return the empty palette.
     if palette == PALETTES[NOCOLOR_PALETTE]:
-        return None
-    return palette
+        return (NOCOLOR_PALETTE, None)
+    return (base_palette, palette)

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1295,6 +1295,15 @@ overrides the value provided by the :setting:`TEST_RUNNER` setting.
 Suppresses all user prompts. A typical prompt is a warning about deleting an
 existing test database.
 
+.. versionadded:: 2.1
+
+If the Pygments library is available, the tracebacks of failing tests and
+the SQL queries (if ``--debug-sql`` was provided) will be colored. Windows
+users will need to have the `ANSICON library`_ installed to get colored output.
+
+.. _ANSICON library: https://github.com/adoxa/ansicon
+
+
 Test runner options
 ~~~~~~~~~~~~~~~~~~~
 
@@ -1714,6 +1723,12 @@ number of roles in which color is used:
 * ``http_server_error`` - A 5XX HTTP Server Error response.
 * ``migrate_heading`` - A heading in a migrations management command.
 * ``migrate_label`` - A migration name.
+* ``test_success`` - A passing test.
+* ``test_fail`` - A failing test.
+* ``test_error`` - A test with error.
+* ``test_expected_failure`` - A test that's expectedly failing.
+* ``test_unexpected_success`` - A test that's unexpectedly passing.
+* ``test_info`` - Important test output parts.
 
 Each of these roles can be assigned a specific foreground and
 background color, from the following list:

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -170,6 +170,12 @@ Management Commands
 * The new :option:`inspectdb --include-views` option allows creating models
   for database views.
 
+* :djadmin:`test` now features colored output. If necessary, colored output
+  can be disabled using the :option:`--no-color` option. Windows users
+  will need to have the `ANSICON library`_ installed for this to work.
+
+.. _ANSICON library: https://github.com/adoxa/ansicon
+
 Migrations
 ~~~~~~~~~~
 

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -532,6 +532,7 @@ Punycode
 Puthraya
 py
 pyformat
+Pygments
 pysqlite
 pythonic
 pytz

--- a/tests/test_runner/test_colored_runner.py
+++ b/tests/test_runner/test_colored_runner.py
@@ -1,0 +1,79 @@
+from io import StringIO
+from unittest import TestCase, mock, skipIf
+
+from django.core.management.color import supports_color
+from django.test.runner import TERMINATOR, DiscoverRunner
+
+
+@mock.patch.dict('django.core.management.color.os.environ', {'DJANGO_COLORS': ''})
+@skipIf(not supports_color(), "terminal does not support color")
+class TestColoredRunner(TestCase):
+
+    class PassingTest(TestCase):
+        def runTest(self):
+            self.assertEqual(1, 1)
+
+    class FailingTest(TestCase):
+        def runTest(self):
+            self.assertEqual(1, 2)
+
+    class ErrorTest(TestCase):
+        def runTest(self):
+            raise Exception
+
+    def _test_output(self, verbosity, no_color=True):
+        runner = DiscoverRunner(debug_sql=True, verbosity=0, no_color=no_color)
+        suite = runner.test_suite()
+        suite.addTest(self.FailingTest())
+        suite.addTest(self.ErrorTest())
+        suite.addTest(self.PassingTest())
+        stream = StringIO()
+        resultclass = runner.get_resultclass()
+        runner.test_runner(
+            verbosity=verbosity,
+            stream=stream,
+            resultclass=resultclass,
+            no_color=no_color
+        ).run(suite)
+        return stream.getvalue()
+
+    def test_no_color_output(self):
+        output = self._test_output(1, no_color=True)
+        self.assertNotIn(TERMINATOR, output)
+        self.assertIn('FE.', output)
+
+    def test_colored_output_error(self):
+        output = self._test_output(1, no_color=False)
+        self.assertIn('\x1b[35;1mE\x1b[0m', output)
+        self.assertIn('\x1b[35;1mERROR: \x1b[37;1mrunTest\x1b[0m', output)
+
+    def test_colored_output_fail(self):
+        output = self._test_output(1, no_color=False)
+        self.assertIn('\x1b[31;1mF\x1b[0m', output)
+        self.assertIn('\x1b[31;1mFAIL: \x1b[37;1mrunTest\x1b[0m', output)
+
+    def test_colored_output_success(self):
+        output = self._test_output(1, no_color=False)
+        self.assertIn('\x1b[32m.\x1b[0m', output)
+
+    def test_colored_summary(self):
+        output = self._test_output(1, no_color=False)
+        # tests count
+        self.assertIn('Ran \x1b[37;1m3\x1b[0m tests', output)
+        # time taken
+        self.assertIn('in \x1b[37;1m', output)
+        self.assertIn('\x1b[0ms', output)
+        # failures count
+        self.assertIn('failures=\x1b[31;1m1\x1b[0m', output)
+        # errors count
+        self.assertIn('errors=\x1b[35;1m1\x1b[0m', output)
+
+    def test_colored_verbose_tests_list(self):
+        output = self._test_output(2, no_color=False)
+        self.assertIn(
+            '\x1b[37;1mrunTest\x1b[0m (test_runner.test_colored_runner.TestColoredRunner.FailingTest)'
+            ' ... \x1b[31;1mFAIL\n\x1b[0m', output)
+        self.assertIn('\x1b[37;1mrunTest\x1b[0m (test_runner.test_colored_runner.TestColoredRunner.ErrorTest)'
+                      ' ... \x1b[35;1mERROR\n\x1b[0m', output)
+        self.assertIn('\x1b[37;1mrunTest\x1b[0m (test_runner.test_colored_runner.TestColoredRunner.PassingTest)'
+                      ' ... \x1b[32mok\n\x1b[0m', output)

--- a/tests/test_runner/test_debug_sql.py
+++ b/tests/test_runner/test_debug_sql.py
@@ -1,6 +1,7 @@
 import unittest
 from io import StringIO
 
+from django.core.management.color import supports_color
 from django.db import connection
 from django.test import TestCase
 from django.test.runner import DiscoverRunner
@@ -8,6 +9,15 @@ from django.test.runner import DiscoverRunner
 from .models import Person
 
 
+def is_pygments():
+    try:
+        import pygments  # noqa
+    except ImportError:
+        return False
+    return True
+
+
+@unittest.mock.patch.dict('django.core.management.color.os.environ', {'DJANGO_COLORS': ''})
 @unittest.skipUnless(connection.vendor == 'sqlite', 'Only run on sqlite so we can check output SQL.')
 class TestDebugSQL(unittest.TestCase):
 
@@ -42,8 +52,8 @@ class TestDebugSQL(unittest.TestCase):
                 Person.objects.filter(first_name='subtest-error').count()
                 raise Exception
 
-    def _test_output(self, verbosity):
-        runner = DiscoverRunner(debug_sql=True, verbosity=0)
+    def _test_output(self, verbosity, no_color=True):
+        runner = DiscoverRunner(debug_sql=True, verbosity=0, no_color=no_color)
         suite = runner.test_suite()
         suite.addTest(self.FailingTest())
         suite.addTest(self.ErrorTest())
@@ -58,6 +68,7 @@ class TestDebugSQL(unittest.TestCase):
             verbosity=verbosity,
             stream=stream,
             resultclass=resultclass,
+            no_color=no_color
         ).run(suite)
         runner.teardown_databases(old_config)
 
@@ -76,6 +87,24 @@ class TestDebugSQL(unittest.TestCase):
             self.assertIn(output, full_output)
         for output in self.verbose_expected_outputs:
             self.assertIn(output, full_output)
+
+    @unittest.skipUnless(supports_color(), "terminal does not support color")
+    @unittest.skipIf(is_pygments(), "pygments is available")
+    def test_colored_output(self):
+        def mock_sql_highlighter(sql):
+            return sql
+        full_output = self._test_output(1, no_color=False)
+        for output in self.expected_outputs:
+            self.assertIn(output, full_output)
+
+    @unittest.skipUnless(supports_color(), "terminal does not support color")
+    @unittest.skipIf(is_pygments(), "pygments is available")
+    def test_colored_output_verbose(self):
+        full_output = self._test_output(2, no_color=False)
+        for output in self.expected_outputs:
+            self.assertIn(output, full_output)
+        for output in self.colored_verbose_expected_outputs:
+            self.assertIn(output.decode(), full_output)
 
     expected_outputs = [
         ('''SELECT COUNT(*) AS "__count" '''
@@ -106,4 +135,15 @@ class TestDebugSQL(unittest.TestCase):
         ('''SELECT COUNT(*) AS "__count" '''
             '''FROM "test_runner_person" WHERE '''
             '''"test_runner_person"."first_name" = 'subtest-pass';'''),
+    ]
+
+    colored_verbose_expected_outputs = [
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.FailingTest) ... \x1b[31;1mFAIL\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.ErrorTest) ... \x1b[35;1mERROR\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.PassingTest) ... \x1b[32mok\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.PassingSubTest) ... \x1b[32mok\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.FailingSubTest) ...',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.ErrorSubTest) (<subtest>)\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.FailingTest)\n\x1b[0m',
+        b'\x1b[37;1mrunTest\x1b[0m (test_runner.test_debug_sql.TestDebugSQL.FailingSubTest) (<subtest>)\n\x1b[0m',
     ]

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -1,10 +1,10 @@
 import os
 from argparse import ArgumentParser
 from contextlib import contextmanager
-from unittest import TestSuite, TextTestRunner, defaultTestLoader
+from unittest import TestSuite, defaultTestLoader
 
 from django.test import TestCase
-from django.test.runner import DiscoverRunner
+from django.test.runner import ColoredTextTestRunner, DiscoverRunner
 from django.test.utils import captured_stdout
 
 
@@ -179,7 +179,7 @@ class DiscoverRunnerTest(TestCase):
         self.assertEqual(DiscoverRunner().test_suite, TestSuite)
 
     def test_overridable_test_runner(self):
-        self.assertEqual(DiscoverRunner().test_runner, TextTestRunner)
+        self.assertEqual(DiscoverRunner().test_runner, ColoredTextTestRunner)
 
     def test_overridable_test_loader(self):
         self.assertEqual(DiscoverRunner().test_loader, defaultTestLoader)

--- a/tests/utils_tests/test_termcolors.py
+++ b/tests/utils_tests/test_termcolors.py
@@ -9,172 +9,176 @@ from django.utils.termcolors import (
 class TermColorTests(unittest.TestCase):
 
     def test_empty_string(self):
-        self.assertEqual(parse_color_setting(''), PALETTES[DEFAULT_PALETTE])
+        self.assertEqual(parse_color_setting(''), (DEFAULT_PALETTE, PALETTES[DEFAULT_PALETTE]))
 
     def test_simple_palette(self):
-        self.assertEqual(parse_color_setting('light'), PALETTES[LIGHT_PALETTE])
-        self.assertEqual(parse_color_setting('dark'), PALETTES[DARK_PALETTE])
-        self.assertIsNone(parse_color_setting('nocolor'))
+        self.assertEqual(parse_color_setting('light'), (LIGHT_PALETTE, PALETTES[LIGHT_PALETTE]))
+        self.assertEqual(parse_color_setting('dark'), (DARK_PALETTE, PALETTES[DARK_PALETTE]))
+        self.assertEqual(parse_color_setting('nocolor'), (NOCOLOR_PALETTE, None))
 
     def test_fg(self):
         self.assertEqual(
             parse_color_setting('error=green'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
 
     def test_fg_bg(self):
         self.assertEqual(
             parse_color_setting('error=green/blue'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'}))
         )
 
     def test_fg_opts(self):
         self.assertEqual(
             parse_color_setting('error=green,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)}))
         )
         self.assertEqual(
             parse_color_setting('error=green,bold,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink', 'bold')})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink', 'bold')}))
         )
 
     def test_fg_bg_opts(self):
         self.assertEqual(
             parse_color_setting('error=green/blue,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(
+                PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink',)}))
         )
         self.assertEqual(
             parse_color_setting('error=green/blue,bold,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink', 'bold')})
+            (NOCOLOR_PALETTE, dict(
+                PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink', 'bold')}))
         )
 
     def test_override_palette(self):
         self.assertEqual(
             parse_color_setting('light;error=green'),
-            dict(PALETTES[LIGHT_PALETTE], ERROR={'fg': 'green'})
+            (LIGHT_PALETTE, dict(PALETTES[LIGHT_PALETTE], ERROR={'fg': 'green'}))
         )
 
     def test_override_nocolor(self):
         self.assertEqual(
             parse_color_setting('nocolor;error=green'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
 
     def test_reverse_override(self):
-        self.assertEqual(parse_color_setting('error=green;light'), PALETTES[LIGHT_PALETTE])
+        self.assertEqual(parse_color_setting('error=green;light'), (LIGHT_PALETTE, PALETTES[LIGHT_PALETTE]))
 
     def test_multiple_roles(self):
         self.assertEqual(
             parse_color_setting('error=green;sql_field=blue'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}, SQL_FIELD={'fg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}, SQL_FIELD={'fg': 'blue'}))
         )
 
     def test_override_with_multiple_roles(self):
         self.assertEqual(
             parse_color_setting('light;error=green;sql_field=blue'),
-            dict(PALETTES[LIGHT_PALETTE], ERROR={'fg': 'green'}, SQL_FIELD={'fg': 'blue'})
+            (LIGHT_PALETTE, dict(PALETTES[LIGHT_PALETTE], ERROR={'fg': 'green'}, SQL_FIELD={'fg': 'blue'}))
         )
 
     def test_empty_definition(self):
-        self.assertIsNone(parse_color_setting(';'))
-        self.assertEqual(parse_color_setting('light;'), PALETTES[LIGHT_PALETTE])
-        self.assertIsNone(parse_color_setting(';;;'))
+        self.assertEqual(parse_color_setting(';'), (NOCOLOR_PALETTE, None))
+        self.assertEqual(parse_color_setting('light;'), (LIGHT_PALETTE, PALETTES[LIGHT_PALETTE]))
+        self.assertEqual(parse_color_setting(';;;'), (NOCOLOR_PALETTE, None))
 
     def test_empty_options(self):
         self.assertEqual(
             parse_color_setting('error=green,'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=green,,,'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=green,,blink,,'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)}))
         )
 
     def test_bad_palette(self):
-        self.assertIsNone(parse_color_setting('unknown'))
+        self.assertEqual(parse_color_setting('unknown'), (NOCOLOR_PALETTE, None))
 
     def test_bad_role(self):
-        self.assertIsNone(parse_color_setting('unknown='))
-        self.assertIsNone(parse_color_setting('unknown=green'))
+        self.assertEqual(parse_color_setting('unknown='), (NOCOLOR_PALETTE, None))
+        self.assertEqual(parse_color_setting('unknown=green'), (NOCOLOR_PALETTE, None))
         self.assertEqual(
             parse_color_setting('unknown=green;sql_field=blue'),
-            dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'}))
         )
 
     def test_bad_color(self):
-        self.assertIsNone(parse_color_setting('error='))
+        self.assertEqual(parse_color_setting('error='), (NOCOLOR_PALETTE, None))
         self.assertEqual(
             parse_color_setting('error=;sql_field=blue'),
-            dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'}))
         )
-        self.assertIsNone(parse_color_setting('error=unknown'))
+        self.assertEqual(parse_color_setting('error=unknown'), (NOCOLOR_PALETTE, None))
         self.assertEqual(
             parse_color_setting('error=unknown;sql_field=blue'),
-            dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], SQL_FIELD={'fg': 'blue'}))
         )
         self.assertEqual(
             parse_color_setting('error=green/unknown'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=green/blue/something'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'})
+            (NOCOLOR_PALETTE, dict(
+                PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'}))
         )
         self.assertEqual(
             parse_color_setting('error=green/blue/something,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(
+                PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue', 'opts': ('blink',)}))
         )
 
     def test_bad_option(self):
         self.assertEqual(
             parse_color_setting('error=green,unknown'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=green,unknown,blink'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)}))
         )
 
     def test_role_case(self):
         self.assertEqual(
             parse_color_setting('ERROR=green'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('eRrOr=green'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
 
     def test_color_case(self):
         self.assertEqual(
             parse_color_setting('error=GREEN'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=GREEN/BLUE'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'}))
         )
         self.assertEqual(
             parse_color_setting('error=gReEn'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green'}))
         )
         self.assertEqual(
             parse_color_setting('error=gReEn/bLuE'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'bg': 'blue'}))
         )
 
     def test_opts_case(self):
         self.assertEqual(
             parse_color_setting('error=green,BLINK'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)}))
         )
         self.assertEqual(
             parse_color_setting('error=green,bLiNk'),
-            dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)})
+            (NOCOLOR_PALETTE, dict(PALETTES[NOCOLOR_PALETTE], ERROR={'fg': 'green', 'opts': ('blink',)}))
         )
 
     def test_colorize_empty_text(self):


### PR DESCRIPTION
Hi,

Here is code with tests and documentation for colorizing output of the `manage.py test` command.

Some features:

-  highlighting tracebacks if pygments library is available
-  highlighting SQL queries if pygments library is available and `manage.py test` command was invoked with `--debug-sql` argument
-  highlighting with corresponding colors based on the used pallete (dark or light)
-  can be switched off with `--no-color` argument
-  switching off automatically if the terminal doesn't support colors

Few screenshots:

![image](https://user-images.githubusercontent.com/952028/36074020-df039d82-0f4a-11e8-9a95-781977f0ffd1.png)

![image](https://user-images.githubusercontent.com/952028/36074013-d6cd5c0c-0f4a-11e8-84bf-8c67762883d1.png)