### PR TITLE
Fixed #24270 -- Scoped bash completion reference to source distribution.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1770,7 +1770,7 @@ Bash completion
 ---------------
 
 If you use the Bash shell, consider installing the Django bash completion
-script, which lives in ``extras/django_bash_completion`` in the Django
+script, which lives in ``extras/django_bash_completion`` in the Django source
 distribution. It enables tab-completion of ``django-admin`` and
 ``manage.py`` commands, so you can, for instance...
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24270 :`django_bash_completion` is not part of the Wheel.

Tim's suggestion: 

> ...the best route might be to clarify the documentation to say that the script is included in the "source distribution"...

c.f. https://code.djangoproject.com/ticket/21511: `wontfix`: not something we want to install to `PATH`