### PR TITLE
Added a test for Client.generic() data coercion.

### DIFF
--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -117,6 +117,13 @@ class ClientTest(TestCase):
         self.assertTrue(mock_encoder.called)
         self.assertTrue(mock_encoding.encode.called)
 
+    def test_put(self):
+        response = self.client.put('/put_view/', {'foo': 'bar'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.templates[0].name, 'PUT Template')
+        self.assertEqual(response.context['data'], "{'foo': 'bar'}")
+        self.assertEqual(response.context['Content-Length'], 14)
+
     def test_trace(self):
         """TRACE a view"""
         response = self.client.trace('/trace_view/')

--- a/tests/test_client/views.py
+++ b/tests/test_client/views.py
@@ -53,7 +53,10 @@ def trace_view(request):
 def put_view(request):
     if request.method == 'PUT':
         t = Template('Data received: {{ data }} is the body.', name='PUT Template')
-        c = Context({'data': request.body.decode()})
+        c = Context({
+            'Content-Length': request.META['CONTENT_LENGTH'],
+            'data': request.body.decode(),
+        })
     else:
         t = Template('Viewing GET page.', name='Empty GET Template')
         c = Context()


### PR DESCRIPTION
The smart_str() call (now force_bytes()) added in
e73838b6ddcc7b37c03f9eee04fa6e6a283fedb3 is otherwise untested.