### PR TITLE
Removed redundant lookup name in register_lookup() calls.

### DIFF
--- a/docs/ref/models/database-functions.txt
+++ b/docs/ref/models/database-functions.txt
@@ -739,7 +739,7 @@ It can also be registered as a transform. For example::
 
     >>> from django.db.models import CharField
     >>> from django.db.models.functions import Length
-    >>> CharField.register_lookup(Length, 'length')
+    >>> CharField.register_lookup(Length)
     >>> # Get authors whose name is longer than 7 characters
     >>> authors = Author.objects.filter(name__length__gt=7)
 

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -540,7 +540,7 @@ ordering. For example::
 
     >>> from django.db.models import CharField
     >>> from django.db.models.functions import Lower
-    >>> CharField.register_lookup(Lower, 'lower')
+    >>> CharField.register_lookup(Lower)
     >>> Blog.objects.values('name__lower')
     <QuerySet [{'name__lower': 'beatles blog'}]>
 
@@ -600,7 +600,7 @@ A few subtleties that are worth mentioning:
 
     >>> from django.db.models import CharField, Count
     >>> from django.db.models.functions import Lower
-    >>> CharField.register_lookup(Lower, 'lower')
+    >>> CharField.register_lookup(Lower)
     >>> Blog.objects.values('entry__authors__name__lower').annotate(entries=Count('entry'))
     <QuerySet [{'entry__authors__name__lower': 'test author', 'entries': 33}]>
     >>> Blog.objects.values(

--- a/tests/db_functions/tests.py
+++ b/tests/db_functions/tests.py
@@ -580,7 +580,7 @@ class FunctionTests(TestCase):
 
     def test_length_transform(self):
         try:
-            CharField.register_lookup(Length, 'length')
+            CharField.register_lookup(Length)
             Author.objects.create(name='John Smith', alias='smithj')
             Author.objects.create(name='Rhonda')
             authors = Author.objects.filter(name__length__gt=7)
@@ -591,11 +591,11 @@ class FunctionTests(TestCase):
                 lambda a: a.name
             )
         finally:
-            CharField._unregister_lookup(Length, 'length')
+            CharField._unregister_lookup(Length)
 
     def test_lower_transform(self):
         try:
-            CharField.register_lookup(Lower, 'lower')
+            CharField.register_lookup(Lower)
             Author.objects.create(name='John Smith', alias='smithj')
             Author.objects.create(name='Rhonda')
             authors = Author.objects.filter(name__lower__exact='john smith')
@@ -606,11 +606,11 @@ class FunctionTests(TestCase):
                 lambda a: a.name
             )
         finally:
-            CharField._unregister_lookup(Lower, 'lower')
+            CharField._unregister_lookup(Lower)
 
     def test_upper_transform(self):
         try:
-            CharField.register_lookup(Upper, 'upper')
+            CharField.register_lookup(Upper)
             Author.objects.create(name='John Smith', alias='smithj')
             Author.objects.create(name='Rhonda')
             authors = Author.objects.filter(name__upper__exact='JOHN SMITH')
@@ -621,14 +621,14 @@ class FunctionTests(TestCase):
                 lambda a: a.name
             )
         finally:
-            CharField._unregister_lookup(Upper, 'upper')
+            CharField._unregister_lookup(Upper)
 
     def test_func_transform_bilateral(self):
         class UpperBilateral(Upper):
             bilateral = True
 
         try:
-            CharField.register_lookup(UpperBilateral, 'upper')
+            CharField.register_lookup(UpperBilateral)
             Author.objects.create(name='John Smith', alias='smithj')
             Author.objects.create(name='Rhonda')
             authors = Author.objects.filter(name__upper__exact='john smith')
@@ -639,14 +639,14 @@ class FunctionTests(TestCase):
                 lambda a: a.name
             )
         finally:
-            CharField._unregister_lookup(UpperBilateral, 'upper')
+            CharField._unregister_lookup(UpperBilateral)
 
     def test_func_transform_bilateral_multivalue(self):
         class UpperBilateral(Upper):
             bilateral = True
 
         try:
-            CharField.register_lookup(UpperBilateral, 'upper')
+            CharField.register_lookup(UpperBilateral)
             Author.objects.create(name='John Smith', alias='smithj')
             Author.objects.create(name='Rhonda')
             authors = Author.objects.filter(name__upper__in=['john smith', 'rhonda'])
@@ -658,7 +658,7 @@ class FunctionTests(TestCase):
                 lambda a: a.name
             )
         finally:
-            CharField._unregister_lookup(UpperBilateral, 'upper')
+            CharField._unregister_lookup(UpperBilateral)
 
     def test_function_as_filter(self):
         Author.objects.create(name='John Smith', alias='SMITHJ')


### PR DESCRIPTION
Without this, the lookup_name of each transform isn't tested.