### PR TITLE
Fixed #29141 -- Corrected BCryptPasswordHasher's docstring about truncation.

### DIFF
--- a/django/contrib/auth/hashers.py
+++ b/django/contrib/auth/hashers.py
@@ -456,10 +456,8 @@ class BCryptPasswordHasher(BCryptSHA256PasswordHasher):
     issues.
 
     This hasher does not first hash the password which means it is subject to
-    the 72 character bcrypt password truncation, most use cases should prefer
-    the BCryptSHA256PasswordHasher.
-
-    See: https://code.djangoproject.com/ticket/20138
+    bcrypt's 72 bytes password truncation. Most use cases should prefer the
+    BCryptSHA256PasswordHasher.
     """
     algorithm = "bcrypt"
     digest = None


### PR DESCRIPTION
BCrypt truncates at 72 bytes and not at 72 characters. Let's be clear
about that.