### PR TITLE
Fixed #29140 -- Fixed crash when email body is None

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -231,7 +231,7 @@ class EmailMessage:
             self.reply_to = []
         self.from_email = from_email or settings.DEFAULT_FROM_EMAIL
         self.subject = subject
-        self.body = body
+        self.body = body or ''
         self.attachments = []
         if attachments:
             for attachment in attachments:

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -357,6 +357,11 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
         msg.attach('example.txt', 'Text file content', 'text/plain')
         self.assertIn(html_content, msg.message().as_string())
 
+    def test_none_body(self):
+        msg = EmailMessage('subject', None, 'from@example.com', ['to@example.com'])
+        self.assertEqual(msg.body, '')
+        self.assertEqual(msg.message().get_payload(), '')
+
     def test_encoding(self):
         """
         Regression for #12791 - Encode body correctly with other encodings


### PR DESCRIPTION
When testing whether a payload has long lines or not,
the code crashed trying to call method "splitlines",
even though users might have attached a file.

So my solution was to simply say it doesn't have long
lines.  Python core mail library would perfectly accept
a payload=None.