### PR TITLE
Fixed #29143 - IntConverter does not accept negative integers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ answer newbie questions, and generally made Django that much better:
     Arvis Bickovskis <viestards.lists@gmail.com>
     Aryeh Leib Taurog <http://www.aryehleib.com/>
     A S Alam <aalam@users.sf.net>
+    Ashish Nitin Patil <ashishnitinpatil@gmail.com>
     Asif Saif Uddin <auvipy@gmail.com>
     atlithorn <atlithorn@gmail.com>
     Audrey Roy <http://audreymroy.com/>

--- a/django/urls/converters.py
+++ b/django/urls/converters.py
@@ -4,7 +4,7 @@ from django.utils import lru_cache
 
 
 class IntConverter:
-    regex = '[0-9]+'
+    regex = '-?[0-9]+'
 
     def to_python(self, value):
         return int(value)

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -77,7 +77,7 @@ class ConverterTests(SimpleTestCase):
             return x
 
         test_data = (
-            ('int', {'0', '1', '01', 1234567890}, int),
+            ('int', {'0', '1', '01', 1234567890, '-1', '-01', -1}, int),
             ('str', {'abcxyz'}, no_converter),
             ('path', {'allows.ANY*characters'}, no_converter),
             ('slug', {'abcxyz-ABCXYZ_01234567890'}, no_converter),
@@ -103,7 +103,7 @@ class ConverterTests(SimpleTestCase):
 
     def test_nonmatching_urls(self):
         test_data = (
-            ('int', {'-1', 'letters'}),
+            ('int', {'letters', '123mixed'}),
             ('str', {'', '/'}),
             ('path', {''}),
             ('slug', {'', 'stars*notallowed'}),


### PR DESCRIPTION
Fixed IntConverter to accept negative integers as well. Modified corresponding tests and added self to AUTHORS.

Ticket link - https://code.djangoproject.com/ticket/29143