### PR TITLE
Fixed #29112 -- Allowed using QuerySet.update() to update specific keys in nested JSONField.

### DIFF
--- a/django/contrib/postgres/functions.py
+++ b/django/contrib/postgres/functions.py
@@ -1,4 +1,15 @@
 from django.db.models import DateTimeField, Func, UUIDField
+from django.db.models.fields import CharField
+
+
+class Jsonify(Func):
+    """
+    Updates the value of a JSONField for a specific key.
+    Works with nested JSON fields as well.
+    """
+    function = 'JSONB_SET'
+    arity = 4
+    output_field = CharField()
 
 
 class RandomUUID(Func):

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -114,6 +114,16 @@ class UpdateQuery(Query):
         """
         values_seq = []
         for name, val in values.items():
+            if "__" in name:
+                attributes = name.split('__')
+                name = attributes.pop(0)
+                hierarchy = (',').join(attributes)
+                field = self.get_meta().get_field(name)
+                from django.contrib.postgres.functions import Jsonify
+                from django.db.models import Value as V
+                val = Jsonify(
+                    field.name, V("{" + hierarchy + "}"), V('"' + val + '"'), V(False)
+                )
             field = self.get_meta().get_field(name)
             direct = not (field.auto_created and not field.concrete) or not field.concrete
             model = field.model._meta.concrete_model

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -80,7 +80,8 @@ Minor features
 :mod:`django.contrib.postgres`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* Fields of type ``JSONField`` can now be updated by specifying the path
+  of the key and the new value in ``update()`` function.
 
 :mod:`django.contrib.redirects`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -259,6 +259,20 @@ class TestQuerying(PostgreSQLTestCase):
     def test_iregex(self):
         self.assertTrue(JSONModel.objects.filter(field__foo__iregex=r'^bAr$').exists())
 
+    def test_update(self):
+        JSONModel.objects.filter(field__k__l='m').update(field__k__l='priyansh')
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__k__l='priyansh'),
+            [self.objs[8]]
+        )
+
+    def test_update_index(self):
+        JSONModel.objects.filter(field__d__1__f='g').update(field__d__1__f='naimish')
+        self.assertSequenceEqual(
+            JSONModel.objects.filter(field__d__1__f='naimish'),
+            [self.objs[8]]
+        )
+
 
 @isolate_apps('postgres_tests')
 class TestChecks(PostgreSQLTestCase):


### PR DESCRIPTION
Specific keys can be updated within a nested JSONField  by specifying
the path and new value as arguments to the update() method, just like
the syntax used in Lookups.
https://code.djangoproject.com/ticket/29112