### PR TITLE
Used a CSS positioning in tutorial 6 that doesn't differ across browsers.

### DIFF
--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -92,11 +92,11 @@ Then, add to your stylesheet (``polls/static/polls/style.css``):
     :filename: polls/static/polls/style.css
 
     body {
-        background: white url("images/background.gif") no-repeat right bottom;
+        background: white url("images/background.gif") no-repeat;
     }
 
 Reload ``http://localhost:8000/polls/`` and you should see the background
-loaded in the bottom right of the screen.
+loaded in the top left of the screen.
 
 .. warning::
 


### PR DESCRIPTION
Otherwise, in FireFox, the <html> and <body> elements take just as much height as is needed for the content, i.e. the unordered list of questions. So the image appears not at the bottom of the browser window, but the bottom of the <body> element, which is surprising when you follow the tutorial.
Please test in your environment as well.