### PR TITLE
Fixed #23406 -- added a MIGRATIONS_INCLUDE_PYC setting

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -609,6 +609,12 @@ STATICFILES_FINDERS = [
 # Migration module overrides for apps, by app label.
 MIGRATION_MODULES = {}
 
+# By default, the migrations loader will only load .py files, to avoid
+# problems with stale .pyc files after switching git branches (for instance).
+# This setting changes the loader to use pkgutil.iter_modules to find any
+# migration modules
+MIGRATIONS_INCLUDE_PYC = False
+
 #################
 # SYSTEM CHECKS #
 #################

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1977,6 +1977,25 @@ testing (tables will still be created for the apps' models). If this is used in
 your general project settings, remember to use the :option:`migrate
 --run-syncdb` option if you want to create tables for the app.
 
+.. setting:: MIGRATIONS_INCLUDE_PYC
+
+``MIGRATIONS_INCLUDE_PYC``
+--------------------------
+
+.. versionadded:: 2.1
+
+Default: ``False``
+
+If ``True``, the migrations loader will consider compiled modules when loading
+migrations from disk. This can be useful in frozen environments, but should
+typically remain off.
+
+.. warning::
+
+    This setting defaults to ``False`` for very good reasons. Loading compiled
+    migrations leads to unexpected behavior and errors when (for instance)
+    switching between git branches which may leave compiled modules behind.
+
 .. setting:: MONTH_DAY_FORMAT
 
 ``MONTH_DAY_FORMAT``

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -195,6 +195,9 @@ Models
 * :meth:`.QuerySet.order_by` and :meth:`distinct(*fields) <.QuerySet.distinct>`
   now support using field transforms.
 
+* A new :setting:`MIGRATIONS_INCLUDE_PYC` setting was added to allow loading migration
+  modules from compiled `.pyc` files.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -1,3 +1,6 @@
+import compileall
+import os
+
 from django.db import connection, connections
 from django.db.migrations.exceptions import (
     AmbiguityError, InconsistentMigrationHistory, NodeNotFoundError,
@@ -5,6 +8,8 @@ from django.db.migrations.exceptions import (
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, modify_settings, override_settings
+
+from .test_base import MigrationTestBase
 
 
 class RecorderTests(TestCase):
@@ -478,3 +483,28 @@ class LoaderTests(TestCase):
             ('app1', '4_auto'),
         }
         self.assertEqual(plan, expected_plan)
+
+
+class PycLoaderTests(MigrationTestBase):
+    """
+    Tests the loader with MIGRATIONS_INCLUDE_PYC enabled.
+    """
+
+    def test_loading_pyc_migrations(self):
+        """
+        Tests that .pyc migrations are loaded when MIGRATIONS_INCLUDE_PYC is True.
+        """
+        module = 'migrations.test_migrations_pyc'
+        with self.temporary_migration_module(module=module) as migration_dir:
+            # Compile all the .py files to (legacy) .pyc files, and delete the originals.
+            compileall.compile_dir(migration_dir, force=True, quiet=1, legacy=True)
+            for name in os.listdir(migration_dir):
+                if name.endswith(".py"):
+                    os.remove(os.path.join(migration_dir, name))
+            # Ensure the default loader settings don't find the compiled migration.
+            loader = MigrationLoader(connection)
+            self.assertNotIn(('migrations', '0001_initial'), loader.disk_migrations)
+            # Now make sure the compiled migration is found when MIGRATIONS_INCLUDE_PYC is True.
+            with override_settings(MIGRATIONS_INCLUDE_PYC=True):
+                loader = MigrationLoader(connection)
+                self.assertIn(('migrations', '0001_initial'), loader.disk_migrations)

--- a/tests/migrations/test_migrations_pyc/0001_initial.py
+++ b/tests/migrations/test_migrations_pyc/0001_initial.py
@@ -1,0 +1,9 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    operations = [
+    ]


### PR DESCRIPTION
…to allow loading compiled migrations. Based on the patch from jdetaeye in the ticket, but with a setting to control the behavior, documentation, and tests.