### PR TITLE
Fixed #29142 -- Fixed crash when OuterRef is used with an operator.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -525,6 +525,9 @@ class ResolvedOuterRef(F):
     def _prepare(self, output_field=None):
         return self
 
+    def relabeled_clone(self, relabels):
+        return self
+
 
 class OuterRef(F):
     def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -575,6 +575,11 @@ class BasicExpressionsTests(TestCase):
         outer = Result.objects.filter(pk__in=Subquery(inner.values('pk')))
         self.assertFalse(outer.exists())
 
+    def test_outerref_with_operator(self):
+        inner = Company.objects.filter(num_employees=OuterRef('ceo__salary') + 2)
+        outer = Company.objects.filter(pk__in=Subquery(inner.values('pk')))
+        self.assertEqual(outer.get().name, 'Test GmbH')
+
 
 class IterableLookupInnerExpressionsTests(TestCase):
     @classmethod


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29142