### PR TITLE
Fixed #29154 -- Corrected examples in pluralize template filter docstring and added tests.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -854,22 +854,22 @@ def pluralize(value, arg='s'):
     Return a plural suffix if the value is not 1. By default, use 's' as the
     suffix:
 
-    * If value is 0, vote{{ value|pluralize }} display "0 votes".
-    * If value is 1, vote{{ value|pluralize }} display "1 vote".
-    * If value is 2, vote{{ value|pluralize }} display "2 votes".
+    * If value is 0, vote{{ value|pluralize }} display "votes".
+    * If value is 1, vote{{ value|pluralize }} display "vote".
+    * If value is 2, vote{{ value|pluralize }} display "votes".
 
     If an argument is provided, use that string instead:
 
-    * If value is 0, class{{ value|pluralize:"es" }} display "0 classes".
-    * If value is 1, class{{ value|pluralize:"es" }} display "1 class".
-    * If value is 2, class{{ value|pluralize:"es" }} display "2 classes".
+    * If value is 0, class{{ value|pluralize:"es" }} display "classes".
+    * If value is 1, class{{ value|pluralize:"es" }} display "class".
+    * If value is 2, class{{ value|pluralize:"es" }} display "classes".
 
     If the provided argument contains a comma, use the text before the comma
     for the singular case and the text after the comma for the plural case:
 
-    * If value is 0, cand{{ value|pluralize:"y,ies" }} display "0 candies".
-    * If value is 1, cand{{ value|pluralize:"y,ies" }} display "1 candy".
-    * If value is 2, cand{{ value|pluralize:"y,ies" }} display "2 candies".
+    * If value is 0, cand{{ value|pluralize:"y,ies" }} display "candies".
+    * If value is 1, cand{{ value|pluralize:"y,ies" }} display "candy".
+    * If value is 2, cand{{ value|pluralize:"y,ies" }} display "candies".
     """
     if ',' not in arg:
         arg = ',' + arg

--- a/tests/template_tests/filter_tests/test_pluralize.py
+++ b/tests/template_tests/filter_tests/test_pluralize.py
@@ -3,6 +3,29 @@ from decimal import Decimal
 from django.template.defaultfilters import pluralize
 from django.test import SimpleTestCase
 
+from ..utils import setup
+
+
+class PluralizeTests(SimpleTestCase):
+
+    def check_values(self, *tests):
+        for value, expected in tests:
+            with self.subTest(value=value):
+                output = self.engine.render_to_string('t', {'value': value})
+                self.assertEqual(output, expected)
+
+    @setup({'t': 'vote{{ value|pluralize }}'})
+    def test_no_arguments(self):
+        self.check_values(('0', 'votes'), ('1', 'vote'), ('2', 'votes'))
+
+    @setup({'t': 'class{{ value|pluralize:"es" }}'})
+    def test_suffix(self):
+        self.check_values(('0', 'classes'), ('1', 'class'), ('2', 'classes'))
+
+    @setup({'t': 'cand{{ value|pluralize:"y,ies" }}'})
+    def test_singular_and_plural_suffix(self):
+        self.check_values(('0', 'candies'), ('1', 'candy'), ('2', 'candies'))
+
 
 class FunctionTests(SimpleTestCase):
 


### PR DESCRIPTION
Fix `pluralize` template filter and add some tests.