### PR TITLE
Removed using argument from admin's get_deleted_objects().

### DIFF
--- a/django/contrib/admin/actions.py
+++ b/django/contrib/admin/actions.py
@@ -6,7 +6,6 @@ from django.contrib import messages
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import get_deleted_objects, model_ngettext
 from django.core.exceptions import PermissionDenied
-from django.db import router
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext as _, gettext_lazy
 
@@ -28,12 +27,10 @@ def delete_selected(modeladmin, request, queryset):
     if not modeladmin.has_delete_permission(request):
         raise PermissionDenied
 
-    using = router.db_for_write(modeladmin.model)
-
     # Populate deletable_objects, a data structure of all related objects that
     # will also be deleted.
     deletable_objects, model_count, perms_needed, protected = get_deleted_objects(
-        queryset, request.user, modeladmin.admin_site, using,
+        queryset, request.user, modeladmin.admin_site,
     )
 
     # The user has already confirmed the deletion.

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1750,12 +1750,10 @@ class ModelAdmin(BaseModelAdmin):
         if obj is None:
             return self._get_obj_does_not_exist_redirect(request, opts, object_id)
 
-        using = router.db_for_write(self.model)
-
         # Populate deleted_objects, a data structure of all related objects that
         # will also be deleted.
         deleted_objects, model_count, perms_needed, protected = get_deleted_objects(
-            [obj], request.user, self.admin_site, using,
+            [obj], request.user, self.admin_site,
         )
 
         if request.POST and not protected:  # The user has confirmed the deletion.

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -61,6 +61,17 @@ class AdminActionsTest(TestCase):
         self.client.post(reverse('admin:admin_views_subscriber_changelist'), delete_confirmation_data)
         self.assertEqual(Subscriber.objects.count(), 0)
 
+    def test_default_delete_action_nonexistent_pk(self):
+        self.assertFalse(Subscriber.objects.filter(id=9998).exists())
+        action_data = {
+            ACTION_CHECKBOX_NAME: ['9998'],
+            'action': 'delete_selected',
+            'index': 0,
+        }
+        response = self.client.post(reverse('admin:admin_views_subscriber_changelist'), action_data)
+        self.assertContains(response, 'Are you sure you want to delete the selected subscribers?')
+        self.assertContains(response, '<ul></ul>', html=True)
+
     @override_settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=True)
     def test_non_localized_pk(self):
         """


### PR DESCRIPTION
The first commit adds a test for the `IndexError` branch in the second commit which would otherwise be untested.