### PR TITLE
Fixed #29158 -- Prevented ModelChoiceIterator crash when checking choices' length

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1130,7 +1130,7 @@ class ModelChoiceIterator:
     def __iter__(self):
         if self.field.empty_label is not None:
             yield ("", self.field.empty_label)
-        queryset = self.queryset.all()
+        queryset = self.queryset
         # Can't use iterator() when queryset uses prefetch_related()
         if not queryset._prefetch_related_lookups:
             queryset = queryset.iterator()
@@ -1194,7 +1194,7 @@ class ModelChoiceField(ChoiceField):
         return self._queryset
 
     def _set_queryset(self, queryset):
-        self._queryset = queryset
+        self._queryset = None if queryset is None else queryset.all()
         self.widget.choices = self.choices
 
     queryset = property(_get_queryset, _set_queryset)

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -249,6 +249,7 @@ class ModelChoiceFieldTests(TestCase):
 
     def test_queryset_manager(self):
         f = forms.ModelChoiceField(Category.objects)
+        self.assertEqual(len(f.choices), 4)
         self.assertEqual(list(f.choices), [
             ('', '---------'),
             (self.c1.pk, 'Entertainment'),

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -2339,7 +2339,7 @@ class OtherModelFormTests(TestCase):
                 return ', '.join(c.name for c in obj.colours.all())
 
         field = ColorModelChoiceField(ColourfulItem.objects.prefetch_related('colours'))
-        with self.assertNumQueries(4):  # would be 5 if prefetch is ignored
+        with self.assertNumQueries(2):  # would be 3 if prefetch is ignored
             self.assertEqual(tuple(field.choices), (
                 ('', '---------'),
                 (multicolor_item.pk, 'blue, red'),


### PR DESCRIPTION
Now the `queryset` property systematically calls `.all()` on the
`QuerySet` or `Manager` when set. That avoids calling `.all()` in the
`__iter__` method, preventing a duplicate query when choices are cast to
a `list` and there's a `prefetch_related()`.

The duplicate query generated when there are no `prefetch_related` will
be removed with [ticket 29159](https://code.djangoproject.com/ticket/29159).

Ticket: https://code.djangoproject.com/ticket/29158