### PR TITLE
Removed "Remove any old versions of Django" install instructions. 

### DIFF
--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -89,18 +89,11 @@ Once you're ready, it is time to :doc:`install the new Django version
 </topics/install>`. If you are using virtualenv_ and it is a major upgrade, you
 might want to set up a new environment with all the dependencies first.
 
-Exactly which steps you will need to take depends on your installation process.
-The most convenient way is to use pip_ with the ``--upgrade`` or ``-U`` flag:
+If you installed Django with pip_, you can use the ``--upgrade`` or ``-U`` flag:
 
 .. console::
 
    $ pip install -U Django
-
-pip_ also automatically uninstalls the previous version of Django.
-
-If you use some other installation process, you might have to manually
-:ref:`uninstall the old Django version <removing-old-versions-of-django>` and
-should look at the complete installation instructions.
 
 .. _pip: https://pip.pypa.io/
 .. _virtualenv: https://virtualenv.pypa.io/

--- a/docs/intro/install.txt
+++ b/docs/intro/install.txt
@@ -34,13 +34,6 @@ This step is only necessary if you'd like to work with a "large" database engine
 like PostgreSQL, MySQL, or Oracle. To install such a database, consult the
 :ref:`database installation information <database-installation>`.
 
-Remove any old versions of Django
-=================================
-
-If you are upgrading your installation of Django from a previous version, you
-will need to :ref:`uninstall the old Django version before installing the new
-version <removing-old-versions-of-django>`.
-
 Install Django
 ==============
 

--- a/docs/topics/install.txt
+++ b/docs/topics/install.txt
@@ -122,28 +122,6 @@ database queries, Django will need permission to create a test database.
 .. _cx_Oracle: https://oracle.github.io/python-cx_Oracle/
 .. _Oracle: https://www.oracle.com/
 
-.. _removing-old-versions-of-django:
-
-Remove any old versions of Django
-=================================
-
-If you are upgrading your installation of Django from a previous version,
-you will need to uninstall the old Django version before installing the
-new version.
-
-If you installed Django using pip_ or ``easy_install`` previously, installing
-with pip_ or ``easy_install`` again will automatically take care of the old
-version, so you don't need to do it yourself.
-
-If you previously installed Django using ``python setup.py install``,
-uninstalling is as simple as deleting the ``django`` directory from your Python
-``site-packages``. To find the directory you need to remove, you can run the
-following at your shell prompt (not the interactive Python prompt):
-
-.. console::
-
-    $ python -c "import django; print(django.__path__)"
-
 .. _install-django-code:
 
 Install the Django code


### PR DESCRIPTION
They are obsolete given the prevalence of pip.