### PR TITLE
Fixed buggy regex in URL dispatcher docs

### DIFF
--- a/docs/topics/http/urls.txt
+++ b/docs/topics/http/urls.txt
@@ -201,7 +201,7 @@ Here's the example URLconf from earlier, rewritten using regular expressions::
         path('articles/2003/', views.special_case_2003),
         re_path(r'^articles/(?P<year>[0-9]{4})/$', views.year_archive),
         re_path(r'^articles/(?P<year>[0-9]{4})/(?P<month>[0-9]{2})/$', views.month_archive),
-        re_path(r'^articles/(?P<year>[0-9]{4})/(?P<month>[0-9]{2})/(?P<slug>[\w-_]+)/$', views.article_detail),
+        re_path(r'^articles/(?P<year>[0-9]{4})/(?P<month>[0-9]{2})/(?P<slug>[\w-]+)/$', views.article_detail),
     ]
 
 This accomplishes roughly the same thing as the previous example, except:


### PR DESCRIPTION
I think we need to escape `-` in `[\w-_]`, otherwise it is interpreted as a range:

```
django.core.exceptions.ImproperlyConfigured: "^articles/(?P<year>[0-9]{4})/(?P<month>[0-9]{2})/(?P<slug>[\w-_]+)/$" is not a valid regular expression: bad character range \w-_ at position 59
```

Furthermore, `\w` already matches `_`, so we can just remove that.