### PR TITLE
Fixed #29176 -- Fixed User.normalize_username() crash if username isn't a string.

### DIFF
--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -138,4 +138,4 @@ class AbstractBaseUser(models.Model):
 
     @classmethod
     def normalize_username(cls, username):
-        return unicodedata.normalize('NFKC', username) if username else username
+        return unicodedata.normalize('NFKC', username) if isinstance(username, str) else username

--- a/docs/releases/2.0.3.txt
+++ b/docs/releases/2.0.3.txt
@@ -28,3 +28,6 @@ Bugfixes
 
 * Fixed crash when using a ``Window()`` expression in a subquery
   (:ticket:`29172`).
+
+* Fixed ``AbstractBaseUser.normalize_username()`` crash if the ``username``
+  argument isn't a string (:ticket:`29176`).

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -12,6 +12,7 @@ from django.core import mail
 from django.db.models.signals import post_save
 from django.test import SimpleTestCase, TestCase, override_settings
 
+from .models import IntegerUsernameUser
 from .models.with_custom_email_field import CustomEmailField
 
 
@@ -156,6 +157,9 @@ class UserManagerTestCase(TestCase):
 
 
 class AbstractBaseUserTests(TestCase):
+
+    def test_normalize_username(self):
+        self.assertEqual(IntegerUsernameUser().normalize_username(123), 123)
 
     def test_clean_normalize_username(self):
         # The normalization happens in AbstractBaseUser.clean()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29176
If you use an other type for username than CharField, unicodedata.normalize will fail.