### PR TITLE
WIP: 29177 - ForeignKeys on Unmanaged models get those serialized into migrations

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -567,10 +567,6 @@ class MigrationAutodetector:
                 beginning=True,
             )
 
-            # Don't add operations which modify the database for unmanaged models
-            if not model_opts.managed:
-                continue
-
             # Generate operations for each related field
             for name, field in sorted(related_fields.items()):
                 dependencies = self._get_dependencies_for_foreign_key(field)


### PR DESCRIPTION
Trac ticket: https://code.djangoproject.com/ticket/29177

Marking as work in progress because it's just a sketch right now, and will need rebasing & tidying up. I've left comments saying as much in the code, so those at least will need to go :)

Specific questions I have:
- how do I verify that the addition of the FK into the migration state won't try to create constraints/indexes? I suspect that's maybe what the `AddField` on `test_unmanaged_model_fk_to_managed_model` might try and do?
- is it *correct* that an FK from an unmanaged model to a managed model leads to a different series of operations (`CreateModel, CreateModel, AddField`) than a FK from an unmanaged model to another unmanaged model (`CreateModel, CreateModel`)?
- I feel like *adding* an FK to an existing unmanaged model ought to do *something* (`test_adding_an_fk_to_an_unmanaged_model`) so that the serialized field is available in subsequent migrations, even if it's a no-op. But it doesn't seem to, given the way I've used `self.get_changes` ... so maybe I've used it wrong?
