### PR TITLE
[RFC] Keep ModelAdmin's JS/CSS before form's

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1535,11 +1535,12 @@ class ModelAdmin(BaseModelAdmin):
             self.get_prepopulated_fields(request, obj),
             self.get_readonly_fields(request, obj),
             model_admin=self)
-        media = self.media + adminForm.media
+        form_media = adminForm.media
 
         inline_formsets = self.get_inline_formsets(request, formsets, inline_instances, obj)
         for inline_formset in inline_formsets:
-            media = media + inline_formset.media
+            form_media += inline_formset.media
+        media = self.media & form_media
 
         context = {
             **self.admin_site.each_context(request),
@@ -1681,18 +1682,16 @@ class ModelAdmin(BaseModelAdmin):
             formset = cl.formset = FormSet(queryset=cl.result_list)
 
         # Build the list of media to be used by the formset.
-        if formset:
-            media = self.media + formset.media
-        else:
-            media = self.media
+        form_media = formset.media if formset else forms.Media()
 
         # Build the action form and populate it with available actions.
         if actions:
             action_form = self.action_form(auto_id=None)
             action_form.fields['action'].choices = self.get_action_choices(request)
-            media += action_form.media
+            form_media += action_form.media
         else:
             action_form = None
+        media = self.media & form_media
 
         selection_note_all = ngettext(
             '%(total_count)s selected',

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.forms.utils import to_current_timezone
 from django.templatetags.static import static
 from django.utils import datetime_safe, formats
+from django.utils.datastructures import OrderedSet
 from django.utils.dates import MONTHS
 from django.utils.formats import get_format
 from django.utils.html import format_html, html_safe
@@ -135,6 +136,16 @@ class Media:
         combined._js = self.merge(self._js, other._js)
         combined._css = {
             medium: self.merge(self._css.get(medium, []), other._css.get(medium, []))
+            for medium in self._css.keys() | other._css.keys()
+        }
+        return combined
+
+    def __and__(self, other):
+        combined = Media()
+        combined._js = OrderedSet(self._js + other._js)
+        combined._css = {
+            medium: OrderedSet(self._css.get(medium, []) +
+                               other._css.get(medium, []))
             for medium in self._css.keys() | other._css.keys()
         }
         return combined

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -35,6 +35,9 @@ class OrderedSet:
     def __len__(self):
         return len(self.dict)
 
+    def __repr__(self):
+        return 'OrderedSet(%r)' % list(self.dict.keys())
+
 
 class MultiValueDictKeyError(KeyError):
     pass

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -539,6 +539,19 @@ class FormsMediaTestCase(SimpleTestCase):
             with self.subTest(list1=list1, list2=list2):
                 self.assertEqual(Media.merge(list1, list2), expected)
 
+    def test_and(self):
+        test_values = (
+            (([1, 2], [3, 4]), [1, 2, 3, 4]),
+            (([1, 2], [2, 3]), [1, 2, 3]),
+            (([2, 3], [1, 2]), [2, 3, 1]),
+            (([1, 3], [2, 3]), [1, 3, 2]),
+            (([1, 2], [1, 3]), [1, 2, 3]),
+            (([1, 2], [3, 2]), [1, 2, 3]),
+        )
+        for (list1, list2), expected in test_values:
+            with self.subTest(list1=list1, list2=list2):
+                self.assertEqual(list((Media(js=list1) & Media(js=list2))._js), expected)
+
     def test_merge_warning(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')


### PR DESCRIPTION
The changes in https://code.djangoproject.com/ticket/28377 (https://github.com/django/django/pull/8667) might cause
unexpected ordering with django-autocomplete-light on an admin page that
also includes a date selector widget.

The reason for this is that the date widget includes
`'admin/js/vendor/jquery/jquery.js'`, which is also included in the
Admin's media already, and then everything before it gets prepended.

Simplified version:

    admin_media = ['jquery.js']
    form_media = ['app/jquery.init.js', 'jquery.js', 'calendar.js']
    merged = ['app/jquery.init.js', 'jquery.js', 'calendar.js']

This causes a JavaScript error, since `app/jquery.init.js` has no jQuery
available.

A solution to this might be to keep the admin's media separate from the
form's media, which this PR tries to do.