### PR TITLE
Fixed #29195 -- Fixed Exists.output_field resolution on single-valued queries.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -960,9 +960,12 @@ class Subquery(Expression):
     def __init__(self, queryset, output_field=None, **extra):
         self.queryset = queryset
         self.extra = extra
-        if output_field is None and len(self.queryset.query.select) == 1:
-            output_field = self.queryset.query.select[0].field
         super().__init__(output_field)
+
+    def _resolve_output_field(self):
+        if len(self.queryset.query.select) == 1:
+            return self.queryset.query.select[0].field
+        return super()._resolve_output_field()
 
     def copy(self):
         clone = super().copy()

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -9,4 +9,5 @@ Django 2.0.4 fixes several bugs in 2.0.3.
 Bugfixes
 ========
 
-* ...
+* Fixed a crash when filtering with an ``Exists()`` annotation of a queryset
+  containing a single field (:ticket:`29195`).

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -417,6 +417,10 @@ class BasicExpressionsTests(TestCase):
         outer = Employee.objects.annotate(is_point_of_contact=Exists(inner))
         self.assertIs(outer.exists(), True)
 
+    def test_exist_single_field_output_field(self):
+        queryset = Company.objects.values('pk')
+        self.assertIsInstance(Exists(queryset).output_field, models.BooleanField)
+
     def test_subquery(self):
         Company.objects.filter(name='Example Inc.').update(
             point_of_contact=Employee.objects.get(firstname='Joe', lastname='Smith'),


### PR DESCRIPTION
The `Subquery` class which `Exists` inherits from defaulted to using single-valued querie's field if no `output_field` was explicitly specified on initialization which was bypassing the `Exists.output_field` defined at the class level.

Moving `Subquery`'s dynamic `output_field` resolution to `_resolve_output_field` should make sure the fallback logic is only performed if required.

Thanks Oli Warner for the detailed report.

https://code.djangoproject.com/ticket/29195