### PR TITLE
Fixed #29184 -- Made TabularInline respect model form's Meta.labels and help_texts.

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -258,18 +258,21 @@ class InlineAdminFormSet:
 
     def fields(self):
         fk = getattr(self.formset, "fk", None)
+        empty_form = self.formset.empty_form
+        meta_labels = empty_form._meta.labels or {}
+        meta_help_texts = empty_form._meta.help_texts or {}
         for i, field_name in enumerate(flatten_fieldsets(self.fieldsets)):
             if fk and fk.name == field_name:
                 continue
             if field_name in self.readonly_fields:
                 yield {
-                    'label': label_for_field(field_name, self.opts.model, self.opts),
+                    'label': meta_labels.get(field_name) or label_for_field(field_name, self.opts.model, self.opts),
                     'widget': {'is_hidden': False},
                     'required': False,
-                    'help_text': help_text_for_field(field_name, self.opts.model),
+                    'help_text': meta_help_texts.get(field_name) or help_text_for_field(field_name, self.opts.model),
                 }
             else:
-                form_field = self.formset.empty_form.fields[field_name]
+                form_field = empty_form.fields[field_name]
                 label = form_field.label
                 if label is None:
                     label = label_for_field(field_name, self.opts.model, self.opts)

--- a/tests/admin_inlines/admin.py
+++ b/tests/admin_inlines/admin.py
@@ -206,6 +206,8 @@ class SomeChildModelForm(forms.ModelForm):
         widgets = {
             'position': forms.HiddenInput,
         }
+        labels = {'readonly_field': 'Label from ModelForm.Meta'}
+        help_texts = {'readonly_field': 'Help text from ModelForm.Meta'}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -215,6 +217,7 @@ class SomeChildModelForm(forms.ModelForm):
 class SomeChildModelInline(admin.TabularInline):
     model = SomeChildModel
     form = SomeChildModelForm
+    readonly_fields = ('readonly_field',)
 
 
 site.register(TitleCollection, inlines=[TitleInline])

--- a/tests/admin_inlines/models.py
+++ b/tests/admin_inlines/models.py
@@ -248,6 +248,7 @@ class SomeChildModel(models.Model):
     name = models.CharField(max_length=1)
     position = models.PositiveIntegerField()
     parent = models.ForeignKey(SomeParentModel, models.CASCADE)
+    readonly_field = models.CharField(max_length=1)
 
 # Other models
 

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -175,6 +175,21 @@ class TestInline(TestDataMixin, TestCase):
             1
         )
 
+    def test_tabular_model_form_meta_readonly_field(self):
+        """
+        Tabular inlines use ModelForm.Meta.help_texts and labels for read-only
+        fields.
+        """
+        response = self.client.get(reverse('admin:admin_inlines_someparentmodel_add'))
+        self.assertContains(
+            response,
+            '<img src="/static/admin/img/icon-unknown.svg" '
+            'class="help help-tooltip" width="10" height="10" '
+            'alt="(Help text from ModelForm.Meta)" '
+            'title="Help text from ModelForm.Meta">'
+        )
+        self.assertContains(response, 'Label from ModelForm.Meta')
+
     def test_inline_hidden_field_no_column(self):
         """#18263 -- Make sure hidden fields don't get a column in tabular inlines"""
         parent = SomeParentModel.objects.create(name='a')


### PR DESCRIPTION
Providing a ModelForm for admin.TabularInline will have any `Meta.labels` or `Meta.help_texts` overrides for read-only fields ignored.