### PR TITLE
Fixed #29213 -- Fixed autocomplete widget's translations for zh-hans/zh-hant.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -371,8 +371,9 @@ SELECT2_TRANSLATIONS = {x.lower(): x for x in [
     'eu', 'fa', 'fi', 'fr', 'gl', 'he', 'hi', 'hr', 'hu', 'id', 'is',
     'it', 'ja', 'km', 'ko', 'lt', 'lv', 'mk', 'ms', 'nb', 'nl', 'pl',
     'pt-BR', 'pt', 'ro', 'ru', 'sk', 'sr-Cyrl', 'sr', 'sv', 'th',
-    'tr', 'uk', 'vi', 'zh-CN', 'zh-TW',
+    'tr', 'uk', 'vi',
 ]}
+SELECT2_TRANSLATIONS.update({'zh-hans': 'zh-CN', 'zh-hant': 'zh-TW'})
 
 
 class AutocompleteMixin:

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a crash when filtering with an ``Exists()`` annotation of a queryset
   containing a single field (:ticket:`29195`).
+
+* Fixed admin autocomplete widget's translations for `zh-hans` and `zh-hant`
+  languages (:ticket:`29213`).

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -120,7 +120,8 @@ class AutocompleteMixinTests(TestCase):
             ('00', None),
             # Language files are case sensitive.
             ('sr-cyrl', 'sr-Cyrl'),
-            ('zh-cn', 'zh-CN'),
+            ('zh-hans', 'zh-CN'),
+            ('zh-hant', 'zh-TW'),
         )
         for lang, select_lang in languages:
             with self.subTest(lang=lang):


### PR DESCRIPTION
Since `zh-cn` and `zh-tw` has been removed from i18n support, [this line](https://github.com/django/django/blob/3c71fb3909d4fdf6691712dfe84d7b7b8e9fcc35/django/contrib/admin/widgets.py#L374) should be updated to make sure js media files for `zh-hans` and `zh-hant` really work.