### PR TITLE
Add silent failure of divisibleby filter

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -765,7 +765,10 @@ def default_if_none(value, arg):
 @register.filter(is_safe=False)
 def divisibleby(value, arg):
     """Return True if the value is divisible by the argument."""
-    return int(value) % int(arg) == 0
+    if (value):
+        return int(value) % int(arg) == 0
+    else:
+        return ''
 
 
 @register.filter(is_safe=False)

--- a/tests/template_tests/filter_tests/test_divisibleby.py
+++ b/tests/template_tests/filter_tests/test_divisibleby.py
@@ -9,3 +9,6 @@ class FunctionTests(SimpleTestCase):
 
     def test_false(self):
         self.assertIs(divisibleby(4, 3), False)
+
+    def test_false_fail_silently(self):
+        self.assertIs(divisibleby(None, 3), '')


### PR DESCRIPTION
Hi,
I understand the community guideline but this simple change did not seem significant enough to warrant a ticket.
If a field can be null and blank, having the value (which would be None) divided by a divisor would show an error, but I think it might be a good decision to make the filter fail silently by returning  an empty string.