### PR TITLE
Auth: change user_passes_test func, new arg arg_position add

### DIFF
--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -18,10 +18,8 @@ def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIE
     def decorator(view_func):
         @wraps(view_func, assigned=available_attrs(view_func))
         def _wrapped_view(request, *args, **kwargs):
-
             if type(arg_position) is int:
-                request = args[arg_position]
-            
+                request = args[arg_position]            
             if test_func(request.user):
                 return view_func(request, *args, **kwargs)
             path = request.build_absolute_uri()

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -7,16 +7,21 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import resolve_url
 
 
-def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):
+def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME, arg_position=None):
     """
     Decorator for views that checks that the user passes the given test,
     redirecting to the log-in page if necessary. The test should be a callable
     that takes the user object and returns True if the user passes.
+    arg_position: int, write on decoration position in args vars of request data
     """
 
     def decorator(view_func):
-        @wraps(view_func)
+        @wraps(view_func, assigned=available_attrs(view_func))
         def _wrapped_view(request, *args, **kwargs):
+
+            if type(arg_position) is int:
+                request = args[arg_position]
+            
             if test_func(request.user):
                 return view_func(request, *args, **kwargs)
             path = request.build_absolute_uri()

--- a/django/contrib/auth/decorators.py
+++ b/django/contrib/auth/decorators.py
@@ -16,10 +16,10 @@ def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIE
     """
 
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if type(arg_position) is int:
-                request = args[arg_position]            
+                request = args[arg_position]
             if test_func(request.user):
                 return view_func(request, *args, **kwargs)
             path = request.build_absolute_uri()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29220
I had problems Add my decorations user_passes_test functions, because decorator _wrapped_view assume, the first arg is the `request` var parameter, when i call user_passes_test from a view into a class, that not work, it take the arg `self` look like a arg `request`

example:
`@user_passes_test(role_client_check)`
   `def index(self, request):`

Fatal error: Class don't have attribute user.

The next new change work for Django 1.11
but i see that Django 2.X file, doesn't change a lot

Now i can call the auth:
`@user_passes_test(role_client_check, arg_position=0)`
   `def index(self, request):`

`arg_position` can be specific when the first argument isn't "request"
`arg_position` is a integer with the position of request on view function

I created my own user_passes_test function to solve this feature.