### PR TITLE
Fixed #29221 -- Corrected admin's autocomplete widget to add a space after custom classes.

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -413,7 +413,7 @@ class AutocompleteMixin:
             'data-theme': 'admin-autocomplete',
             'data-allow-clear': json.dumps(not self.is_required),
             'data-placeholder': '',  # Allows clearing of the input.
-            'class': attrs['class'] + 'admin-autocomplete',
+            'class': attrs['class'] + (' ' if attrs['class'] else '') + 'admin-autocomplete',
         })
         return attrs
 

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Fixed admin autocomplete widget's translations for `zh-hans` and `zh-hant`
   languages (:ticket:`29213`).
+
+* Corrected admin's autocomplete widget to add a space after custom classes
+  (:ticket:`29221`).

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -50,7 +50,7 @@ class AutocompleteMixinTests(TestCase):
         form = AlbumForm()
         attrs = form['band'].field.widget.get_context(name='my_field', value=None, attrs={})['widget']['attrs']
         self.assertEqual(attrs, {
-            'class': 'my-classadmin-autocomplete',
+            'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
             'data-ajax--type': 'GET',
             'data-ajax--url': '/admin_widgets/band/autocomplete/',
@@ -58,6 +58,11 @@ class AutocompleteMixinTests(TestCase):
             'data-allow-clear': 'false',
             'data-placeholder': ''
         })
+
+    def test_build_attrs_no_custom_class(self):
+        form = AlbumForm()
+        attrs = form['featuring'].field.widget.get_context(name='name', value=None, attrs={})['widget']['attrs']
+        self.assertEqual(attrs['class'], 'admin-autocomplete')
 
     def test_build_attrs_not_required_field(self):
         form = NotRequiredBandForm()


### PR DESCRIPTION
Put space between the `admin-autocomplete` CSS class and the preceding classes 

Fixes ticket_29221