### PR TITLE
Refs #29155 -- Fixed LookupTests.test_pattern_lookups_with_substr() crash on Oracle.

### DIFF
--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -15,8 +15,8 @@ class LookupTests(TestCase):
 
     def setUp(self):
         # Create a few Authors.
-        self.au1 = Author.objects.create(name='Author 1')
-        self.au2 = Author.objects.create(name='Author 2')
+        self.au1 = Author.objects.create(name='Author 1', alias='a1')
+        self.au2 = Author.objects.create(name='Author 2', alias='a2')
         # Create a few Articles.
         self.a1 = Article.objects.create(
             headline='Article 1',


### PR DESCRIPTION
Test introduced in feb683c4c2c5ecfb61e4cb490c3e357450c0c0e8 revealed unexpected behavior on Oracle, that allows to concatenate `NULL` with strings (see [29222](https://code.djangoproject.com/ticket/29222)).