### PR TITLE
Removed DatabaseFeatures.can_introspect_null.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -109,13 +109,6 @@ class BaseDatabaseFeatures:
     # Does the backend reset sequences between tests?
     supports_sequence_reset = True
 
-    # Can the backend determine reliably if a field is nullable?
-    # Note that this is separate from interprets_empty_strings_as_nulls,
-    # although the latter feature, when true, interferes with correct
-    # setting (and introspection) of CharFields' nullability.
-    # This is True for all core backends.
-    can_introspect_null = True
-
     # Can the backend introspect the default value of a column?
     can_introspect_default = True
 
@@ -286,6 +279,6 @@ class BaseDatabaseFeatures:
         introspection results; it should provide expectations, not run an
         introspection itself.
         """
-        if self.can_introspect_null and field and field.null:
+        if field and field.null:
             return 'NullBooleanField'
         return 'BooleanField'

--- a/tests/inspectdb/tests.py
+++ b/tests/inspectdb/tests.py
@@ -104,10 +104,7 @@ class InspectDBTestCase(TestCase):
         if 'BooleanField' in null_bool_field_type:
             assertFieldType('null_bool_field', "models.{}()".format(null_bool_field_type))
         else:
-            if connection.features.can_introspect_null:
-                assertFieldType('null_bool_field', "models.{}(blank=True, null=True)".format(null_bool_field_type))
-            else:
-                assertFieldType('null_bool_field', "models.{}()".format(null_bool_field_type))
+            assertFieldType('null_bool_field', "models.{}(blank=True, null=True)".format(null_bool_field_type))
 
         if connection.features.can_introspect_decimal_field:
             assertFieldType('decimal_field', "models.DecimalField(max_digits=6, decimal_places=1)")

--- a/tests/introspection/tests.py
+++ b/tests/introspection/tests.py
@@ -92,7 +92,6 @@ class IntrospectionTests(TransactionTestCase):
             [30, 30, 254]
         )
 
-    @skipUnlessDBFeature('can_introspect_null')
     def test_get_table_description_nullable(self):
         with connection.cursor() as cursor:
             desc = connection.introspection.get_table_description(cursor, Reporter._meta.db_table)


### PR DESCRIPTION
The only known usage is in the unmaintained django-pymssql project.