### PR TITLE
Removed args in Index.clone.

### DIFF
--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -69,8 +69,8 @@ class Index:
 
     def clone(self):
         """Create a copy of this Index."""
-        path, args, kwargs = self.deconstruct()
-        return self.__class__(*args, **kwargs)
+        _, _, kwargs = self.deconstruct()
+        return self.__class__(**kwargs)
 
     @staticmethod
     def _hash_generator(*args):


### PR DESCRIPTION
The constructor does not accept list-arguments, and the `deconstruct`-method always returns the empty tuple.