### PR TITLE
Fixed #29229 -- Fixed column mismatch crash when combining two annotated values_list() querysets with union(), difference(), or intersection().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -408,7 +408,8 @@ class SQLCompiler:
                 # If the columns list is limited, then all combined queries
                 # must have the same columns list. Set the selects defined on
                 # the query on all combined queries, if not already set.
-                if not compiler.query.values_select and self.query.values_select:
+                if (not compiler.query.values_select and not compiler.query.annotations and
+                        self.query.values_select):
                     compiler.query.set_values(self.query.values_select)
                 parts += (compiler.as_sql(),)
             except EmptyResultSet:

--- a/docs/releases/1.11.12.txt
+++ b/docs/releases/1.11.12.txt
@@ -9,4 +9,6 @@ Django 1.11.12 fixes a bug in 1.11.11.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 1.11.8 where combining two annotated
+  ``values_list()`` querysets with ``union()``, ``difference()``, or
+  ``intersection()`` crashed due to mismatching columns (:ticket:`29229`).

--- a/docs/releases/2.0.4.txt
+++ b/docs/releases/2.0.4.txt
@@ -21,3 +21,7 @@ Bugfixes
 * Fixed ``PasswordResetConfirmView`` crash when using a user model with a
   ``UUIDField`` primary key and the reset URL contains an encoded primary key
   value that decodes to an invalid UUID (:ticket:`29206`).
+
+* Fixed a regression in Django 1.11.8 where combining two annotated
+  ``values_list()`` querysets with ``union()``, ``difference()``, or
+  ``intersection()`` crashed due to mismatching columns (:ticket:`29229`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -119,6 +119,17 @@ class QuerySetSetOperationTests(TestCase):
         reserved_name = qs1.union(qs1).values_list('name', 'order', 'id').get()
         self.assertEqual(reserved_name[:2], ('a', 2))
 
+    def test_union_with_two_annotated_values_list(self):
+        qs1 = Number.objects.filter(num=1).annotate(
+            count=Value(0, IntegerField()),
+        ).values_list('num', 'count')
+        qs2 = Number.objects.filter(num=2).values('pk').annotate(
+            count=F('num'),
+        ).annotate(
+            num=Value(1, IntegerField()),
+        ).values_list('num', 'count')
+        self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
+
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')
         qs2 = Number.objects.filter(num__gte=2, num__lte=3).values('num')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29229