### PR TITLE
Increased test coverage for i18n template tags.

### DIFF
--- a/tests/template_tests/syntax_tests/i18n/test_blocktrans.py
+++ b/tests/template_tests/syntax_tests/i18n/test_blocktrans.py
@@ -233,6 +233,45 @@ class I18nBlockTransTagTests(SimpleTestCase):
         output = self.engine.render_to_string('template')
         self.assertEqual(output, '%s')
 
+    @setup({'template': '{% load i18n %}{% blocktrans %}{% block b %} {% endblock %}{% endblocktrans %}'})
+    def test_with_block(self):
+        msg = "'blocktrans' doesn't allow other block tags (seen 'block b') inside it"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')
+
+    @setup({'template': '{% load i18n %}{% blocktrans %}{% for b in [1, 2, 3] %} {% endfor %}{% endblocktrans %}'})
+    def test_with_for(self):
+        msg = "'blocktrans' doesn't allow other block tags (seen 'for b in [1, 2, 3]') inside it"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')
+
+    @setup({'template': '{% load i18n %}{% blocktrans with foo=bar with %}{{ foo }}{% endblocktrans %}'})
+    def test_variable_twice(self):
+        with self.assertRaisesMessage(TemplateSyntaxError, "The 'with' option was specified more than once"):
+            self.engine.render_to_string('template', {'foo': 'bar'})
+
+    @setup({'template': '{% load i18n %}{% blocktrans with %}{% endblocktrans %}'})
+    def test_no_args_with(self):
+        msg = '"with" in \'blocktrans\' tag needs at least one keyword argument.'
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')
+
+    @setup({'template': '{% load i18n %}{% blocktrans count a %}{% endblocktrans %}'})
+    def test_count(self):
+        msg = '"count" in \'blocktrans\' tag expected exactly one keyword argument.'
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template', {'a': [1, 2, 3]})
+
+    @setup({'template': (
+        '{% load i18n %}{% blocktrans count count=var|length %}'
+        'There is {{ count }} object. {% block a %} {% endblock %}'
+        '{% endblocktrans %}'
+    )})
+    def test_plural_bad_syntax(self):
+        msg = "'blocktrans' doesn't allow other block tags inside it"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template', {'var': [1, 2, 3]})
+
 
 class TranslationBlockTransTagTests(SimpleTestCase):
 

--- a/tests/template_tests/syntax_tests/i18n/test_get_available_languages.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_available_languages.py
@@ -1,3 +1,4 @@
+from django.template import TemplateSyntaxError
 from django.test import SimpleTestCase
 
 from ...utils import setup
@@ -12,3 +13,9 @@ class GetAvailableLanguagesTagTests(SimpleTestCase):
     def test_i18n12(self):
         output = self.engine.render_to_string('i18n12')
         self.assertEqual(output, 'de')
+
+    @setup({'syntax_i18n': '{% load i18n %}{% get_available_languages a langs %}'})
+    def test_no_as_var(self):
+        msg = "'get_available_languages' requires 'as variable' (got ['get_available_languages', 'a', 'langs'])"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('syntax_i18n')

--- a/tests/template_tests/syntax_tests/i18n/test_get_current_language.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_current_language.py
@@ -1,0 +1,14 @@
+from template_tests.utils import setup
+
+from django.template import TemplateSyntaxError
+from django.test import SimpleTestCase
+
+
+class I18nGetCurrentLanguageTagTests(SimpleTestCase):
+    libraries = {'i18n': 'django.templatetags.i18n'}
+
+    @setup({'template': '{% load i18n %} {% get_current_language %}'})
+    def test_no_as_var(self):
+        msg = "'get_current_language' requires 'as variable' (got ['get_current_language'])"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')

--- a/tests/template_tests/syntax_tests/i18n/test_get_current_language_bidi.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_current_language_bidi.py
@@ -1,0 +1,14 @@
+from template_tests.utils import setup
+
+from django.template import TemplateSyntaxError
+from django.test import SimpleTestCase
+
+
+class I18nGetCurrentLanguageBidiTagTests(SimpleTestCase):
+    libraries = {'i18n': 'django.templatetags.i18n'}
+
+    @setup({'template': '{% load i18n %} {% get_current_language_bidi %}'})
+    def test_no_as_var(self):
+        msg = "'get_current_language_bidi' requires 'as variable' (got ['get_current_language_bidi'])"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')

--- a/tests/template_tests/syntax_tests/i18n/test_get_language_info.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_language_info.py
@@ -1,3 +1,4 @@
+from django.template import TemplateSyntaxError
 from django.test import SimpleTestCase
 from django.utils import translation
 
@@ -34,3 +35,9 @@ class I18nGetLanguageInfoTagTests(SimpleTestCase):
         with translation.override('cs'):
             output = self.engine.render_to_string('i18n38')
         self.assertEqual(output, 'de: German/Deutsch/německy bidi=False')
+
+    @setup({'template': '{% load i18n %}''{% get_language_info %}'})
+    def test_no_for_as(self):
+        msg = "'get_language_info' requires 'for string as variable' (got [])"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('template')

--- a/tests/template_tests/syntax_tests/i18n/test_get_language_info_list.py
+++ b/tests/template_tests/syntax_tests/i18n/test_get_language_info_list.py
@@ -1,3 +1,4 @@
+from django.template import TemplateSyntaxError
 from django.test import SimpleTestCase
 from django.utils import translation
 
@@ -43,3 +44,9 @@ class GetLanguageInfoListTests(SimpleTestCase):
             'it: Italian/italiano/italsky bidi=False; '
             'fr: French/français/francouzsky bidi=False; '
         )
+
+    @setup({'i18n_syntax': '{% load i18n %} {% get_language_info_list error %}'})
+    def test_no_for_as(self):
+        msg = "'get_language_info_list' requires 'for sequence as variable' (got ['error'])"
+        with self.assertRaisesMessage(TemplateSyntaxError, msg):
+            self.engine.render_to_string('i18n_syntax')

--- a/tests/template_tests/syntax_tests/i18n/test_language.py
+++ b/tests/template_tests/syntax_tests/i18n/test_language.py
@@ -1,0 +1,13 @@
+from template_tests.utils import setup
+
+from django.template import TemplateSyntaxError
+from django.test import SimpleTestCase
+
+
+class I18nLanguageTagTests(SimpleTestCase):
+    libraries = {'i18n': 'django.templatetags.i18n'}
+
+    @setup({'i18n_language': '{% load i18n %} {% language %} {% endlanguage %}'})
+    def test_no_arg(self):
+        with self.assertRaisesMessage(TemplateSyntaxError, "'language' takes one argument (language)"):
+            self.engine.render_to_string('i18n_language')


### PR DESCRIPTION
The chunk starting with this is tricky to write tests for. I suppose it'd involve mocking. I introduce new files for template tags that didn't have one; it seems to be the convention that each template tag has a devoted file. 

```
except (KeyError, ValueError): 
    if nested:
```