### PR TITLE
Update order of import statements to reflect code

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -289,8 +289,8 @@ The next step is to point the root URLconf at the ``polls.urls`` module. In
 .. snippet::
     :filename: mysite/urls.py
 
-    from django.urls import include, path
     from django.contrib import admin
+    from django.urls import include, path
 
     urlpatterns = [
         path('polls/', include('polls.urls')),


### PR DESCRIPTION
It's small, but the docs currently depict the mysite/urls.py import statements in the opposite order of how they appear in the code.

As this appears to be a trivial change, I have not created a corresponding Trac ticket. Thank you!