### PR TITLE
Fixed #29403 -- Fixed storing too large values in PyLibMCCache.

### DIFF
--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1283,15 +1283,7 @@ class BaseMemcachedTests(BaseCacheTests):
         self.assertEqual(cache.get('small_value'), 'a')
 
         large_value = 'a' * (max_value_length + 1)
-        try:
-            cache.set('small_value', large_value)
-        except Exception:
-            # Some clients (e.g. pylibmc) raise when the value is too large,
-            # while others (e.g. python-memcached) intentionally return True
-            # indicating success. This test is primarily checking that the key
-            # was deleted, so the return/exception behavior for the set()
-            # itself is not important.
-            pass
+        cache.set('small_value', large_value)
         # small_value should be deleted, or set if configured to accept larger values
         value = cache.get('small_value')
         self.assertTrue(value is None or value == large_value)


### PR DESCRIPTION
This issue was previosly reported as a test failure five years ago, in issue #19914. Sadly the approach taken to fix it then was simply to paper over the exception in the test case, instead of handling it in the cache backend. This meant that for actual users of the code the issue remained even though the test no longer failed. This PR removes the papering-over and fixes the bug.
https://code.djangoproject.com/ticket/29403