### PR TITLE
Add app_name to auth/urls.py

### DIFF
--- a/django/contrib/auth/urls.py
+++ b/django/contrib/auth/urls.py
@@ -6,6 +6,7 @@
 from django.contrib.auth import views
 from django.urls import path
 
+app_name = 'auth'
 urlpatterns = [
     path('login/', views.LoginView.as_view(), name='login'),
     path('logout/', views.LogoutView.as_view(), name='logout'),


### PR DESCRIPTION
Since Django 2.0 you need to specify app_name to use namespace, without app_name you cannot use namespace in project urls.py.

https://docs.djangoproject.com/en/2.0/topics/http/urls/#url-namespaces-and-included-urlconfs

**When it's missing?**
Simple example, in your app_name/app_name/urls.py set auth.urls, then in template try to use it from another app - you gonna need declared namespace to acccess it. And you cannot set namespace if there is no app_name.

