### PR TITLE
Fixed #29250 -- Added 'django_version' context to startapp/project docs.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1198,6 +1198,7 @@ files is:
 - ``app_directory`` -- the full path of the newly created app
 - ``camel_case_app_name`` -- the app name in camel case format
 - ``docs_version`` -- the version of the documentation: ``'dev'`` or ``'1.x'``
+- ``django_version`` -- the version of Django, e.g.``'2.0.3'``
 
 .. _render_warning:
 
@@ -1267,6 +1268,7 @@ The :class:`template context <django.template.Context>` used is:
 - ``project_directory`` -- the full path of the newly created project
 - ``secret_key`` -- a random key for the :setting:`SECRET_KEY` setting
 - ``docs_version`` -- the version of the documentation: ``'dev'`` or ``'1.x'``
+- ``django_version`` -- the version of Django, e.g.``'2.0.3'``
 
 Please also see the :ref:`rendering warning <render_warning>` as mentioned
 for :djadmin:`startapp`.


### PR DESCRIPTION
The reference documentation for management commands `startapp` and `startproject` (see https://docs.djangoproject.com/en/2.0/ref/django-admin/#startapp and https://docs.djangoproject.com/en/2.0/ref/django-admin/#startproject) omits a useful context variable, 'django_version'.

This PR illuminates use of 'django_version' when rendering app and project template files.