### PR TITLE
added note on page object context name in pagination docs

### DIFF
--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -126,6 +126,11 @@ pages along with any interesting information from the objects themselves::
         </span>
     </div>
 
+When using the class-based view :class:`~django.views.generic.list.ListView` or
+:class:`~django.views.generic.list.MultipleObjectMixin`, the page object will be in the context
+under the name `page_obj`, so all instances of `contacts` in the template example will need to be
+changed to `page_obj`.
+
 ``Paginator`` objects
 =====================
 


### PR DESCRIPTION
Creating this PR without a ticket as it's only one simple paragraph, fairly straightforward.

I will add a ticket if needed.

I think it's a good idea to have this note because:
- in pagination doc page `contacts` is a page object, but in a `ListView`, normally `contacts` would be a queryset, and page object would be `page_obj`, and there's no setting to change its name.
- if this code is used as-is, there is no error, just some expected attributes would be missing, showing up as blanks on the page, so it's not obvious how to investigate or what the issue is
- IIRC GCBVs are the preferred way to do views so it would be good to have 'pagination' doc page provide an easy, direct note on how to handle them in the template
- other alternative would be to link to the ListView docs but the only example of pagination there is under 'how to combine ListView with SingleObjectMixin', which is more of a corner case, while this note applies in general to `ListView` and `MultipleObjectMixin`.
