### PR TITLE
Fixed #29249 -- Added option to dumpdata with unicode

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -64,6 +64,10 @@ class Command(BaseCommand):
             '-o', '--output', default=None, dest='output',
             help='Specifies file to which the output is written.'
         )
+        parser.add_argument(
+            '--allow-unicode', action='store_false', dest='allow_unicode',
+            help="Allow for unicode characters in output."
+        )
 
     def handle(self, *app_labels, **options):
         format = options['format']
@@ -76,6 +80,7 @@ class Command(BaseCommand):
         use_natural_primary_keys = options['use_natural_primary_keys']
         use_base_manager = options['use_base_manager']
         pks = options['primary_keys']
+        allow_unicode = options['allow_unicode']
 
         if pks:
             primary_keys = [pk.strip() for pk in pks.split(',')]
@@ -183,7 +188,7 @@ class Command(BaseCommand):
                     use_natural_foreign_keys=use_natural_foreign_keys,
                     use_natural_primary_keys=use_natural_primary_keys,
                     stream=stream or self.stdout, progress_output=progress_output,
-                    object_count=object_count,
+                    object_count=object_count, allow_unicode=allow_unicode,
                 )
             finally:
                 if stream:

--- a/django/core/serializers/json.py
+++ b/django/core/serializers/json.py
@@ -28,6 +28,7 @@ class Serializer(PythonSerializer):
         if self.options.get('indent'):
             # Prevent trailing spaces
             self.json_kwargs['separators'] = (',', ': ')
+        self.json_kwargs['ensure_ascii'] = not self.json_kwargs.pop('allow_unicode', False)
         self.json_kwargs.setdefault('cls', DjangoJSONEncoder)
 
     def start_serialization(self):

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -11,7 +11,7 @@ from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.utils import isolate_apps
 from django.utils.translation import gettext_lazy, override
 
-from .models import Score
+from .models import Actor, Score
 from .tests import SerializersTestBase, SerializersTransactionTestBase
 
 
@@ -69,6 +69,15 @@ class JsonSerializerTestCase(SerializersTestBase, TestCase):
         for line in json_data.splitlines():
             if re.search(r'.+,\s*$', line):
                 self.assertEqual(line, line.rstrip())
+
+    def test_ensure_ascii(self):
+        s = serializers.json.Serializer()
+
+        json_data = s.serialize([Actor(name='יוניקוד')], allow_unicode=False)
+        self.assertTrue('\\u05d9\\u05d5\\u05e0\\u05d9\\u05e7\\u05d5\\u05d3' in json_data)
+
+        json_data = s.serialize([Actor(name='יוניקוד')], allow_unicode=True)
+        self.assertTrue('יוניקוד' in json_data)
 
     @isolate_apps('serializers')
     def test_custom_encoder(self):

--- a/tests/serializers/test_yaml.py
+++ b/tests/serializers/test_yaml.py
@@ -176,3 +176,17 @@ class YamlSerializerTransactionTestCase(SerializersTransactionTestBase, Transact
     name: Agnes
   pk: 1
   model: serializers.author"""
+
+
+@unittest.skipUnless(HAS_YAML, "No yaml library detected")
+class UnicodeSerializerTestCase(SimpleTestCase):
+
+    def test_should_allow_unicode(self):
+        s = serializers.pyyaml.Serializer()
+        yaml_string = s.serialize([Author(name='יוניקוד')], allow_unicode=True)
+        self.assertTrue('יוניקוד' in yaml_string)
+
+    def test_should_escape_unicode(self):
+        s = serializers.pyyaml.Serializer()
+        yaml_string = s.serialize([Author(name='יוניקוד')], allow_unicode=False)
+        self.assertTrue('\\u05D9\\u05D5\\u05E0\\u05D9\\u05E7\\u05D5\\u05D3' in yaml_string)


### PR DESCRIPTION
Added the flag `--alow-unicode` to `dumpdata` managemet comment to prevent the
serializers from escaping unicode data.

PR adds support for JSON and YAML serializers.