### PR TITLE
Fixed #29258 -- Added type checking for login()'s backend argument.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Cannon <cannona@fireantproductions.com>
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
+    Abeer Upadhyay <ab.esquarer@gmail.com>
     Abhishek Gautam <abhishekg1128@yahoo.com>
     Adam Bogdał <adam@bogdal.pl>
     Adam Johnson <https://github.com/adamchainz>

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -119,6 +119,9 @@ def login(request, user, backend=None):
                 'therefore must provide the `backend` argument or set the '
                 '`backend` attribute on the user.'
             )
+    else:
+        if not isinstance(backend, str):
+            raise TypeError('backend must be a dotted import path string (got %r).' % backend)
 
     request.session[SESSION_KEY] = user._meta.pk.value_to_string(user)
     request.session[BACKEND_SESSION_KEY] = backend

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -695,6 +695,15 @@ class SelectingBackendTests(TestCase):
         with self.assertRaisesMessage(ValueError, expected_message):
             self.client._login(user)
 
+    def test_non_string_backend(self):
+        user = User.objects.create_user(self.username, 'email', self.password)
+        expected_message = (
+            'backend must be a dotted import path string (got '
+            '<class \'django.contrib.auth.backends.ModelBackend\'>).'
+        )
+        with self.assertRaisesMessage(TypeError, expected_message):
+            self.client._login(user, backend=ModelBackend)
+
     @override_settings(AUTHENTICATION_BACKENDS=[backend, other_backend])
     def test_backend_path_login_with_explicit_backends(self):
         user = User.objects.create_user(self.username, 'email', self.password)


### PR DESCRIPTION
Fixes https://code.djangoproject.com/ticket/29258

Raised a  **TypeError** when the type of backend passed to `contrib.auth.login` is invalid. Provides better error messaging.