### PR TITLE
settings.py: SCHEMA field (merged)

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -226,6 +226,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             " NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS.FF'" +
             (" TIME_ZONE = 'UTC'" if settings.USE_TZ else '')
         )
+        if 'SCHEMA' in self.settings_dict:
+            cursor.execute(
+                "ALTER SESSION SET CURRENT_SCHEMA = %s" %
+                self.settings_dict['SCHEMA']
+            )
         cursor.close()
         if 'operators' not in self.__dict__:
             # Ticket #14149: Check whether our LIKE implementation will


### PR DESCRIPTION
allow to set connection schema in settings.py

FIXME: pattern "sql query" % param is bad practice and allows SQL Injection. It can be exploied in this example:
'SCHEMA': 'MYSCHEMA; DROP DATABASE'
But who in clear mind will set this schema?