### PR TITLE
Replaced 'python -Wall' with 'python -Wa'.

### DIFF
--- a/docs/howto/upgrade-version.txt
+++ b/docs/howto/upgrade-version.txt
@@ -59,12 +59,12 @@ warnings before upgrading ensures that you're informed about areas of the code
 that need altering.
 
 In Python, deprecation warnings are silenced by default. You must turn them on
-using the ``-Wall`` Python command line option or the :envvar:`PYTHONWARNINGS`
+using the ``-Wa`` Python command line option or the :envvar:`PYTHONWARNINGS`
 environment variable. For example, to show warnings while running tests:
 
 .. console::
 
-    $ python -Wall manage.py test
+    $ python -Wa manage.py test
 
 If you're not using the Django test runner, you may need to also ensure that
 any console output is not captured which would hide deprecation warnings. For
@@ -72,7 +72,7 @@ example, if you use `py.test`:
 
 .. code-block:: console
 
-    $ PYTHONWARNINGS=all py.test tests --capture=no
+    $ PYTHONWARNINGS=always py.test tests --capture=no
 
 Resolve any deprecation warnings with your current version of Django before
 continuing the upgrade process.
@@ -108,7 +108,7 @@ use the flag if you test your app manually using ``manage.py runserver``):
 
 .. console::
 
-    $ python -Wall manage.py test
+    $ python -Wa manage.py test
 
 After you have run the tests, fix any failures. While you have the release
 notes fresh in your mind, it may also be a good time to take advantage of new

--- a/docs/internals/contributing/writing-code/submitting-patches.txt
+++ b/docs/internals/contributing/writing-code/submitting-patches.txt
@@ -175,7 +175,7 @@ the first release of Django that deprecates a feature (``A.B``) should raise a
 will be removed) when the deprecated feature is invoked. Assuming we have good
 test coverage, these warnings are converted to errors when :ref:`running the
 test suite <running-unit-tests>` with warnings enabled:
-``python -Wall runtests.py``. Thus, when adding a ``RemovedInDjangoXXWarning``
+``python -Wa runtests.py``. Thus, when adding a ``RemovedInDjangoXXWarning``
 you need to eliminate or silence any warnings generated when running the tests.
 
 The first step is to remove any use of the deprecated behavior by Django itself.

--- a/docs/topics/testing/overview.txt
+++ b/docs/topics/testing/overview.txt
@@ -128,7 +128,7 @@ be reported, and any test databases created by the run will not be destroyed.
 .. admonition:: Test with warnings enabled
 
     It's a good idea to run your tests with Python warnings enabled:
-    ``python -Wall manage.py test``. The ``-Wall`` flag tells Python to
+    ``python -Wa manage.py test``. The ``-Wa`` flag tells Python to
     display deprecation warnings. Django, like many other Python libraries,
     uses these warnings to flag when features are going away. It also might
     flag areas in your code that aren't strictly wrong but could benefit


### PR DESCRIPTION
As the Python 3.7 docs says:
https://docs.python.org/3.7/using/cmdline.html#cmdoption-w

The non abbreviate form of running with warnings is: ``-Walways`` 