### PR TITLE
Fixed #29275 -- Print "(actual errors: none)" instead of "(actual errors: )" in assertFormError.

### DIFF
--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -429,7 +429,7 @@ class SimpleTestCase(unittest.TestCase):
                         msg_prefix + "The form '%s' in context %d does not"
                         " contain the non-field error '%s'"
                         " (actual errors: %s)" %
-                        (form, i, err, non_field_errors)
+                        (form, i, err, non_field_errors or 'none')
                     )
         if not found_form:
             self.fail(msg_prefix + "The form '%s' was not used to render the response" % form)

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -631,7 +631,7 @@ class AssertFormErrorTests(SimpleTestCase):
         except AssertionError as e:
             self.assertIn(
                 "The form 'form' in context 0 does not contain the non-field "
-                "error 'Some error.' (actual errors: )",
+                "error 'Some error.' (actual errors: none)",
                 str(e)
             )
         try:
@@ -639,7 +639,7 @@ class AssertFormErrorTests(SimpleTestCase):
         except AssertionError as e:
             self.assertIn(
                 "abc: The form 'form' in context 0 does not contain the "
-                "non-field error 'Some error.' (actual errors: )",
+                "non-field error 'Some error.' (actual errors: none)",
                 str(e)
             )
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29275