### PR TITLE
Fixed #29226 -- Doc'd modify_settings() ordering considerations for Python < 3.6.

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1277,6 +1277,23 @@ The decorator can also be applied to test case classes::
     decorator. For a given class, :func:`~django.test.modify_settings` is
     always applied after :func:`~django.test.override_settings`.
 
+.. admonition:: Considerations with Python 3.5
+
+    If using Python 3.5 (or older, if using an older version of Django), avoid
+    mixing  ``remove`` with ``append`` and ``prepend`` in
+    :func:`~django.test.modify_settings`. In some cases it matters whether a
+    value is first added and then removed or vice versa, and dictionary key
+    order isn't preserved until Python 3.6. Instead, apply the decorator twice
+    to guarantee the order of operations. For example, to ensure that
+    ``SessionMiddleware`` appears first in ``MIDDLEWARE``::
+
+        @modify_settings(MIDDLEWARE={
+            'remove': ['django.contrib.sessions.middleware.SessionMiddleware'],
+        )
+        @modify_settings(MIDDLEWARE={
+            'prepend': ['django.contrib.sessions.middleware.SessionMiddleware'],
+        })
+
 .. warning::
 
     The settings file contains some settings that are only consulted during


### PR DESCRIPTION
Am pretty sure that the docs were wrong about using pure strings instead of lists for append/prepend. They are iterated as lists of strings.

Can squash all this as requested, just wanted to hear back firstly, if the changes are pleasing.

https://code.djangoproject.com/ticket/29226

Takes over for #9842