### PR TITLE
Fixed #29284 -- Made ImageField render with accept="image/*"' HTML attribute.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -20,7 +20,7 @@ from django.forms.boundfield import BoundField
 from django.forms.utils import from_current_timezone, to_current_timezone
 from django.forms.widgets import (
     FILE_INPUT_CONTRADICTION, CheckboxInput, ClearableFileInput, DateInput,
-    DateTimeInput, EmailInput, HiddenInput, MultipleHiddenInput,
+    DateTimeInput, EmailInput, FileInput, HiddenInput, MultipleHiddenInput,
     NullBooleanSelect, NumberInput, Select, SelectMultiple,
     SplitDateTimeWidget, SplitHiddenDateTimeWidget, TextInput, TimeInput,
     URLInput,
@@ -645,6 +645,12 @@ class ImageField(FileField):
         if hasattr(f, 'seek') and callable(f.seek):
             f.seek(0)
         return f
+
+    def widget_attrs(self, widget):
+        attrs = super().widget_attrs(widget)
+        if isinstance(widget, FileInput) and 'accept' not in widget.attrs:
+            attrs.setdefault('accept', 'image/*')
+        return attrs
 
 
 class URLField(CharField):

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -166,7 +166,8 @@ File Uploads
 Forms
 ~~~~~
 
-* ...
+* The widget for ``ImageField`` now renders with the HTML attribute
+  ``accept="image/*"``.
 
 Generic Views
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This pr is for this ticket: https://code.djangoproject.com/ticket/29284