### PR TITLE
Fixed #29288 -- Made {% widthratio %} assign to a variable if an exception occurs.

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -483,9 +483,9 @@ class WidthRatioNode(Node):
             ratio = (value / max_value) * max_width
             result = str(round(ratio))
         except ZeroDivisionError:
-            return '0'
+            result = '0'
         except (ValueError, TypeError, OverflowError):
-            return ''
+            result = ''
 
         if self.asvar:
             context[self.asvar] = result

--- a/tests/template_tests/syntax_tests/test_width_ratio.py
+++ b/tests/template_tests/syntax_tests/test_width_ratio.py
@@ -142,3 +142,13 @@ class WidthRatioTagTests(SimpleTestCase):
     def test_widthratio21(self):
         output = self.engine.render_to_string('widthratio21', {'a': float('inf'), 'b': 2})
         self.assertEqual(output, '')
+
+    @setup({'t': '{% widthratio a b 100 as variable %}-{{ variable }}-'})
+    def test_zerodivisionerror_as_var(self):
+        output = self.engine.render_to_string('t', {'a': 0, 'b': 0})
+        self.assertEqual(output, '-0-')
+
+    @setup({'t': '{% widthratio a b c as variable %}-{{ variable }}-'})
+    def test_typeerror_as_var(self):
+        output = self.engine.render_to_string('t', {'a': 'a', 'c': 100, 'b': 100})
+        self.assertEqual(output, '--')


### PR DESCRIPTION
…when requested if arguments cause an exception