### PR TITLE
Fixed #28312 -- Reused ModelChoiceIterator's queryset

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1132,11 +1132,7 @@ class ModelChoiceIterator:
     def __iter__(self):
         if self.field.empty_label is not None:
             yield ("", self.field.empty_label)
-        queryset = self.queryset
-        # Can't use iterator() when queryset uses prefetch_related()
-        if not queryset._prefetch_related_lookups and queryset._result_cache is None:
-            queryset = queryset.iterator()
-        for obj in queryset:
+        for obj in self.queryset:
             yield self.choice(obj)
 
     def __len__(self):

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -257,9 +257,10 @@ class ModelChoiceFieldTests(TestCase):
             (self.c3.pk, 'Third'),
         ])
 
-    def test_queryset_result_cache_is_reused(self):
+    def test_queryset_cached_on__len__(self):
         f = forms.ModelChoiceField(Category.objects.all())
         with self.assertNumQueries(1):
+            self.assertEqual(4, len(f.choices))
             # list() calls __len__() and __iter__(); no duplicate queries.
             self.assertEqual(list(f.choices), [
                 ('', '---------'),
@@ -267,6 +268,19 @@ class ModelChoiceFieldTests(TestCase):
                 (self.c2.pk, 'A test'),
                 (self.c3.pk, 'Third'),
             ])
+
+    def test_queryset_cached_on__iter__(self):
+        f = forms.ModelChoiceField(Category.objects.all())
+        with self.assertNumQueries(1):
+            # Call __iter__ first.
+            choices = [(val, label) for val, label in f.choices]
+            self.assertEqual(choices, [
+                ('', '---------'),
+                (self.c1.pk, 'Entertainment'),
+                (self.c2.pk, 'A test'),
+                (self.c3.pk, 'Third'),
+            ])
+            self.assertEqual(4, len(f.choices))
 
     def test_num_queries(self):
         """

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1484,63 +1484,6 @@ class ModelFormBasicTests(TestCase):
         self.assertEqual(form.save().name, 'Third')
         self.assertEqual(Category.objects.get(id=cat.id).name, 'Third')
 
-    def test_runtime_choicefield_populated(self):
-        self.maxDiff = None
-        # Here, we demonstrate that choices for a ForeignKey ChoiceField are determined
-        # at runtime, based on the data in the database when the form is displayed, not
-        # the data in the database when the form is instantiated.
-        self.create_basic_data()
-        f = ArticleForm(auto_id=False)
-        self.assertHTMLEqual(
-            f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
-<option value="%s">Bob Woodward</option>
-<option value="%s">Mike Royko</option>
-</select></li>
-<li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
-<option value="%s">Entertainment</option>
-<option value="%s">It&#39;s a test</option>
-<option value="%s">Third test</option>
-</select> </li>
-<li>Status: <select name="status">
-<option value="" selected>---------</option>
-<option value="1">Draft</option>
-<option value="2">Pending</option>
-<option value="3">Live</option>
-</select></li>''' % (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk))
-
-        c4 = Category.objects.create(name='Fourth', url='4th')
-        w_bernstein = Writer.objects.create(name='Carl Bernstein')
-        self.assertHTMLEqual(
-            f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
-<option value="%s">Bob Woodward</option>
-<option value="%s">Carl Bernstein</option>
-<option value="%s">Mike Royko</option>
-</select></li>
-<li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
-<option value="%s">Entertainment</option>
-<option value="%s">It&#39;s a test</option>
-<option value="%s">Third test</option>
-<option value="%s">Fourth</option>
-</select></li>
-<li>Status: <select name="status">
-<option value="" selected>---------</option>
-<option value="1">Draft</option>
-<option value="2">Pending</option>
-<option value="3">Live</option>
-</select></li>''' % (self.w_woodward.pk, w_bernstein.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk, c4.pk))
-
     def test_recleaning_model_form_instance(self):
         """
         Re-cleaning an instance that was added via a ModelForm shouldn't raise


### PR DESCRIPTION
Reusing the ModelChoiceIterator queryset results, instead of issuing a
new query whenever the ModelChoiceIterator instance is evaluated
(through `__len__`, `__iter__` or `__bool__`), is the only way to guarantee
results consistency across calls to the choices attribute of a
ChoiceField instance. If the QuerySet results were to change, there
could be mismatches, for example between the choices count and the
actual number of choices offered to the user.

Ticket: https://code.djangoproject.com/ticket/28312

See https://groups.google.com/forum/#!topic/django-developers/7UZyY0IX5aw for a more detailed description.