### PR TITLE
Fixed #29695 -- Added system checks for admin's app dependencies and TEMPLATES setting.

### DIFF
--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -624,7 +624,26 @@ The following checks are performed on the default
 * **admin.E401**: :mod:`django.contrib.contenttypes` must be in
   :setting:`INSTALLED_APPS` in order to use the admin application.
 * **admin.E402**: :mod:`django.contrib.auth.context_processors.auth`
-  must be in :setting:`TEMPLATES` in order to use the admin application.
+  must be enabled in :class:`~django.template.backends.django.DjangoTemplates`
+  (:setting:`TEMPLATES`) if using the default auth backend in order to use the
+  admin application.
+* **admin.E403**: A :class:`django.template.backends.django.DjangoTemplates`
+  instance must be configured in :setting:`TEMPLATES` in order to use the
+  admin application.
+* **admin.E404**: ``django.contrib.messages.context_processors.messages``
+  must be enabled in :class:`~django.template.backends.django.DjangoTemplates`
+  (:setting:`TEMPLATES`) in order to use the admin application.
+* **admin.E405**: :mod:`django.contrib.auth` must be in
+  :setting:`INSTALLED_APPS` in order to use the admin application.
+* **admin.E406**: :mod:`django.contrib.messages` must be in
+  :setting:`INSTALLED_APPS` in order to use the admin application.
+* **admin.E407**: :mod:`django.contrib.sessions` must be in
+  :setting:`INSTALLED_APPS` in order to use the admin application.
+* **admin.E408**:
+  :class:`django.contrib.auth.middleware.AuthenticationMiddleware` must be in
+  :setting:`MIDDLEWARE` in order to use the admin application.
+* **admin.E409**: :class:`django.contrib.messages.middleware.MessageMiddleware`
+  must be in :setting:`MIDDLEWARE` in order to use the admin application.
 
 ``auth``
 --------

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1172,9 +1172,28 @@ class ManageCheck(AdminScriptTestCase):
                 'django.contrib.admin.apps.SimpleAdminConfig',
                 'django.contrib.auth',
                 'django.contrib.contenttypes',
+                'django.contrib.messages',
+                'django.contrib.sessions',
             ],
             sdict={
-                'DEBUG': True
+                'DEBUG': True,
+                'MIDDLEWARE': [
+                    'django.contrib.messages.middleware.MessageMiddleware',
+                    'django.contrib.auth.middleware.AuthenticationMiddleware',
+                ],
+                'TEMPLATES': [
+                    {
+                        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                        'DIRS': [],
+                        'APP_DIRS': True,
+                        'OPTIONS': {
+                            'context_processors': [
+                                'django.contrib.auth.context_processors.auth',
+                                'django.contrib.messages.context_processors.messages',
+                            ],
+                        },
+                    },
+                ],
             }
         )
         args = ['check']


### PR DESCRIPTION
- Add the following to AdminSite checks:

 * admin.E403: A DjangoTemplates instance must be configured in TEMPLATES
 * admin.E404: context_processors.messages must be enabled in DjangoTemplates
 * admin.E405: django.contrib.auth must be in INSTALLED_APPS
 * admin.E406: django.contrib.messages must be in INSTALLED_APPS
 * admin.E407: django.contrib.sessions must be in INSTALLED_APPS
 * admin.E408: AuthenticationMiddleware must be in MIDDLEWARE
 * admin.E409: MessageMiddleware must be in MIDDLEWARE.

- Improve the error message of admin.E402 (auth context processor needed in Django
  Templates if default auth backed is used).

- Updated the documentation and tests accordingly.

As a side-effect, two tests needed tweaking:

 * migrations.test_commands.tests.test_migrate_with_system_checks
    Left a note for the maintainer because admin checks are triggered without the
    admin app installed

 * admin_scripts.tests.ManageCheck.test_complex_app.

This is motivated by https://github.com/django/django/pull/9682