### PR TITLE
Fixed #29286 -- Fixed column mismatch crash with QuerySet.values() or values_list() after combining an annotated and unannotated queryset with union(), difference(), or intersection().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -408,9 +408,8 @@ class SQLCompiler:
                 # If the columns list is limited, then all combined queries
                 # must have the same columns list. Set the selects defined on
                 # the query on all combined queries, if not already set.
-                if (not compiler.query.values_select and not compiler.query.annotations and
-                        self.query.values_select):
-                    compiler.query.set_values(self.query.values_select)
+                if not compiler.query.values_select and self.query.values_select:
+                    compiler.query.set_values((*self.query.values_select, *self.query.annotation_select))
                 parts += (compiler.as_sql(),)
             except EmptyResultSet:
                 # Omit the empty queryset with UNION and with DIFFERENCE if the

--- a/docs/releases/1.11.13.txt
+++ b/docs/releases/1.11.13.txt
@@ -15,3 +15,8 @@ Bugfixes
 
 * Fixed crashes in ``django.contrib.admindocs`` when a view is a callable
   object, such as ``django.contrib.syndication.views.Feed`` (:ticket:`29296`).
+
+* Fixed a regression in Django 1.11.12 where ``QuerySet.values()`` or
+  ``values_list()`` after combining an annotated and unannotated queryset with
+  ``union()``, ``difference()``, or ``intersection()`` crashed due to mismatching
+  columns (:ticket:`29286`).

--- a/docs/releases/2.0.5.txt
+++ b/docs/releases/2.0.5.txt
@@ -18,3 +18,8 @@ Bugfixes
 
 * Fixed crashes in ``django.contrib.admindocs`` when a view is a callable
   object, such as ``django.contrib.syndication.views.Feed`` (:ticket:`29296`).
+
+* Fixed a regression in Django 1.11.12 where ``QuerySet.values()`` or
+  ``values_list()`` after combining an annotated and unannotated queryset with
+  ``union()``, ``difference()``, or ``intersection()`` crashed due to mismatching
+  columns (:ticket:`29286`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -1,4 +1,4 @@
-from django.db.models import F, IntegerField, Value
+from django.db.models import Exists, F, IntegerField, OuterRef, Value
 from django.db.utils import DatabaseError, NotSupportedError
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -129,6 +129,14 @@ class QuerySetSetOperationTests(TestCase):
             num=Value(1, IntegerField()),
         ).values_list('num', 'count')
         self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
+
+    def test_union_with_values_list_on_annotated_and_unannotated(self):
+        ReservedName.objects.create(name='rn1', order=1)
+        qs1 = Number.objects.annotate(
+            has_reserved_name=Exists(ReservedName.objects.filter(order=OuterRef('num')))
+        ).filter(has_reserved_name=True)
+        qs2 = Number.objects.filter(num=9)
+        self.assertCountEqual(qs1.union(qs2).values_list('num', flat=True), [1, 9])
 
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29286

Regression in a0c03c62a8ac586e5be5b21393c925afa581efaf.