### PR TITLE
Fixes a grammatical error in docs/topics/i18n/translation.txt

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -235,7 +235,7 @@ sophisticated, but will produce incorrect results for some languages::
         'name': name
     }
 
-Don't try to implement your own singular-or-plural logic, it won't be correct.
+Don't try to implement your own singular-or-plural logic; it won't be correct.
 In a case like this, consider something like the following::
 
     text = ngettext(


### PR DESCRIPTION
This changes a comma to a semicolon where two independent clauses were connected under the topic of pluralization. See [here](https://writing.wisc.edu/Handbook/Semicolons.html) for reference.

Apologies for maybe the most pedantic pull request I've ever sent.