### PR TITLE
Fixed #29174, #29175 -- Doc'd that f-strings and JavaScript template strings can't be translated.

### DIFF
--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -138,6 +138,13 @@ instead of positional interpolation (e.g., ``%s`` or ``%d``) whenever you
 have more than a single parameter. If you used positional interpolation,
 translations wouldn't be able to reorder placeholder text.
 
+Since string extraction is done by the ``xgettext`` command, only syntaxes
+supported by ``gettext`` are supported by Django. Python f-strings_ and
+`JavaScript template strings`_ are not yet supported by ``xgettext``.
+
+.. _f-strings: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
+.. _JavaScript template strings: https://savannah.gnu.org/bugs/?50920
+
 .. _translator-comments:
 
 Comments for translators


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29174
https://code.djangoproject.com/ticket/29175