### PR TITLE
Refs #23890 -- Removed numpy deprecation warning silencing.

### DIFF
--- a/tests/template_tests/syntax_tests/test_numpy.py
+++ b/tests/template_tests/syntax_tests/test_numpy.py
@@ -1,4 +1,3 @@
-import warnings
 from unittest import skipIf
 
 from django.test import SimpleTestCase
@@ -7,23 +6,12 @@ from ..utils import setup
 
 try:
     import numpy
-    VisibleDeprecationWarning = numpy.VisibleDeprecationWarning
 except ImportError:
     numpy = False
-except AttributeError:  # numpy < 1.9.0, e.g. 1.8.2 in Debian 8
-    VisibleDeprecationWarning = DeprecationWarning
 
 
 @skipIf(numpy is False, "Numpy must be installed to run these tests.")
 class NumpyTests(SimpleTestCase):
-    # Ignore numpy deprecation warnings (#23890)
-    if numpy:
-        warnings.filterwarnings(
-            "ignore",
-            "Using a non-integer number instead of an "
-            "integer will result in an error in the future",
-            VisibleDeprecationWarning
-        )
 
     @setup({'numpy-array-index01': '{{ var.1 }}'})
     def test_numpy_array_index01(self):


### PR DESCRIPTION
Obsolete since numpy 1.12.0.