### PR TITLE
Fixed #29337 -- Added  __len__() & __bool__() to RawQuerySet.

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1293,6 +1293,14 @@ class RawQuerySet:
         if self._result_cache is None:
             self._result_cache = list(self.iterator())
 
+    def __len__(self):
+        self._fetch_all()
+        return len(self._result_cache)
+
+    def __bool__(self):
+        self._fetch_all()
+        return bool(self._result_cache)
+
     def __iter__(self):
         self._fetch_all()
         return iter(self._result_cache)

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -85,14 +85,6 @@ options that make it very powerful.
     both rows will match. To prevent this, perform the correct typecasting
     before using the value in a query.
 
-.. warning::
-
-    While a ``RawQuerySet`` instance can be iterated over like a normal
-    :class:`~django.db.models.query.QuerySet`, ``RawQuerySet`` doesn't
-    implement all methods you can use with ``QuerySet``. For example,
-    ``__bool__()`` and ``__len__()`` are not defined in ``RawQuerySet``, and
-    thus all ``RawQuerySet`` instances are considered ``True``.
-
 Mapping query fields to model fields
 ------------------------------------
 

--- a/tests/raw_query/tests.py
+++ b/tests/raw_query/tests.py
@@ -330,3 +330,11 @@ class RawQueryTests(TestCase):
             books = Book.objects.raw('SELECT * FROM raw_query_book')
             list(books.iterator())
             list(books.iterator())
+
+    def test_bool(self):
+        self.assertIs(bool(Book.objects.raw('SELECT * FROM raw_query_book')), True)
+        self.assertIs(bool(Book.objects.raw('SELECT * FROM raw_query_book WHERE id = 0')), False)
+
+    def test_len(self):
+        self.assertEqual(len(Book.objects.raw('SELECT * FROM raw_query_book')), 4)
+        self.assertEqual(len(Book.objects.raw('SELECT * FROM raw_query_book WHERE id = 0')), 0)


### PR DESCRIPTION
This PR adds support for `__len__` & `__bool__` in `RawQuerySet`

Ticket: https://code.djangoproject.com/ticket/29337
This PR has a dependency on https://github.com/django/django/pull/9151