### PR TITLE
Fix cls.name tuple error

### DIFF
--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -133,7 +133,10 @@ class AppConfig:
         # Obtain app name here rather than in AppClass.__init__ to keep
         # all error checking for entries in INSTALLED_APPS in one place.
         try:
-            app_name = cls.name
+            if type(cls.name) == tuple:
+                app_name = cls.name[0]
+            else:
+                app_name = cls.name
         except AttributeError:
             raise ImproperlyConfigured(
                 "'%s' must supply a name attribute." % entry)

--- a/django/apps/config.py
+++ b/django/apps/config.py
@@ -133,7 +133,7 @@ class AppConfig:
         # Obtain app name here rather than in AppClass.__init__ to keep
         # all error checking for entries in INSTALLED_APPS in one place.
         try:
-            if type(cls.name) == tuple:
+            if isinstance(cls.name, tuple):
                 app_name = cls.name[0]
             else:
                 app_name = cls.name


### PR DESCRIPTION
sometimes `cls.name` returns tuple and `importlib` module throw error

`Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "C:\ProgramData\Anaconda3\envs\django\lib\site-packages\django\core\management\__init__.py", line 371, in execute_from_command_line
    utility.execute()
  File "C:\ProgramData\Anaconda3\envs\django\lib\site-packages\django\core\management\__init__.py", line 347, in execute
    django.setup()
  File "C:\ProgramData\Anaconda3\envs\django\lib\site-packages\django\__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "C:\ProgramData\Anaconda3\envs\django\lib\site-packages\django\apps\registry.py", line 89, in populate
    app_config = AppConfig.create(entry)
  File "C:\ProgramData\Anaconda3\envs\django\lib\site-packages\django\apps\config.py", line 143, in create
    app_module = import_module(app_name)
  File "C:\ProgramData\Anaconda3\envs\django\lib\importlib\__init__.py", line 117, in import_module
    if name.startswith('.'):
AttributeError: 'tuple' object has no attribute 'startswith'`