### PR TITLE
Fixed #29351 --  Doc'd that ModelAdmin.prepopulated_fields removes stop words.

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1068,7 +1068,8 @@ subclass::
     automatically generate the value for ``SlugField`` fields from one or more
     other fields. The generated value is produced by concatenating the values
     of the source fields, and then by transforming that result into a valid
-    slug (e.g. substituting dashes for spaces).
+    slug (e.g. substituting dashes for spaces; lowercasing ASCII letters; and
+    removing various English stop words such as 'a', 'an', 'as', and similar).
 
     Fields are prepopulated on add forms but not on change forms. It's usually
     undesired that slugs change after an object is created (which would cause


### PR DESCRIPTION
Fixes [#29351](https://code.djangoproject.com/ticket/29351)

Updated the docs to include the fact that ModelAdmin.prepopulated_fields removes stop words. The list of stop words that are removed has also been added.