### PR TITLE
Fixed #29358 -- Added a system check to prohibit models with more than one primary key.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1189,6 +1189,7 @@ class Model(metaclass=ModelBase):
                 *cls._check_field_name_clashes(),
                 *cls._check_model_name_db_lookup_clashes(),
                 *cls._check_property_name_related_field_accessor_clashes(),
+                *cls._check_single_primary_key(),
             )
             errors.extend(clash_errors)
             # If there are field name clashes, hide consequent column name
@@ -1434,6 +1435,19 @@ class Model(metaclass=ModelBase):
                         id='models.E025',
                     )
                 )
+        return errors
+
+    @classmethod
+    def _check_single_primary_key(cls):
+        errors = []
+        if sum(1 for f in cls._meta.local_fields if f.primary_key) > 1:
+            errors.append(
+                checks.Error(
+                    "Model can not contain more than one 'primary_key' field.",
+                    obj=cls,
+                    id='models.E026',
+                )
+            )
         return errors
 
     @classmethod

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -295,6 +295,7 @@ Models
   as it collides with the query lookup syntax.
 * **models.E025**: The property ``<property name>`` clashes with a related
   field accessor.
+* **models.E026**: Model can not contain more than one ``primary_key`` field.
 
 Security
 --------

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -717,6 +717,19 @@ class OtherModelTests(SimpleTestCase):
             )
         ])
 
+    def test_single_primary_key(self):
+        class Model(models.Model):
+            foo = models.IntegerField(primary_key=True)
+            bar = models.IntegerField(primary_key=True)
+
+        self.assertEqual(Model.check(), [
+            Error(
+                "Model can not contain more than one 'primary_key' field.",
+                obj=Model,
+                id='models.E026',
+            )
+        ])
+
     @override_settings(TEST_SWAPPED_MODEL_BAD_VALUE='not-a-model')
     def test_swappable_missing_app_name(self):
         class Model(models.Model):


### PR DESCRIPTION
Add a system check to prohibit models with more than one primary_key field([ticket_29358](https://code.djangoproject.com/ticket/29358))