### PR TITLE
Use double quotation marks for csrf form element

### DIFF
--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -54,7 +54,7 @@ class CsrfTokenNode(Node):
             if csrf_token == 'NOTPROVIDED':
                 return format_html("")
             else:
-                return format_html("<input type='hidden' name='csrfmiddlewaretoken' value='{}'>", csrf_token)
+                return format_html('<input type="hidden" name="csrfmiddlewaretoken" value="{}">', csrf_token)
         else:
             # It's very probable that the token is missing because of
             # misconfiguration, so we raise a warning

--- a/tests/csrf_tests/tests.py
+++ b/tests/csrf_tests/tests.py
@@ -64,7 +64,7 @@ class CsrfViewMiddlewareTestMixin:
 
     def _check_token_present(self, response, csrf_id=None):
         text = str(response.content, response.charset)
-        match = re.search("name='csrfmiddlewaretoken' value='(.*?)'", text)
+        match = re.search('name="csrfmiddlewaretoken" value="(.*?)"', text)
         csrf_token = csrf_id or self._csrf_id
         self.assertTrue(
             match and equivalent_tokens(csrf_token, match.group(1)),


### PR DESCRIPTION
Make it in line with other form elements output by django.