### PR TITLE
Fixed #29370 -- Added choices to LogEntry.action_flag field.

### DIFF
--- a/django/contrib/admin/migrations/0003_logentry_add_action_flag_choices.py
+++ b/django/contrib/admin/migrations/0003_logentry_add_action_flag_choices.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('admin', '0002_logentry_remove_auto_add'),
+    ]
+
+    # No database changes; adds choices to action_flag.
+    operations = [
+        migrations.AlterField(
+            model_name='logentry',
+            name='action_flag',
+            field=models.PositiveSmallIntegerField(
+                choices=[(1, 'Addition'), (2, 'Change'), (3, 'Deletion')],
+                verbose_name='action flag',
+            ),
+        ),
+    ]

--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -13,6 +13,12 @@ ADDITION = 1
 CHANGE = 2
 DELETION = 3
 
+ACTION_FLAG_CHOICES = (
+    (ADDITION, _('Addition')),
+    (CHANGE, _('Change')),
+    (DELETION, _('Deletion')),
+)
+
 
 class LogEntryManager(models.Manager):
     use_in_migrations = True
@@ -50,7 +56,7 @@ class LogEntry(models.Model):
     object_id = models.TextField(_('object id'), blank=True, null=True)
     # Translators: 'repr' means representation (https://docs.python.org/3/library/functions.html#repr)
     object_repr = models.CharField(_('object repr'), max_length=200)
-    action_flag = models.PositiveSmallIntegerField(_('action flag'))
+    action_flag = models.PositiveSmallIntegerField(_('action flag'), choices=ACTION_FLAG_CHOICES)
     # change_message is either a string or a JSON structure
     change_message = models.TextField(_('change message'), blank=True)
 

--- a/tests/admin_utils/test_logentry.py
+++ b/tests/admin_utils/test_logentry.py
@@ -253,3 +253,10 @@ class LogEntryTests(TestCase):
         proxy_delete_log = LogEntry.objects.latest('id')
         self.assertEqual(proxy_delete_log.action_flag, DELETION)
         self.assertEqual(proxy_delete_log.content_type, proxy_content_type)
+
+    def test_action_flag_choices(self):
+        tests = ((1, 'Addition'), (2, 'Change'), (3, 'Deletion'))
+        for action_flag, display_name in tests:
+            with self.subTest(action_flag=action_flag):
+                log = LogEntry(action_flag=action_flag)
+                self.assertEqual(log.get_action_flag_display(), display_name)


### PR DESCRIPTION
I kept things as simple as possible, keeping constants out of the `LogEntry` class so we don't break the API and documentation.