### PR TITLE
Fixed #28913 -- Fixed error handling when MIGRATIONS_MODULES has a missing top-level package

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -722,6 +722,7 @@ answer newbie questions, and generally made Django that much better:
     Ryno Mathee <rmathee@gmail.com>
     Sam Newman <http://www.magpiebrain.com/>
     Sander Dijkhuis <sander.dijkhuis@gmail.com>
+    Sanket Saurav <sanketsaurav@gmail.com>
     Sarthak Mehrish <sarthakmeh03@gmail.com>
     schwank@gmail.com
     Scot Hacker <shacker@birdhouse.org>

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -240,7 +240,7 @@ class MigrationWriter:
             missing_dirs.insert(0, existing_dirs.pop(-1))
             try:
                 base_module = import_module(".".join(existing_dirs))
-            except ImportError:
+            except (ImportError, ValueError):
                 continue
             else:
                 try:

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1116,6 +1116,16 @@ class MakeMigrationsTests(MigrationTestBase):
         # Command output indicates the migration is created.
         self.assertIn(" - Create model SillyModel", out.getvalue())
 
+    @override_settings(MIGRATION_MODULES={'migrations': 'some.nonexistent.path'})
+    def test_makemigrations_migrations_modules_nonexistent_toplevel_package(self):
+        msg = (
+            'Could not locate an appropriate location to create migrations '
+            'package some.nonexistent.path. Make sure the toplevel package '
+            'exists and can be imported.'
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            call_command('makemigrations', 'migrations', empty=True, verbosity=0)
+
     def test_makemigrations_interactive_by_default(self):
         """
         The user is prompted to merge by default if there are conflicts and


### PR DESCRIPTION
When specifying a custom migration module package for an app in
the MIGRATIONS_MODULES setting, if the top-level package does not
exist, added relevant error handling so an informative
error message is displayed to the user while trying to make
migrations.

Signed-off-by: Sanket Saurav <sanketsaurav@gmail.com>