### PR TITLE
Fixed #29392 -- Disallowed use of abbreviated forms of --settings and --pythonpath management command options.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -311,7 +311,7 @@ class ManagementUtility:
         # Preprocess options to extract --settings and --pythonpath.
         # These options could affect the commands that are available, so they
         # must be processed early.
-        parser = CommandParser(usage='%(prog)s subcommand [options] [args]', add_help=False)
+        parser = CommandParser(usage='%(prog)s subcommand [options] [args]', add_help=False, allow_abbrev=False)
         parser.add_argument('--settings')
         parser.add_argument('--pythonpath')
         parser.add_argument('args', nargs='*')  # catch-all

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -423,6 +423,9 @@ Miscellaneous
   to insert untranslated content into the database), use the new
   :ref:`@no_translations decorator <management-commands-and-locales>`.
 
+* Management commands no longer allow the abbreviated forms of the
+  ``--settings`` and ``--pythonpath`` arguments.
+
 .. _deprecated-features-2.1:
 
 Features deprecated in 2.1

--- a/tests/user_commands/management/commands/set_option.py
+++ b/tests/user_commands/management/commands/set_option.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('--set')
+
+    def handle(self, **options):
+        self.stdout.write('Set %s' % options['set'])

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -232,6 +232,16 @@ class CommandRunTests(AdminScriptTestCase):
         self.assertNoOutput(err)
         self.assertEqual(out.strip(), '/PREFIX/some/url/')
 
+    def test_disallowed_abbreviated_options(self):
+        """
+        To avoid conflicts with custom options, commands don't allow
+        abbreviated forms of the --setting and --pythonpath options.
+        """
+        self.write_settings('settings.py', apps=['user_commands'])
+        out, err = self.run_manage(['set_option', '--set', 'foo'])
+        self.assertNoOutput(err)
+        self.assertEqual(out.strip(), 'Set foo')
+
 
 class UtilsTests(SimpleTestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29392

Test failure output:

```
======================================================================
FAIL: test_ambiguous_arguments (user_commands.tests.CommandRunTests)
----------------------------------------------------------------------
```
```python
Traceback (most recent call last):
  File "./django/tests/user_commands/tests.py", line 241, in test_ambiguous_arguments
    self.assertNoOutput(err)
  File "./django/tests/admin_scripts/tests.py", line 187, in assertNoOutput
    self.assertEqual(len(stream), 0, "Stream should be empty: actually contains '%s'" % stream)
AssertionError: 1646 != 0 : Stream should be empty: actually contains 'Traceback (most recent call last):
  File "./django/django/core/management/__init__.py", line 204, in fetch_command
    app_name = commands[subcommand]
KeyError: 'config'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "./django/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "./django/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "./django/django/core/management/__init__.py", line 211, in fetch_command
    settings.INSTALLED_APPS
  File "./django/django/conf/__init__.py", line 57, in __getattr__
    self._setup(name)
  File "./django/django/conf/__init__.py", line 44, in _setup
    self._wrapped = Settings(settings_module)
  File "./django/django/conf/__init__.py", line 107, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 978, in _gcd_import
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 948, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'foo'
```