### PR TITLE
Fixed #29389 -- Made Paginator reject non-integer page numbers of type float.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -35,6 +35,8 @@ class Paginator:
     def validate_number(self, number):
         """Validate the given 1-based page number."""
         try:
+            if isinstance(number, float) and not number.is_integer():
+                raise ValueError
             number = int(number)
         except (TypeError, ValueError):
             raise PageNotAnInteger(_('That page number is not an integer'))

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -120,6 +120,12 @@ class PaginationTests(unittest.TestCase):
             paginator.validate_number(None)
         with self.assertRaises(PageNotAnInteger):
             paginator.validate_number('x')
+
+    def test_float_integer_page(self):
+        paginator = Paginator([1, 2, 3], 2)
+        self.assertEqual(paginator.validate_number(1.0), 1)
+
+    def test_no_content_allow_empty_first_page(self):
         # With no content and allow_empty_first_page=True, 1 is a valid page number
         paginator = Paginator([], 2)
         self.assertEqual(paginator.validate_number(1), 1)

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -120,6 +120,8 @@ class PaginationTests(unittest.TestCase):
             paginator.validate_number(None)
         with self.assertRaises(PageNotAnInteger):
             paginator.validate_number('x')
+        with self.assertRaises(PageNotAnInteger):
+            paginator.validate_number(1.2)
 
     def test_float_integer_page(self):
         paginator = Paginator([1, 2, 3], 2)


### PR DESCRIPTION
- Is a remark in release notes needed? On one side it's just a bug fix, on the other one the behavior of the Paginator changes.
- Another option: we could also accept floats that can be converted to int without any loss of precision (i.e. 2.0 would be accepted). I didn't took this route to keep things straightforward (the exception is called `PageNotAnInteger`), but others may disagree. 