### PR TITLE
Restore user.backend when loading from session

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -187,8 +187,9 @@ def get_user(request):
         if backend_path in settings.AUTHENTICATION_BACKENDS:
             backend = load_backend(backend_path)
             user = backend.get_user(user_id)
-            # Annotate the user object with the path of the backend.
-            user.backend = backend_path
+            if user:
+                # Annotate the user object with the path of the backend.
+                user.backend = backend_path
             # Verify the session
             if hasattr(user, 'get_session_auth_hash'):
                 session_hash = request.session.get(HASH_SESSION_KEY)

--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -187,6 +187,8 @@ def get_user(request):
         if backend_path in settings.AUTHENTICATION_BACKENDS:
             backend = load_backend(backend_path)
             user = backend.get_user(user_id)
+            # Annotate the user object with the path of the backend.
+            user.backend = backend_path
             # Verify the session
             if hasattr(user, 'get_session_auth_hash'):
                 session_hash = request.session.get(HASH_SESSION_KEY)


### PR DESCRIPTION
Having `user.backend` available only during the login request isn't that useful.
This standardises access to the value, without requiring knowledge of sessions.