### PR TITLE
Move `to_locale` to `django/utils/translation/__init__.py`

### DIFF
--- a/django/utils/translation/__init__.py
+++ b/django/utils/translation/__init__.py
@@ -194,7 +194,20 @@ def check_for_language(lang_code):
 
 
 def to_locale(language):
-    return _trans.to_locale(language)
+    """Turn a language name (en-us) into a locale name (en_US)."""
+    language = language.lower()
+    parts = language.split('-')
+    try:
+        country = parts[1]
+    except IndexError:
+        return language
+    else:
+        # A language with > 2 characters after the dash only has its first
+        # character after the dash capitalized; e.g. sr-latn becomes sr_Latn.
+        # A language with 2 characters after the dash has both characters
+        # capitalized; e.g. en-us becomes en_US.
+        parts[1] = country.title() if len(country) > 2 else country.upper()
+    return parts[0] + '_' + '-'.join(parts[1:])
 
 
 def get_language_from_request(request, check_path=False):

--- a/django/utils/translation/trans_null.py
+++ b/django/utils/translation/trans_null.py
@@ -4,8 +4,6 @@
 
 from django.conf import settings
 
-from .trans_real import to_locale as trans_real_to_locale
-
 
 def gettext(message):
     return message
@@ -52,9 +50,6 @@ def get_language_bidi():
 
 def check_for_language(x):
     return True
-
-
-to_locale = trans_real_to_locale
 
 
 def get_language_from_request(request, check_path=False):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -15,7 +15,7 @@ from django.core.exceptions import AppRegistryNotReady
 from django.core.signals import setting_changed
 from django.dispatch import receiver
 from django.utils.safestring import SafeData, mark_safe
-from django.utils.translation import LANGUAGE_SESSION_KEY
+from django.utils.translation import LANGUAGE_SESSION_KEY, to_locale
 
 # Translations are cached in a dictionary for every language.
 # The active translations are stored by threadid to make them thread local.
@@ -54,23 +54,6 @@ def reset_cache(**kwargs):
         check_for_language.cache_clear()
         get_languages.cache_clear()
         get_supported_language_variant.cache_clear()
-
-
-def to_locale(language):
-    """Turn a language name (en-us) into a locale name (en_US)."""
-    language = language.lower()
-    parts = language.split('-')
-    try:
-        country = parts[1]
-    except IndexError:
-        return language
-    else:
-        # A language with > 2 characters after the dash only has its first
-        # character after the dash capitalized; e.g. sr-latn becomes sr_Latn.
-        # A language with 2 characters after the dash has both characters
-        # capitalized; e.g. en-us becomes en_US.
-        parts[1] = country.title() if len(country) > 2 else country.upper()
-    return parts[0] + '_' + '-'.join(parts[1:])
 
 
 def to_language(locale):

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -286,7 +286,6 @@ class TranslationTests(SimpleTestCase):
         for lang, locale in tests:
             with self.subTest(lang=lang):
                 self.assertEqual(to_locale(lang), locale)
-                self.assertEqual(trans_null.to_locale(lang), locale)
 
     def test_to_language(self):
         self.assertEqual(trans_real.to_language('en_US'), 'en-us')


### PR DESCRIPTION
Move `to_locale` to `django/utils/translation/__init__.py`, and remove it from tran_real.py and trans_null.py