### PR TITLE
Don't Make Migrations For Trivial (Non-DB-related) Changes to Models

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -89,10 +89,10 @@ class MigrationAutodetector:
             return obj
 
     def _dbrelated_fields(self, field_dec):
-        return {k:v for k, v in field_dec[2].items() if k not in TRIVAL_FIELD_ATTRS}
+        return {k: v for k, v in field_dec[2].items() if k not in TRIVAL_FIELD_ATTRS}
 
     def has_dbrelated_change(self, old_field_dec, new_field_dec):
-        old_fields  = self._dbrelated_fields(old_field_dec)
+        old_fields = self._dbrelated_fields(old_field_dec)
         new_fields = self._dbrelated_fields(new_field_dec)
         return new_fields != old_fields
 

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -10,7 +10,8 @@ from django.db.migrations.operations.models import AlterModelOptions
 from django.db.migrations.optimizer import MigrationOptimizer
 from django.db.migrations.questioner import MigrationQuestioner
 from django.db.migrations.utils import (
-    COMPILED_REGEX_TYPE, TRIVAL_FIELD_ATTRS, RegexObject, get_migration_name_timestamp,
+    COMPILED_REGEX_TYPE, TRIVAL_FIELD_ATTRS, RegexObject,
+    get_migration_name_timestamp,
 )
 
 from .topological_sort import stable_topological_sort

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -2,7 +2,7 @@ import datetime
 import re
 
 COMPILED_REGEX_TYPE = type(re.compile(''))
-
+TRIVAL_FIELD_ATTRS = ("verbose_name", "blank", "editable", "help_text")
 
 class RegexObject:
     def __init__(self, obj):

--- a/django/db/migrations/utils.py
+++ b/django/db/migrations/utils.py
@@ -4,6 +4,7 @@ import re
 COMPILED_REGEX_TYPE = type(re.compile(''))
 TRIVAL_FIELD_ATTRS = ("verbose_name", "blank", "editable", "help_text")
 
+
 class RegexObject:
     def __init__(self, obj):
         self.pattern = obj.pattern

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -256,9 +256,9 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("publishers", models.ManyToManyField("testapp.Publisher")),
     ])
-    author_with_m2m_blank = ModelState("testapp", "Author", [
+    author_with_m2m_null = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
-        ("publishers", models.ManyToManyField("testapp.Publisher", blank=True)),
+        ("publishers", models.ManyToManyField("testapp.Publisher", null=True)),
     ])
     author_with_m2m_through = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
@@ -1861,7 +1861,7 @@ class AutodetectorTests(TestCase):
 
     def test_alter_many_to_many(self):
         changes = self.get_changes(
-            [self.author_with_m2m, self.publisher], [self.author_with_m2m_blank, self.publisher]
+            [self.author_with_m2m, self.publisher], [self.author_with_m2m_null, self.publisher]
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -53,6 +53,10 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=400)),
     ])
+    author_name_help_text = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200, null=True, help_text="help")),
+    ])
     author_name_renamed = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("names", models.CharField(max_length=200)),
@@ -719,6 +723,12 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+
+    def test_alter_field_trivial(self):
+        """Tests autodetection of new fields."""
+        changes = self.get_changes([self.author_name_null], [self.author_name_help_text])
+        # Right number/type of migrations?
+        self.assertEqual(len(changes), 0)
 
     def test_supports_functools_partial(self):
         def _content_file_name(instance, filename, key, **kwargs):

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -57,6 +57,18 @@ class AutodetectorTests(TestCase):
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200, null=True, help_text="help")),
     ])
+    author_name_verbose = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200, null=True, verbose_name="Authorae")),
+    ])
+    author_name_editable = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200, null=True, editable=False)),
+    ])
+    author_name_blank = ModelState("testapp", "Author", [
+        ("id", models.AutoField(primary_key=True)),
+        ("name", models.CharField(max_length=200, null=True, blank=True)),
+    ])
     author_name_renamed = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("names", models.CharField(max_length=200)),
@@ -724,11 +736,30 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
         self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
 
-    def test_alter_field_trivial(self):
+    def test_alter_field_trivial_help_text(self):
         """Tests autodetection of new fields."""
         changes = self.get_changes([self.author_name_null], [self.author_name_help_text])
         # Right number/type of migrations?
         self.assertEqual(len(changes), 0)
+
+    def test_alter_field_trivial_verbose(self):
+        """Tests autodetection of new fields."""
+        changes = self.get_changes([self.author_name_null], [self.author_name_verbose])
+        # Right number/type of migrations?
+        self.assertEqual(len(changes), 0)
+
+    def test_alter_field_trivial_blank(self):
+        """Tests autodetection of new fields."""
+        changes = self.get_changes([self.author_name_null], [self.author_name_blank])
+        # Right number/type of migrations?
+        self.assertEqual(len(changes), 0)
+
+    def test_alter_field_trivial_editable(self):
+        """Tests autodetection of new fields."""
+        changes = self.get_changes([self.author_name_null], [self.author_name_editable])
+        # Right number/type of migrations?
+        self.assertEqual(len(changes), 0)
+
 
     def test_supports_functools_partial(self):
         def _content_file_name(instance, filename, key, **kwargs):

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -760,7 +760,6 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertEqual(len(changes), 0)
 
-
     def test_supports_functools_partial(self):
         def _content_file_name(instance, filename, key, **kwargs):
             return '{}/{}'.format(instance, filename)


### PR DESCRIPTION
## Summary
Currently, changing non-db-related fields l(i.e `verbose_name`, `editable`, `help_text`) result in detected migrations that create an `AlterField` database migration action. This migration action does not impact the database; it's extra code that probably doesn't need to be generated.

## Details
- exclude non-db field attributes when detecting changes to fields in migrations. Excluding `"verbose_name", "blank", "editable", "help_text"`
- add tests to ensure no migrations detected for changes in those attributes.
- updated one test that expects a migration count of **1** for adding a `blank=True` attribute. Changed that to a `null=True` (even though that may be trivial for M2M, idk)

> NOTE: long time consumer of django (10+ years), first contribution.