### PR TITLE
Fixed #29410 -- Added project urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,12 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    project_urls={
+        'Documentation': 'https://docs.djangoproject.com/',
+        'Funding': 'https://www.djangoproject.com/fundraising/',
+        'Source': 'https://github.com/django/django',
+        'Tracker': 'https://code.djangoproject.com/',
+    },
 )
 
 


### PR DESCRIPTION
Added URLs relevant to the Django project to the setup.py file. These URLs will
show up in the sidebar of the Django PyPI page.