### PR TITLE
Fixed #29415 -- Fixed detection of custom URL converters in included patterns.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -773,6 +773,7 @@ answer newbie questions, and generally made Django that much better:
     Stephan Jaekel <steph@rdev.info>
     Stephen Burrows <stephen.r.burrows@gmail.com>
     Steven L. Smith (fvox13) <steven@stevenlsmith.com>
+    Steven Noorbergen (Xaroth) <xaroth+django@xaroth.nl>
     Stuart Langridge <http://www.kryogenix.org/>
     Sujay S Kumar <sujay.skumar141295@gmail.com>
     Sune Kirkeby <http://ibofobi.dk/>

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -49,6 +49,7 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
 
         resolved_path = []
         ns_pattern = ''
+        ns_converters = {}
         while path:
             ns = path.pop()
             current_ns = current_path.pop() if current_path else None
@@ -74,6 +75,7 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
                 extra, resolver = resolver.namespace_dict[ns]
                 resolved_path.append(ns)
                 ns_pattern = ns_pattern + extra
+                ns_converters.update(resolver.pattern.converters)
             except KeyError as key:
                 if resolved_path:
                     raise NoReverseMatch(
@@ -83,7 +85,7 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
                 else:
                     raise NoReverseMatch("%s is not a registered namespace" % key)
         if ns_pattern:
-            resolver = get_ns_resolver(ns_pattern, resolver)
+            resolver = get_ns_resolver(ns_pattern, resolver, tuple(ns_converters.items()))
 
     return iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs))
 

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -68,11 +68,13 @@ def get_resolver(urlconf=None):
 
 
 @functools.lru_cache(maxsize=None)
-def get_ns_resolver(ns_pattern, resolver):
+def get_ns_resolver(ns_pattern, resolver, converters):
     # Build a namespaced resolver for the given parent URLconf pattern.
     # This makes it possible to have captured parameters in the parent
     # URLconf pattern.
-    ns_resolver = URLResolver(RegexPattern(ns_pattern), resolver.url_patterns)
+    pattern = RegexPattern(ns_pattern)
+    pattern.converters = dict(converters)
+    ns_resolver = URLResolver(pattern, resolver.url_patterns)
     return URLResolver(RegexPattern(r'^/'), [ns_resolver])
 
 
@@ -439,7 +441,7 @@ class URLResolver:
                                         new_matches,
                                         p_pattern + pat,
                                         {**defaults, **url_pattern.default_kwargs},
-                                        {**self.pattern.converters, **converters}
+                                        {**self.pattern.converters, **url_pattern.pattern.converters, **converters}
                                     )
                                 )
                         for namespace, (prefix, sub_pattern) in url_pattern.namespace_dict.items():

--- a/docs/releases/2.0.6.txt
+++ b/docs/releases/2.0.6.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a regression that broke custom template filters that use decorators
   (:ticket:`29400`).
+
+* Fixed detection of custom URL converters in included patterns
+  (:ticket:`29415`).

--- a/tests/urlpatterns/path_base64_urls.py
+++ b/tests/urlpatterns/path_base64_urls.py
@@ -1,9 +1,15 @@
-from django.urls import path, register_converter
+from django.urls import include, path, register_converter
 
 from . import converters, views
 
 register_converter(converters.Base64Converter, 'base64')
 
+subpatterns = [
+    path('<base64:value>/', views.empty_view, name='subpattern-base64'),
+]
+
 urlpatterns = [
     path('base64/<base64:value>/', views.empty_view, name='base64'),
+    path('base64/<base64:base>/subpatterns/', include(subpatterns)),
+    path('base64/<base64:base>/namespaced/', include((subpatterns, 'namespaced-base64'))),
 ]


### PR DESCRIPTION
As described in https://code.djangoproject.com/ticket/29415

Main changes made:

- Push converters from parent sections onto namespace url resolvers when reverse()'ing
- Add converters from the base url pattern to sub-urls for included urlpatterns
- Add tests for reversing custom url converters