### PR TITLE
Added help for common 404 error in tutorial 1.

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -324,6 +324,11 @@ Go to http://localhost:8000/polls/ in your browser, and you should see the
 text "*Hello, world. You're at the polls index.*", which you defined in the
 ``index`` view.
 
+.. admonition:: Page not found?
+
+    If you get an error page here, check that you're going to
+    http://localhost:8000/polls/ and not http://localhost:8000/.
+
 The :func:`~django.urls.path` function is passed four arguments, two required:
 ``route`` and ``view``, and two optional: ``kwargs``, and ``name``.
 At this point, it's worth reviewing what these arguments are for.


### PR DESCRIPTION
It seems to be very common for people following the tutorial to get a
404 when they try and open their first page because they go to the root
path rather than /polls/. This adds a help box to point them in the
right direction.