### PR TITLE
Fixed #29198  --  Added `--plan` option to migrate command.

### DIFF
--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -804,6 +804,13 @@ option does not, however, check for matching database schema beyond matching
 table names and so is only safe to use if you are confident that your existing
 schema matches what is recorded in your initial migration.
 
+.. django-admin-option:: --plan
+
+.. versionadded:: 2.2
+
+Shows the migration operations that will be performed for the given ``migrate``
+command.
+
 .. django-admin-option:: --run-syncdb
 
 Allows creating tables for apps without migrations. While this isn't

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -175,7 +175,8 @@ Management Commands
 Migrations
 ~~~~~~~~~~
 
-* ...
+* The new :option:`migrate --plan` option prints the list of migration
+  operations that will be performed.
 
 Models
 ~~~~~~

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -298,6 +298,73 @@ class MigrateTests(MigrationTestBase):
         # Cleanup by unmigrating everything
         call_command("migrate", "migrations", "zero", verbosity=0)
 
+    @override_settings(MIGRATION_MODULES={'migrations': 'migrations.test_migrations_plan'})
+    def test_migrate_plan(self):
+        """Tests migrate --plan output."""
+        out = io.StringIO()
+        # Show the plan up to the third migration.
+        call_command('migrate', 'migrations', '0003', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0001_initial\n'
+            '    Create model Salamander\n'
+            '    Raw Python operation -> Grow salamander tail.\n'
+            'migrations.0002_second\n'
+            '    Create model Book\n'
+            '    Raw SQL operation -> SELECT * FROM migrations_book\n'
+            'migrations.0003_third\n'
+            '    Create model Author\n'
+            '    Raw SQL operation -> SELECT * FROM migrations_author\n',
+            out.getvalue()
+        )
+        # Migrate to the third migration.
+        call_command('migrate', 'migrations', '0003', verbosity=0)
+        out = io.StringIO()
+        # Show the plan for when there is nothing to apply.
+        call_command('migrate', 'migrations', '0003', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            '  No planned migration operations.\n',
+            out.getvalue()
+        )
+        out = io.StringIO()
+        # Show the plan for reverse migration back to 0001.
+        call_command('migrate', 'migrations', '0001', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0003_third\n'
+            '    Undo Create model Author\n'
+            '    Raw SQL operation -> SELECT * FROM migrations_book\n'
+            'migrations.0002_second\n'
+            '    Undo Create model Book\n'
+            '    Raw SQL operation -> SELECT * FROM migrations_salamander\n',
+            out.getvalue()
+        )
+        out = io.StringIO()
+        # Show the migration plan to fourth, with truncated details.
+        call_command('migrate', 'migrations', '0004', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0004_fourth\n'
+            '    Raw SQL operation -> SELECT * FROM migrations_author W...\n',
+            out.getvalue()
+        )
+        # Migrate to the fourth migration.
+        call_command('migrate', 'migrations', '0004', verbosity=0)
+        out = io.StringIO()
+        # Show the plan when an operation is irreversible.
+        call_command('migrate', 'migrations', '0003', plan=True, stdout=out, no_color=True)
+        self.assertEqual(
+            'Planned operations:\n'
+            'migrations.0004_fourth\n'
+            '    Raw SQL operation -> IRREVERSIBLE\n',
+            out.getvalue()
+        )
+        # Cleanup by unmigrating everything: fake the irreversible, then
+        # migrate all to zero.
+        call_command('migrate', 'migrations', '0003', fake=True, verbosity=0)
+        call_command('migrate', 'migrations', 'zero', verbosity=0)
+
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_empty"})
     def test_showmigrations_plan_no_migrations(self):
         """

--- a/tests/migrations/test_migrations_plan/0001_initial.py
+++ b/tests/migrations/test_migrations_plan/0001_initial.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+def grow_tail(x, y):
+    """Grow salamander tail."""
+    pass
+
+
+def shrink_tail(x, y):
+    """Shrink salamander tail."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    operations = [
+        migrations.CreateModel(
+            'Salamander',
+            [
+                ('id', models.AutoField(primary_key=True)),
+                ('tail', models.IntegerField(default=0)),
+                ('silly_field', models.BooleanField(default=False)),
+            ],
+        ),
+        migrations.RunPython(grow_tail, shrink_tail),
+    ]

--- a/tests/migrations/test_migrations_plan/0002_second.py
+++ b/tests/migrations/test_migrations_plan/0002_second.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('migrations', '0001_initial'),
+    ]
+
+    operations = [
+
+        migrations.CreateModel(
+            'Book',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+        migrations.RunSQL('SELECT * FROM migrations_book', 'SELECT * FROM migrations_salamander')
+
+    ]

--- a/tests/migrations/test_migrations_plan/0003_third.py
+++ b/tests/migrations/test_migrations_plan/0003_third.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('migrations', '0002_second'),
+    ]
+
+    operations = [
+
+        migrations.CreateModel(
+            'Author',
+            [
+                ('id', models.AutoField(primary_key=True)),
+            ],
+        ),
+        migrations.RunSQL('SELECT * FROM migrations_author', 'SELECT * FROM migrations_book')
+    ]

--- a/tests/migrations/test_migrations_plan/0004_fourth.py
+++ b/tests/migrations/test_migrations_plan/0004_fourth.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("migrations", "0003_third"),
+    ]
+
+    operations = [
+        migrations.RunSQL('SELECT * FROM migrations_author WHERE id = 1')
+    ]


### PR DESCRIPTION
## Summary
Initial Stab at the ticket #29198 (https://code.djangoproject.com/ticket/29198)

## Highlights
- Show the planned migrations in the order they will be applied with each of the operations in the order they will be applied. 
- Ensure that we respect the direction of the migration when describing the operation (i.e backwards and forwards)
- If an operation in the reverse migration plan is irreversible, say so (with warning text style). See Fig 3
- Try to describe SQL and Python operations with a little bit of detail.

#### Fig 1: Forwards
![image](https://user-images.githubusercontent.com/174766/40270503-bf81e230-5b5c-11e8-9057-1f05c568498b.png)

#### Fig 2: Backwards
![image](https://user-images.githubusercontent.com/174766/40270369-314dc5c6-5b5a-11e8-8b3e-1647bf44f2d5.png)

#### Fig 3: Backwards with Warning
![image](https://user-images.githubusercontent.com/174766/40270375-407181c8-5b5a-11e8-9d94-511aa204933c.png)