### PR TITLE
Fixed #29419 -- Added release notes about ModelAdmin.get_actions change.

### DIFF
--- a/docs/ref/contrib/admin/actions.txt
+++ b/docs/ref/contrib/admin/actions.txt
@@ -340,8 +340,10 @@ Conditionally enabling or disabling actions
     Finally, you can conditionally enable or disable actions on a per-request
     (and hence per-user basis) by overriding :meth:`ModelAdmin.get_actions`.
 
-    This doesn't return any actions if the user doesn't have the "change"
-    permission for the model.
+    .. versionadded:: 2.1
+
+       This doesn't return any actions if the user doesn't have the "change"
+       permission for the model.
 
     This returns a dictionary of actions allowed. The keys are action names, and
     the values are ``(function, name, short_description)`` tuples.

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -324,6 +324,12 @@ If you have a custom permission with a codename of the form
 allow view access to the changelist and detail pages for those models. If this
 is unwanted, you must change your custom permission codename.
 
+``ModelAdmin.get_actions`` requires "change" permission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`.ModelAdmin.get_actions` returns empty :class:`~collections.OrderedDict`
+when requests doesn't have `"change"` permission.
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
Refs https://code.djangoproject.com/ticket/29419

Added release notes about changing `ModelAdmin.get_actions` behavior.
It will return empty OrderedDict if requests hasn't `"change"` permission.
