### PR TITLE
Fixed #29301 -- Added custom help formatter to BaseCommand class

### DIFF
--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -145,6 +145,11 @@ Management Commands
 * The new :option:`inspectdb --include-views` option allows creating models
   for database views.
 
+* The :class:`~django.core.management.BaseCommand` class now uses a custom help
+  formatter so that the standard options like ``--verbosity`` or ``--settings``
+  appear last in the help output, giving a more prominent position to subclassed
+  command's options.
+
 Migrations
 ~~~~~~~~~~
 

--- a/tests/user_commands/management/commands/common_args.py
+++ b/tests/user_commands/management/commands/common_args.py
@@ -1,0 +1,16 @@
+from argparse import ArgumentError
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        try:
+            parser.add_argument('--version', action='version', version='A.B.C')
+        except ArgumentError:
+            pass
+        else:
+            raise CommandError('--version argument does no yet exist')
+
+    def handle(self, *args, **options):
+        return 'Detected that --version already exists'

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -205,6 +205,11 @@ class CommandTests(SimpleTestCase):
         self.assertIn('need_me', out.getvalue())
         self.assertIn('needme2', out.getvalue())
 
+    def test_command_add_arguments_after_common_arguments(self):
+        out = StringIO()
+        management.call_command('common_args', stdout=out)
+        self.assertIn('Detected that --version already exists', out.getvalue())
+
     def test_subparser(self):
         out = StringIO()
         management.call_command('subparser', 'foo', 12, stdout=out)


### PR DESCRIPTION
This partially reverts c3055242c81812278ebdc93dd109f30d2cbd1610.