### PR TITLE
Fixed #29426 -- Made UUID inputs in the admin match the width of a UUID.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -92,6 +92,7 @@ FORMFIELD_FOR_DBFIELD_DEFAULTS = {
     models.ImageField: {'widget': widgets.AdminFileWidget},
     models.FileField: {'widget': widgets.AdminFileWidget},
     models.EmailField: {'widget': widgets.AdminEmailInputWidget},
+    models.UUIDField: {'widget': widgets.AdminUUIDInputWidget},
 }
 
 csrf_protect_m = method_decorator(csrf_protect)

--- a/django/contrib/admin/static/admin/css/forms.css
+++ b/django/contrib/admin/static/admin/css/forms.css
@@ -353,7 +353,7 @@ body.popup .submit-row {
     width: 2.2em;
 }
 
-.vTextField {
+.vTextField, .vUUIDField {
     width: 20em;
 }
 

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -351,6 +351,11 @@ class AdminBigIntegerFieldWidget(AdminIntegerFieldWidget):
     class_name = 'vBigIntegerField'
 
 
+class AdminUUIDInputWidget(forms.TextInput):
+    def __init__(self, attrs=None):
+        super().__init__(attrs={'class': 'vUUIDField', **(attrs or {})})
+
+
 # Mapping of lower case language codes [returned by Django's get_language()]
 # to language codes supported by select2.
 # See django/contrib/admin/static/admin/js/vendor/select2/i18n/*

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -408,6 +408,20 @@ class AdminURLWidgetTest(SimpleTestCase):
         )
 
 
+class AdminUUIDWidgetTests(SimpleTestCase):
+    def test_attrs(self):
+        w = widgets.AdminUUIDInputWidget()
+        self.assertHTMLEqual(
+            w.render('test', '550e8400-e29b-41d4-a716-446655440000'),
+            '<input value="550e8400-e29b-41d4-a716-446655440000" type="text" class="vUUIDField" name="test">',
+        )
+        w = widgets.AdminUUIDInputWidget(attrs={'class': 'myUUIDInput'})
+        self.assertHTMLEqual(
+            w.render('test', '550e8400-e29b-41d4-a716-446655440000'),
+            '<input value="550e8400-e29b-41d4-a716-446655440000" type="text" class="myUUIDInput" name="test">',
+        )
+
+
 @override_settings(ROOT_URLCONF='admin_widgets.urls')
 class AdminFileWidgetTests(TestDataMixin, TestCase):
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29426