### PR TITLE
Refs #29324 -- Fixed SECRET_KEY validation when using settings.configure().

### DIFF
--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from .. import Tags, Warning, register
 
@@ -182,11 +183,16 @@ def check_ssl_redirect(app_configs, **kwargs):
 
 @register(Tags.security, deploy=True)
 def check_secret_key(app_configs, **kwargs):
-    passed_check = (
-        getattr(settings, 'SECRET_KEY', None) and
-        len(set(settings.SECRET_KEY)) >= SECRET_KEY_MIN_UNIQUE_CHARACTERS and
-        len(settings.SECRET_KEY) >= SECRET_KEY_MIN_LENGTH
-    )
+    try:
+        getattr(settings, 'SECRET_KEY')
+    except (AttributeError, ImproperlyConfigured):
+        passed_check = False
+    else:
+        passed_check = (
+            settings.SECRET_KEY and
+            len(set(settings.SECRET_KEY)) >= SECRET_KEY_MIN_UNIQUE_CHARACTERS and
+            len(settings.SECRET_KEY) >= SECRET_KEY_MIN_LENGTH
+        )
     return [] if passed_check else [W009]
 
 

--- a/tests/settings_tests/tests.py
+++ b/tests/settings_tests/tests.py
@@ -299,6 +299,13 @@ class SettingsTests(SimpleTestCase):
         finally:
             del sys.modules['fake_settings_module']
 
+    def test_lazy_settings_no_secret_key(self):
+        lazy_settings = LazySettings()
+        lazy_settings.configure()
+        msg = 'The SECRET_KEY setting must be set.'
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            lazy_settings.SECRET_KEY
+
     def test_secret_key_empty_string(self):
         settings_module = ModuleType('fake_settings_module')
         settings_module.SECRET_KEY = ''
@@ -309,6 +316,13 @@ class SettingsTests(SimpleTestCase):
                 Settings('fake_settings_module')
         finally:
             del sys.modules['fake_settings_module']
+
+    def test_lazy_settings_secret_key_empty_string(self):
+        lazy_settings = LazySettings()
+        lazy_settings.configure(SECRET_KEY='')
+        msg = 'The SECRET_KEY setting must not be empty.'
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            lazy_settings.SECRET_KEY
 
     def test_no_settings_module(self):
         msg = (


### PR DESCRIPTION
Regression in b3cffde5559c4fa97625512d7ec41a674be26076.
https://code.djangoproject.com/ticket/29324#comment:5