### PR TITLE
Fixed #29400: Allow @register.filter on already-decorated functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -722,6 +722,7 @@ answer newbie questions, and generally made Django that much better:
     ryankanno
     Ryan Kelly <ryan@rfk.id.au>
     Ryan Niemeyer <https://profiles.google.com/ryan.niemeyer/about>
+    Ryan Rubin <ryanmrubin@gmail.com>
     Ryno Mathee <rmathee@gmail.com>
     Sam Newman <http://www.magpiebrain.com/>
     Sander Dijkhuis <sander.dijkhuis@gmail.com>

--- a/django/template/base.py
+++ b/django/template/base.py
@@ -53,7 +53,7 @@ times with multiple contexts)
 import logging
 import re
 from enum import Enum
-from inspect import getcallargs, getfullargspec
+from inspect import getcallargs, getfullargspec, unwrap
 
 from django.template.context import (  # NOQA: imported for backwards compatibility
     BaseContext, Context, ContextPopException, RequestContext,
@@ -707,7 +707,7 @@ class FilterExpression:
         # First argument, filter input, is implied.
         plen = len(provided) + 1
         # Check to see if a decorator is providing the real function.
-        func = getattr(func, '_decorated_function', func)
+        func = unwrap(func)
 
         args, _, _, defaults, _, _, _ = getfullargspec(func)
         alen = len(args)

--- a/docs/releases/2.0.6.txt
+++ b/docs/releases/2.0.6.txt
@@ -9,4 +9,5 @@ Django 2.0.6 fixes several bugs in 2.0.5.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression that broke custom template filters that use decorators
+  (:ticket:`29400`).

--- a/tests/template_tests/templatetags/custom.py
+++ b/tests/template_tests/templatetags/custom.py
@@ -3,6 +3,7 @@ import operator
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.html import escape, format_html
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -11,6 +12,13 @@ register = template.Library()
 @stringfilter
 def trim(value, num):
     return value[:num]
+
+
+@register.filter
+@mark_safe
+def make_data_div(value):
+    """A filter that uses a decorator (@mark_safe)."""
+    return '<div data-name="%s"></div>' % value
 
 
 @register.filter

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -25,6 +25,11 @@ class CustomFilterTests(SimpleTestCase):
             "abcde"
         )
 
+    def test_decorated_filter(self):
+        engine = Engine(libraries=LIBRARIES)
+        t = engine.from_string('{% load custom %}{{ name|make_data_div }}')
+        self.assertEqual(t.render(Context({'name': 'foo'})), '<div data-name="foo"></div>')
+
 
 class TagTestCase(SimpleTestCase):
 


### PR DESCRIPTION
`inspect.getfullargspec` is being passed the function, but if that function is decorated, `inspect.getfullargspec` [does not read `__wrapped__` attributes as of Python 3.4](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec).

The function object is checked for a _decorated_function attribute, but that's not always present. 

`inspect.unwrap` will get the original function for the call to `inspect.getfullargspec`, though.