### PR TITLE
Refs #29444 -- Allowed returning multiple fields from INSERT statements on PostgreSQL.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -23,6 +23,7 @@ class BaseDatabaseFeatures:
 
     can_use_chunked_reads = True
     can_return_columns_from_insert = False
+    can_return_multiple_columns_from_insert = False
     can_return_rows_from_bulk_insert = False
     has_bulk_insert = True
     uses_savepoints = True

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -176,13 +176,12 @@ class BaseDatabaseOperations:
         else:
             return ['DISTINCT'], []
 
-    def fetch_returned_insert_id(self, cursor):
+    def fetch_returned_insert_columns(self, cursor):
         """
         Given a cursor object that has just performed an INSERT...RETURNING
-        statement into a table that has an auto-incrementing ID, return the
-        newly created ID.
+        statement into a table, return the newly created data.
         """
-        return cursor.fetchone()[0]
+        return cursor.fetchone()
 
     def field_cast_sql(self, db_type, internal_type):
         """
@@ -314,12 +313,11 @@ class BaseDatabaseOperations:
         """
         return value
 
-    def return_insert_id(self, field):
+    def return_insert_columns(self, fields):
         """
-        For backends that support returning the last insert ID as part of an
-        insert query, return the SQL and params to append to the INSERT query.
-        The returned fragment should contain a format string to hold the
-        appropriate column.
+        For backends that support returning columns as part of an insert query,
+        return the SQL and params to append to the INSERT query. The returned
+        fragment should contain a format string to hold the appropriate column.
         """
         pass
 

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -20,7 +20,7 @@ class InsertVar:
         'PositiveIntegerField': int,
         'FloatField': Database.NATIVE_FLOAT,
         'DateTimeField': Database.TIMESTAMP,
-        'DateField': Database.DATETIME,
+        'DateField': Database.Date,
         'DecimalField': Database.NUMBER,
     }
 

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 class DatabaseFeatures(BaseDatabaseFeatures):
     allows_group_by_selected_pks = True
     can_return_columns_from_insert = True
+    can_return_multiple_columns_from_insert = True
     can_return_rows_from_bulk_insert = True
     has_real_datatype = True
     has_native_uuid_field = True

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -876,10 +876,10 @@ class Model(metaclass=ModelBase):
             if not pk_set:
                 fields = [f for f in fields if f is not meta.auto_field]
 
-            update_pk = meta.auto_field and not pk_set
-            result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
-            if update_pk:
-                setattr(self, meta.pk.attname, result)
+            returning_fields = meta.db_returning_fields
+            results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
+            for result, field in zip(results, returning_fields):
+                setattr(self, field.attname, result)
         return updated
 
     def _do_update(self, base_qs, using, pk_val, values, update_fields, forced_update):
@@ -909,13 +909,15 @@ class Model(metaclass=ModelBase):
             )
         return filtered._update(values) > 0
 
-    def _do_insert(self, manager, using, fields, update_pk, raw):
+    def _do_insert(self, manager, using, fields, returning_fields, raw):
         """
-        Do an INSERT. If update_pk is defined then this method should return
-        the new pk for the model.
+        Do an INSERT. If returning_fields is defined then this method should
+        return the newly created data for the model.
         """
-        return manager._insert([self], fields=fields, return_id=update_pk,
-                               using=using, raw=raw)
+        return manager._insert(
+            [self], fields=fields, returning_fields=returning_fields,
+            using=using, raw=raw,
+        )
 
     def delete(self, using=None, keep_parents=False):
         using = using or router.db_for_write(self.__class__, instance=self)

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -735,6 +735,14 @@ class Field(RegisterLookupMixin):
     def db_tablespace(self):
         return self._db_tablespace or settings.DEFAULT_INDEX_TABLESPACE
 
+    @property
+    def db_returning(self):
+        """
+        Private API intended only to be used by Django itself. Currently only
+        the PostgreSQL backend supports returning multiple fields on a model.
+        """
+        return False
+
     def set_attributes_from_name(self, name):
         self.name = self.name or name
         self.attname, self.column = self.get_attname_column()
@@ -2311,6 +2319,7 @@ class UUIDField(Field):
 
 
 class AutoFieldMixin:
+    db_returning = True
 
     def __init__(self, *args, **kwargs):
         kwargs['blank'] = True

--- a/django/db/models/options.py
+++ b/django/db/models/options.py
@@ -842,3 +842,14 @@ class Options:
             if isinstance(attr, property):
                 names.append(name)
         return frozenset(names)
+
+    @cached_property
+    def db_returning_fields(self):
+        """
+        Private API intended only to be used by Django itself.
+        Fields to be returned after a database insert.
+        """
+        return [
+            field for field in self._get_fields(forward=True, reverse=False, include_parents=PROXY_PARENTS)
+            if getattr(field, 'db_returning', False)
+        ]

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -448,13 +448,19 @@ backends.
   :class:`~django.db.models.DateTimeField` in ``datetime_cast_date_sql()``,
   ``datetime_extract_sql()``, etc.
 
-* ``DatabaseOperations.return_insert_id()`` now requires an additional
-  ``field`` argument with the model field.
-
 * Entries for ``AutoField``, ``BigAutoField``, and ``SmallAutoField`` are added
   to  ``DatabaseOperations.integer_field_ranges`` to support the integer range
   validators on these field types. Third-party backends may need to customize
   the default entries.
+
+* ``DatabaseOperations.fetch_returned_insert_id()`` is replaced by
+  ``fetch_returned_insert_columns()`` which returns a list of values returned
+  by the ``INSERT … RETURNING`` statement, instead of a single value.
+
+* ``DatabaseOperations.return_insert_id()`` is replaced by
+  ``return_insert_columns()`` that accepts a ``fields``
+  argument, which is an iterable of fields to be returned after insert. Usually
+  this is only the auto-generated primary key.
 
 :mod:`django.contrib.admin`
 ---------------------------

--- a/tests/backends/models.py
+++ b/tests/backends/models.py
@@ -5,10 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 
-class NonIntegerAutoField(models.Model):
-    creation_datetime = models.DateTimeField(primary_key=True)
-
-
 class Square(models.Model):
     root = models.IntegerField()
     square = models.PositiveIntegerField()

--- a/tests/backends/oracle/tests.py
+++ b/tests/backends/oracle/tests.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 
 from django.db import connection
@@ -6,7 +5,7 @@ from django.db.models.fields import BooleanField, NullBooleanField
 from django.db.utils import DatabaseError
 from django.test import TransactionTestCase
 
-from ..models import NonIntegerAutoField, Square
+from ..models import Square
 
 
 @unittest.skipUnless(connection.vendor == 'oracle', 'Oracle tests')
@@ -96,23 +95,3 @@ class TransactionalTests(TransactionTestCase):
             self.assertIn('ORA-01017', context.exception.args[0].message)
         finally:
             connection.settings_dict['PASSWORD'] = old_password
-
-    def test_non_integer_auto_field(self):
-        with connection.cursor() as cursor:
-            # Create trigger that fill non-integer auto field.
-            cursor.execute("""
-                CREATE OR REPLACE TRIGGER "TRG_FILL_CREATION_DATETIME"
-                BEFORE INSERT ON "BACKENDS_NONINTEGERAUTOFIELD"
-                FOR EACH ROW
-                BEGIN
-                    :NEW.CREATION_DATETIME := SYSTIMESTAMP;
-                END;
-            """)
-        try:
-            NonIntegerAutoField._meta.auto_field = NonIntegerAutoField.creation_datetime
-            obj = NonIntegerAutoField.objects.create()
-            self.assertIsNotNone(obj.creation_datetime)
-            self.assertIsInstance(obj.creation_datetime, datetime.datetime)
-        finally:
-            with connection.cursor() as cursor:
-                cursor.execute('DROP TRIGGER "TRG_FILL_CREATION_DATETIME"')

--- a/tests/model_meta/tests.py
+++ b/tests/model_meta/tests.py
@@ -279,3 +279,8 @@ class PropertyNamesTests(SimpleTestCase):
         # Instance only descriptors don't appear in _property_names.
         self.assertEqual(AbstractPerson().test_instance_only_descriptor, 1)
         self.assertEqual(AbstractPerson._meta._property_names, frozenset(['pk', 'test_property']))
+
+
+class ReturningFieldsTests(SimpleTestCase):
+    def test_pk(self):
+        self.assertEqual(Relation._meta.db_returning_fields, [Relation._meta.pk])

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -4,6 +4,7 @@ Various complex queries that have been problematic in the past.
 import threading
 
 from django.db import models
+from django.db.models.functions import Now
 
 
 class DumbCategory(models.Model):
@@ -730,3 +731,19 @@ class RelatedIndividual(models.Model):
 class CustomDbColumn(models.Model):
     custom_column = models.IntegerField(db_column='custom_name', null=True)
     ip_address = models.GenericIPAddressField(null=True)
+
+
+class CreatedField(models.DateTimeField):
+    db_returning = True
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('default', Now)
+        super().__init__(*args, **kwargs)
+
+
+class ReturningModel(models.Model):
+    created = CreatedField(editable=False)
+
+
+class NonIntegerPKReturningModel(models.Model):
+    created = CreatedField(editable=False, primary_key=True)

--- a/tests/queries/test_db_returning.py
+++ b/tests/queries/test_db_returning.py
@@ -1,0 +1,64 @@
+import datetime
+
+from django.db import NotSupportedError, connection
+from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
+from django.test.utils import CaptureQueriesContext
+
+from .models import DumbCategory, NonIntegerPKReturningModel, ReturningModel
+
+
+@skipUnlessDBFeature('can_return_columns_from_insert')
+class ReturningValuesTests(TestCase):
+    def test_insert_returning(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            DumbCategory.objects.create()
+        self.assertIn(
+            'RETURNING %s.%s' % (
+                connection.ops.quote_name(DumbCategory._meta.db_table),
+                connection.ops.quote_name(DumbCategory._meta.get_field('id').column),
+            ),
+            captured_queries[-1]['sql'],
+        )
+
+    def test_insert_returning_non_integer(self):
+        obj = NonIntegerPKReturningModel.objects.create()
+        self.assertTrue(obj.created)
+        self.assertIsInstance(obj.created, datetime.datetime)
+
+    @skipUnlessDBFeature('can_return_multiple_columns_from_insert')
+    def test_insert_returning_multiple(self):
+        with CaptureQueriesContext(connection) as captured_queries:
+            obj = ReturningModel.objects.create()
+        table_name = connection.ops.quote_name(ReturningModel._meta.db_table)
+        self.assertIn(
+            'RETURNING %s.%s, %s.%s' % (
+                table_name,
+                connection.ops.quote_name(ReturningModel._meta.get_field('id').column),
+                table_name,
+                connection.ops.quote_name(ReturningModel._meta.get_field('created').column),
+            ),
+            captured_queries[-1]['sql'],
+        )
+        self.assertTrue(obj.pk)
+        self.assertIsInstance(obj.created, datetime.datetime)
+
+    @skipIfDBFeature('can_return_multiple_columns_from_insert')
+    def test_insert_returning_multiple_not_supported(self):
+        msg = (
+            'Returning multiple columns from INSERT statements is '
+            'not supported on this database backend.'
+        )
+        with self.assertRaisesMessage(NotSupportedError, msg):
+            ReturningModel.objects.create()
+
+    @skipUnlessDBFeature(
+        'can_return_rows_from_bulk_insert',
+        'can_return_multiple_columns_from_insert',
+    )
+    def test_bulk_insert(self):
+        objs = [ReturningModel(), ReturningModel(pk=2 ** 11), ReturningModel()]
+        ReturningModel.objects.bulk_create(objs)
+        for obj in objs:
+            with self.subTest(obj=obj):
+                self.assertTrue(obj.pk)
+                self.assertIsInstance(obj.created, datetime.datetime)


### PR DESCRIPTION
Ticket [#29444](https://code.djangoproject.com/ticket/29444)

Currently the PK is hardcoded as the only retuning object which is not necessary and currently blocking [#27452](https://code.djangoproject.com/ticket/27452).

### Side note:

**This change should be fully backwards compatible.** I am aware that this fix allows adding database defaults to all backends but MySQL. This is why **I want to keep this an undocumented API** for now.
People will find out about it anyways.

You can implement a database default as follows:

```python
class Default:
    """
    Expression for ``DEFAULT``.

    In an insert query this will return the database default.
    """

    def as_sql(self, compiler, connection):
        return connection.ops.pk_default_value(), []


class MyModel(models.Model):
    my_uuid_with_db_default = models.UUIDField(default=Default)
```

If you have a default set for your column in the database, it will return that instead of trying to set null.
You no longer need to call `refresh_from_db` or any other strange thing.