### PR TITLE
Fixed #23869 -- Made ModelAdmin.get_deleted_objects() use has_delete_permission() for permissions checking.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -590,6 +590,7 @@ answer newbie questions, and generally made Django that much better:
     Mikhail Korobov <kmike84@googlemail.com>
     Mikko Hellsing <mikko@sorl.net>
     Mikołaj Siedlarek <mikolaj.siedlarek@gmail.com>
+    milkomeda
     Milton Waddams
     mitakummaa@gmail.com
     mmarshall

--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1812,7 +1812,7 @@ class ModelAdmin(BaseModelAdmin):
         Hook for customizing the delete process for the delete view and the
         "delete selected" action.
         """
-        return get_deleted_objects(objs, request.user, self.admin_site)
+        return get_deleted_objects(objs, request, self.admin_site)
 
     @csrf_protect_m
     def delete_view(self, request, object_id, extra_context=None):

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -669,11 +669,32 @@ class ModelAdminTests(TestCase):
     def test_get_deleted_objects(self):
         mock_request = MockRequest()
         mock_request.user = User.objects.create_superuser(username='bob', email='bob@test.com', password='test')
-        ma = ModelAdmin(Band, self.site)
+        self.site.register(Band, ModelAdmin)
+        ma = self.site._registry[Band]
         deletable_objects, model_count, perms_needed, protected = ma.get_deleted_objects([self.band], request)
         self.assertEqual(deletable_objects, ['Band: The Doors'])
         self.assertEqual(model_count, {'bands': 1})
         self.assertEqual(perms_needed, set())
+        self.assertEqual(protected, [])
+
+    def test_get_deleted_objects_with_custom_has_delete_permission(self):
+        """
+        ModelAdmin.get_deleted_objects() uses ModelAdmin.has_delete_permission()
+        for permissions checking.
+        """
+        mock_request = MockRequest()
+        mock_request.user = User.objects.create_superuser(username='bob', email='bob@test.com', password='test')
+
+        class TestModelAdmin(ModelAdmin):
+            def has_delete_permission(self, request, obj=None):
+                return False
+
+        self.site.register(Band, TestModelAdmin)
+        ma = self.site._registry[Band]
+        deletable_objects, model_count, perms_needed, protected = ma.get_deleted_objects([self.band], request)
+        self.assertEqual(deletable_objects, ['Band: The Doors'])
+        self.assertEqual(model_count, {'bands': 1})
+        self.assertEqual(perms_needed, {'band'})
         self.assertEqual(protected, [])
 
 


### PR DESCRIPTION
Instead of checking user.has_perm get_deleted_objects checks
has_delete_permission.