### PR TITLE
Fixed #29432 -- Allowed passing an integer to the slice template filter.

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -573,7 +573,7 @@ def slice_filter(value, arg):
     """
     try:
         bits = []
-        for x in arg.split(':'):
+        for x in str(arg).split(':'):
             if not x:
                 bits.append(None)
             else:

--- a/tests/template_tests/filter_tests/test_slice.py
+++ b/tests/template_tests/filter_tests/test_slice.py
@@ -26,6 +26,9 @@ class FunctionTests(SimpleTestCase):
     def test_index(self):
         self.assertEqual(slice_filter('abcdefg', '1'), 'a')
 
+    def test_index_integer(self):
+        self.assertEqual(slice_filter('abcdefg', 1), 'a')
+
     def test_negative_index(self):
         self.assertEqual(slice_filter('abcdefg', '-1'), 'abcdef')
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29432