### PR TITLE
Validate the scheme in a separate method of URLValidator

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -110,7 +110,7 @@ class URLValidator(RegexValidator):
     def __call__(self, value):
         # Check first if the scheme is valid
         scheme = value.split('://')[0].lower()
-        if scheme not in self.schemes:
+        if not self.validate_scheme(scheme):
             raise ValidationError(self.message, code=self.code)
 
         # Then check full URL
@@ -147,6 +147,9 @@ class URLValidator(RegexValidator):
         # that's used to indicate absolute names in DNS.
         if len(urlsplit(value).netloc) > 253:
             raise ValidationError(self.message, code=self.code)
+
+    def validate_scheme(self, scheme):
+        return scheme in self.schemes
 
 
 integer_validator = RegexValidator(

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -342,6 +342,33 @@ def create_simple_test_method(validator, expected, value, num):
 # Dynamically assemble a test class with the contents of TEST_DATA
 
 
+class TestURLValidator(SimpleTestCase):
+    def test_validate_scheme(self):
+        v = URLValidator(schemes=["http", "https"])
+        self.assertTrue(v.validate_scheme("http"))
+        self.assertTrue(v.validate_scheme("https"))
+        self.assertFalse(v.validate_scheme("ftp"))
+
+    def test_validate_scheme_override_false(self):
+        class CustomURLValidator(URLValidator):
+            def validate_scheme(self, scheme):
+                return False
+
+        v = CustomURLValidator(schemes=["http"])
+        for scheme in ["http", "https", "ftp"]:
+            with self.assertRaises(ValidationError):
+                v("%s://example.com" % (scheme))
+
+    def test_validate_scheme_override_true(self):
+        class CustomURLValidator(URLValidator):
+            def validate_scheme(self, scheme):
+                return True
+
+        v = CustomURLValidator(schemes=["http"])
+        for scheme in ["http", "https", "ftp"]:
+            v("%s://example.com" % (scheme))
+
+
 class TestSimpleValidators(SimpleTestCase):
     def test_single_message(self):
         v = ValidationError('Not Valid')


### PR DESCRIPTION
This allows subclassing URLValidator to do fancier types of validation
such as regex matching, etc.

----

Use case: in [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit), the list of allowed schemes is dynamic. This trivial change allows DOT to subclass URLValidator rather than having to reimplement it entirely.