### PR TITLE
Removed unused variables in BaseHandler

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -13,10 +13,8 @@ logger = logging.getLogger('django.request')
 
 
 class BaseHandler:
-    _request_middleware = None
     _view_middleware = None
     _template_response_middleware = None
-    _response_middleware = None
     _exception_middleware = None
     _middleware_chain = None
 
@@ -26,10 +24,8 @@ class BaseHandler:
 
         Must be called after the environment is fixed (see __call__ in subclasses).
         """
-        self._request_middleware = []
         self._view_middleware = []
         self._template_response_middleware = []
-        self._response_middleware = []
         self._exception_middleware = []
 
         handler = convert_exception_to_response(self._get_response)

--- a/tests/handlers/tests.py
+++ b/tests/handlers/tests.py
@@ -17,7 +17,7 @@ class HandlerTests(SimpleTestCase):
 
     def test_middleware_initialized(self):
         handler = WSGIHandler()
-        self.assertIsNotNone(handler._request_middleware)
+        self.assertIsNotNone(handler._middleware_chain)
 
     def test_bad_path_info(self):
         """


### PR DESCRIPTION
These variables are no longer used since the introduction of new-style middleware in Django 1.10