### PR TITLE
Fixed #29452 -- Fixed setting charset of .pot files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,6 +97,7 @@ answer newbie questions, and generally made Django that much better:
     Baptiste Mispelon <bmispelon@gmail.com>
     Barry Pederson <bp@barryp.org>
     Bartolome Sanchez Salado <i42sasab@uco.es>
+    Bartosz Grabski <bartosz.grabski@gmail.com>
     Bashar Al-Abdulhadi
     Bastian Kleineidam <calvin@debian.org>
     Batiste Bieler <batiste.bieler@gmail.com>

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -182,8 +182,9 @@ def write_pot_file(potfile, msgs):
         found, header_read = False, False
         for line in pot_lines:
             if not found and not header_read:
-                found = True
-                line = line.replace('charset=CHARSET', 'charset=UTF-8')
+                if 'charset=CHARSET' in line:
+                    found = True
+                    line = line.replace('charset=CHARSET', 'charset=UTF-8')
             if not line and not found:
                 header_read = True
             lines.append(line)


### PR DESCRIPTION
Fixed setting charset of .pot files generated using makemessages
command.