### PR TITLE
Fixed wrong signature for HttpResponse.set_signed_cookie

### DIFF
--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -793,7 +793,7 @@ Methods
         to store a cookie of more than 4096 bytes, but many browsers will not
         set the cookie correctly.
 
-.. method:: HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=True, samesite=None)
+.. method:: HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=False, samesite=None)
 
     Like :meth:`~HttpResponse.set_cookie()`, but
     :doc:`cryptographic signing </topics/signing>` the cookie before setting


### PR DESCRIPTION
The `HttpResponse.set_signed_cookie` method has a wrong signature for the `httpOnly` parameter. In the source code, it's `False` just like `HttpResponse.set_cookie` but the documentation says it's `True`

Quoting the [documentation:](https://docs.djangoproject.com/en/2.0/ref/request-response/#django.http.HttpResponse.set_signed_cookie)

`HttpResponse.set_signed_cookie(key, value, salt='', max_age=None, expires=None, path='/', domain=None, secure=None, httponly=True)`

>     Like set_cookie(), but cryptographic signing the cookie before setting it. Use in conjunction with HttpRequest.get_signed_cookie(). You can use the optional salt argument for added key strength, but you will need to remember to pass it to the corresponding HttpRequest.get_signed_cookie() call.

This code is from the latest master:

```python
def set_signed_cookie(self, key, value, salt='', **kwargs):
    value = signing.get_cookie_signer(salt=key + salt).sign(value)
    return self.set_cookie(key, value, **kwargs)
```
The only optional argument here is `salt`

This pull request provides a simple patch to fix that.
