### PR TITLE
Fixed #10827 -- Ensured ContentTypes are created before permission creation

### DIFF
--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -6,6 +6,7 @@ import unicodedata
 
 from django.apps import apps as global_apps
 from django.contrib.auth import get_permission_codename
+from django.contrib.contenttypes.management import create_contenttypes
 from django.core import exceptions
 from django.db import DEFAULT_DB_ALIAS, router
 
@@ -36,6 +37,11 @@ def _get_builtin_permissions(opts):
 def create_permissions(app_config, verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, apps=global_apps, **kwargs):
     if not app_config.models_module:
         return
+
+    # Ensure that contenttypes are created for this app. Needed if
+    # 'django.contrib.auth' is in INSTALLED_APPS before
+    # 'django.contrib.contenttypes'.
+    create_contenttypes(app_config, verbosity=verbosity, interactive=interactive, using=using, apps=apps, **kwargs)
 
     app_label = app_config.label
     try:

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -838,3 +838,15 @@ class CreatePermissionsTests(TestCase):
         state = migrations.state.ProjectState(real_apps=['contenttypes'])
         with self.assertNumQueries(0):
             create_permissions(self.app_config, verbosity=0, apps=state.apps)
+
+    def test_create_permissions_checks_contenttypes_created(self):
+        """
+        `post_migrate` handler ordering isn't guaranteed. Simulate a case
+        where create_permissions() is called before create_contenttypes().
+        """
+        # Warm the manager cache.
+        ContentType.objects.get_for_model(Group)
+        # Apply a deletion as if e.g. a database 'flush' had been executed.
+        ContentType.objects.filter(app_label='auth', model='group').delete()
+        # This fails with a foreign key constraint without the fix.
+        create_permissions(apps.get_app_config('auth'), interactive=False, verbosity=0)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/10827