### PR TITLE
Forgotten snippet in `mysite/urls.py` added

### DIFF
--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -98,6 +98,17 @@ Wire these new views into the ``polls.urls`` module by adding the following
         path('<int:question_id>/vote/', views.vote, name='vote'),
     ]
 
+.. snippet::
+    :filename: mysite/urls.py
+
+    from django.contrib import admin
+    from django.urls import include, path
+
+    urlpatterns = [
+        path('admin/', admin.site.urls),
+        path('polls/', include('polls.urls')),
+    ]
+
 Take a look in your browser, at "/polls/34/". It'll run the ``detail()``
 method and display whatever ID you provide in the URL. Try
 "/polls/34/results/" and "/polls/34/vote/" too -- these will display the

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -66,6 +66,9 @@ slightly different, because they take an argument:
 
 .. snippet::
     :filename: polls/views.py
+    
+    from django.http import HttpResponse
+
 
     def detail(request, question_id):
         return HttpResponse("You're looking at question %s." % question_id)


### PR DESCRIPTION
Without the step I added in a new snippet nothing was working, since `path('polls/', include('polls.urls')),` wasn't there, hence Django was unaware of `urlpatterns` inside `polls/urls.py`.