### PR TITLE
Doc'd how to set SPATIALITE_LIBRARY_PATH for Debian Buster/Ubuntu 18.04.

### DIFF
--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -27,6 +27,9 @@ __ https://www.gaia-gis.it/gaia-sins/
 
         SPATIALITE_LIBRARY_PATH = 'mod_spatialite'
 
+    Your operating system may require a different variant such as
+    ``mod_spatialite.so`` (observed with Debian Buster and Ubuntu 18.04).
+
 .. _spatialite_source:
 
 Installing from source


### PR DESCRIPTION
On Debian buster/testing and Ubuntu 18.04, I've found that `SPATIALITE_LIBRARY_PATH = 'mod_spatialite'` doesn't work.

I've been successfully using `SPATIALITE_LIBRARY_PATH = '/usr/lib/x86_64-linux-gnu/mod_spatialite.so'`, so I'm adding this note to the docs here.