### PR TITLE
Fixed #29457 -- Allowed spaces between augment separator and augments…

### DIFF
--- a/django/template/base.py
+++ b/django/template/base.py
@@ -590,7 +590,7 @@ filter_raw_string = r"""
 ^(?P<var>[%(var_chars)s]+|%(num)s)|
  (?:\s*%(filter_sep)s\s*
      (?P<filter_name>\w+)
-         (?:%(arg_sep)s
+         (?:%(arg_sep)s\s*
              (?:
               (?P<constant_arg>%(constant)s)|
               (?P<var_arg>[%(var_chars)s]+|%(num)s)


### PR DESCRIPTION
… in template filter

https://code.djangoproject.com/ticket/29457