### PR TITLE
Fixed #29430 -- Clarified send_mail()'s fail_silently docs.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -776,6 +776,7 @@ answer newbie questions, and generally made Django that much better:
     Steven L. Smith (fvox13) <steven@stevenlsmith.com>
     Steven Noorbergen (Xaroth) <xaroth+django@xaroth.nl>
     Stuart Langridge <http://www.kryogenix.org/>
+    Subhav Gautam <subhavgautam@yahoo.co.uk>
     Sujay S Kumar <sujay.skumar141295@gmail.com>
     Sune Kirkeby <http://ibofobi.dk/>
     Sung-Jin Hong <serialx.net@gmail.com>

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -57,9 +57,9 @@ are required.
 * ``recipient_list``: A list of strings, each an email address. Each
   member of ``recipient_list`` will see the other recipients in the "To:"
   field of the email message.
-* ``fail_silently``: A boolean. If it's ``False``, ``send_mail`` will raise
-  an :exc:`smtplib.SMTPException`. See the :mod:`smtplib` docs for a list of
-  possible exceptions, all of which are subclasses of
+* ``fail_silently``: A boolean. When it's ``False``, ``send_mail()`` will raise
+  an :exc:`smtplib.SMTPException` if an error occurs. See the :mod:`smtplib`
+  docs for a list of possible exceptions, all of which are subclasses of
   :exc:`~smtplib.SMTPException`.
 * ``auth_user``: The optional username to use to authenticate to the SMTP
   server. If this isn't provided, Django will use the value of the


### PR DESCRIPTION
Fix for https://code.djangoproject.com/ticket/29430

Documentation for ```fail_silently``` was slightly confusing and needed rewording. The following change should clarify what the boolean option's purpose is.