### PR TITLE
Refs #29416 -- Fixed GeoExpressionsTests.test_multiple_annotation() failure on MySQL 5.7.

### DIFF
--- a/tests/gis_tests/geoapp/test_expressions.py
+++ b/tests/gis_tests/geoapp/test_expressions.py
@@ -3,7 +3,7 @@ from unittest import skipUnless
 from django.contrib.gis.db.models import F, GeometryField, Value, functions
 from django.contrib.gis.geos import Point, Polygon
 from django.db import connection
-from django.db.models import Count
+from django.db.models import Count, Min
 from django.test import TestCase, skipUnlessDBFeature
 
 from ..utils import postgis
@@ -56,7 +56,7 @@ class GeoExpressionsTests(TestCase):
             poly=Polygon(((1, 1), (1, 2), (2, 2), (2, 1), (1, 1))),
         )
         qs = City.objects.values('name').annotate(
-            distance=functions.Distance('multifields__point', multi_field.city.point),
+            distance=Min(functions.Distance('multifields__point', multi_field.city.point)),
         ).annotate(count=Count('multifields'))
         self.assertTrue(qs.first())
 


### PR DESCRIPTION
Failure introduced in b6e48f514ebe4e31b76e1750e043d4f296e645dc.

Ticket [29416](https://code.djangoproject.com/ticket/29416#comment:17).