### PR TITLE
File extension method

### DIFF
--- a/django/core/files/base.py
+++ b/django/core/files/base.py
@@ -117,6 +117,12 @@ class File(FileProxyMixin):
     def close(self):
         self.file.close()
 
+    def extension(self):
+        ext = self.name.split('.')[-1]
+        if ext == self.name:
+            return
+        return ext
+
 
 class ContentFile(File):
     """


### PR DESCRIPTION
Why not? Sometimes I want to use file extension for some checks. I think it will be better if method will be native.
(it's only scratch now)