### PR TITLE
[2.0.x] Bumped version for 2.0.6 release.

### DIFF
--- a/django/__init__.py
+++ b/django/__init__.py
@@ -1,6 +1,6 @@
 from django.utils.version import get_version
 
-VERSION = (2, 0, 6, 'alpha', 0)
+VERSION = (2, 0, 6, 'final', 0)
 
 __version__ = get_version(VERSION)
 


### PR DESCRIPTION
Jenkins is [showing a failure for the 2.0.x branch](https://djangoci.com/job/django-2.0/lastFailedBuild/).

That doesn't look right. I'm just using this to verify. 