### PR TITLE
Fix typo in customizing authentication docs

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -3,8 +3,8 @@ Customizing authentication in Django
 ====================================
 
 The authentication that comes with Django is good enough for most common cases,
-but you may have needs not met by the out-of-the-box defaults. To customize
-authentication to your projects needs involves understanding what points of the
+but you may have needs not met by the out-of-the-box defaults. Customizing
+authentication in your projects requires understanding what points of the
 provided system are extensible or replaceable. This document provides details
 about how the auth system can be customized.
 


### PR DESCRIPTION
There was an ill-formed sentence that didn't make sense in the 'customizing authentication'
page for Django's authentication system.