### PR TITLE
[WIP] Refs #29392 -- Added command line short option `-s` for specifying setting.

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -308,11 +308,11 @@ class ManagementUtility:
         except IndexError:
             subcommand = 'help'  # Display help if no arguments were given.
 
-        # Preprocess options to extract --settings and --pythonpath.
+        # Preprocess options to extract -s/--settings and --pythonpath.
         # These options could affect the commands that are available, so they
         # must be processed early.
         parser = CommandParser(usage='%(prog)s subcommand [options] [args]', add_help=False, allow_abbrev=False)
-        parser.add_argument('--settings')
+        parser.add_argument('-s', '--settings')
         parser.add_argument('--pythonpath')
         parser.add_argument('args', nargs='*')  # catch-all
         try:

--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -242,7 +242,7 @@ class BaseCommand:
             help='Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output',
         )
         parser.add_argument(
-            '--settings',
+            '-s', '--settings',
             help=(
                 'The Python path to a settings module, e.g. '
                 '"myproject.settings.main". If this isn\'t provided, the '

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -238,7 +238,7 @@ class Command(BaseCommand):
                  'commas, or use -e multiple times.',
         )
         parser.add_argument(
-            '--symlinks', '-s', action='store_true', dest='symlinks',
+            '--symlinks', action='store_true', dest='symlinks',
             help='Follows symlinks to directories when examining source code '
                  'and templates for translation strings.',
         )

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -403,6 +403,15 @@ class DjangoAdminMinimalSettings(AdminScriptTestCase):
         self.assertNoOutput(out)
         self.assertOutput(err, "No installed app with label 'admin_scripts'.")
 
+    def test_builtin_with_short_options_settings(self):
+        """
+        django-admin builtin accept short flag -s for settings.
+        """
+        args = ['check', '-s', 'test_project.settings', 'admin_scripts']
+        out, err = self.run_django_admin(args)
+        self.assertNoOutput(out)
+        self.assertOutput(err, "No installed app with label 'admin_scripts'.")
+
     def test_builtin_with_environment(self):
         "minimal: django-admin builtin commands fail if settings are provided in the environment"
         args = ['check', 'admin_scripts']
@@ -729,6 +738,15 @@ class ManageDefaultSettings(AdminScriptTestCase):
     def test_builtin_with_settings(self):
         "default: manage.py builtin commands succeed if settings are provided as argument"
         args = ['check', '--settings=test_project.settings', 'admin_scripts']
+        out, err = self.run_manage(args)
+        self.assertNoOutput(err)
+        self.assertOutput(out, SYSTEM_CHECK_MSG)
+
+    def test_builtin_with_short_options_settings(self):
+        """
+        manage.py builtin accept short flag -s for settings.
+        """
+        args = ['check', '-s', 'test_project.settings', 'admin_scripts']
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
         self.assertOutput(out, SYSTEM_CHECK_MSG)

--- a/tests/user_commands/management/commands/dance.py
+++ b/tests/user_commands/management/commands/dance.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("integer", nargs='?', type=int, default=0)
-        parser.add_argument("-s", "--style", default="Rock'n'Roll")
+        parser.add_argument("--style", default="Rock'n'Roll")
         parser.add_argument("-x", "--example")
         parser.add_argument("--opt-3", action='store_true', dest='option3')
 


### PR DESCRIPTION
PR #9933 (for [ticket #29392](https://code.djangoproject.com/ticket/#29392)) removed the ability to use abbreviations of the shared options in commands. The key one there is `--settings`. 

Why? Because you couldn't define a command with e.g. a `--set` option, as this was getting swallowed as `--settings` by the first _pre-run_ parser. (This even though it's unambiguous to the final command parser.) 

Someone at DjangoCon (who will remain anonymous 🙂) said this was a usability back-step: in the shell they were used to doing something like `--s` and having it work. 

The example provided in the bug report struck me (and still does) as compelling. I think it was the right fix (correctness trumping convenience) but I'm opening this to discuss. 

This PR adds a short option `-s` to `--settings`. The hope is, that's the best of both worlds. 

BC Issues: 

* `makemessages` already uses `-s`. It does this for `--symlinks`. I'd argue moving it to `--settings`  is a win (`--settings` is always in use, `--symlinks` how often?) (Discuss)
* User-land commands may be using `-s`. Again, I'd probably be happy to steal that. (Discuss.) 

Other options: 

* Leave it as-is. 
* Revert the change from #9933. 

Todo to merge: 

- [ ] Update 2.1 release notes with extra changes. 
- [ ] Update `django-admin.txt` with changes to `--settings` in general and `makemessages` in particular. 
- ...anything else...?

Is this worth A) a new ticket, B) a post to Django Developers?