### PR TITLE
Fixed #29152 -- Allowed passing kwargs to ArgumentParser initialization in management commands.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -244,7 +244,7 @@ class BaseCommand:
         """
         return django.get_version()
 
-    def create_parser(self, prog_name, subcommand):
+    def create_parser(self, prog_name, subcommand, **kwargs):
         """
         Create and return the ``ArgumentParser`` which will be used to
         parse the arguments to this command.
@@ -255,6 +255,7 @@ class BaseCommand:
             formatter_class=DjangoHelpFormatter,
             missing_args_message=getattr(self, 'missing_args_message', None),
             called_from_command_line=getattr(self, '_called_from_command_line', None),
+            **kwargs
         )
         parser.add_argument('--version', action='version', version=self.get_version())
         parser.add_argument(

--- a/docs/howto/custom-management-commands.txt
+++ b/docs/howto/custom-management-commands.txt
@@ -255,6 +255,19 @@ the :meth:`~BaseCommand.handle` method must be implemented.
                 super().__init__(*args, **kwargs)
                 # ...
 
+.. method:: BaseCommand.create_parser(prog_name, subcommand, **kwargs)
+
+    Returns a ``CommandParser`` instance, which is an
+    :class:`~argparse.ArgumentParser` subclass with a few customizations for
+    Django.
+
+    You can customize the instance by overriding this method and calling
+    ``super()`` with ``kwargs`` of :class:`~argparse.ArgumentParser` parameters.
+
+    .. versionchanged:: 2.2
+
+        ``kwargs`` was added.
+
 .. method:: BaseCommand.add_arguments(parser)
 
     Entry point to add parser arguments to handle command line arguments passed

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -220,6 +220,12 @@ class CommandTests(SimpleTestCase):
         with self.assertRaisesMessage(CommandError, msg):
             management.call_command('subparser', 'test', 12)
 
+    def test_create_parser_kwargs(self):
+        """BaseCommand.create_parser() passes kwargs to CommandParser."""
+        epilog = 'some epilog text'
+        parser = BaseCommand().create_parser('prog_name', 'subcommand', epilog=epilog)
+        self.assertEqual(parser.epilog, epilog)
+
 
 class CommandRunTests(AdminScriptTestCase):
     """


### PR DESCRIPTION
CommandParser now takes additional arguments to be passed on to ArgumentParser upon initialization through kwargs. Test suite passing, but regression test and pertinent documentation for this enhancement is still pending (working on it). 
I'd be glad to receive some feedback on my proposed fix.