### PR TITLE
Add details about the request in the user_logged_in signal

### DIFF
--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -427,7 +427,11 @@ can be used for notification when a user logs in or out.
         The class of the user that just logged in.
 
     ``request``
-        The current :class:`~django.http.HttpRequest` instance.
+        The current :class:`~django.http.HttpRequest` instance. This instance
+        contains the session *before* it is cleared by the authentication
+        backend, so if you need to associate data from or perform actions on
+        the anonymous instance with the new user, that can be done in this
+        signal.
 
     ``user``
         The user instance that just logged in.


### PR DESCRIPTION
The current documentation about `user_logged_in` doesn't clarify whether the session has been cleared post-login or not. I have added some information there, because I searched the web on how to associate anonymous session data with the logged-in user and couldn't find anything, but in testing I realized that `user_logged_in` does exactly the right thing, so this seemed valuable to mention in the docs.