### PR TITLE
implement Django 2.0 plural handling fix to Django 1.11

### DIFF
--- a/django/views/i18n.py
+++ b/django/views/i18n.py
@@ -388,8 +388,9 @@ class JavaScriptCatalog(View):
         catalog = {}
         trans_cat = self.translation._catalog
         trans_fallback_cat = self.translation._fallback._catalog if self.translation._fallback else {}
+        seen_keys = set()
         for key, value in itertools.chain(six.iteritems(trans_cat), six.iteritems(trans_fallback_cat)):
-            if key == '' or key in catalog:
+            if key == '' or key in seen_keys:
                 continue
             if isinstance(key, six.string_types):
                 catalog[key] = value
@@ -400,6 +401,7 @@ class JavaScriptCatalog(View):
                 pdict.setdefault(msgid, {})[cnt] = value
             else:
                 raise TypeError(key)
+            seen_keys.add(key)
         for k, v in pdict.items():
             catalog[k] = [v.get(i, '') for i in range(maxcnts[k] + 1)]
         return catalog

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -317,13 +317,28 @@ class JsI18NTests(SimpleTestCase):
     def test_i18n_fallback_language_plural(self):
         """
         The fallback to a language with less plural forms maintains the real
-        language's number of plural forms.
+        language's number of plural forms and correct translations.
         """
         with self.settings(LANGUAGE_CODE='pt'), override('ru'):
             response = self.client.get('/jsi18n/')
             self.assertEqual(
                 response.context['catalog']['{count} plural3'],
+                ['{count} plural3 p3', '{count} plural3 p3s', '{count} plural3 p3t']
+            )
+            self.assertEqual(
+                response.context['catalog']['{count} plural2'],
+                ['{count} plural2', '{count} plural2s']
+            )
+
+        with self.settings(LANGUAGE_CODE='ru'), override('pt'):
+            response = self.client.get('/jsi18n/')
+            self.assertEqual(
+                response.context['catalog']['{count} plural3'],
                 ['{count} plural3', '{count} plural3s', '{count} plural3 p3t']
+            )
+            self.assertEqual(
+                response.context['catalog']['{count} plural2'],
+                ['{count} plural2', '{count} plural2s']
             )
 
     def test_i18n_english_variant(self):

--- a/tests/view_tests/tests/test_i18n_deprecated.py
+++ b/tests/view_tests/tests/test_i18n_deprecated.py
@@ -104,7 +104,7 @@ class JsI18NTests(SimpleTestCase):
             response = self.client.get('/jsi18n/')
             self.assertEqual(
                 response.context['catalog']['{count} plural3'],
-                ['{count} plural3', '{count} plural3s', '{count} plural3 p3t']
+                ['{count} plural3 p3', '{count} plural3 p3s', '{count} plural3 p3t']
             )
 
     def test_i18n_english_variant(self):


### PR DESCRIPTION
Implement fix from https://github.com/django/django/commit/2cbb095bec757b804e8b6d9d0930ef3c6446a591#diff-1e9839033582752049574f4b3376bfa3 to Django 1.11