### PR TITLE
Fixed #29428 -- Fixed admin changelist crash when using a query expression without asc()/desc() in the ordering.

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -10,6 +10,7 @@ from django.core import checks
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.expressions import Combinable, F, OrderBy
 from django.forms.models import (
     BaseModelForm, BaseModelFormSet, _get_foreign_key,
 )
@@ -489,7 +490,13 @@ class BaseModelAdminChecks:
 
     def _check_ordering_item(self, obj, model, field_name, label):
         """ Check that `ordering` refers to existing fields. """
-
+        if isinstance(field_name, (Combinable, OrderBy)):
+            if not isinstance(field_name, OrderBy):
+                field_name = field_name.asc()
+            if isinstance(field_name.expression, F):
+                field_name = field_name.expression.name
+            else:
+                return []
         if field_name == '?' and len(obj.ordering) != 1:
             return [
                 checks.Error(

--- a/django/contrib/admin/views/main.py
+++ b/django/contrib/admin/views/main.py
@@ -17,7 +17,7 @@ from django.core.exceptions import (
 )
 from django.core.paginator import InvalidPage
 from django.db import models
-from django.db.models.expressions import F, OrderBy
+from django.db.models.expressions import Combinable, F, OrderBy
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.timezone import make_aware
@@ -326,7 +326,9 @@ class ChangeList:
             # the right column numbers absolutely, because there might be more
             # than one column associated with that ordering, so we guess.
             for field in ordering:
-                if isinstance(field, OrderBy):
+                if isinstance(field, (Combinable, OrderBy)):
+                    if not isinstance(field, OrderBy):
+                        field = field.asc()
                     if isinstance(field.expression, F):
                         order_type = 'desc' if field.descending else 'asc'
                         field = field.expression.name

--- a/docs/releases/2.0.7.txt
+++ b/docs/releases/2.0.7.txt
@@ -9,4 +9,5 @@ Django 2.0.7 fixes several bugs in 2.0.6.
 Bugfixes
 ========
 
-* ...
+* Fixed admin changelist crash when using a query expression without ``asc()``
+  or ``desc()`` in the page's ordering (:ticket:`29428`).

--- a/docs/releases/2.0.7.txt
+++ b/docs/releases/2.0.7.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed admin changelist crash when using a query expression without ``asc()``
   or ``desc()`` in the page's ordering (:ticket:`29428`).
+
+* Fixed admin check crash when using a query expression in
+  ``ModelAdmin.ordering`` (:ticket:`29428`).

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -77,6 +77,17 @@ class ChangeListTests(TestCase):
         cl = m.get_changelist_instance(request)
         self.assertEqual(cl.get_ordering_field_columns(), {3: 'desc', 2: 'asc'})
 
+    def test_specified_ordering_by_f_expression_without_asc_desc(self):
+        class OrderedByFBandAdmin(admin.ModelAdmin):
+            list_display = ['name', 'genres', 'nr_of_members']
+            ordering = (F('nr_of_members'), Upper('name'), F('genres'))
+
+        m = OrderedByFBandAdmin(Band, custom_site)
+        request = self.factory.get('/band/')
+        request.user = self.superuser
+        cl = m.get_changelist_instance(request)
+        self.assertEqual(cl.get_ordering_field_columns(), {3: 'asc', 2: 'asc'})
+
     def test_select_related_preserved(self):
         """
         Regression test for #10348: ChangeList.get_queryset() shouldn't


### PR DESCRIPTION
https://code.djangoproject.com/ticket/26257