### PR TITLE
Fixed #29503 -- Made __in lookup keep order of values in query.

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -6,6 +6,7 @@ from django.core.exceptions import EmptyResultSet
 from django.db.models.expressions import Func, Value
 from django.db.models.fields import DateTimeField, Field, IntegerField
 from django.db.models.query_utils import RegisterLookupMixin
+from django.utils.datastructures import OrderedSet
 from django.utils.functional import cached_property
 
 
@@ -326,7 +327,7 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
 
         if self.rhs_is_direct_value():
             try:
-                rhs = set(self.rhs)
+                rhs = OrderedSet(self.rhs)
             except TypeError:  # Unhashable items in self.rhs
                 rhs = self.rhs
 

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -556,6 +556,10 @@ class LookupTests(TestCase):
         ):
             list(Article.objects.filter(id__in=Article.objects.using('other').all()))
 
+    def test_in_keeps_value_ordering(self):
+        query = Article.objects.filter(slug__in=['a%d' % i for i in range(1, 8)]).values('pk').query
+        self.assertIn(' IN (a1, a2, a3, a4, a5, a6, a7) ', str(query))
+
     def test_error_messages(self):
         # Programming errors are pointed out with nice error messages
         with self.assertRaisesMessage(


### PR DESCRIPTION
Regression in 86eccdc8b67728d84440a46e5bf62c78f2eddf6d.

Ticket [#29503](https://code.djangoproject.com/ticket/29503).