### PR TITLE
Refs #29449 -- Documented that auth forms expect USERNAME_FIELD to be a CharField.

### DIFF
--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -814,20 +814,11 @@ are working with.
 The following forms are compatible with any subclass of
 :class:`~django.contrib.auth.models.AbstractBaseUser`:
 
-* :class:`~django.contrib.auth.forms.AuthenticationForm`
+* :class:`~django.contrib.auth.forms.AuthenticationForm`: Uses the username
+  field specified by :attr:`~models.CustomUser.USERNAME_FIELD`.
 * :class:`~django.contrib.auth.forms.SetPasswordForm`
 * :class:`~django.contrib.auth.forms.PasswordChangeForm`
 * :class:`~django.contrib.auth.forms.AdminPasswordChangeForm`
-* :class:`~django.contrib.auth.forms.UserCreationForm`
-* :class:`~django.contrib.auth.forms.UserChangeForm`
-
-The forms that handle a username use the username field specified by
-:attr:`~models.CustomUser.USERNAME_FIELD`.
-
-.. versionchanged:: 2.1
-
-    In older versions, ``UserCreationForm`` and ``UserChangeForm`` need to be
-    rewritten to work with custom user models.
 
 The following forms make assumptions about the user model and can be used as-is
 if those assumptions are met:
@@ -837,6 +828,15 @@ if those assumptions are met:
   by :meth:`~models.AbstractBaseUser.get_email_field_name` (``email`` by
   default) that can be used to identify the user and a boolean field named
   ``is_active`` to prevent password resets for inactive users.
+* :class:`~django.contrib.auth.forms.UserCreationForm` and
+  :class:`~django.contrib.auth.forms.UserChangeForm`: Assume that the user has
+  a username field specified by :attr:`~models.CustomUser.USERNAME_FIELD` and
+  that this field is a subclass of :class:`~django.db.models.CharField`.
+
+  .. versionchanged:: 2.1
+
+    In older versions, ``UserCreationForm`` and ``UserChangeForm`` need to be
+    rewritten to work with custom user models.
 
 Custom users and :mod:`django.contrib.admin`
 --------------------------------------------


### PR DESCRIPTION
Adjusts the [docs changes from 3333d935d2914](https://github.com/django/django/commit/3333d935d2914cd80cf31f4803821ad5c0e2a51d#diff-b07fab64b491042224a7d4e823a80202L823) to state the requirement for `USERNAME_FIELD` to be a `CharField` subclass. 

