### PR TITLE
Clarified sentence about removal of inline flag support in url().

### DIFF
--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -93,8 +93,8 @@ details on these changes.
 
 * The ``Model._meta.has_auto_field`` attribute will be removed.
 
-* Support for regular expression groups with ``iLmsu#`` in ``url()`` will be
-  removed.
+* ``url()``'s support for inline flags in regular expression groups (``(?i)``,
+  ``(?L)``, ``(?m)``, ``(?s)``, and ``(?u)``) will be removed.
 
 * Support for ``Widget.render()`` methods without the ``renderer`` argument
   will be removed.

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -456,7 +456,8 @@ to remove usage of these features.
 
 * The ``Model._meta.has_auto_field`` attribute is removed.
 
-* Support for regular expression groups with ``iLmsu#`` in ``url()`` is removed.
+* ``url()``'s support for inline flags in regular expression groups (``(?i)``,
+  ``(?L)``, ``(?m)``, ``(?s)``, and ``(?u)``) is removed.
 
 * Support for ``Widget.render()`` methods without the ``renderer`` argument
   is removed.


### PR DESCRIPTION
The current wording is very obscure so I changed it a bit, best could even be to [link to the issue](https://code.djangoproject.com/ticket/27648) but it looks like it's not the current practice.