### PR TITLE
Fixed #29467 -- Ensured override_settings catches signal handler error on enter/exit.

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -401,8 +401,11 @@ class override_settings(TestContextDecorator):
         self.wrapped = settings._wrapped
         settings._wrapped = override
         for key, new_value in self.options.items():
-            setting_changed.send(sender=settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=True)
+            try:
+                setting_changed.send(sender=settings._wrapped.__class__,
+                                     setting=key, value=new_value, enter=True)
+            except Exception:
+                pass  # We should probably output something to the console here.
 
     def disable(self):
         if 'INSTALLED_APPS' in self.options:
@@ -411,8 +414,11 @@ class override_settings(TestContextDecorator):
         del self.wrapped
         for key in self.options:
             new_value = getattr(settings, key, None)
-            setting_changed.send(sender=settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=False)
+            try:
+                setting_changed.send(sender=settings._wrapped.__class__,
+                                     setting=key, value=new_value, enter=False)
+            except Exception:
+                pass
 
     def save_options(self, test_func):
         if test_func._overridden_settings is None:


### PR DESCRIPTION
**WIP**: This is a sketch at [#29467](https://code.djangoproject.com/ticket/29467) to see what the issues are.

From the ticket: 

> `override_settings` context manager should be more defensive inside the "enter" part when the `setting_changed` signal is sent. 

So the simplest thing possible is just to wrap the `setting_changed.send()` in a `try...except..`. This is that. 

When run against PR #10020 we see the expected 3 failures from the new regression tests. 

* What's wrong with this approach? 
* Where we `pass` what should we output there? (A warning presumably.) 
* Is there any way to promote that to a test failure (for the current test only)? (Should we try to?)

@slafs Can you comment? (Ta!)