### PR TITLE
Fixed #29467 -- Made override_settings handle errors in setting_changed signal receivers. 

### DIFF
--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -382,6 +382,8 @@ class override_settings(TestContextDecorator):
     with the ``with`` statement. In either event, entering/exiting are called
     before and after, respectively, the function/block is executed.
     """
+    enable_exception = None
+
     def __init__(self, **kwargs):
         self.options = kwargs
         super().__init__()
@@ -401,18 +403,35 @@ class override_settings(TestContextDecorator):
         self.wrapped = settings._wrapped
         settings._wrapped = override
         for key, new_value in self.options.items():
-            setting_changed.send(sender=settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=True)
+            try:
+                setting_changed.send(
+                    sender=settings._wrapped.__class__,
+                    setting=key, value=new_value, enter=True,
+                )
+            except Exception as exc:
+                self.enable_exception = exc
+                self.disable()
 
     def disable(self):
         if 'INSTALLED_APPS' in self.options:
             apps.unset_installed_apps()
         settings._wrapped = self.wrapped
         del self.wrapped
+        responses = []
         for key in self.options:
             new_value = getattr(settings, key, None)
-            setting_changed.send(sender=settings._wrapped.__class__,
-                                 setting=key, value=new_value, enter=False)
+            responses_for_setting = setting_changed.send_robust(
+                sender=settings._wrapped.__class__,
+                setting=key, value=new_value, enter=False,
+            )
+            responses.extend(responses_for_setting)
+        if self.enable_exception is not None:
+            exc = self.enable_exception
+            self.enable_exception = None
+            raise exc
+        for _, response in responses:
+            if isinstance(response, Exception):
+                raise response
 
     def save_options(self, test_func):
         if test_func._overridden_settings is None:


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29467

Check 3 things when using `override_settings`:
1. It returns the receiver exception
   when at least one of the receivers fail.
2. It restores original settings when exception occurs.
3. It calls *every* receiver when exiting the context
   and reraises the first exception that occured.

Check that for 3 cases of exception occurance in the receiver
- exception occurs when a receiver is called with `enter=True`
- exception occurs when a receiver is called with `enter=False`
- exception occurs regardless of the `enter` keyword argument.

I've introduced 4 custom and (hopefully) unique setting names
and used them for testing.

A receiver handles those settings:
- `SETTING_BOTH` raises an error while receiving the
  signal on both entering and exiting the context manager
- `SETTING_ENTER` raises an error only on enter.
- `SETTING_EXIT` raises an error only on exit.
- `SETTING_PASS` passes without errors.

*Re: 1. It returns the receiver exception...*

Because "errors should never pass silently".

*Re: 2. It restores original settings when exception occurs.*

I think that's pretty obvious - that's the main pain point of #29467

*Re: 3. It calls every receiver when exiting the context...*

One of the patterns for connecting to the `setting_changed` signal is to
prepare a valid environment when the change occurs and clean it up when
the setting is restored (e.g. see `django.test.signals` module).
When an exception occurs while entering the `override_settings`
context manager we want to make sure to propagate that error,
but also it makes sense to ensure that every receiver is called when
exiting the context so that receivers have a chance to clean up after
themselves.

**Example:**

Given a list of receivers for `setting_changed` signal:
- a receiver X that fails only when passed `enter=False`,
- `django.test.signals.static_finders_changed`,
- others.

While calling e.g. `override_settings(STATIC_ROOT=new_path)`
we want to make sure that outside of that manager we not only have
restored the `STATIC_ROOT` setting after receiver X failed,
but also that we've cleared the cache for staticfiles finder.

Similar examples could be made with most of the receivers from
`django.test.signals` module.


EDIT:
I've updated the description after cfa613be5c72a7