### PR TITLE
Fixed #29508 -- Use import_string to import login_form in AdminSite

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -2828,7 +2828,8 @@ Templates can override or extend base admin templates as described in
 .. attribute:: AdminSite.login_form
 
     Subclass of :class:`~django.contrib.auth.forms.AuthenticationForm` that
-    will be used by the admin site login view.
+    will be used by the admin site login view. This attribute can be specified
+    as a string to avoid an ``AppRegistryNotReady`` exception.
 
 .. attribute:: AdminSite.logout_template
 


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/29508