### PR TITLE
Fixed #29504 -- Clarified interpretation of integer JSONField lookups.

### DIFF
--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -554,8 +554,8 @@ Multiple keys can be chained together to form a path lookup::
     >>> Dog.objects.filter(data__owner__name='Bob')
     <QuerySet [<Dog: Rufus>]>
 
-If the key is an integer, it will be interpreted as an index lookup in an
-array::
+If the key is an integer, it will be used like any other key for a dictionary,
+but will be interpreted as an index lookup for an array::
 
     >>> Dog.objects.filter(data__owner__other_pets__0__name='Fishy')
     <QuerySet [<Dog: Rufus>]>


### PR DESCRIPTION
As per [Ticket 29504](https://code.djangoproject.com/ticket/29504) this is an attempt to clarify the interpretation of "integer" keys.