### PR TITLE
Updated a test example to use snake case

### DIFF
--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1073,7 +1073,7 @@ subclass::
             # Test definitions as before.
             call_setup_methods()
 
-        def testFluffyAnimals(self):
+        def test_fluffy_animals(self):
             # A test that uses the fixtures.
             call_some_test_code()
 


### PR DESCRIPTION
Although unittest finds any method starting `test`, this is the more common style, and what Django itself uses.