### PR TITLE
Fixed #29514 -- Made get_default_timezone() use module utc instance.

### DIFF
--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -75,8 +75,9 @@ def get_default_timezone():
     Return the default time zone as a tzinfo instance.
 
     This is the time zone defined by settings.TIME_ZONE.
+    For 'UTC' use module level utc object.
     """
-    return pytz.timezone(settings.TIME_ZONE)
+    return utc if settings.TIME_ZONE.upper() == 'UTC' else pytz.timezone(settings.TIME_ZONE)
 
 
 # This function exists for consistency with get_current_timezone_name

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -189,6 +189,8 @@ class TimezoneTests(SimpleTestCase):
 
     def test_get_default_timezone(self):
         self.assertEqual(timezone.get_default_timezone_name(), 'America/Chicago')
+        with override_settings(USE_TZ=True, TIME_ZONE='UTC'):
+            self.assertIs(timezone.get_default_timezone(), timezone.utc)
 
     def test_fixedoffset_timedelta(self):
         delta = datetime.timedelta(hours=1)


### PR DESCRIPTION
Regression in 27ca5ce19f5f184018a61611c1bc319113b1d107.

https://code.djangoproject.com/ticket/29514