### PR TITLE
Fixed #29525 -- Handle strings as allowed_hosts arguments to is_safe_url()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -678,6 +678,7 @@ answer newbie questions, and generally made Django that much better:
     Preston Holmes <preston@ptone.com>
     Preston Timmons <prestontimmons@gmail.com>
     Priyansh Saxena <askpriyansh@gmail.com>
+    Przemysław Suliga <http://suligap.net>
     Rachel Tobin <rmtobin@me.com>
     Rachel Willmer <http://www.willmer.com/kb/>
     Radek Švarz <http://www.svarz.cz/translate/>

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -298,6 +298,8 @@ def is_safe_url(url, allowed_hosts, require_https=False):
         return False
     if allowed_hosts is None:
         allowed_hosts = set()
+    elif isinstance(allowed_hosts, str):
+        allowed_hosts = {allowed_hosts}
     # Chrome treats \ completely as / in paths but it could be part of some
     # basic auth credentials so we need to check both URLs.
     return (_is_safe_url(url, allowed_hosts, require_https=require_https) and

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -165,6 +165,10 @@ class IsSafeURLTests(unittest.TestCase):
         # Basic auth without host is not allowed.
         self.assertIs(is_safe_url(r'http://testserver\@example.com', allowed_hosts=None), False)
 
+    def test_allowed_hosts_str(self):
+        self.assertIs(is_safe_url('http://good.com/good', allowed_hosts='good.com'), True)
+        self.assertIs(is_safe_url('http://good.co/evil', allowed_hosts='good.com'), False)
+
     def test_secure_param_https_urls(self):
         secure_urls = (
             'https://example.com/p',


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29525

When `allowed_hosts` is passed in incorrectly as a string instead of as a sequence of strings like this

    >>> is_safe_url('http://good.co/evil', allowed_hosts='good.com')
    True

`is_safe_url()` will return `True` for some cases which might be exploited.

This is an attempt to fix this.