### PR TITLE
admin docs: Add TextField to the list of acceptable list_filter field types

### DIFF
--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -864,8 +864,9 @@ subclass::
     should be of one of the following types:
 
     * a field name, where the specified field should be either a
-      ``BooleanField``, ``CharField``, ``DateField``, ``DateTimeField``,
-      ``IntegerField``, ``ForeignKey`` or ``ManyToManyField``, for example::
+      ``BooleanField``, ``CharField``, ``TextField``, ``DateField``,
+      ``DateTimeField``, ``IntegerField``, ``ForeignKey`` or
+      ``ManyToManyField``, for example::
 
           class PersonAdmin(admin.ModelAdmin):
               list_filter = ('is_staff', 'company')


### PR DESCRIPTION
The `list_filter` option has no problem accepting a TextField in addition to CharFields.