### PR TITLE
Fixed #29528 -- Made URLValidator reject invalid characters in the username and password.

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -94,7 +94,7 @@ class URLValidator(RegexValidator):
 
     regex = _lazy_re_compile(
         r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
-        r'(?:\S+(?::\S*)?@)?'  # user:pass authentication
+        r'(?:[^\s:@/]+(?::[^\s:@/]*)?@)?'  # user:pass authentication
         r'(?:' + ipv4_re + '|' + ipv6_re + '|' + host_re + ')'
         r'(?::\d{2,5})?'  # port
         r'(?:[/?#][^\s]*)?'  # resource path

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -57,3 +57,5 @@ http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
 http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaa
 https://test.[com
+http://foo/bar@example.com
+http://invalid-.com/?m=foo@example.com

--- a/tests/validators/invalid_urls.txt
+++ b/tests/validators/invalid_urls.txt
@@ -57,5 +57,9 @@ http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
 http://example.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 http://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaa
 https://test.[com
+http://foo@bar@example.com
 http://foo/bar@example.com
+http://foo:bar:baz@example.com
+http://foo:bar@baz@example.com
+http://foo:bar/baz@example.com
 http://invalid-.com/?m=foo@example.com

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -48,7 +48,7 @@ http://foo.bar/?q=Test%20URL-encoded%20stuff
 http://مثال.إختبار
 http://例子.测试
 http://उदाहरण.परीक्षा
-http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com
+http://-.~_!$&'()*+,;=%40:80%2f@example.com
 http://xn--7sbb4ac0ad0be6cf.xn--p1ai
 http://1337.net
 http://a.b-c.de

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -48,7 +48,6 @@ http://foo.bar/?q=Test%20URL-encoded%20stuff
 http://مثال.إختبار
 http://例子.测试
 http://उदाहरण.परीक्षा
-http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com
 http://xn--7sbb4ac0ad0be6cf.xn--p1ai
 http://1337.net
 http://a.b-c.de

--- a/tests/validators/valid_urls.txt
+++ b/tests/validators/valid_urls.txt
@@ -48,6 +48,7 @@ http://foo.bar/?q=Test%20URL-encoded%20stuff
 http://مثال.إختبار
 http://例子.测试
 http://उदाहरण.परीक्षा
+http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com
 http://xn--7sbb4ac0ad0be6cf.xn--p1ai
 http://1337.net
 http://a.b-c.de


### PR DESCRIPTION
This PR fixes issue 29528, and adds two new URLs to the test cases. It also removes one URL from the `valid_urls.txt` file that is invalid, and that this fix now correctly rejects.

URLs with un-escaped "/", "@" or ":" characters in the username or password fields should be rejected. This fix replaces the `\S` set with its equivalent `[^\s]`, and then adds the above characters to the exclusion set, giving `[^\s:@/]`. 