### PR TITLE
Preparation for Filter Expressions/Expression Filters.

### DIFF
--- a/django/contrib/gis/db/models/aggregates.py
+++ b/django/contrib/gis/db/models/aggregates.py
@@ -31,8 +31,8 @@ class GeoAggregate(Aggregate):
         template = None if self.is_extent else '%(function)s(SDOAGGRTYPE(%(expressions)s,%(tolerance)s))'
         return self.as_sql(compiler, connection, template=template, tolerance=tolerance)
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        c = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+    def resolve_expression(self, *args, **kwargs):
+        c = super().resolve_expression(*args, **kwargs)
         for expr in c.get_source_expressions():
             if not hasattr(expr.field, 'geom_type'):
                 raise ValueError('Geospatial aggregates only allowed on geometry fields.')

--- a/django/contrib/postgres/aggregates/statistics.py
+++ b/django/contrib/postgres/aggregates/statistics.py
@@ -15,8 +15,8 @@ class StatAggregate(Aggregate):
             raise ValueError('Both y and x must be provided.')
         super().__init__(y, x, output_field=output_field, filter=filter)
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        return super().resolve_expression(query, allow_joins, reuse, summarize)
+    def resolve_expression(self, *args, **kwargs):
+        return super().resolve_expression(*args, **kwargs)
 
 
 class Corr(StatAggregate):

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -61,13 +61,13 @@ class SearchVector(SearchVectorCombinable, Func):
             weight = Value(weight)
         self.weight = weight
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        resolved = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+    def resolve_expression(self, *args, **kwargs):
+        resolved = super().resolve_expression(*args, **kwargs)
         if self.config:
             if not hasattr(self.config, 'resolve_expression'):
-                resolved.config = Value(self.config).resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                resolved.config = Value(self.config).resolve_expression(*args, **kwargs)
             else:
-                resolved.config = self.config.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                resolved.config = self.config.resolve_expression(*args, **kwargs)
         return resolved
 
     def as_sql(self, compiler, connection, function=None, template=None):
@@ -132,13 +132,13 @@ class SearchQuery(SearchQueryCombinable, Value):
         self.invert = invert
         super().__init__(value, output_field=output_field)
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        resolved = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+    def resolve_expression(self, *args, **kwargs):
+        resolved = super().resolve_expression(*args, **kwargs)
         if self.config:
             if not hasattr(self.config, 'resolve_expression'):
-                resolved.config = Value(self.config).resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                resolved.config = Value(self.config).resolve_expression(*args, **kwargs)
             else:
-                resolved.config = self.config.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+                resolved.config = self.config.resolve_expression(*args, **kwargs)
         return resolved
 
     def as_sql(self, compiler, connection):

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -34,10 +34,10 @@ class Aggregate(Func):
         self.filter = self.filter and exprs.pop()
         return super().set_source_expressions(exprs)
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False, for_where=False):
         # Aggregates are not allowed in UPDATE queries, so ignore for_save
-        c = super().resolve_expression(query, allow_joins, reuse, summarize)
-        c.filter = c.filter and c.filter.resolve_expression(query, allow_joins, reuse, summarize)
+        c = super().resolve_expression(query, allow_joins, reuse, summarize, for_where=for_where)
+        c.filter = c.filter and c.filter.resolve_expression(query, allow_joins, reuse, summarize, for_where=for_where)
         if not summarize:
             # Call Aggregate.get_source_expressions() to avoid
             # returning self.filter and including that in this loop.

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -60,8 +60,8 @@ class Extract(TimezoneMixin, Transform):
             assert False, "Tried to Extract from an invalid type."
         return sql, params
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        copy = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+    def resolve_expression(self, *args, **kwargs):
+        copy = super().resolve_expression(*args, **kwargs)
         field = copy.lhs.output_field
         if not isinstance(field, (DateField, DateTimeField, TimeField, DurationField)):
             raise ValueError(
@@ -177,8 +177,8 @@ class TruncBase(TimezoneMixin, Transform):
             raise ValueError('Trunc only valid on DateField, TimeField, or DateTimeField.')
         return sql, inner_params
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
-        copy = super().resolve_expression(query, allow_joins, reuse, summarize, for_save)
+    def resolve_expression(self, *args, **kwargs):
+        copy = super().resolve_expression(*args, **kwargs)
         field = copy.lhs.output_field
         # DateTimeField is a subclass of DateField so this works for both.
         assert isinstance(field, (DateField, TimeField)), (

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -89,7 +89,7 @@ class Q(tree.Node):
         obj.negate()
         return obj
 
-    def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
+    def resolve_expression(self, query=None, allow_joins=True, reuse=None, **kwargs):
         # We must promote any new joins to left outer joins so that when Q is
         # used as an expression, rows aren't filtered due to joins.
         clause, joins = query._add_q(self, reuse, allow_joins=allow_joins, split_subq=False)

--- a/docs/ref/models/expressions.txt
+++ b/docs/ref/models/expressions.txt
@@ -910,7 +910,7 @@ calling the appropriate methods on the wrapped expression.
         in :class:`~django.db.models.expressions.Window`. Defaults to
         ``False``.
 
-    .. method:: resolve_expression(query=None, allow_joins=True, reuse=None, summarize=False, for_save=False)
+    .. method:: resolve_expression(query=None, allow_joins=True, reuse=None, summarize=False, for_save=False, for_where=False)
 
         Provides the chance to do any pre-processing or validation of
         the expression before it's added to the query. ``resolve_expression()``
@@ -926,6 +926,12 @@ calling the appropriate methods on the wrapped expression.
 
         ``summarize`` is a boolean that, when ``True``, signals that the
         query being computed is a terminal aggregate query.
+
+        .. versionadded:: 2.2
+
+        ``for_where`` is a boolean that, when ``True`` indicates that the
+        expression is to be used in the ``WHERE`` clause of a query, and
+        will not be used in a ``SELECT``.
 
     .. method:: get_source_expressions()
 


### PR DESCRIPTION
This is in preparation for https://github.com/django/django/pull/8119.

In order to make it possible to have different behaviour when an
expression is to be used _only_ in a WHERE clause, we need to have
some tag on the expression.

I think maybe we need to make the resolve_expression() accept arbitrary
kwargs - it's either that or just add for_where=False.