### PR TITLE
Fixed #29520 -- Fixed test client crash when posting bytes.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -310,7 +310,7 @@ class RequestFactory:
                 charset = match.group(1)
             else:
                 charset = settings.DEFAULT_CHARSET
-            return data.encode(charset)
+            return force_bytes(data, encoding=charset)
 
     def _encode_json(self, data, content_type):
         """

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1196,6 +1196,10 @@ class RequestMethodStringDataTests(SimpleTestCase):
         response = self.client.head('/body/', data='', content_type='application/json')
         self.assertEqual(response.content, b'')
 
+    def test_json_bytes(self):
+        response = self.client.post('/body/', data=b"{'value': 37}", content_type='application/json')
+        self.assertEqual(response.content, b"{'value': 37}")
+
     def test_json(self):
         response = self.client.get('/json_response/')
         self.assertEqual(response.json(), {'key': 'value'})


### PR DESCRIPTION
Regression in b8a41a2872624a6d9e61308932dd81d001e31eb9.
https://code.djangoproject.com/ticket/29520