### PR TITLE
Fixed #29514 -- Fixed get_default_timezone()/utc equality.

### DIFF
--- a/django/contrib/sessions/backends/file.py
+++ b/django/contrib/sessions/backends/file.py
@@ -59,7 +59,10 @@ class SessionStore(SessionBase):
         Return the modification time of the file storing the session's content.
         """
         modification = os.stat(self._key_to_file()).st_mtime
-        return datetime.datetime.fromtimestamp(modification, timezone.utc if settings.USE_TZ else None)
+        if settings.USE_TZ:
+            modification = datetime.datetime.utcfromtimestamp(modification)
+            return modification.replace(tzinfo=timezone.utc)
+        return datetime.datetime.fromtimestamp(modification)
 
     def _expiry_date(self, session_data):
         """

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -336,7 +336,11 @@ class FileSystemStorage(Storage):
         If timezone support is enabled, make an aware datetime object in UTC;
         otherwise make a naive one in the local timezone.
         """
-        return datetime.fromtimestamp(ts, timezone.utc if settings.USE_TZ else None)
+        if settings.USE_TZ:
+            # Safe to use .replace() because UTC doesn't have DST
+            return datetime.utcfromtimestamp(ts).replace(tzinfo=timezone.utc)
+        else:
+            return datetime.fromtimestamp(ts)
 
     def get_accessed_time(self, name):
         return self._datetime_from_timestamp(os.path.getatime(self.path(name)))

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -50,7 +50,7 @@ class DatetimeSerializer(BaseSerializer):
     def serialize(self):
         if self.value.tzinfo is not None and self.value.tzinfo != utc:
             self.value = self.value.astimezone(utc)
-        value_repr = repr(self.value).replace("datetime.timezone(datetime.timedelta(0), 'UTC')", 'utc')
+        value_repr = repr(self.value).replace("<UTC>", "utc")
         if isinstance(self.value, datetime_safe.datetime):
             value_repr = "datetime.%s" % value_repr
         imports = ["import datetime"]

--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -173,7 +173,8 @@ class SyndicationFeed:
                     if latest_date is None or item_date > latest_date:
                         latest_date = item_date
 
-        return latest_date or datetime.datetime.now(utc)
+        # datetime.now(tz=utc) is slower, as documented in django.utils.timezone.now
+        return latest_date or datetime.datetime.utcnow().replace(tzinfo=utc)
 
 
 class Enclosure:

--- a/django/utils/timezone.py
+++ b/django/utils/timezone.py
@@ -2,10 +2,9 @@
 Timezone-related classes and functions.
 """
 
-import datetime
 import functools
 from contextlib import ContextDecorator
-from datetime import timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo
 from threading import local
 
 import pytz
@@ -53,8 +52,7 @@ class FixedOffset(tzinfo):
 
 
 # UTC time zone as a tzinfo instance.
-# (Use utc = datetime.timezone.utc here when PY35 isn't supported.)
-utc = datetime.timezone(ZERO, 'UTC')
+utc = pytz.utc
 
 
 def get_fixed_timezone(offset):
@@ -174,7 +172,7 @@ def template_localtime(value, use_tz=None):
     This function is designed for use by the template engine.
     """
     should_convert = (
-        isinstance(value, datetime.datetime) and
+        isinstance(value, datetime) and
         (settings.USE_TZ if use_tz is None else use_tz) and
         not is_naive(value) and
         getattr(value, 'convert_to_local_time', True)
@@ -221,7 +219,11 @@ def now():
     """
     Return an aware or naive datetime.datetime, depending on settings.USE_TZ.
     """
-    return datetime.datetime.now(utc if settings.USE_TZ else None)
+    if settings.USE_TZ:
+        # timeit shows that datetime.now(tz=utc) is 24% slower
+        return datetime.utcnow().replace(tzinfo=utc)
+    else:
+        return datetime.now()
 
 
 # By design, these four functions don't perform any checks on their arguments.

--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -190,6 +190,10 @@ class TimezoneTests(SimpleTestCase):
     def test_get_default_timezone(self):
         self.assertEqual(timezone.get_default_timezone_name(), 'America/Chicago')
 
+    def test_get_default_timezone_utc(self):
+        with override_settings(USE_TZ=True, TIME_ZONE='UTC'):
+            self.assertIs(timezone.get_default_timezone(), timezone.utc)
+
     def test_fixedoffset_timedelta(self):
         delta = datetime.timedelta(hours=1)
         self.assertEqual(timezone.get_fixed_timezone(delta).utcoffset(''), delta)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29514