### PR TITLE
Fixed #29534 -- Made dbshell use rlwrap on Oracle if available.

### DIFF
--- a/django/db/backends/oracle/client.py
+++ b/django/db/backends/oracle/client.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 
 from django.db.backends.base.client import BaseDatabaseClient
@@ -5,8 +6,15 @@ from django.db.backends.base.client import BaseDatabaseClient
 
 class DatabaseClient(BaseDatabaseClient):
     executable_name = 'sqlplus'
+    wrapper_name = 'rlwrap'
+
+    def wrapper_args(self, wrapper_path):
+        return [wrapper_path, '--history', '2000']
 
     def runshell(self):
         conn_string = self.connection._connect_string()
         args = [self.executable_name, "-L", conn_string]
+        wrapper_path = shutil.which(self.wrapper_name)
+        if wrapper_path:
+            args = self.wrapper_args(wrapper_path) + args
         subprocess.check_call(args)

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -126,6 +126,12 @@ CSRF
 * Added the :setting:`CSRF_COOKIE_SAMESITE` setting to set the ``SameSite``
   cookie flag on CSRF cookies.
 
+Database Backends
+~~~~~~~~~~~~~~~~~
+
+* The Oracle backend client is modified so that the dbshell management command
+  will be called wrapped with rlwrap when rlwrap is available.
+
 Forms
 ~~~~~
 

--- a/tests/dbshell/test_oracle.py
+++ b/tests/dbshell/test_oracle.py
@@ -1,0 +1,70 @@
+import os
+import signal
+from unittest import mock
+
+from django.db.backends.oracle.client import DatabaseClient
+from django.test import SimpleTestCase
+
+
+class MockConnection(object):
+
+    def __init__(self, connect_string):
+        self.connect_string = connect_string
+
+    def _connect_string(self):
+        return self.connect_string
+
+
+
+class OracleDbshellCommandTestCase(SimpleTestCase):
+
+    def _run_it(self, connectstring, have_rlwrap=False):
+        """
+        That function invokes the runshell command, while mocking
+        subprocess.call. It returns a 2-tuple with:
+        - The command line list
+        - The content of the file pointed by environment PGPASSFILE, or None.
+        """
+        connection = MockConnection(connectstring)
+        client = DatabaseClient(connection)
+
+        def _mock_subprocess_call(*args):
+            self.subprocess_args = list(*args)
+            return 0
+        def _mock_shutil_which(*args):
+            return '/usr/bin/rlwrap' if have_rlwrap else None
+
+        self.subprocess_args = None
+        with mock.patch('subprocess.call', new=_mock_subprocess_call):
+            with mock.patch('shutil.which', new=_mock_shutil_which):
+                client.runshell()
+        return self.subprocess_args
+
+    def test_basic(self):
+        connectstring = 'USER/PASSWORD@TNSNAME'
+
+        expected_args = ['sqlplus', '-L', connectstring]
+        actual_args = self._run_it(connectstring, have_rlwrap=False)
+
+        self.assertEqual(
+            actual_args,
+            expected_args
+        )
+
+    def test_with_rlwrap(self):
+        connectstring = 'USER/PASSWORD@TNSNAME'
+
+        expected_args = [
+            '/usr/bin/rlwrap',
+            '--history',
+            '2000',
+            'sqlplus',
+            '-L',
+            connectstring]
+
+        actual_args = self._run_it(connectstring, have_rlwrap=True)
+
+        self.assertEqual(
+            actual_args,
+            expected_args
+        )


### PR DESCRIPTION
Design of the code is that another wrapper can easily be used and the way to wrap it can easily be modified.