### PR TITLE
Refs #17235 -- Made MultiPartParser leave request.FILES immutable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -847,6 +847,7 @@ answer newbie questions, and generally made Django that much better:
     Victor Andrée
     viestards.lists@gmail.com
     Ville Säävuori <http://www.unessa.net/>
+    Vinay Karanam <https://github.com/vinayinvicible>
     Vinay Sajip <vinay_sajip@yahoo.co.uk>
     Vincent Foley <vfoleybourgon@yahoo.ca>
     Vitaly Babiy <vbabiy86@gmail.com>

--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -16,7 +16,7 @@ from django.core.exceptions import (
 from django.core.files.uploadhandler import (
     SkipFile, StopFutureHandlers, StopUpload,
 )
-from django.utils.datastructures import MultiValueDict
+from django.utils.datastructures import ImmutableMultiValueDict
 from django.utils.encoding import force_text
 from django.utils.text import unescape_entities
 
@@ -43,8 +43,8 @@ class MultiPartParser:
     """
     A rfc2388 multipart/form-data parser.
 
-    ``MultiValueDict.parse()`` reads the input stream in ``chunk_size`` chunks
-    and returns a tuple of ``(MultiValueDict(POST), MultiValueDict(FILES))``.
+    ``MultiPartParser.parse()`` reads the input stream in ``chunk_size`` chunks
+    and returns a tuple of ``(QueryDict(POST), ImmutableMultiValueDict(FILES))``.
     """
     def __init__(self, META, input_data, upload_handlers, encoding=None):
         """
@@ -99,8 +99,8 @@ class MultiPartParser:
 
     def parse(self):
         """
-        Parse the POST data and break it into a FILES MultiValueDict and a POST
-        MultiValueDict.
+        Parse the POST data and break it into a FILES ImmutableMultiValueDict
+        and a POST QueryDict.
 
         Return a tuple containing the POST and FILES dictionary, respectively.
         """
@@ -112,7 +112,7 @@ class MultiPartParser:
         # HTTP spec says that Content-Length >= 0 is valid
         # handling content-length == 0 before continuing
         if self._content_length == 0:
-            return QueryDict(encoding=self._encoding), MultiValueDict()
+            return QueryDict(encoding=self._encoding), ImmutableMultiValueDict()
 
         # See if any of the handlers take care of the parsing.
         # This allows overriding everything if need be.
@@ -130,7 +130,7 @@ class MultiPartParser:
 
         # Create the data structures to be used later.
         self._post = QueryDict(mutable=True)
-        self._files = MultiValueDict()
+        self._files = ImmutableMultiValueDict(mutable=True)
 
         # Instantiate the parser and stream:
         stream = LazyStream(ChunkIter(self._input_data, self._chunk_size))
@@ -279,7 +279,7 @@ class MultiPartParser:
         # Signal that the upload has completed.
         # any() shortcircuits if a handler's upload_complete() returns a value.
         any(handler.upload_complete() for handler in handlers)
-        self._post._mutable = False
+        self._post._mutable = self._files._mutable = False
         return self._post, self._files
 
     def handle_file_complete(self, old_field_name, counters):

--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -213,6 +213,73 @@ class MultiValueDict(dict):
         return {key: self[key] for key in self}
 
 
+class ImmutableMultiValueDict(MultiValueDict):
+    _mutable = False
+
+    def __init__(self, key_to_list_mapping=(), mutable=False):
+        super().__init__(key_to_list_mapping)
+        self._mutable = mutable
+
+    def _assert_mutable(self):
+        if not self._mutable:
+            raise AttributeError(
+                "This ImmutableMultiValueDict instance is immutable"
+            )
+
+    def __setitem__(self, key, value):
+        self._assert_mutable()
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self._assert_mutable()
+        super().__delitem__(key)
+
+    def __copy__(self):
+        result = self.__class__(mutable=True)
+        for key, value in self.lists():
+            result.setlist(key, value)
+        return result
+
+    def __deepcopy__(self, memo):
+        result = self.__class__(mutable=True)
+        memo[id(self)] = result
+        for key, value in self.lists():
+            result.setlist(copy.deepcopy(key, memo), copy.deepcopy(value, memo))
+        return result
+
+    def setlist(self, key, list_):
+        self._assert_mutable()
+        super().setlist(key, list_)
+
+    def setlistdefault(self, key, default_list=None):
+        self._assert_mutable()
+        return super().setlistdefault(key, default_list)
+
+    def appendlist(self, key, value):
+        self._assert_mutable()
+        super().appendlist(key, value)
+
+    def pop(self, key, *args):
+        self._assert_mutable()
+        return super().pop(key, *args)
+
+    def popitem(self):
+        self._assert_mutable()
+        return super().popitem()
+
+    def clear(self):
+        self._assert_mutable()
+        super().clear()
+
+    def setdefault(self, key, default=None):
+        self._assert_mutable()
+        return super().setdefault(key, default)
+
+    def copy(self):
+        """Return a mutable copy of this object."""
+        return self.__deepcopy__({})
+
+
 class ImmutableList(tuple):
     """
     A tuple-like object that raises useful errors when it is asked to mutate.

--- a/tests/requests/tests.py
+++ b/tests/requests/tests.py
@@ -494,6 +494,27 @@ class RequestsTests(SimpleTestCase):
         request.encoding = 'iso-8859-16'
         self.assertEqual(request.GET, {'name': ['Hello G\u0102\u0152nter']})
 
+    def test_FILES_immutable(self):
+        """
+        MultiPartParser.parse() leaves request.FILES immutable.
+        """
+        payload = FakePayload("\r\n".join([
+            '--boundary',
+            'Content-Disposition: form-data; name="upload_file"; filename="asd.txt"',
+            'Content-Type: text/plain',
+            '',
+            'asd',
+            '--boundary--',
+        ]))
+        request = WSGIRequest({
+            'REQUEST_METHOD': 'POST',
+            'CONTENT_TYPE': 'multipart/form-data; boundary=boundary',
+            'CONTENT_LENGTH': len(payload),
+            'wsgi.input': payload,
+        })
+        self.assertTrue('upload_file' in request.FILES)
+        self.assertFalse(request.FILES._mutable)
+
     def test_FILES_connection_error(self):
         """
         If wsgi.input.read() raises an exception while trying to read() the


### PR DESCRIPTION
Extended on top of @hirokiky's patch

Ref: https://code.djangoproject.com/ticket/17235
