### PR TITLE
Updated docs to use :file: role.

### DIFF
--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -122,7 +122,7 @@ that allows you to keep a separate directory of installed packages for each of
 your projects so that they don't interfere with each other.
 
 It's a good idea to keep all your virtualenvs in one place, for example in
-``.virtualenvs/`` in your home directory. Create it if it doesn't exist yet:
+:file:`.virtualenvs/` in your home directory. Create it if it doesn't exist yet:
 
 .. console::
 
@@ -209,8 +209,8 @@ working on your own patch for a ticket!**
 __ https://github.com/django/django/commit/4df7e8483b2679fc1cba3410f08960bac6f51115
 __ https://github.com/django/django/commit/4ccfc4439a7add24f8db4ef3960d02ef8ae09887
 
-Navigate into Django's root directory (that's the one that contains ``django``,
-``docs``, ``tests``, ``AUTHORS``, etc.). You can then check out the older
+Navigate into Django's root directory (that's the one that contains :file:`django`,
+:file:`docs`, :file:`tests`, :file:`AUTHORS`, etc.). You can then check out the older
 revision of Django that we'll be using in the tutorial below:
 
 .. console::
@@ -229,7 +229,7 @@ before, it's a good idea to run it once beforehand just to get familiar with
 what its output is supposed to look like.
 
 Before running the test suite, install its dependencies by first ``cd``-ing
-into the Django ``tests/`` directory and then running:
+into the Django :file:`tests/` directory and then running:
 
 .. console::
 
@@ -346,8 +346,8 @@ Before we make those changes though, we're going to write a couple tests to
 verify that our modification functions correctly and continues to function
 correctly in the future.
 
-Navigate to Django's ``tests/forms_tests/tests/`` folder and open the
-``test_forms.py`` file. Add the following code on line 1674 right before the
+Navigate to Django's :file:`tests/forms_tests/tests/` folder and open the
+:file:`test_forms.py` file. Add the following code on line 1674 right before the
 ``test_forms_with_null_boolean`` function::
 
     def test_class_prefix(self):
@@ -386,7 +386,7 @@ Running your new test
 Remember that we haven't actually made any modifications to ``BaseForm`` yet,
 so our tests are going to fail. Let's run all the tests in the ``forms_tests``
 folder to make sure that's really what happens. From the command line, ``cd``
-into the Django ``tests/`` directory and run:
+into the Django :file:`tests/` directory and run:
 
 .. console::
 
@@ -405,7 +405,7 @@ Django.
 Writing the code for ticket #24788
 ----------------------------------
 
-Navigate to the ``django/django/forms/`` folder and open the ``forms.py`` file.
+Navigate to the :file:`django/django/forms/` folder and open the :file:`forms.py` file.
 Find the ``BaseForm`` class on line 72 and add the ``prefix`` class attribute
 right after the ``field_order`` attribute::
 
@@ -423,7 +423,7 @@ Verifying your test now passes
 Once you're done modifying Django, we need to make sure that the tests we wrote
 earlier pass, so we can see whether the code we wrote above is working
 correctly. To run the tests in the ``forms_tests`` folder, ``cd`` into the
-Django ``tests/`` directory and run:
+Django :file:`tests/` directory and run:
 
 .. console::
 
@@ -436,7 +436,7 @@ the following exception::
 
 We forgot to add the conditional statement in the ``__init__`` method. Go ahead
 and change ``self.prefix = prefix`` that is now on line 87 of
-``django/forms/forms.py``, adding a conditional statement::
+:file:`django/forms/forms.py`, adding a conditional statement::
 
     if prefix is not None:
         self.prefix = prefix
@@ -454,7 +454,7 @@ hasn't introduced any bugs into other areas of Django. While successfully
 passing the entire test suite doesn't guarantee your code is bug free, it does
 help identify many bugs and regressions that might otherwise go unnoticed.
 
-To run the entire Django test suite, ``cd`` into the Django ``tests/``
+To run the entire Django test suite, ``cd`` into the Django :file:`tests/`
 directory and run:
 
 .. console::
@@ -467,7 +467,7 @@ Writing Documentation
 =====================
 
 This is a new feature, so it should be documented. Add the following section on
-line 1068 (at the end of the file) of ``django/docs/ref/forms/api.txt``::
+line 1068 (at the end of the file) of :file:`django/docs/ref/forms/api.txt`::
 
     The prefix can also be specified on the form class::
 
@@ -481,7 +481,7 @@ line 1068 (at the end of the file) of ``django/docs/ref/forms/api.txt``::
 
 Since this new feature will be in an upcoming release it is also added to the
 release notes for Django 1.9, on line 164 under the "Forms" section in the file
-``docs/releases/1.9.txt``::
+:file:`docs/releases/1.9.txt`::
 
     * A form prefix can be specified inside a form class, not only when
       instantiating a form. See :ref:`form-prefix` for details.

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -247,14 +247,14 @@ to use.
 Design your templates
 =====================
 
-The code above loads the ``news/year_archive.html`` template.
+The code above loads the :file:`news/year_archive.html` template.
 
 Django has a template search path, which allows you to minimize redundancy among
 templates. In your Django settings, you specify a list of directories to check
 for templates with :setting:`DIRS <TEMPLATES-DIRS>`. If a template doesn't exist
 in the first directory, it checks the second, and so on.
 
-Let's say the ``news/year_archive.html`` template was found. Here's what that
+Let's say the :file:`news/year_archive.html` template was found. Here's what that
 might look like:
 
 .. snippet:: html+django

--- a/docs/intro/reusable-apps.txt
+++ b/docs/intro/reusable-apps.txt
@@ -38,8 +38,8 @@ projects and ready to publish for others to install and use.
     as "modules").
 
     A package can be imported with ``import foo.bar`` or ``from foo import
-    bar``. For a directory (like ``polls``) to form a package, it must contain
-    a special file ``__init__.py``, even if this file is empty.
+    bar``. For a directory (like :file:`polls`) to form a package, it must contain
+    a special file :file:`__init__.py`, even if this file is empty.
 
     A Django *application* is just a Python package that is specifically
     intended for use in a Django project. An application may use common Django
@@ -86,14 +86,14 @@ After the previous tutorials, our project should look like this::
             admin/
                 base_site.html
 
-You created ``mysite/templates`` in :doc:`Tutorial 7 </intro/tutorial07>`,
-and ``polls/templates`` in :doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps
+You created :file:`mysite/templates` in :doc:`Tutorial 7 </intro/tutorial07>`,
+and :file:`polls/templates` in :doc:`Tutorial 3 </intro/tutorial03>`. Now perhaps
 it is clearer why we chose to have separate template directories for the
 project and application: everything that is part of the polls application is in
-``polls``. It makes the application self-contained and easier to drop into a
+:file:`polls`. It makes the application self-contained and easier to drop into a
 new project.
 
-The ``polls`` directory could now be copied into a new Django project and
+The :file:`polls` directory could now be copied into a new Django project and
 immediately reused. It's not quite ready to be published though. For that, we
 need to package the app to make it easy for others to install.
 
@@ -120,8 +120,8 @@ Python *packaging* refers to preparing your app in a specific format that can
 be easily installed and used. Django itself is packaged very much like
 this. For a small app like polls, this process isn't too difficult.
 
-1. First, create a parent directory for ``polls``, outside of your Django
-   project. Call this directory ``django-polls``.
+1. First, create a parent directory for :file:`polls`, outside of your Django
+   project. Call this directory :file:`django-polls`.
 
    .. admonition::  Choosing a name for your app
 
@@ -137,9 +137,9 @@ this. For a small app like polls, this process isn't too difficult.
        </ref/contrib/index>`, for example ``auth``, ``admin``, or
        ``messages``.
 
-2. Move the ``polls`` directory into the ``django-polls`` directory.
+2. Move the :file:`polls` directory into the :file:`django-polls` directory.
 
-3. Create a file ``django-polls/README.rst`` with the following contents:
+3. Create a file :file:`django-polls/README.rst` with the following contents:
 
    .. snippet::
        :filename: django-polls/README.rst
@@ -174,18 +174,18 @@ this. For a small app like polls, this process isn't too difficult.
 
        5. Visit http://127.0.0.1:8000/polls/ to participate in the poll.
 
-4. Create a ``django-polls/LICENSE`` file. Choosing a license is beyond the
+4. Create a :file:`django-polls/LICENSE` file. Choosing a license is beyond the
    scope of this tutorial, but suffice it to say that code released publicly
    without a license is *useless*. Django and many Django-compatible apps are
    distributed under the BSD license; however, you're free to pick your own
    license. Just be aware that your licensing choice will affect who is able
    to use your code.
 
-5. Next we'll create a ``setup.py`` file which provides details about how to
+5. Next we'll create a :file:`setup.py` file which provides details about how to
    build and install the app.  A full explanation of this file is beyond the
    scope of this tutorial, but the `setuptools docs
    <https://setuptools.readthedocs.io/en/latest/>`_ have a good
-   explanation. Create a file ``django-polls/setup.py`` with the following
+   explanation. Create a file :file:`django-polls/setup.py` with the following
    contents:
 
    .. snippet::
@@ -227,10 +227,10 @@ this. For a small app like polls, this process isn't too difficult.
        )
 
 6. Only Python modules and packages are included in the package by default. To
-   include additional files, we'll need to create a ``MANIFEST.in`` file. The
+   include additional files, we'll need to create a :file:`MANIFEST.in` file. The
    setuptools docs referred to in the previous step discuss this file in more
-   details. To include the templates, the ``README.rst`` and our ``LICENSE``
-   file, create a file ``django-polls/MANIFEST.in`` with the following
+   details. To include the templates, the :file:`README.rst` and our :file:`LICENSE`
+   file, create a file :file:`django-polls/MANIFEST.in` with the following
    contents:
 
    .. snippet::
@@ -242,18 +242,18 @@ this. For a small app like polls, this process isn't too difficult.
        recursive-include polls/templates *
 
 7. It's optional, but recommended, to include detailed documentation with your
-   app. Create an empty directory ``django-polls/docs`` for future
-   documentation. Add an additional line to ``django-polls/MANIFEST.in``::
+   app. Create an empty directory :file:`django-polls/docs` for future
+   documentation. Add an additional line to :file:`django-polls/MANIFEST.in`::
 
     recursive-include docs *
 
-   Note that the ``docs`` directory won't be included in your package unless
+   Note that the :file:`docs` directory won't be included in your package unless
    you add some files to it. Many Django apps also provide their documentation
    online through sites like `readthedocs.org <https://readthedocs.org>`_.
 
 8. Try building your package with ``python setup.py sdist`` (run from inside
-   ``django-polls``). This creates a directory called ``dist`` and builds your
-   new package, ``django-polls-0.1.tar.gz``.
+   :file:`django-polls`). This creates a directory called :file:`dist` and builds your
+   new package, :file:`django-polls-0.1.tar.gz`.
 
 For more information on packaging, see Python's `Tutorial on Packaging and
 Distributing Projects <https://packaging.python.org/distributing/>`_.
@@ -261,7 +261,7 @@ Distributing Projects <https://packaging.python.org/distributing/>`_.
 Using your own package
 ======================
 
-Since we moved the ``polls`` directory out of the project, it's no longer
+Since we moved the :file:`polls` directory out of the project, it's no longer
 working. We'll now fix this by installing our new ``django-polls`` package.
 
 .. admonition:: Installing as a user library

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -70,7 +70,7 @@ work, see :ref:`troubleshooting-django-admin`.
 
     If your background is in plain old PHP (with no use of modern frameworks),
     you're probably used to putting code under the Web server's document root
-    (in a place such as ``/var/www``). With Django, you don't do that. It's
+    (in a place such as :file:`/var/www`). With Django, you don't do that. It's
     not a good idea to put any of this Python code within your Web server's
     document root, because it risks the possibility that people may be able
     to view your code over the Web. That's not good for security.

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -56,7 +56,7 @@ code, then run the following command:
 
    $ django-admin startproject mysite
 
-This will create a ``mysite`` directory in your current directory. If it didn't
+This will create a :file:`mysite` directory in your current directory. If it didn't
 work, see :ref:`troubleshooting-django-admin`.
 
 .. note::

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -255,7 +255,7 @@ and put the following Python code in it:
 This is the simplest view possible in Django. To call the view, we need to map
 it to a URL - and for this we need a URLconf.
 
-To create a URLconf in the polls directory, create a file called ``urls.py``.
+To create a URLconf in the polls directory, create a file called :file:`urls.py`.
 Your app directory should now look like::
 
     polls/
@@ -269,7 +269,7 @@ Your app directory should now look like::
         urls.py
         views.py
 
-In the ``polls/urls.py`` file include the following code:
+In the :file:`polls/urls.py` file include the following code:
 
 .. snippet::
     :filename: polls/urls.py
@@ -283,7 +283,7 @@ In the ``polls/urls.py`` file include the following code:
     ]
 
 The next step is to point the root URLconf at the ``polls.urls`` module. In
-``mysite/urls.py``, add an import for ``django.urls.include`` and insert an
+:file:`mysite/urls.py`, add an import for ``django.urls.include`` and insert an
 :func:`~django.urls.include` in the ``urlpatterns`` list, so you have:
 
 .. snippet::
@@ -304,8 +304,8 @@ included URLconf for further processing.
 
 The idea behind :func:`~django.urls.include` is to make it easy to
 plug-and-play URLs. Since polls are in their own URLconf
-(``polls/urls.py``), they can be placed under "/polls/", or under
-"/fun_polls/", or under "/content/polls/", or any other path root, and the
+(:file:`polls/urls.py`), they can be placed under :file:`/polls/`, or under
+:file:`/fun_polls/`, or under :file:`/content/polls/`, or any other path root, and the
 app will still work.
 
 .. admonition:: When to use :func:`~django.urls.include()`

--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -240,7 +240,7 @@ This directory structure will house the poll application.
 Write your first view
 =====================
 
-Let's write the first view. Open the file ``polls/views.py``
+Let's write the first view. Open the file :file:`polls/views.py`
 and put the following Python code in it:
 
 .. snippet::

--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -247,7 +247,7 @@ you'd like the changes to be stored as a *migration*.
 Migrations are how Django stores changes to your models (and thus your
 database schema) - they're just files on disk. You can read the migration
 for your new model if you like; it's the file
-``polls/migrations/0001_initial.py``. Don't worry, you're not expected to read
+:file:`polls/migrations/0001_initial.py`. Don't worry, you're not expected to read
 them every time Django makes one, but they're designed to be human-editable
 in case you want to manually tweak how Django changes things.
 
@@ -353,7 +353,7 @@ make new ones - it specializes in upgrading your database live, without
 losing data. We'll cover them in more depth in a later part of the tutorial,
 but for now, remember the three-step guide to making model changes:
 
-* Change your models (in ``models.py``).
+* Change your models (in :file:`models.py`).
 * Run :djadmin:`python manage.py makemigrations <makemigrations>` to create
   migrations for those changes
 * Run :djadmin:`python manage.py migrate <migrate>` to apply those changes to
@@ -419,7 +419,7 @@ Once you're in the shell, explore the :doc:`database API </topics/db/queries>`::
 
 Wait a minute. ``<Question: Question object (1)>`` isn't a helpful
 representation of this object. Let's fix that by editing the ``Question`` model
-(in the ``polls/models.py`` file) and adding a
+(in the :file:`polls/models.py` file) and adding a
 :meth:`~django.db.models.Model.__str__` method to both ``Question`` and
 ``Choice``:
 

--- a/docs/intro/tutorial03.txt
+++ b/docs/intro/tutorial03.txt
@@ -61,7 +61,7 @@ refer to :doc:`/topics/http/urls` for more information.
 Writing more views
 ==================
 
-Now let's add a few more views to ``polls/views.py``. These views are
+Now let's add a few more views to :file:`polls/views.py`. These views are
 slightly different, because they take an argument:
 
 .. snippet::
@@ -167,7 +167,7 @@ you want to change the way the page looks, you'll have to edit this Python code.
 So let's use Django's template system to separate the design from Python by
 creating a template that the view can use.
 
-First, create a directory called ``templates`` in your ``polls`` directory.
+First, create a directory called :file:`templates` in your :file:`polls` directory.
 Django will look for templates in there.
 
 Your project's :setting:`TEMPLATES` setting describes how Django will load and
@@ -176,17 +176,17 @@ backend whose :setting:`APP_DIRS <TEMPLATES-APP_DIRS>` option is set to
 ``True``. By convention ``DjangoTemplates`` looks for a "templates"
 subdirectory in each of the :setting:`INSTALLED_APPS`.
 
-Within the ``templates`` directory you have just created, create another
-directory called ``polls``, and within that create a file called
-``index.html``. In other words, your template should be at
-``polls/templates/polls/index.html``. Because of how the ``app_directories``
+Within the :file:`templates` directory you have just created, create another
+directory called :file:`polls`, and within that create a file called
+:file:`index.html`. In other words, your template should be at
+:file:`polls/templates/polls/index.html`. Because of how the ``app_directories``
 template loader works as described above, you can refer to this template within
 Django simply as ``polls/index.html``.
 
 .. admonition:: Template namespacing
 
     Now we *might* be able to get away with putting our templates directly in
-    ``polls/templates`` (rather than creating another ``polls`` subdirectory),
+    :file:`polls/templates` (rather than creating another :file:`polls` subdirectory),
     but it would actually be a bad idea. Django will choose the first template
     it finds whose name matches, and if you had a template with the same name
     in a *different* application, Django would be unable to distinguish between
@@ -209,7 +209,7 @@ Put the following code in that template:
         <p>No polls are available.</p>
     {% endif %}
 
-Now let's update our ``index`` view in ``polls/views.py`` to use the template:
+Now let's update our ``index`` view in :file:`polls/views.py` to use the template:
 
 .. snippet::
     :filename: polls/views.py
@@ -405,7 +405,7 @@ defined below::
 
 If you want to change the URL of the polls detail view to something else,
 perhaps to something like ``polls/specifics/12/`` instead of doing it in the
-template (or templates) you would change it in ``polls/urls.py``::
+template (or templates) you would change it in :file:`polls/urls.py`::
 
     ...
     # added the word 'specifics'
@@ -422,7 +422,7 @@ view, and so might an app on the same project that is for a blog. How does one
 make it so that Django knows which app view to create for a url when using the
 ``{% url %}`` template tag?
 
-The answer is to add namespaces to your  URLconf. In the ``polls/urls.py``
+The answer is to add namespaces to your  URLconf. In the :file:`polls/urls.py`
 file, go ahead and add an ``app_name`` to set the application namespace:
 
 .. snippet::

--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -64,7 +64,7 @@ created a URLconf for the polls application that includes this line:
     path('<int:question_id>/vote/', views.vote, name='vote'),
 
 We also created a dummy implementation of the ``vote()`` function. Let's
-create a real version. Add the following to ``polls/views.py``:
+create a real version. Add the following to :file:`polls/views.py`:
 
 .. snippet::
     :filename: polls/views.py
@@ -232,7 +232,7 @@ Read on for details.
 Amend URLconf
 -------------
 
-First, open the ``polls/urls.py`` URLconf and change it like so:
+First, open the :file:`polls/urls.py` URLconf and change it like so:
 
 .. snippet::
     :filename: polls/urls.py
@@ -257,7 +257,7 @@ Amend views
 
 Next, we're going to remove our old ``index``, ``detail``, and ``results``
 views and use Django's generic views instead. To do so, open the
-``polls/views.py`` file and change it like so:
+:file:`polls/views.py` file and change it like so:
 
 .. snippet::
     :filename: polls/views.py

--- a/docs/intro/tutorial05.txt
+++ b/docs/intro/tutorial05.txt
@@ -161,10 +161,10 @@ What we've just done in the :djadmin:`shell` to test for the problem is exactly
 what we can do in an automated test, so let's turn that into an automated test.
 
 A conventional place for an application's tests is in the application's
-``tests.py`` file; the testing system will automatically find tests in any file
+:file:`tests.py` file; the testing system will automatically find tests in any file
 whose name begins with ``test``.
 
-Put the following in the ``tests.py`` file in the ``polls`` application:
+Put the following in the :file:`tests.py` file in the ``polls`` application:
 
 .. snippet::
     :filename: polls/tests.py
@@ -245,7 +245,7 @@ Fixing the bug
 
 We already know what the problem is: ``Question.was_published_recently()`` should
 return ``False`` if its ``pub_date`` is in the future. Amend the method in
-``models.py``, so that it will only return ``True`` if the date is also in the
+:file:`models.py`, so that it will only return ``True`` if the date is also in the
 past:
 
 .. snippet::
@@ -337,11 +337,11 @@ The Django test client
 ----------------------
 
 Django provides a test :class:`~django.test.Client` to simulate a user
-interacting with the code at the view level.  We can use it in ``tests.py``
+interacting with the code at the view level.  We can use it in :file:`tests.py`
 or even in the :djadmin:`shell`.
 
 We will start again with the :djadmin:`shell`, where we need to do a couple of
-things that won't be necessary in ``tests.py``. The first is to set up the test
+things that won't be necessary in :file:`tests.py`. The first is to set up the test
 environment in the :djadmin:`shell`:
 
 .. console::
@@ -359,10 +359,10 @@ which will allow us to examine some additional attributes on responses such as
 method *does not* setup a test database, so the following will be run against
 the existing database and the output may differ slightly depending on what
 questions you already created. You might get unexpected results if your
-``TIME_ZONE`` in ``settings.py`` isn't correct. If you don't remember setting
+``TIME_ZONE`` in :file:`settings.py` isn't correct. If you don't remember setting
 it earlier, check it before continuing.
 
-Next we need to import the test client class (later in ``tests.py`` we will use
+Next we need to import the test client class (later in :file:`tests.py` we will use
 the :class:`django.test.TestCase` class, which comes with its own client, so
 this won't be required)::
 
@@ -448,7 +448,7 @@ are listed.  You don't want to have to do that *every single time you make any
 change that might affect this* - so let's also create a test, based on our
 :djadmin:`shell` session above.
 
-Add the following to ``polls/tests.py``:
+Add the following to :file:`polls/tests.py`:
 
 .. snippet::
     :filename: polls/tests.py

--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -24,9 +24,9 @@ single location that can easily be served in production.
 Customize your *app's* look and feel
 ====================================
 
-First, create a directory called ``static`` in your ``polls`` directory. Django
+First, create a directory called :file:`static` in your :file:`polls` directory. Django
 will look for static files there, similarly to how Django finds templates
-inside ``polls/templates/``.
+inside :file:`polls/templates/`.
 
 Django's :setting:`STATICFILES_FINDERS` setting contains a list
 of finders that know how to discover static files from various
@@ -35,9 +35,9 @@ looks for a "static" subdirectory in each of the
 :setting:`INSTALLED_APPS`, like the one in ``polls`` we just created. The admin
 site uses the same directory structure for its static files.
 
-Within the ``static`` directory you have just created, create another directory
-called ``polls`` and within that create a file called ``style.css``. In other
-words, your stylesheet should be at ``polls/static/polls/style.css``. Because
+Within the :file:`static` directory you have just created, create another directory
+called :file:`polls` and within that create a file called :file:`style.css`. In other
+words, your stylesheet should be at :file:`polls/static/polls/style.css`. Because
 of how the ``AppDirectoriesFinder`` staticfile finder works, you can refer to
 this static file in Django simply as ``polls/style.css``, similar to how you
 reference the path for templates.
@@ -45,7 +45,7 @@ reference the path for templates.
 .. admonition:: Static file namespacing
 
     Just like templates, we *might* be able to get away with putting our static
-    files directly in ``polls/static`` (rather than creating another ``polls``
+    files directly in :file:`polls/static` (rather than creating another :file:`polls`
     subdirectory), but it would actually be a bad idea. Django will choose the
     first static file it finds whose name matches, and if you had a static file
     with the same name in a *different* application, Django would be unable to
@@ -54,7 +54,7 @@ reference the path for templates.
     by putting those static files inside *another* directory named for the
     application itself.
 
-Put the following code in that stylesheet (``polls/static/polls/style.css``):
+Put the following code in that stylesheet (:file:`polls/static/polls/style.css`):
 
 .. snippet:: css
     :filename: polls/static/polls/style.css
@@ -63,7 +63,7 @@ Put the following code in that stylesheet (``polls/static/polls/style.css``):
         color: green;
     }
 
-Next, add the following at the top of ``polls/templates/polls/index.html``:
+Next, add the following at the top of :file:`polls/templates/polls/index.html`:
 
 .. snippet:: html+django
     :filename: polls/templates/polls/index.html
@@ -81,12 +81,12 @@ green (Django style!) which means that your stylesheet was properly loaded.
 Adding a background-image
 =========================
 
-Next, we'll create a subdirectory for images. Create an ``images`` subdirectory
-in the ``polls/static/polls/`` directory. Inside this directory, put an image
-called ``background.gif``. In other words, put your image in
-``polls/static/polls/images/background.gif``.
+Next, we'll create a subdirectory for images. Create an :file:`images` subdirectory
+in the :file:`polls/static/polls/` directory. Inside this directory, put an image
+called :file:`background.gif`. In other words, put your image in
+:file:`polls/static/polls/images/background.gif`.
 
-Then, add to your stylesheet (``polls/static/polls/style.css``):
+Then, add to your stylesheet (:file:`polls/static/polls/style.css`):
 
 .. snippet:: css
     :filename: polls/static/polls/style.css

--- a/docs/intro/tutorial07.txt
+++ b/docs/intro/tutorial07.txt
@@ -293,8 +293,8 @@ system.
 Customizing your *project's* templates
 --------------------------------------
 
-Create a ``templates`` directory in your project directory (the one that
-contains ``manage.py``). Templates can live anywhere on your filesystem that
+Create a :file:`templates` directory in your project directory (the one that
+contains :file:`manage.py`). Templates can live anywhere on your filesystem that
 Django can access. (Django runs as whatever user your server runs.) However,
 keeping your templates within the project is a good convention to follow.
 
@@ -328,14 +328,14 @@ when loading Django templates; it's a search path.
     Just like the static files, we *could* have all our templates together, in
     one big templates directory, and it would work perfectly well. However,
     templates that belong to a particular application should be placed in that
-    application's template directory (e.g. ``polls/templates``) rather than the
-    project's (``templates``). We'll discuss in more detail in the
+    application's template directory (e.g. :file:`polls/templates`) rather than the
+    project's (:file:`templates`). We'll discuss in more detail in the
     :doc:`reusable apps tutorial </intro/reusable-apps>` *why* we do this.
 
-Now create a directory called ``admin`` inside ``templates``, and copy the
+Now create a directory called ``admin`` inside :file:`templates`, and copy the
 template ``admin/base_site.html`` from within the default Django admin
 template directory in the source code of Django itself
-(``django/contrib/admin/templates``) into that directory.
+(:file:`django/contrib/admin/templates`) into that directory.
 
 .. admonition:: Where are the Django source files?
 
@@ -379,7 +379,7 @@ Customizing your *application's* templates
 Astute readers will ask: But if :setting:`DIRS <TEMPLATES-DIRS>` was empty by
 default, how was Django finding the default admin templates? The answer is
 that, since :setting:`APP_DIRS <TEMPLATES-APP_DIRS>` is set to ``True``,
-Django automatically looks for a ``templates/`` subdirectory within each
+Django automatically looks for a :file:`templates/` subdirectory within each
 application package, for use as a fallback (don't forget that
 ``django.contrib.admin`` is an application).
 

--- a/docs/intro/whatsnext.txt
+++ b/docs/intro/whatsnext.txt
@@ -138,11 +138,11 @@ For offline reading, or just for convenience, you can read the Django
 documentation in plain text.
 
 If you're using an official release of Django, the zipped package (tarball) of
-the code includes a ``docs/`` directory, which contains all the documentation
+the code includes a :file:`docs/` directory, which contains all the documentation
 for that release.
 
 If you're using the development version of Django (aka the master branch), the
-``docs/`` directory contains all of the documentation. You can update your
+:file:`docs/` directory contains all of the documentation. You can update your
 Git checkout to get the latest changes.
 
 One low-tech way of taking advantage of the text documentation is by using the
@@ -184,7 +184,7 @@ You can get a local copy of the HTML documentation following a few easy steps:
         cd path\to\django\docs
         make.bat html
 
-* The HTML documentation will be placed in ``docs/_build/html``.
+* The HTML documentation will be placed in :file:`docs/_build/html`.
 
 __ http://sphinx-doc.org/
 __ https://www.gnu.org/software/make/


### PR DESCRIPTION
Use `file` role in reStructuredText Markup for directories and files.