### PR TITLE
Lowercase "web," per AP Style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Django is a high-level Python Web framework that encourages rapid development
+Django is a high-level Python web framework that encourages rapid development
 and clean, pragmatic design. Thanks for checking it out.
 
 All documentation is in the "``docs``" directory and online at


### PR DESCRIPTION
According to the Associated Press' official style guide, the word "web" has been lowercase [since 2016](https://twitter.com/apstylebook/status/716279539052191746?lang=en). Let's change it here as well.