### PR TITLE
Fixed app order in settings for tutorial.

### DIFF
--- a/docs/intro/tutorial02.txt
+++ b/docs/intro/tutorial02.txt
@@ -215,13 +215,13 @@ this:
     :filename: mysite/settings.py
 
     INSTALLED_APPS = [
-        'polls.apps.PollsConfig',
         'django.contrib.admin',
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
         'django.contrib.messages',
         'django.contrib.staticfiles',
+        'polls.apps.PollsConfig',
     ]
 
 Now Django knows to include the ``polls`` app. Let's run another command:


### PR DESCRIPTION
I was following the tutorial and I got an error that polls.app is not an app...
So after changing the order the error disappeared.