### PR TITLE
Fixed #29449 -- Reverted "Fixed #28757 -- Allowed using contrib.auth forms without installing contrib.auth."

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -7,6 +7,7 @@ from django.contrib.auth import (
 from django.contrib.auth.hashers import (
     UNUSABLE_PASSWORD_PREFIX, identify_hasher,
 )
+from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMultiAlternatives
@@ -82,9 +83,9 @@ class UserCreationForm(forms.ModelForm):
     )
 
     class Meta:
-        model = UserModel
-        fields = (UserModel.USERNAME_FIELD,)
-        field_classes = {UserModel.USERNAME_FIELD: UsernameField}
+        model = User
+        fields = ("username",)
+        field_classes = {'username': UsernameField}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -131,9 +132,9 @@ class UserChangeForm(forms.ModelForm):
     )
 
     class Meta:
-        model = UserModel
+        model = User
         fields = '__all__'
-        field_classes = {UserModel.USERNAME_FIELD: UsernameField}
+        field_classes = {'username': UsernameField}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/docs/topics/auth/customizing.txt
+++ b/docs/topics/auth/customizing.txt
@@ -814,20 +814,11 @@ are working with.
 The following forms are compatible with any subclass of
 :class:`~django.contrib.auth.models.AbstractBaseUser`:
 
-* :class:`~django.contrib.auth.forms.AuthenticationForm`
+* :class:`~django.contrib.auth.forms.AuthenticationForm`: Uses the username
+  field specified by :attr:`~models.CustomUser.USERNAME_FIELD`.
 * :class:`~django.contrib.auth.forms.SetPasswordForm`
 * :class:`~django.contrib.auth.forms.PasswordChangeForm`
 * :class:`~django.contrib.auth.forms.AdminPasswordChangeForm`
-* :class:`~django.contrib.auth.forms.UserCreationForm`
-* :class:`~django.contrib.auth.forms.UserChangeForm`
-
-The forms that handle a username use the username field specified by
-:attr:`~models.CustomUser.USERNAME_FIELD`.
-
-.. versionchanged:: 2.1
-
-    In older versions, ``UserCreationForm`` and ``UserChangeForm`` need to be
-    rewritten to work with custom user models.
 
 The following forms make assumptions about the user model and can be used as-is
 if those assumptions are met:
@@ -837,6 +828,25 @@ if those assumptions are met:
   by :meth:`~models.AbstractBaseUser.get_email_field_name` (``email`` by
   default) that can be used to identify the user and a boolean field named
   ``is_active`` to prevent password resets for inactive users.
+
+Finally, the following forms are tied to
+:class:`~django.contrib.auth.models.User` and need to be rewritten or extended
+to work with a custom user model:
+
+* :class:`~django.contrib.auth.forms.UserCreationForm`
+* :class:`~django.contrib.auth.forms.UserChangeForm`
+
+If your custom user model is a simple subclass of ``AbstractUser``, then you
+can extend these forms in this manner::
+
+    from django.contrib.auth.forms import UserCreationForm
+    from myapp.models import CustomUser
+
+    class CustomUserCreationForm(UserCreationForm):
+
+        class Meta(UserCreationForm.Meta):
+            model = CustomUser
+            fields = UserCreationForm.Meta.fields + ('custom_field',)
 
 Custom users and :mod:`django.contrib.admin`
 --------------------------------------------

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1508,12 +1508,9 @@ provides several built-in forms located in :mod:`django.contrib.auth.forms`:
 
     A :class:`~django.forms.ModelForm` for creating a new user.
 
-    It has three fields: one named after the
-    :attr:`~django.contrib.auth.models.CustomUser.USERNAME_FIELD` from the
-    user model, and ``password1`` and ``password2``.
-
-    It verifies that ``password1`` and ``password2`` match, validates the
-    password using
+    It has three fields: ``username`` (from the user model), ``password1``,
+    and ``password2``. It verifies that ``password1`` and ``password2`` match,
+    validates the password using
     :func:`~django.contrib.auth.password_validation.validate_password`, and
     sets the user's password using
     :meth:`~django.contrib.auth.models.User.set_password()`.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29449