### PR TITLE
Fix typo in json_script docs

### DIFF
--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1804,7 +1804,7 @@ For example::
 
     {{ value|json_script:"hello-data" }}
 
-If ``value`` is a the dictionary ``{'hello': 'world'}``, the output will be:
+If ``value`` is the dictionary ``{'hello': 'world'}``, the output will be:
 
 .. code-block:: html
 


### PR DESCRIPTION
Fix typo in the documentation about `json_script` template filter from 8c709d7.