### PR TITLE
Refs #26608 -- Removed unneeded name attribute in window functions.

### DIFF
--- a/django/db/models/functions/window.py
+++ b/django/db/models/functions/window.py
@@ -8,14 +8,12 @@ __all__ = [
 
 class CumeDist(Func):
     function = 'CUME_DIST'
-    name = 'CumeDist'
     output_field = FloatField()
     window_compatible = True
 
 
 class DenseRank(Func):
     function = 'DENSE_RANK'
-    name = 'DenseRank'
     output_field = IntegerField()
     window_compatible = True
 
@@ -23,7 +21,6 @@ class DenseRank(Func):
 class FirstValue(Func):
     arity = 1
     function = 'FIRST_VALUE'
-    name = 'FirstValue'
     window_compatible = True
 
 
@@ -53,24 +50,20 @@ class LagLeadFunction(Func):
 
 class Lag(LagLeadFunction):
     function = 'LAG'
-    name = 'Lag'
 
 
 class LastValue(Func):
     arity = 1
     function = 'LAST_VALUE'
-    name = 'LastValue'
     window_compatible = True
 
 
 class Lead(LagLeadFunction):
     function = 'LEAD'
-    name = 'Lead'
 
 
 class NthValue(Func):
     function = 'NTH_VALUE'
-    name = 'NthValue'
     window_compatible = True
 
     def __init__(self, expression, nth=1, **extra):
@@ -87,7 +80,6 @@ class NthValue(Func):
 
 class Ntile(Func):
     function = 'NTILE'
-    name = 'Ntile'
     output_field = IntegerField()
     window_compatible = True
 
@@ -99,20 +91,17 @@ class Ntile(Func):
 
 class PercentRank(Func):
     function = 'PERCENT_RANK'
-    name = 'PercentRank'
     output_field = FloatField()
     window_compatible = True
 
 
 class Rank(Func):
     function = 'RANK'
-    name = 'Rank'
     output_field = IntegerField()
     window_compatible = True
 
 
 class RowNumber(Func):
     function = 'ROW_NUMBER'
-    name = 'RowNumber'
     output_field = IntegerField()
     window_compatible = True


### PR DESCRIPTION
@ngnpope correctly pointed out that `name` is an unneeded attribute.