### PR TITLE
Fixed #29544 -- Fixed regex lookup on MariaDB.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -326,11 +326,19 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return True
 
     @cached_property
-    def mysql_version(self):
+    def mysql_server_info(self):
         with self.temporary_connection() as cursor:
             cursor.execute('SELECT VERSION()')
-            server_info = cursor.fetchone()[0]
-        match = server_version_re.match(server_info)
+            return cursor.fetchone()[0]
+
+    @cached_property
+    def mysql_version(self):
+        match = server_version_re.match(self.mysql_server_info)
         if not match:
-            raise Exception('Unable to determine MySQL version from version string %r' % server_info)
+            raise Exception('Unable to determine MySQL version from version string %r' % self.mysql_server_info)
         return tuple(int(x) for x in match.groups())
+
+    @cached_property
+    def mysql_is_mariadb(self):
+        # MariaDB isn't officially supported.
+        return 'mariadb' in self.mysql_server_info.lower()

--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -285,8 +285,8 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def regex_lookup(self, lookup_type):
         # REGEXP BINARY doesn't work correctly in MySQL 8+ and REGEXP_LIKE
-        # doesn't exist in MySQL 5.6.
-        if self.connection.mysql_version < (8, 0, 0):
+        # doesn't exist in MySQL 5.6 or in MariaDB.
+        if self.connection.mysql_version < (8, 0, 0) or self.connection.mysql_is_mariadb:
             if lookup_type == 'regex':
                 return '%s REGEXP BINARY %s'
             return '%s REGEXP %s'

--- a/docs/releases/2.0.8.txt
+++ b/docs/releases/2.0.8.txt
@@ -9,4 +9,5 @@ Django 2.0.8 fixes several bugs in 2.0.7.
 Bugfixes
 ========
 
-* ...
+* Fixed a regression in Django 2.0.7 that broke the ``regex`` lookup on MariaDB
+  (even though MariaDB isn't officially supported) (:ticket:`29544`).


### PR DESCRIPTION
The REGEXP_LIKE fuction is currently available only in MySQL
and not in MariaDB.