### PR TITLE
Fixed #20584 -- Fixed memcached's get_many() with single-use iterators.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -168,6 +168,7 @@ answer newbie questions, and generally made Django that much better:
     Chris Jones <chris@brack3t.com>
     Chris Lamb <chris@chris-lamb.co.uk>
     Chris Streeter <chris@chrisstreeter.com>
+    Christian Barcenas <christian@cbarcenas.com>
     Christian Metts
     Christian Oudard <christian.oudard@gmail.com>
     Christian Tanzer <tanzer@swing.co.at>

--- a/django/core/cache/backends/memcached.py
+++ b/django/core/cache/backends/memcached.py
@@ -84,12 +84,9 @@ class BaseMemcachedCache(BaseCache):
         self._cache.delete(key)
 
     def get_many(self, keys, version=None):
-        new_keys = [self.make_key(x, version=version) for x in keys]
-        ret = self._cache.get_multi(new_keys)
-        if ret:
-            m = dict(zip(new_keys, keys))
-            return {m[k]: v for k, v in ret.items()}
-        return ret
+        key_map = {self.make_key(key, version=version): key for key in keys}
+        ret = self._cache.get_multi(key_map.keys())
+        return {key_map[k]: v for k, v in ret.items()}
 
     def close(self, **kwargs):
         # Many clients don't clean up connections properly.

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -312,6 +312,7 @@ class BaseCacheTests:
         cache.set('d', 'd')
         self.assertEqual(cache.get_many(['a', 'c', 'd']), {'a': 'a', 'c': 'c', 'd': 'd'})
         self.assertEqual(cache.get_many(['a', 'b', 'e']), {'a': 'a', 'b': 'b'})
+        self.assertEqual(cache.get_many(iter(['a', 'b', 'e'])), {'a': 'a', 'b': 'b'})
 
     def test_delete(self):
         # Cache keys can be deleted


### PR DESCRIPTION
The Django cache get_many() method is supposed to accept any iterable of
cache keys as input.

However, the Memcache cache get_many() implementation will fail on iterators,
because it tries to iterate over the contents of the iterator more than once.

This change fixes the aforementioned bug by ensuring that the iterator
is consumed only once by get_many().

Thanks to Guyon Morée for the report!