### PR TITLE
Removed usage of 'object' variable name in docs.

### DIFF
--- a/docs/topics/class-based-views/generic-display.txt
+++ b/docs/topics/class-based-views/generic-display.txt
@@ -418,13 +418,11 @@ object -- so we simply override it and wrap the call::
         queryset = Author.objects.all()
 
         def get_object(self):
-            # Call the superclass
-            object = super().get_object()
+            obj = super().get_object()
             # Record the last accessed date
-            object.last_accessed = timezone.now()
-            object.save()
-            # Return the object
-            return object
+            obj.last_accessed = timezone.now()
+            obj.save()
+            return obj
 
 .. note::
 

--- a/docs/topics/http/shortcuts.txt
+++ b/docs/topics/http/shortcuts.txt
@@ -127,8 +127,8 @@ You can use the :func:`redirect` function in a number of ways.
 
         def my_view(request):
             ...
-            object = MyModel.objects.get(...)
-            return redirect(object)
+            obj = MyModel.objects.get(...)
+            return redirect(obj)
 
 2. By passing the name of a view and optionally some positional or
    keyword arguments; the URL will be reverse resolved using the
@@ -156,8 +156,8 @@ will be returned::
 
     def my_view(request):
         ...
-        object = MyModel.objects.get(...)
-        return redirect(object, permanent=True)
+        obj = MyModel.objects.get(...)
+        return redirect(obj, permanent=True)
 
 ``get_object_or_404()``
 =======================
@@ -190,7 +190,7 @@ The following example gets the object with the primary key of 1 from
     from django.shortcuts import get_object_or_404
 
     def my_view(request):
-        my_object = get_object_or_404(MyModel, pk=1)
+        obj = get_object_or_404(MyModel, pk=1)
 
 This example is equivalent to::
 
@@ -198,7 +198,7 @@ This example is equivalent to::
 
     def my_view(request):
         try:
-            my_object = MyModel.objects.get(pk=1)
+            obj = MyModel.objects.get(pk=1)
         except MyModel.DoesNotExist:
             raise Http404("No MyModel matches the given query.")
 


### PR DESCRIPTION
`object` is a keyword in python, despite the name of the function `get_object` we shouldn't use the variable name `object` inside the function.