### PR TITLE
Change Spanish noun for "sentence"

### DIFF
--- a/docs/ref/files/file.txt
+++ b/docs/ref/files/file.txt
@@ -99,7 +99,7 @@ The ``ContentFile`` class
 
         from django.core.files.base import ContentFile
 
-        f1 = ContentFile("esta sentencia está en español")
+        f1 = ContentFile("esta frase está en español")
         f2 = ContentFile(b"these are bytes")
 
 .. currentmodule:: django.core.files.images


### PR DESCRIPTION
A `sentencia` is a sentence from a judge, it doesn't fit here. Either `frase` or `oración` works better.