### PR TITLE
Fixed #29538 -- Added support for ordering related objects by query expressions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ answer newbie questions, and generally made Django that much better:
     Alexander Dutton <dev@alexdutton.co.uk>
     Alexander Myodov <alex@myodov.com>
     Alexandr Tatarinov <tatarinov1997@gmail.com>
+    Alexandre Laplante <https://github.com/alexandrelaplante>
     Alex Couper <http://alexcouper.com/>
     Alex Dedul
     Alex Gaynor <alex.gaynor@gmail.com>

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import re
 import warnings
+from copy import deepcopy
 from itertools import chain
 
 from django.core.exceptions import EmptyResultSet, FieldError
@@ -661,7 +662,6 @@ class SQLCompiler:
 
         if hasattr(name, 'resolve_expression'):
 
-            from copy import deepcopy
             field = deepcopy(name)
 
             if not isinstance(field, OrderBy):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -699,10 +699,10 @@ class SQLCompiler:
             results = []
             for item in opts.ordering:
 
-                def _join_strings(*strings):
-                    return LOOKUP_SEP.join(filter(None, strings))
-
-                new_prefix = _join_strings(prefix, name)
+                if prefix is None:
+                    new_prefix = name
+                else:
+                    new_prefix = prefix + LOOKUP_SEP + name
 
                 results.extend(self.convert_to_expression(item, opts, alias, order,
                                                           already_seen, new_prefix))

--- a/tests/order_with_expression/models.py
+++ b/tests/order_with_expression/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+
+class Musician(models.Model):
+    instrument = models.CharField(max_length=100, null=True, blank=True)
+
+    class Meta:
+        ordering = [models.F('instrument').asc(nulls_last=True)]
+
+
+class Album(models.Model):
+    artist = models.ForeignKey(Musician, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        ordering = ['artist']
+
+
+class Song(models.Model):
+    album = models.ForeignKey(Album, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        ordering = ['album']

--- a/tests/order_with_expression/tests.py
+++ b/tests/order_with_expression/tests.py
@@ -1,10 +1,10 @@
-from unittest import mock, skip
 from operator import attrgetter
+from unittest import mock, skip
 
-from django.test import TestCase
 from django.db import models
+from django.test import TestCase
 
-from .models import Musician, Album, Song
+from .models import Album, Musician, Song
 
 
 class OrderWithExpressionTests(TestCase):

--- a/tests/order_with_expression/tests.py
+++ b/tests/order_with_expression/tests.py
@@ -1,0 +1,131 @@
+from unittest import mock, skip
+from operator import attrgetter
+
+from django.test import TestCase
+from django.db import models
+
+from .models import Musician, Album, Song
+
+
+class OrderWithExpressionTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.musician1 = Musician.objects.create(instrument='mayonaise')
+        cls.musician3 = Musician.objects.create(instrument=None)
+        cls.musician2 = Musician.objects.create(instrument='zoo')
+
+        cls.album1 = Album.objects.create(
+            artist=cls.musician1,
+            name='Album 1',
+        )
+        cls.album3 = Album.objects.create(
+            artist=cls.musician3,
+            name='Album 3',
+        )
+        cls.album2 = Album.objects.create(
+            artist=cls.musician2,
+            name='Album 2',
+        )
+
+        cls.song1 = Song.objects.create(
+            album=cls.album1,
+            name='Song 1',
+        )
+        cls.song3 = Song.objects.create(
+            album=cls.album3,
+            name='Song 3',
+        )
+        cls.song2 = Song.objects.create(
+            album=cls.album2,
+            name='Song 2',
+        )
+
+    def test_order_by_expression_nulls_last(self):
+        self.assertQuerysetEqual(
+            Musician.objects.all(),
+            ['mayonaise', 'zoo', None],
+            attrgetter('instrument')
+        )
+
+    def test_order_by_related_expression_nulls_last(self):
+        self.assertQuerysetEqual(
+            Album.objects.all(),
+            ['Album 1', 'Album 2', 'Album 3'],
+            attrgetter('name')
+        )
+
+    def test_order_by_related_expression_through_related_field_nulls_last(self):
+        self.assertQuerysetEqual(
+            Song.objects.all(),
+            ['Song 1', 'Song 2', 'Song 3'],
+            attrgetter('name')
+        )
+
+    def test_order_by_expression_nulls_first(self):
+
+        ordering = [models.F('instrument').asc(nulls_first=True)]
+
+        with mock.patch.object(Musician._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Musician.objects.all(),
+                [None, 'mayonaise', 'zoo'],
+                attrgetter('instrument')
+            )
+
+    def test_order_by_related_expression_nulls_first(self):
+
+        ordering = [models.F('instrument').asc(nulls_first=True)]
+
+        with mock.patch.object(Musician._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Album.objects.all(),
+                ['Album 3', 'Album 1', 'Album 2'],
+                attrgetter('name')
+            )
+
+    def test_depth_3_nulls_first(self):
+
+        ordering = [models.F('instrument').asc(nulls_first=True)]
+
+        with mock.patch.object(Musician._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Song.objects.all(),
+                ['Song 3', 'Song 1', 'Song 2'],
+                attrgetter('name')
+            )
+
+    @skip('What should the behavior be?')
+    def test_order_by_related_expression_through_expression(self):
+
+        ordering = [models.F('artist').asc(nulls_first=True)]
+
+        with mock.patch.object(Album._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Album.objects.all(),
+                ['Album 3', 'Album 1', 'Album 2'],
+                attrgetter('name')
+            )
+
+    @skip('What should the behavior be?')
+    def test_order_by_related_expression_through_related_expression(self):
+
+        ordering = [models.F('artist').asc(nulls_first=True)]
+
+        with mock.patch.object(Album._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Song.objects.all(),
+                ['Song 3', 'Song 1', 'Song 2'],
+                attrgetter('name')
+            )
+
+    def test_order_by_expression_through_double_forward_relation(self):
+
+        ordering = ['album__artist']
+
+        with mock.patch.object(Song._meta, 'ordering', ordering):
+            self.assertQuerysetEqual(
+                Song.objects.all(),
+                ['Song 1', 'Song 2', 'Song 3'],
+                attrgetter('name')
+            )

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -47,3 +47,15 @@ class Reference(models.Model):
 
     class Meta:
         ordering = ('article',)
+
+
+class CircularAuthor(models.Model):
+    class Meta:
+        ordering = ('circulararticle',)
+
+
+class CircularArticle(models.Model):
+    author = models.ForeignKey(CircularAuthor, models.CASCADE)
+
+    class Meta:
+        ordering = ('author',)

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -42,12 +42,6 @@ class OrderedByAuthorArticle(Article):
         ordering = ('author', 'second_author')
 
 
-class OrderedByFArticle(Article):
-    class Meta:
-        proxy = True
-        ordering = (models.F('author').asc(nulls_first=True), 'id')
-
-
 class Reference(models.Model):
     article = models.ForeignKey(OrderedByAuthorArticle, models.CASCADE)
 

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -5,7 +5,7 @@ from django.db.models import DateTimeField, F, Max, OuterRef, Subquery
 from django.db.models.functions import Upper
 from django.test import TestCase
 
-from .models import Article, Author, OrderedByFArticle, Reference
+from .models import Article, Author, Reference
 
 
 class OrderingTests(TestCase):
@@ -393,13 +393,3 @@ class OrderingTests(TestCase):
         r1 = Reference.objects.create(article_id=self.a1.pk)
         r2 = Reference.objects.create(article_id=self.a2.pk)
         self.assertSequenceEqual(Reference.objects.all(), [r2, r1])
-
-    def test_default_ordering_by_f_expression(self):
-        """F expressions can be used in Meta.ordering."""
-        articles = OrderedByFArticle.objects.all()
-        articles.filter(headline='Article 2').update(author=self.author_2)
-        articles.filter(headline='Article 3').update(author=self.author_1)
-        self.assertQuerysetEqual(
-            articles, ['Article 1', 'Article 4', 'Article 3', 'Article 2'],
-            attrgetter('headline')
-        )

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from operator import attrgetter
 
+from django.core.exceptions import FieldError
 from django.db.models import DateTimeField, F, Max, OuterRef, Subquery
 from django.db.models.functions import Upper
 from django.test import TestCase
 
-from .models import Article, Author, Reference
+from .models import Article, Author, CircularArticle, Reference
 
 
 class OrderingTests(TestCase):
@@ -393,3 +394,8 @@ class OrderingTests(TestCase):
         r1 = Reference.objects.create(article_id=self.a1.pk)
         r2 = Reference.objects.create(article_id=self.a2.pk)
         self.assertSequenceEqual(Reference.objects.all(), [r2, r1])
+
+    def test_circular_ordering(self):
+        msg = 'Infinite loop caused by ordering.'
+        with self.assertRaisesMessage(FieldError, msg):
+            list(CircularArticle.objects.all())


### PR DESCRIPTION
Added support for ordering related objects by query expressions

https://code.djangoproject.com/ticket/29538