### PR TITLE
Add check for type of ALLOWED_HOSTS

### DIFF
--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -106,6 +106,11 @@ W021 = Warning(
     id='security.W021',
 )
 
+W022 = Warning(
+    "ALLOWED_HOSTS should be list, not string.",
+    id='security.W022',
+)
+
 
 def _security_middleware():
     return 'django.middleware.security.SecurityMiddleware' in settings.MIDDLEWARE
@@ -208,3 +213,8 @@ def check_xframe_deny(app_configs, **kwargs):
 @register(Tags.security, deploy=True)
 def check_allowed_hosts(app_configs, **kwargs):
     return [] if settings.ALLOWED_HOSTS else [W020]
+
+
+@register(Tags.security, deploy=True)
+def check_type_of_allowed_hosts(app_configs, **kwargs):
+    return [] if not isinstance(settings.ALLOWED_HOSTS, str) else [W022]

--- a/tests/check_framework/test_security.py
+++ b/tests/check_framework/test_security.py
@@ -534,3 +534,18 @@ class CheckAllowedHostsTest(SimpleTestCase):
     @override_settings(ALLOWED_HOSTS=['.example.com'])
     def test_allowed_hosts_set(self):
         self.assertEqual(self.func(None), [])
+
+
+class CheckTypeOfAllowedHostsTest(SimpleTestCase):
+    @property
+    def func(self):
+        from django.core.checks.security.base import check_type_of_allowed_hosts
+        return check_type_of_allowed_hosts
+
+    @override_settings(ALLOWED_HOSTS='example.com')
+    def test_allowed_hosts_is_string(self):
+        self.assertEqual(self.func(None), [base.W022])
+
+    @override_settings(ALLOWED_HOSTS=['example.com'])
+    def test_allowed_hosts_is_list(self):
+        self.assertEqual(self.func(None), [])


### PR DESCRIPTION
Python has strange behavior that is iterating over the list and over the string is done in the same way `for item in str_or_list:`. This makes many bugs to happen. For example, if we set `ALLOWED_HOSTS = 'example.com'` this will perform check of the `Host:` header against each character in this string, but I'm sure that there are no single character domains on the internet.