### PR TITLE
A minor fix to support Python 3.7

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -149,7 +149,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             params = self.url_parameters()
             if params:
                 related_url += '?' + '&amp;'.join(
-                    '%s=%s' % (k, v) for k, v in params.items(),
+                    ('%s=%s' % (k, v) for k, v in params.items())
                 )
             context['related_url'] = mark_safe(related_url)
             context['link_title'] = _('Lookup')


### PR DESCRIPTION
Previously threw a "SyntaxError: Generator expression must be parenthesized" as the new Python3.7 has added a small "change in python behavior" as documented in the python docs: https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior