### PR TITLE
Fixed #29553 -- Made test client set Content-Length header to a string rather than integer.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -401,7 +401,7 @@ class RequestFactory:
         }
         if data:
             r.update({
-                'CONTENT_LENGTH': len(data),
+                'CONTENT_LENGTH': str(len(data)),
                 'CONTENT_TYPE': content_type,
                 'wsgi.input': FakePayload(data),
             })

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -228,6 +228,9 @@ Miscellaneous
   have existing invalid data and run a migration that recreates a table, you'll
   see ``CHECK constraint failed``.
 
+* For consistency with WSGI servers, the test client now sets the
+  ``Content-Length`` header to a string rather than an integer.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/test_client/tests.py
+++ b/tests/test_client/tests.py
@@ -122,7 +122,7 @@ class ClientTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.templates[0].name, 'PUT Template')
         self.assertEqual(response.context['data'], "{'foo': 'bar'}")
-        self.assertEqual(response.context['Content-Length'], 14)
+        self.assertEqual(response.context['Content-Length'], '14')
 
     def test_trace(self):
         """TRACE a view"""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29553