### PR TITLE
Fixed #28862 Removing a field from index_together/unique_together and from the model generates a migration that crashes

### DIFF
--- a/django/core/management/commands/squashmigrations.py
+++ b/django/core/management/commands/squashmigrations.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.MIGRATE_HEADING("Optimizing..."))
 
             optimizer = MigrationOptimizer()
-            new_operations = optimizer.optimize(operations, migration.app_label)
+            new_operations = optimizer.optimize(operations, app_label=migration.app_label)
 
             if self.verbosity > 0:
                 if len(new_operations) == len(operations):

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -355,7 +355,11 @@ class MigrationAutodetector:
         # Optimize migrations
         for app_label, migrations in self.migrations.items():
             for migration in migrations:
-                migration.operations = MigrationOptimizer().optimize(migration.operations, app_label=app_label)
+                migration.operations = MigrationOptimizer().optimize(
+                    migration.operations,
+                    from_state=self.from_state.models,
+                    app_label=app_label
+                )
 
     def check_dependency(self, operation, dependency):
         """

--- a/django/db/migrations/optimizer.py
+++ b/django/db/migrations/optimizer.py
@@ -1,3 +1,5 @@
+from django.db.migrations.operations.fields import RemoveField
+
 class MigrationOptimizer:
     """
     Power the optimization process, where you provide a list of Operations
@@ -51,10 +53,12 @@ class MigrationOptimizer:
                 try:
                     model_name = getattr(operation, "model_name", None) or operation.name
                     state = from_state[app_label, model_name]
-
-                    # flatten unique/indexed/order_with_respect fields into a set
-                    unique = {k for i in state.options.values() for j in i for k in j}
-                    can_optimize = can_optimize and operation.name not in unique
+                    if isinstance(operation, RemoveField) and bool(state.options):
+                        # flatten unique/indexed/order_with_respect fields into a set
+                        unique = {k for i in state.options.values() for j in i for k in j}
+                        can_optimize = can_optimize and operation.name not in unique
+                    else:
+                        can_optimize = False
                 except (AttributeError, KeyError, TypeError):
                     pass
 

--- a/django/db/migrations/optimizer.py
+++ b/django/db/migrations/optimizer.py
@@ -1,5 +1,6 @@
 from django.db.migrations.operations.fields import RemoveField
 
+
 class MigrationOptimizer:
     """
     Power the optimization process, where you provide a list of Operations

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -418,10 +418,6 @@ class AutodetectorTests(TestCase):
         "index_together": {("title", "newfield2")},
         "unique_together": {("title", "newfield2")},
     })
-    book_foo_together_5 = ModelState("otherapp", "Book", [
-        ("id", models.AutoField(primary_key=True)),
-        ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
-    ])
     attribution = ModelState("otherapp", "Attribution", [
         ("id", models.AutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
@@ -1494,24 +1490,10 @@ class AutodetectorTests(TestCase):
         )
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, "otherapp", 1)
-        self.assertOperationTypes(changes, "otherapp", 0, ["RemoveField", "AlterUniqueTogether", "AlterIndexTogether"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, model_name="book", name="newfield")
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={("author", "title")})
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("author", "title")})
-
-    def test_remove_field_that_was_indexed(self):
-        """
-        Removed fields will be removed after updating index/unique_together.
-        """
-        changes = self.get_changes(
-            [self.author_empty, self.book_foo_together], [self.author_empty, self.book_foo_together_5]
-        )
-        # Right number/type of migrations?
-        self.assertNumberMigrations(changes, "otherapp", 1)
         self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether", "RemoveField"])
-        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together=set())
-        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together=set())
-        self.assertOperationAttributes(changes, "otherapp", 0, 2, model_name="book", name="title")
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together={("author", "title")})
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together={("author", "title")})
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, model_name="book", name="newfield")
 
     def test_rename_field_and_foo_together(self):
         """

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -418,6 +418,10 @@ class AutodetectorTests(TestCase):
         "index_together": {("title", "newfield2")},
         "unique_together": {("title", "newfield2")},
     })
+    book_foo_together_5 = ModelState("otherapp", "Book", [
+        ("id", models.AutoField(primary_key=True)),
+        ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
+    ])
     attribution = ModelState("otherapp", "Attribution", [
         ("id", models.AutoField(primary_key=True)),
         ("author", models.ForeignKey("testapp.Author", models.CASCADE)),
@@ -1494,6 +1498,20 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, "otherapp", 0, 0, model_name="book", name="newfield")
         self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", unique_together={("author", "title")})
         self.assertOperationAttributes(changes, "otherapp", 0, 2, name="book", index_together={("author", "title")})
+
+    def test_remove_field_that_was_indexed(self):
+        """
+        Removed fields will be removed after updating index/unique_together.
+        """
+        changes = self.get_changes(
+            [self.author_empty, self.book_foo_together], [self.author_empty, self.book_foo_together_5]
+        )
+        # Right number/type of migrations?
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(changes, "otherapp", 0, ["AlterUniqueTogether", "AlterIndexTogether", "RemoveField"])
+        self.assertOperationAttributes(changes, "otherapp", 0, 0, name="book", unique_together=set())
+        self.assertOperationAttributes(changes, "otherapp", 0, 1, name="book", index_together=set())
+        self.assertOperationAttributes(changes, "otherapp", 0, 2, model_name="book", name="title")
 
     def test_rename_field_and_foo_together(self):
         """

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -16,7 +16,7 @@ class OptimizerTests(SimpleTestCase):
         Handy shortcut for getting results + number of loops
         """
         optimizer = MigrationOptimizer()
-        return optimizer.optimize(operations, app_label), optimizer._iterations
+        return optimizer.optimize(operations, app_label=app_label), optimizer._iterations
 
     def assertOptimizesTo(self, operations, expected, exact=None, less_than=None, app_label=None):
         result, iterations = self.optimize(operations, app_label)


### PR DESCRIPTION
update optimizer to correctly order RemoveField after any necessary removal restraints.