### PR TITLE
Fixed #29045 -- Fixed admin CSS so that select multiple elements honor the HTML size attribute.

### DIFF
--- a/django/contrib/admin/static/admin/css/base.css
+++ b/django/contrib/admin/static/admin/css/base.css
@@ -441,6 +441,8 @@ select {
 }
 
 select[multiple] {
+    /* Allow HTML size attribute to override the height in the rule above. */
+    height: auto;
     min-height: 150px;
 }
 


### PR DESCRIPTION
Multiple select controls in the Django admin pages were not honoring the
size HTML attribute. The underlying cause was a style rule for the
select element that forced the height to 30px. Fixing the issue was as
simple as introducing a new rule for the select[multiple] case.