### PR TITLE
Fixed #29559 -- Fixed TransactionTestCase.reset_sequences for auto-created m2m through models.

### DIFF
--- a/django/db/backends/base/introspection.py
+++ b/django/db/backends/base/introspection.py
@@ -127,7 +127,7 @@ class BaseDatabaseIntrospection:
                     for f in model._meta.local_many_to_many:
                         # If this is an m2m using an intermediate table,
                         # we don't need to reset the sequence.
-                        if f.remote_field.through is None:
+                        if f.remote_field.through._meta.auto_created:
                             sequence = self.get_sequences(cursor, f.m2m_db_table())
                             sequence_list.extend(sequence or [{'table': f.m2m_db_table(), 'column': None}])
         return sequence_list

--- a/tests/m2m_through_regress/models.py
+++ b/tests/m2m_through_regress/models.py
@@ -40,25 +40,6 @@ class Group(models.Model):
         return self.name
 
 
-# A set of models that use a non-abstract inherited model as the 'through' model.
-class A(models.Model):
-    a_text = models.CharField(max_length=20)
-
-
-class ThroughBase(models.Model):
-    a = models.ForeignKey(A, models.CASCADE)
-    b = models.ForeignKey('B', models.CASCADE)
-
-
-class Through(ThroughBase):
-    extra = models.CharField(max_length=20)
-
-
-class B(models.Model):
-    b_text = models.CharField(max_length=20)
-    a_list = models.ManyToManyField(A, through=Through)
-
-
 # Using to_field on the through model
 class Car(models.Model):
     make = models.CharField(max_length=20, unique=True, null=True)

--- a/tests/test_runner/models.py
+++ b/tests/test_runner/models.py
@@ -4,6 +4,7 @@ from django.db import models
 class Person(models.Model):
     first_name = models.CharField(max_length=20)
     last_name = models.CharField(max_length=20)
+    friends = models.ManyToManyField('self')
 
 
 # A set of models that use a non-abstract inherited 'through' model.

--- a/tests/test_runner/models.py
+++ b/tests/test_runner/models.py
@@ -4,3 +4,17 @@ from django.db import models
 class Person(models.Model):
     first_name = models.CharField(max_length=20)
     last_name = models.CharField(max_length=20)
+
+
+# A set of models that use a non-abstract inherited 'through' model.
+class ThroughBase(models.Model):
+    person = models.ForeignKey(Person, models.CASCADE)
+    b = models.ForeignKey('B', models.CASCADE)
+
+
+class Through(ThroughBase):
+    extra = models.CharField(max_length=20)
+
+
+class B(models.Model):
+    people = models.ManyToManyField(Person, through=Through)

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -342,6 +342,9 @@ class AutoIncrementResetTest(TransactionTestCase):
         # Regular model
         p = Person.objects.create(first_name='Jack', last_name='Smith')
         self.assertEqual(p.pk, 1)
+        # Auto-created many-to-many through model
+        p.friends.add(Person.objects.create(first_name='Jacky', last_name='Smith'))
+        self.assertEqual(p.friends.through.objects.first().pk, 1)
         # Many-to-many through model
         b = B.objects.create()
         t = Through.objects.create(person=p, b=b)


### PR DESCRIPTION
Properly detect whether a m2m is intermediate or not.

Open question remains whether `f.remote_field.through` can ever be `None`. Left check for safety reason for now.