### PR TITLE
Fixed #28478 -- Make DiscoverRunner skip creating unused test databases.

### DIFF
--- a/django/test/runner.py
+++ b/django/test/runner.py
@@ -391,6 +391,9 @@ class ParallelTestSuite(unittest.TestSuite):
 
         return result
 
+    def __iter__(self):
+        return iter(self.subsuites)
+
 
 class DiscoverRunner:
     """A Django test runner that uses unittest2 test discovery."""
@@ -587,6 +590,27 @@ class DiscoverRunner:
     def suite_result(self, suite, result, **kwargs):
         return len(result.failures) + len(result.errors)
 
+    def _get_databases(self, suite):
+        databases = set()
+        for test in suite:
+            if isinstance(test, unittest.TestCase):
+                test_databases = getattr(test, 'databases', None)
+                if test_databases == '__all__':
+                    return set(connections)
+                if test_databases:
+                    databases.update(test_databases)
+            else:
+                databases.update(self._get_databases(test))
+        return databases
+
+    def get_databases(self, suite):
+        databases = self._get_databases(suite)
+        if self.verbosity >= 2:
+            unused_databases = [alias for alias in connections if alias not in databases]
+            if unused_databases:
+                print('Skipping setup of unused database(s): %s.' % ', '.join(sorted(unused_databases)))
+        return databases
+
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         """
         Run the unit tests for all the test labels in the provided list.
@@ -601,7 +625,8 @@ class DiscoverRunner:
         """
         self.setup_test_environment()
         suite = self.build_suite(test_labels, extra_tests)
-        old_config = self.setup_databases()
+        databases = self.get_databases(suite)
+        old_config = self.setup_databases(aliases=databases)
         run_failed = False
         try:
             self.run_checks()

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -152,9 +152,9 @@ def teardown_test_environment():
     del mail.outbox
 
 
-def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, **kwargs):
+def setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs):
     """Create the test databases."""
-    test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
+    test_databases, mirrored_aliases = get_unique_databases_and_mirrors(aliases)
 
     old_names = []
 
@@ -238,7 +238,7 @@ def dependency_ordered(test_databases, dependencies):
     return ordered_test_databases
 
 
-def get_unique_databases_and_mirrors():
+def get_unique_databases_and_mirrors(aliases=None):
     """
     Figure out which databases actually need to be created.
 
@@ -250,6 +250,8 @@ def get_unique_databases_and_mirrors():
                       where all aliases share the same underlying database.
     - mirrored_aliases: mapping of mirror aliases to original aliases.
     """
+    if aliases is None:
+        aliases = connections
     mirrored_aliases = {}
     test_databases = {}
     dependencies = {}
@@ -262,7 +264,7 @@ def get_unique_databases_and_mirrors():
         if test_settings['MIRROR']:
             # If the database is marked as a test mirror, save the alias.
             mirrored_aliases[alias] = test_settings['MIRROR']
-        else:
+        elif alias in aliases:
             # Store a tuple with DB parameters that uniquely identify it.
             # If we have two aliases with the same values for that tuple,
             # we only need to create the test database once.

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -32,6 +32,9 @@ details on these changes.
 * ``RemoteUserBackend.configure_user()`` will require ``request`` as the first
   positional argument.
 
+* Support for ``SimpleTestCase.allow_database_queries`` and
+  ``TransactionTestCase.multi_db`` will be removed.
+
 .. _deprecation-removed-in-3.0:
 
 3.0

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -513,3 +513,12 @@ Miscellaneous
 * :meth:`.RemoteUserBackend.configure_user` is now passed ``request`` as the
   first positional argument, if it accepts it. Support for overrides that don't
   accept it will be removed in Django 3.1.
+
+* The :attr:`.SimpleTestCase.allow_database_queries`,
+  :attr:`.TransactionTestCase.multi_db`, and :attr:`.TestCase.multi_db`
+  attributes are deprecated in favor of :attr:`.SimpleTestCase.databases`,
+  :attr:`.TransactionTestCase.databases`, and :attr:`.TestCase.databases`.
+  These new attributes allow databases dependencies to be declared in order to
+  prevent unexpected queries against non-default databases to leak state
+  between tests. The previous behavior of ``allow_database_queries=True`` and
+  ``multi_db=True`` can be achieved by setting ``databases='__all__'``.

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -293,6 +293,9 @@ Tests
   for older versions of SQLite because they would require expensive table
   introspection there.
 
+* :class:`~django.test.runner.DiscoverRunner` now skips the setup of databases
+  not :ref:`referenced by tests<testing-multi-db>`.
+
 URLs
 ~~~~
 

--- a/docs/topics/testing/advanced.txt
+++ b/docs/topics/testing/advanced.txt
@@ -614,13 +614,21 @@ utility methods in the ``django.test.utils`` module.
     Performs global post-test teardown, such as removing instrumentation from
     the template system and restoring normal email services.
 
-.. function:: setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, **kwargs)
+.. function:: setup_databases(verbosity, interactive, keepdb=False, debug_sql=False, parallel=0, aliases=None, **kwargs)
 
     Creates the test databases.
 
     Returns a data structure that provides enough detail to undo the changes
     that have been made. This data will be provided to the
     :func:`teardown_databases` function at the conclusion of testing.
+
+    The ``aliases`` argument determines which :setting:`DATABASES` aliases test
+    databases should be setup for. If it's not provided, it defaults to all of
+    :setting:`DATABASES` aliases.
+
+    .. versionadded:: 2.2
+
+        The ``aliases`` argument was added.
 
 .. function:: teardown_databases(old_config, parallel=0, keepdb=False)
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1134,13 +1134,14 @@ Multi-database support
 .. versionadded:: 2.2
 
 Django sets up a test database corresponding to every database that is
-defined in the :setting:`DATABASES` definition in your settings
-file. However, a big part of the time taken to run a Django TestCase
-is consumed by the call to ``flush`` that ensures that you have a
-clean database at the start of each test run. If you have multiple
-databases, multiple flushes are required (one for each database),
-which can be a time consuming activity -- especially if your tests
-don't need to test multi-database activity.
+defined in the :setting:`DATABASES` definition in your settings and referred to
+by at least one test through ``databases``.
+
+However, a big part of the time taken to run a Django ``TestCase`` is consumed
+by the call to ``flush`` that ensures that you have a clean database at the
+start of each test run. If you have multiple databases, multiple flushes are
+required (one for each database), which can be a time consuming activity --
+especially if your tests don't need to test multi-database activity.
 
 As an optimization, Django only flushes the ``default`` database at
 the start of each test run. If your setup contains multiple databases,

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -722,14 +722,24 @@ A subclass of :class:`unittest.TestCase` that adds this functionality:
 If your tests make any database queries, use subclasses
 :class:`~django.test.TransactionTestCase` or :class:`~django.test.TestCase`.
 
-.. attribute:: SimpleTestCase.allow_database_queries
+.. attribute:: SimpleTestCase.databases
+
+    .. versionadded:: 2.2
 
     :class:`~SimpleTestCase` disallows database queries by default. This
     helps to avoid executing write queries which will affect other tests
     since each ``SimpleTestCase`` test isn't run in a transaction. If you
     aren't concerned about this problem, you can disable this behavior by
-    setting the ``allow_database_queries`` class attribute to ``True`` on
-    your test class.
+    setting the ``databases`` class attribute to ``'__all__'`` on your test
+    class.
+
+.. attribute:: SimpleTestCase.allow_database_queries
+
+    .. deprecated:: 2.2
+
+    This attribute is deprecated in favor of :attr:`databases`. The previous
+    behavior of ``allow_database_queries = True`` can be achieved by setting
+    ``databases = '__all__'``.
 
 .. warning::
 
@@ -1101,8 +1111,8 @@ you can be certain that the outcome of a test will not be affected by another
 test or by the order of test execution.
 
 By default, fixtures are only loaded into the ``default`` database. If you are
-using multiple databases and set :attr:`multi_db=True
-<TransactionTestCase.multi_db>`, fixtures will be loaded into all databases.
+using multiple databases and set :attr:`TransactionTestCase.databases`,
+fixtures will be loaded into all specified databases.
 
 URLconf configuration
 ---------------------
@@ -1119,7 +1129,9 @@ particular URL. Decorate your test class or test method with
 Multi-database support
 ----------------------
 
-.. attribute:: TransactionTestCase.multi_db
+.. attribute:: TransactionTestCase.databases
+
+.. versionadded:: 2.2
 
 Django sets up a test database corresponding to every database that is
 defined in the :setting:`DATABASES` definition in your settings
@@ -1133,24 +1145,67 @@ don't need to test multi-database activity.
 As an optimization, Django only flushes the ``default`` database at
 the start of each test run. If your setup contains multiple databases,
 and you have a test that requires every database to be clean, you can
-use the ``multi_db`` attribute on the test suite to request a full
-flush.
+use the ``databases`` attribute on the test suite to request extra databases
+to be flushed.
 
 For example::
 
-    class TestMyViews(TestCase):
-        multi_db = True
+    class TestMyViews(TransactionTestCase):
+        databases = {'default', 'other'}
 
         def test_index_page_view(self):
             call_some_test_code()
 
-This test case will flush *all* the test databases before running
-``test_index_page_view``.
+This test case will flush the ``default`` and ``other`` test databases before
+running ``test_index_page_view``. You can also use ``'__all__'`` to specify
+that all of the test databases must be flushed.
 
-The ``multi_db`` flag also affects into which databases the
-:attr:`TransactionTestCase.fixtures` are loaded. By default (when
-``multi_db=False``), fixtures are only loaded into the ``default`` database.
-If ``multi_db=True``, fixtures are loaded into all databases.
+The ``databases`` flag also controls which databases the
+:attr:`TransactionTestCase.fixtures` are loaded into. By default, fixtures are
+only loaded into the ``default`` database.
+
+Queries against databases not in ``databases`` will give assertion errors to
+prevent state leaking between tests.
+
+.. attribute:: TransactionTestCase.multi_db
+
+.. deprecated:: 2.2
+
+This attribute is deprecated in favor of :attr:`~TransactionTestCase.databases`.
+The previous behavior of ``multi_db = True`` can be achieved by setting
+``databases = '__all__'``.
+
+.. attribute:: TestCase.databases
+
+.. versionadded:: 2.2
+
+By default, only the ``default`` database will be wrapped in a transaction
+during a ``TestCase``'s execution and attempts to query other databases will
+result in assertion errors to prevent state leaking between tests.
+
+Use the ``databases`` class attribute on the test class to request transaction
+wrapping against non-``default`` databases.
+
+For example::
+
+    class OtherDBTests(TestCase):
+        databases = {'other'}
+
+        def test_other_db_query(self):
+            ...
+
+This test will only allow queries against the ``other`` database. Just like for
+:attr:`SimpleTestCase.databases` and :attr:`TransactionTestCase.databases`, the
+``'__all__'`` constant can be used to specify that the test should allow
+queries to all databases.
+
+.. attribute:: TestCase.multi_db
+
+.. deprecated:: 2.2
+
+This attribute is deprecated in favor of :attr:`~TestCase.databases`. The
+previous behavior of ``multi_db = True`` can be achieved by setting
+``databases = '__all__'``.
 
 .. _overriding-settings:
 

--- a/tests/admin_views/test_multidb.py
+++ b/tests/admin_views/test_multidb.py
@@ -28,7 +28,7 @@ urlpatterns = [
 
 @override_settings(ROOT_URLCONF=__name__, DATABASE_ROUTERS=['%s.Router' % __name__])
 class MultiDatabaseTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @classmethod
     def setUpTestData(cls):

--- a/tests/auth_tests/test_admin_multidb.py
+++ b/tests/auth_tests/test_admin_multidb.py
@@ -27,7 +27,7 @@ urlpatterns = [
 
 @override_settings(ROOT_URLCONF=__name__, DATABASE_ROUTERS=['%s.Router' % __name__])
 class MultiDatabaseTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @classmethod
     def setUpTestData(cls):

--- a/tests/auth_tests/test_management.py
+++ b/tests/auth_tests/test_management.py
@@ -213,7 +213,7 @@ class ChangepasswordManagementCommandTestCase(TestCase):
 
 
 class MultiDBChangepasswordManagementCommandTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @mock.patch.object(changepassword.Command, '_get_pass', return_value='not qwerty')
     def test_that_changepassword_command_with_database_option_uses_given_db(self, mock_get_pass):
@@ -906,7 +906,7 @@ class CreatesuperuserManagementCommandTestCase(TestCase):
 
 
 class MultiDBCreatesuperuserTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_createsuperuser_command_with_database_option(self):
         """

--- a/tests/auth_tests/test_models.py
+++ b/tests/auth_tests/test_models.py
@@ -47,7 +47,7 @@ class LoadDataWithNaturalKeysTestCase(TestCase):
 
 
 class LoadDataWithNaturalKeysAndMultipleDatabasesTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_load_data_with_user_permissions(self):
         # Create test contenttypes for both databases

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1085,7 +1085,7 @@ class DBCacheRouter:
     },
 )
 class CreateCacheTableForDBCacheTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @override_settings(DATABASE_ROUTERS=[DBCacheRouter()])
     def test_createcachetable_observes_database_router(self):

--- a/tests/check_framework/test_database.py
+++ b/tests/check_framework/test_database.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 
 class DatabaseCheckTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @property
     def func(self):

--- a/tests/contenttypes_tests/test_models.py
+++ b/tests/contenttypes_tests/test_models.py
@@ -214,7 +214,7 @@ class TestRouter:
 
 @override_settings(DATABASE_ROUTERS=[TestRouter()])
 class ContentTypesMultidbTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_multidb(self):
         """

--- a/tests/context_processors/tests.py
+++ b/tests/context_processors/tests.py
@@ -64,7 +64,7 @@ class DebugContextProcessorTests(TestCase):
     """
     Tests for the ``django.template.context_processors.debug`` processor.
     """
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_debug(self):
         url = '/debug/'

--- a/tests/gis_tests/layermap/tests.py
+++ b/tests/gis_tests/layermap/tests.py
@@ -341,7 +341,7 @@ class OtherRouter:
 
 @override_settings(DATABASE_ROUTERS=[OtherRouter()])
 class LayerMapRouterTest(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @unittest.skipUnless(len(settings.DATABASES) > 1, 'multiple databases required')
     def test_layermapping_default_db(self):

--- a/tests/migrations/test_base.py
+++ b/tests/migrations/test_base.py
@@ -18,7 +18,7 @@ class MigrationTestBase(TransactionTestCase):
     """
 
     available_apps = ["migrations"]
-    multi_db = True
+    databases = {'default', 'other'}
 
     def tearDown(self):
         # Reset applied-migrations state.

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -25,7 +25,7 @@ class MigrateTests(MigrationTestBase):
     """
     Tests running the migrate command.
     """
-    multi_db = True
+    databases = {'default', 'other'}
 
     @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations"})
     def test_migrate(self):

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -16,7 +16,7 @@ class RecorderTests(TestCase):
     """
     Tests recording migrations as applied or not.
     """
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_apply(self):
         """

--- a/tests/migrations/test_multidb.py
+++ b/tests/migrations/test_multidb.py
@@ -38,7 +38,7 @@ class MigrateWhenFooRouter:
 
 
 class MultiDBOperationTests(OperationTestBase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def _test_create_model(self, app_label, should_run):
         """

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -17,7 +17,7 @@ from .routers import AuthRouter, TestRouter, WriteRouter
 
 
 class QueryTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_db_selection(self):
         "Querysets will use the default database by default"
@@ -998,7 +998,7 @@ class ConnectionRouterTestCase(SimpleTestCase):
 # Make the 'other' database appear to be a replica of the 'default'
 @override_settings(DATABASE_ROUTERS=[TestRouter()])
 class RouterTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_db_selection(self):
         "Querysets obey the router for db suggestions"
@@ -1526,7 +1526,7 @@ class RouterTestCase(TestCase):
 
 @override_settings(DATABASE_ROUTERS=[AuthRouter()])
 class AuthTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_auth_manager(self):
         "The methods on the auth manager obey database hints"
@@ -1589,7 +1589,7 @@ class AntiPetRouter:
 
 
 class FixtureTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
     fixtures = ['multidb-common', 'multidb']
 
     @override_settings(DATABASE_ROUTERS=[AntiPetRouter()])
@@ -1629,7 +1629,7 @@ class FixtureTestCase(TestCase):
 
 
 class PickleQuerySetTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_pickling(self):
         for db in connections:
@@ -1655,7 +1655,7 @@ class WriteToOtherRouter:
 
 
 class SignalTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def override_router(self):
         return override_settings(DATABASE_ROUTERS=[WriteToOtherRouter()])
@@ -1755,7 +1755,7 @@ class AttributeErrorRouter:
 
 
 class RouterAttributeErrorTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def override_router(self):
         return override_settings(DATABASE_ROUTERS=[AttributeErrorRouter()])
@@ -1807,7 +1807,7 @@ class ModelMetaRouter:
 
 @override_settings(DATABASE_ROUTERS=[ModelMetaRouter()])
 class RouterModelArgumentTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_m2m_collection(self):
         b = Book.objects.create(title="Pro Django",
@@ -1845,7 +1845,7 @@ class MigrateTestCase(TestCase):
         'django.contrib.auth',
         'django.contrib.contenttypes'
     ]
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_migrate_to_other_database(self):
         """Regression test for #16039: migrate with --database option."""
@@ -1879,7 +1879,7 @@ class RouterUsed(Exception):
 
 
 class RouteForWriteTestCase(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     class WriteCheckRouter:
         def db_for_write(self, model, **hints):
@@ -2093,7 +2093,7 @@ class NoRelationRouter:
 @override_settings(DATABASE_ROUTERS=[NoRelationRouter()])
 class RelationAssignmentTests(SimpleTestCase):
     """allow_relation() is called with unsaved model instances."""
-    multi_db = True
+    databases = {'default', 'other'}
     router_prevents_msg = 'the current database router prevents this relation'
 
     def test_foreign_key_relation(self):

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1155,7 +1155,7 @@ class NullableTest(TestCase):
 
 
 class MultiDbTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     def test_using_is_honored_m2m(self):
         B = Book.objects.using('other')

--- a/tests/servers/tests.py
+++ b/tests/servers/tests.py
@@ -209,8 +209,7 @@ class LiveServerPort(LiveServerBase):
                 "Acquired duplicate server addresses for server threads: %s" % self.live_server_url
             )
         finally:
-            if hasattr(TestCase, 'server_thread'):
-                TestCase.server_thread.terminate()
+            TestCase.tearDownClass()
 
     def test_specified_port_bind(self):
         """LiveServerTestCase.port customizes the server's port."""
@@ -227,8 +226,7 @@ class LiveServerPort(LiveServerBase):
                 'Did not use specified port for LiveServerTestCase thread: %s' % TestCase.port
             )
         finally:
-            if hasattr(TestCase, 'server_thread'):
-                TestCase.server_thread.terminate()
+            TestCase.tearDownClass()
 
 
 class LiverServerThreadedTests(LiveServerBase):

--- a/tests/sites_tests/tests.py
+++ b/tests/sites_tests/tests.py
@@ -18,7 +18,7 @@ from django.test.utils import captured_stdout
 
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sites'})
 class SitesFrameworkTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @classmethod
     def setUpTestData(cls):
@@ -236,7 +236,7 @@ class JustOtherRouter:
 
 @modify_settings(INSTALLED_APPS={'append': 'django.contrib.sites'})
 class CreateDefaultSiteTests(TestCase):
-    multi_db = True
+    databases = {'default', 'other'}
 
     @classmethod
     def setUpTestData(cls):

--- a/tests/test_runner/test_discover_runner.py
+++ b/tests/test_runner/test_discover_runner.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 from contextlib import contextmanager
 from unittest import TestSuite, TextTestRunner, defaultTestLoader
 
+from django.db import connections
 from django.test import SimpleTestCase
 from django.test.runner import DiscoverRunner
 from django.test.utils import captured_stdout
@@ -223,3 +224,47 @@ class DiscoverRunnerTests(SimpleTestCase):
         with captured_stdout() as stdout:
             runner.build_suite(['test_runner_apps.tagged.tests'])
             self.assertIn('Excluding test tag(s): bar, foo.\n', stdout.getvalue())
+
+
+class DiscoverRunnerGetDatabasesTests(SimpleTestCase):
+    runner = DiscoverRunner(verbosity=2)
+    skip_msg = 'Skipping setup of unused database(s): '
+
+    def get_databases(self, test_labels):
+        suite = self.runner.build_suite(test_labels)
+        with captured_stdout() as stdout:
+            databases = self.runner.get_databases(suite)
+        return databases, stdout.getvalue()
+
+    def test_mixed(self):
+        databases, output = self.get_databases(['test_runner_apps.databases.tests'])
+        self.assertEqual(databases, set(connections))
+        self.assertNotIn(self.skip_msg, output)
+
+    def test_all(self):
+        databases, output = self.get_databases(['test_runner_apps.databases.tests.AllDatabasesTests'])
+        self.assertEqual(databases, set(connections))
+        self.assertNotIn(self.skip_msg, output)
+
+    def test_default_and_other(self):
+        databases, output = self.get_databases([
+            'test_runner_apps.databases.tests.DefaultDatabaseTests',
+            'test_runner_apps.databases.tests.OtherDatabaseTests',
+        ])
+        self.assertEqual(databases, set(connections))
+        self.assertNotIn(self.skip_msg, output)
+
+    def test_default_only(self):
+        databases, output = self.get_databases(['test_runner_apps.databases.tests.DefaultDatabaseTests'])
+        self.assertEqual(databases, {'default'})
+        self.assertIn(self.skip_msg + 'other', output)
+
+    def test_other_only(self):
+        databases, output = self.get_databases(['test_runner_apps.databases.tests.OtherDatabaseTests'])
+        self.assertEqual(databases, {'other'})
+        self.assertIn(self.skip_msg + 'default', output)
+
+    def test_no_databases_required(self):
+        databases, output = self.get_databases(['test_runner_apps.databases.tests.NoDatabaseTests'])
+        self.assertEqual(databases, set())
+        self.assertIn(self.skip_msg + 'default, other', output)

--- a/tests/test_runner/tests.py
+++ b/tests/test_runner/tests.py
@@ -241,8 +241,8 @@ class Ticket17477RegressionTests(AdminScriptTestCase):
 
 
 class SQLiteInMemoryTestDbs(TransactionTestCase):
-    multi_db = True
     available_apps = ['test_runner']
+    databases = {'default', 'other'}
 
     @unittest.skipUnless(all(db.connections[conn].vendor == 'sqlite' for conn in db.connections),
                          "This is an sqlite-specific issue")

--- a/tests/test_runner_apps/databases/tests.py
+++ b/tests/test_runner_apps/databases/tests.py
@@ -1,0 +1,18 @@
+import unittest
+
+
+class NoDatabaseTests(unittest.TestCase):
+    def test_nothing(self):
+        pass
+
+
+class DefaultDatabaseTests(NoDatabaseTests):
+    databases = {'default'}
+
+
+class OtherDatabaseTests(NoDatabaseTests):
+    databases = {'other'}
+
+
+class AllDatabasesTests(NoDatabaseTests):
+    databases = '__all__'

--- a/tests/test_utils/test_deprecated_features.py
+++ b/tests/test_utils/test_deprecated_features.py
@@ -1,0 +1,64 @@
+from django.db import connections
+from django.db.utils import DEFAULT_DB_ALIAS
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
+from django.utils.deprecation import RemovedInDjango31Warning
+
+
+class AllowDatabaseQueriesDeprecationTests(SimpleTestCase):
+    def test_enabled(self):
+        class AllowedDatabaseQueries(SimpleTestCase):
+            allow_database_queries = True
+        message = (
+            '`SimpleTestCase.allow_database_queries` is deprecated. Restrict '
+            'the databases available during the execution of '
+            'test_utils.test_deprecated_features.AllowDatabaseQueriesDeprecationTests.'
+            'test_enabled.<locals>.AllowedDatabaseQueries with the '
+            '`databases` attribute instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(AllowedDatabaseQueries.databases, {'default'})
+
+    def test_explicitly_disabled(self):
+        class AllowedDatabaseQueries(SimpleTestCase):
+            allow_database_queries = False
+        message = (
+            '`SimpleTestCase.allow_database_queries` is deprecated. Restrict '
+            'the databases available during the execution of '
+            'test_utils.test_deprecated_features.AllowDatabaseQueriesDeprecationTests.'
+            'test_explicitly_disabled.<locals>.AllowedDatabaseQueries with '
+            'the `databases` attribute instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(AllowedDatabaseQueries.databases, set())
+
+
+class MultiDbDeprecationTests(SimpleTestCase):
+    def test_transaction_test_case(self):
+        class MultiDbTestCase(TransactionTestCase):
+            multi_db = True
+        message = (
+            '`TransactionTestCase.multi_db` is deprecated. Databases '
+            'available during this test can be defined using '
+            'test_utils.test_deprecated_features.MultiDbDeprecationTests.'
+            'test_transaction_test_case.<locals>.MultiDbTestCase.databases.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(MultiDbTestCase.databases, set(connections))
+        MultiDbTestCase.multi_db = False
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(MultiDbTestCase.databases, {DEFAULT_DB_ALIAS})
+
+    def test_test_case(self):
+        class MultiDbTestCase(TestCase):
+            multi_db = True
+        message = (
+            '`TestCase.multi_db` is deprecated. Databases available during '
+            'this test can be defined using '
+            'test_utils.test_deprecated_features.MultiDbDeprecationTests.'
+            'test_test_case.<locals>.MultiDbTestCase.databases.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(MultiDbTestCase.databases, set(connections))
+        MultiDbTestCase.multi_db = False
+        with self.assertWarnsMessage(RemovedInDjango31Warning, message):
+            self.assertEqual(MultiDbTestCase.databases, {DEFAULT_DB_ALIAS})

--- a/tests/test_utils/test_testcase.py
+++ b/tests/test_utils/test_testcase.py
@@ -1,7 +1,7 @@
 from django.db import IntegrityError, transaction
 from django.test import TestCase, skipUnlessDBFeature
 
-from .models import PossessedCar
+from .models import Car, PossessedCar
 
 
 class TestTestCase(TestCase):
@@ -18,3 +18,12 @@ class TestTestCase(TestCase):
             car.delete()
         finally:
             self._rollback_atomics = rollback_atomics
+
+    def test_disallowed_database_queries(self):
+        message = (
+            "Database queries to 'other' are not allowed in this test. "
+            "Add 'other' to test_utils.test_testcase.TestTestCase.databases to "
+            "ensure proper test isolation and silence this failure."
+        )
+        with self.assertRaisesMessage(AssertionError, message):
+            Car.objects.using('other').get()

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -225,7 +225,7 @@ class DebugViewTests(SimpleTestCase):
 
 class DebugViewQueriesAllowedTests(SimpleTestCase):
     # May need a query to initialize MySQL connection
-    allow_database_queries = True
+    databases = {'default'}
 
     def test_handle_db_exception(self):
         """


### PR DESCRIPTION
Here's a refined version of the patch for #28478. I opted for not including support for `databases = '__all__'` for an exact replacement of `multi_db = True` because the assertion error should make it clear from now on which action should be taken while we were previously silently leaking non-default database changes between tests.

You can test the database skipping work appropriately by testing app that don't require database interactions (e.g. `./runtests.py csrf_tests`)

~~There still a bit of work left:~~

- [x] Test the deprecation warnings.
- [x] Test disallowed database accesses on `TestCase` and `TransactionTestCase` (current only `SimpleTestCase` is tested).
- [x] Raise `ImproperlyConfigured` when `databases` contain unrecognized aliases to help with typos.
- [x] Document the deprecation and the new `databases` attribute.
- [x] Add release notes.

https://code.djangoproject.com/ticket/28478