### PR TITLE
Allow provide a function in template caching.

### DIFF
--- a/django/templatetags/cache.py
+++ b/django/templatetags/cache.py
@@ -44,6 +44,11 @@ class CacheNode(Node):
         cache_key = make_template_fragment_key(self.fragment_name, vary_on)
         value = fragment_cache.get(cache_key)
         if value is None:
+            fragment_var = context.get(self.fragment_name)
+            if callable(fragment_var):
+                extra = fragment_var(*vary_on)
+                if type(extra) is dict:
+                    context.update(extra)
             value = self.nodelist.render(context)
             fragment_cache.set(cache_key, value, expire_time)
         return value


### PR DESCRIPTION
Django provides template fragment caching, such as :
```
{% load cache %}
{% cache 500 sidebar %}
    .. sidebar ..
{% endcache %}
```
But the variable `sidebar` still to be passed to the template every time, otherwise the fragment is blank when the cache expires.

If the data acquisition process is time consuming, then the fragment cache is to exist in name only.

So, this RP provides another way to improve it.

It allows provide a callable object to tell module how to get data, and the function return a dict. and **only call function when cache expires**.

## Use
for example in views.py:
```
import time
def get_data(num=10):
    time.sleep(3)
    return {'nums': list(range(num))}  # return dict object

def test(request):
    return render(request, 'test.html', {'get_data': get_data})
```
and in the template:
```
{% load cache %}
{% cache 500 get_data 6 %}
    <ul>
        {% for i in nums %}
            <li> {{ i }}</li>
        {% endfor %}
    </ul>
{% endcache %}
```
