### PR TITLE
Fixed #25884 -- Fixed migrate --run-syncdb when specifying an app label

### DIFF
--- a/tests/migrations/migrations_test_apps/unmigrated_app_simple/models.py
+++ b/tests/migrations/migrations_test_apps/unmigrated_app_simple/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class UnmigratedModel(models.Model):
+    """
+    A model that is in a migration-less app (which this app is
+    if its migrations directory has not been repointed)
+    """
+    pass


### PR DESCRIPTION
Previous behavior was to sync all unmigrated apps, and specifying an app
label would raise a CommandError.
https://code.djangoproject.com/ticket/25884