### PR TITLE
fixed #29572 -- Use pymysql instead of mysqldb to solve the compatibility problem that python3 can't use mysqldb package.

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -12,7 +12,8 @@ from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils.functional import cached_property
 
 try:
-    import MySQLdb as Database
+    import pymysql as Database
+    pymysql.install_as_MySQLdb()
 except ImportError as err:
     raise ImproperlyConfigured(
         'Error loading MySQLdb module.\n'

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -13,15 +13,22 @@ from django.utils.functional import cached_property
 
 try:
     import pymysql as Database
-    pymysql.install_as_MySQLdb()
-except ImportError as err:
-    raise ImproperlyConfigured(
-        'Error loading MySQLdb module.\n'
-        'Did you install mysqlclient?'
-    ) from err
+    Database.install_as_MySQLdb()
+except ImportError:
+    try:
+        import MySQLdb as Database
+    except ImportError as err:
+        raise ImproperlyConfigured(
+            'Error loading pymysql or MySQLdb module.\n'
+            'Did you install pymysql or mysqlclient?'
+        ) from err
 
-from MySQLdb.constants import CLIENT, FIELD_TYPE                # isort:skip
-from MySQLdb.converters import conversions                      # isort:skip
+try:
+    from pymysql.constants import CLIENT, FIELD_TYPE                # isort:skip
+    from pymysql.converters import conversions                      # isort:skip
+except ImportError:
+    from MySQLdb.constants import CLIENT, FIELD_TYPE                # isort:skip
+    from MySQLdb.converters import conversions                      # isort:skip
 
 # Some of these import MySQLdb, so import them after checking if it's installed.
 from .client import DatabaseClient                          # isort:skip


### PR DESCRIPTION
Use pymysql instead of mysqldb to solve the compatibility
problem that python3 can't use mysqldb package.

fixed #29572 -- Use pymysql instead of mysqldb to solve the
compatibility problem that python3 can't use mysqldb package.