### PR TITLE
Fixed #28540 -- Added FILE_UPLOAD_PERMISSIONS to deploymet checklist.

### DIFF
--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -154,6 +154,16 @@ server never attempts to interpret them. For instance, if a user uploads a
 
 Now is a good time to check your backup strategy for these files.
 
+:setting:`FILE_UPLOAD_PERMISSIONS`
+----------------------------------
+
+With the default file upload settings, files smaller than
+:setting:`FILE_UPLOAD_MAX_MEMORY_SIZE` may be stored with a different mode
+than larger files as described in :setting:`FILE_UPLOAD_PERMISSIONS`.
+
+Setting :setting:`FILE_UPLOAD_PERMISSIONS` ensures all files are uploaded with
+the same permissions.
+
 HTTPS
 =====
 

--- a/docs/releases/1.11.txt
+++ b/docs/releases/1.11.txt
@@ -777,6 +777,13 @@ Miscellaneous
   :data:`~django.core.validators.validate_image_file_extension` validator.
   See the note in :meth:`.Client.post`.
 
+* :class:`~django.db.models.FileField` now moves rather than copies the file
+  it receives. With the default file upload settings, files larger than
+  :setting:`FILE_UPLOAD_MAX_MEMORY_SIZE` now have the same permissions as
+  temporary files (often ``0o600``) rather than the system's standard umask
+  (often ``0o6644``). Set the :setting:`FILE_UPLOAD_PERMISSIONS` if you need
+  the same permission regardless of file size.
+
 .. _deprecated-features-1.11:
 
 Features deprecated in 1.11


### PR DESCRIPTION
This is an attempt at [Tim's suggestion](https://code.djangoproject.com/ticket/28540#comment:11) to add `FILE_UPLOAD_PERMISSIONS` to the deployment checklist. 

> ... attempt... 

Happy to take input on the wording. 🙂

