### PR TITLE
Fixed grammar in various comments and documentation.

### DIFF
--- a/django/contrib/gis/db/backends/base/features.py
+++ b/django/contrib/gis/db/backends/base/features.py
@@ -27,7 +27,7 @@ class BaseSpatialFeatures:
     supports_null_geometries = True
     # Are empty geometries supported?
     supports_empty_geometries = False
-    # Can the the function be applied on geodetic coordinate systems?
+    # Can the function be applied on geodetic coordinate systems?
     supports_distance_geodetic = True
     supports_length_geodetic = True
     supports_perimeter_geodetic = False

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -118,8 +118,8 @@ def call_command(command_name, *args, **options):
     }
     arg_options = {opt_mapping.get(key, key): value for key, value in options.items()}
     parse_args = [str(a) for a in args]
-    # Any required arguments which are passed in via **options must must be
-    # passed to parse_args().
+    # Any required arguments which are passed in via **options must be passed
+    # to parse_args().
     parse_args += [
         '{}={}'.format(min(opt.option_strings), arg_options[opt.dest])
         for opt in parser._actions if opt.required and opt.dest in options

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1484,7 +1484,7 @@ class Query:
         joins = [alias]
         # The transform can't be applied yet, as joins must be trimmed later.
         # To avoid making every caller of this method look up transforms
-        # directly, compute transforms here and and create a partial that
+        # directly, compute transforms here and create a partial that
         # converts fields to the appropriate wrapped version.
 
         def final_transformer(field, alias):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -626,7 +626,7 @@ class SimpleTestCase(unittest.TestCase):
 
     def assertRaisesMessage(self, expected_exception, expected_message, *args, **kwargs):
         """
-        Assert that expected_message is found in the the message of a raised
+        Assert that expected_message is found in the message of a raised
         exception.
 
         Args:

--- a/django/utils/tree.py
+++ b/django/utils/tree.py
@@ -52,7 +52,7 @@ class Node:
         return obj
 
     def __len__(self):
-        """Return the the number of children this node has."""
+        """Return the number of children this node has."""
         return len(self.children)
 
     def __bool__(self):

--- a/docs/internals/contributing/writing-code/coding-style.txt
+++ b/docs/internals/contributing/writing-code/coding-style.txt
@@ -48,7 +48,7 @@ Python style
   This makes better use of space and avoids having to realign strings if the
   length of the first line changes.
 
-* Use single quotes for strings, or a double quote if the the string contains a
+* Use single quotes for strings, or a double quote if the string contains a
   single quote. Don't waste time doing unrelated refactoring of existing code
   to conform to this style.
 

--- a/docs/ref/contrib/gis/gdal.txt
+++ b/docs/ref/contrib/gis/gdal.txt
@@ -1337,7 +1337,7 @@ blue.
         disk.
 
         The only parameter that is set differently from the source raster is the
-        name. The default value of the the raster name is the name of the source
+        name. The default value of the raster name is the name of the source
         raster appended with ``'_copy' + source_driver_name``. For file-based
         rasters it is recommended to provide the file path of the target raster.
 

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -55,7 +55,7 @@ Minor features
 * The new :meth:`.ModelAdmin.delete_queryset` method allows customizing the
   deletion process of the "delete selected objects" action.
 
-* You can now :ref:`override the the default admin site
+* You can now :ref:`override the default admin site
   <overriding-default-admin-site>`.
 
 * The new :attr:`.ModelAdmin.sortable_by` attribute and


### PR DESCRIPTION
I searched with `grep -r -E " (\w) \1 "`, and ignored matches in `1.11.txt`, `1.9.txt` and `1.8.txt` (the pattern `the the` is found there).