### PR TITLE
Fixed #29570 - Added check that MEDIA_URL isn't in STATIC_URL

### DIFF
--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -1,5 +1,6 @@
 import fnmatch
 import os
+import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -56,3 +57,5 @@ def check_settings(base_url=None):
             (settings.MEDIA_ROOT == settings.STATIC_ROOT)):
         raise ImproperlyConfigured("The MEDIA_ROOT and STATIC_ROOT "
                                    "settings must have different values")
+    if settings.MEDIA_URL and base_url and settings.MEDIA_URL.startswith(base_url):
+        warnings.warn("The contrib.staticfiles app will not serve media if MEDIA_URL is within STATIC_URL", UserWarning)

--- a/tests/staticfiles_tests/test_checks.py
+++ b/tests/staticfiles_tests/test_checks.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.conf import settings
 from django.contrib.staticfiles.checks import check_finders
 from django.contrib.staticfiles.finders import BaseFinder
+from django.contrib.staticfiles.utils import check_settings
 from django.core.checks import Error
 from django.test import SimpleTestCase, override_settings
 
@@ -75,3 +76,8 @@ class FindersCheckTests(SimpleTestCase):
                 id='staticfiles.E002',
             )
         ])
+
+    @override_settings(MEDIA_URL='/static/media/')
+    def test_warn_media_url_in_static_url(self):
+        with self.assertWarnsMessage(UserWarning, "The contrib.staticfiles app will not serve media if MEDIA_URL is within STATIC_URL"):    
+            check_settings()


### PR DESCRIPTION
The check runs only in development mode, since that is what the warning
warns about