### PR TITLE
Fixed #29576 -- Corrected the test client's HTTP_COOKIE header.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -277,7 +277,10 @@ class RequestFactory:
         # - REMOTE_ADDR: often useful, see #8551.
         # See http://www.python.org/dev/peps/pep-3333/#environ-variables
         return {
-            'HTTP_COOKIE': self.cookies.output(header='', sep='; '),
+            'HTTP_COOKIE': "; ".join(
+                f"{morsel.key}={morsel.coded_value}"
+                for morsel in self.cookies.values()
+            ),
             'PATH_INFO': '/',
             'REMOTE_ADDR': '127.0.0.1',
             'REQUEST_METHOD': 'GET',

--- a/django/test/client.py
+++ b/django/test/client.py
@@ -278,7 +278,7 @@ class RequestFactory:
         # See http://www.python.org/dev/peps/pep-3333/#environ-variables
         return {
             'HTTP_COOKIE': "; ".join(
-                f"{morsel.key}={morsel.coded_value}"
+                "{}={}".format(morsel.key, morsel.coded_value)
                 for morsel in self.cookies.values()
             ),
             'PATH_INFO': '/',


### PR DESCRIPTION
This existing implementation wrongly constructs cookies into:
' sessionid=helloworld; Domain=None; expires=None; Max-Age=None; Path=/'

For the given example, this fix will correct the construction to be:
'sessionid=helloworld'