### PR TITLE
Fixed #29570 - Added check that MEDIA_URL isn't in STATIC_URL

### DIFF
--- a/django/contrib/staticfiles/utils.py
+++ b/django/contrib/staticfiles/utils.py
@@ -52,6 +52,11 @@ def check_settings(base_url=None):
     if settings.MEDIA_URL == base_url:
         raise ImproperlyConfigured("The MEDIA_URL and STATIC_URL "
                                    "settings must have different values")
+    if (settings.DEBUG and settings.MEDIA_URL and settings.STATIC_URL and
+            settings.MEDIA_URL.startswith(settings.STATIC_URL)):
+        raise ImproperlyConfigured(
+            "runserver can't serve media if MEDIA_URL is within STATIC_URL."
+        )
     if ((settings.MEDIA_ROOT and settings.STATIC_ROOT) and
             (settings.MEDIA_ROOT == settings.STATIC_ROOT)):
         raise ImproperlyConfigured("The MEDIA_ROOT and STATIC_ROOT "

--- a/tests/staticfiles_tests/test_utils.py
+++ b/tests/staticfiles_tests/test_utils.py
@@ -1,0 +1,14 @@
+from django.contrib.staticfiles.utils import check_settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase, override_settings
+
+
+class CheckSettingsTests(SimpleTestCase):
+
+    @override_settings(DEBUG=True, MEDIA_URL='/static/media/', STATIC_URL='/static/',)
+    def test_media_url_in_static_url(self):
+        msg = "runserver can't serve media if MEDIA_URL is within STATIC_URL."
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            check_settings()
+        with self.settings(DEBUG=False):  # Check disabled if DEBUG=False.
+            check_settings()


### PR DESCRIPTION
The check runs only in development mode, since that is what the warning
warns about