### PR TITLE
Fixed #29578 - Made numberformat.format() honor forced l10n usage

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -179,7 +179,8 @@ def number_format(value, decimal_pos=None, use_l10n=None, force_grouping=False):
         decimal_pos,
         get_format('NUMBER_GROUPING', lang, use_l10n=use_l10n),
         get_format('THOUSAND_SEPARATOR', lang, use_l10n=use_l10n),
-        force_grouping=force_grouping
+        force_grouping=force_grouping,
+        use_l10n=use_l10n,
     )
 
 

--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -5,7 +5,7 @@ from django.utils.safestring import mark_safe
 
 
 def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
-           force_grouping=False):
+           force_grouping=False, use_l10n=None):
     """
     Get a number (as a number or string), and return it as a string,
     using formats defined as arguments:
@@ -18,7 +18,7 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
         module in locale.localeconv() LC_NUMERIC grouping (e.g. (3, 2, 0)).
     * thousand_sep: Thousand separator symbol (for example ",")
     """
-    use_grouping = settings.USE_L10N and settings.USE_THOUSAND_SEPARATOR
+    use_grouping = (use_l10n or (use_l10n is None and settings.USE_L10N)) and settings.USE_THOUSAND_SEPARATOR
     use_grouping = use_grouping or force_grouping
     use_grouping = use_grouping and grouping != 0
     # Make the common case fast

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -72,7 +72,7 @@ class AdminActionsTest(TestCase):
         self.assertContains(response, 'Are you sure you want to delete the selected subscribers?')
         self.assertContains(response, '<ul></ul>', html=True)
 
-    @override_settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=True)
+    @override_settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=True, NUMBER_GROUPING=3)
     def test_non_localized_pk(self):
         """
         If USE_THOUSAND_SEPARATOR is set, the ids for the objects selected for

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1039,33 +1039,35 @@ class FormattingTests(SimpleTestCase):
         """
         Test the {% localize %} templatetag and the localize/unlocalize filters.
         """
-        context = Context({'float': 3.14, 'date': datetime.date(2016, 12, 31)})
+        context = Context({'int': 1455, 'float': 3.14, 'date': datetime.date(2016, 12, 31)})
         template1 = Template(
-            '{% load l10n %}{% localize %}{{ float }}/{{ date }}{% endlocalize %}; '
-            '{% localize on %}{{ float }}/{{ date }}{% endlocalize %}'
+            '{% load l10n %}{% localize %}{{ int }}/{{ float }}/{{ date }}{% endlocalize %}; '
+            '{% localize on %}{{ int }}/{{ float }}/{{ date }}{% endlocalize %}'
         )
         template2 = Template(
-            '{% load l10n %}{{ float }}/{{ date }}; '
-            '{% localize off %}{{ float }}/{{ date }};{% endlocalize %} '
-            '{{ float }}/{{ date }}'
+            '{% load l10n %}{{ int }}/{{ float }}/{{ date }}; '
+            '{% localize off %}{{ int }}/{{ float }}/{{ date }};{% endlocalize %} '
+            '{{ int }}/{{ float }}/{{ date }}'
         )
         template3 = Template(
-            '{% load l10n %}{{ float }}/{{ date }}; {{ float|unlocalize }}/{{ date|unlocalize }}'
+            '{% load l10n %}{{ int }}/{{ float }}/{{ date }}; '
+            '{{ int|unlocalize }}/{{ float|unlocalize }}/{{ date|unlocalize }}'
         )
         template4 = Template(
-            '{% load l10n %}{{ float }}/{{ date }}; {{ float|localize }}/{{ date|localize }}'
+            '{% load l10n %}{{ int }}/{{ float }}/{{ date }}; '
+            '{{ int|localize }}/{{ float|localize }}/{{ date|localize }}'
         )
-        expected_localized = '3,14/31. Dezember 2016'
-        expected_unlocalized = '3.14/Dez. 31, 2016'
+        expected_localized = '1.455/3,14/31. Dezember 2016'
+        expected_unlocalized = '1455/3.14/Dez. 31, 2016'
         output1 = '; '.join([expected_localized, expected_localized])
         output2 = '; '.join([expected_localized, expected_unlocalized, expected_localized])
         output3 = '; '.join([expected_localized, expected_unlocalized])
         output4 = '; '.join([expected_unlocalized, expected_localized])
         with translation.override('de', deactivate=True):
-            with self.settings(USE_L10N=False):
+            with self.settings(USE_L10N=False, USE_THOUSAND_SEPARATOR=True):
                 self.assertEqual(template1.render(context), output1)
                 self.assertEqual(template4.render(context), output4)
-            with self.settings(USE_L10N=True):
+            with self.settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True):
                 self.assertEqual(template1.render(context), output1)
                 self.assertEqual(template2.render(context), output2)
                 self.assertEqual(template3.render(context), output3)

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -1,11 +1,11 @@
 from decimal import Decimal
 from sys import float_info
-from unittest import TestCase
 
+from django.test import SimpleTestCase
 from django.utils.numberformat import format as nformat
 
 
-class TestNumberFormat(TestCase):
+class TestNumberFormat(SimpleTestCase):
 
     def test_format_number(self):
         self.assertEqual(nformat(1234, '.'), '1234')
@@ -14,6 +14,11 @@ class TestNumberFormat(TestCase):
         self.assertEqual(nformat(1234, '.', grouping=2, thousand_sep=','), '1234')
         self.assertEqual(nformat(1234, '.', grouping=2, thousand_sep=',', force_grouping=True), '12,34')
         self.assertEqual(nformat(-1234.33, '.', decimal_pos=1), '-1234.3')
+        # The use_l10n parameter can force thousand grouping behavior.
+        with self.settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=True):
+            self.assertEqual(nformat(1234, '.', grouping=3, thousand_sep=',', use_l10n=False), '1234')
+        with self.settings(USE_THOUSAND_SEPARATOR=True, USE_L10N=False):
+            self.assertEqual(nformat(1234, '.', grouping=3, thousand_sep=',', use_l10n=True), '1,234')
 
     def test_format_string(self):
         self.assertEqual(nformat('1234', '.'), '1234')


### PR DESCRIPTION
Thanks Sassan Haradji for the bug report.