### PR TITLE
HttpResponse import not required in tutorial 04 code

### DIFF
--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -69,7 +69,7 @@ create a real version. Add the following to ``polls/views.py``:
 .. snippet::
     :filename: polls/views.py
 
-    from django.http import HttpResponse, HttpResponseRedirect
+    from django.http import HttpResponseRedirect
     from django.shortcuts import get_object_or_404, render
     from django.urls import reverse
 


### PR DESCRIPTION
The HttpResponse import was not required. Hence edited.