### PR TITLE
Fixed #29560 -- Added --force-color management command option.

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -95,7 +95,7 @@ class DjangoHelpFormatter(HelpFormatter):
     """
     show_last = {
         '--version', '--verbosity', '--traceback', '--settings', '--pythonpath',
-        '--no-color',
+        '--no-color', '--force_color',
     }
 
     def _reordered_actions(self, actions):
@@ -227,13 +227,15 @@ class BaseCommand:
     # Command-specific options not defined by the argument parser.
     stealth_options = ()
 
-    def __init__(self, stdout=None, stderr=None, no_color=False):
+    def __init__(self, stdout=None, stderr=None, no_color=False, force_color=False):
         self.stdout = OutputWrapper(stdout or sys.stdout)
         self.stderr = OutputWrapper(stderr or sys.stderr)
+        if no_color and force_color:
+            raise CommandError("'no_color' and 'force_color' can't be used together.")
         if no_color:
             self.style = no_style()
         else:
-            self.style = color_style()
+            self.style = color_style(force_color)
             self.stderr.style_func = self.style.ERROR
 
     def get_version(self):
@@ -279,6 +281,10 @@ class BaseCommand:
         parser.add_argument(
             '--no-color', action='store_true',
             help="Don't colorize the command output.",
+        )
+        parser.add_argument(
+            '--force-color', action='store_true',
+            help='Force colorization of the command output.',
         )
         self.add_arguments(parser)
         return parser
@@ -339,7 +345,11 @@ class BaseCommand:
         controlled by the ``requires_system_checks`` attribute, except if
         force-skipped).
         """
-        if options['no_color']:
+        if options['force_color'] and options['no_color']:
+            raise CommandError("The --no-color and --force-color options can't be used together.")
+        if options['force_color']:
+            self.style = color_style(force_color=True)
+        elif options['no_color']:
             self.style = no_style()
             self.stderr.style_func = None
         if options.get('stdout'):

--- a/django/core/management/color.py
+++ b/django/core/management/color.py
@@ -64,10 +64,10 @@ def no_style():
     return make_style('nocolor')
 
 
-def color_style():
+def color_style(force_color=False):
     """
     Return a Style object from the Django color scheme.
     """
-    if not supports_color():
+    if not force_color and not supports_color():
         return no_style()
     return make_style(os.environ.get('DJANGO_COLORS', ''))

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1657,6 +1657,14 @@ Example usage::
 
     django-admin runserver --no-color
 
+.. django-admin-option:: --force-color
+
+.. versionadded:: 2.2
+
+Forces colorization of the command output if it would otherwise be disabled
+as discussed in :ref:`syntax-coloring`. For example, you may want to pipe
+colored output to another command.
+
 Extra niceties
 ==============
 
@@ -1668,7 +1676,7 @@ Syntax coloring
 The ``django-admin`` / ``manage.py`` commands will use pretty
 color-coded output if your terminal supports ANSI-colored output. It
 won't use the color codes if you're piping the command's output to
-another program.
+another program unless the :option:`--force-color` option is used.
 
 Under Windows, the native console doesn't support ANSI escape sequences so by
 default there is no color output. But you can install the `ANSICON`_

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -170,7 +170,8 @@ Internationalization
 Management Commands
 ~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :option:`--force-color` option forces colorization of the command
+  output.
 
 Migrations
 ~~~~~~~~~~

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1459,6 +1459,13 @@ class ManageTestserver(AdminScriptTestCase):
 # user-space commands are correctly handled - in particular, arguments to
 # the commands are correctly parsed and processed.
 ##########################################################################
+class ColorCommand(BaseCommand):
+    requires_system_checks = False
+
+    def handle(self, *args, **options):
+        self.stdout.write('Hello, world!', self.style.ERROR)
+        self.stderr.write('Hello, world!', self.style.ERROR)
+
 
 class CommandTypes(AdminScriptTestCase):
     "Tests for the various types of base command types that can be defined."
@@ -1542,16 +1549,9 @@ class CommandTypes(AdminScriptTestCase):
         self.assertNotEqual(style.ERROR('Hello, world!'), 'Hello, world!')
 
     def test_command_color(self):
-        class Command(BaseCommand):
-            requires_system_checks = False
-
-            def handle(self, *args, **options):
-                self.stdout.write('Hello, world!', self.style.ERROR)
-                self.stderr.write('Hello, world!', self.style.ERROR)
-
         out = StringIO()
         err = StringIO()
-        command = Command(stdout=out, stderr=err)
+        command = ColorCommand(stdout=out, stderr=err)
         call_command(command)
         if color.supports_color():
             self.assertIn('Hello, world!\n', out.getvalue())
@@ -1564,23 +1564,16 @@ class CommandTypes(AdminScriptTestCase):
 
     def test_command_no_color(self):
         "--no-color prevent colorization of the output"
-        class Command(BaseCommand):
-            requires_system_checks = False
-
-            def handle(self, *args, **options):
-                self.stdout.write('Hello, world!', self.style.ERROR)
-                self.stderr.write('Hello, world!', self.style.ERROR)
-
         out = StringIO()
         err = StringIO()
-        command = Command(stdout=out, stderr=err, no_color=True)
+        command = ColorCommand(stdout=out, stderr=err, no_color=True)
         call_command(command)
         self.assertEqual(out.getvalue(), 'Hello, world!\n')
         self.assertEqual(err.getvalue(), 'Hello, world!\n')
 
         out = StringIO()
         err = StringIO()
-        command = Command(stdout=out, stderr=err)
+        command = ColorCommand(stdout=out, stderr=err)
         call_command(command, no_color=True)
         self.assertEqual(out.getvalue(), 'Hello, world!\n')
         self.assertEqual(err.getvalue(), 'Hello, world!\n')

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -179,18 +179,18 @@ class CommandTests(SimpleTestCase):
     def test_call_command_unrecognized_option(self):
         msg = (
             'Unknown option(s) for dance command: unrecognized. Valid options '
-            'are: example, help, integer, no_color, opt_3, option3, '
-            'pythonpath, settings, skip_checks, stderr, stdout, style, '
-            'traceback, verbosity, version.'
+            'are: example, force_color, help, integer, no_color, opt_3, '
+            'option3, pythonpath, settings, skip_checks, stderr, stdout, '
+            'style, traceback, verbosity, version.'
         )
         with self.assertRaisesMessage(TypeError, msg):
             management.call_command('dance', unrecognized=1)
 
         msg = (
             'Unknown option(s) for dance command: unrecognized, unrecognized2. '
-            'Valid options are: example, help, integer, no_color, opt_3, '
-            'option3, pythonpath, settings, skip_checks, stderr, stdout, '
-            'style, traceback, verbosity, version.'
+            'Valid options are: example, force_color, help, integer, no_color, '
+            'opt_3, option3, pythonpath, settings, skip_checks, stderr, '
+            'stdout, style, traceback, verbosity, version.'
         )
         with self.assertRaisesMessage(TypeError, msg):
             management.call_command('dance', unrecognized=1, unrecognized2=1)


### PR DESCRIPTION
Add `--force-color` option to management command([ticket 29560](https://code.djangoproject.com/ticket/29560))