### PR TITLE
Fixed #29589 -- Insert a new method part_page_range() for class Page in django.core.paginator.py

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -185,3 +185,19 @@ class Page(collections.abc.Sequence):
         if self.number == self.paginator.num_pages:
             return self.paginator.count
         return self.number * self.paginator.per_page
+
+    def part_page_range(self, show_count=10):
+        """
+        Return a 1-based range of part pages for iterating through within
+        a template for loop. This page num is in the middle of range.
+        Can set show_count control the range length.
+        """
+        bottom = self.number - show_count//2
+        top = self.number + show_count//2
+        if self.paginator.num_pages <= show_count:
+            return range(1, self.paginator.num_pages)
+        if bottom <= 0:
+            return range(1, show_count + 1)
+        if top >= self.paginator.num_pages:
+            return range(self.paginator.num_pages - show_count + 1, self.paginator.num_pages + 1)
+        return range(bottom + 1, top + 1)

--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -192,8 +192,8 @@ class Page(collections.abc.Sequence):
         a template for loop. This page num is in the middle of range.
         Can set show_count control the range length.
         """
-        bottom = self.number - show_count//2
-        top = self.number + show_count//2
+        bottom = self.number - show_count // 2
+        top = self.number + show_count // 2
         if self.paginator.num_pages <= show_count:
             return range(1, self.paginator.num_pages)
         if bottom <= 0:


### PR DESCRIPTION
Class `Pagination` have a attribute `page_range`,
it's very useful when I want to write the other page link in the html.
We only need write in html like 

```
<!-- contacts is a instance of Page class -->
{% for p in contacts.paginator.page_range %}
<li>
    <a href="{% url 'admin_user_index' %}?&page={{ p }}">
        {{ p }}
    </a>
</li>
{% endfor %}
```

But, when the pages is too more, for example 1000, Things are going to get scary.

So, I suggest insert a method `part_page_range()` for class Page.

For example, 
When the `contacts.paginator.num_pages` `=1000`,
and the `contacts.number` `=500`,
I can use the

```
contacts.part_page_range(5)
```

to acquire a range instance `range(498, 503)`.
I think Django will be more handy after insert this method.
