### PR TITLE
Refs #29592 -- fix sqlite error when field_maps is empty, it cause copying zero columns

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -269,12 +269,13 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
             # Copy data from the old table into the new table
             field_maps = list(mapping.items())
-            self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
-                self.quote_name(temp_model._meta.db_table),
-                ', '.join(self.quote_name(x) for x, y in field_maps),
-                ', '.join(y for x, y in field_maps),
-                self.quote_name(model._meta.db_table),
-            ))
+            if len(field_maps) > 0:
+                self.execute("INSERT INTO %s (%s) SELECT %s FROM %s" % (
+                    self.quote_name(temp_model._meta.db_table),
+                    ', '.join(self.quote_name(x) for x, y in field_maps),
+                    ', '.join(y for x, y in field_maps),
+                    self.quote_name(model._meta.db_table),
+                ))
 
             # Delete the old table
             self.delete_model(model, handle_autom2m=False)


### PR DESCRIPTION
When `field_map` is empty, the sqlite driver will generate sql like this `INSERT INTO "myapp_mymodel" () SELECT  FROM "myapp_mymodel__old"`. It raise SQL Syntax Error because there is no fields.