### PR TITLE
Refs #24424 -- Added regression tests for MTI-inheritance model removal.

### DIFF
--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2354,3 +2354,13 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AddField", "AddField"])
         self.assertOperationAttributes(changes, 'testapp', 0, 0)
+
+    def test_mti_inheritance_model_removal(self):
+        Animal = ModelState('app', 'Animal', [
+            ("id", models.AutoField(primary_key=True)),
+        ])
+        Dog = ModelState('app', 'Dog', [], bases=('app.Animal',))
+        changes = self.get_changes([Animal, Dog], [Animal])
+        self.assertNumberMigrations(changes, 'app', 1)
+        self.assertOperationTypes(changes, 'app', 0, ['DeleteModel'])
+        self.assertOperationAttributes(changes, 'app', 0, 0, name='Dog')

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -588,6 +588,29 @@ class OperationTests(OperationTestBase):
         self.assertTableExists("test_dlprmo_pony")
         self.assertTableNotExists("test_dlprmo_proxypony")
 
+    def test_delete_mti_model(self):
+        project_state = self.set_up_test_model('test_dlmtimo', mti_model=True)
+        # Test the state alteration
+        operation = migrations.DeleteModel('ShetlandPony')
+        new_state = project_state.clone()
+        operation.state_forwards('test_dlmtimo', new_state)
+        self.assertIn(('test_dlmtimo', 'shetlandpony'), project_state.models)
+        self.assertNotIn(('test_dlmtimo', 'shetlandpony'), new_state.models)
+        # Test the database alteration
+        self.assertTableExists('test_dlmtimo_pony')
+        self.assertTableExists('test_dlmtimo_shetlandpony')
+        self.assertColumnExists('test_dlmtimo_shetlandpony', 'pony_ptr_id')
+        with connection.schema_editor() as editor:
+            operation.database_forwards('test_dlmtimo', editor, project_state, new_state)
+        self.assertTableExists('test_dlmtimo_pony')
+        self.assertTableNotExists('test_dlmtimo_shetlandpony')
+        # And test reversal
+        with connection.schema_editor() as editor:
+            operation.database_backwards('test_dlmtimo', editor, new_state, project_state)
+        self.assertTableExists('test_dlmtimo_pony')
+        self.assertTableExists('test_dlmtimo_shetlandpony')
+        self.assertColumnExists('test_dlmtimo_shetlandpony', 'pony_ptr_id')
+
     def test_rename_model(self):
         """
         Tests the RenameModel operation.


### PR DESCRIPTION
https://code.djangoproject.com/ticket/24424

The actual issue was fixed as a side effect of implementing `RemoveField`'s redution of `DeleteModel` to a `DeleteModel` in ad82900ad94ed4bbad050b9993373dafbe66b610.