### PR TITLE
 Fixed #29593 -- Added QUERY_TERMS removal to v2.1 release notes.

### DIFF
--- a/docs/ref/models/lookups.txt
+++ b/docs/ref/models/lookups.txt
@@ -57,6 +57,11 @@ register lookups on itself. The two prominent examples are
         and checks if any has a registered lookup named ``lookup_name``, returning
         the first match.
 
+    .. method:: get_lookups()
+
+        Returns a dictionary of each lookup name registered in the class mapped
+        to the :class:`Lookup` class.
+
     .. method:: get_transform(transform_name)
 
         Returns a :class:`Transform` named ``transform_name``. The default

--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -391,6 +391,13 @@ Miscellaneous
 * Management commands no longer allow the abbreviated forms of the
   ``--settings`` and ``--pythonpath`` arguments.
 
+* The private ``django.db.models.sql.constants.QUERY_TERMS`` constant is
+  removed. The :meth:`~.RegisterLookupMixin.get_lookup`
+  and :meth:`~.RegisterLookupMixin.get_lookups` methods
+  of the :ref:`Lookup Registration API <lookup-registration-api>` may be
+  suitable alternatives. Compared to the ``QUERY_TERMS`` constant, they allow
+  your code to also account for any custom lookups that have been registered.
+
 .. _deprecated-features-2.1:
 
 Features deprecated in 2.1


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29593

* `QUERY_TERMS` is quite widely used. It seems fair to at least mention it's removal.  
* When working around `QUERY_TERMS` removal for django-filter (https://github.com/carltongibson/django-filter/pull/851), we used the `get_lookups()` method added in #6906. (cc @rpkilby) It's likely others will need this too. 

This PR: 

* Adds `get_lookups()` to the Lookup Registration API docs. 
* Adds note about QUERY_TERMS removal to 2.1 release notes. 
