### PR TITLE
Fixed #29595 -- Allowed using timedelta in migrations questioner.

### DIFF
--- a/django/db/migrations/questioner.py
+++ b/django/db/migrations/questioner.py
@@ -1,10 +1,11 @@
+import datetime
 import importlib
 import os
 import sys
 
 from django.apps import apps
 from django.db.models.fields import NOT_PROVIDED
-from django.utils import datetime_safe, timezone
+from django.utils import timezone
 
 from .loader import MigrationLoader
 
@@ -135,7 +136,7 @@ class InteractiveMigrationQuestioner(MigrationQuestioner):
                 sys.exit(1)
             else:
                 try:
-                    return eval(code, {}, {"datetime": datetime_safe, "timezone": timezone})
+                    return eval(code, {}, {'datetime': datetime, 'timezone': timezone})
                 except (SyntaxError, NameError) as e:
                     print("Invalid input: %s" % e)
 

--- a/tests/migrations/test_questioner.py
+++ b/tests/migrations/test_questioner.py
@@ -1,6 +1,11 @@
-from django.db.migrations.questioner import MigrationQuestioner
+import datetime
+from unittest import mock
+
+from django.db.migrations.questioner import (
+    InteractiveMigrationQuestioner, MigrationQuestioner,
+)
 from django.test import SimpleTestCase
-from django.test.utils import override_settings
+from django.test.utils import captured_stdout, override_settings
 
 
 class QuestionerTests(SimpleTestCase):
@@ -11,3 +16,10 @@ class QuestionerTests(SimpleTestCase):
     def test_ask_initial_with_disabled_migrations(self):
         questioner = MigrationQuestioner()
         self.assertIs(False, questioner.ask_initial('migrations'))
+
+    @mock.patch('builtins.input', return_value='datetime.timedelta(days=1)')
+    def test_timedelta_default(self, mock):
+        questioner = InteractiveMigrationQuestioner()
+        with captured_stdout():
+            value = questioner._ask_default()
+        self.assertEqual(value, datetime.timedelta(days=1))

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -19,7 +19,6 @@ from django.db.migrations.writer import (
     MigrationWriter, OperationWriter, SettingsReference,
 )
 from django.test import SimpleTestCase
-from django.utils import datetime_safe
 from django.utils.deconstruct import deconstructible
 from django.utils.functional import SimpleLazyObject
 from django.utils.timezone import get_default_timezone, get_fixed_timezone, utc
@@ -362,20 +361,6 @@ class WriterTests(SimpleTestCase):
                 "datetime.datetime(2012, 1, 1, 1, 1, tzinfo=utc)",
                 {'import datetime', 'from django.utils.timezone import utc'},
             )
-        )
-
-    def test_serialize_datetime_safe(self):
-        self.assertSerializedResultEqual(
-            datetime_safe.date(2014, 3, 31),
-            ("datetime.date(2014, 3, 31)", {'import datetime'})
-        )
-        self.assertSerializedResultEqual(
-            datetime_safe.time(10, 25),
-            ("datetime.time(10, 25)", {'import datetime'})
-        )
-        self.assertSerializedResultEqual(
-            datetime_safe.datetime(2014, 3, 31, 16, 4, 31),
-            ("datetime.datetime(2014, 3, 31, 16, 4, 31)", {'import datetime'})
         )
 
     def test_serialize_fields(self):


### PR DESCRIPTION
Refs #29600 -- Removed usage of django.utils.datetime_safe in migrations.
https://code.djangoproject.com/ticket/29595
https://code.djangoproject.com/ticket/29600