### PR TITLE
Refs #29600 -- Removed datetime_safe usage in feedgenerator.

### DIFF
--- a/django/utils/feedgenerator.py
+++ b/django/utils/feedgenerator.py
@@ -26,7 +26,6 @@ import email
 from io import StringIO
 from urllib.parse import urlparse
 
-from django.utils import datetime_safe
 from django.utils.encoding import iri_to_uri
 from django.utils.timezone import utc
 from django.utils.xmlutils import SimplerXMLGenerator
@@ -53,7 +52,7 @@ def get_tag_uri(url, date):
     bits = urlparse(url)
     d = ''
     if date is not None:
-        d = ',%s' % datetime_safe.new_datetime(date).strftime('%Y-%m-%d')
+        d = ',%s' % date.strftime('%Y-%m-%d')
     return 'tag:%s%s:%s/%s' % (bits.hostname, d, bits.path, bits.fragment)
 
 


### PR DESCRIPTION
The only effect would be if items in Atom feeds had a published date
year of < 1000.