### PR TITLE
Fixed #29139 -- Fixed aggregation crash when using nested KeyTransforms.

### DIFF
--- a/django/contrib/postgres/fields/jsonb.py
+++ b/django/contrib/postgres/fields/jsonb.py
@@ -107,7 +107,8 @@ class KeyTransform(Transform):
             previous = previous.lhs
         lhs, params = compiler.compile(previous)
         if len(key_transforms) > 1:
-            return "(%s %s %%s)" % (lhs, self.nested_operator), [key_transforms] + params
+            key_transforms_str = "{%s}" % ",".join(key_transforms)
+            return "(%s %s %%s)" % (lhs, self.nested_operator), [key_transforms_str] + params
         try:
             int(self.key_name)
         except ValueError:


### PR DESCRIPTION
This PR resolve [#29139](https://code.djangoproject.com/ticket/29139), which generate incorrect params in as_sql(), when using nested KeyTransform.