### PR TITLE
Fixed #29623 -- Fixed translation failure of DurationField's "overflow" error message.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -468,12 +468,7 @@ class DateTimeField(BaseTemporalField):
 class DurationField(Field):
     default_error_messages = {
         'invalid': _('Enter a valid duration.'),
-        'overflow': _(
-            'The number of days must be between {min_days} and {max_days}.'.format(
-                min_days=datetime.timedelta.min.days,
-                max_days=datetime.timedelta.max.days,
-            )
-        )
+        'overflow': _('The number of days must be between {min_days} and {max_days}.')
     }
 
     def prepare_value(self, value):
@@ -489,7 +484,10 @@ class DurationField(Field):
         try:
             value = parse_duration(str(value))
         except OverflowError:
-            raise ValidationError(self.error_messages['overflow'], code='overflow')
+            raise ValidationError(self.error_messages['overflow'].format(
+                min_days=datetime.timedelta.min.days,
+                max_days=datetime.timedelta.max.days,
+            ), code='overflow')
         if value is None:
             raise ValidationError(self.error_messages['invalid'], code='invalid')
         return value

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -21,3 +21,6 @@ Bugfixes
 
 * Fixed a regression in Django 2.0 where combining ``Q`` objects with ``__in``
   lookups and lists crashed (:ticket:`29643`).
+
+* Fixed translation failure of ``DurationField``'s "overflow" error message
+  (:ticket:`29623`).

--- a/tests/forms_tests/field_tests/test_durationfield.py
+++ b/tests/forms_tests/field_tests/test_durationfield.py
@@ -3,6 +3,7 @@ import datetime
 from django.core.exceptions import ValidationError
 from django.forms import DurationField
 from django.test import SimpleTestCase
+from django.utils import translation
 from django.utils.duration import duration_string
 
 from . import FormFieldAssertionsMixin
@@ -30,6 +31,15 @@ class DurationFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             f.clean('1000000000 00:00:00')
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean('-1000000000 00:00:00')
+
+    def test_overflow_translation(self):
+        msg = "Le nombre de jours doit être entre {min_days} et {max_days}.".format(
+            min_days=datetime.timedelta.min.days,
+            max_days=datetime.timedelta.max.days,
+        )
+        with translation.override('fr'):
+            with self.assertRaisesMessage(ValidationError, msg):
+                DurationField().clean('1000000000 00:00:00')
 
     def test_durationfield_render(self):
         self.assertWidgetRendersTo(


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29623