### PR TITLE
Fixed #29625 -- Expose RelatedManager._remove_prefetched_objects as p…

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -579,11 +579,16 @@ def create_reverse_many_to_one_manager(superclass, rel):
             queryset._known_related_objects = {self.field: {self.instance.pk: self.instance}}
             return queryset
 
-        def _remove_prefetched_objects(self):
+        def remove_prefetched_objects(self):
+            """Remove the cached objects from memory that was loaded by prefetch_related()"""
             try:
                 self.instance._prefetched_objects_cache.pop(self.field.remote_field.get_cache_name())
             except (AttributeError, KeyError):
                 pass  # nothing to clear from cache
+
+        def _remove_prefetched_objects(self):
+            """Deprecated in favor of remove_prefetched_objects"""
+            return self.remove_prefetched_objects()
 
         def get_queryset(self):
             try:
@@ -614,7 +619,7 @@ def create_reverse_many_to_one_manager(superclass, rel):
             return queryset, rel_obj_attr, instance_attr, False, cache_name, False
 
         def add(self, *objs, bulk=True):
-            self._remove_prefetched_objects()
+            self.remove_prefetched_objects()
             objs = list(objs)
             db = router.db_for_write(self.model, instance=self.instance)
 
@@ -686,7 +691,7 @@ def create_reverse_many_to_one_manager(superclass, rel):
             clear.alters_data = True
 
             def _clear(self, queryset, bulk):
-                self._remove_prefetched_objects()
+                self.remove_prefetched_objects()
                 db = router.db_for_write(self.model, instance=self.instance)
                 queryset = queryset.using(db)
                 if bulk:
@@ -860,11 +865,16 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                 queryset = queryset.using(self._db)
             return queryset._next_is_sticky().filter(**self.core_filters)
 
-        def _remove_prefetched_objects(self):
+        def remove_prefetched_objects(self):
+            """Remove the cached objects from memory that was loaded by prefetch_related()"""
             try:
                 self.instance._prefetched_objects_cache.pop(self.prefetch_cache_name)
             except (AttributeError, KeyError):
                 pass  # nothing to clear from cache
+
+        def _remove_prefetched_objects(self):
+            """Deprecated in favor of remove_prefetched_objects"""
+            return self.remove_prefetched_objects()
 
         def get_queryset(self):
             try:
@@ -920,7 +930,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                     "intermediary model. Use %s.%s's Manager instead." %
                     (opts.app_label, opts.object_name)
                 )
-            self._remove_prefetched_objects()
+            self.remove_prefetched_objects()
             db = router.db_for_write(self.through, instance=self.instance)
             with transaction.atomic(using=db, savepoint=False):
                 self._add_items(self.source_field_name, self.target_field_name, *objs)
@@ -938,7 +948,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                     "an intermediary model. Use %s.%s's Manager instead." %
                     (opts.app_label, opts.object_name)
                 )
-            self._remove_prefetched_objects()
+            self.remove_prefetched_objects()
             self._remove_items(self.source_field_name, self.target_field_name, *objs)
         remove.alters_data = True
 
@@ -950,7 +960,7 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                     instance=self.instance, reverse=self.reverse,
                     model=self.model, pk_set=None, using=db,
                 )
-                self._remove_prefetched_objects()
+                self.remove_prefetched_objects()
                 filters = self._build_remove_filters(super().get_queryset().using(db))
                 self.through._default_manager.using(db).filter(filters).delete()
 

--- a/docs/ref/models/relations.txt
+++ b/docs/ref/models/relations.txt
@@ -172,18 +172,31 @@ Related objects reference
         race conditions. For instance, new objects may be added to the database
         in between the call to ``clear()`` and the call to ``add()``.
 
+    .. method:: remove_prefetched_objects()
+
+        Remove the cached objects from memory that was loaded by
+        :meth:`~django.db.models.query.QuerySet.prefetch_related`.
+
+            >>> pizza = Pizza.objects.prefetch_related('toppings').first()
+            >>> list(pizza.toppings.all())  # cache is used
+            >>> pizza.toppings.remove_prefetched_objects()
+            >>> list(pizza.toppings.all())  # load from database again
+
+        This can be helpful when the relation is modified from the other side,
+        and you want to manually invalidate the cache.
+
     .. note::
 
-       Note that ``add()``, ``create()``, ``remove()``, ``clear()``, and
-       ``set()`` all apply database changes immediately for all types of
-       related fields. In other words, there is no need to call ``save()``
-       on either end of the relationship.
+        Note that ``add()``, ``create()``, ``remove()``, ``clear()``, and
+        ``set()`` all apply database changes immediately for all types of
+        related fields. In other words, there is no need to call ``save()``
+        on either end of the relationship.
 
-       Also, if you are using :ref:`an intermediate model
-       <intermediary-manytomany>` for a many-to-many relationship, then the
-       ``add()``, ``create()``, ``remove()``, and ``set()`` methods are
-       disabled.
+        Also, if you are using :ref:`an intermediate model
+        <intermediary-manytomany>` for a many-to-many relationship, then the
+        ``add()``, ``create()``, ``remove()``, and ``set()`` methods are
+        disabled.
 
-       If you use :meth:`~django.db.models.query.QuerySet.prefetch_related`,
-       the ``add()``, ``remove()``, ``clear()``, and ``set()`` methods clear
-       the prefetched cache.
+        If you use :meth:`~django.db.models.query.QuerySet.prefetch_related`,
+        the ``add()``, ``remove()``, ``clear()``, and ``set()`` methods clear
+        the prefetched cache.


### PR DESCRIPTION
…ublic method

The method currently starts with underscore, meaning it's not supposed to be accessed from the outside. But I find that sometimes I have to use this method to clear the cache, otherwise the outdated data will be returned. The new test shows a scenario where this method is useful.

See ticket https://code.djangoproject.com/ticket/29625