### PR TITLE
added Azure Pipelines hosted CI

### DIFF
--- a/.azure_pipelines/ci.yml
+++ b/.azure_pipelines/ci.yml
@@ -1,0 +1,86 @@
+#################
+# Azure Pipelines
+#################
+
+jobs:
+######################
+- job: Django
+######################
+
+  strategy:
+    matrix:
+      'SQLite Python 3.5':
+        PYTHON_VERSION: '3.5'
+        COMPOSE_SERVICE: sqlite
+      'Postgres Python 3.5':
+        PYTHON_VERSION: '3.5'
+        COMPOSE_SERVICE: postgres
+      'MySQL Python 3.5':
+        PYTHON_VERSION: '3.5'
+        COMPOSE_SERVICE: mysql
+      'MariaDB Python 3.5':
+        PYTHON_VERSION: '3.5'
+        COMPOSE_SERVICE: mariadb
+      'SQLite Python 3.6':
+        PYTHON_VERSION: '3.6'
+        COMPOSE_SERVICE: sqlite
+      'Postgres Python 3.6':
+        PYTHON_VERSION: '3.6'
+        COMPOSE_SERVICE: postgres
+      'MySQL Python 3.6':
+        PYTHON_VERSION: '3.6'
+        COMPOSE_SERVICE: mysql
+      'MariaDB Python 3.6':
+        PYTHON_VERSION: '3.6'
+        COMPOSE_SERVICE: mariadb
+      'SQLite Python 3.7':
+        PYTHON_VERSION: '3.7'
+        COMPOSE_SERVICE: sqlite
+      'Postgres Python 3.7':
+        PYTHON_VERSION: '3.7'
+        COMPOSE_SERVICE: postgres
+      'MySQL Python 3.7':
+        PYTHON_VERSION: '3.7'
+        COMPOSE_SERVICE: mysql
+      'MariaDB Python 3.7':
+        PYTHON_VERSION: '3.7'
+        COMPOSE_SERVICE: mariadb
+
+  pool:
+    vmImage: ubuntu-16.04
+
+  variables:
+    DJANGO_PATH: $(Build.SourcesDirectory)
+
+  steps:
+  - template: steps.yml
+
+######################
+- job: Utilities
+######################
+
+  pool:
+    vmImage: ubuntu-16.04
+
+  variables:
+    DJANGO_PATH: $(Build.SourcesDirectory)
+    PYTHON_VERSION: '3.6'
+
+  steps:
+  - script: git clone https://github.com/orf/django-docker-box.git
+    displayName: Get Django-Docker-Box
+    workingDirectory: $(Build.SourcesDirectory)
+
+  - script: |
+      docker-compose pull docs
+      docker-compose pull flake8
+    displayName: Get images
+    workingDirectory: $(Build.SourcesDirectory)/django-docker-box
+
+  - script: docker-compose run --rm docs
+    displayName: Run docs
+    workingDirectory: $(Build.SourcesDirectory)/django-docker-box
+
+  - script: docker-compose run --rm flake8
+    displayName: Run flake8
+    workingDirectory: $(Build.SourcesDirectory)/django-docker-box

--- a/.azure_pipelines/steps.yml
+++ b/.azure_pipelines/steps.yml
@@ -1,0 +1,24 @@
+steps:
+- script: git clone https://github.com/orf/django-docker-box.git
+  displayName: Get Django-Docker-Box
+  workingDirectory: $(Build.SourcesDirectory)
+
+- bash: |
+    docker-compose pull --include-deps $(COMPOSE_SERVICE)
+  displayName: Get $(COMPOSE_SERVICE) image
+  workingDirectory: $(Build.SourcesDirectory)/django-docker-box
+
+- bash: |
+    mkdir $TEST_RESULTS_DIR
+    chmod a+rw $TEST_RESULTS_DIR
+    docker-compose run -v$TEST_RESULTS_DIR:/tests/results $(COMPOSE_SERVICE) --noinput
+  displayName: Run tests
+  workingDirectory: $(Build.SourcesDirectory)/django-docker-box
+  env:
+    TEST_RESULTS_DIR: $(Build.SourcesDirectory)/results
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: "**/TEST-*.xml"
+    testRunTitle: '$(COMPOSE_SERVICE) Python $(PYTHON_VERSION)'
+  displayName: Publish test results


### PR DESCRIPTION
This proof-of-concept demonstrates Visual Studio Team Services running the Django test suite on Linux and Windows against SQLite. The files in this PR define the pipeline, and I have a testing instance of VSTS ready to connect to the Django repo.

Carlton Gibson and I have been corresponding about the feature gaps in Microsoft's CI offering with respect to big open source projects. I'm asking to stand this up as a demo working against the real Django repo in order to have more pointed conversations about what's missing, what's not as nice as Jenkins, etc. It'll run alongside the existing Jenkins infrastructure, adding one additional gate on PRs (which can be set to not required).