### PR TITLE
Removed odd sentence in count() documentation.

### DIFF
--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2085,7 +2085,7 @@ where the default is such that at most 999 variables per query are used.
 .. method:: count()
 
 Returns an integer representing the number of objects in the database matching
-the ``QuerySet``. The ``count()`` method never raises exceptions.
+the ``QuerySet``.
 
 Example::
 


### PR DESCRIPTION
Rereading the docs today I saw this sentence. It has been there since c2e42e1c5c11b45b8136aff36065cb879d12862c , pre version 1.0, when the docs were in a much different state, with each method describing which exceptions it can raise. I think it can go now, as we don't mention the explicit exceptions for any of the other methods, plus the wording is a bit confusing, as e.g. `DatabaseError` can certainly by raised by `count()`.