### PR TITLE
Fixed #29627 -- Fixed QueryDict.urlencode() crash with non-string values.

### DIFF
--- a/django/http/request.py
+++ b/django/http/request.py
@@ -511,7 +511,7 @@ class QueryDict(MultiValueDict):
                 return urlencode({k: v})
         for k, list_ in self.lists():
             output.extend(
-                encode(k.encode(self.encoding), v.encode(self.encoding))
+                encode(k.encode(self.encoding), str(v).encode(self.encoding))
                 for v in list_
             )
         return '&'.join(output)

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -11,3 +11,6 @@ Bugfixes
 
 * Fixed a race condition in ``QuerySet.update_or_create()`` that could result
   in data loss (:ticket:`29499`).
+
+* Fixed a regression where ``QueryDict.urlencode()`` crashed if the dictionary
+  contains a non-string value (:ticket:`29627`).

--- a/tests/httpwrappers/tests.py
+++ b/tests/httpwrappers/tests.py
@@ -114,6 +114,13 @@ class QueryDictTests(SimpleTestCase):
         self.assertEqual(q.urlencode(), 'next=%2Ft%C3%ABst%26key%2F')
         self.assertEqual(q.urlencode(safe='/'), 'next=/t%C3%ABst%26key/')
 
+    def test_urlencode_int(self):
+        # Normally QueryDict doesn't contain non-string values but lazily
+        # written tests may make that mistake.
+        q = QueryDict(mutable=True)
+        q['a'] = 1
+        self.assertEqual(q.urlencode(), 'a=1')
+
     def test_mutable_copy(self):
         """A copy of a QueryDict is mutable."""
         q = QueryDict().copy()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29627