### PR TITLE
Fixed #29643 -- Fixed crash when combining Q objects with __in lookups and lists.

### DIFF
--- a/django/utils/tree.py
+++ b/django/utils/tree.py
@@ -71,7 +71,10 @@ class Node:
         )
 
     def __hash__(self):
-        return hash((self.__class__, self.connector, self.negated) + tuple(self.children))
+        return hash((self.__class__, self.connector, self.negated) + tuple([
+            tuple(child) if isinstance(child, list) else child
+            for child in self.children
+        ]))
 
     def add(self, data, conn_type, squash=True):
         """

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -18,3 +18,6 @@ Bugfixes
 * Fixed a regression in Django 2.0 where using ``manage.py test --keepdb``
   fails on PostgreSQL if the database exists and the user doesn't have
   permission to create databases (:ticket:`29613`).
+
+* Fixed a regression in Django 2.0 where combining ``Q`` objects with ``__in``
+  lookups and lists crashed (:ticket:`29643`).

--- a/tests/utils_tests/test_tree.py
+++ b/tests/utils_tests/test_tree.py
@@ -23,10 +23,12 @@ class NodeTests(unittest.TestCase):
         node3 = Node(self.node1_children, negated=True)
         node4 = Node(self.node1_children, connector='OTHER')
         node5 = Node(self.node1_children)
+        node6 = Node([['a', 1], ['b', 2]])
         self.assertNotEqual(hash(self.node1), hash(self.node2))
         self.assertNotEqual(hash(self.node1), hash(node3))
         self.assertNotEqual(hash(self.node1), hash(node4))
         self.assertEqual(hash(self.node1), hash(node5))
+        self.assertEqual(hash(self.node1), hash(node6))
         self.assertEqual(hash(self.node2), hash(Node()))
 
     def test_len(self):


### PR DESCRIPTION
Regression in fc6528b25ab1834be1a478b405bf8f7ec5cf860c.

Ticket [29643](https://code.djangoproject.com/ticket/29643).