### PR TITLE
Fixed #29653 -- Fixed missing related_query_name reverse accessor if GenericRelation is declared on an abstract base model.

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -280,7 +280,8 @@ class ModelBase(type):
                         )
                 else:
                     field = copy.deepcopy(field)
-                    field.mti_inherited = True
+                    if not base._meta.abstract:
+                        field.mti_inherited = True
                     new_class.add_to_class(field.name, field)
 
         # Copy indexes so that index names are unique when models extend an

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -28,3 +28,7 @@ Bugfixes
 * Fixed a regression where the admin change form crashed if the user doesn't
   have the 'add' permission to a model that uses ``TabularInline``
   (:ticket:`29637`).
+
+* Fixed a regression where a ``related_query_name`` reverse accessor wasn't set
+  up when a ``GenericRelation`` is declared on an abstract base model
+  (:ticket:`29653`).

--- a/tests/generic_relations_regress/models.py
+++ b/tests/generic_relations_regress/models.py
@@ -158,7 +158,7 @@ class SpecialGenericRelation(GenericRelation):
 
 
 class HasLinks(models.Model):
-    links = SpecialGenericRelation(Link)
+    links = SpecialGenericRelation(Link, related_query_name='targets')
 
     class Meta:
         abstract = True

--- a/tests/generic_relations_regress/tests.py
+++ b/tests/generic_relations_regress/tests.py
@@ -273,3 +273,12 @@ class GenericRelationTests(TestCase):
         link = Link.objects.create(content_object=place)
         result = Link.objects.filter(places=place)
         self.assertCountEqual(result, [link])
+
+    def test_generic_reverse_relation_with_abc(self):
+        """
+        The reverse generic relation accessor (targets) is created if the
+        GenericRelation comes from an abstract base model (HasLinks).
+        """
+        thing = HasLinkThing.objects.create()
+        link = Link.objects.create(content_object=thing)
+        self.assertCountEqual(link.targets.all(), [thing])


### PR DESCRIPTION
It was incorrectly removed when it points to a concrete model which
inherits from an abstract one.

Regression in 4ab027b9.

Thanks Lauri Kainulainen for the report.