### PR TITLE
Fixed #29660 -- Fixed admin to 403 on POST to change view w/o permission.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1556,7 +1556,10 @@ class ModelAdmin(BaseModelAdmin):
         else:
             obj = self.get_object(request, unquote(object_id), to_field)
 
-            if not self.has_view_permission(request, obj) and not self.has_change_permission(request, obj):
+            if request.method == 'POST':
+                if not self.has_change_permission(request, obj):
+                    raise PermissionDenied
+            elif not self.has_view_permission(request, obj) and not self.has_change_permission(request, obj):
                 raise PermissionDenied
 
             if obj is None:

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -32,3 +32,7 @@ Bugfixes
 * Fixed a regression where a ``related_query_name`` reverse accessor wasn't set
   up when a ``GenericRelation`` is declared on an abstract base model
   (:ticket:`29653`).
+
+* Fixed a regression where a POST request to an admin change view by a user
+  without change permission would redirect to the admin index instead of
+  receiving a 403 response (:ticket:`29660`).


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29660