### PR TITLE
Fixed #29662 -- Allowed test client to accept structured suffix JSON content types.

### DIFF
--- a/django/test/client.py
+++ b/django/test/client.py
@@ -34,8 +34,8 @@ __all__ = ('Client', 'RedirectCycleError', 'RequestFactory', 'encode_file', 'enc
 BOUNDARY = 'BoUnDaRyStRiNg'
 MULTIPART_CONTENT = 'multipart/form-data; boundary=%s' % BOUNDARY
 CONTENT_TYPE_RE = re.compile(r'.*; charset=([\w\d-]+);?')
-# JSON Vendor Tree spec: https://tools.ietf.org/html/rfc6838#section-3.2
-JSON_CONTENT_TYPE_RE = re.compile(r'^application\/(vnd\..+\+)?json')
+# Structured suffix spec: https://tools.ietf.org/html/rfc6838#section-4.2.8
+JSON_CONTENT_TYPE_RE = re.compile(r'^application\/(.+\+)?json')
 
 
 class RedirectCycleError(Exception):

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -32,3 +32,6 @@ Bugfixes
 * Fixed a regression where a ``related_query_name`` reverse accessor wasn't set
   up when a ``GenericRelation`` is declared on an abstract base model
   (:ticket:`29653`).
+
+* Fixed the test client's JSON serialization of a request data dictionary for
+  structured content type suffixes (:ticket:`29662`).

--- a/tests/test_client_regress/tests.py
+++ b/tests/test_client_regress/tests.py
@@ -1204,11 +1204,13 @@ class RequestMethodStringDataTests(SimpleTestCase):
         response = self.client.get('/json_response/')
         self.assertEqual(response.json(), {'key': 'value'})
 
-    def test_json_vendor(self):
+    def test_json_structured_suffixes(self):
         valid_types = (
             'application/vnd.api+json',
             'application/vnd.api.foo+json',
             'application/json; charset=utf-8',
+            'application/activity+json',
+            'application/activity+json; charset=utf-8',
         )
         for content_type in valid_types:
             response = self.client.get('/json_response/', {'content_type': content_type})


### PR DESCRIPTION
Allowed the test client to recognise Content-Types like
"application/activity+json" as indicating valid JSON.