### PR TITLE
Refs #29449 -- Reverted release note for "Allowed using contrib.auth forms without installing contrib.auth." 

### DIFF
--- a/docs/releases/2.1.txt
+++ b/docs/releases/2.1.txt
@@ -93,10 +93,6 @@ Minor features
 * :djadmin:`createsuperuser` now gives a prompt to allow bypassing the
   :setting:`AUTH_PASSWORD_VALIDATORS` checks.
 
-* :class:`~django.contrib.auth.forms.UserCreationForm` and
-  :class:`~django.contrib.auth.forms.UserChangeForm` no longer need to be
-  rewritten for a custom user model.
-
 :mod:`django.contrib.gis`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
UserCreationForm and UserChangeForm still need to be rewritten for a custom User model. The mentioned change was introduced with commit 3333d935d2914cd80cf31f4803821ad5c0e2a51d but reverted later with 78f502cd0bc834422c3f189e852564fe4b6459f2 - the changelog entry persisted. The forms still have issues with custom User models.