### PR TITLE
Fixed #29529 -- FilePathField path parameter now accepts a callable.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1077,7 +1077,11 @@ class MultiValueField(Field):
 class FilePathField(ChoiceField):
     def __init__(self, path, *, match=None, recursive=False, allow_files=True,
                  allow_folders=False, **kwargs):
-        self.path, self.match, self.recursive = path, match, recursive
+        if callable(path):
+            self.path = path()
+        else:
+            self.path = path
+        self.match, self.recursive = match, recursive
         self.allow_files, self.allow_folders = allow_files, allow_folders
         super().__init__(choices=(), **kwargs)
 

--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -867,6 +867,18 @@ directory on the filesystem. Has three special arguments, of which the first is
     Required. The absolute filesystem path to a directory from which this
     :class:`FilePathField` should get its choices. Example: ``"/home/images"``.
 
+    A callable (such as a function) can also be passed to dynamically sets the
+    path at runtime::
+
+        def generate_path():
+            return os.path.join(settings.LOCAL_FILE_DIR, '/images')
+
+        file = models.FilePathField(path=generate_path)
+
+    .. versionchanged:: 2.2
+
+        Older versions don't allow passing a callable.
+
 .. attribute:: FilePathField.match
 
     Optional. A regular expression, as a string, that :class:`FilePathField`

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -189,6 +189,9 @@ Models
   :meth:`.QuerySet.bulk_create` to ``True`` tells the database to ignore
   failure to insert rows that fail uniqueness constraints or other checks.
 
+* :class:`~django.db.models.FilePathField` ``path`` parameter now accepts a
+  callable.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/forms_tests/field_tests/test_filepathfield.py
+++ b/tests/forms_tests/field_tests/test_filepathfield.py
@@ -19,6 +19,10 @@ def fix_os_paths(x):
         return x
 
 
+def _build_path():
+    return os.path.join(PATH, 'filepathfield_test_dir') + '/'
+
+
 class FilePathFieldTest(SimpleTestCase):
     expected_choices = [
         ('/filepathfield_test_dir/__init__.py', '__init__.py'),
@@ -33,7 +37,7 @@ class FilePathFieldTest(SimpleTestCase):
         ('/filepathfield_test_dir/h/__init__.py', '__init__.py'),
         ('/filepathfield_test_dir/j/__init__.py', '__init__.py'),
     ]
-    path = os.path.join(PATH, 'filepathfield_test_dir') + '/'
+    path = _build_path()
 
     def assertChoices(self, field, expected_choices):
         self.assertEqual(fix_os_paths(field.choices), expected_choices)
@@ -43,6 +47,13 @@ class FilePathFieldTest(SimpleTestCase):
 
     def test_no_options(self):
         f = FilePathField(path=self.path)
+        expected = [
+            ('/filepathfield_test_dir/README', 'README'),
+        ] + self.expected_choices[:4]
+        self.assertChoices(f, expected)
+
+    def test_callable_path(self):
+        f = FilePathField(path=_build_path)
         expected = [
             ('/filepathfield_test_dir/README', 'README'),
         ] + self.expected_choices[:4]


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29529