### PR TITLE
Fixes #29681-- Support XHTML5 (XML serialization of HTML5)

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -850,7 +850,7 @@ class ModelAdmin(BaseModelAdmin):
         A list_display column containing a checkbox widget.
         """
         return helpers.checkbox.render(helpers.ACTION_CHECKBOX_NAME, str(obj.pk))
-    action_checkbox.short_description = mark_safe('<input type="checkbox" id="action-toggle">')
+    action_checkbox.short_description = mark_safe('<input type="checkbox" id="action-toggle" />')
 
     def _get_base_actions(self):
         """Return the list of actions, prior to any request-based filtering."""

--- a/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
+++ b/django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js
@@ -1,7 +1,7 @@
 /*global Calendar, findPosX, findPosY, getStyle, get_format, gettext, gettext_noop, interpolate, ngettext, quickElement*/
 // Inserts shortcut buttons after all of the following:
-//     <input type="text" class="vDateField">
-//     <input type="text" class="vTimeField">
+//     <input type="text" class="vDateField" />
+//     <input type="text" class="vTimeField" />
 (function() {
     'use strict';
     var DateTimeShortcuts = {

--- a/django/contrib/admin/templates/admin/auth/user/change_password.html
+++ b/django/contrib/admin/templates/admin/auth/user/change_password.html
@@ -5,7 +5,7 @@
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 {% endblock %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block bodyclass %}{{ block.super }} {{ opts.app_label }}-{{ opts.model_name }} change-form{% endblock %}
 {% if not is_popup %}
 {% block breadcrumbs %}
@@ -20,9 +20,9 @@
 {% endif %}
 {% block content %}<div id="content-main">
 <form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
-<input type="text" name="username" value="{{ original.get_username }}" style="display: none">
+<input type="text" name="username" value="{{ original.get_username }}" style="display: none" />
 <div>
-{% if is_popup %}<input type="hidden" name="_popup" value="1">{% endif %}
+{% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if form.errors %}
     <p class="errornote">
     {% if form.errors.items|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
@@ -52,7 +52,7 @@
 </fieldset>
 
 <div class="submit-row">
-<input type="submit" value="{% trans 'Change password' %}" class="default">
+<input type="submit" value="{% trans 'Change password' %}" class="default" />
 </div>
 
 </div>

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -3,16 +3,16 @@
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
 <title>{% block title %}{% endblock %}</title>
-<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" />
 {% block extrastyle %}{% endblock %}
-{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" />{% endif %}
 {% block extrahead %}{% endblock %}
 {% block responsive %}
-    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
-    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}" />
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}" />{% endif %}
 {% endblock %}
-{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
+{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE" />{% endblock %}
 </head>
 {% load i18n %}
 
@@ -81,7 +81,7 @@
         {{ content }}
         {% endblock %}
         {% block sidebar %}{% endblock %}
-        <br class="clear">
+        <br class="clear" />
     </div>
     <!-- END Content -->
 

--- a/django/contrib/admin/templates/admin/change_form.html
+++ b/django/contrib/admin/templates/admin/change_form.html
@@ -6,7 +6,7 @@
 {{ media }}
 {% endblock %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 
 {% block coltype %}colM{% endblock %}
 
@@ -35,8 +35,8 @@
 {% endblock %}
 <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>{% csrf_token %}{% block form_top %}{% endblock %}
 <div>
-{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
-{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
+{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}" />{% endif %}
 {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
 {% if errors %}
     <p class="errornote">

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -3,9 +3,9 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}" />
   {% if cl.formset %}
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />
   {% endif %}
   {% if cl.formset or action_form %}
     <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>

--- a/django/contrib/admin/templates/admin/date_hierarchy.html
+++ b/django/contrib/admin/templates/admin/date_hierarchy.html
@@ -11,6 +11,6 @@
 {% endfor %}
 {% endblock %}
 {% endblock %}
-</ul><br class="clear">
+</ul><br class="clear" />
 </div>
 {% endif %}

--- a/django/contrib/admin/templates/admin/delete_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_confirmation.html
@@ -41,10 +41,10 @@
     <ul>{{ deleted_objects|unordered_list }}</ul>
     <form method="post">{% csrf_token %}
     <div>
-    <input type="hidden" name="post" value="yes">
-    {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
-    {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
-    <input type="submit" value="{% trans "Yes, I'm sure" %}">
+    <input type="hidden" name="post" value="yes" />
+    {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
+    {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}" />{% endif %}
+    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
     <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
     </div>
     </form>

--- a/django/contrib/admin/templates/admin/delete_selected_confirmation.html
+++ b/django/contrib/admin/templates/admin/delete_selected_confirmation.html
@@ -43,11 +43,11 @@
     <form method="post">{% csrf_token %}
     <div>
     {% for obj in queryset %}
-    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
     {% endfor %}
-    <input type="hidden" name="action" value="delete_selected">
-    <input type="hidden" name="post" value="yes">
-    <input type="submit" value="{% trans "Yes, I'm sure" %}">
+    <input type="hidden" name="action" value="delete_selected" />
+    <input type="hidden" name="post" value="yes" />
+    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
     <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
     </div>
     </form>

--- a/django/contrib/admin/templates/admin/edit_inline/tabular.html
+++ b/django/contrib/admin/templates/admin/edit_inline/tabular.html
@@ -13,7 +13,7 @@
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
-         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
          </th>
        {% endif %}
      {% endfor %}

--- a/django/contrib/admin/templates/admin/index.html
+++ b/django/contrib/admin/templates/admin/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}" />{% endblock %}
 
 {% block coltype %}colMS{% endblock %}
 
@@ -71,7 +71,7 @@
                 {% else %}
                     <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
                 {% endif %}
-                <br>
+                <br/>
                 {% if entry.content_type %}
                     <span class="mini quiet">{% filter capfirst %}{{ entry.content_type }}{% endfilter %}</span>
                 {% else %}

--- a/django/contrib/admin/templates/admin/login.html
+++ b/django/contrib/admin/templates/admin/login.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}">
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />
 {{ form.media }}
 {% endblock %}
 
@@ -49,7 +49,7 @@
   <div class="form-row">
     {{ form.password.errors }}
     {{ form.password.label_tag }} {{ form.password }}
-    <input type="hidden" name="next" value="{{ next }}">
+    <input type="hidden" name="next" value="{{ next }}" />
   </div>
   {% url 'admin_password_reset' as password_reset_url %}
   {% if password_reset_url %}
@@ -58,7 +58,7 @@
   </div>
   {% endif %}
   <div class="submit-row">
-    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}">
+    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
   </div>
 </form>
 

--- a/django/contrib/admin/templates/admin/pagination.html
+++ b/django/contrib/admin/templates/admin/pagination.html
@@ -8,5 +8,5 @@
 {% endif %}
 {{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
 {% if show_all_url %}&nbsp;&nbsp;<a href="{{ show_all_url }}" class="showall">{% trans 'Show all' %}</a>{% endif %}
-{% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% trans 'Save' %}">{% endif %}
+{% if cl.formset and cl.result_count %}<input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>{% endif %}
 </p>

--- a/django/contrib/admin/templates/admin/related_widget_wrapper.html
+++ b/django/contrib/admin/templates/admin/related_widget_wrapper.html
@@ -9,10 +9,10 @@
             data-href-template="{{ change_related_template_url }}?{{ url_params }}"
             {% if can_change_related %}
             title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}">
+            <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}"/>
             {% else %}
             title="{% blocktrans %}View selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-viewlink.svg' %}" alt="{% trans 'View' %}">
+            <img src="{% static 'admin/img/icon-viewlink.svg' %}" alt="{% trans 'View' %}"/>
             {% endif %}
         </a>
         {% endif %}
@@ -20,14 +20,14 @@
         <a class="related-widget-wrapper-link add-related" id="add_id_{{ name }}"
             href="{{ add_related_url }}?{{ url_params }}"
             title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}">
+            <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}"/>
         </a>
         {% endif %}
         {% if can_delete_related %}
         <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
             data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
             title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}">
+            <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}"/>
         </a>
         {% endif %}
         {% endspaceless %}

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -2,14 +2,14 @@
 {% if cl.search_fields %}
 <div id="toolbar"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
-<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
-<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
-<input type="submit" value="{% trans 'Search' %}">
+<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
+<input type="submit" value="{% trans 'Search' %}" />
 {% if show_result_count %}
     <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
 {% endif %}
 {% for pair in cl.params.items %}
-    {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}">{% endif %}
+    {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
 {% endfor %}
 </div>
 </form></div>

--- a/django/contrib/admin/templates/admin/search_form.html
+++ b/django/contrib/admin/templates/admin/search_form.html
@@ -3,7 +3,7 @@
 <div id="toolbar"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
 <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
-<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus="autofocus" />
 <input type="submit" value="{% trans 'Search' %}" />
 {% if show_result_count %}
     <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>

--- a/django/contrib/admin/templates/admin/submit_line.html
+++ b/django/contrib/admin/templates/admin/submit_line.html
@@ -1,14 +1,14 @@
 {% load i18n admin_urls %}
 <div class="submit-row">
 {% block submit-row %}
-{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save">{% endif %}
+{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
 {% if show_delete_link %}
     {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
     <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% trans "Delete" %}</a></p>
 {% endif %}
-{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew">{% endif %}
-{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother">{% endif %}
-{% if show_save_and_continue %}<input type="submit" value="{% if can_change %}{% trans 'Save and continue editing' %}{% else %}{% trans 'Save and view' %}{% endif %}" name="_continue">{% endif %}
+{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" />{% endif %}
+{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
+{% if show_save_and_continue %}<input type="submit" value="{% if can_change %}{% trans 'Save and continue editing' %}{% else %}{% trans 'Save and view' %}{% endif %}" name="_continue" />{% endif %}
 {% if show_close %}<a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% trans 'Close' %}</a>{% endif %}
 {% endblock %}
 </div>

--- a/django/contrib/admin/templates/admin/widgets/clearable_file_input.html
+++ b/django/contrib/admin/templates/admin/widgets/clearable_file_input.html
@@ -1,6 +1,6 @@
 {% if widget.is_initial %}<p class="file-upload">{{ widget.initial_text }}: <a href="{{ widget.value.url }}">{{ widget.value }}</a>{% if not widget.required %}
 <span class="clearable-file-input">
-<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
-<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}<br>
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}" />
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label></span>{% endif %}<br />
 {{ widget.input_text }}:{% endif %}
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% if widget.is_initial %}</p>{% endif %}
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} />{% if widget.is_initial %}</p>{% endif %}

--- a/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
+++ b/django/contrib/admin/templates/admin/widgets/related_widget_wrapper.html
@@ -7,21 +7,21 @@
         <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
             data-href-template="{{ change_related_template_url }}?{{ url_params }}"
             title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}">
+            <img src="{% static 'admin/img/icon-changelink.svg' %}" alt="{% trans 'Change' %}"/>
         </a>
         {% endif %}
         {% if can_add_related %}
         <a class="related-widget-wrapper-link add-related" id="add_id_{{ name }}"
             href="{{ add_related_url }}?{{ url_params }}"
             title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}">
+            <img src="{% static 'admin/img/icon-addlink.svg' %}" alt="{% trans 'Add' %}"/>
         </a>
         {% endif %}
         {% if can_delete_related %}
         <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
             data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
             title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
-            <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}">
+            <img src="{% static 'admin/img/icon-deletelink.svg' %}" alt="{% trans 'Delete' %}"/>
         </a>
         {% endif %}
         {% endspaceless %}

--- a/django/contrib/admin/templates/admin/widgets/split_datetime.html
+++ b/django/contrib/admin/templates/admin/widgets/split_datetime.html
@@ -1,4 +1,4 @@
 <p class="datetime">
-  {{ date_label }} {% with widget=widget.subwidgets.0 %}{% include widget.template_name %}{% endwith %}<br>
+  {{ date_label }} {% with widget=widget.subwidgets.0 %}{% include widget.template_name %}{% endwith %}<br />
   {{ time_label }} {% with widget=widget.subwidgets.1 %}{% include widget.template_name %}{% endwith %}
 </p>

--- a/django/contrib/admin/templates/admin/widgets/url.html
+++ b/django/contrib/admin/templates/admin/widgets/url.html
@@ -1,1 +1,1 @@
-{% if widget.value %}<p class="url">{{ current_label }} <a href="{{ widget.href }}">{{ widget.value }}</a><br>{{ change_label }} {% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.value %}</p>{% endif %}
+{% if widget.value %}<p class="url">{{ current_label }} <a href="{{ widget.href }}">{{ widget.value }}</a><br />{{ change_label }} {% endif %}{% include "django/forms/widgets/input.html" %}{% if widget.value %}</p>{% endif %}

--- a/django/contrib/admin/templates/registration/password_change_form.html
+++ b/django/contrib/admin/templates/registration/password_change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block userlinks %}{% url 'django-admindocs-docroot' as docsroot %}{% if docsroot %}<a href="{{ docsroot }}">{% trans 'Documentation' %}</a> / {% endif %} {% trans 'Change password' %} / <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
@@ -51,7 +51,7 @@
 </fieldset>
 
 <div class="submit-row">
-    <input type="submit" value="{% trans 'Change my password' %}" class="default">
+    <input type="submit" value="{% trans 'Change my password' %}" class="default" />
 </div>
 
 </div>

--- a/django/contrib/admin/templates/registration/password_reset_confirm.html
+++ b/django/contrib/admin/templates/registration/password_reset_confirm.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -29,7 +29,7 @@
         <label for="id_new_password2">{% trans 'Confirm password:' %}</label>
         {{ form.new_password2 }}
     </div>
-    <input type="submit" value="{% trans 'Change my password' %}">
+    <input type="submit" value="{% trans 'Change my password' %}" />
 </fieldset>
 </form>
 

--- a/django/contrib/admin/templates/registration/password_reset_form.html
+++ b/django/contrib/admin/templates/registration/password_reset_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -22,7 +22,7 @@
         <label for="id_email">{% trans 'Email address:' %}</label>
         {{ form.email }}
     </div>
-    <input type="submit" value="{% trans 'Reset my password' %}">
+    <input type="submit" value="{% trans 'Reset my password' %}" />
 </fieldset>
 </form>
 

--- a/django/contrib/admin/templatetags/admin_list.py
+++ b/django/contrib/admin/templatetags/admin_list.py
@@ -192,7 +192,7 @@ def result_headers(cl):
 def _boolean_icon(field_val):
     icon_url = static('admin/img/icon-%s.svg' %
                       {True: 'yes', False: 'no', None: 'unknown'}[field_val])
-    return format_html('<img src="{}" alt="{}">', icon_url, field_val)
+    return format_html('<img src="{}" alt="{}" />', icon_url, field_val)
 
 
 def _coerce_field_name(field_name, field_index):

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -205,7 +205,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
 class ManyToManyRawIdWidget(ForeignKeyRawIdWidget):
     """
     A Widget for displaying ManyToMany ids in the "raw_id" interface rather than
-    in a <select multiple> box.
+    in a <select multiple="multiple"> box.
     """
     template_name = 'admin/widgets/many_to_many_raw_id.html'
 

--- a/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_filter_index.html
@@ -20,12 +20,12 @@
 {% for library in filter_libraries %}
 <div class="module">
     <h2>{% firstof library.grouper _("Built-in filters") %}</h2>
-    {% if library.grouper %}<p class="small quiet">{% blocktrans with code="{"|add:"% load "|add:library.grouper|add:" %"|add:"}" %}To use these filters, put <code>{{ code }}</code> in your template before using the filter.{% endblocktrans %}</p><hr>{% endif %}
+    {% if library.grouper %}<p class="small quiet">{% blocktrans with code="{"|add:"% load "|add:library.grouper|add:" %"|add:"}" %}To use these filters, put <code>{{ code }}</code> in your template before using the filter.{% endblocktrans %}</p><hr />{% endif %}
     {% for filter in library.list|dictsort:"name" %}
     <h3 id="{{ library.grouper|default:"built_in" }}-{{ filter.name }}">{{ filter.name }}</h3>
     {{ filter.title }}
     {{ filter.body }}
-    {% if not forloop.last %}<hr>{% endif %}
+    {% if not forloop.last %}<hr />{% endif %}
     {% endfor %}
 </div>
 {% endfor %}

--- a/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/template_tag_index.html
@@ -20,12 +20,12 @@
 {% for library in tag_libraries %}
 <div class="module">
     <h2>{% firstof library.grouper _("Built-in tags") %}</h2>
-    {% if library.grouper %}<p class="small quiet">{% blocktrans with code="{"|add:"% load "|add:library.grouper|add:" %"|add:"}" %}To use these tags, put <code>{{ code }}</code> in your template before using the tag.{% endblocktrans %}</p><hr>{% endif %}
+    {% if library.grouper %}<p class="small quiet">{% blocktrans with code="{"|add:"% load "|add:library.grouper|add:" %"|add:"}" %}To use these tags, put <code>{{ code }}</code> in your template before using the tag.{% endblocktrans %}</p><hr />{% endif %}
     {% for tag in library.list|dictsort:"name" %}
     <h3 id="{{ library.grouper|default:"built_in" }}-{{ tag.name }}">{{ tag.name }}</h3>
     <h4>{{ tag.title|striptags }}</h4>
     {{ tag.body }}
-    {% if not forloop.last %}<hr>{% endif %}
+    {% if not forloop.last %}<hr />{% endif %}
     {% endfor %}
 </div>
 {% endfor %}

--- a/django/contrib/admindocs/templates/admin_doc/view_index.html
+++ b/django/contrib/admindocs/templates/admin_doc/view_index.html
@@ -50,7 +50,7 @@
     View function: <code>{{ full_name }}</code>. Name: <code>{{ url_name }}</code>.
 {% endblocktrans %}</p>
 <p>{{ view.title }}</p>
-<hr>
+<hr />
 {% endifchanged %}
 {% endfor %}
 </div>

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -95,7 +95,7 @@ class BoundField:
 
     def as_text(self, attrs=None, **kwargs):
         """
-        Return a string of HTML for representing this as an <input type="text">.
+        Return a string of HTML for representing this as an <input type="text" />.
         """
         return self.as_widget(TextInput(), attrs, **kwargs)
 
@@ -105,7 +105,7 @@ class BoundField:
 
     def as_hidden(self, attrs=None, **kwargs):
         """
-        Return a string of HTML for representing this as an <input type="hidden">.
+        Return a string of HTML for representing this as an <input type="hidden" />.
         """
         return self.as_widget(self.field.hidden_widget(), attrs, **kwargs)
 

--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -280,7 +280,7 @@ class BaseForm:
             normal_row='<tr%(html_class_attr)s><th>%(label)s</th><td>%(errors)s%(field)s%(help_text)s</td></tr>',
             error_row='<tr><td colspan="2">%s</td></tr>',
             row_ender='</td></tr>',
-            help_text_html='<br><span class="helptext">%s</span>',
+            help_text_html='<br /><span class="helptext">%s</span>',
             errors_on_separate_row=False,
         )
 

--- a/django/forms/jinja2/django/forms/widgets/attrs.html
+++ b/django/forms/jinja2/django/forms/widgets/attrs.html
@@ -1,1 +1,1 @@
-{% for name, value in widget.attrs.items() %}{% if value is not sameas False %} {{ name }}{% if value is not sameas True %}="{{ value }}"{% endif %}{% endif %}{% endfor %}
+{% for name, value in widget.attrs.items() %}{% if value is not sameas False %} {{ name }}="{% if value is not sameas True %}{{ value }}{% else %}{{ name }}{% endif %}"{% endif %}{% endfor %}

--- a/django/forms/jinja2/django/forms/widgets/clearable_file_input.html
+++ b/django/forms/jinja2/django/forms/widgets/clearable_file_input.html
@@ -1,5 +1,5 @@
 {% if widget.is_initial %}{{ widget.initial_text }}: <a href="{{ widget.value.url }}">{{ widget.value }}</a>{% if not widget.required %}
-<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
-<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label>{% endif %}<br>
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}" />
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label>{% endif %}<br />
 {{ widget.input_text }}:{% endif %}
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} />

--- a/django/forms/jinja2/django/forms/widgets/input.html
+++ b/django/forms/jinja2/django/forms/widgets/input.html
@@ -1,1 +1,1 @@
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />

--- a/django/forms/templates/django/forms/widgets/attrs.html
+++ b/django/forms/templates/django/forms/widgets/attrs.html
@@ -1,1 +1,1 @@
-{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}
+{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}="{% if value is not True %}{{ value|stringformat:'s' }}{% else %}{{ name }}{% endif %}"{% endif %}{% endfor %}

--- a/django/forms/templates/django/forms/widgets/clearable_file_input.html
+++ b/django/forms/templates/django/forms/widgets/clearable_file_input.html
@@ -1,5 +1,5 @@
 {% if widget.is_initial %}{{ widget.initial_text }}: <a href="{{ widget.value.url }}">{{ widget.value }}</a>{% if not widget.required %}
-<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}">
-<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label>{% endif %}<br>
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}" />
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label>{% endif %}<br />
 {{ widget.input_text }}:{% endif %}
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} />

--- a/django/forms/templates/django/forms/widgets/input.html
+++ b/django/forms/templates/django/forms/widgets/input.html
@@ -1,1 +1,1 @@
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -682,7 +682,7 @@ class Select(ChoiceWidget):
         invalid HTML.
         """
         use_required_attribute = super().use_required_attribute(initial)
-        # 'required' is always okay for <select multiple>.
+        # 'required' is always okay for <select multiple="multiple">.
         if self.allow_multiple_selected:
             return use_required_attribute
 
@@ -731,7 +731,7 @@ class SelectMultiple(Select):
         return getter(name)
 
     def value_omitted_from_data(self, data, files, name):
-        # An unselected <select multiple> doesn't appear in POST data, so it's
+        # An unselected <select multiple="multiple"> doesn't appear in POST data, so it's
         # never known if the value is actually omitted.
         return False
 

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -74,7 +74,7 @@ class Media:
         media = sorted(self._css)
         return chain.from_iterable([
             format_html(
-                '<link href="{}" type="text/css" media="{}" rel="stylesheet">',
+                '<link href="{}" type="text/css" media="{}" rel="stylesheet" />',
                 self.absolute_path(path), medium
             ) for path in self._css[medium]
         ] for medium in media)
@@ -324,7 +324,7 @@ class HiddenInput(Input):
 
 class MultipleHiddenInput(HiddenInput):
     """
-    Handle <input type="hidden"> for fields that have a list
+    Handle <input type="hidden" /> for fields that have a list
     of values.
     """
     template_name = 'django/forms/widgets/multiple_hidden.html'
@@ -864,7 +864,7 @@ class MultiWidget(Widget):
 
 class SplitDateTimeWidget(MultiWidget):
     """
-    A widget that splits datetime input into two <input type="text"> boxes.
+    A widget that splits datetime input into two <input type="text" /> boxes.
     """
     supports_microseconds = False
     template_name = 'django/forms/widgets/splitdatetime.html'
@@ -891,7 +891,7 @@ class SplitDateTimeWidget(MultiWidget):
 
 class SplitHiddenDateTimeWidget(SplitDateTimeWidget):
     """
-    A widget that splits datetime input into two <input type="hidden"> inputs.
+    A widget that splits datetime input into two <input type="hidden" /> inputs.
     """
     template_name = 'django/forms/widgets/splithiddendatetime.html'
 

--- a/django/http/request.py
+++ b/django/http/request.py
@@ -374,7 +374,7 @@ class QueryDict(MultiValueDict):
 
     A QueryDict can be used to represent GET or POST data. It subclasses
     MultiValueDict since keys in such data can be repeated, for instance
-    in the data from a form with a <select multiple> field.
+    in the data from a form with a <select multiple="multiple"> field.
 
     By default QueryDicts are immutable, though the copy() method
     will always return a mutable copy.

--- a/django/template/backends/utils.py
+++ b/django/template/backends/utils.py
@@ -6,7 +6,7 @@ from django.utils.safestring import SafeText
 
 def csrf_input(request):
     return format_html(
-        '<input type="hidden" name="csrfmiddlewaretoken" value="{}">',
+        '<input type="hidden" name="csrfmiddlewaretoken" value="{}" />',
         get_token(request))
 
 

--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -413,7 +413,7 @@ def force_escape(value):
 def linebreaks_filter(value, autoescape=True):
     """
     Replace line breaks in plain text with appropriate HTML; a single
-    newline becomes an HTML line break (``<br>``) and a new line
+    newline becomes an HTML line break (``<br />``) and a new line
     followed by a blank line becomes a paragraph break (``</p>``).
     """
     autoescape = autoescape and not isinstance(value, SafeData)
@@ -425,13 +425,13 @@ def linebreaks_filter(value, autoescape=True):
 def linebreaksbr(value, autoescape=True):
     """
     Convert all newlines in a piece of plain text to HTML line breaks
-    (``<br>``).
+    (``<br />``).
     """
     autoescape = autoescape and not isinstance(value, SafeData)
     value = normalize_newlines(value)
     if autoescape:
         value = escape(value)
-    return mark_safe(value.replace('\n', '<br>'))
+    return mark_safe(value.replace('\n', '<br />'))
 
 
 @register.filter(is_safe=True)

--- a/django/template/defaulttags.py
+++ b/django/template/defaulttags.py
@@ -54,7 +54,7 @@ class CsrfTokenNode(Node):
             if csrf_token == 'NOTPROVIDED':
                 return format_html("")
             else:
-                return format_html('<input type="hidden" name="csrfmiddlewaretoken" value="{}">', csrf_token)
+                return format_html('<input type="hidden" name="csrfmiddlewaretoken" value="{}" />', csrf_token)
         else:
             # It's very probable that the token is missing because of
             # misconfiguration, so we raise a warning
@@ -1409,7 +1409,7 @@ def widthratio(parser, token):
     For example::
 
         <img src="bar.png" alt="Bar"
-             height="10" width="{% widthratio this_value max_value max_width %}">
+             height="10" width="{% widthratio this_value max_value max_width %}" />
 
     If ``this_value`` is 175, ``max_value`` is 200, and ``max_width`` is 100,
     the image in the above example will be 88 pixels wide

--- a/django/test/html.py
+++ b/django/test/html.py
@@ -59,7 +59,7 @@ class Element:
         if self.attributes != element.attributes:
             # attributes without a value is same as attribute with value that
             # equals the attributes name:
-            # <input checked> == <input checked="checked">
+            # <input checked> == <input checked="checked" />
             for i in range(len(self.attributes)):
                 attr, value = self.attributes[i]
                 other_attr, other_value = element.attributes[i]

--- a/django/test/html.py
+++ b/django/test/html.py
@@ -118,7 +118,7 @@ class Element:
             output += ''.join(str(c) for c in self.children)
             output += '\n</%s>' % self.name
         else:
-            output += '>'
+            output += ' />'
         return output
 
     def __repr__(self):

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -139,13 +139,13 @@ def format_html_join(sep, format_string, args_generator):
 
 @keep_lazy_text
 def linebreaks(value, autoescape=False):
-    """Convert newlines into <p> and <br>s."""
+    """Convert newlines into <p> and <br />s."""
     value = normalize_newlines(value)
     paras = re.split('\n{2,}', str(value))
     if autoescape:
-        paras = ['<p>%s</p>' % escape(p).replace('\n', '<br>') for p in paras]
+        paras = ['<p>%s</p>' % escape(p).replace('\n', '<br />') for p in paras]
     else:
-        paras = ['<p>%s</p>' % p.replace('\n', '<br>') for p in paras]
+        paras = ['<p>%s</p>' % p.replace('\n', '<br />') for p in paras]
     return '\n\n'.join(paras)
 
 

--- a/django/views/csrf.py
+++ b/django/views/csrf.py
@@ -16,8 +16,8 @@ CSRF_FAILURE_TEMPLATE = """
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="robots" content="NONE,NOARCHIVE">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta name="robots" content="NONE,NOARCHIVE" />
   <title>403 Forbidden</title>
   <style type="text/css">
     html * { padding:0; margin:0; }
@@ -122,7 +122,7 @@ def csrf_failure(request, reason="", template_name=CSRF_FAILURE_TEMPLATE_NAME):
             "connections, or for 'same-origin' requests."),
         'no_referer3': _(
             "If you are using the <meta name=\"referrer\" "
-            "content=\"no-referrer\"> tag or including the 'Referrer-Policy: "
+            "content=\"no-referrer\" /> tag or including the 'Referrer-Policy: "
             "no-referrer' header, please remove them. The CSRF protection "
             "requires the 'Referer' header to do strict referer checking. If "
             "you're concerned about privacy, use alternatives like "

--- a/django/views/static.py
+++ b/django/views/static.py
@@ -59,9 +59,9 @@ DEFAULT_DIRECTORY_INDEX_TEMPLATE = """
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-    <meta http-equiv="Content-Language" content="en-us">
-    <meta name="robots" content="NONE,NOARCHIVE">
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Language" content="en-us" />
+    <meta name="robots" content="NONE,NOARCHIVE" />
     <title>{% blocktrans %}Index of {{ directory }}{% endblocktrans %}</title>
   </head>
   <body>

--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -2,10 +2,10 @@
 <!doctype html>
 <html>
     <head>
-        <meta charset="utf-8">
+        <meta charset="utf-8" />
         <title>{% trans "Django: the Web framework for perfectionists with deadlines." %}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css" href="/static/admin/css/fonts.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" type="text/css" href="/static/admin/css/fonts.css" />
         <style type="text/css">
           body, main {
             margin: 0 auto;

--- a/django/views/templates/technical_404.html
+++ b/django/views/templates/technical_404.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   <title>Page not found at {{ request.path_info }}</title>
-  <meta name="robots" content="NONE,NOARCHIVE">
+  <meta name="robots" content="NONE,NOARCHIVE" />
   <style type="text/css">
     html * { padding:0; margin:0; }
     body * { padding:10px 20px; }

--- a/django/views/templates/technical_500.html
+++ b/django/views/templates/technical_500.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <meta name="robots" content="NONE,NOARCHIVE">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta name="robots" content="NONE,NOARCHIVE" />
   <title>{% if exception_type %}{{ exception_type }}{% else %}Report{% endif %}
          {% if request %} at {{ request.path_info }}{% endif %}</title>
   <style type="text/css">
@@ -281,11 +281,11 @@
   <form action="http://dpaste.com/" name="pasteform" id="pasteform" method="post">
 {% if not is_email %}
   <div id="pastebinTraceback" class="pastebin">
-    <input type="hidden" name="language" value="PythonConsole">
+    <input type="hidden" name="language" value="PythonConsole" />
     <input type="hidden" name="title"
-      value="{{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}">
-    <input type="hidden" name="source" value="Django Dpaste Agent">
-    <input type="hidden" name="poster" value="Django">
+      value="{{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}" />
+    <input type="hidden" name="source" value="Django Dpaste Agent" />
+    <input type="hidden" name="poster" value="Django" />
     <textarea name="content" id="traceback_area" cols="140" rows="25">
 Environment:
 
@@ -326,8 +326,8 @@ File "{{ frame.filename }}" in {{ frame.function }}
 Exception Type: {{ exception_type }}{% if request %} at {{ request.path_info }}{% endif %}
 Exception Value: {{ exception_value|force_escape }}
 </textarea>
-  <br><br>
-  <input type="submit" value="Share this traceback on a public website">
+  <br/><br/>
+  <input type="submit" value="Share this traceback on a public website" />
   </div>
 </form>
 </div>

--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -370,7 +370,7 @@ def visit_console_html(self, node):
         uid = node['uid']
         self.body.append('''\
 <div class="console-block" id="console-block-%(id)s">
-<input class="c-tab-unix" id="c-tab-%(id)s-unix" type="radio" name="console-%(id)s" checked />
+<input class="c-tab-unix" id="c-tab-%(id)s-unix" type="radio" name="console-%(id)s" checked="checked" />
 <label for="c-tab-%(id)s-unix" title="Linux/macOS">&#xf17c/&#xf179</label>
 <input class="c-tab-win" id="c-tab-%(id)s-win" type="radio" name="console-%(id)s" />
 <label for="c-tab-%(id)s-win" title="Windows">&#xf17a</label>

--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -370,9 +370,9 @@ def visit_console_html(self, node):
         uid = node['uid']
         self.body.append('''\
 <div class="console-block" id="console-block-%(id)s">
-<input class="c-tab-unix" id="c-tab-%(id)s-unix" type="radio" name="console-%(id)s" checked>
+<input class="c-tab-unix" id="c-tab-%(id)s-unix" type="radio" name="console-%(id)s" checked />
 <label for="c-tab-%(id)s-unix" title="Linux/macOS">&#xf17c/&#xf179</label>
-<input class="c-tab-win" id="c-tab-%(id)s-win" type="radio" name="console-%(id)s">
+<input class="c-tab-win" id="c-tab-%(id)s-win" type="radio" name="console-%(id)s" />
 <label for="c-tab-%(id)s-win" title="Windows">&#xf17a</label>
 <section class="c-content-unix" id="c-content-%(id)s-unix">\n''' % {'id': uid})
         try:

--- a/docs/howto/static-files/index.txt
+++ b/docs/howto/static-files/index.txt
@@ -26,7 +26,7 @@ Configuring static files
    .. code-block:: html+django
 
         {% load static %}
-        <img src="{% static "my_app/example.jpg" %}" alt="My image">
+        <img src="{% static "my_app/example.jpg" %}" alt="My image"/>
 
 4. Store your static files in a folder called ``static`` in your app. For
    example ``my_app/static/my_app/example.jpg``.

--- a/docs/intro/contributing.txt
+++ b/docs/intro/contributing.txt
@@ -535,8 +535,8 @@ Use the arrow keys to move up and down.
     +++ b/docs/ref/forms/api.txt
     @@ -1065,3 +1065,13 @@ You can put several Django forms inside one ``<form>`` tag. To give each
          >>> print(father.as_ul())
-         <li><label for="id_father-first_name">First name:</label> <input type="text" name="father-first_name" id="id_father-first_name"></li>
-         <li><label for="id_father-last_name">Last name:</label> <input type="text" name="father-last_name" id="id_father-last_name"></li>
+         <li><label for="id_father-first_name">First name:</label> <input type="text" name="father-first_name" id="id_father-first_name" /></li>
+         <li><label for="id_father-last_name">Last name:</label> <input type="text" name="father-last_name" id="id_father-last_name" /></li>
     +
     +The prefix can also be specified on the form class::
     +

--- a/docs/intro/overview.txt
+++ b/docs/intro/overview.txt
@@ -307,7 +307,7 @@ Here's what the "base.html" template, including the use of :doc:`static files
         <title>{% block title %}{% endblock %}</title>
     </head>
     <body>
-        <img src="{% static "images/sitelogo.png" %}" alt="Logo">
+        <img src="{% static "images/sitelogo.png" %}" alt="Logo" />
         {% block content %}{% endblock %}
     </body>
     </html>

--- a/docs/intro/tutorial04.txt
+++ b/docs/intro/tutorial04.txt
@@ -22,10 +22,10 @@ tutorial, so that the template contains an HTML ``<form>`` element:
     <form action="{% url 'polls:vote' question.id %}" method="post">
     {% csrf_token %}
     {% for choice in question.choice_set.all %}
-        <input type="radio" name="choice" id="choice{{ forloop.counter }}" value="{{ choice.id }}">
-        <label for="choice{{ forloop.counter }}">{{ choice.choice_text }}</label><br>
+        <input type="radio" name="choice" id="choice{{ forloop.counter }}" value="{{ choice.id }}" />
+        <label for="choice{{ forloop.counter }}">{{ choice.choice_text }}</label><br />
     {% endfor %}
-    <input type="submit" value="Vote">
+    <input type="submit" value="Vote" />
     </form>
 
 A quick rundown:

--- a/docs/intro/tutorial06.txt
+++ b/docs/intro/tutorial06.txt
@@ -70,7 +70,7 @@ Next, add the following at the top of ``polls/templates/polls/index.html``:
 
     {% load static %}
 
-    <link rel="stylesheet" type="text/css" href="{% static 'polls/style.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'polls/style.css' %}" />
 
 The ``{% static %}`` template tag generates the absolute URL of static files.
 

--- a/docs/ref/class-based-views/generic-editing.txt
+++ b/docs/ref/class-based-views/generic-editing.txt
@@ -76,7 +76,7 @@ editing content:
 
         <form method="post">{% csrf_token %}
             {{ form.as_p }}
-            <input type="submit" value="Send message">
+            <input type="submit" value="Send message" />
         </form>
 
 
@@ -132,7 +132,7 @@ editing content:
 
         <form method="post">{% csrf_token %}
             {{ form.as_p }}
-            <input type="submit" value="Save">
+            <input type="submit" value="Save" />
         </form>
 
 ``UpdateView``
@@ -189,7 +189,7 @@ editing content:
 
         <form method="post">{% csrf_token %}
             {{ form.as_p }}
-            <input type="submit" value="Update">
+            <input type="submit" value="Update" />
         </form>
 
 ``DeleteView``
@@ -240,5 +240,5 @@ editing content:
 
         <form method="post">{% csrf_token %}
             <p>Are you sure you want to delete "{{ object }}"?</p>
-            <input type="submit" value="Confirm">
+            <input type="submit" value="Confirm" />
         </form>

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1208,7 +1208,7 @@ subclass::
                 # for each line of the address and you want to separate each
                 # line by a linebreak
                 return format_html_join(
-                    mark_safe('<br>'),
+                    mark_safe('<br/>'),
                     '{}',
                     ((line,) for line in instance.get_full_address()),
                 ) or mark_safe("<span class='errors'>I can't determine this address.</span>")

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -255,9 +255,9 @@ precedence::
     ...     comment = forms.CharField()
     >>> f = CommentForm(initial={'name': 'instance'}, auto_id=False)
     >>> print(f)
-    <tr><th>Name:</th><td><input type="text" name="name" value="instance" required></td></tr>
-    <tr><th>Url:</th><td><input type="url" name="url" required></td></tr>
-    <tr><th>Comment:</th><td><input type="text" name="comment" required></td></tr>
+    <tr><th>Name:</th><td><input type="text" name="name" value="instance" required /></td></tr>
+    <tr><th>Url:</th><td><input type="url" name="url" required /></td></tr>
+    <tr><th>Comment:</th><td><input type="text" name="comment" required /></td></tr>
 
 .. method:: Form.get_initial_for_field(field, field_name)
 
@@ -322,10 +322,10 @@ You can alter the field of :class:`Form` instance to change the way it is
 presented in the form::
 
     >>> f.as_table().split('\n')[0]
-    '<tr><th>Name:</th><td><input name="name" type="text" value="instance" required></td></tr>'
+    '<tr><th>Name:</th><td><input name="name" type="text" value="instance" required /></td></tr>'
     >>> f.fields['name'].label = "Username"
     >>> f.as_table().split('\n')[0]
-    '<tr><th>Username:</th><td><input name="name" type="text" value="instance" required></td></tr>'
+    '<tr><th>Username:</th><td><input name="name" type="text" value="instance" required /></td></tr>'
 
 Beware not to alter the ``base_fields`` attribute because this modification
 will influence all subsequent ``ContactForm`` instances within the same Python
@@ -334,7 +334,7 @@ process::
     >>> f.base_fields['name'].label = "Username"
     >>> another_f = CommentForm(auto_id=False)
     >>> another_f.as_table().split('\n')[0]
-    '<tr><th>Username:</th><td><input name="name" type="text" value="class" required></td></tr>'
+    '<tr><th>Username:</th><td><input name="name" type="text" value="class" required /></td></tr>'
 
 Accessing "clean" data
 ======================
@@ -438,10 +438,10 @@ simply ``print`` it::
 
     >>> f = ContactForm()
     >>> print(f)
-    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required></td></tr>
-    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required></td></tr>
-    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself"></td></tr>
+    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required /></td></tr>
+    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required /></td></tr>
+    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself" /></td></tr>
 
 If the form is bound to data, the HTML output will include that data
 appropriately. For example, if a field is represented by an
@@ -455,10 +455,10 @@ include ``checked`` if appropriate::
     ...         'cc_myself': True}
     >>> f = ContactForm(data)
     >>> print(f)
-    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" value="hello" required></td></tr>
-    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" value="Hi there" required></td></tr>
-    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" value="foo@example.com" required></td></tr>
-    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself" checked></td></tr>
+    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" value="hello" required /></td></tr>
+    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" value="Hi there" required /></td></tr>
+    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" value="foo@example.com" required /></td></tr>
+    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself" checked /></td></tr>
 
 This default output is a two-column HTML table, with a ``<tr>`` for each field.
 Notice the following:
@@ -506,12 +506,12 @@ containing one field::
 
     >>> f = ContactForm()
     >>> f.as_p()
-    '<p><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required></p>\n<p><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required></p>\n<p><label for="id_sender">Sender:</label> <input type="text" name="sender" id="id_sender" required></p>\n<p><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself"></p>'
+    '<p><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required /></p>\n<p><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required /></p>\n<p><label for="id_sender">Sender:</label> <input type="text" name="sender" id="id_sender" required /></p>\n<p><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself" /></p>'
     >>> print(f.as_p())
-    <p><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required></p>
-    <p><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required></p>
-    <p><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required></p>
-    <p><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself"></p>
+    <p><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required /></p>
+    <p><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required /></p>
+    <p><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required /></p>
+    <p><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself" /></p>
 
 ``as_ul()``
 -----------
@@ -525,12 +525,12 @@ flexibility::
 
     >>> f = ContactForm()
     >>> f.as_ul()
-    '<li><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required></li>\n<li><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required></li>\n<li><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required></li>\n<li><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself"></li>'
+    '<li><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required /></li>\n<li><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required /></li>\n<li><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required /></li>\n<li><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself" /></li>'
     >>> print(f.as_ul())
-    <li><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required></li>
-    <li><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required></li>
-    <li><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required></li>
-    <li><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself"></li>
+    <li><label for="id_subject">Subject:</label> <input id="id_subject" type="text" name="subject" maxlength="100" required /></li>
+    <li><label for="id_message">Message:</label> <input type="text" name="message" id="id_message" required /></li>
+    <li><label for="id_sender">Sender:</label> <input type="email" name="sender" id="id_sender" required /></li>
+    <li><label for="id_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_cc_myself" /></li>
 
 ``as_table()``
 --------------
@@ -543,12 +543,12 @@ it calls its ``as_table()`` method behind the scenes::
 
     >>> f = ContactForm()
     >>> f.as_table()
-    '<tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required></td></tr>\n<tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required></td></tr>\n<tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required></td></tr>\n<tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself"></td></tr>'
+    '<tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required /></td></tr>\n<tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required /></td></tr>\n<tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required /></td></tr>\n<tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself" /></td></tr>'
     >>> print(f)
-    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required></td></tr>
-    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required></td></tr>
-    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself"></td></tr>
+    <tr><th><label for="id_subject">Subject:</label></th><td><input id="id_subject" type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th><label for="id_message">Message:</label></th><td><input type="text" name="message" id="id_message" required /></td></tr>
+    <tr><th><label for="id_sender">Sender:</label></th><td><input type="email" name="sender" id="id_sender" required /></td></tr>
+    <tr><th><label for="id_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_cc_myself" /></td></tr>
 
 .. _ref-forms-api-styling-form-rows:
 
@@ -618,20 +618,20 @@ tags nor ``id`` attributes::
 
     >>> f = ContactForm(auto_id=False)
     >>> print(f.as_table())
-    <tr><th>Subject:</th><td><input type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th>Message:</th><td><input type="text" name="message" required></td></tr>
-    <tr><th>Sender:</th><td><input type="email" name="sender" required></td></tr>
-    <tr><th>Cc myself:</th><td><input type="checkbox" name="cc_myself"></td></tr>
+    <tr><th>Subject:</th><td><input type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th>Message:</th><td><input type="text" name="message" required /></td></tr>
+    <tr><th>Sender:</th><td><input type="email" name="sender" required /></td></tr>
+    <tr><th>Cc myself:</th><td><input type="checkbox" name="cc_myself" /></td></tr>
     >>> print(f.as_ul())
-    <li>Subject: <input type="text" name="subject" maxlength="100" required></li>
-    <li>Message: <input type="text" name="message" required></li>
-    <li>Sender: <input type="email" name="sender" required></li>
-    <li>Cc myself: <input type="checkbox" name="cc_myself"></li>
+    <li>Subject: <input type="text" name="subject" maxlength="100" required /></li>
+    <li>Message: <input type="text" name="message" required /></li>
+    <li>Sender: <input type="email" name="sender" required /></li>
+    <li>Cc myself: <input type="checkbox" name="cc_myself" /></li>
     >>> print(f.as_p())
-    <p>Subject: <input type="text" name="subject" maxlength="100" required></p>
-    <p>Message: <input type="text" name="message" required></p>
-    <p>Sender: <input type="email" name="sender" required></p>
-    <p>Cc myself: <input type="checkbox" name="cc_myself"></p>
+    <p>Subject: <input type="text" name="subject" maxlength="100" required /></p>
+    <p>Message: <input type="text" name="message" required /></p>
+    <p>Sender: <input type="email" name="sender" required /></p>
+    <p>Cc myself: <input type="checkbox" name="cc_myself" /></p>
 
 If ``auto_id`` is set to ``True``, then the form output *will* include
 ``<label>`` tags and will simply use the field name as its ``id`` for each form
@@ -639,20 +639,20 @@ field::
 
     >>> f = ContactForm(auto_id=True)
     >>> print(f.as_table())
-    <tr><th><label for="subject">Subject:</label></th><td><input id="subject" type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th><label for="message">Message:</label></th><td><input type="text" name="message" id="message" required></td></tr>
-    <tr><th><label for="sender">Sender:</label></th><td><input type="email" name="sender" id="sender" required></td></tr>
-    <tr><th><label for="cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="cc_myself"></td></tr>
+    <tr><th><label for="subject">Subject:</label></th><td><input id="subject" type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th><label for="message">Message:</label></th><td><input type="text" name="message" id="message" required /></td></tr>
+    <tr><th><label for="sender">Sender:</label></th><td><input type="email" name="sender" id="sender" required /></td></tr>
+    <tr><th><label for="cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="cc_myself" /></td></tr>
     >>> print(f.as_ul())
-    <li><label for="subject">Subject:</label> <input id="subject" type="text" name="subject" maxlength="100" required></li>
-    <li><label for="message">Message:</label> <input type="text" name="message" id="message" required></li>
-    <li><label for="sender">Sender:</label> <input type="email" name="sender" id="sender" required></li>
-    <li><label for="cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="cc_myself"></li>
+    <li><label for="subject">Subject:</label> <input id="subject" type="text" name="subject" maxlength="100" required /></li>
+    <li><label for="message">Message:</label> <input type="text" name="message" id="message" required /></li>
+    <li><label for="sender">Sender:</label> <input type="email" name="sender" id="sender" required /></li>
+    <li><label for="cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="cc_myself" /></li>
     >>> print(f.as_p())
-    <p><label for="subject">Subject:</label> <input id="subject" type="text" name="subject" maxlength="100" required></p>
-    <p><label for="message">Message:</label> <input type="text" name="message" id="message" required></p>
-    <p><label for="sender">Sender:</label> <input type="email" name="sender" id="sender" required></p>
-    <p><label for="cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="cc_myself"></p>
+    <p><label for="subject">Subject:</label> <input id="subject" type="text" name="subject" maxlength="100" required /></p>
+    <p><label for="message">Message:</label> <input type="text" name="message" id="message" required /></p>
+    <p><label for="sender">Sender:</label> <input type="email" name="sender" id="sender" required /></p>
+    <p><label for="cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="cc_myself" /></p>
 
 If ``auto_id`` is set to a string containing the format character ``'%s'``,
 then the form output will include ``<label>`` tags, and will generate ``id``
@@ -662,20 +662,20 @@ attributes based on the format string. For example, for a format string
 
     >>> f = ContactForm(auto_id='id_for_%s')
     >>> print(f.as_table())
-    <tr><th><label for="id_for_subject">Subject:</label></th><td><input id="id_for_subject" type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th><label for="id_for_message">Message:</label></th><td><input type="text" name="message" id="id_for_message" required></td></tr>
-    <tr><th><label for="id_for_sender">Sender:</label></th><td><input type="email" name="sender" id="id_for_sender" required></td></tr>
-    <tr><th><label for="id_for_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_for_cc_myself"></td></tr>
+    <tr><th><label for="id_for_subject">Subject:</label></th><td><input id="id_for_subject" type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th><label for="id_for_message">Message:</label></th><td><input type="text" name="message" id="id_for_message" required /></td></tr>
+    <tr><th><label for="id_for_sender">Sender:</label></th><td><input type="email" name="sender" id="id_for_sender" required /></td></tr>
+    <tr><th><label for="id_for_cc_myself">Cc myself:</label></th><td><input type="checkbox" name="cc_myself" id="id_for_cc_myself" /></td></tr>
     >>> print(f.as_ul())
-    <li><label for="id_for_subject">Subject:</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required></li>
-    <li><label for="id_for_message">Message:</label> <input type="text" name="message" id="id_for_message" required></li>
-    <li><label for="id_for_sender">Sender:</label> <input type="email" name="sender" id="id_for_sender" required></li>
-    <li><label for="id_for_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself"></li>
+    <li><label for="id_for_subject">Subject:</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required /></li>
+    <li><label for="id_for_message">Message:</label> <input type="text" name="message" id="id_for_message" required /></li>
+    <li><label for="id_for_sender">Sender:</label> <input type="email" name="sender" id="id_for_sender" required /></li>
+    <li><label for="id_for_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself" /></li>
     >>> print(f.as_p())
-    <p><label for="id_for_subject">Subject:</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required></p>
-    <p><label for="id_for_message">Message:</label> <input type="text" name="message" id="id_for_message" required></p>
-    <p><label for="id_for_sender">Sender:</label> <input type="email" name="sender" id="id_for_sender" required></p>
-    <p><label for="id_for_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself"></p>
+    <p><label for="id_for_subject">Subject:</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required /></p>
+    <p><label for="id_for_message">Message:</label> <input type="text" name="message" id="id_for_message" required /></p>
+    <p><label for="id_for_sender">Sender:</label> <input type="email" name="sender" id="id_for_sender" required /></p>
+    <p><label for="id_for_cc_myself">Cc myself:</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself" /></p>
 
 If ``auto_id`` is set to any other true value -- such as a string that doesn't
 include ``%s`` -- then the library will act as if ``auto_id`` is ``True``.
@@ -692,16 +692,16 @@ It's possible to customize that character, or omit it entirely, using the
 
     >>> f = ContactForm(auto_id='id_for_%s', label_suffix='')
     >>> print(f.as_ul())
-    <li><label for="id_for_subject">Subject</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required></li>
-    <li><label for="id_for_message">Message</label> <input type="text" name="message" id="id_for_message" required></li>
-    <li><label for="id_for_sender">Sender</label> <input type="email" name="sender" id="id_for_sender" required></li>
-    <li><label for="id_for_cc_myself">Cc myself</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself"></li>
+    <li><label for="id_for_subject">Subject</label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required /></li>
+    <li><label for="id_for_message">Message</label> <input type="text" name="message" id="id_for_message" required /></li>
+    <li><label for="id_for_sender">Sender</label> <input type="email" name="sender" id="id_for_sender" required /></li>
+    <li><label for="id_for_cc_myself">Cc myself</label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself" /></li>
     >>> f = ContactForm(auto_id='id_for_%s', label_suffix=' ->')
     >>> print(f.as_ul())
-    <li><label for="id_for_subject">Subject -></label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required></li>
-    <li><label for="id_for_message">Message -></label> <input type="text" name="message" id="id_for_message" required></li>
-    <li><label for="id_for_sender">Sender -></label> <input type="email" name="sender" id="id_for_sender" required></li>
-    <li><label for="id_for_cc_myself">Cc myself -></label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself"></li>
+    <li><label for="id_for_subject">Subject -></label> <input id="id_for_subject" type="text" name="subject" maxlength="100" required /></li>
+    <li><label for="id_for_message">Message -></label> <input type="text" name="message" id="id_for_message" required /></li>
+    <li><label for="id_for_sender">Sender -></label> <input type="email" name="sender" id="id_for_sender" required /></li>
+    <li><label for="id_for_cc_myself">Cc myself -></label> <input type="checkbox" name="cc_myself" id="id_for_cc_myself" /></li>
 
 Note that the label suffix is added only if the last character of the
 label isn't a punctuation character (in English, those are ``.``, ``!``, ``?``
@@ -788,22 +788,22 @@ method you're using::
     ...         'cc_myself': True}
     >>> f = ContactForm(data, auto_id=False)
     >>> print(f.as_table())
-    <tr><th>Subject:</th><td><ul class="errorlist"><li>This field is required.</li></ul><input type="text" name="subject" maxlength="100" required></td></tr>
-    <tr><th>Message:</th><td><input type="text" name="message" value="Hi there" required></td></tr>
-    <tr><th>Sender:</th><td><ul class="errorlist"><li>Enter a valid email address.</li></ul><input type="email" name="sender" value="invalid email address" required></td></tr>
-    <tr><th>Cc myself:</th><td><input checked type="checkbox" name="cc_myself"></td></tr>
+    <tr><th>Subject:</th><td><ul class="errorlist"><li>This field is required.</li></ul><input type="text" name="subject" maxlength="100" required /></td></tr>
+    <tr><th>Message:</th><td><input type="text" name="message" value="Hi there" required /></td></tr>
+    <tr><th>Sender:</th><td><ul class="errorlist"><li>Enter a valid email address.</li></ul><input type="email" name="sender" value="invalid email address" required /></td></tr>
+    <tr><th>Cc myself:</th><td><input checked type="checkbox" name="cc_myself" /></td></tr>
     >>> print(f.as_ul())
-    <li><ul class="errorlist"><li>This field is required.</li></ul>Subject: <input type="text" name="subject" maxlength="100" required></li>
-    <li>Message: <input type="text" name="message" value="Hi there" required></li>
-    <li><ul class="errorlist"><li>Enter a valid email address.</li></ul>Sender: <input type="email" name="sender" value="invalid email address" required></li>
-    <li>Cc myself: <input checked type="checkbox" name="cc_myself"></li>
+    <li><ul class="errorlist"><li>This field is required.</li></ul>Subject: <input type="text" name="subject" maxlength="100" required /></li>
+    <li>Message: <input type="text" name="message" value="Hi there" required /></li>
+    <li><ul class="errorlist"><li>Enter a valid email address.</li></ul>Sender: <input type="email" name="sender" value="invalid email address" required /></li>
+    <li>Cc myself: <input checked type="checkbox" name="cc_myself" /></li>
     >>> print(f.as_p())
     <p><ul class="errorlist"><li>This field is required.</li></ul></p>
-    <p>Subject: <input type="text" name="subject" maxlength="100" required></p>
-    <p>Message: <input type="text" name="message" value="Hi there" required></p>
+    <p>Subject: <input type="text" name="subject" maxlength="100" required /></p>
+    <p>Message: <input type="text" name="message" value="Hi there" required /></p>
     <p><ul class="errorlist"><li>Enter a valid email address.</li></ul></p>
-    <p>Sender: <input type="email" name="sender" value="invalid email address" required></p>
-    <p>Cc myself: <input checked type="checkbox" name="cc_myself"></p>
+    <p>Sender: <input type="email" name="sender" value="invalid email address" required /></p>
+    <p>Cc myself: <input checked type="checkbox" name="cc_myself" /></p>
 
 .. _ref-forms-error-list-format:
 
@@ -824,11 +824,11 @@ pass that in at construction time::
     >>> f = ContactForm(data, auto_id=False, error_class=DivErrorList)
     >>> f.as_p()
     <div class="errorlist"><div class="error">This field is required.</div></div>
-    <p>Subject: <input type="text" name="subject" maxlength="100" required></p>
-    <p>Message: <input type="text" name="message" value="Hi there" required></p>
+    <p>Subject: <input type="text" name="subject" maxlength="100" required /></p>
+    <p>Message: <input type="text" name="message" value="Hi there" required /></p>
     <div class="errorlist"><div class="error">Enter a valid email address.</div></div>
-    <p>Sender: <input type="email" name="sender" value="invalid email address" required></p>
-    <p>Cc myself: <input checked type="checkbox" name="cc_myself"></p>
+    <p>Sender: <input type="email" name="sender" value="invalid email address" required /></p>
+    <p>Cc myself: <input checked type="checkbox" name="cc_myself" /></p>
 
 More granular output
 ====================
@@ -848,25 +848,25 @@ using the field's name as the key::
 
     >>> form = ContactForm()
     >>> print(form['subject'])
-    <input id="id_subject" type="text" name="subject" maxlength="100" required>
+    <input id="id_subject" type="text" name="subject" maxlength="100" required />
 
 To retrieve all ``BoundField`` objects, iterate the form::
 
     >>> form = ContactForm()
     >>> for boundfield in form: print(boundfield)
-    <input id="id_subject" type="text" name="subject" maxlength="100" required>
-    <input type="text" name="message" id="id_message" required>
-    <input type="email" name="sender" id="id_sender" required>
-    <input type="checkbox" name="cc_myself" id="id_cc_myself">
+    <input id="id_subject" type="text" name="subject" maxlength="100" required />
+    <input type="text" name="message" id="id_message" required />
+    <input type="email" name="sender" id="id_sender" required />
+    <input type="checkbox" name="cc_myself" id="id_cc_myself" />
 
 The field-specific output honors the form object's ``auto_id`` setting::
 
     >>> f = ContactForm(auto_id=False)
     >>> print(f['message'])
-    <input type="text" name="message" required>
+    <input type="text" name="message" required />
     >>> f = ContactForm(auto_id='id_%s')
     >>> print(f['message'])
-    <input type="text" name="message" id="id_message" required>
+    <input type="text" name="message" id="id_message" required />
 
 Attributes of ``BoundField``
 ----------------------------
@@ -897,7 +897,7 @@ Attributes of ``BoundField``
         >>> data = {'subject': 'hi', 'message': '', 'sender': '', 'cc_myself': ''}
         >>> f = ContactForm(data, auto_id=False)
         >>> print(f['message'])
-        <input type="text" name="message" required>
+        <input type="text" name="message" required />
         >>> f['message'].errors
         ['This field is required.']
         >>> print(f['message'].errors)
@@ -949,7 +949,7 @@ Attributes of ``BoundField``
 
     .. code-block:: html
 
-        <label for="myFIELD">...</label><input id="myFIELD" type="text" name="my_field" required>
+        <label for="myFIELD">...</label><input id="myFIELD" type="text" name="my_field" required />
 
 .. attribute:: BoundField.is_hidden
 
@@ -1168,11 +1168,11 @@ fields are ordered first::
     ...     priority = forms.CharField()
     >>> f = ContactFormWithPriority(auto_id=False)
     >>> print(f.as_ul())
-    <li>Subject: <input type="text" name="subject" maxlength="100" required></li>
-    <li>Message: <input type="text" name="message" required></li>
-    <li>Sender: <input type="email" name="sender" required></li>
-    <li>Cc myself: <input type="checkbox" name="cc_myself"></li>
-    <li>Priority: <input type="text" name="priority" required></li>
+    <li>Subject: <input type="text" name="subject" maxlength="100" required /></li>
+    <li>Message: <input type="text" name="message" required /></li>
+    <li>Sender: <input type="email" name="sender" required /></li>
+    <li>Cc myself: <input type="checkbox" name="cc_myself" /></li>
+    <li>Priority: <input type="text" name="priority" required /></li>
 
 It's possible to subclass multiple forms, treating forms as mixins. In this
 example, ``BeatleForm`` subclasses both ``PersonForm`` and ``InstrumentForm``
@@ -1189,10 +1189,10 @@ classes::
     ...     haircut_type = forms.CharField()
     >>> b = BeatleForm(auto_id=False)
     >>> print(b.as_ul())
-    <li>First name: <input type="text" name="first_name" required></li>
-    <li>Last name: <input type="text" name="last_name" required></li>
-    <li>Instrument: <input type="text" name="instrument" required></li>
-    <li>Haircut type: <input type="text" name="haircut_type" required></li>
+    <li>First name: <input type="text" name="first_name" required /></li>
+    <li>Last name: <input type="text" name="last_name" required /></li>
+    <li>Instrument: <input type="text" name="instrument" required /></li>
+    <li>Haircut type: <input type="text" name="haircut_type" required /></li>
 
 It's possible to declaratively remove a ``Field`` inherited from a parent class
 by setting the name of the field to ``None`` on the subclass. For example::
@@ -1222,11 +1222,11 @@ You can put several Django forms inside one ``<form>`` tag. To give each
     >>> mother = PersonForm(prefix="mother")
     >>> father = PersonForm(prefix="father")
     >>> print(mother.as_ul())
-    <li><label for="id_mother-first_name">First name:</label> <input type="text" name="mother-first_name" id="id_mother-first_name" required></li>
-    <li><label for="id_mother-last_name">Last name:</label> <input type="text" name="mother-last_name" id="id_mother-last_name" required></li>
+    <li><label for="id_mother-first_name">First name:</label> <input type="text" name="mother-first_name" id="id_mother-first_name" required /></li>
+    <li><label for="id_mother-last_name">Last name:</label> <input type="text" name="mother-last_name" id="id_mother-last_name" required /></li>
     >>> print(father.as_ul())
-    <li><label for="id_father-first_name">First name:</label> <input type="text" name="father-first_name" id="id_father-first_name" required></li>
-    <li><label for="id_father-last_name">Last name:</label> <input type="text" name="father-last_name" id="id_father-last_name" required></li>
+    <li><label for="id_father-first_name">First name:</label> <input type="text" name="father-first_name" id="id_father-first_name" required /></li>
+    <li><label for="id_father-last_name">Last name:</label> <input type="text" name="father-last_name" id="id_father-last_name" required /></li>
 
 The prefix can also be specified on the form class::
 

--- a/docs/ref/forms/fields.txt
+++ b/docs/ref/forms/fields.txt
@@ -119,9 +119,9 @@ We've specified ``auto_id=False`` to simplify the output::
     ...     comment = forms.CharField()
     >>> f = CommentForm(auto_id=False)
     >>> print(f)
-    <tr><th>Your name:</th><td><input type="text" name="name" required></td></tr>
-    <tr><th>Your website:</th><td><input type="url" name="url"></td></tr>
-    <tr><th>Comment:</th><td><input type="text" name="comment" required></td></tr>
+    <tr><th>Your name:</th><td><input type="text" name="name" required /></td></tr>
+    <tr><th>Your website:</th><td><input type="url" name="url" /></td></tr>
+    <tr><th>Comment:</th><td><input type="text" name="comment" required /></td></tr>
 
 ``label_suffix``
 ----------------
@@ -137,9 +137,9 @@ The ``label_suffix`` argument lets you override the form's
     ...     captcha_answer = forms.IntegerField(label='2 + 2', label_suffix=' =')
     >>> f = ContactForm(label_suffix='?')
     >>> print(f.as_p())
-    <p><label for="id_age">Age?</label> <input id="id_age" name="age" type="number" required></p>
-    <p><label for="id_nationality">Nationality?</label> <input id="id_nationality" name="nationality" type="text" required></p>
-    <p><label for="id_captcha_answer">2 + 2 =</label> <input id="id_captcha_answer" name="captcha_answer" type="number" required></p>
+    <p><label for="id_age">Age?</label> <input id="id_age" name="age" type="number" required /></p>
+    <p><label for="id_nationality">Nationality?</label> <input id="id_nationality" name="nationality" type="text" required /></p>
+    <p><label for="id_captcha_answer">2 + 2 =</label> <input id="id_captcha_answer" name="captcha_answer" type="number" required /></p>
 
 ``initial``
 -----------
@@ -161,9 +161,9 @@ field is initialized to a particular value. For example::
     ...     comment = forms.CharField()
     >>> f = CommentForm(auto_id=False)
     >>> print(f)
-    <tr><th>Name:</th><td><input type="text" name="name" value="Your name" required></td></tr>
-    <tr><th>Url:</th><td><input type="url" name="url" value="http://" required></td></tr>
-    <tr><th>Comment:</th><td><input type="text" name="comment" required></td></tr>
+    <tr><th>Name:</th><td><input type="text" name="name" value="Your name" required /></td></tr>
+    <tr><th>Url:</th><td><input type="url" name="url" value="http://" required /></td></tr>
+    <tr><th>Comment:</th><td><input type="text" name="comment" required /></td></tr>
 
 You may be thinking, why not just pass a dictionary of the initial values as
 data when displaying the form? Well, if you do that, you'll trigger validation,
@@ -176,9 +176,9 @@ and the HTML output will include any validation errors::
     >>> default_data = {'name': 'Your name', 'url': 'http://'}
     >>> f = CommentForm(default_data, auto_id=False)
     >>> print(f)
-    <tr><th>Name:</th><td><input type="text" name="name" value="Your name" required></td></tr>
-    <tr><th>Url:</th><td><ul class="errorlist"><li>Enter a valid URL.</li></ul><input type="url" name="url" value="http://" required></td></tr>
-    <tr><th>Comment:</th><td><ul class="errorlist"><li>This field is required.</li></ul><input type="text" name="comment" required></td></tr>
+    <tr><th>Name:</th><td><input type="text" name="name" value="Your name" required /></td></tr>
+    <tr><th>Url:</th><td><ul class="errorlist"><li>Enter a valid URL.</li></ul><input type="url" name="url" value="http://" required /></td></tr>
+    <tr><th>Comment:</th><td><ul class="errorlist"><li>This field is required.</li></ul><input type="text" name="comment" required /></td></tr>
 
 This is why ``initial`` values are only displayed for unbound forms. For bound
 forms, the HTML output will use the bound data.
@@ -205,7 +205,7 @@ Instead of a constant, you can also pass any callable::
     >>> class DateForm(forms.Form):
     ...     day = forms.DateField(initial=datetime.date.today)
     >>> print(DateForm())
-    <tr><th>Day:</th><td><input type="text" name="day" value="12/23/2008" required><td></tr>
+    <tr><th>Day:</th><td><input type="text" name="day" value="12/23/2008" required /><td></tr>
 
 The callable will be evaluated only when the unbound form is displayed, not when it is defined.
 
@@ -241,20 +241,20 @@ fields. We've specified ``auto_id=False`` to simplify the output::
     ...     cc_myself = forms.BooleanField(required=False)
     >>> f = HelpTextContactForm(auto_id=False)
     >>> print(f.as_table())
-    <tr><th>Subject:</th><td><input type="text" name="subject" maxlength="100" required><br><span class="helptext">100 characters max.</span></td></tr>
-    <tr><th>Message:</th><td><input type="text" name="message" required></td></tr>
-    <tr><th>Sender:</th><td><input type="email" name="sender" required><br>A valid email address, please.</td></tr>
-    <tr><th>Cc myself:</th><td><input type="checkbox" name="cc_myself"></td></tr>
+    <tr><th>Subject:</th><td><input type="text" name="subject" maxlength="100" required /><br /><span class="helptext">100 characters max.</span></td></tr>
+    <tr><th>Message:</th><td><input type="text" name="message" required /></td></tr>
+    <tr><th>Sender:</th><td><input type="email" name="sender" required /><br />A valid email address, please.</td></tr>
+    <tr><th>Cc myself:</th><td><input type="checkbox" name="cc_myself" /></td></tr>
     >>> print(f.as_ul()))
-    <li>Subject: <input type="text" name="subject" maxlength="100" required> <span class="helptext">100 characters max.</span></li>
-    <li>Message: <input type="text" name="message" required></li>
-    <li>Sender: <input type="email" name="sender" required> A valid email address, please.</li>
-    <li>Cc myself: <input type="checkbox" name="cc_myself"></li>
+    <li>Subject: <input type="text" name="subject" maxlength="100" required /> <span class="helptext">100 characters max.</span></li>
+    <li>Message: <input type="text" name="message" required /></li>
+    <li>Sender: <input type="email" name="sender" required /> A valid email address, please.</li>
+    <li>Cc myself: <input type="checkbox" name="cc_myself" /></li>
     >>> print(f.as_p())
-    <p>Subject: <input type="text" name="subject" maxlength="100" required> <span class="helptext">100 characters max.</span></p>
-    <p>Message: <input type="text" name="message" required></p>
-    <p>Sender: <input type="email" name="sender" required> A valid email address, please.</p>
-    <p>Cc myself: <input type="checkbox" name="cc_myself"></p>
+    <p>Subject: <input type="text" name="subject" maxlength="100" required /> <span class="helptext">100 characters max.</span></p>
+    <p>Message: <input type="text" name="message" required /></p>
+    <p>Sender: <input type="email" name="sender" required /> A valid email address, please.</p>
+    <p>Cc myself: <input type="checkbox" name="cc_myself" /></p>
 
 ``error_messages``
 ------------------

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -142,9 +142,9 @@ provided for each widget will be rendered exactly the same::
 
     >>> f = CommentForm(auto_id=False)
     >>> f.as_table()
-    <tr><th>Name:</th><td><input type="text" name="name" required></td></tr>
-    <tr><th>Url:</th><td><input type="url" name="url" required></td></tr>
-    <tr><th>Comment:</th><td><input type="text" name="comment" required></td></tr>
+    <tr><th>Name:</th><td><input type="text" name="name" required /></td></tr>
+    <tr><th>Url:</th><td><input type="url" name="url" required /></td></tr>
+    <tr><th>Comment:</th><td><input type="text" name="comment" required /></td></tr>
 
 On a real Web page, you probably don't want every widget to look the same. You
 might want a larger input element for the comment, and you might want the
@@ -180,9 +180,9 @@ Django will then include the extra attributes in the rendered output:
 
     >>> f = CommentForm(auto_id=False)
     >>> f.as_table()
-    <tr><th>Name:</th><td><input type="text" name="name" class="special" required></td></tr>
-    <tr><th>Url:</th><td><input type="url" name="url" required></td></tr>
-    <tr><th>Comment:</th><td><input type="text" name="comment" size="40" required></td></tr>
+    <tr><th>Name:</th><td><input type="text" name="name" class="special" required /></td></tr>
+    <tr><th>Url:</th><td><input type="url" name="url" required /></td></tr>
+    <tr><th>Comment:</th><td><input type="text" name="comment" size="40" required /></td></tr>
 
 You can also set the HTML ``id`` using :attr:`~Widget.attrs`. See
 :attr:`BoundField.id_for_label` for an example.
@@ -230,18 +230,18 @@ foundation for custom widgets.
             >>> from django import forms
             >>> name = forms.TextInput(attrs={'size': 10, 'title': 'Your name'})
             >>> name.render('name', 'A name')
-            '<input title="Your name" type="text" name="name" value="A name" size="10">'
+            '<input title="Your name" type="text" name="name" value="A name" size="10" />'
 
         If you assign a value of ``True`` or ``False`` to an attribute,
         it will be rendered as an HTML5 boolean attribute::
 
             >>> name = forms.TextInput(attrs={'required': True})
             >>> name.render('name', 'A name')
-            '<input name="name" type="text" value="A name" required>'
+            '<input name="name" type="text" value="A name" required />'
             >>>
             >>> name = forms.TextInput(attrs={'required': False})
             >>> name.render('name', 'A name')
-            '<input name="name" type="text" value="A name">'
+            '<input name="name" type="text" value="A name" />'
 
     .. attribute:: Widget.supports_microseconds
 
@@ -720,16 +720,16 @@ that specifies the template used to render each choice. For example, for the
     .. code-block:: html
 
         <div class="myradio">
-            <label for="id_beatles_0"><input id="id_beatles_0" name="beatles" type="radio" value="john" required> John</label>
+            <label for="id_beatles_0"><input id="id_beatles_0" name="beatles" type="radio" value="john" required /> John</label>
         </div>
         <div class="myradio">
-            <label for="id_beatles_1"><input id="id_beatles_1" name="beatles" type="radio" value="paul" required> Paul</label>
+            <label for="id_beatles_1"><input id="id_beatles_1" name="beatles" type="radio" value="paul" required /> Paul</label>
         </div>
         <div class="myradio">
-            <label for="id_beatles_2"><input id="id_beatles_2" name="beatles" type="radio" value="george" required> George</label>
+            <label for="id_beatles_2"><input id="id_beatles_2" name="beatles" type="radio" value="george" required /> George</label>
         </div>
         <div class="myradio">
-            <label for="id_beatles_3"><input id="id_beatles_3" name="beatles" type="radio" value="ringo" required> Ringo</label>
+            <label for="id_beatles_3"><input id="id_beatles_3" name="beatles" type="radio" value="ringo" required /> Ringo</label>
         </div>
 
     That included the ``<label>`` tags. To get more granular, you can use each
@@ -751,22 +751,22 @@ that specifies the template used to render each choice. For example, for the
 
         <label for="id_beatles_0">
             John
-            <span class="radio"><input id="id_beatles_0" name="beatles" type="radio" value="john" required></span>
+            <span class="radio"><input id="id_beatles_0" name="beatles" type="radio" value="john" required /></span>
         </label>
 
         <label for="id_beatles_1">
             Paul
-            <span class="radio"><input id="id_beatles_1" name="beatles" type="radio" value="paul" required></span>
+            <span class="radio"><input id="id_beatles_1" name="beatles" type="radio" value="paul" required /></span>
         </label>
 
         <label for="id_beatles_2">
             George
-            <span class="radio"><input id="id_beatles_2" name="beatles" type="radio" value="george" required></span>
+            <span class="radio"><input id="id_beatles_2" name="beatles" type="radio" value="george" required /></span>
         </label>
 
         <label for="id_beatles_3">
             Ringo
-            <span class="radio"><input id="id_beatles_3" name="beatles" type="radio" value="ringo" required></span>
+            <span class="radio"><input id="id_beatles_3" name="beatles" type="radio" value="ringo" required /></span>
         </label>
 
     If you decide not to loop over the radio buttons -- e.g., if your template

--- a/docs/ref/request-response.txt
+++ b/docs/ref/request-response.txt
@@ -124,7 +124,7 @@ All attributes should be considered read-only, unless stated otherwise.
 .. attribute:: HttpRequest.FILES
 
     A dictionary-like object containing all uploaded files. Each key in
-    ``FILES`` is the ``name`` from the ``<input type="file" name="">``. Each
+    ``FILES`` is the ``name`` from the ``<input type="file" name="" />``. Each
     value in ``FILES`` is an :class:`~django.core.files.uploadedfile.UploadedFile`.
 
     See :doc:`/topics/files` for more information.

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1192,7 +1192,7 @@ value to a maximum value, and then applies that ratio to a constant.
 For example::
 
     <img src="bar.png" alt="Bar"
-         height="10" width="{% widthratio this_value max_value max_width %}">
+         height="10" width="{% widthratio this_value max_value max_width %}" />
 
 If ``this_value`` is 175, ``max_value`` is 200, and ``max_width`` is 100, the
 image in the above example will be 88 pixels wide
@@ -1877,14 +1877,14 @@ If ``value`` is ``['a', 'b', 'c', 'd']`` or ``"abcd"``, the output will be
 --------------
 
 Replaces line breaks in plain text with appropriate HTML; a single
-newline becomes an HTML line break (``<br>``) and a new line
+newline becomes an HTML line break (``<br />``) and a new line
 followed by a blank line becomes a paragraph break (``</p>``).
 
 For example::
 
     {{ value|linebreaks }}
 
-If ``value`` is ``Joel\nis a slug``, the output will be ``<p>Joel<br>is a
+If ``value`` is ``Joel\nis a slug``, the output will be ``<p>Joel<br />is a
 slug</p>``.
 
 .. templatefilter:: linebreaksbr
@@ -1893,13 +1893,13 @@ slug</p>``.
 ----------------
 
 Converts all newlines in a piece of plain text to HTML line breaks
-(``<br>``).
+(``<br />``).
 
 For example::
 
     {{ value|linebreaksbr }}
 
-If ``value`` is ``Joel\nis a slug``, the output will be ``Joel<br>is a
+If ``value`` is ``Joel\nis a slug``, the output will be ``Joel<br />is a
 slug``.
 
 .. templatefilter:: linenumbers
@@ -2576,20 +2576,20 @@ app is installed, the tag will serve files using ``url()`` method of the
 storage specified by :setting:`STATICFILES_STORAGE`. For example::
 
     {% load static %}
-    <img src="{% static "images/hi.jpg" %}" alt="Hi!">
+    <img src="{% static "images/hi.jpg" %}" alt="Hi!" />
 
 It is also able to consume standard context variables, e.g. assuming a
 ``user_stylesheet`` variable is passed to the template::
 
     {% load static %}
-    <link rel="stylesheet" href="{% static user_stylesheet %}" type="text/css" media="screen">
+    <link rel="stylesheet" href="{% static user_stylesheet %}" type="text/css" media="screen" />
 
 If you'd like to retrieve a static URL without displaying it, you can use a
 slightly different call::
 
     {% load static %}
     {% static "images/hi.jpg" as myphoto %}
-    <img src="{{ myphoto }}">
+    <img src="{{ myphoto }}"></img>
 
 .. admonition:: Using Jinja2 templates?
 
@@ -2606,7 +2606,7 @@ over exactly where and how :setting:`STATIC_URL` is injected into the template,
 you can use the :ttag:`get_static_prefix` template tag::
 
     {% load static %}
-    <img src="{% get_static_prefix %}images/hi.jpg" alt="Hi!">
+    <img src="{% get_static_prefix %}images/hi.jpg" alt="Hi!" />
 
 There's also a second form you can use to avoid extra processing if you need
 the value multiple times::
@@ -2614,8 +2614,8 @@ the value multiple times::
     {% load static %}
     {% get_static_prefix as STATIC_PREFIX %}
 
-    <img src="{{ STATIC_PREFIX }}images/hi.jpg" alt="Hi!">
-    <img src="{{ STATIC_PREFIX }}images/hi2.jpg" alt="Hello!">
+    <img src="{{ STATIC_PREFIX }}images/hi.jpg" alt="Hi!" />
+    <img src="{{ STATIC_PREFIX }}images/hi2.jpg" alt="Hello!" />
 
 .. templatetag:: get_media_prefix
 

--- a/docs/ref/templates/language.txt
+++ b/docs/ref/templates/language.txt
@@ -294,7 +294,7 @@ It's easiest to understand template inheritance by starting with an example::
     <!DOCTYPE html>
     <html lang="en">
     <head>
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="style.css" />
         <title>{% block title %}My amazing site{% endblock %}</title>
     </head>
 
@@ -347,7 +347,7 @@ like::
     <!DOCTYPE html>
     <html lang="en">
     <head>
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="style.css" />
         <title>My amazing blog</title>
     </head>
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -1078,8 +1078,8 @@ implementation details see :ref:`using-the-views`.
         </tr>
         </table>
 
-        <input type="submit" value="login">
-        <input type="hidden" name="next" value="{{ next }}">
+        <input type="submit" value="login" />
+        <input type="hidden" name="next" value="{{ next }}" />
         </form>
 
         {# Assumes you setup the password_reset view in your URLconf #}

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -29,8 +29,8 @@ would with a regular form::
     >>> formset = ArticleFormSet()
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date" /></td></tr>
 
 As you can see it only displayed one empty form. The number of empty forms
 that is displayed is controlled by the ``extra`` parameter. By default,
@@ -69,12 +69,12 @@ example::
 
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Django is now open source" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-12" id="id_form-0-pub_date"></td></tr>
-    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" id="id_form-1-title"></td></tr>
-    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" id="id_form-1-pub_date"></td></tr>
-    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title"></td></tr>
-    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Django is now open source" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-12" id="id_form-0-pub_date" /></td></tr>
+    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" id="id_form-1-title" /></td></tr>
+    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" id="id_form-1-pub_date" /></td></tr>
+    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title" /></td></tr>
+    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date" /></td></tr>
 
 There are now a total of three forms showing above. One for the initial data
 that was passed in and two extra forms. Also note that we are passing in a
@@ -103,8 +103,8 @@ gives you the ability to limit the number of forms the formset will display::
     >>> formset = ArticleFormSet()
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date" /></td></tr>
 
 If the value of ``max_num`` is greater than the number of existing items in the
 initial data, up to ``extra`` additional blank forms will be added to the
@@ -406,15 +406,15 @@ Lets you create a formset with the ability to order::
     ... ])
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Article #1" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-10" id="id_form-0-pub_date"></td></tr>
-    <tr><th><label for="id_form-0-ORDER">Order:</label></th><td><input type="number" name="form-0-ORDER" value="1" id="id_form-0-ORDER"></td></tr>
-    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" value="Article #2" id="id_form-1-title"></td></tr>
-    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" value="2008-05-11" id="id_form-1-pub_date"></td></tr>
-    <tr><th><label for="id_form-1-ORDER">Order:</label></th><td><input type="number" name="form-1-ORDER" value="2" id="id_form-1-ORDER"></td></tr>
-    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title"></td></tr>
-    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date"></td></tr>
-    <tr><th><label for="id_form-2-ORDER">Order:</label></th><td><input type="number" name="form-2-ORDER" id="id_form-2-ORDER"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Article #1" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-10" id="id_form-0-pub_date" /></td></tr>
+    <tr><th><label for="id_form-0-ORDER">Order:</label></th><td><input type="number" name="form-0-ORDER" value="1" id="id_form-0-ORDER" /></td></tr>
+    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" value="Article #2" id="id_form-1-title" /></td></tr>
+    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" value="2008-05-11" id="id_form-1-pub_date" /></td></tr>
+    <tr><th><label for="id_form-1-ORDER">Order:</label></th><td><input type="number" name="form-1-ORDER" value="2" id="id_form-1-ORDER" /></td></tr>
+    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title" /></td></tr>
+    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date" /></td></tr>
+    <tr><th><label for="id_form-2-ORDER">Order:</label></th><td><input type="number" name="form-2-ORDER" id="id_form-2-ORDER" /></td></tr>
 
 This adds an additional field to each form. This new field is named ``ORDER``
 and is an ``forms.IntegerField``. For the forms that came from the initial
@@ -466,15 +466,15 @@ Lets you create a formset with the ability to select forms for deletion::
     ... ])
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Article #1" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-10" id="id_form-0-pub_date"></td></tr>
-    <tr><th><label for="id_form-0-DELETE">Delete:</label></th><td><input type="checkbox" name="form-0-DELETE" id="id_form-0-DELETE"></td></tr>
-    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" value="Article #2" id="id_form-1-title"></td></tr>
-    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" value="2008-05-11" id="id_form-1-pub_date"></td></tr>
-    <tr><th><label for="id_form-1-DELETE">Delete:</label></th><td><input type="checkbox" name="form-1-DELETE" id="id_form-1-DELETE"></td></tr>
-    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title"></td></tr>
-    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date"></td></tr>
-    <tr><th><label for="id_form-2-DELETE">Delete:</label></th><td><input type="checkbox" name="form-2-DELETE" id="id_form-2-DELETE"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" value="Article #1" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" value="2008-05-10" id="id_form-0-pub_date" /></td></tr>
+    <tr><th><label for="id_form-0-DELETE">Delete:</label></th><td><input type="checkbox" name="form-0-DELETE" id="id_form-0-DELETE" /></td></tr>
+    <tr><th><label for="id_form-1-title">Title:</label></th><td><input type="text" name="form-1-title" value="Article #2" id="id_form-1-title" /></td></tr>
+    <tr><th><label for="id_form-1-pub_date">Pub date:</label></th><td><input type="text" name="form-1-pub_date" value="2008-05-11" id="id_form-1-pub_date" /></td></tr>
+    <tr><th><label for="id_form-1-DELETE">Delete:</label></th><td><input type="checkbox" name="form-1-DELETE" id="id_form-1-DELETE" /></td></tr>
+    <tr><th><label for="id_form-2-title">Title:</label></th><td><input type="text" name="form-2-title" id="id_form-2-title" /></td></tr>
+    <tr><th><label for="id_form-2-pub_date">Pub date:</label></th><td><input type="text" name="form-2-pub_date" id="id_form-2-pub_date" /></td></tr>
+    <tr><th><label for="id_form-2-DELETE">Delete:</label></th><td><input type="checkbox" name="form-2-DELETE" id="id_form-2-DELETE" /></td></tr>
 
 Similar to ``can_order`` this adds a new field to each form named ``DELETE``
 and is a ``forms.BooleanField``. When data comes through marking any of the
@@ -540,9 +540,9 @@ default fields/attributes of the order and deletion fields::
     >>> formset = ArticleFormSet()
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title"></td></tr>
-    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date"></td></tr>
-    <tr><th><label for="id_form-0-my_field">My field:</label></th><td><input type="text" name="form-0-my_field" id="id_form-0-my_field"></td></tr>
+    <tr><th><label for="id_form-0-title">Title:</label></th><td><input type="text" name="form-0-title" id="id_form-0-title" /></td></tr>
+    <tr><th><label for="id_form-0-pub_date">Pub date:</label></th><td><input type="text" name="form-0-pub_date" id="id_form-0-pub_date" /></td></tr>
+    <tr><th><label for="id_form-0-my_field">My field:</label></th><td><input type="text" name="form-0-my_field" id="id_form-0-my_field" /></td></tr>
 
 .. _custom-formset-form-kwargs:
 
@@ -592,14 +592,14 @@ For example, in the default case, you might see:
 .. code-block:: html
 
     <label for="id_form-0-title">Title:</label>
-    <input type="text" name="form-0-title" id="id_form-0-title">
+    <input type="text" name="form-0-title" id="id_form-0-title" />
 
 But with ``ArticleFormset(prefix='article')`` that becomes:
 
 .. code-block:: html
 
     <label for="id_article-0-title">Title:</label>
-    <input type="text" name="article-0-title" id="id_article-0-title">
+    <input type="text" name="article-0-title" id="id_article-0-title" />
 
 This is useful if you want to :ref:`use more than one formset in a view
 <multiple-formsets-in-view>`.

--- a/docs/topics/forms/index.txt
+++ b/docs/topics/forms/index.txt
@@ -259,7 +259,7 @@ The whole form, when rendered for the first time, will look like:
 .. code-block:: html+django
 
     <label for="your_name">Your name: </label>
-    <input id="your_name" type="text" name="your_name" maxlength="100" required>
+    <input id="your_name" type="text" name="your_name" maxlength="100" required />
 
 Note that it **does not** include the ``<form>`` tags, or a submit button.
 We'll have to provide those ourselves in the template.
@@ -334,7 +334,7 @@ is:
     <form action="/your-name/" method="post">
         {% csrf_token %}
         {{ form }}
-        <input type="submit" value="Submit">
+        <input type="submit" value="Submit" />
     </form>
 
 All the form's fields and their attributes will be unpacked into HTML markup
@@ -514,13 +514,13 @@ Here's the output of ``{{ form.as_p }}`` for our ``ContactForm`` instance:
 .. code-block:: html+django
 
     <p><label for="id_subject">Subject:</label>
-        <input id="id_subject" type="text" name="subject" maxlength="100" required></p>
+        <input id="id_subject" type="text" name="subject" maxlength="100" required /></p>
     <p><label for="id_message">Message:</label>
         <textarea name="message" id="id_message" required></textarea></p>
     <p><label for="id_sender">Sender:</label>
-        <input type="email" name="sender" id="id_sender" required></p>
+        <input type="email" name="sender" id="id_sender" required /></p>
     <p><label for="id_cc_myself">Cc myself:</label>
-        <input type="checkbox" name="cc_myself" id="id_cc_myself"></p>
+        <input type="checkbox" name="cc_myself" id="id_cc_myself" /></p>
 
 Note that each form field has an ID attribute set to ``id_<field-name>``, which
 is referenced by the accompanying label tag. This is important in ensuring that

--- a/docs/topics/forms/media.txt
+++ b/docs/topics/forms/media.txt
@@ -71,7 +71,7 @@ can be retrieved through this property::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
 
@@ -114,9 +114,9 @@ requirements::
 
 If this last CSS definition were to be rendered, it would become the following HTML::
 
-    <link href="http://static.example.com/pretty.css" type="text/css" media="screen" rel="stylesheet">
-    <link href="http://static.example.com/lo_res.css" type="text/css" media="tv,projector" rel="stylesheet">
-    <link href="http://static.example.com/newspaper.css" type="text/css" media="print" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="screen" rel="stylesheet" />
+    <link href="http://static.example.com/lo_res.css" type="text/css" media="tv,projector" rel="stylesheet" />
+    <link href="http://static.example.com/newspaper.css" type="text/css" media="print" rel="stylesheet" />
 
 ``js``
 ------
@@ -145,8 +145,8 @@ example above::
 
     >>> w = FancyCalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
-    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
+    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>
@@ -165,7 +165,7 @@ an ``extend=False`` declaration to the ``Media`` declaration::
 
     >>> w = FancyCalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/fancy.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>
 
 If you require even more control over inheritance, define your assets using a
@@ -228,7 +228,7 @@ was ``None``::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://uploads.example.com/animations.js"></script>
     <script type="text/javascript" src="http://othersite.com/actions.js"></script>
 
@@ -236,7 +236,7 @@ But if :setting:`STATIC_URL` is ``'http://static.example.com/'``::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://othersite.com/actions.js"></script>
 
@@ -245,7 +245,7 @@ Or if :mod:`~django.contrib.staticfiles` is configured using the
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="/css/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="https://static.example.com/animations.27e20196a850.js"></script>
     <script type="text/javascript" src="http://othersite.com/actions.js"></script>
 
@@ -268,12 +268,12 @@ operator to filter out a medium of interest. For example::
 
     >>> w = CalendarWidget()
     >>> print(w.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
 
     >>> print(w.media['css'])
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
 
 When you use the subscript operator, the value that is returned is a
 new ``Media`` object -- but one that only contains the media of interest.
@@ -300,7 +300,7 @@ specified by both::
     >>> w1 = CalendarWidget()
     >>> w2 = OtherWidget()
     >>> print(w1.media + w2.media)
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>
@@ -362,7 +362,7 @@ are part of the form::
 
     >>> f = ContactForm()
     >>> f.media
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>
@@ -382,8 +382,8 @@ form::
 
     >>> f = ContactForm()
     >>> f.media
-    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet">
-    <link href="http://static.example.com/layout.css" type="text/css" media="all" rel="stylesheet">
+    <link href="http://static.example.com/pretty.css" type="text/css" media="all" rel="stylesheet" />
+    <link href="http://static.example.com/layout.css" type="text/css" media="all" rel="stylesheet" />
     <script type="text/javascript" src="http://static.example.com/animations.js"></script>
     <script type="text/javascript" src="http://static.example.com/actions.js"></script>
     <script type="text/javascript" src="http://static.example.com/whizbang.js"></script>

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -772,14 +772,14 @@ with the ``Author`` model. It works just like a regular formset::
 
     >>> formset = AuthorFormSet()
     >>> print(formset)
-    <input type="hidden" name="form-TOTAL_FORMS" value="1" id="id_form-TOTAL_FORMS"><input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS"><input type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS">
-    <tr><th><label for="id_form-0-name">Name:</label></th><td><input id="id_form-0-name" type="text" name="form-0-name" maxlength="100"></td></tr>
+    <input type="hidden" name="form-TOTAL_FORMS" value="1" id="id_form-TOTAL_FORMS" /><input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS" /><input type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS" />
+    <tr><th><label for="id_form-0-name">Name:</label></th><td><input id="id_form-0-name" type="text" name="form-0-name" maxlength="100" /></td></tr>
     <tr><th><label for="id_form-0-title">Title:</label></th><td><select name="form-0-title" id="id_form-0-title">
     <option value="" selected>---------</option>
     <option value="MR">Mr.</option>
     <option value="MRS">Mrs.</option>
     <option value="MS">Ms.</option>
-    </select><input type="hidden" name="form-0-id" id="id_form-0-id"></td></tr>
+    </select><input type="hidden" name="form-0-id" id="id_form-0-id" /></td></tr>
 
 .. note::
 
@@ -961,10 +961,10 @@ so long as the total number of forms does not exceed ``max_num``::
     >>> formset = AuthorFormSet(queryset=Author.objects.order_by('name'))
     >>> for form in formset:
     ...     print(form.as_table())
-    <tr><th><label for="id_form-0-name">Name:</label></th><td><input id="id_form-0-name" type="text" name="form-0-name" value="Charles Baudelaire" maxlength="100"><input type="hidden" name="form-0-id" value="1" id="id_form-0-id"></td></tr>
-    <tr><th><label for="id_form-1-name">Name:</label></th><td><input id="id_form-1-name" type="text" name="form-1-name" value="Paul Verlaine" maxlength="100"><input type="hidden" name="form-1-id" value="3" id="id_form-1-id"></td></tr>
-    <tr><th><label for="id_form-2-name">Name:</label></th><td><input id="id_form-2-name" type="text" name="form-2-name" value="Walt Whitman" maxlength="100"><input type="hidden" name="form-2-id" value="2" id="id_form-2-id"></td></tr>
-    <tr><th><label for="id_form-3-name">Name:</label></th><td><input id="id_form-3-name" type="text" name="form-3-name" maxlength="100"><input type="hidden" name="form-3-id" id="id_form-3-id"></td></tr>
+    <tr><th><label for="id_form-0-name">Name:</label></th><td><input id="id_form-0-name" type="text" name="form-0-name" value="Charles Baudelaire" maxlength="100" /><input type="hidden" name="form-0-id" value="1" id="id_form-0-id" /></td></tr>
+    <tr><th><label for="id_form-1-name">Name:</label></th><td><input id="id_form-1-name" type="text" name="form-1-name" value="Paul Verlaine" maxlength="100" /><input type="hidden" name="form-1-id" value="3" id="id_form-1-id" /></td></tr>
+    <tr><th><label for="id_form-2-name">Name:</label></th><td><input id="id_form-2-name" type="text" name="form-2-name" value="Walt Whitman" maxlength="100" /><input type="hidden" name="form-2-id" value="2" id="id_form-2-id" /></td></tr>
+    <tr><th><label for="id_form-3-name">Name:</label></th><td><input id="id_form-3-name" type="text" name="form-3-name" maxlength="100" /><input type="hidden" name="form-3-id" id="id_form-3-id" /></td></tr>
 
 A ``max_num`` value of ``None`` (the default) puts a high limit on the number
 of forms displayed (1000). In practice this is equivalent to no limit.

--- a/docs/topics/i18n/timezones.txt
+++ b/docs/topics/i18n/timezones.txt
@@ -204,7 +204,7 @@ Include a form in ``template.html`` that will ``POST`` to this view:
             <option value="{{ tz }}"{% if tz == TIME_ZONE %} selected{% endif %}>{{ tz }}</option>
             {% endfor %}
         </select>
-        <input type="submit" value="Set">
+        <input type="submit" value="Set" />
     </form>
 
 .. _time-zones-in-forms:

--- a/docs/topics/i18n/translation.txt
+++ b/docs/topics/i18n/translation.txt
@@ -617,7 +617,7 @@ filters::
     </h1>
     <p>
     {% for stage in tour_stages %}
-        {% cycle start end %}: {{ stage }}{% if forloop.counter|divisibleby:2 %}<br>{% else %}, {% endif %}
+        {% cycle start end %}: {{ stage }}{% if forloop.counter|divisibleby:2 %}<br />{% else %}, {% endif %}
     {% endfor %}
     </p>
 
@@ -903,9 +903,9 @@ use the ``{% get_language_info %}`` tag::
 
 You can then access the information::
 
-    Language code: {{ lang.code }}<br>
-    Name of language: {{ lang.name_local }}<br>
-    Name in English: {{ lang.name }}<br>
+    Language code: {{ lang.code }}<br />
+    Name of language: {{ lang.name_local }}<br />
+    Name in English: {{ lang.name }}<br />
     Bi-directional: {{ lang.bidi }}
     Name in the active language: {{ lang.name_translated }}
 
@@ -1800,7 +1800,7 @@ Here's example HTML template code:
     {% load i18n %}
 
     <form action="{% url 'set_language' %}" method="post">{% csrf_token %}
-        <input name="next" type="hidden" value="{{ redirect_to }}">
+        <input name="next" type="hidden" value="{{ redirect_to }}" />
         <select name="language">
             {% get_current_language as LANGUAGE_CODE %}
             {% get_available_languages as LANGUAGES %}
@@ -1811,7 +1811,7 @@ Here's example HTML template code:
                 </option>
             {% endfor %}
         </select>
-        <input type="submit" value="Go">
+        <input type="submit" value="Go" />
     </form>
 
 In this example, Django looks up the URL of the page to which the user will be

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -104,7 +104,7 @@ pages along with any interesting information from the objects themselves:
 
     {% for contact in contacts %}
         {# Each "contact" is a Contact model object. #}
-        {{ contact.full_name|upper }}<br>
+        {{ contact.full_name|upper }}<br />
         ...
     {% endfor %}
 

--- a/docs/topics/testing/tools.txt
+++ b/docs/topics/testing/tools.txt
@@ -1519,7 +1519,7 @@ your test suite.
         self.assertHTMLEqual(
             '<p>Hello <b>world!</p>',
             '''<p>
-                Hello   <b>world! </b>
+                Hello   <b>world! <b/>
             </p>'''
         )
         self.assertHTMLEqual(

--- a/js_tests/admin/DateTimeShortcuts.test.js
+++ b/js_tests/admin/DateTimeShortcuts.test.js
@@ -7,7 +7,7 @@ QUnit.module('admin.DateTimeShortcuts');
 QUnit.test('init', function(assert) {
     var $ = django.jQuery;
 
-    var dateField = $('<input type="text" class="vDateField" value="2015-03-16"><br>');
+    var dateField = $('<input type="text" class="vDateField" value="2015-03-16" /><br/>');
     $('#qunit-fixture').append(dateField);
 
     DateTimeShortcuts.init();
@@ -24,7 +24,7 @@ QUnit.test('init', function(assert) {
 
 QUnit.test('custom time shortcuts', function(assert) {
     var $ = django.jQuery;
-    var timeField = $('<input type="text" name="time_test" class="vTimeField">');
+    var timeField = $('<input type="text" name="time_test" class="vTimeField" />');
     $('#qunit-fixture').append(timeField);
     DateTimeShortcuts.clockHours.time_test = [['3 a.m.', 3]];
     DateTimeShortcuts.init();

--- a/js_tests/qunit/qunit.js
+++ b/js_tests/qunit/qunit.js
@@ -2730,7 +2730,7 @@ function toolbarModuleFilter () {
 		"<label class='clickable" +
 		( config.moduleId.length ? "" : " checked" ) +
 		"'><input type='checkbox'" + ( config.moduleId.length ? "" : " checked='checked'" ) +
-		">All modules</label>";
+		" />All modules</label>";
 	allCheckbox = actions.lastChild.firstChild;
 	commit = actions.firstChild;
 	reset = commit.nextSibling;

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -48,35 +48,35 @@
     <script src='../django/contrib/admin/static/admin/js/jquery.init.js'></script>
     <script src='./admin/jsi18n-mocks.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/core.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/core.js' data-cover="data-cover"></script>
     <script src='./admin/core.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/timeparse.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/timeparse.js' data-cover="data-cover"></script>
     <script src='./admin/timeparse.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/admin/RelatedObjectLookups.js' data-cover="data-cover"></script>
     <script src='./admin/RelatedObjectLookups.test.js'></script>
 
     <script src='./admin/DateTimeShortcuts.test.js'></script>
-    <script src='../django/contrib/admin/static/admin/js/calendar.js' data-cover></script>
-    <script src='../django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/calendar.js' data-cover="data-cover"></script>
+    <script src='../django/contrib/admin/static/admin/js/admin/DateTimeShortcuts.js' data-cover="data-cover"></script>
 
-    <script src='../django/contrib/admin/static/admin/js/actions.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/actions.js' data-cover="data-cover"></script>
     <script src='./admin/actions.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/SelectBox.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/SelectBox.js' data-cover="data-cover"></script>
     <script src='./admin/SelectBox.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/SelectFilter2.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/SelectFilter2.js' data-cover="data-cover"></script>
     <script src='./admin/SelectFilter2.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/inlines.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/inlines.js' data-cover="data-cover"></script>
     <script src='./admin/inlines.test.js'></script>
 
-    <script src='../django/contrib/admin/static/admin/js/actions.js' data-cover></script>
-    <script src='../django/contrib/admin/static/admin/js/collapse.js' data-cover></script>
-    <script src='../django/contrib/admin/static/admin/js/prepopulate.js' data-cover></script>
-    <script src='../django/contrib/admin/static/admin/js/urlify.js' data-cover></script>
+    <script src='../django/contrib/admin/static/admin/js/actions.js' data-cover="data-cover"></script>
+    <script src='../django/contrib/admin/static/admin/js/collapse.js' data-cover="data-cover"></script>
+    <script src='../django/contrib/admin/static/admin/js/prepopulate.js' data-cover="data-cover"></script>
+    <script src='../django/contrib/admin/static/admin/js/urlify.js' data-cover="data-cover"></script>
     <script src='./admin/URLify.test.js'></script>
 
     <div id="id_point_map" style="display:none;">
@@ -89,7 +89,7 @@
                   style="display:none;" rows="10" cols="150"></textarea>
     </div>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.5/ol.js'></script>
-    <script src='../django/contrib/gis/static/gis/js/OLMapWidget.js' data-cover></script>
+    <script src='../django/contrib/gis/static/gis/js/OLMapWidget.js' data-cover="data-cover"></script>
     <script src='./gis/mapwidget.test.js'></script>
 
 </body>

--- a/js_tests/tests.html
+++ b/js_tests/tests.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Django JavaScript Tests</title>
-    <link rel="stylesheet" href="./qunit/qunit.css">
+    <link rel="stylesheet" href="./qunit/qunit.css" />
 </head>
 <body>
 
@@ -14,28 +14,28 @@
         <table id="result_list">
             <tr>
                 <th>
-                   <input type="checkbox" id="action-toggle">
+                   <input type="checkbox" id="action-toggle" />
                 </th>
             </tr>
             <tr>
                 <td class="action-checkbox">
-                    <input class="action-select" type="checkbox" value="618">
+                    <input class="action-select" type="checkbox" value="618" />
                 </td>
             </tr>
         </table>
     </script>
     <script type="text/html" id="tabular-formset">
-        <input id="id_first-TOTAL_FORMS" value="1">
-        <input id="id_first-MAX_NUM_FORMS" value="">
+        <input id="id_first-TOTAL_FORMS" value="1" />
+        <input id="id_first-MAX_NUM_FORMS" value="" />
         <table class="inline">
             <tr id="first-0" class="form-row">
                 <td class="field-test_field">
-                    <input id="id_first-test_field">
+                    <input id="id_first-test_field" />
                 </td>
             </tr>
             <tr id="first-empty" class="empty-row">
                 <td class="field-test_field">
-                    <input id="id_first-test_field">
+                    <input id="id_first-test_field" />
                 </td>
             </tr>
         </table>

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -41,7 +41,7 @@ def build_tbody_html(pk, href, extra_fields):
         '<tbody><tr class="row1">'
         '<td class="action-checkbox">'
         '<input type="checkbox" name="_selected_action" value="{}" '
-        'class="action-select"></td>'
+        'class="action-select" /></td>'
         '<th class="field-name"><a href="{}">name</a></th>'
         '{}</tr></tbody>'
     ).format(pk, href, extra_fields)
@@ -233,7 +233,7 @@ class ChangeListTests(TestCase):
         # make sure that hidden fields are in the correct place
         hiddenfields_div = (
             '<div class="hiddenfields">'
-            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id">'
+            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id" />'
             '</div>'
         ) % new_child.id
         self.assertInHTML(hiddenfields_div, table_output, msg_prefix='Failed to find hidden fields')
@@ -241,7 +241,7 @@ class ChangeListTests(TestCase):
         # make sure that list editable fields are rendered in divs correctly
         editable_name_field = (
             '<input name="form-0-name" value="name" class="vTextField" '
-            'maxlength="30" type="text" id="id_form-0-name">'
+            'maxlength="30" type="text" id="id_form-0-name" />'
         )
         self.assertInHTML(
             '<td class="field-name">%s</td>' % editable_name_field,

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -28,7 +28,7 @@ class AdminDocViewTests(TestDataMixin, AdminDocsTestCase):
         self.client.logout()
         response = self.client.get(reverse('django-admindocs-docroot'), follow=True)
         # Should display the login screen
-        self.assertContains(response, '<input type="hidden" name="next" value="/admindocs/">', html=True)
+        self.assertContains(response, '<input type="hidden" name="next" value="/admindocs/" />', html=True)
 
     def test_bookmarklets(self):
         response = self.client.get(reverse('django-admindocs-bookmarklets'))

--- a/tests/admin_inlines/tests.py
+++ b/tests/admin_inlines/tests.py
@@ -161,7 +161,7 @@ class TestInline(TestDataMixin, TestCase):
             '<img src="/static/admin/img/icon-unknown.svg" '
             'class="help help-tooltip" width="10" height="10" '
             'alt="(Awesome tabular help text is awesome.)" '
-            'title="Awesome tabular help text is awesome.">',
+            'title="Awesome tabular help text is awesome." />',
             1
         )
         # ReadOnly fields
@@ -171,7 +171,7 @@ class TestInline(TestDataMixin, TestCase):
             '<img src="/static/admin/img/icon-unknown.svg" '
             'class="help help-tooltip" width="10" height="10" '
             'alt="(Help text for ReadOnlyInline)" '
-            'title="Help text for ReadOnlyInline">',
+            'title="Help text for ReadOnlyInline" />',
             1
         )
 
@@ -186,7 +186,7 @@ class TestInline(TestDataMixin, TestCase):
             '<img src="/static/admin/img/icon-unknown.svg" '
             'class="help help-tooltip" width="10" height="10" '
             'alt="(Help text from ModelForm.Meta)" '
-            'title="Help text from ModelForm.Meta">'
+            'title="Help text from ModelForm.Meta" />'
         )
         self.assertContains(response, 'Label from ModelForm.Meta')
 
@@ -199,7 +199,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertNotContains(response, '<td class="field-position">')
         self.assertInHTML(
             '<input id="id_somechildmodel_set-1-position" '
-            'name="somechildmodel_set-1-position" type="hidden" value="1">',
+            'name="somechildmodel_set-1-position" type="hidden" value="1" />',
             response.rendered_content,
         )
 
@@ -208,26 +208,26 @@ class TestInline(TestDataMixin, TestCase):
         Multiple inlines with related_name='+' have correct form prefixes.
         """
         response = self.client.get(reverse('admin:admin_inlines_capofamiglia_add'))
-        self.assertContains(response, '<input type="hidden" name="-1-0-id" id="id_-1-0-id">', html=True)
+        self.assertContains(response, '<input type="hidden" name="-1-0-id" id="id_-1-0-id" />', html=True)
         self.assertContains(
             response,
-            '<input type="hidden" name="-1-0-capo_famiglia" id="id_-1-0-capo_famiglia">',
+            '<input type="hidden" name="-1-0-capo_famiglia" id="id_-1-0-capo_famiglia" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input id="id_-1-0-name" type="text" class="vTextField" name="-1-0-name" maxlength="100">',
+            '<input id="id_-1-0-name" type="text" class="vTextField" name="-1-0-name" maxlength="100" />',
             html=True
         )
-        self.assertContains(response, '<input type="hidden" name="-2-0-id" id="id_-2-0-id">', html=True)
+        self.assertContains(response, '<input type="hidden" name="-2-0-id" id="id_-2-0-id" />', html=True)
         self.assertContains(
             response,
-            '<input type="hidden" name="-2-0-capo_famiglia" id="id_-2-0-capo_famiglia">',
+            '<input type="hidden" name="-2-0-capo_famiglia" id="id_-2-0-capo_famiglia" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input id="id_-2-0-name" type="text" class="vTextField" name="-2-0-name" maxlength="100">',
+            '<input id="id_-2-0-name" type="text" class="vTextField" name="-2-0-name" maxlength="100" />',
             html=True
         )
 
@@ -280,12 +280,12 @@ class TestInline(TestDataMixin, TestCase):
         # ModelAdmin
         max_forms_input = (
             '<input id="id_binarytree_set-MAX_NUM_FORMS" '
-            'name="binarytree_set-MAX_NUM_FORMS" type="hidden" value="%d">'
+            'name="binarytree_set-MAX_NUM_FORMS" type="hidden" value="%d" />'
         )
         # The total number of forms will remain the same in either case
         total_forms_hidden = (
             '<input id="id_binarytree_set-TOTAL_FORMS" '
-            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="2">'
+            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="2" />'
         )
         response = self.client.get(reverse('admin:admin_inlines_binarytree_add'))
         self.assertInHTML(max_forms_input % 3, response.rendered_content)
@@ -308,11 +308,11 @@ class TestInline(TestDataMixin, TestCase):
         modeladmin.inlines = [MinNumInline]
         min_forms = (
             '<input id="id_binarytree_set-MIN_NUM_FORMS" '
-            'name="binarytree_set-MIN_NUM_FORMS" type="hidden" value="2">'
+            'name="binarytree_set-MIN_NUM_FORMS" type="hidden" value="2" />'
         )
         total_forms = (
             '<input id="id_binarytree_set-TOTAL_FORMS" '
-            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="5">'
+            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="5" />'
         )
         request = self.factory.get(reverse('admin:admin_inlines_binarytree_add'))
         request.user = User(username='super', is_superuser=True)
@@ -337,11 +337,11 @@ class TestInline(TestDataMixin, TestCase):
         modeladmin.inlines = [MinNumInline]
         min_forms = (
             '<input id="id_binarytree_set-MIN_NUM_FORMS" '
-            'name="binarytree_set-MIN_NUM_FORMS" type="hidden" value="%d">'
+            'name="binarytree_set-MIN_NUM_FORMS" type="hidden" value="%d" />'
         )
         total_forms = (
             '<input id="id_binarytree_set-TOTAL_FORMS" '
-            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="%d">'
+            'name="binarytree_set-TOTAL_FORMS" type="hidden" value="%d" />'
         )
         request = self.factory.get(reverse('admin:admin_inlines_binarytree_add'))
         request.user = User(username='super', is_superuser=True)
@@ -360,13 +360,13 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input id="id_nonautopkbook_set-0-rand_pk" '
-            'name="nonautopkbook_set-0-rand_pk" type="hidden">',
+            'name="nonautopkbook_set-0-rand_pk" type="hidden" />',
             html=True
         )
         self.assertContains(
             response,
             '<input id="id_nonautopkbook_set-2-0-rand_pk" '
-            'name="nonautopkbook_set-2-0-rand_pk" type="hidden">',
+            'name="nonautopkbook_set-2-0-rand_pk" type="hidden" />',
             html=True
         )
 
@@ -375,13 +375,13 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input id="id_nonautopkbookchild_set-0-nonautopkbook_ptr" '
-            'name="nonautopkbookchild_set-0-nonautopkbook_ptr" type="hidden">',
+            'name="nonautopkbookchild_set-0-nonautopkbook_ptr" type="hidden" />',
             html=True
         )
         self.assertContains(
             response,
             '<input id="id_nonautopkbookchild_set-2-nonautopkbook_ptr" '
-            'name="nonautopkbookchild_set-2-nonautopkbook_ptr" type="hidden">',
+            'name="nonautopkbookchild_set-2-nonautopkbook_ptr" type="hidden" />',
             html=True
         )
 
@@ -390,13 +390,13 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input class="vIntegerField" id="id_editablepkbook_set-0-manual_pk" '
-            'name="editablepkbook_set-0-manual_pk" type="number">',
+            'name="editablepkbook_set-0-manual_pk" type="number" />',
             html=True, count=1
         )
         self.assertContains(
             response,
             '<input class="vIntegerField" id="id_editablepkbook_set-2-0-manual_pk" '
-            'name="editablepkbook_set-2-0-manual_pk" type="number">',
+            'name="editablepkbook_set-2-0-manual_pk" type="number" />',
             html=True, count=1
         )
 
@@ -453,7 +453,7 @@ class TestInline(TestDataMixin, TestCase):
         self.assertContains(
             response,
             '<input type="text" name="chapter_set-0-name" '
-            'class="vTextField" maxlength="40" id="id_chapter_set-0-name">',
+            'class="vTextField" maxlength="40" id="id_chapter_set-0-name" />',
             html=True
         )
 
@@ -638,7 +638,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(response, '<h2>Inner2s</h2>')
         self.assertContains(response, 'Add another Inner2')
         self.assertContains(response, '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" '
-                            'value="3" name="inner2_set-TOTAL_FORMS">', html=True)
+                            'value="3" name="inner2_set-TOTAL_FORMS" />', html=True)
 
     def test_inline_change_m2m_add_perm(self):
         permission = Permission.objects.get(codename='add_book', content_type=self.book_ct)
@@ -658,11 +658,11 @@ class TestInlinePermissions(TestCase):
         self.assertContains(response, '<h2>Author-book relationships</h2>')
         self.assertContains(response, 'Add another Author-book relationship')
         self.assertContains(response, '<input type="hidden" id="id_Author_books-TOTAL_FORMS" '
-                            'value="4" name="Author_books-TOTAL_FORMS">', html=True)
+                            'value="4" name="Author_books-TOTAL_FORMS" />', html=True)
         self.assertContains(
             response,
             '<input type="hidden" id="id_Author_books-0-id" value="%i" '
-            'name="Author_books-0-id">' % self.author_book_auto_m2m_intermediate_id,
+            'name="Author_books-0-id" />' % self.author_book_auto_m2m_intermediate_id,
             html=True
         )
         self.assertContains(response, 'id="id_Author_books-0-DELETE"')
@@ -678,12 +678,12 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="3" '
-            'name="inner2_set-TOTAL_FORMS">',
+            'name="inner2_set-TOTAL_FORMS" />',
             html=True
         )
         self.assertNotContains(
             response,
-            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id">' % self.inner2.id,
+            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id" />' % self.inner2.id,
             html=True
         )
 
@@ -695,18 +695,18 @@ class TestInlinePermissions(TestCase):
         self.assertContains(response, '<h2>Inner2s</h2>', count=2)
         # Just the one form for existing instances
         self.assertContains(
-            response, '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="1" name="inner2_set-TOTAL_FORMS">',
+            response, '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="1" name="inner2_set-TOTAL_FORMS" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id">' % self.inner2.id,
+            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id" />' % self.inner2.id,
             html=True
         )
         # max-num 0 means we can't add new ones
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-MAX_NUM_FORMS" value="0" name="inner2_set-MAX_NUM_FORMS">',
+            '<input type="hidden" id="id_inner2_set-MAX_NUM_FORMS" value="0" name="inner2_set-MAX_NUM_FORMS" />',
             html=True
         )
         # TabularInline
@@ -714,7 +714,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="number" name="inner2_set-2-0-dummy" value="%s" '
-            'class="vIntegerField" id="id_inner2_set-2-0-dummy">' % self.inner2.dummy,
+            'class="vIntegerField" id="id_inner2_set-2-0-dummy" />' % self.inner2.dummy,
             html=True,
         )
 
@@ -728,12 +728,12 @@ class TestInlinePermissions(TestCase):
         self.assertContains(response, '<h2>Inner2s</h2>')
         # One form for existing instance and three extra for new
         self.assertContains(
-            response, '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="4" name="inner2_set-TOTAL_FORMS">',
+            response, '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="4" name="inner2_set-TOTAL_FORMS" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id">' % self.inner2.id,
+            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id" />' % self.inner2.id,
             html=True
         )
 
@@ -748,12 +748,12 @@ class TestInlinePermissions(TestCase):
         # One form for existing instance only, no new
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="1" name="inner2_set-TOTAL_FORMS">',
+            '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="1" name="inner2_set-TOTAL_FORMS" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id">' % self.inner2.id,
+            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id" />' % self.inner2.id,
             html=True
         )
         self.assertContains(response, 'id="id_inner2_set-0-DELETE"')
@@ -771,12 +771,12 @@ class TestInlinePermissions(TestCase):
         # One form for existing instance only, three for new
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="4" name="inner2_set-TOTAL_FORMS">',
+            '<input type="hidden" id="id_inner2_set-TOTAL_FORMS" value="4" name="inner2_set-TOTAL_FORMS" />',
             html=True
         )
         self.assertContains(
             response,
-            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id">' % self.inner2.id,
+            '<input type="hidden" id="id_inner2_set-0-id" value="%i" name="inner2_set-0-id" />' % self.inner2.id,
             html=True
         )
         self.assertContains(response, 'id="id_inner2_set-0-DELETE"')
@@ -785,7 +785,7 @@ class TestInlinePermissions(TestCase):
         self.assertContains(
             response,
             '<input type="number" name="inner2_set-2-0-dummy" value="%s" '
-            'class="vIntegerField" id="id_inner2_set-2-0-dummy">' % self.inner2.dummy,
+            'class="vIntegerField" id="id_inner2_set-2-0-dummy" />' % self.inner2.dummy,
             html=True,
         )
 

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -163,7 +163,7 @@ class UtilsTests(SimpleTestCase):
         # Regression test for #13071: NullBooleanField has special
         # handling.
         display_value = display_for_field(None, models.NullBooleanField(), self.empty_value)
-        expected = '<img src="%sadmin/img/icon-unknown.svg" alt="None">' % settings.STATIC_URL
+        expected = '<img src="%sadmin/img/icon-unknown.svg" alt="None" />' % settings.STATIC_URL
         self.assertHTMLEqual(display_value, expected)
 
         display_value = display_for_field(None, models.BooleanField(null=True), self.empty_value)
@@ -208,11 +208,11 @@ class UtilsTests(SimpleTestCase):
     def test_list_display_for_value_boolean(self):
         self.assertEqual(
             display_for_value(True, '', boolean=True),
-            '<img src="/static/admin/img/icon-yes.svg" alt="True">'
+            '<img src="/static/admin/img/icon-yes.svg" alt="True" />'
         )
         self.assertEqual(
             display_for_value(False, '', boolean=True),
-            '<img src="/static/admin/img/icon-no.svg" alt="False">'
+            '<img src="/static/admin/img/icon-no.svg" alt="False" />'
         )
         self.assertEqual(display_for_value(True, ''), 'True')
         self.assertEqual(display_for_value(False, ''), 'False')

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -476,7 +476,7 @@ class PostAdmin(admin.ModelAdmin):
         return "Multiline\ntest\nstring"
 
     def multiline_html(self, instance):
-        return mark_safe("Multiline<br>\nhtml<br>\ncontent")
+        return mark_safe("Multiline<br/>\nhtml<br/>\ncontent")
 
 
 class FieldOverridePostForm(forms.ModelForm):

--- a/tests/admin_views/templates/admin/admin_views/article/search_form.html
+++ b/tests/admin_views/templates/admin/admin_views/article/search_form.html
@@ -3,7 +3,7 @@
 <div id="toolbar" class="override-search_form"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
 <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search" /></label>
-<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus />
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus="autofocus" />
 <input type="submit" value="{% trans 'Search' %}" />
 {% if show_result_count %}
     <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>

--- a/tests/admin_views/test_actions.py
+++ b/tests/admin_views/test_actions.py
@@ -226,8 +226,8 @@ class AdminActionsTest(TestCase):
     def test_actions_ordering(self):
         """Actions are ordered as expected."""
         response = self.client.get(reverse('admin:admin_views_externalsubscriber_changelist'))
-        self.assertContains(response, '''<label>Action: <select name="action" required>
-<option value="" selected>---------</option>
+        self.assertContains(response, '''<label>Action: <select name="action" required="required">
+<option value="" selected="selected">---------</option>
 <option value="delete_selected">Delete selected external
 subscribers</option>
 <option value="redirect_to">Redirect to (Awesome action)</option>

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1062,7 +1062,7 @@ class AdminCustomTemplateTests(AdminViewBasicTestCase):
         # When a site has multiple passwords in the browser's password manager,
         # a browser pop up asks which user the new password is for. To prevent
         # this, the username is added to the change password form.
-        self.assertContains(response, '<input type="text" name="username" value="super" style="display: none">')
+        self.assertContains(response, '<input type="text" name="username" value="super" style="display: none" />')
 
     def test_extended_bodyclass_template_index(self):
         """
@@ -1684,7 +1684,7 @@ class AdminViewPermissionsTest(TestCase):
         # Now give the user permission to add but not change.
         self.viewuser.user_permissions.add(get_perm(Article, get_permission_codename('add', Article._meta)))
         response = self.client.get(reverse('admin:admin_views_article_add'))
-        self.assertContains(response, '<input type="submit" value="Save and view" name="_continue">')
+        self.assertContains(response, '<input type="submit" value="Save and view" name="_continue" />')
         post = self.client.post(reverse('admin:admin_views_article_add'), add_dict, follow=False)
         self.assertEqual(post.status_code, 302)
         self.assertEqual(Article.objects.count(), 4)
@@ -3120,8 +3120,8 @@ class AdminViewListEditable(TestCase):
         self.assertContains(
             response,
             '<div class="hiddenfields">\n'
-            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id">'
-            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id">\n</div>'
+            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id" />'
+            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id" />\n</div>'
             % (story2.id, story1.id),
             html=True
         )
@@ -3150,8 +3150,8 @@ class AdminViewListEditable(TestCase):
         self.assertContains(
             response,
             '<div class="hiddenfields">\n'
-            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id">'
-            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id">\n</div>'
+            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id" />'
+            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id" />\n</div>'
             % (story2.id, story1.id),
             html=True
         )
@@ -3208,7 +3208,7 @@ class AdminSearchTest(TestCase):
         """
         response = self.client.get(reverse('admin:auth_user_changelist') + '?q=joe&%s=id' % TO_FIELD_VAR)
         self.assertContains(response, "\n1 user\n")
-        self.assertContains(response, '<input type="hidden" name="%s" value="id">' % TO_FIELD_VAR, html=True)
+        self.assertContains(response, '<input type="hidden" name="%s" value="id"/>' % TO_FIELD_VAR, html=True)
 
     def test_exact_matches(self):
         response = self.client.get(reverse('admin:admin_views_recommendation_changelist') + '?q=bar')
@@ -4599,10 +4599,10 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         self.assertContains(response, "Unknown coolness.")
         self.assertContains(response, "foo")
 
-        # Multiline text in a readonly field gets <br> tags
-        self.assertContains(response, 'Multiline<br>test<br>string')
-        self.assertContains(response, '<div class="readonly">Multiline<br>html<br>content</div>', html=True)
-        self.assertContains(response, 'InlineMultiline<br>test<br>string')
+        # Multiline text in a readonly field gets <br /> tags
+        self.assertContains(response, 'Multiline<br />test<br />string')
+        self.assertContains(response, '<div class="readonly">Multiline<br />html<br />content</div>', html=True)
+        self.assertContains(response, 'InlineMultiline<br />test<br />string')
 
         self.assertContains(response, formats.localize(datetime.date.today() - datetime.timedelta(days=7)))
 
@@ -4643,9 +4643,9 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         )
         response = self.client.get(reverse('admin:admin_views_post_change', args=(p.pk,)))
         # Checking readonly field.
-        self.assertContains(response, 'test<br><br>test<br><br>test<br><br>test')
+        self.assertContains(response, 'test<br /><br />test<br /><br />test<br /><br />test')
         # Checking readonly field in inline.
-        self.assertContains(response, 'test<br>link')
+        self.assertContains(response, 'test<br />link')
 
     def test_readonly_post(self):
         data = {
@@ -5487,7 +5487,7 @@ class AdminViewLogoutTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'admin/login.html')
         self.assertEqual(response.request['PATH_INFO'], reverse('admin:login'))
-        self.assertContains(response, '<input type="hidden" name="next" value="%s">' % reverse('admin:index'))
+        self.assertContains(response, '<input type="hidden" name="next" value="%s" />' % reverse('admin:index'))
 
 
 @override_settings(ROOT_URLCONF='admin_views.urls')

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -86,15 +86,15 @@ class AutocompleteMixinTests(TestCase):
         # With 'band', a ForeignKey.
         form = AlbumForm(initial={'band': beatles.pk})
         output = form.as_table()
-        selected_option = '<option value="%s" selected>The Beatles</option>' % beatles.pk
+        selected_option = '<option value="%s" selected="selected">The Beatles</option>' % beatles.pk
         option = '<option value="%s">The Who</option>' % who.pk
         self.assertIn(selected_option, output)
         self.assertNotIn(option, output)
         # With 'featuring', a ManyToManyField.
         form = AlbumForm(initial={'featuring': [beatles.pk, who.pk]})
         output = form.as_table()
-        selected_option = '<option value="%s" selected>The Beatles</option>' % beatles.pk
-        option = '<option value="%s" selected>The Who</option>' % who.pk
+        selected_option = '<option value="%s" selected="selected">The Beatles</option>' % beatles.pk
+        option = '<option value="%s" selected="selected">The Who</option>' % who.pk
         self.assertIn(selected_option, output)
         self.assertIn(option, output)
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -280,13 +280,13 @@ class AdminDateWidgetTest(SimpleTestCase):
         w = widgets.AdminDateWidget()
         self.assertHTMLEqual(
             w.render('test', datetime(2007, 12, 1, 9, 30)),
-            '<input value="2007-12-01" type="text" class="vDateField" name="test" size="10">',
+            '<input value="2007-12-01" type="text" class="vDateField" name="test" size="10" />',
         )
         # pass attrs to widget
         w = widgets.AdminDateWidget(attrs={'size': 20, 'class': 'myDateField'})
         self.assertHTMLEqual(
             w.render('test', datetime(2007, 12, 1, 9, 30)),
-            '<input value="2007-12-01" type="text" class="myDateField" name="test" size="20">',
+            '<input value="2007-12-01" type="text" class="myDateField" name="test" size="20" />',
         )
 
 
@@ -295,13 +295,13 @@ class AdminTimeWidgetTest(SimpleTestCase):
         w = widgets.AdminTimeWidget()
         self.assertHTMLEqual(
             w.render('test', datetime(2007, 12, 1, 9, 30)),
-            '<input value="09:30:00" type="text" class="vTimeField" name="test" size="8">',
+            '<input value="09:30:00" type="text" class="vTimeField" name="test" size="8" />',
         )
         # pass attrs to widget
         w = widgets.AdminTimeWidget(attrs={'size': 20, 'class': 'myTimeField'})
         self.assertHTMLEqual(
             w.render('test', datetime(2007, 12, 1, 9, 30)),
-            '<input value="09:30:00" type="text" class="myTimeField" name="test" size="20">',
+            '<input value="09:30:00" type="text" class="myTimeField" name="test" size="20" />',
         )
 
 
@@ -312,9 +312,9 @@ class AdminSplitDateTimeWidgetTest(SimpleTestCase):
             w.render('test', datetime(2007, 12, 1, 9, 30)),
             '<p class="datetime">'
             'Date: <input value="2007-12-01" type="text" class="vDateField" '
-            'name="test_0" size="10"><br>'
+            'name="test_0" size="10" /><br />'
             'Time: <input value="09:30:00" type="text" class="vTimeField" '
-            'name="test_1" size="8"></p>'
+            'name="test_1" size="8" /></p>'
         )
 
     def test_localization(self):
@@ -326,9 +326,9 @@ class AdminSplitDateTimeWidgetTest(SimpleTestCase):
                 w.render('test', datetime(2007, 12, 1, 9, 30)),
                 '<p class="datetime">'
                 'Datum: <input value="01.12.2007" type="text" '
-                'class="vDateField" name="test_0"size="10"><br>'
+                'class="vDateField" name="test_0"size="10" /><br />'
                 'Zeit: <input value="09:30:00" type="text" class="vTimeField" '
-                'name="test_1" size="8"></p>'
+                'name="test_1" size="8" /></p>'
             )
 
 
@@ -337,14 +337,14 @@ class AdminURLWidgetTest(SimpleTestCase):
         w = widgets.AdminURLFieldWidget()
         self.assertHTMLEqual(
             w.render('test', ''),
-            '<input class="vURLField" name="test" type="url">'
+            '<input class="vURLField" name="test" type="url" />'
         )
         self.assertHTMLEqual(
             w.render('test', 'http://example.com'),
             '<p class="url">Currently:<a href="http://example.com">'
-            'http://example.com</a><br>'
+            'http://example.com</a><br />'
             'Change:<input class="vURLField" name="test" type="url" '
-            'value="http://example.com"></p>'
+            'value="http://example.com" /></p>'
         )
 
     def test_render_idn(self):
@@ -352,9 +352,9 @@ class AdminURLWidgetTest(SimpleTestCase):
         self.assertHTMLEqual(
             w.render('test', 'http://example-äüö.com'),
             '<p class="url">Currently: <a href="http://xn--example--7za4pnc.com">'
-            'http://example-äüö.com</a><br>'
+            'http://example-äüö.com</a><br />'
             'Change:<input class="vURLField" name="test" type="url" '
-            'value="http://example-äüö.com"></p>'
+            'value="http://example-äüö.com" /></p>'
         )
 
     def test_render_quoting(self):
@@ -426,15 +426,15 @@ class AdminFileWidgetTests(TestDataMixin, TestCase):
             '<p class="file-upload">Currently: <a href="%(STORAGE_URL)salbums/'
             r'hybrid_theory.jpg">albums\hybrid_theory.jpg</a> '
             '<span class="clearable-file-input">'
-            '<input type="checkbox" name="test-clear" id="test-clear_id"> '
-            '<label for="test-clear_id">Clear</label></span><br>'
-            'Change: <input type="file" name="test"></p>' % {
+            '<input type="checkbox" name="test-clear" id="test-clear_id" /> '
+            '<label for="test-clear_id">Clear</label></span><br />'
+            'Change: <input type="file" name="test" /></p>' % {
                 'STORAGE_URL': default_storage.url(''),
             },
         )
         self.assertHTMLEqual(
             w.render('test', SimpleUploadedFile('test', b'content')),
-            '<input type="file" name="test">',
+            '<input type="file" name="test" />',
         )
 
     def test_render_required(self):
@@ -443,8 +443,8 @@ class AdminFileWidgetTests(TestDataMixin, TestCase):
         self.assertHTMLEqual(
             widget.render('test', self.album.cover_art),
             '<p class="file-upload">Currently: <a href="%(STORAGE_URL)salbums/'
-            r'hybrid_theory.jpg">albums\hybrid_theory.jpg</a><br>'
-            'Change: <input type="file" name="test"></p>' % {
+            r'hybrid_theory.jpg">albums\hybrid_theory.jpg</a><br />'
+            'Change: <input type="file" name="test" /></p>' % {
                 'STORAGE_URL': default_storage.url(''),
             },
         )
@@ -463,7 +463,7 @@ class AdminFileWidgetTests(TestDataMixin, TestCase):
         )
         self.assertNotContains(
             response,
-            '<input type="file" name="cover_art" id="id_cover_art">',
+            '<input type="file" name="cover_art" id="id_cover_art" />',
             html=True,
         )
         response = self.client.get(reverse('admin:admin_widgets_album_add'))
@@ -488,7 +488,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         self.assertHTMLEqual(
             w.render('test', band.pk, attrs={}),
             '<input type="text" name="test" value="%(bandpk)s" '
-            'class="vForeignKeyRawIdAdminField">'
+            'class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/band/?_to_field=id" class="related-lookup" '
             'id="lookup_id_test" title="Lookup"></a>&nbsp;<strong>'
             '<a href="/admin_widgets/band/%(bandpk)s/change/">Linkin Park</a>'
@@ -508,7 +508,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         self.assertHTMLEqual(
             w.render('test', core.parent_id, attrs={}),
             '<input type="text" name="test" value="86" '
-            'class="vForeignKeyRawIdAdminField">'
+            'class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/inventory/?_to_field=barcode" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
             '&nbsp;<strong><a href="/admin_widgets/inventory/%(pk)s/change/">'
@@ -525,7 +525,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('honeycomb_widget', big_honeycomb.pk, attrs={}),
-            '<input type="text" name="honeycomb_widget" value="%(hcombpk)s">'
+            '<input type="text" name="honeycomb_widget" value="%(hcombpk)s" />'
             '&nbsp;<strong>%(hcomb)s</strong>'
             % {'hcombpk': big_honeycomb.pk, 'hcomb': big_honeycomb}
         )
@@ -540,7 +540,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         w = widgets.ForeignKeyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('individual_widget', subject1.pk, attrs={}),
-            '<input type="text" name="individual_widget" value="%(subj1pk)s">'
+            '<input type="text" name="individual_widget" value="%(subj1pk)s" />'
             '&nbsp;<strong>%(subj1)s</strong>'
             % {'subj1pk': subject1.pk, 'subj1': subject1}
         )
@@ -558,7 +558,7 @@ class ForeignKeyRawIdWidgetTest(TestCase):
         )
         self.assertHTMLEqual(
             w.render('test', child_of_hidden.parent_id, attrs={}),
-            '<input type="text" name="test" value="93" class="vForeignKeyRawIdAdminField">'
+            '<input type="text" name="test" value="93" class="vForeignKeyRawIdAdminField" />'
             '<a href="/admin_widgets/inventory/?_to_field=barcode" '
             'class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
             '&nbsp;<strong><a href="/admin_widgets/inventory/%(pk)s/change/">'
@@ -580,14 +580,14 @@ class ManyToManyRawIdWidgetTest(TestCase):
         w = widgets.ManyToManyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('test', [m1.pk, m2.pk], attrs={}), (
-                '<input type="text" name="test" value="%(m1pk)s,%(m2pk)s" class="vManyToManyRawIdAdminField">'
+                '<input type="text" name="test" value="%(m1pk)s,%(m2pk)s" class="vManyToManyRawIdAdminField" />'
                 '<a href="/admin_widgets/member/" class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
             ) % {'m1pk': m1.pk, 'm2pk': m2.pk}
         )
 
         self.assertHTMLEqual(
             w.render('test', [m1.pk]), (
-                '<input type="text" name="test" value="%(m1pk)s" class="vManyToManyRawIdAdminField">'
+                '<input type="text" name="test" value="%(m1pk)s" class="vManyToManyRawIdAdminField" />'
                 '<a href="/admin_widgets/member/" class="related-lookup" id="lookup_id_test" title="Lookup"></a>'
             ) % {'m1pk': m1.pk}
         )
@@ -605,12 +605,12 @@ class ManyToManyRawIdWidgetTest(TestCase):
         w = widgets.ManyToManyRawIdWidget(rel, widget_admin_site)
         self.assertHTMLEqual(
             w.render('company_widget1', [c1.pk, c2.pk], attrs={}),
-            '<input type="text" name="company_widget1" value="%(c1pk)s,%(c2pk)s">' % {'c1pk': c1.pk, 'c2pk': c2.pk}
+            '<input type="text" name="company_widget1" value="%(c1pk)s,%(c2pk)s" />' % {'c1pk': c1.pk, 'c2pk': c2.pk}
         )
 
         self.assertHTMLEqual(
             w.render('company_widget2', [c1.pk]),
-            '<input type="text" name="company_widget2" value="%(c1pk)s">' % {'c1pk': c1.pk}
+            '<input type="text" name="company_widget2" value="%(c1pk)s" />' % {'c1pk': c1.pk}
         )
 
 

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -261,7 +261,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         w = widgets.FilteredSelectMultiple('test\\', False)
         self.assertHTMLEqual(
             w.render('test', 'test'),
-            '<select multiple name="test" class="selectfilter" '
+            '<select multiple="multiple" name="test" class="selectfilter" '
             'data-field-name="test\\" data-is-stacked="0">\n</select>'
         )
 
@@ -270,7 +270,7 @@ class FilteredSelectMultipleWidgetTest(SimpleTestCase):
         w = widgets.FilteredSelectMultiple('test\\', True)
         self.assertHTMLEqual(
             w.render('test', 'test'),
-            '<select multiple name="test" class="selectfilterstacked" '
+            '<select multiple="multiple" name="test" class="selectfilterstacked" '
             'data-field-name="test\\" data-is-stacked="1">\n</select>'
         )
 

--- a/tests/csrf_tests/views.py
+++ b/tests/csrf_tests/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 def post_form_view(request):
     """Return a POST form (without a token)."""
     return HttpResponse(content="""
-<html><body><h1>\u00a1Unicode!<form method="post"><input type="text"></form></body></html>
+<html><body><h1>\u00a1Unicode!<form method="post"><input type="text" /></form></body></html>
 """, mimetype='text/html')
 
 

--- a/tests/forms_tests/field_tests/test_charfield.py
+++ b/tests/forms_tests/field_tests/test_charfield.py
@@ -145,7 +145,7 @@ class CharFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_charfield_disabled(self):
         f = CharField(disabled=True)
-        self.assertWidgetRendersTo(f, '<input type="text" name="f" id="id_f" disabled required />')
+        self.assertWidgetRendersTo(f, '<input type="text" name="f" id="id_f" disabled="disabled" required="required" />')
 
     def test_null_characters_prohibited(self):
         f = CharField()

--- a/tests/forms_tests/field_tests/test_charfield.py
+++ b/tests/forms_tests/field_tests/test_charfield.py
@@ -145,7 +145,7 @@ class CharFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_charfield_disabled(self):
         f = CharField(disabled=True)
-        self.assertWidgetRendersTo(f, '<input type="text" name="f" id="id_f" disabled required>')
+        self.assertWidgetRendersTo(f, '<input type="text" name="f" id="id_f" disabled required />')
 
     def test_null_characters_prohibited(self):
         f = CharField()

--- a/tests/forms_tests/field_tests/test_choicefield.py
+++ b/tests/forms_tests/field_tests/test_choicefield.py
@@ -83,6 +83,6 @@ class ChoiceFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = ChoiceField(choices=[('J', 'John'), ('P', 'Paul')], disabled=True)
         self.assertWidgetRendersTo(
             f,
-            '<select id="id_f" name="f" disabled><option value="J">John</option>'
+            '<select id="id_f" name="f" disabled="disabled"><option value="J">John</option>'
             '<option value="P">Paul</option></select>'
         )

--- a/tests/forms_tests/field_tests/test_datefield.py
+++ b/tests/forms_tests/field_tests/test_datefield.py
@@ -22,7 +22,7 @@ class DateFieldTest(SimpleTestCase):
         # accept the input from the "as_hidden" rendering as well.
         self.assertHTMLEqual(
             a['mydate'].as_hidden(),
-            '<input type="hidden" name="mydate" value="2008-4-1" id="id_mydate">',
+            '<input type="hidden" name="mydate" value="2008-4-1" id="id_mydate" />',
         )
 
         b = GetDate({'mydate': '2008-4-1'})

--- a/tests/forms_tests/field_tests/test_decimalfield.py
+++ b/tests/forms_tests/field_tests/test_decimalfield.py
@@ -11,7 +11,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_decimalfield_1(self):
         f = DecimalField(max_digits=4, decimal_places=2)
-        self.assertWidgetRendersTo(f, '<input id="id_f" step="0.01" type="number" name="f" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" step="0.01" type="number" name="f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -78,7 +78,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         )
         self.assertWidgetRendersTo(
             f,
-            '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" required />',
+            '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" required="required" />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
             f.clean('1.6')
@@ -136,7 +136,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = DecimalField(max_digits=20)
         self.assertEqual(f.widget_attrs(NumberInput()), {'step': 'any'})
         f = DecimalField(max_digits=6, widget=NumberInput(attrs={'step': '0.01'}))
-        self.assertWidgetRendersTo(f, '<input step="0.01" name="f" type="number" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input step="0.01" name="f" type="number" id="id_f" required="required" />')
 
     def test_decimalfield_localized(self):
         """
@@ -144,7 +144,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f = DecimalField(localize=True)
-        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required="required" />')
 
     def test_decimalfield_changed(self):
         f = DecimalField(max_digits=2, decimal_places=2)

--- a/tests/forms_tests/field_tests/test_decimalfield.py
+++ b/tests/forms_tests/field_tests/test_decimalfield.py
@@ -11,7 +11,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_decimalfield_1(self):
         f = DecimalField(max_digits=4, decimal_places=2)
-        self.assertWidgetRendersTo(f, '<input id="id_f" step="0.01" type="number" name="f" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" step="0.01" type="number" name="f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -78,7 +78,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         )
         self.assertWidgetRendersTo(
             f,
-            '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" required>',
+            '<input step="0.01" name="f" min="0.5" max="1.5" type="number" id="id_f" required />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
             f.clean('1.6')
@@ -136,7 +136,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = DecimalField(max_digits=20)
         self.assertEqual(f.widget_attrs(NumberInput()), {'step': 'any'})
         f = DecimalField(max_digits=6, widget=NumberInput(attrs={'step': '0.01'}))
-        self.assertWidgetRendersTo(f, '<input step="0.01" name="f" type="number" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input step="0.01" name="f" type="number" id="id_f" required />')
 
     def test_decimalfield_localized(self):
         """
@@ -144,7 +144,7 @@ class DecimalFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f = DecimalField(localize=True)
-        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required />')
 
     def test_decimalfield_changed(self):
         f = DecimalField(max_digits=2, decimal_places=2)

--- a/tests/forms_tests/field_tests/test_durationfield.py
+++ b/tests/forms_tests/field_tests/test_durationfield.py
@@ -44,7 +44,7 @@ class DurationFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
     def test_durationfield_render(self):
         self.assertWidgetRendersTo(
             DurationField(initial=datetime.timedelta(hours=1)),
-            '<input id="id_f" type="text" name="f" value="01:00:00" required>',
+            '<input id="id_f" type="text" name="f" value="01:00:00" required />',
         )
 
     def test_durationfield_integer_value(self):

--- a/tests/forms_tests/field_tests/test_durationfield.py
+++ b/tests/forms_tests/field_tests/test_durationfield.py
@@ -44,7 +44,7 @@ class DurationFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
     def test_durationfield_render(self):
         self.assertWidgetRendersTo(
             DurationField(initial=datetime.timedelta(hours=1)),
-            '<input id="id_f" type="text" name="f" value="01:00:00" required />',
+            '<input id="id_f" type="text" name="f" value="01:00:00" required="required" />',
         )
 
     def test_durationfield_integer_value(self):

--- a/tests/forms_tests/field_tests/test_emailfield.py
+++ b/tests/forms_tests/field_tests/test_emailfield.py
@@ -8,7 +8,7 @@ class EmailFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_emailfield_1(self):
         f = EmailField()
-        self.assertWidgetRendersTo(f, '<input type="email" name="f" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input type="email" name="f" id="id_f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -41,7 +41,7 @@ class EmailFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = EmailField(min_length=10, max_length=15)
         self.assertWidgetRendersTo(
             f,
-            '<input id="id_f" type="email" name="f" maxlength="15" minlength="10" required>',
+            '<input id="id_f" type="email" name="f" maxlength="15" minlength="10" required />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 9).'"):
             f.clean('a@foo.com')

--- a/tests/forms_tests/field_tests/test_emailfield.py
+++ b/tests/forms_tests/field_tests/test_emailfield.py
@@ -8,7 +8,7 @@ class EmailFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_emailfield_1(self):
         f = EmailField()
-        self.assertWidgetRendersTo(f, '<input type="email" name="f" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input type="email" name="f" id="id_f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -41,7 +41,7 @@ class EmailFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = EmailField(min_length=10, max_length=15)
         self.assertWidgetRendersTo(
             f,
-            '<input id="id_f" type="email" name="f" maxlength="15" minlength="10" required />',
+            '<input id="id_f" type="email" name="f" maxlength="15" minlength="10" required="required" />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 10 characters (it has 9).'"):
             f.clean('a@foo.com')

--- a/tests/forms_tests/field_tests/test_floatfield.py
+++ b/tests/forms_tests/field_tests/test_floatfield.py
@@ -10,7 +10,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_floatfield_1(self):
         f = FloatField()
-        self.assertWidgetRendersTo(f, '<input step="any" type="number" name="f" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input step="any" type="number" name="f" id="id_f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -49,7 +49,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = FloatField(max_value=1.5, min_value=0.5)
         self.assertWidgetRendersTo(
             f,
-            '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" required />',
+            '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" required="required" />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
             f.clean('1.6')
@@ -64,7 +64,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = FloatField(widget=NumberInput(attrs={'step': 0.01, 'max': 1.0, 'min': 0.0}))
         self.assertWidgetRendersTo(
             f,
-            '<input step="0.01" name="f" min="0.0" max="1.0" type="number" id="id_f" required />',
+            '<input step="0.01" name="f" min="0.0" max="1.0" type="number" id="id_f" required="required" />',
         )
 
     def test_floatfield_localized(self):
@@ -73,7 +73,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f = FloatField(localize=True)
-        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required="required" />')
 
     def test_floatfield_changed(self):
         f = FloatField()

--- a/tests/forms_tests/field_tests/test_floatfield.py
+++ b/tests/forms_tests/field_tests/test_floatfield.py
@@ -10,7 +10,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_floatfield_1(self):
         f = FloatField()
-        self.assertWidgetRendersTo(f, '<input step="any" type="number" name="f" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input step="any" type="number" name="f" id="id_f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -49,7 +49,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = FloatField(max_value=1.5, min_value=0.5)
         self.assertWidgetRendersTo(
             f,
-            '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" required>',
+            '<input step="any" name="f" min="0.5" max="1.5" type="number" id="id_f" required />',
         )
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is less than or equal to 1.5.'"):
             f.clean('1.6')
@@ -64,7 +64,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         f = FloatField(widget=NumberInput(attrs={'step': 0.01, 'max': 1.0, 'min': 0.0}))
         self.assertWidgetRendersTo(
             f,
-            '<input step="0.01" name="f" min="0.0" max="1.0" type="number" id="id_f" required>',
+            '<input step="0.01" name="f" min="0.0" max="1.0" type="number" id="id_f" required />',
         )
 
     def test_floatfield_localized(self):
@@ -73,7 +73,7 @@ class FloatFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f = FloatField(localize=True)
-        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" name="f" type="text" required />')
 
     def test_floatfield_changed(self):
         f = FloatField()

--- a/tests/forms_tests/field_tests/test_imagefield.py
+++ b/tests/forms_tests/field_tests/test_imagefield.py
@@ -75,14 +75,14 @@ class ImageFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         self.assertEqual(f.widget_attrs(Widget()), {})
         self.assertEqual(f.widget_attrs(FileInput()), {'accept': 'image/*'})
         self.assertEqual(f.widget_attrs(ClearableFileInput()), {'accept': 'image/*'})
-        self.assertWidgetRendersTo(f, '<input type="file" name="f" accept="image/*" required id="id_f" />')
+        self.assertWidgetRendersTo(f, '<input type="file" name="f" accept="image/*" required="required"  id="id_f" />')
 
     def test_widge_attrs_accept_specified(self):
         f = ImageField(widget=FileInput(attrs={'accept': 'image/png'}))
         self.assertEqual(f.widget_attrs(f.widget), {})
-        self.assertWidgetRendersTo(f, '<input type="file" name="f" accept="image/png" required id="id_f" />')
+        self.assertWidgetRendersTo(f, '<input type="file" name="f" accept="image/png" required="required"  id="id_f" />')
 
     def test_widge_attrs_accept_false(self):
         f = ImageField(widget=FileInput(attrs={'accept': False}))
         self.assertEqual(f.widget_attrs(f.widget), {})
-        self.assertWidgetRendersTo(f, '<input type="file" name="f" required id="id_f" />')
+        self.assertWidgetRendersTo(f, '<input type="file" name="f" required="required"  id="id_f" />')

--- a/tests/forms_tests/field_tests/test_integerfield.py
+++ b/tests/forms_tests/field_tests/test_integerfield.py
@@ -8,7 +8,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_1(self):
         f = IntegerField()
-        self.assertWidgetRendersTo(f, '<input type="number" name="f" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input type="number" name="f" id="id_f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -50,7 +50,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_3(self):
         f = IntegerField(max_value=10)
-        self.assertWidgetRendersTo(f, '<input max="10" type="number" name="f" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input max="10" type="number" name="f" id="id_f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         self.assertEqual(1, f.clean(1))
@@ -65,7 +65,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_4(self):
         f = IntegerField(min_value=10)
-        self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
@@ -79,7 +79,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_5(self):
         f = IntegerField(min_value=10, max_value=20)
-        self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
@@ -100,7 +100,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f1 = IntegerField(localize=True)
-        self.assertWidgetRendersTo(f1, '<input id="id_f" name="f" type="text" required>')
+        self.assertWidgetRendersTo(f1, '<input id="id_f" name="f" type="text" required />')
 
     def test_integerfield_float(self):
         f = IntegerField()

--- a/tests/forms_tests/field_tests/test_integerfield.py
+++ b/tests/forms_tests/field_tests/test_integerfield.py
@@ -8,7 +8,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_1(self):
         f = IntegerField()
-        self.assertWidgetRendersTo(f, '<input type="number" name="f" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input type="number" name="f" id="id_f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -50,7 +50,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_3(self):
         f = IntegerField(max_value=10)
-        self.assertWidgetRendersTo(f, '<input max="10" type="number" name="f" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input max="10" type="number" name="f" id="id_f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         self.assertEqual(1, f.clean(1))
@@ -65,7 +65,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_4(self):
         f = IntegerField(min_value=10)
-        self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" type="number" name="f" min="10" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
@@ -79,7 +79,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_integerfield_5(self):
         f = IntegerField(min_value=10, max_value=20)
-        self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" max="20" type="number" name="f" min="10" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean(None)
         with self.assertRaisesMessage(ValidationError, "'Ensure this value is greater than or equal to 10.'"):
@@ -100,7 +100,7 @@ class IntegerFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
         number input specific attributes.
         """
         f1 = IntegerField(localize=True)
-        self.assertWidgetRendersTo(f1, '<input id="id_f" name="f" type="text" required />')
+        self.assertWidgetRendersTo(f1, '<input id="id_f" name="f" type="text" required="required" />')
 
     def test_integerfield_float(self):
         f = IntegerField()

--- a/tests/forms_tests/field_tests/test_multivaluefield.py
+++ b/tests/forms_tests/field_tests/test_multivaluefield.py
@@ -128,15 +128,15 @@ class MultiValueFieldTest(SimpleTestCase):
             form.as_table(),
             """
             <tr><th><label for="id_field1_0">Field1:</label></th>
-            <td><input type="text" name="field1_0" id="id_field1_0" required>
+            <td><input type="text" name="field1_0" id="id_field1_0" required />
             <select multiple name="field1_1" id="id_field1_1" required>
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
             </select>
-            <input type="text" name="field1_2_0" id="id_field1_2_0" required>
-            <input type="text" name="field1_2_1" id="id_field1_2_1" required></td></tr>
+            <input type="text" name="field1_2_0" id="id_field1_2_0" required />
+            <input type="text" name="field1_2_1" id="id_field1_2_1" required /></td></tr>
             """,
         )
 
@@ -151,15 +151,15 @@ class MultiValueFieldTest(SimpleTestCase):
             form.as_table(),
             """
             <tr><th><label for="id_field1_0">Field1:</label></th>
-            <td><input type="text" name="field1_0" value="some text" id="id_field1_0" required>
+            <td><input type="text" name="field1_0" value="some text" id="id_field1_0" required />
             <select multiple name="field1_1" id="id_field1_1" required>
             <option value="J" selected>John</option>
             <option value="P" selected>Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
             </select>
-            <input type="text" name="field1_2_0" value="2007-04-25" id="id_field1_2_0" required>
-            <input type="text" name="field1_2_1" value="06:24:00" id="id_field1_2_1" required></td></tr>
+            <input type="text" name="field1_2_0" value="2007-04-25" id="id_field1_2_0" required />
+            <input type="text" name="field1_2_1" value="06:24:00" id="id_field1_2_1" required /></td></tr>
             """,
         )
 

--- a/tests/forms_tests/field_tests/test_multivaluefield.py
+++ b/tests/forms_tests/field_tests/test_multivaluefield.py
@@ -128,15 +128,15 @@ class MultiValueFieldTest(SimpleTestCase):
             form.as_table(),
             """
             <tr><th><label for="id_field1_0">Field1:</label></th>
-            <td><input type="text" name="field1_0" id="id_field1_0" required />
-            <select multiple name="field1_1" id="id_field1_1" required>
+            <td><input type="text" name="field1_0" id="id_field1_0" required="required" />
+            <select multiple="multiple" name="field1_1" id="id_field1_1" required="required">
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
             </select>
-            <input type="text" name="field1_2_0" id="id_field1_2_0" required />
-            <input type="text" name="field1_2_1" id="id_field1_2_1" required /></td></tr>
+            <input type="text" name="field1_2_0" id="id_field1_2_0" required="required" />
+            <input type="text" name="field1_2_1" id="id_field1_2_1" required="required" /></td></tr>
             """,
         )
 
@@ -151,15 +151,15 @@ class MultiValueFieldTest(SimpleTestCase):
             form.as_table(),
             """
             <tr><th><label for="id_field1_0">Field1:</label></th>
-            <td><input type="text" name="field1_0" value="some text" id="id_field1_0" required />
-            <select multiple name="field1_1" id="id_field1_1" required>
-            <option value="J" selected>John</option>
-            <option value="P" selected>Paul</option>
+            <td><input type="text" name="field1_0" value="some text" id="id_field1_0" required="required" />
+            <select multiple="multiple" name="field1_1" id="id_field1_1" required="required">
+            <option value="J" selected="selected">John</option>
+            <option value="P" selected="selected">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
             </select>
-            <input type="text" name="field1_2_0" value="2007-04-25" id="id_field1_2_0" required />
-            <input type="text" name="field1_2_1" value="06:24:00" id="id_field1_2_1" required /></td></tr>
+            <input type="text" name="field1_2_0" value="2007-04-25" id="id_field1_2_0" required="required" />
+            <input type="text" name="field1_2_1" value="06:24:00" id="id_field1_2_1" required="required" /></td></tr>
             """,
         )
 

--- a/tests/forms_tests/field_tests/test_nullbooleanfield.py
+++ b/tests/forms_tests/field_tests/test_nullbooleanfield.py
@@ -27,8 +27,8 @@ class NullBooleanFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
             hidden_nullbool2 = NullBooleanField(widget=HiddenInput, initial=False)
         f = HiddenNullBooleanForm()
         self.assertHTMLEqual(
-            '<input type="hidden" name="hidden_nullbool1" value="True" id="id_hidden_nullbool1">'
-            '<input type="hidden" name="hidden_nullbool2" value="False" id="id_hidden_nullbool2">',
+            '<input type="hidden" name="hidden_nullbool1" value="True" id="id_hidden_nullbool1" />'
+            '<input type="hidden" name="hidden_nullbool2" value="False" id="id_hidden_nullbool2" />',
             str(f)
         )
 

--- a/tests/forms_tests/field_tests/test_urlfield.py
+++ b/tests/forms_tests/field_tests/test_urlfield.py
@@ -8,7 +8,7 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_urlfield_1(self):
         f = URLField()
-        self.assertWidgetRendersTo(f, '<input type="url" name="f" id="id_f" required>')
+        self.assertWidgetRendersTo(f, '<input type="url" name="f" id="id_f" required />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -88,7 +88,7 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_urlfield_5(self):
         f = URLField(min_length=15, max_length=20)
-        self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" minlength="15" required>')
+        self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" minlength="15" required />')
         with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 15 characters (it has 12).'"):
             f.clean('http://f.com')
         self.assertEqual('http://example.com', f.clean('http://example.com'))

--- a/tests/forms_tests/field_tests/test_urlfield.py
+++ b/tests/forms_tests/field_tests/test_urlfield.py
@@ -8,7 +8,7 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_urlfield_1(self):
         f = URLField()
-        self.assertWidgetRendersTo(f, '<input type="url" name="f" id="id_f" required />')
+        self.assertWidgetRendersTo(f, '<input type="url" name="f" id="id_f" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
             f.clean('')
         with self.assertRaisesMessage(ValidationError, "'This field is required.'"):
@@ -88,7 +88,7 @@ class URLFieldTest(FormFieldAssertionsMixin, SimpleTestCase):
 
     def test_urlfield_5(self):
         f = URLField(min_length=15, max_length=20)
-        self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" minlength="15" required />')
+        self.assertWidgetRendersTo(f, '<input id="id_f" type="url" name="f" maxlength="20" minlength="15" required="required" />')
         with self.assertRaisesMessage(ValidationError, "'Ensure this value has at least 15 characters (it has 12).'"):
             f.clean('http://f.com')
         self.assertEqual('http://example.com', f.clean('http://example.com'))

--- a/tests/forms_tests/jinja2/forms_tests/custom_widget.html
+++ b/tests/forms_tests/jinja2/forms_tests/custom_widget.html
@@ -1,1 +1,1 @@
-<input type="text" name="custom">
+<input type="text" name="custom" />

--- a/tests/forms_tests/templates/forms_tests/article_form.html
+++ b/tests/forms_tests/templates/forms_tests/article_form.html
@@ -1,8 +1,8 @@
 <html>
 <body>
   <form method="post">{% csrf_token %}
-    {{ form.as_p }}<br>
-    <input id="submit" type="submit">
+    {{ form.as_p }}<br/>
+    <input id="submit" type="submit" />
   </form>
 </body>
 </html>

--- a/tests/forms_tests/templates/forms_tests/custom_widget.html
+++ b/tests/forms_tests/templates/forms_tests/custom_widget.html
@@ -1,1 +1,1 @@
-<input type="text" name="custom">
+<input type="text" name="custom" />

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -59,15 +59,15 @@ class FormsTestCase(SimpleTestCase):
         self.assertEqual(p.cleaned_data["birthday"], datetime.date(1940, 10, 9))
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="first_name" value="John" id="id_first_name" required>'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required />'
         )
         self.assertHTMLEqual(
             str(p['last_name']),
-            '<input type="text" name="last_name" value="Lennon" id="id_last_name" required>'
+            '<input type="text" name="last_name" value="Lennon" id="id_last_name" required />'
         )
         self.assertHTMLEqual(
             str(p['birthday']),
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required />'
         )
 
         msg = "Key 'nonexistentfield' not found in 'Person'. Choices are: birthday, first_name, last_name."
@@ -81,9 +81,9 @@ class FormsTestCase(SimpleTestCase):
 
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<input type="text" name="first_name" value="John" id="id_first_name" required>
-<input type="text" name="last_name" value="Lennon" id="id_last_name" required>
-<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required>"""
+            """<input type="text" name="first_name" value="John" id="id_first_name" required />
+<input type="text" name="last_name" value="Lennon" id="id_last_name" required />
+<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required />"""
         )
 
         form_output = []
@@ -99,11 +99,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" value="John" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" value="John" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" value="Lennon" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" value="Lennon" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required></td></tr>"""
+<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></td></tr>"""
         )
 
     def test_empty_dict(self):
@@ -119,49 +119,49 @@ class FormsTestCase(SimpleTestCase):
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="first_name" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="last_name" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="birthday" id="id_birthday" required></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="first_name" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="last_name" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="birthday" id="id_birthday" required></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></li>
+<input type="text" name="first_name" id="id_first_name" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></li>
+<input type="text" name="last_name" id="id_last_name" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required></li>"""
+<input type="text" name="birthday" id="id_birthday" required /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></p>
+<input type="text" name="first_name" id="id_first_name" required /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></p>
+<input type="text" name="last_name" id="id_last_name" required /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required></p>"""
+<input type="text" name="birthday" id="id_birthday" required /></p>"""
         )
 
     def test_empty_querydict_args(self):
@@ -185,38 +185,38 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></li>
+<input type="text" name="first_name" id="id_first_name" required /></li>
 <li><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></li>
+<input type="text" name="last_name" id="id_last_name" required /></li>
 <li><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required></li>"""
+<input type="text" name="birthday" id="id_birthday" required /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></p>
+<input type="text" name="first_name" id="id_first_name" required /></p>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></p>
+<input type="text" name="last_name" id="id_last_name" required /></p>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required></p>"""
+<input type="text" name="birthday" id="id_birthday" required /></p>"""
         )
 
     def test_unicode_values(self):
@@ -229,33 +229,33 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_table(),
             '<tr><th><label for="id_first_name">First name:</label></th><td>'
-            '<input type="text" name="first_name" value="John" id="id_first_name" required></td></tr>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required /></td></tr>\n'
             '<tr><th><label for="id_last_name">Last name:</label>'
             '</th><td><input type="text" name="last_name" '
             'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111"'
-            'id="id_last_name" required></td></tr>\n'
+            'id="id_last_name" required /></td></tr>\n'
             '<tr><th><label for="id_birthday">Birthday:</label></th><td>'
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required></td></tr>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></td></tr>'
         )
         self.assertHTMLEqual(
             p.as_ul(),
             '<li><label for="id_first_name">First name:</label> '
-            '<input type="text" name="first_name" value="John" id="id_first_name" required></li>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required /></li>\n'
             '<li><label for="id_last_name">Last name:</label> '
             '<input type="text" name="last_name" '
-            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required></li>\n'
+            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required /></li>\n'
             '<li><label for="id_birthday">Birthday:</label> '
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required></li>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></li>'
         )
         self.assertHTMLEqual(
             p.as_p(),
             '<p><label for="id_first_name">First name:</label> '
-            '<input type="text" name="first_name" value="John" id="id_first_name" required></p>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required /></p>\n'
             '<p><label for="id_last_name">Last name:</label> '
             '<input type="text" name="last_name" '
-            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required></p>\n'
+            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required /></p>\n'
             '<p><label for="id_birthday">Birthday:</label> '
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required></p>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></p>'
         )
 
         p = Person({'last_name': 'Lennon'})
@@ -277,10 +277,10 @@ class FormsTestCase(SimpleTestCase):
         p = Person()
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="first_name" id="id_first_name" required>',
+            '<input type="text" name="first_name" id="id_first_name" required />',
         )
-        self.assertHTMLEqual(str(p['last_name']), '<input type="text" name="last_name" id="id_last_name" required>')
-        self.assertHTMLEqual(str(p['birthday']), '<input type="text" name="birthday" id="id_birthday" required>')
+        self.assertHTMLEqual(str(p['last_name']), '<input type="text" name="last_name" id="id_last_name" required />')
+        self.assertHTMLEqual(str(p['birthday']), '<input type="text" name="birthday" id="id_birthday" required />')
 
     def test_cleaned_data_only_fields(self):
         # cleaned_data will always *only* contain a key for fields defined in the
@@ -340,29 +340,29 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="first_name_id">First name:</label></th><td>
-<input type="text" name="first_name" id="first_name_id" required></td></tr>
+<input type="text" name="first_name" id="first_name_id" required /></td></tr>
 <tr><th><label for="last_name_id">Last name:</label></th><td>
-<input type="text" name="last_name" id="last_name_id" required></td></tr>
+<input type="text" name="last_name" id="last_name_id" required /></td></tr>
 <tr><th><label for="birthday_id">Birthday:</label></th><td>
-<input type="text" name="birthday" id="birthday_id" required></td></tr>"""
+<input type="text" name="birthday" id="birthday_id" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" name="first_name" id="first_name_id" required></li>
+<input type="text" name="first_name" id="first_name_id" required /></li>
 <li><label for="last_name_id">Last name:</label>
-<input type="text" name="last_name" id="last_name_id" required></li>
+<input type="text" name="last_name" id="last_name_id" required /></li>
 <li><label for="birthday_id">Birthday:</label>
-<input type="text" name="birthday" id="birthday_id" required></li>"""
+<input type="text" name="birthday" id="birthday_id" required /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="first_name_id">First name:</label>
-<input type="text" name="first_name" id="first_name_id" required></p>
+<input type="text" name="first_name" id="first_name_id" required /></p>
 <p><label for="last_name_id">Last name:</label>
-<input type="text" name="last_name" id="last_name_id" required></p>
+<input type="text" name="last_name" id="last_name_id" required /></p>
 <p><label for="birthday_id">Birthday:</label>
-<input type="text" name="birthday" id="birthday_id" required></p>"""
+<input type="text" name="birthday" id="birthday_id" required /></p>"""
         )
 
     def test_auto_id_true(self):
@@ -372,11 +372,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name">First name:</label>
-<input type="text" name="first_name" id="first_name" required></li>
+<input type="text" name="first_name" id="first_name" required /></li>
 <li><label for="last_name">Last name:</label>
-<input type="text" name="last_name" id="last_name" required></li>
+<input type="text" name="last_name" id="last_name" required /></li>
 <li><label for="birthday">Birthday:</label>
-<input type="text" name="birthday" id="birthday" required></li>"""
+<input type="text" name="birthday" id="birthday" required /></li>"""
         )
 
     def test_auto_id_false(self):
@@ -385,9 +385,9 @@ class FormsTestCase(SimpleTestCase):
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required></li>"""
+            """<li>First name: <input type="text" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /></li>"""
         )
 
     def test_id_on_field(self):
@@ -397,9 +397,9 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" id="first_name_id" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required></li>"""
+<input type="text" id="first_name_id" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /></li>"""
         )
 
     def test_auto_id_on_form_and_field(self):
@@ -409,11 +409,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" id="first_name_id" name="first_name" required></li>
+<input type="text" id="first_name_id" name="first_name" required /></li>
 <li><label for="last_name">Last name:</label>
-<input type="text" name="last_name" id="last_name" required></li>
+<input type="text" name="last_name" id="last_name" required /></li>
 <li><label for="birthday">Birthday:</label>
-<input type="text" name="birthday" id="birthday" required></li>"""
+<input type="text" name="birthday" id="birthday" required /></li>"""
         )
 
     def test_various_boolean_values(self):
@@ -422,33 +422,33 @@ class FormsTestCase(SimpleTestCase):
             get_spam = BooleanField()
 
         f = SignupForm(auto_id=False)
-        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" required>')
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required>')
+        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" required />')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': True}, auto_id=False)
-        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" value="test@example.com" required>')
+        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" value="test@example.com" required />')
         self.assertHTMLEqual(
             str(f['get_spam']),
-            '<input checked type="checkbox" name="get_spam" required>',
+            '<input checked type="checkbox" name="get_spam" required />',
         )
 
         # 'True' or 'true' should be rendered without a value attribute
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'True'}, auto_id=False)
         self.assertHTMLEqual(
             str(f['get_spam']),
-            '<input checked type="checkbox" name="get_spam" required>',
+            '<input checked type="checkbox" name="get_spam" required />',
         )
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'true'}, auto_id=False)
         self.assertHTMLEqual(
-            str(f['get_spam']), '<input checked type="checkbox" name="get_spam" required>')
+            str(f['get_spam']), '<input checked type="checkbox" name="get_spam" required />')
 
         # A value of 'False' or 'false' should be rendered unchecked
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'False'}, auto_id=False)
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required>')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'false'}, auto_id=False)
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required>')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
 
         # A value of '0' should be interpreted as a True value (#16820)
         f = SignupForm({'email': 'test@example.com', 'get_spam': '0'})
@@ -462,7 +462,7 @@ class FormsTestCase(SimpleTestCase):
             message = CharField(widget=Textarea)
 
         f = ContactForm(auto_id=False)
-        self.assertHTMLEqual(str(f['subject']), '<input type="text" name="subject" required>')
+        self.assertHTMLEqual(str(f['subject']), '<input type="text" name="subject" required />')
         self.assertHTMLEqual(str(f['message']), '<textarea name="message" rows="10" cols="40" required></textarea>')
 
         # as_textarea(), as_text() and as_hidden() are shortcuts for changing the output
@@ -471,8 +471,8 @@ class FormsTestCase(SimpleTestCase):
             f['subject'].as_textarea(),
             '<textarea name="subject" rows="10" cols="40" required></textarea>',
         )
-        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required>')
-        self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message">')
+        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required />')
+        self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message" />')
 
         # The 'widget' parameter to a Field can also be an instance:
         class ContactForm(Form):
@@ -484,7 +484,7 @@ class FormsTestCase(SimpleTestCase):
 
         # Instance-level attrs are *not* carried over to as_textarea(), as_text() and
         # as_hidden():
-        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required>')
+        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required />')
         f = ContactForm({'subject': 'Hello', 'message': 'I love you.'}, auto_id=False)
         self.assertHTMLEqual(
             f['subject'].as_textarea(),
@@ -492,9 +492,9 @@ class FormsTestCase(SimpleTestCase):
         )
         self.assertHTMLEqual(
             f['message'].as_text(),
-            '<input type="text" name="message" value="I love you." required>',
+            '<input type="text" name="message" value="I love you." required />',
         )
-        self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message" value="I love you.">')
+        self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message" value="I love you." />')
 
     def test_forms_with_choices(self):
         # For a form with a <select>, use ChoiceField:
@@ -585,18 +585,18 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(str(f['language']), """<ul>
-<li><label><input type="radio" name="language" value="P" required> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
 </ul>""")
-        self.assertHTMLEqual(f.as_table(), """<tr><th>Name:</th><td><input type="text" name="name" required></td></tr>
+        self.assertHTMLEqual(f.as_table(), """<tr><th>Name:</th><td><input type="text" name="name" required /></td></tr>
 <tr><th>Language:</th><td><ul>
-<li><label><input type="radio" name="language" value="P" required> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
 </ul></td></tr>""")
-        self.assertHTMLEqual(f.as_ul(), """<li>Name: <input type="text" name="name" required></li>
+        self.assertHTMLEqual(f.as_ul(), """<li>Name: <input type="text" name="name" required /></li>
 <li>Language: <ul>
-<li><label><input type="radio" name="language" value="P" required> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
 </ul></li>""")
 
         # Regarding auto_id and <label>, RadioSelect is a special case. Each radio button
@@ -606,9 +606,9 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(f['language']),
             """<ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required>
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required>
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
 Java</label></li>
 </ul>"""
         )
@@ -618,31 +618,31 @@ Java</label></li>
         # ID of the *first* radio button.
         self.assertHTMLEqual(
             f.as_table(),
-            """<tr><th><label for="id_name">Name:</label></th><td><input type="text" name="name" id="id_name" required></td></tr>
+            """<tr><th><label for="id_name">Name:</label></th><td><input type="text" name="name" id="id_name" required /></td></tr>
 <tr><th><label for="id_language_0">Language:</label></th><td><ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required>
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required>
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
 Java</label></li>
 </ul></td></tr>"""
         )
         self.assertHTMLEqual(
             f.as_ul(),
-            """<li><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required></li>
+            """<li><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></li>
 <li><label for="id_language_0">Language:</label> <ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required>
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required>
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
 Java</label></li>
 </ul></li>"""
         )
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required></p>
+            """<p><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></p>
 <p><label for="id_language_0">Language:</label> <ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required>
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required>
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
 Java</label></li>
 </ul></p>"""
         )
@@ -652,9 +652,9 @@ Java</label></li>
         self.assertHTMLEqual(
             t.render(Context({'form': f})),
             """<div class="myradio"><label for="id_language_0">
-<input id="id_language_0" name="language" type="radio" value="P" required> Python</label></div>
+<input id="id_language_0" name="language" type="radio" value="P" required /> Python</label></div>
 <div class="myradio"><label for="id_language_1">
-<input id="id_language_1" name="language" type="radio" value="J" required> Java</label></div>"""
+<input id="id_language_1" name="language" type="radio" value="J" required /> Java</label></div>"""
         )
 
     def test_form_with_iterable_boundfield(self):
@@ -667,17 +667,17 @@ Java</label></li>
         f = BeatleForm(auto_id=False)
         self.assertHTMLEqual(
             '\n'.join(str(bf) for bf in f['name']),
-            """<label><input type="radio" name="name" value="john" required> John</label>
-<label><input type="radio" name="name" value="paul" required> Paul</label>
-<label><input type="radio" name="name" value="george" required> George</label>
-<label><input type="radio" name="name" value="ringo" required> Ringo</label>"""
+            """<label><input type="radio" name="name" value="john" required /> John</label>
+<label><input type="radio" name="name" value="paul" required /> Paul</label>
+<label><input type="radio" name="name" value="george" required /> George</label>
+<label><input type="radio" name="name" value="ringo" required /> Ringo</label>"""
         )
         self.assertHTMLEqual(
             '\n'.join('<div>%s</div>' % bf for bf in f['name']),
-            """<div><label><input type="radio" name="name" value="john" required> John</label></div>
-<div><label><input type="radio" name="name" value="paul" required> Paul</label></div>
-<div><label><input type="radio" name="name" value="george" required> George</label></div>
-<div><label><input type="radio" name="name" value="ringo" required> Ringo</label></div>"""
+            """<div><label><input type="radio" name="name" value="john" required /> John</label></div>
+<div><label><input type="radio" name="name" value="paul" required /> Paul</label></div>
+<div><label><input type="radio" name="name" value="george" required /> George</label></div>
+<div><label><input type="radio" name="name" value="ringo" required /> Ringo</label></div>"""
         )
 
     def test_form_with_iterable_boundfield_id(self):
@@ -693,24 +693,24 @@ Java</label></li>
         self.assertEqual(fields[0].choice_label, 'John')
         self.assertHTMLEqual(
             fields[0].tag(),
-            '<input type="radio" name="name" value="john" id="id_name_0" required>'
+            '<input type="radio" name="name" value="john" id="id_name_0" required />'
         )
         self.assertHTMLEqual(
             str(fields[0]),
             '<label for="id_name_0"><input type="radio" name="name" '
-            'value="john" id="id_name_0" required> John</label>'
+            'value="john" id="id_name_0" required /> John</label>'
         )
 
         self.assertEqual(fields[1].id_for_label, 'id_name_1')
         self.assertEqual(fields[1].choice_label, 'Paul')
         self.assertHTMLEqual(
             fields[1].tag(),
-            '<input type="radio" name="name" value="paul" id="id_name_1" required>'
+            '<input type="radio" name="name" value="paul" id="id_name_1" required />'
         )
         self.assertHTMLEqual(
             str(fields[1]),
             '<label for="id_name_1"><input type="radio" name="name" '
-            'value="paul" id="id_name_1" required> Paul</label>'
+            'value="paul" id="id_name_1" required /> Paul</label>'
         )
 
     def test_iterable_boundfield_select(self):
@@ -730,7 +730,7 @@ Java</label></li>
             name = CharField()
 
         f = BeatleForm(auto_id=False)
-        self.assertHTMLEqual('\n'.join(str(bf) for bf in f['name']), '<input type="text" name="name" required>')
+        self.assertHTMLEqual('\n'.join(str(bf) for bf in f['name']), '<input type="text" name="name" required />')
 
     def test_boundfield_slice(self):
         class BeatleForm(Form):
@@ -773,7 +773,7 @@ Java</label></li>
 <option value="P">Paul McCartney</option>
 </select>""")
         f = SongForm({'name': 'Yesterday', 'composers': ['P']}, auto_id=False)
-        self.assertHTMLEqual(str(f['name']), '<input type="text" name="name" value="Yesterday" required>')
+        self.assertHTMLEqual(str(f['name']), '<input type="text" name="name" value="Yesterday" required />')
         self.assertHTMLEqual(str(f['composers']), """<select multiple name="composers" required>
 <option value="J">John Lennon</option>
 <option value="P" selected>Paul McCartney</option>
@@ -824,13 +824,13 @@ Java</label></li>
             composers = MultipleChoiceField(choices=[('J', 'John Lennon'), ('P', 'Paul McCartney')])
 
         # MultipleChoiceField rendered as_hidden() is a special case. Because it can
-        # have multiple values, its as_hidden() renders multiple <input type="hidden">
+        # have multiple values, its as_hidden() renders multiple <input type="hidden" />
         # tags.
         f = SongForm({'name': 'Yesterday', 'composers': ['P']}, auto_id=False)
-        self.assertHTMLEqual(f['composers'].as_hidden(), '<input type="hidden" name="composers" value="P">')
+        self.assertHTMLEqual(f['composers'].as_hidden(), '<input type="hidden" name="composers" value="P" />')
         f = SongForm({'name': 'From Me To You', 'composers': ['P', 'J']}, auto_id=False)
-        self.assertHTMLEqual(f['composers'].as_hidden(), """<input type="hidden" name="composers" value="P">
-<input type="hidden" name="composers" value="J">""")
+        self.assertHTMLEqual(f['composers'].as_hidden(), """<input type="hidden" name="composers" value="P" />
+<input type="hidden" name="composers" value="J" />""")
 
         # DateTimeField rendered as_hidden() is special too
         class MessageForm(Form):
@@ -840,13 +840,13 @@ Java</label></li>
         self.assertTrue(f.is_valid())
         self.assertHTMLEqual(
             str(f['when']),
-            '<input type="text" name="when_0" value="1992-01-01" id="id_when_0" required>'
-            '<input type="text" name="when_1" value="01:01" id="id_when_1" required>'
+            '<input type="text" name="when_0" value="1992-01-01" id="id_when_0" required />'
+            '<input type="text" name="when_1" value="01:01" id="id_when_1" required />'
         )
         self.assertHTMLEqual(
             f['when'].as_hidden(),
-            '<input type="hidden" name="when_0" value="1992-01-01" id="id_when_0">'
-            '<input type="hidden" name="when_1" value="01:01" id="id_when_1">'
+            '<input type="hidden" name="when_0" value="1992-01-01" id="id_when_0" />'
+            '<input type="hidden" name="when_1" value="01:01" id="id_when_1" />'
         )
 
     def test_multiple_choice_checkbox(self):
@@ -860,25 +860,25 @@ Java</label></li>
 
         f = SongForm(auto_id=False)
         self.assertHTMLEqual(str(f['composers']), """<ul>
-<li><label><input type="checkbox" name="composers" value="J"> John Lennon</label></li>
-<li><label><input type="checkbox" name="composers" value="P"> Paul McCartney</label></li>
+<li><label><input type="checkbox" name="composers" value="J" /> John Lennon</label></li>
+<li><label><input type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
 </ul>""")
         f = SongForm({'composers': ['J']}, auto_id=False)
         self.assertHTMLEqual(str(f['composers']), """<ul>
-<li><label><input checked type="checkbox" name="composers" value="J"> John Lennon</label></li>
-<li><label><input type="checkbox" name="composers" value="P"> Paul McCartney</label></li>
+<li><label><input checked type="checkbox" name="composers" value="J" /> John Lennon</label></li>
+<li><label><input type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
 </ul>""")
         f = SongForm({'composers': ['J', 'P']}, auto_id=False)
         self.assertHTMLEqual(str(f['composers']), """<ul>
-<li><label><input checked type="checkbox" name="composers" value="J"> John Lennon</label></li>
-<li><label><input checked type="checkbox" name="composers" value="P"> Paul McCartney</label></li>
+<li><label><input checked type="checkbox" name="composers" value="J" /> John Lennon</label></li>
+<li><label><input checked type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
 </ul>""")
         # Test iterating on individual checkboxes in a template
         t = Template('{% for checkbox in form.composers %}<div class="mycheckbox">{{ checkbox }}</div>{% endfor %}')
         self.assertHTMLEqual(t.render(Context({'form': f})), """<div class="mycheckbox"><label>
-<input checked name="composers" type="checkbox" value="J"> John Lennon</label></div>
+<input checked name="composers" type="checkbox" value="J" /> John Lennon</label></div>
 <div class="mycheckbox"><label>
-<input checked name="composers" type="checkbox" value="P"> Paul McCartney</label></div>""")
+<input checked name="composers" type="checkbox" value="P" /> Paul McCartney</label></div>""")
 
     def test_checkbox_auto_id(self):
         # Regarding auto_id, CheckboxSelectMultiple is a special case. Each checkbox
@@ -896,9 +896,9 @@ Java</label></li>
             str(f['composers']),
             """<ul id="composers_id">
 <li><label for="composers_id_0">
-<input type="checkbox" name="composers" value="J" id="composers_id_0"> John Lennon</label></li>
+<input type="checkbox" name="composers" value="J" id="composers_id_0" /> John Lennon</label></li>
 <li><label for="composers_id_1">
-<input type="checkbox" name="composers" value="P" id="composers_id_1"> Paul McCartney</label></li>
+<input type="checkbox" name="composers" value="P" id="composers_id_1" /> Paul McCartney</label></li>
 </ul>"""
         )
 
@@ -949,9 +949,9 @@ Java</label></li>
         f = SongFormHidden(MultiValueDict({'name': ['Yesterday'], 'composers': ['J', 'P']}), auto_id=False)
         self.assertHTMLEqual(
             f.as_ul(),
-            """<li>Name: <input type="text" name="name" value="Yesterday" required>
-<input type="hidden" name="composers" value="J">
-<input type="hidden" name="composers" value="P"></li>"""
+            """<li>Name: <input type="text" name="name" value="Yesterday" required />
+<input type="hidden" name="composers" value="J" />
+<input type="hidden" name="composers" value="P" /></li>"""
         )
 
         # When using CheckboxSelectMultiple, the framework expects a list of input and
@@ -996,10 +996,10 @@ Java</label></li>
             f.as_table(),
             """<tr><th>&lt;em&gt;Special&lt;/em&gt; Field:</th><td>
 <ul class="errorlist"><li>Something&#39;s wrong with &#39;Nothing to escape&#39;</li></ul>
-<input type="text" name="special_name" value="Nothing to escape" required></td></tr>
+<input type="text" name="special_name" value="Nothing to escape" required /></td></tr>
 <tr><th><em>Special</em> Field:</th><td>
 <ul class="errorlist"><li>'<b>Nothing to escape</b>' is a safe string</li></ul>
-<input type="text" name="special_safe_name" value="Nothing to escape" required></td></tr>"""
+<input type="text" name="special_safe_name" value="Nothing to escape" required /></td></tr>"""
         )
         f = EscapingForm({
             'special_name': "Should escape < & > and <script>alert('xss')</script>",
@@ -1011,10 +1011,10 @@ Java</label></li>
 <ul class="errorlist"><li>Something&#39;s wrong with &#39;Should escape &lt; &amp; &gt; and
 &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;&#39;</li></ul>
 <input type="text" name="special_name"
-value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;" required></td></tr>
+value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;" required /></td></tr>
 <tr><th><em>Special</em> Field:</th><td>
 <ul class="errorlist"><li>'<b><i>Do not escape</i></b>' is a safe string</li></ul>
-<input type="text" name="special_safe_name" value="&lt;i&gt;Do not escape&lt;/i&gt;" required></td></tr>"""
+<input type="text" name="special_safe_name" value="&lt;i&gt;Do not escape&lt;/i&gt;" required /></td></tr>"""
         )
 
     def test_validating_multiple_fields(self):
@@ -1101,11 +1101,11 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             f.as_table(),
             """<tr><th>Username:</th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="username" maxlength="10" required></td></tr>
+<input type="text" name="username" maxlength="10" required /></td></tr>
 <tr><th>Password1:</th><td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="password" name="password1" required></td></tr>
+<input type="password" name="password1" required /></td></tr>
 <tr><th>Password2:</th><td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="password" name="password2" required></td></tr>"""
+<input type="password" name="password2" required /></td></tr>"""
         )
         self.assertEqual(f.errors['username'], ['This field is required.'])
         self.assertEqual(f.errors['password1'], ['This field is required.'])
@@ -1117,17 +1117,17 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             f.as_table(),
             """<tr><td colspan="2">
 <ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul></td></tr>
-<tr><th>Username:</th><td><input type="text" name="username" value="adrian" maxlength="10" required></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required></td></tr>"""
+<tr><th>Username:</th><td><input type="text" name="username" value="adrian" maxlength="10" required /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             f.as_ul(),
             """<li><ul class="errorlist nonfield">
 <li>Please make sure your passwords match.</li></ul></li>
-<li>Username: <input type="text" name="username" value="adrian" maxlength="10" required></li>
-<li>Password1: <input type="password" name="password1" required></li>
-<li>Password2: <input type="password" name="password2" required></li>"""
+<li>Username: <input type="text" name="username" value="adrian" maxlength="10" required /></li>
+<li>Password1: <input type="password" name="password1" required /></li>
+<li>Password2: <input type="password" name="password2" required /></li>"""
         )
 
         f = UserRegistration({'username': 'adrian', 'password1': 'foo', 'password2': 'foo'}, auto_id=False)
@@ -1251,9 +1251,9 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>First name:</th><td><input type="text" name="first_name" required></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" required></td></tr>
-<tr><th>Birthday:</th><td><input type="text" name="birthday" required></td></tr>"""
+            """<tr><th>First name:</th><td><input type="text" name="first_name" required /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" required /></td></tr>
+<tr><th>Birthday:</th><td><input type="text" name="birthday" required /></td></tr>"""
         )
 
         # Instances of a dynamic Form do not persist fields from one Form instance to
@@ -1269,15 +1269,15 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Field1:</th><td><input type="text" name="field1" required></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required></td></tr>"""
+            """<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>"""
         )
         field_list = [('field3', CharField()), ('field4', CharField())]
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Field3:</th><td><input type="text" name="field3" required></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required></td></tr>"""
+            """<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>"""
         )
 
         class MyForm(Form):
@@ -1294,19 +1294,19 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required></td></tr>
-<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required></td></tr>
-<tr><th>Field1:</th><td><input type="text" name="field1" required></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required></td></tr>"""
+            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required /></td></tr>
+<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required /></td></tr>
+<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>"""
         )
         field_list = [('field3', CharField()), ('field4', CharField())]
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required></td></tr>
-<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required></td></tr>
-<tr><th>Field3:</th><td><input type="text" name="field3" required></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required></td></tr>"""
+            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required /></td></tr>
+<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required /></td></tr>
+<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>"""
         )
 
         # Similarly, changes to field attributes do not persist from one Form instance
@@ -1404,21 +1404,21 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>First name:</th><td><input type="text" name="first_name" required></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" required></td></tr>
+            """<tr><th>First name:</th><td><input type="text" name="first_name" required /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" required /></td></tr>
 <tr><th>Birthday:</th>
-<td><input type="text" name="birthday" required><input type="hidden" name="hidden_text"></td></tr>"""
+<td><input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required><input type="hidden" name="hidden_text"></li>"""
+            """<li>First name: <input type="text" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
-            p.as_p(), """<p>First name: <input type="text" name="first_name" required></p>
-<p>Last name: <input type="text" name="last_name" required></p>
-<p>Birthday: <input type="text" name="birthday" required><input type="hidden" name="hidden_text"></p>"""
+            p.as_p(), """<p>First name: <input type="text" name="first_name" required /></p>
+<p>Last name: <input type="text" name="last_name" required /></p>
+<p>Birthday: <input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></p>"""
         )
 
         # With auto_id set, a HiddenInput still gets an ID, but it doesn't get a label.
@@ -1426,32 +1426,32 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required></td></tr>
+<input type="text" name="first_name" id="id_first_name" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required></td></tr>
+<input type="text" name="last_name" id="id_last_name" required /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required>
-<input type="hidden" name="hidden_text" id="id_hidden_text"></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required />
+<input type="hidden" name="hidden_text" id="id_hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></li>
+<input type="text" name="first_name" id="id_first_name" required /></li>
 <li><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></li>
+<input type="text" name="last_name" id="id_last_name" required /></li>
 <li><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required>
-<input type="hidden" name="hidden_text" id="id_hidden_text"></li>"""
+<input type="text" name="birthday" id="id_birthday" required />
+<input type="hidden" name="hidden_text" id="id_hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required></p>
+<input type="text" name="first_name" id="id_first_name" required /></p>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required></p>
+<input type="text" name="last_name" id="id_last_name" required /></p>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required>
-<input type="hidden" name="hidden_text" id="id_hidden_text"></p>"""
+<input type="text" name="birthday" id="id_birthday" required />
+<input type="hidden" name="hidden_text" id="id_hidden_text" /></p>"""
         )
 
         # If a field with a HiddenInput has errors, the as_table() and as_ul() output
@@ -1463,26 +1463,26 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             p.as_table(),
             """<tr><td colspan="2">
 <ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul></td></tr>
-<tr><th>First name:</th><td><input type="text" name="first_name" value="John" required></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" value="Lennon" required></td></tr>
-<tr><th>Birthday:</th><td><input type="text" name="birthday" value="1940-10-9" required>
-<input type="hidden" name="hidden_text"></td></tr>"""
+<tr><th>First name:</th><td><input type="text" name="first_name" value="John" required /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" value="Lennon" required /></td></tr>
+<tr><th>Birthday:</th><td><input type="text" name="birthday" value="1940-10-9" required />
+<input type="hidden" name="hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul></li>
-<li>First name: <input type="text" name="first_name" value="John" required></li>
-<li>Last name: <input type="text" name="last_name" value="Lennon" required></li>
-<li>Birthday: <input type="text" name="birthday" value="1940-10-9" required>
-<input type="hidden" name="hidden_text"></li>"""
+<li>First name: <input type="text" name="first_name" value="John" required /></li>
+<li>Last name: <input type="text" name="last_name" value="Lennon" required /></li>
+<li>Birthday: <input type="text" name="birthday" value="1940-10-9" required />
+<input type="hidden" name="hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul>
-<p>First name: <input type="text" name="first_name" value="John" required></p>
-<p>Last name: <input type="text" name="last_name" value="Lennon" required></p>
-<p>Birthday: <input type="text" name="birthday" value="1940-10-9" required>
-<input type="hidden" name="hidden_text"></p>"""
+<p>First name: <input type="text" name="first_name" value="John" required /></p>
+<p>Last name: <input type="text" name="last_name" value="Lennon" required /></p>
+<p>Birthday: <input type="text" name="birthday" value="1940-10-9" required />
+<input type="hidden" name="hidden_text" /></p>"""
         )
 
         # A corner case: It's possible for a form to have only HiddenInputs.
@@ -1491,9 +1491,9 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             bar = CharField(widget=HiddenInput)
 
         p = TestForm(auto_id=False)
-        self.assertHTMLEqual(p.as_table(), '<input type="hidden" name="foo"><input type="hidden" name="bar">')
-        self.assertHTMLEqual(p.as_ul(), '<input type="hidden" name="foo"><input type="hidden" name="bar">')
-        self.assertHTMLEqual(p.as_p(), '<input type="hidden" name="foo"><input type="hidden" name="bar">')
+        self.assertHTMLEqual(p.as_table(), '<input type="hidden" name="foo" /><input type="hidden" name="bar" />')
+        self.assertHTMLEqual(p.as_ul(), '<input type="hidden" name="foo" /><input type="hidden" name="bar" />')
+        self.assertHTMLEqual(p.as_p(), '<input type="hidden" name="foo" /><input type="hidden" name="bar" />')
 
     def test_field_order(self):
         # A Form's fields are displayed in the same order in which they were defined.
@@ -1514,20 +1514,20 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             field14 = CharField()
 
         p = TestForm(auto_id=False)
-        self.assertHTMLEqual(p.as_table(), """<tr><th>Field1:</th><td><input type="text" name="field1" required></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required></td></tr>
-<tr><th>Field3:</th><td><input type="text" name="field3" required></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required></td></tr>
-<tr><th>Field5:</th><td><input type="text" name="field5" required></td></tr>
-<tr><th>Field6:</th><td><input type="text" name="field6" required></td></tr>
-<tr><th>Field7:</th><td><input type="text" name="field7" required></td></tr>
-<tr><th>Field8:</th><td><input type="text" name="field8" required></td></tr>
-<tr><th>Field9:</th><td><input type="text" name="field9" required></td></tr>
-<tr><th>Field10:</th><td><input type="text" name="field10" required></td></tr>
-<tr><th>Field11:</th><td><input type="text" name="field11" required></td></tr>
-<tr><th>Field12:</th><td><input type="text" name="field12" required></td></tr>
-<tr><th>Field13:</th><td><input type="text" name="field13" required></td></tr>
-<tr><th>Field14:</th><td><input type="text" name="field14" required></td></tr>""")
+        self.assertHTMLEqual(p.as_table(), """<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>
+<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>
+<tr><th>Field5:</th><td><input type="text" name="field5" required /></td></tr>
+<tr><th>Field6:</th><td><input type="text" name="field6" required /></td></tr>
+<tr><th>Field7:</th><td><input type="text" name="field7" required /></td></tr>
+<tr><th>Field8:</th><td><input type="text" name="field8" required /></td></tr>
+<tr><th>Field9:</th><td><input type="text" name="field9" required /></td></tr>
+<tr><th>Field10:</th><td><input type="text" name="field10" required /></td></tr>
+<tr><th>Field11:</th><td><input type="text" name="field11" required /></td></tr>
+<tr><th>Field12:</th><td><input type="text" name="field12" required /></td></tr>
+<tr><th>Field13:</th><td><input type="text" name="field13" required /></td></tr>
+<tr><th>Field14:</th><td><input type="text" name="field14" required /></td></tr>""")
 
     def test_explicit_field_order(self):
         class TestFormParent(Form):
@@ -1586,10 +1586,10 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" maxlength="10" required></li>
-<li>Realname: <input type="text" name="realname" maxlength="10" required></li>
-<li>Address: <input type="text" name="address" required></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" maxlength="10" required /></li>
+<li>Realname: <input type="text" name="realname" maxlength="10" required /></li>
+<li>Address: <input type="text" name="address" required /></li>"""
         )
 
         # If you specify a custom "attrs" that includes the "maxlength" attribute,
@@ -1602,8 +1602,8 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" maxlength="10" required></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" maxlength="10" required /></li>"""
         )
 
     def test_specifying_labels(self):
@@ -1618,9 +1618,9 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Your username: <input type="text" name="username" maxlength="10" required></li>
-<li>Password1: <input type="password" name="password1" required></li>
-<li>Contraseña (de nuevo): <input type="password" name="password2" required></li>"""
+            """<li>Your username: <input type="text" name="username" maxlength="10" required /></li>
+<li>Password1: <input type="password" name="password1" required /></li>
+<li>Contraseña (de nuevo): <input type="password" name="password2" required /></li>"""
         )
 
         # Labels for as_* methods will only end in a colon if they don't end in other
@@ -1634,19 +1634,19 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
 
         self.assertHTMLEqual(
             Questions(auto_id=False).as_p(),
-            """<p>The first question: <input type="text" name="q1" required></p>
-<p>What is your name? <input type="text" name="q2" required></p>
-<p>The answer to life is: <input type="text" name="q3" required></p>
-<p>Answer this question! <input type="text" name="q4" required></p>
-<p>The last question. Period. <input type="text" name="q5" required></p>"""
+            """<p>The first question: <input type="text" name="q1" required /></p>
+<p>What is your name? <input type="text" name="q2" required /></p>
+<p>The answer to life is: <input type="text" name="q3" required /></p>
+<p>Answer this question! <input type="text" name="q4" required /></p>
+<p>The last question. Period. <input type="text" name="q5" required /></p>"""
         )
         self.assertHTMLEqual(
             Questions().as_p(),
-            """<p><label for="id_q1">The first question:</label> <input type="text" name="q1" id="id_q1" required></p>
-<p><label for="id_q2">What is your name?</label> <input type="text" name="q2" id="id_q2" required></p>
-<p><label for="id_q3">The answer to life is:</label> <input type="text" name="q3" id="id_q3" required></p>
-<p><label for="id_q4">Answer this question!</label> <input type="text" name="q4" id="id_q4" required></p>
-<p><label for="id_q5">The last question. Period.</label> <input type="text" name="q5" id="id_q5" required></p>"""
+            """<p><label for="id_q1">The first question:</label> <input type="text" name="q1" id="id_q1" required /></p>
+<p><label for="id_q2">What is your name?</label> <input type="text" name="q2" id="id_q2" required /></p>
+<p><label for="id_q3">The answer to life is:</label> <input type="text" name="q3" id="id_q3" required /></p>
+<p><label for="id_q4">Answer this question!</label> <input type="text" name="q4" id="id_q4" required /></p>
+<p><label for="id_q5">The last question. Period.</label> <input type="text" name="q5" id="id_q5" required /></p>"""
         )
 
         # If a label is set to the empty string for a field, that field won't get a label.
@@ -1655,14 +1655,14 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             password = CharField(widget=PasswordInput)
 
         p = UserRegistration(auto_id=False)
-        self.assertHTMLEqual(p.as_ul(), """<li> <input type="text" name="username" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>""")
+        self.assertHTMLEqual(p.as_ul(), """<li> <input type="text" name="username" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>""")
         p = UserRegistration(auto_id='id_%s')
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li> <input id="id_username" type="text" name="username" maxlength="10" required></li>
+            """<li> <input id="id_username" type="text" name="username" maxlength="10" required /></li>
 <li><label for="id_password">Password:</label>
-<input type="password" name="password" id="id_password" required></li>"""
+<input type="password" name="password" id="id_password" required /></li>"""
         )
 
         # If label is None, Django will auto-create the label from the field name. This
@@ -1674,16 +1674,16 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration(auto_id='id_%s')
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_username">Username:</label>
-<input id="id_username" type="text" name="username" maxlength="10" required></li>
+<input id="id_username" type="text" name="username" maxlength="10" required /></li>
 <li><label for="id_password">Password:</label>
-<input type="password" name="password" id="id_password" required></li>"""
+<input type="password" name="password" id="id_password" required /></li>"""
         )
 
     def test_label_suffix(self):
@@ -1698,26 +1698,26 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             answer = CharField(label='Secret answer', label_suffix=' =')
 
         f = FavoriteForm(auto_id=False)
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required></li>
-<li>Favorite animal: <input type="text" name="animal" required></li>
-<li>Secret answer = <input type="text" name="answer" required></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
+<li>Favorite animal: <input type="text" name="animal" required /></li>
+<li>Secret answer = <input type="text" name="answer" required /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='?')
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required></li>
-<li>Favorite animal? <input type="text" name="animal" required></li>
-<li>Secret answer = <input type="text" name="answer" required></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
+<li>Favorite animal? <input type="text" name="animal" required /></li>
+<li>Secret answer = <input type="text" name="answer" required /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='')
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required></li>
-<li>Favorite animal <input type="text" name="animal" required></li>
-<li>Secret answer = <input type="text" name="answer" required></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
+<li>Favorite animal <input type="text" name="animal" required /></li>
+<li>Secret answer = <input type="text" name="answer" required /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='\u2192')
         self.assertHTMLEqual(
             f.as_ul(),
-            '<li>Favorite color? <input type="text" name="color" required></li>\n'
-            '<li>Favorite animal\u2192 <input type="text" name="animal" required></li>\n'
-            '<li>Secret answer = <input type="text" name="answer" required></li>'
+            '<li>Favorite color? <input type="text" name="color" required /></li>\n'
+            '<li>Favorite animal\u2192 <input type="text" name="animal" required /></li>\n'
+            '<li>Secret answer = <input type="text" name="answer" required /></li>'
         )
 
     def test_initial_data(self):
@@ -1734,8 +1734,8 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>"""
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>"""
         )
 
         # Here, we're submitting data, so the initial value will *not* be displayed.
@@ -1743,24 +1743,24 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required></li>
+Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration({'username': ''}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required></li>
+Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration({'username': 'foo'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required></li>
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
 
         # An 'initial' value is *not* used as a fallback if data is not provided. In this
@@ -1784,14 +1784,14 @@ Password: <input type="password" name="password" required></li>"""
         p = UserRegistration(initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>"""
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration(initial={'username': 'stephane'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>"""
+            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>"""
         )
 
         # The 'initial' parameter is meaningless if you pass data.
@@ -1799,23 +1799,23 @@ Password: <input type="password" name="password" required></li>"""
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required></li>
+Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration({'username': ''}, initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required></li>
+Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
         p = UserRegistration({'username': 'foo'}, initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
-            p.as_ul(), """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required></li>
+            p.as_ul(), """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>"""
+Password: <input type="password" name="password" required /></li>"""
         )
 
         # A dynamic 'initial' value is *not* used as a fallback if data is not provided.
@@ -1834,8 +1834,8 @@ Password: <input type="password" name="password" required></li>"""
         p = UserRegistration(initial={'username': 'babik'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="babik" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>"""
+            """<li>Username: <input type="text" name="username" value="babik" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>"""
         )
 
     def test_callable_initial_data(self):
@@ -1863,8 +1863,8 @@ Password: <input type="password" name="password" required></li>"""
         p = UserRegistration(initial={'username': initial_django, 'options': initial_options}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>
 <li>Options: <select multiple name="options" required>
 <option value="f" selected>foo</option>
 <option value="b" selected>bar</option>
@@ -1877,9 +1877,9 @@ Password: <input type="password" name="password" required></li>"""
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required></li>
+Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>
+Password: <input type="password" name="password" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 Options: <select multiple name="options" required>
 <option value="f">foo</option>
@@ -1891,9 +1891,9 @@ Options: <select multiple name="options" required>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-            Username: <input type="text" name="username" maxlength="10" required></li>
+            Username: <input type="text" name="username" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>
+Password: <input type="password" name="password" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 Options: <select multiple name="options" required>
 <option value="f">foo</option>
@@ -1906,9 +1906,9 @@ Options: <select multiple name="options" required>
         )
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required></li>
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required></li>
+Password: <input type="password" name="password" required /></li>
 <li>Options: <select multiple name="options" required>
 <option value="f" selected>foo</option>
 <option value="b" selected>bar</option>
@@ -1936,8 +1936,8 @@ Password: <input type="password" name="password" required></li>
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>
 <li>Options: <select multiple name="options" required>
 <option value="f">foo</option>
 <option value="b" selected>bar</option>
@@ -1947,8 +1947,8 @@ Password: <input type="password" name="password" required></li>
         p = UserRegistration(initial={'username': initial_stephane, 'options': initial_options}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required></li>
-<li>Password: <input type="password" name="password" required></li>
+            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required /></li>
+<li>Password: <input type="password" name="password" required /></li>
 <li>Options: <select multiple name="options" required>
 <option value="f" selected>foo</option>
 <option value="b" selected>bar</option>
@@ -2112,23 +2112,23 @@ Password: <input type="password" name="password" required></li>
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required>
+            """<li>Username: <input type="text" name="username" maxlength="10" required />
 <span class="helptext">e.g., user@example.com</span></li>
-<li>Password: <input type="password" name="password" required>
+<li>Password: <input type="password" name="password" required />
 <span class="helptext">Wählen Sie mit Bedacht.</span></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
-            """<p>Username: <input type="text" name="username" maxlength="10" required>
+            """<p>Username: <input type="text" name="username" maxlength="10" required />
 <span class="helptext">e.g., user@example.com</span></p>
-<p>Password: <input type="password" name="password" required>
+<p>Password: <input type="password" name="password" required />
 <span class="helptext">Wählen Sie mit Bedacht.</span></p>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required><br>
+            """<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required /><br />
 <span class="helptext">e.g., user@example.com</span></td></tr>
-<tr><th>Password:</th><td><input type="password" name="password" required><br>
+<tr><th>Password:</th><td><input type="password" name="password" required /><br />
 <span class="helptext">Wählen Sie mit Bedacht.</span></td></tr>"""
         )
 
@@ -2136,10 +2136,10 @@ Password: <input type="password" name="password" required></li>
         p = UserRegistration({'username': 'foo'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required>
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required />
 <span class="helptext">e.g., user@example.com</span></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required>
+Password: <input type="password" name="password" required />
 <span class="helptext">Wählen Sie mit Bedacht.</span></li>"""
         )
 
@@ -2153,10 +2153,10 @@ Password: <input type="password" name="password" required>
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required>
+            """<li>Username: <input type="text" name="username" maxlength="10" required />
 <span class="helptext">e.g., user@example.com</span></li>
-<li>Password: <input type="password" name="password" required>
-<input type="hidden" name="next" value="/"></li>"""
+<li>Password: <input type="password" name="password" required />
+<input type="hidden" name="next" value="/" /></li>"""
         )
 
     def test_subclassing_forms(self):
@@ -2174,17 +2174,17 @@ Password: <input type="password" name="password" required>
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required></li>"""
+            """<li>First name: <input type="text" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /></li>"""
         )
         m = Musician(auto_id=False)
         self.assertHTMLEqual(
             m.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required></li>
-<li>Instrument: <input type="text" name="instrument" required></li>"""
+            """<li>First name: <input type="text" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /></li>
+<li>Instrument: <input type="text" name="instrument" required /></li>"""
         )
 
         # Yes, you can subclass multiple forms. The fields are added in the order in
@@ -2201,11 +2201,11 @@ Password: <input type="password" name="password" required>
             haircut_type = CharField()
 
         b = Beatle(auto_id=False)
-        self.assertHTMLEqual(b.as_ul(), """<li>Instrument: <input type="text" name="instrument" required></li>
-<li>First name: <input type="text" name="first_name" required></li>
-<li>Last name: <input type="text" name="last_name" required></li>
-<li>Birthday: <input type="text" name="birthday" required></li>
-<li>Haircut type: <input type="text" name="haircut_type" required></li>""")
+        self.assertHTMLEqual(b.as_ul(), """<li>Instrument: <input type="text" name="instrument" required /></li>
+<li>First name: <input type="text" name="first_name" required /></li>
+<li>Last name: <input type="text" name="last_name" required /></li>
+<li>Birthday: <input type="text" name="birthday" required /></li>
+<li>Haircut type: <input type="text" name="haircut_type" required /></li>""")
 
     def test_forms_with_prefixes(self):
         # Sometimes it's necessary to have multiple forms display on the same HTML page,
@@ -2229,23 +2229,23 @@ Password: <input type="password" name="password" required>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_person1-first_name">First name:</label>
-<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required></li>
+<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required /></li>
 <li><label for="id_person1-last_name">Last name:</label>
-<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required></li>
+<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required /></li>
 <li><label for="id_person1-birthday">Birthday:</label>
-<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required></li>"""
+<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required /></li>"""
         )
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required>'
+            '<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required />'
         )
         self.assertHTMLEqual(
             str(p['last_name']),
-            '<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required>'
+            '<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required />'
         )
         self.assertHTMLEqual(
             str(p['birthday']),
-            '<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required>'
+            '<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required />'
         )
         self.assertEqual(p.errors, {})
         self.assertTrue(p.is_valid())
@@ -2318,11 +2318,11 @@ Password: <input type="password" name="password" required>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_foo-prefix-first_name">First name:</label>
-<input type="text" name="foo-prefix-first_name" id="id_foo-prefix-first_name" required></li>
+<input type="text" name="foo-prefix-first_name" id="id_foo-prefix-first_name" required /></li>
 <li><label for="id_foo-prefix-last_name">Last name:</label>
-<input type="text" name="foo-prefix-last_name" id="id_foo-prefix-last_name" required></li>
+<input type="text" name="foo-prefix-last_name" id="id_foo-prefix-last_name" required /></li>
 <li><label for="id_foo-prefix-birthday">Birthday:</label>
-<input type="text" name="foo-prefix-birthday" id="id_foo-prefix-birthday" required></li>"""
+<input type="text" name="foo-prefix-birthday" id="id_foo-prefix-birthday" required /></li>"""
         )
         data = {
             'foo-prefix-first_name': 'John',
@@ -2400,7 +2400,7 @@ Password: <input type="password" name="password" required>
         f = FileForm(auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
         )
 
         f = FileForm(data={}, files={}, auto_id=False)
@@ -2408,7 +2408,7 @@ Password: <input type="password" name="password" required>
             f.as_table(),
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>This field is required.</li></ul>'
-            '<input type="file" name="file1" required></td></tr>'
+            '<input type="file" name="file1" required /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': SimpleUploadedFile('name', b'')}, auto_id=False)
@@ -2416,7 +2416,7 @@ Password: <input type="password" name="password" required>
             f.as_table(),
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>The submitted file is empty.</li></ul>'
-            '<input type="file" name="file1" required></td></tr>'
+            '<input type="file" name="file1" required /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': 'something that is not a file'}, auto_id=False)
@@ -2425,13 +2425,13 @@ Password: <input type="password" name="password" required>
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>No file was submitted. Check the '
             'encoding type on the form.</li></ul>'
-            '<input type="file" name="file1" required></td></tr>'
+            '<input type="file" name="file1" required /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': SimpleUploadedFile('name', b'some content')}, auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
         )
         self.assertTrue(f.is_valid())
 
@@ -2439,7 +2439,7 @@ Password: <input type="password" name="password" required>
         f = FileForm(data={}, files={'file1': file1}, auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
         )
 
         # A required file field with initial data should not contain the
@@ -2448,7 +2448,7 @@ Password: <input type="password" name="password" required>
         f = FileForm(initial={'file1': 'resume.txt'}, auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1"></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" /></td></tr>',
         )
 
     def test_filefield_initial_callable(self):
@@ -2481,20 +2481,20 @@ Password: <input type="password" name="password" required>
             if form.is_valid():
                 return 'VALID: %r' % sorted(form.cleaned_data.items())
 
-            t = Template(
+            t = Template(\
                 '<form method="post">\n'
-                '<table>\n{{ form }}\n</table>\n<input type="submit" required>\n</form>'
+                '<table>\n{{ form }}\n</table>\n<input type="submit" required />\n</form>'
             )
             return t.render(Context({'form': form}))
 
         # Case 1: GET (an empty form, with no errors).)
         self.assertHTMLEqual(my_function('GET', {}), """<form method="post">
 <table>
-<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required></td></tr>
+<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>
 </table>
-<input type="submit" required>
+<input type="submit" required />
 </form>""")
         # Case 2: POST with erroneous data (a redisplayed form, with errors).)
         self.assertHTMLEqual(
@@ -2504,11 +2504,11 @@ Password: <input type="password" name="password" required>
 <tr><td colspan="2"><ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul></td></tr>
 <tr><th>Username:</th><td><ul class="errorlist">
 <li>Ensure this value has at most 10 characters (it has 23).</li></ul>
-<input type="text" name="username" value="this-is-a-long-username" maxlength="10" required></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required></td></tr>
+<input type="text" name="username" value="this-is-a-long-username" maxlength="10" required /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>
 </table>
-<input type="submit" required>
+<input type="submit" required />
 </form>"""
         )
         # Case 3: POST with valid data (the success message).)
@@ -2539,23 +2539,23 @@ Password: <input type="password" name="password" required>
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p><label>Your username: <input type="text" name="username" maxlength="10" required></label></p>
-<p><label>Password: <input type="password" name="password1" required></label></p>
-<p><label>Password (again): <input type="password" name="password2" required></label></p>
-<input type="submit" required>
+<p><label>Your username: <input type="text" name="username" maxlength="10" required /></label></p>
+<p><label>Password: <input type="password" name="password1" required /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required /></label></p>
+<input type="submit" required />
 </form>""")
         self.assertHTMLEqual(
             t.render(Context({'form': UserRegistration({'username': 'django'}, auto_id=False)})),
             """<form>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required></label></p>
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
 <ul class="errorlist"><li>This field is required.</li></ul><p>
-<label>Password: <input type="password" name="password1" required></label></p>
+<label>Password: <input type="password" name="password1" required /></label></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<p><label>Password (again): <input type="password" name="password2" required></label></p>
-<input type="submit" required>
+<p><label>Password (again): <input type="password" name="password2" required /></label></p>
+<input type="submit" required />
 </form>"""
         )
 
@@ -2567,13 +2567,13 @@ Password: <input type="password" name="password" required>
 <p><label>{{ form.username.label }}: {{ form.username }}</label></p>
 <p><label>{{ form.password1.label }}: {{ form.password1 }}</label></p>
 <p><label>{{ form.password2.label }}: {{ form.password2 }}</label></p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p><label>Username: <input type="text" name="username" maxlength="10" required></label></p>
-<p><label>Password1: <input type="password" name="password1" required></label></p>
-<p><label>Password2: <input type="password" name="password2" required></label></p>
-<input type="submit" required>
+<p><label>Username: <input type="text" name="username" maxlength="10" required /></label></p>
+<p><label>Password1: <input type="password" name="password1" required /></label></p>
+<p><label>Password2: <input type="password" name="password2" required /></label></p>
+<input type="submit" required />
 </form>""")
 
         # User form.[field].label_tag to output a field's label with a <label> tag
@@ -2584,40 +2584,40 @@ Password: <input type="password" name="password" required>
 <p>{{ form.username.label_tag }} {{ form.username }}</p>
 <p>{{ form.password1.label_tag }} {{ form.password1 }}</p>
 <p>{{ form.password2.label_tag }} {{ form.password2 }}</p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p>Username: <input type="text" name="username" maxlength="10" required></p>
-<p>Password1: <input type="password" name="password1" required></p>
-<p>Password2: <input type="password" name="password2" required></p>
-<input type="submit" required>
+<p>Username: <input type="text" name="username" maxlength="10" required /></p>
+<p>Password1: <input type="password" name="password1" required /></p>
+<p>Password2: <input type="password" name="password2" required /></p>
+<input type="submit" required />
 </form>""")
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id='id_%s')})), """<form>
 <p><label for="id_username">Username:</label>
-<input id="id_username" type="text" name="username" maxlength="10" required></p>
+<input id="id_username" type="text" name="username" maxlength="10" required /></p>
 <p><label for="id_password1">Password1:</label>
-<input type="password" name="password1" id="id_password1" required></p>
+<input type="password" name="password1" id="id_password1" required /></p>
 <p><label for="id_password2">Password2:</label>
-<input type="password" name="password2" id="id_password2" required></p>
-<input type="submit" required>
+<input type="password" name="password2" id="id_password2" required /></p>
+<input type="submit" required />
 </form>""")
 
         # User form.[field].help_text to output a field's help text. If the given field
         # does not have help text, nothing will be output.
         t = Template('''<form>
-<p>{{ form.username.label_tag }} {{ form.username }}<br>{{ form.username.help_text }}</p>
+<p>{{ form.username.label_tag }} {{ form.username }}<br />{{ form.username.help_text }}</p>
 <p>{{ form.password1.label_tag }} {{ form.password1 }}</p>
 <p>{{ form.password2.label_tag }} {{ form.password2 }}</p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({'form': UserRegistration(auto_id=False)})),
             """<form>
-<p>Username: <input type="text" name="username" maxlength="10" required><br>
+<p>Username: <input type="text" name="username" maxlength="10" required /><br />
 Good luck picking a username that doesn&#39;t already exist.</p>
-<p>Password1: <input type="password" name="password1" required></p>
-<p>Password2: <input type="password" name="password2" required></p>
-<input type="submit" required>
+<p>Password1: <input type="password" name="password1" required /></p>
+<p>Password2: <input type="password" name="password2" required /></p>
+<input type="submit" required />
 </form>"""
         )
         self.assertEqual(
@@ -2633,17 +2633,17 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({
                 'form': UserRegistration({'username': 'django', 'password1': 'foo', 'password2': 'bar'}, auto_id=False)
             })),
             """<form>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required></label></p>
-<p><label>Password: <input type="password" name="password1" required></label></p>
-<p><label>Password (again): <input type="password" name="password2" required></label></p>
-<input type="submit" required>
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
+<p><label>Password: <input type="password" name="password1" required /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required /></label></p>
+<input type="submit" required />
 </form>"""
         )
         t = Template('''<form>
@@ -2651,7 +2651,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required>
+<input type="submit" required />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({
@@ -2659,10 +2659,10 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             })),
             """<form>
 <ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required></label></p>
-<p><label>Password: <input type="password" name="password1" required></label></p>
-<p><label>Password (again): <input type="password" name="password2" required></label></p>
-<input type="submit" required>
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
+<p><label>Password: <input type="password" name="password1" required /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required /></label></p>
+<input type="submit" required />
 </form>"""
         )
 
@@ -2737,8 +2737,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             MyForm().as_table(),
             '<tr><th><label for="id_field1">Field1:</label></th>'
-            '<td><input id="id_field1" type="text" name="field1" maxlength="50" required>'
-            '<input type="hidden" name="initial-field1" id="initial-id_field1"></td></tr>'
+            '<td><input id="id_field1" type="text" name="field1" maxlength="50" required />'
+            '<input type="hidden" name="initial-field1" id="initial-id_field1" /></td></tr>'
         )
 
     def test_error_html_required_html_classes(self):
@@ -2755,33 +2755,33 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li class="required error"><ul class="errorlist"><li>This field is required.</li></ul>
-<label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" required></li>
+<label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></li>
 <li class="required"><label class="required" for="id_is_cool">Is cool:</label>
 <select name="is_cool" id="id_is_cool">
 <option value="1" selected>Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select></li>
-<li><label for="id_email">Email:</label> <input type="email" name="email" id="id_email"></li>
+<li><label for="id_email">Email:</label> <input type="email" name="email" id="id_email" /></li>
 <li class="required error"><ul class="errorlist"><li>This field is required.</li></ul>
-<label class="required" for="id_age">Age:</label> <input type="number" name="age" id="id_age" required></li>"""
+<label class="required" for="id_age">Age:</label> <input type="number" name="age" id="id_age" required /></li>"""
         )
 
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist"><li>This field is required.</li></ul>
 <p class="required error"><label class="required" for="id_name">Name:</label>
-<input type="text" name="name" id="id_name" required></p>
+<input type="text" name="name" id="id_name" required /></p>
 <p class="required"><label class="required" for="id_is_cool">Is cool:</label>
 <select name="is_cool" id="id_is_cool">
 <option value="1" selected>Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select></p>
-<p><label for="id_email">Email:</label> <input type="email" name="email" id="id_email"></p>
+<p><label for="id_email">Email:</label> <input type="email" name="email" id="id_email" /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p class="required error"><label class="required" for="id_age">Age:</label>
-<input type="number" name="age" id="id_age" required></p>"""
+<input type="number" name="age" id="id_age" required /></p>"""
         )
 
         self.assertHTMLEqual(
@@ -2789,7 +2789,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<tr class="required error">
 <th><label class="required" for="id_name">Name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="name" id="id_name" required></td></tr>
+<input type="text" name="name" id="id_name" required /></td></tr>
 <tr class="required"><th><label class="required" for="id_is_cool">Is cool:</label></th>
 <td><select name="is_cool" id="id_is_cool">
 <option value="1" selected>Unknown</option>
@@ -2797,10 +2797,10 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 <option value="3">No</option>
 </select></td></tr>
 <tr><th><label for="id_email">Email:</label></th><td>
-<input type="email" name="email" id="id_email"></td></tr>
+<input type="email" name="email" id="id_email" /></td></tr>
 <tr class="required error"><th><label class="required" for="id_age">Age:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="number" name="age" id="id_age" required></td></tr>"""
+<input type="number" name="age" id="id_age" required /></td></tr>"""
         )
 
     def test_label_has_required_css_class(self):
@@ -2827,8 +2827,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = EventForm()
         self.assertHTMLEqual(
             form.as_ul(),
-            '<input type="hidden" name="happened_at_0" id="id_happened_at_0">'
-            '<input type="hidden" name="happened_at_1" id="id_happened_at_1">'
+            '<input type="hidden" name="happened_at_0" id="id_happened_at_0" />'
+            '<input type="hidden" name="happened_at_1" id="id_happened_at_1" />'
         )
 
     def test_multivalue_field_validation(self):
@@ -3163,9 +3163,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><input id="id_custom" name="custom" type="text" required> custom'
-            '<input id="id_hidden1" name="hidden1" type="hidden">'
-            '<input id="id_hidden2" name="hidden2" type="hidden"></p>'
+            '<p><input id="id_custom" name="custom" type="text" required /> custom'
+            '<input id="id_hidden1" name="hidden1" type="hidden" />'
+            '<input id="id_hidden2" name="hidden2" type="hidden" /></p>'
         )
 
     def test_field_name_with_hidden_input_and_non_matching_row_ender(self):
@@ -3182,7 +3182,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
                 return self._html_output(
                     normal_row='<p%(html_class_attr)s>%(field)s %(field_name)s</p>',
                     error_row='%s',
-                    row_ender='<hr><hr>',
+                    row_ender='<hr /><hr />',
                     help_text_html=' %s',
                     errors_on_separate_row=True
                 )
@@ -3190,9 +3190,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><input id="id_custom" name="custom" type="text" required> custom</p>\n'
-            '<input id="id_hidden1" name="hidden1" type="hidden">'
-            '<input id="id_hidden2" name="hidden2" type="hidden"><hr><hr>'
+            '<p><input id="id_custom" name="custom" type="text" required /> custom</p>\n'
+            '<input id="id_hidden1" name="hidden1" type="hidden" />'
+            '<input id="id_hidden2" name="hidden2" type="hidden" /><hr /><hr />'
         )
 
     def test_error_dict(self):
@@ -3322,23 +3322,23 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<li><ul class="errorlist nonfield">
 <li>(Hidden field last_name) This field is required.</li></ul></li><li>
 <label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required>
-<input id="id_last_name" name="last_name" type="hidden"></li>"""
+<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_last_name" name="last_name" type="hidden" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist nonfield"><li>(Hidden field last_name) This field is required.</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required>
-<input id="id_last_name" name="last_name" type="hidden"></p>"""
+<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_last_name" name="last_name" type="hidden" /></p>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><td colspan="2"><ul class="errorlist nonfield">
 <li>(Hidden field last_name) This field is required.</li></ul></td></tr>
 <tr><th><label for="id_first_name">First name:</label></th><td>
-<input id="id_first_name" name="first_name" type="text" value="John" required>
-<input id="id_last_name" name="last_name" type="hidden"></td></tr>"""
+<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_last_name" name="last_name" type="hidden" /></td></tr>"""
         )
 
     def test_error_list_with_non_field_errors_has_correct_class(self):
@@ -3359,9 +3359,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<li>
 <ul class="errorlist nonfield"><li>Generic validation error</li></ul></li>
 <li><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required></li>
+<input id="id_first_name" name="first_name" type="text" value="John" required /></li>
 <li><label for="id_last_name">Last name:</label>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required></li>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></li>"""
         )
         self.assertHTMLEqual(
             p.non_field_errors().as_text(),
@@ -3371,17 +3371,17 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             p.as_p(),
             """<ul class="errorlist nonfield"><li>Generic validation error</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required></p>
+<input id="id_first_name" name="first_name" type="text" value="John" required /></p>
 <p><label for="id_last_name">Last name:</label>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required></p>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></p>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><td colspan="2"><ul class="errorlist nonfield"><li>Generic validation error</li></ul></td></tr>
 <tr><th><label for="id_first_name">First name:</label></th><td>
-<input id="id_first_name" name="first_name" type="text" value="John" required></td></tr>
+<input id="id_first_name" name="first_name" type="text" value="John" required /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required></td></tr>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></td></tr>"""
         )
 
     def test_errorlist_override(self):
@@ -3402,11 +3402,11 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 
         data = {'email': 'invalid'}
         f = CommentForm(data, auto_id=False, error_class=DivErrorList)
-        self.assertHTMLEqual(f.as_p(), """<p>Name: <input type="text" name="name" maxlength="50"></p>
+        self.assertHTMLEqual(f.as_p(), """<p>Name: <input type="text" name="name" maxlength="50" /></p>
 <div class="errorlist"><div class="error">Enter a valid email address.</div></div>
-<p>Email: <input type="email" name="email" value="invalid" required></p>
+<p>Email: <input type="email" name="email" value="invalid" required /></p>
 <div class="errorlist"><div class="error">This field is required.</div></div>
-<p>Comment: <input type="text" name="comment" required></p>""")
+<p>Comment: <input type="text" name="comment" required /></p>""")
 
     def test_error_escaping(self):
         class TestForm(Form):
@@ -3425,8 +3425,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             '<li><ul class="errorlist nonfield"><li>(Hidden field hidden) Foo &amp; &quot;bar&quot;!</li></ul></li>'
             '<li><ul class="errorlist"><li>Foo &amp; &quot;bar&quot;!</li></ul>'
             '<label for="id_visible">Visible:</label> '
-            '<input type="text" name="visible" value="b" id="id_visible" required>'
-            '<input type="hidden" name="hidden" value="a" id="id_hidden"></li>'
+            '<input type="text" name="visible" value="b" id="id_visible" required />'
+            '<input type="hidden" name="hidden" value="a" id="id_hidden" /></li>'
         )
 
     def test_baseform_repr(self):
@@ -3539,8 +3539,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = MyForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" required></p>'
-            '<p><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text"></p>'
+            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" required /></p>'
+            '<p><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></p>'
             '<p><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10" required>'
             '</textarea></p>'
             '<p><label for="id_f4">F4:</label> <select id="id_f4" name="f4">'
@@ -3551,8 +3551,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             form.as_ul(),
             '<li><label for="id_f1">F1:</label> '
-            '<input id="id_f1" maxlength="30" name="f1" type="text" required></li>'
-            '<li><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text"></li>'
+            '<input id="id_f1" maxlength="30" name="f1" type="text" required /></li>'
+            '<li><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></li>'
             '<li><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10" required>'
             '</textarea></li>'
             '<li><label for="id_f4">F4:</label> <select id="id_f4" name="f4">'
@@ -3563,9 +3563,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             form.as_table(),
             '<tr><th><label for="id_f1">F1:</label></th>'
-            '<td><input id="id_f1" maxlength="30" name="f1" type="text" required></td></tr>'
+            '<td><input id="id_f1" maxlength="30" name="f1" type="text" required /></td></tr>'
             '<tr><th><label for="id_f2">F2:</label></th>'
-            '<td><input id="id_f2" maxlength="30" name="f2" type="text"></td></tr>'
+            '<td><input id="id_f2" maxlength="30" name="f2" type="text" /></td></tr>'
             '<tr><th><label for="id_f3">F3:</label></th>'
             '<td><textarea cols="40" id="id_f3" name="f3" rows="10" required>'
             '</textarea></td></tr>'
@@ -3586,8 +3586,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = MyForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text"></p>'
-            '<p><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text"></p>'
+            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" /></p>'
+            '<p><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></p>'
             '<p><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10">'
             '</textarea></p>'
             '<p><label for="id_f4">F4:</label> <select id="id_f4" name="f4">'
@@ -3597,8 +3597,8 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         )
         self.assertHTMLEqual(
             form.as_ul(),
-            '<li><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text"></li>'
-            '<li><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text"></li>'
+            '<li><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" /></li>'
+            '<li><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></li>'
             '<li><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10">'
             '</textarea></li>'
             '<li><label for="id_f4">F4:</label> <select id="id_f4" name="f4">'
@@ -3609,9 +3609,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             form.as_table(),
             '<tr><th><label for="id_f1">F1:</label></th>'
-            '<td><input id="id_f1" maxlength="30" name="f1" type="text"></td></tr>'
+            '<td><input id="id_f1" maxlength="30" name="f1" type="text" /></td></tr>'
             '<tr><th><label for="id_f2">F2:</label></th>'
-            '<td><input id="id_f2" maxlength="30" name="f2" type="text"></td></tr>'
+            '<td><input id="id_f2" maxlength="30" name="f2" type="text" /></td></tr>'
             '<tr><th><label for="id_f3">F3:</label></th><td><textarea cols="40" id="id_f3" name="f3" rows="10">'
             '</textarea></td></tr>'
             '<tr><th><label for="id_f4">F4:</label></th><td><select id="id_f4" name="f4">'
@@ -3630,13 +3630,13 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             f.as_p(),
             '<ul class="errorlist nonfield">'
             '<li>(Hidden field data) This field is required.</li></ul>\n<p> '
-            '<input type="hidden" name="data" id="id_data"></p>'
+            '<input type="hidden" name="data" id="id_data" /></p>'
         )
         self.assertHTMLEqual(
             f.as_table(),
             '<tr><td colspan="2"><ul class="errorlist nonfield">'
             '<li>(Hidden field data) This field is required.</li></ul>'
-            '<input type="hidden" name="data" id="id_data"></td></tr>'
+            '<input type="hidden" name="data" id="id_data" /></td></tr>'
         )
 
     def test_field_named_data(self):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -59,15 +59,15 @@ class FormsTestCase(SimpleTestCase):
         self.assertEqual(p.cleaned_data["birthday"], datetime.date(1940, 10, 9))
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="first_name" value="John" id="id_first_name" required />'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required="required" />'
         )
         self.assertHTMLEqual(
             str(p['last_name']),
-            '<input type="text" name="last_name" value="Lennon" id="id_last_name" required />'
+            '<input type="text" name="last_name" value="Lennon" id="id_last_name" required="required" />'
         )
         self.assertHTMLEqual(
             str(p['birthday']),
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required />'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" />'
         )
 
         msg = "Key 'nonexistentfield' not found in 'Person'. Choices are: birthday, first_name, last_name."
@@ -81,9 +81,9 @@ class FormsTestCase(SimpleTestCase):
 
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<input type="text" name="first_name" value="John" id="id_first_name" required />
-<input type="text" name="last_name" value="Lennon" id="id_last_name" required />
-<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required />"""
+            """<input type="text" name="first_name" value="John" id="id_first_name" required="required" />
+<input type="text" name="last_name" value="Lennon" id="id_last_name" required="required" />
+<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" />"""
         )
 
         form_output = []
@@ -99,11 +99,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" value="John" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" value="John" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" value="Lennon" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" value="Lennon" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></td></tr>"""
+<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" /></td></tr>"""
         )
 
     def test_empty_dict(self):
@@ -119,49 +119,49 @@ class FormsTestCase(SimpleTestCase):
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="first_name" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="last_name" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="first_name" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="last_name" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></li>
+<input type="text" name="first_name" id="id_first_name" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></li>
+<input type="text" name="last_name" id="id_last_name" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
 <label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required /></li>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></p>
+<input type="text" name="first_name" id="id_first_name" required="required" /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></p>
+<input type="text" name="last_name" id="id_last_name" required="required" /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required /></p>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></p>"""
         )
 
     def test_empty_querydict_args(self):
@@ -185,38 +185,38 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(p),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required /></td></tr>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></li>
+<input type="text" name="first_name" id="id_first_name" required="required" /></li>
 <li><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></li>
+<input type="text" name="last_name" id="id_last_name" required="required" /></li>
 <li><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required /></li>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></p>
+<input type="text" name="first_name" id="id_first_name" required="required" /></p>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></p>
+<input type="text" name="last_name" id="id_last_name" required="required" /></p>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required /></p>"""
+<input type="text" name="birthday" id="id_birthday" required="required" /></p>"""
         )
 
     def test_unicode_values(self):
@@ -229,33 +229,33 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_table(),
             '<tr><th><label for="id_first_name">First name:</label></th><td>'
-            '<input type="text" name="first_name" value="John" id="id_first_name" required /></td></tr>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required="required" /></td></tr>\n'
             '<tr><th><label for="id_last_name">Last name:</label>'
             '</th><td><input type="text" name="last_name" '
             'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111"'
-            'id="id_last_name" required /></td></tr>\n'
+            'id="id_last_name" required="required" /></td></tr>\n'
             '<tr><th><label for="id_birthday">Birthday:</label></th><td>'
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></td></tr>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" /></td></tr>'
         )
         self.assertHTMLEqual(
             p.as_ul(),
             '<li><label for="id_first_name">First name:</label> '
-            '<input type="text" name="first_name" value="John" id="id_first_name" required /></li>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required="required" /></li>\n'
             '<li><label for="id_last_name">Last name:</label> '
             '<input type="text" name="last_name" '
-            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required /></li>\n'
+            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required="required" /></li>\n'
             '<li><label for="id_birthday">Birthday:</label> '
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></li>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" /></li>'
         )
         self.assertHTMLEqual(
             p.as_p(),
             '<p><label for="id_first_name">First name:</label> '
-            '<input type="text" name="first_name" value="John" id="id_first_name" required /></p>\n'
+            '<input type="text" name="first_name" value="John" id="id_first_name" required="required" /></p>\n'
             '<p><label for="id_last_name">Last name:</label> '
             '<input type="text" name="last_name" '
-            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required /></p>\n'
+            'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" id="id_last_name" required="required" /></p>\n'
             '<p><label for="id_birthday">Birthday:</label> '
-            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required /></p>'
+            '<input type="text" name="birthday" value="1940-10-9" id="id_birthday" required="required" /></p>'
         )
 
         p = Person({'last_name': 'Lennon'})
@@ -277,10 +277,10 @@ class FormsTestCase(SimpleTestCase):
         p = Person()
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="first_name" id="id_first_name" required />',
+            '<input type="text" name="first_name" id="id_first_name" required="required" />',
         )
-        self.assertHTMLEqual(str(p['last_name']), '<input type="text" name="last_name" id="id_last_name" required />')
-        self.assertHTMLEqual(str(p['birthday']), '<input type="text" name="birthday" id="id_birthday" required />')
+        self.assertHTMLEqual(str(p['last_name']), '<input type="text" name="last_name" id="id_last_name" required="required" />')
+        self.assertHTMLEqual(str(p['birthday']), '<input type="text" name="birthday" id="id_birthday" required="required" />')
 
     def test_cleaned_data_only_fields(self):
         # cleaned_data will always *only* contain a key for fields defined in the
@@ -340,29 +340,29 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="first_name_id">First name:</label></th><td>
-<input type="text" name="first_name" id="first_name_id" required /></td></tr>
+<input type="text" name="first_name" id="first_name_id" required="required" /></td></tr>
 <tr><th><label for="last_name_id">Last name:</label></th><td>
-<input type="text" name="last_name" id="last_name_id" required /></td></tr>
+<input type="text" name="last_name" id="last_name_id" required="required" /></td></tr>
 <tr><th><label for="birthday_id">Birthday:</label></th><td>
-<input type="text" name="birthday" id="birthday_id" required /></td></tr>"""
+<input type="text" name="birthday" id="birthday_id" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" name="first_name" id="first_name_id" required /></li>
+<input type="text" name="first_name" id="first_name_id" required="required" /></li>
 <li><label for="last_name_id">Last name:</label>
-<input type="text" name="last_name" id="last_name_id" required /></li>
+<input type="text" name="last_name" id="last_name_id" required="required" /></li>
 <li><label for="birthday_id">Birthday:</label>
-<input type="text" name="birthday" id="birthday_id" required /></li>"""
+<input type="text" name="birthday" id="birthday_id" required="required" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="first_name_id">First name:</label>
-<input type="text" name="first_name" id="first_name_id" required /></p>
+<input type="text" name="first_name" id="first_name_id" required="required" /></p>
 <p><label for="last_name_id">Last name:</label>
-<input type="text" name="last_name" id="last_name_id" required /></p>
+<input type="text" name="last_name" id="last_name_id" required="required" /></p>
 <p><label for="birthday_id">Birthday:</label>
-<input type="text" name="birthday" id="birthday_id" required /></p>"""
+<input type="text" name="birthday" id="birthday_id" required="required" /></p>"""
         )
 
     def test_auto_id_true(self):
@@ -372,11 +372,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name">First name:</label>
-<input type="text" name="first_name" id="first_name" required /></li>
+<input type="text" name="first_name" id="first_name" required="required" /></li>
 <li><label for="last_name">Last name:</label>
-<input type="text" name="last_name" id="last_name" required /></li>
+<input type="text" name="last_name" id="last_name" required="required" /></li>
 <li><label for="birthday">Birthday:</label>
-<input type="text" name="birthday" id="birthday" required /></li>"""
+<input type="text" name="birthday" id="birthday" required="required" /></li>"""
         )
 
     def test_auto_id_false(self):
@@ -385,9 +385,9 @@ class FormsTestCase(SimpleTestCase):
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /></li>"""
+            """<li>First name: <input type="text" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /></li>"""
         )
 
     def test_id_on_field(self):
@@ -397,9 +397,9 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" id="first_name_id" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /></li>"""
+<input type="text" id="first_name_id" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /></li>"""
         )
 
     def test_auto_id_on_form_and_field(self):
@@ -409,11 +409,11 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="first_name_id">First name:</label>
-<input type="text" id="first_name_id" name="first_name" required /></li>
+<input type="text" id="first_name_id" name="first_name" required="required" /></li>
 <li><label for="last_name">Last name:</label>
-<input type="text" name="last_name" id="last_name" required /></li>
+<input type="text" name="last_name" id="last_name" required="required" /></li>
 <li><label for="birthday">Birthday:</label>
-<input type="text" name="birthday" id="birthday" required /></li>"""
+<input type="text" name="birthday" id="birthday" required="required" /></li>"""
         )
 
     def test_various_boolean_values(self):
@@ -422,33 +422,33 @@ class FormsTestCase(SimpleTestCase):
             get_spam = BooleanField()
 
         f = SignupForm(auto_id=False)
-        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" required />')
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
+        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" required="required" />')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required="required" />')
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': True}, auto_id=False)
-        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" value="test@example.com" required />')
+        self.assertHTMLEqual(str(f['email']), '<input type="email" name="email" value="test@example.com" required="required" />')
         self.assertHTMLEqual(
             str(f['get_spam']),
-            '<input checked type="checkbox" name="get_spam" required />',
+            '<input checked="checked" type="checkbox" name="get_spam" required="required" />',
         )
 
         # 'True' or 'true' should be rendered without a value attribute
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'True'}, auto_id=False)
         self.assertHTMLEqual(
             str(f['get_spam']),
-            '<input checked type="checkbox" name="get_spam" required />',
+            '<input checked="checked" type="checkbox" name="get_spam" required="required" />',
         )
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'true'}, auto_id=False)
         self.assertHTMLEqual(
-            str(f['get_spam']), '<input checked type="checkbox" name="get_spam" required />')
+            str(f['get_spam']), '<input checked="checked" type="checkbox" name="get_spam" required="required" />')
 
         # A value of 'False' or 'false' should be rendered unchecked
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'False'}, auto_id=False)
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required="required" />')
 
         f = SignupForm({'email': 'test@example.com', 'get_spam': 'false'}, auto_id=False)
-        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required />')
+        self.assertHTMLEqual(str(f['get_spam']), '<input type="checkbox" name="get_spam" required="required" />')
 
         # A value of '0' should be interpreted as a True value (#16820)
         f = SignupForm({'email': 'test@example.com', 'get_spam': '0'})
@@ -462,7 +462,7 @@ class FormsTestCase(SimpleTestCase):
             message = CharField(widget=Textarea)
 
         f = ContactForm(auto_id=False)
-        self.assertHTMLEqual(str(f['subject']), '<input type="text" name="subject" required />')
+        self.assertHTMLEqual(str(f['subject']), '<input type="text" name="subject" required="required" />')
         self.assertHTMLEqual(str(f['message']), '<textarea name="message" rows="10" cols="40" required></textarea>')
 
         # as_textarea(), as_text() and as_hidden() are shortcuts for changing the output
@@ -471,7 +471,7 @@ class FormsTestCase(SimpleTestCase):
             f['subject'].as_textarea(),
             '<textarea name="subject" rows="10" cols="40" required></textarea>',
         )
-        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required />')
+        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required="required" />')
         self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message" />')
 
         # The 'widget' parameter to a Field can also be an instance:
@@ -484,7 +484,7 @@ class FormsTestCase(SimpleTestCase):
 
         # Instance-level attrs are *not* carried over to as_textarea(), as_text() and
         # as_hidden():
-        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required />')
+        self.assertHTMLEqual(f['message'].as_text(), '<input type="text" name="message" required="required" />')
         f = ContactForm({'subject': 'Hello', 'message': 'I love you.'}, auto_id=False)
         self.assertHTMLEqual(
             f['subject'].as_textarea(),
@@ -492,7 +492,7 @@ class FormsTestCase(SimpleTestCase):
         )
         self.assertHTMLEqual(
             f['message'].as_text(),
-            '<input type="text" name="message" value="I love you." required />',
+            '<input type="text" name="message" value="I love you." required="required" />',
         )
         self.assertHTMLEqual(f['message'].as_hidden(), '<input type="hidden" name="message" value="I love you." />')
 
@@ -509,7 +509,7 @@ class FormsTestCase(SimpleTestCase):
 </select>""")
         f = FrameworkForm({'name': 'Django', 'language': 'P'}, auto_id=False)
         self.assertHTMLEqual(str(f['language']), """<select name="language">
-<option value="P" selected>Python</option>
+<option value="P" selected="selected">Python</option>
 <option value="J">Java</option>
 </select>""")
 
@@ -520,8 +520,8 @@ class FormsTestCase(SimpleTestCase):
             language = ChoiceField(choices=[('', '------'), ('P', 'Python'), ('J', 'Java')])
 
         f = FrameworkForm(auto_id=False)
-        self.assertHTMLEqual(str(f['language']), """<select name="language" required>
-<option value="" selected>------</option>
+        self.assertHTMLEqual(str(f['language']), """<select name="language" required="required">
+<option value="" selected="selected">------</option>
 <option value="P">Python</option>
 <option value="J">Java</option>
 </select>""")
@@ -538,7 +538,7 @@ class FormsTestCase(SimpleTestCase):
 </select>""")
         f = FrameworkForm({'name': 'Django', 'language': 'P'}, auto_id=False)
         self.assertHTMLEqual(str(f['language']), """<select class="foo" name="language">
-<option value="P" selected>Python</option>
+<option value="P" selected="selected">Python</option>
 <option value="J">Java</option>
 </select>""")
 
@@ -559,7 +559,7 @@ class FormsTestCase(SimpleTestCase):
 </select>""")
         f = FrameworkForm({'name': 'Django', 'language': 'P'}, auto_id=False)
         self.assertHTMLEqual(str(f['language']), """<select class="foo" name="language">
-<option value="P" selected>Python</option>
+<option value="P" selected="selected">Python</option>
 <option value="J">Java</option>
 </select>""")
 
@@ -585,18 +585,18 @@ class FormsTestCase(SimpleTestCase):
 
         f = FrameworkForm(auto_id=False)
         self.assertHTMLEqual(str(f['language']), """<ul>
-<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required="required" /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required="required" /> Java</label></li>
 </ul>""")
-        self.assertHTMLEqual(f.as_table(), """<tr><th>Name:</th><td><input type="text" name="name" required /></td></tr>
+        self.assertHTMLEqual(f.as_table(), """<tr><th>Name:</th><td><input type="text" name="name" required="required" /></td></tr>
 <tr><th>Language:</th><td><ul>
-<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required="required" /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required="required" /> Java</label></li>
 </ul></td></tr>""")
-        self.assertHTMLEqual(f.as_ul(), """<li>Name: <input type="text" name="name" required /></li>
+        self.assertHTMLEqual(f.as_ul(), """<li>Name: <input type="text" name="name" required="required" /></li>
 <li>Language: <ul>
-<li><label><input type="radio" name="language" value="P" required /> Python</label></li>
-<li><label><input type="radio" name="language" value="J" required /> Java</label></li>
+<li><label><input type="radio" name="language" value="P" required="required" /> Python</label></li>
+<li><label><input type="radio" name="language" value="J" required="required" /> Java</label></li>
 </ul></li>""")
 
         # Regarding auto_id and <label>, RadioSelect is a special case. Each radio button
@@ -606,9 +606,9 @@ class FormsTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             str(f['language']),
             """<ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required="required" />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required="required" />
 Java</label></li>
 </ul>"""
         )
@@ -618,31 +618,31 @@ Java</label></li>
         # ID of the *first* radio button.
         self.assertHTMLEqual(
             f.as_table(),
-            """<tr><th><label for="id_name">Name:</label></th><td><input type="text" name="name" id="id_name" required /></td></tr>
+            """<tr><th><label for="id_name">Name:</label></th><td><input type="text" name="name" id="id_name" required="required" /></td></tr>
 <tr><th><label for="id_language_0">Language:</label></th><td><ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required="required" />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required="required" />
 Java</label></li>
 </ul></td></tr>"""
         )
         self.assertHTMLEqual(
             f.as_ul(),
-            """<li><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></li>
+            """<li><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required="required" /></li>
 <li><label for="id_language_0">Language:</label> <ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required="required" />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required="required" />
 Java</label></li>
 </ul></li>"""
         )
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></p>
+            """<p><label for="id_name">Name:</label> <input type="text" name="name" id="id_name" required="required" /></p>
 <p><label for="id_language_0">Language:</label> <ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required />
+<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required="required" />
 Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required />
+<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required="required" />
 Java</label></li>
 </ul></p>"""
         )
@@ -652,9 +652,9 @@ Java</label></li>
         self.assertHTMLEqual(
             t.render(Context({'form': f})),
             """<div class="myradio"><label for="id_language_0">
-<input id="id_language_0" name="language" type="radio" value="P" required /> Python</label></div>
+<input id="id_language_0" name="language" type="radio" value="P" required="required" /> Python</label></div>
 <div class="myradio"><label for="id_language_1">
-<input id="id_language_1" name="language" type="radio" value="J" required /> Java</label></div>"""
+<input id="id_language_1" name="language" type="radio" value="J" required="required" /> Java</label></div>"""
         )
 
     def test_form_with_iterable_boundfield(self):
@@ -667,17 +667,17 @@ Java</label></li>
         f = BeatleForm(auto_id=False)
         self.assertHTMLEqual(
             '\n'.join(str(bf) for bf in f['name']),
-            """<label><input type="radio" name="name" value="john" required /> John</label>
-<label><input type="radio" name="name" value="paul" required /> Paul</label>
-<label><input type="radio" name="name" value="george" required /> George</label>
-<label><input type="radio" name="name" value="ringo" required /> Ringo</label>"""
+            """<label><input type="radio" name="name" value="john" required="required" /> John</label>
+<label><input type="radio" name="name" value="paul" required="required" /> Paul</label>
+<label><input type="radio" name="name" value="george" required="required" /> George</label>
+<label><input type="radio" name="name" value="ringo" required="required" /> Ringo</label>"""
         )
         self.assertHTMLEqual(
             '\n'.join('<div>%s</div>' % bf for bf in f['name']),
-            """<div><label><input type="radio" name="name" value="john" required /> John</label></div>
-<div><label><input type="radio" name="name" value="paul" required /> Paul</label></div>
-<div><label><input type="radio" name="name" value="george" required /> George</label></div>
-<div><label><input type="radio" name="name" value="ringo" required /> Ringo</label></div>"""
+            """<div><label><input type="radio" name="name" value="john" required="required" /> John</label></div>
+<div><label><input type="radio" name="name" value="paul" required="required" /> Paul</label></div>
+<div><label><input type="radio" name="name" value="george" required="required" /> George</label></div>
+<div><label><input type="radio" name="name" value="ringo" required="required" /> Ringo</label></div>"""
         )
 
     def test_form_with_iterable_boundfield_id(self):
@@ -693,24 +693,24 @@ Java</label></li>
         self.assertEqual(fields[0].choice_label, 'John')
         self.assertHTMLEqual(
             fields[0].tag(),
-            '<input type="radio" name="name" value="john" id="id_name_0" required />'
+            '<input type="radio" name="name" value="john" id="id_name_0" required="required" />'
         )
         self.assertHTMLEqual(
             str(fields[0]),
             '<label for="id_name_0"><input type="radio" name="name" '
-            'value="john" id="id_name_0" required /> John</label>'
+            'value="john" id="id_name_0" required="required" /> John</label>'
         )
 
         self.assertEqual(fields[1].id_for_label, 'id_name_1')
         self.assertEqual(fields[1].choice_label, 'Paul')
         self.assertHTMLEqual(
             fields[1].tag(),
-            '<input type="radio" name="name" value="paul" id="id_name_1" required />'
+            '<input type="radio" name="name" value="paul" id="id_name_1" required="required" />'
         )
         self.assertHTMLEqual(
             str(fields[1]),
             '<label for="id_name_1"><input type="radio" name="name" '
-            'value="paul" id="id_name_1" required /> Paul</label>'
+            'value="paul" id="id_name_1" required="required" /> Paul</label>'
         )
 
     def test_iterable_boundfield_select(self):
@@ -730,7 +730,7 @@ Java</label></li>
             name = CharField()
 
         f = BeatleForm(auto_id=False)
-        self.assertHTMLEqual('\n'.join(str(bf) for bf in f['name']), '<input type="text" name="name" required />')
+        self.assertHTMLEqual('\n'.join(str(bf) for bf in f['name']), '<input type="text" name="name" required="required" />')
 
     def test_boundfield_slice(self):
         class BeatleForm(Form):
@@ -760,7 +760,7 @@ Java</label></li>
             composers = MultipleChoiceField()
 
         f = SongForm(auto_id=False)
-        self.assertHTMLEqual(str(f['composers']), """<select multiple name="composers" required>
+        self.assertHTMLEqual(str(f['composers']), """<select multiple="multiple" name="composers" required="required">
 </select>""")
 
         class SongForm(Form):
@@ -768,15 +768,15 @@ Java</label></li>
             composers = MultipleChoiceField(choices=[('J', 'John Lennon'), ('P', 'Paul McCartney')])
 
         f = SongForm(auto_id=False)
-        self.assertHTMLEqual(str(f['composers']), """<select multiple name="composers" required>
+        self.assertHTMLEqual(str(f['composers']), """<select multiple="multiple" name="composers" required="required">
 <option value="J">John Lennon</option>
 <option value="P">Paul McCartney</option>
 </select>""")
         f = SongForm({'name': 'Yesterday', 'composers': ['P']}, auto_id=False)
-        self.assertHTMLEqual(str(f['name']), '<input type="text" name="name" value="Yesterday" required />')
-        self.assertHTMLEqual(str(f['composers']), """<select multiple name="composers" required>
+        self.assertHTMLEqual(str(f['name']), '<input type="text" name="name" value="Yesterday" required="required" />')
+        self.assertHTMLEqual(str(f['composers']), """<select multiple="multiple" name="composers" required="required">
 <option value="J">John Lennon</option>
-<option value="P" selected>Paul McCartney</option>
+<option value="P" selected="selected">Paul McCartney</option>
 </select>""")
 
     def test_form_with_disabled_fields(self):
@@ -840,8 +840,8 @@ Java</label></li>
         self.assertTrue(f.is_valid())
         self.assertHTMLEqual(
             str(f['when']),
-            '<input type="text" name="when_0" value="1992-01-01" id="id_when_0" required />'
-            '<input type="text" name="when_1" value="01:01" id="id_when_1" required />'
+            '<input type="text" name="when_0" value="1992-01-01" id="id_when_0" required="required" />'
+            '<input type="text" name="when_1" value="01:01" id="id_when_1" required="required" />'
         )
         self.assertHTMLEqual(
             f['when'].as_hidden(),
@@ -865,20 +865,20 @@ Java</label></li>
 </ul>""")
         f = SongForm({'composers': ['J']}, auto_id=False)
         self.assertHTMLEqual(str(f['composers']), """<ul>
-<li><label><input checked type="checkbox" name="composers" value="J" /> John Lennon</label></li>
+<li><label><input checked="checked" type="checkbox" name="composers" value="J" /> John Lennon</label></li>
 <li><label><input type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
 </ul>""")
         f = SongForm({'composers': ['J', 'P']}, auto_id=False)
         self.assertHTMLEqual(str(f['composers']), """<ul>
-<li><label><input checked type="checkbox" name="composers" value="J" /> John Lennon</label></li>
-<li><label><input checked type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
+<li><label><input checked="checked" type="checkbox" name="composers" value="J" /> John Lennon</label></li>
+<li><label><input checked="checked" type="checkbox" name="composers" value="P" /> Paul McCartney</label></li>
 </ul>""")
         # Test iterating on individual checkboxes in a template
         t = Template('{% for checkbox in form.composers %}<div class="mycheckbox">{{ checkbox }}</div>{% endfor %}')
         self.assertHTMLEqual(t.render(Context({'form': f})), """<div class="mycheckbox"><label>
-<input checked name="composers" type="checkbox" value="J" /> John Lennon</label></div>
+<input checked="checked" name="composers" type="checkbox" value="J" /> John Lennon</label></div>
 <div class="mycheckbox"><label>
-<input checked name="composers" type="checkbox" value="P" /> Paul McCartney</label></div>""")
+<input checked="checked" name="composers" type="checkbox" value="P" /> Paul McCartney</label></div>""")
 
     def test_checkbox_auto_id(self):
         # Regarding auto_id, CheckboxSelectMultiple is a special case. Each checkbox
@@ -949,7 +949,7 @@ Java</label></li>
         f = SongFormHidden(MultiValueDict({'name': ['Yesterday'], 'composers': ['J', 'P']}), auto_id=False)
         self.assertHTMLEqual(
             f.as_ul(),
-            """<li>Name: <input type="text" name="name" value="Yesterday" required />
+            """<li>Name: <input type="text" name="name" value="Yesterday" required="required" />
 <input type="hidden" name="composers" value="J" />
 <input type="hidden" name="composers" value="P" /></li>"""
         )
@@ -996,10 +996,10 @@ Java</label></li>
             f.as_table(),
             """<tr><th>&lt;em&gt;Special&lt;/em&gt; Field:</th><td>
 <ul class="errorlist"><li>Something&#39;s wrong with &#39;Nothing to escape&#39;</li></ul>
-<input type="text" name="special_name" value="Nothing to escape" required /></td></tr>
+<input type="text" name="special_name" value="Nothing to escape" required="required" /></td></tr>
 <tr><th><em>Special</em> Field:</th><td>
 <ul class="errorlist"><li>'<b>Nothing to escape</b>' is a safe string</li></ul>
-<input type="text" name="special_safe_name" value="Nothing to escape" required /></td></tr>"""
+<input type="text" name="special_safe_name" value="Nothing to escape" required="required" /></td></tr>"""
         )
         f = EscapingForm({
             'special_name': "Should escape < & > and <script>alert('xss')</script>",
@@ -1011,10 +1011,10 @@ Java</label></li>
 <ul class="errorlist"><li>Something&#39;s wrong with &#39;Should escape &lt; &amp; &gt; and
 &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;&#39;</li></ul>
 <input type="text" name="special_name"
-value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;" required /></td></tr>
+value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;" required="required" /></td></tr>
 <tr><th><em>Special</em> Field:</th><td>
 <ul class="errorlist"><li>'<b><i>Do not escape</i></b>' is a safe string</li></ul>
-<input type="text" name="special_safe_name" value="&lt;i&gt;Do not escape&lt;/i&gt;" required /></td></tr>"""
+<input type="text" name="special_safe_name" value="&lt;i&gt;Do not escape&lt;/i&gt;" required="required" /></td></tr>"""
         )
 
     def test_validating_multiple_fields(self):
@@ -1101,11 +1101,11 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             f.as_table(),
             """<tr><th>Username:</th><td>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="username" maxlength="10" required /></td></tr>
+<input type="text" name="username" maxlength="10" required="required" /></td></tr>
 <tr><th>Password1:</th><td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="password" name="password1" required /></td></tr>
+<input type="password" name="password1" required="required" /></td></tr>
 <tr><th>Password2:</th><td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="password" name="password2" required /></td></tr>"""
+<input type="password" name="password2" required="required" /></td></tr>"""
         )
         self.assertEqual(f.errors['username'], ['This field is required.'])
         self.assertEqual(f.errors['password1'], ['This field is required.'])
@@ -1117,17 +1117,17 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             f.as_table(),
             """<tr><td colspan="2">
 <ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul></td></tr>
-<tr><th>Username:</th><td><input type="text" name="username" value="adrian" maxlength="10" required /></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>"""
+<tr><th>Username:</th><td><input type="text" name="username" value="adrian" maxlength="10" required="required" /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required="required" /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required="required" /></td></tr>"""
         )
         self.assertHTMLEqual(
             f.as_ul(),
             """<li><ul class="errorlist nonfield">
 <li>Please make sure your passwords match.</li></ul></li>
-<li>Username: <input type="text" name="username" value="adrian" maxlength="10" required /></li>
-<li>Password1: <input type="password" name="password1" required /></li>
-<li>Password2: <input type="password" name="password2" required /></li>"""
+<li>Username: <input type="text" name="username" value="adrian" maxlength="10" required="required" /></li>
+<li>Password1: <input type="password" name="password1" required="required" /></li>
+<li>Password2: <input type="password" name="password2" required="required" /></li>"""
         )
 
         f = UserRegistration({'username': 'adrian', 'password1': 'foo', 'password2': 'foo'}, auto_id=False)
@@ -1251,9 +1251,9 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>First name:</th><td><input type="text" name="first_name" required /></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" required /></td></tr>
-<tr><th>Birthday:</th><td><input type="text" name="birthday" required /></td></tr>"""
+            """<tr><th>First name:</th><td><input type="text" name="first_name" required="required" /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" required="required" /></td></tr>
+<tr><th>Birthday:</th><td><input type="text" name="birthday" required="required" /></td></tr>"""
         )
 
         # Instances of a dynamic Form do not persist fields from one Form instance to
@@ -1269,15 +1269,15 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>"""
+            """<tr><th>Field1:</th><td><input type="text" name="field1" required="required" /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required="required" /></td></tr>"""
         )
         field_list = [('field3', CharField()), ('field4', CharField())]
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>"""
+            """<tr><th>Field3:</th><td><input type="text" name="field3" required="required" /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required="required" /></td></tr>"""
         )
 
         class MyForm(Form):
@@ -1294,19 +1294,19 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required /></td></tr>
-<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required /></td></tr>
-<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>"""
+            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required="required" /></td></tr>
+<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required="required" /></td></tr>
+<tr><th>Field1:</th><td><input type="text" name="field1" required="required" /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required="required" /></td></tr>"""
         )
         field_list = [('field3', CharField()), ('field4', CharField())]
         my_form = MyForm(field_list=field_list)
         self.assertHTMLEqual(
             my_form.as_table(),
-            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required /></td></tr>
-<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required /></td></tr>
-<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>"""
+            """<tr><th>Default field 1:</th><td><input type="text" name="default_field_1" required="required" /></td></tr>
+<tr><th>Default field 2:</th><td><input type="text" name="default_field_2" required="required" /></td></tr>
+<tr><th>Field3:</th><td><input type="text" name="field3" required="required" /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required="required" /></td></tr>"""
         )
 
         # Similarly, changes to field attributes do not persist from one Form instance
@@ -1404,21 +1404,21 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>First name:</th><td><input type="text" name="first_name" required /></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" required /></td></tr>
+            """<tr><th>First name:</th><td><input type="text" name="first_name" required="required" /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" required="required" /></td></tr>
 <tr><th>Birthday:</th>
-<td><input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></td></tr>"""
+<td><input type="text" name="birthday" required="required" /><input type="hidden" name="hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></li>"""
+            """<li>First name: <input type="text" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /><input type="hidden" name="hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
-            p.as_p(), """<p>First name: <input type="text" name="first_name" required /></p>
-<p>Last name: <input type="text" name="last_name" required /></p>
-<p>Birthday: <input type="text" name="birthday" required /><input type="hidden" name="hidden_text" /></p>"""
+            p.as_p(), """<p>First name: <input type="text" name="first_name" required="required" /></p>
+<p>Last name: <input type="text" name="last_name" required="required" /></p>
+<p>Birthday: <input type="text" name="birthday" required="required" /><input type="hidden" name="hidden_text" /></p>"""
         )
 
         # With auto_id set, a HiddenInput still gets an ID, but it doesn't get a label.
@@ -1426,31 +1426,31 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><th><label for="id_first_name">First name:</label></th><td>
-<input type="text" name="first_name" id="id_first_name" required /></td></tr>
+<input type="text" name="first_name" id="id_first_name" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input type="text" name="last_name" id="id_last_name" required /></td></tr>
+<input type="text" name="last_name" id="id_last_name" required="required" /></td></tr>
 <tr><th><label for="id_birthday">Birthday:</label></th><td>
-<input type="text" name="birthday" id="id_birthday" required />
+<input type="text" name="birthday" id="id_birthday" required="required" />
 <input type="hidden" name="hidden_text" id="id_hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></li>
+<input type="text" name="first_name" id="id_first_name" required="required" /></li>
 <li><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></li>
+<input type="text" name="last_name" id="id_last_name" required="required" /></li>
 <li><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required />
+<input type="text" name="birthday" id="id_birthday" required="required" />
 <input type="hidden" name="hidden_text" id="id_hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<p><label for="id_first_name">First name:</label>
-<input type="text" name="first_name" id="id_first_name" required /></p>
+<input type="text" name="first_name" id="id_first_name" required="required" /></p>
 <p><label for="id_last_name">Last name:</label>
-<input type="text" name="last_name" id="id_last_name" required /></p>
+<input type="text" name="last_name" id="id_last_name" required="required" /></p>
 <p><label for="id_birthday">Birthday:</label>
-<input type="text" name="birthday" id="id_birthday" required />
+<input type="text" name="birthday" id="id_birthday" required="required" />
 <input type="hidden" name="hidden_text" id="id_hidden_text" /></p>"""
         )
 
@@ -1463,25 +1463,25 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             p.as_table(),
             """<tr><td colspan="2">
 <ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul></td></tr>
-<tr><th>First name:</th><td><input type="text" name="first_name" value="John" required /></td></tr>
-<tr><th>Last name:</th><td><input type="text" name="last_name" value="Lennon" required /></td></tr>
-<tr><th>Birthday:</th><td><input type="text" name="birthday" value="1940-10-9" required />
+<tr><th>First name:</th><td><input type="text" name="first_name" value="John" required="required" /></td></tr>
+<tr><th>Last name:</th><td><input type="text" name="last_name" value="Lennon" required="required" /></td></tr>
+<tr><th>Birthday:</th><td><input type="text" name="birthday" value="1940-10-9" required="required" />
 <input type="hidden" name="hidden_text" /></td></tr>"""
         )
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul></li>
-<li>First name: <input type="text" name="first_name" value="John" required /></li>
-<li>Last name: <input type="text" name="last_name" value="Lennon" required /></li>
-<li>Birthday: <input type="text" name="birthday" value="1940-10-9" required />
+<li>First name: <input type="text" name="first_name" value="John" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" value="Lennon" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" value="1940-10-9" required="required" />
 <input type="hidden" name="hidden_text" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist nonfield"><li>(Hidden field hidden_text) This field is required.</li></ul>
-<p>First name: <input type="text" name="first_name" value="John" required /></p>
-<p>Last name: <input type="text" name="last_name" value="Lennon" required /></p>
-<p>Birthday: <input type="text" name="birthday" value="1940-10-9" required />
+<p>First name: <input type="text" name="first_name" value="John" required="required" /></p>
+<p>Last name: <input type="text" name="last_name" value="Lennon" required="required" /></p>
+<p>Birthday: <input type="text" name="birthday" value="1940-10-9" required="required" />
 <input type="hidden" name="hidden_text" /></p>"""
         )
 
@@ -1514,20 +1514,20 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             field14 = CharField()
 
         p = TestForm(auto_id=False)
-        self.assertHTMLEqual(p.as_table(), """<tr><th>Field1:</th><td><input type="text" name="field1" required /></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required /></td></tr>
-<tr><th>Field3:</th><td><input type="text" name="field3" required /></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required /></td></tr>
-<tr><th>Field5:</th><td><input type="text" name="field5" required /></td></tr>
-<tr><th>Field6:</th><td><input type="text" name="field6" required /></td></tr>
-<tr><th>Field7:</th><td><input type="text" name="field7" required /></td></tr>
-<tr><th>Field8:</th><td><input type="text" name="field8" required /></td></tr>
-<tr><th>Field9:</th><td><input type="text" name="field9" required /></td></tr>
-<tr><th>Field10:</th><td><input type="text" name="field10" required /></td></tr>
-<tr><th>Field11:</th><td><input type="text" name="field11" required /></td></tr>
-<tr><th>Field12:</th><td><input type="text" name="field12" required /></td></tr>
-<tr><th>Field13:</th><td><input type="text" name="field13" required /></td></tr>
-<tr><th>Field14:</th><td><input type="text" name="field14" required /></td></tr>""")
+        self.assertHTMLEqual(p.as_table(), """<tr><th>Field1:</th><td><input type="text" name="field1" required="required" /></td></tr>
+<tr><th>Field2:</th><td><input type="text" name="field2" required="required" /></td></tr>
+<tr><th>Field3:</th><td><input type="text" name="field3" required="required" /></td></tr>
+<tr><th>Field4:</th><td><input type="text" name="field4" required="required" /></td></tr>
+<tr><th>Field5:</th><td><input type="text" name="field5" required="required" /></td></tr>
+<tr><th>Field6:</th><td><input type="text" name="field6" required="required" /></td></tr>
+<tr><th>Field7:</th><td><input type="text" name="field7" required="required" /></td></tr>
+<tr><th>Field8:</th><td><input type="text" name="field8" required="required" /></td></tr>
+<tr><th>Field9:</th><td><input type="text" name="field9" required="required" /></td></tr>
+<tr><th>Field10:</th><td><input type="text" name="field10" required="required" /></td></tr>
+<tr><th>Field11:</th><td><input type="text" name="field11" required="required" /></td></tr>
+<tr><th>Field12:</th><td><input type="text" name="field12" required="required" /></td></tr>
+<tr><th>Field13:</th><td><input type="text" name="field13" required="required" /></td></tr>
+<tr><th>Field14:</th><td><input type="text" name="field14" required="required" /></td></tr>""")
 
     def test_explicit_field_order(self):
         class TestFormParent(Form):
@@ -1586,10 +1586,10 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" maxlength="10" required /></li>
-<li>Realname: <input type="text" name="realname" maxlength="10" required /></li>
-<li>Address: <input type="text" name="address" required /></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" maxlength="10" required="required" /></li>
+<li>Realname: <input type="text" name="realname" maxlength="10" required="required" /></li>
+<li>Address: <input type="text" name="address" required="required" /></li>"""
         )
 
         # If you specify a custom "attrs" that includes the "maxlength" attribute,
@@ -1602,8 +1602,8 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" maxlength="10" required /></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" maxlength="10" required="required" /></li>"""
         )
 
     def test_specifying_labels(self):
@@ -1618,9 +1618,9 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Your username: <input type="text" name="username" maxlength="10" required /></li>
-<li>Password1: <input type="password" name="password1" required /></li>
-<li>Contraseña (de nuevo): <input type="password" name="password2" required /></li>"""
+            """<li>Your username: <input type="text" name="username" maxlength="10" required="required" /></li>
+<li>Password1: <input type="password" name="password1" required="required" /></li>
+<li>Contraseña (de nuevo): <input type="password" name="password2" required="required" /></li>"""
         )
 
         # Labels for as_* methods will only end in a colon if they don't end in other
@@ -1634,19 +1634,19 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
 
         self.assertHTMLEqual(
             Questions(auto_id=False).as_p(),
-            """<p>The first question: <input type="text" name="q1" required /></p>
-<p>What is your name? <input type="text" name="q2" required /></p>
-<p>The answer to life is: <input type="text" name="q3" required /></p>
-<p>Answer this question! <input type="text" name="q4" required /></p>
-<p>The last question. Period. <input type="text" name="q5" required /></p>"""
+            """<p>The first question: <input type="text" name="q1" required="required" /></p>
+<p>What is your name? <input type="text" name="q2" required="required" /></p>
+<p>The answer to life is: <input type="text" name="q3" required="required" /></p>
+<p>Answer this question! <input type="text" name="q4" required="required" /></p>
+<p>The last question. Period. <input type="text" name="q5" required="required" /></p>"""
         )
         self.assertHTMLEqual(
             Questions().as_p(),
-            """<p><label for="id_q1">The first question:</label> <input type="text" name="q1" id="id_q1" required /></p>
-<p><label for="id_q2">What is your name?</label> <input type="text" name="q2" id="id_q2" required /></p>
-<p><label for="id_q3">The answer to life is:</label> <input type="text" name="q3" id="id_q3" required /></p>
-<p><label for="id_q4">Answer this question!</label> <input type="text" name="q4" id="id_q4" required /></p>
-<p><label for="id_q5">The last question. Period.</label> <input type="text" name="q5" id="id_q5" required /></p>"""
+            """<p><label for="id_q1">The first question:</label> <input type="text" name="q1" id="id_q1" required="required" /></p>
+<p><label for="id_q2">What is your name?</label> <input type="text" name="q2" id="id_q2" required="required" /></p>
+<p><label for="id_q3">The answer to life is:</label> <input type="text" name="q3" id="id_q3" required="required" /></p>
+<p><label for="id_q4">Answer this question!</label> <input type="text" name="q4" id="id_q4" required="required" /></p>
+<p><label for="id_q5">The last question. Period.</label> <input type="text" name="q5" id="id_q5" required="required" /></p>"""
         )
 
         # If a label is set to the empty string for a field, that field won't get a label.
@@ -1655,14 +1655,14 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             password = CharField(widget=PasswordInput)
 
         p = UserRegistration(auto_id=False)
-        self.assertHTMLEqual(p.as_ul(), """<li> <input type="text" name="username" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>""")
+        self.assertHTMLEqual(p.as_ul(), """<li> <input type="text" name="username" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>""")
         p = UserRegistration(auto_id='id_%s')
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li> <input id="id_username" type="text" name="username" maxlength="10" required /></li>
+            """<li> <input id="id_username" type="text" name="username" maxlength="10" required="required" /></li>
 <li><label for="id_password">Password:</label>
-<input type="password" name="password" id="id_password" required /></li>"""
+<input type="password" name="password" id="id_password" required="required" /></li>"""
         )
 
         # If label is None, Django will auto-create the label from the field name. This
@@ -1674,16 +1674,16 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>"""
+            """<li>Username: <input type="text" name="username" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration(auto_id='id_%s')
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_username">Username:</label>
-<input id="id_username" type="text" name="username" maxlength="10" required /></li>
+<input id="id_username" type="text" name="username" maxlength="10" required="required" /></li>
 <li><label for="id_password">Password:</label>
-<input type="password" name="password" id="id_password" required /></li>"""
+<input type="password" name="password" id="id_password" required="required" /></li>"""
         )
 
     def test_label_suffix(self):
@@ -1698,26 +1698,26 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
             answer = CharField(label='Secret answer', label_suffix=' =')
 
         f = FavoriteForm(auto_id=False)
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
-<li>Favorite animal: <input type="text" name="animal" required /></li>
-<li>Secret answer = <input type="text" name="answer" required /></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required="required" /></li>
+<li>Favorite animal: <input type="text" name="animal" required="required" /></li>
+<li>Secret answer = <input type="text" name="answer" required="required" /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='?')
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
-<li>Favorite animal? <input type="text" name="animal" required /></li>
-<li>Secret answer = <input type="text" name="answer" required /></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required="required" /></li>
+<li>Favorite animal? <input type="text" name="animal" required="required" /></li>
+<li>Secret answer = <input type="text" name="answer" required="required" /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='')
-        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required /></li>
-<li>Favorite animal <input type="text" name="animal" required /></li>
-<li>Secret answer = <input type="text" name="answer" required /></li>""")
+        self.assertHTMLEqual(f.as_ul(), """<li>Favorite color? <input type="text" name="color" required="required" /></li>
+<li>Favorite animal <input type="text" name="animal" required="required" /></li>
+<li>Secret answer = <input type="text" name="answer" required="required" /></li>""")
 
         f = FavoriteForm(auto_id=False, label_suffix='\u2192')
         self.assertHTMLEqual(
             f.as_ul(),
-            '<li>Favorite color? <input type="text" name="color" required /></li>\n'
-            '<li>Favorite animal\u2192 <input type="text" name="animal" required /></li>\n'
-            '<li>Secret answer = <input type="text" name="answer" required /></li>'
+            '<li>Favorite color? <input type="text" name="color" required="required" /></li>\n'
+            '<li>Favorite animal\u2192 <input type="text" name="animal" required="required" /></li>\n'
+            '<li>Secret answer = <input type="text" name="answer" required="required" /></li>'
         )
 
     def test_initial_data(self):
@@ -1734,8 +1734,8 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>"""
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>"""
         )
 
         # Here, we're submitting data, so the initial value will *not* be displayed.
@@ -1743,24 +1743,24 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#39;xss&#39;)&lt;/
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required /></li>
+Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration({'username': ''}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required /></li>
+Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration({'username': 'foo'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
 
         # An 'initial' value is *not* used as a fallback if data is not provided. In this
@@ -1784,14 +1784,14 @@ Password: <input type="password" name="password" required /></li>"""
         p = UserRegistration(initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>"""
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration(initial={'username': 'stephane'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>"""
+            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>"""
         )
 
         # The 'initial' parameter is meaningless if you pass data.
@@ -1799,23 +1799,23 @@ Password: <input type="password" name="password" required /></li>"""
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required /></li>
+Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration({'username': ''}, initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required /></li>
+Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
         p = UserRegistration({'username': 'foo'}, initial={'username': 'django'}, auto_id=False)
         self.assertHTMLEqual(
-            p.as_ul(), """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
+            p.as_ul(), """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>"""
+Password: <input type="password" name="password" required="required" /></li>"""
         )
 
         # A dynamic 'initial' value is *not* used as a fallback if data is not provided.
@@ -1834,8 +1834,8 @@ Password: <input type="password" name="password" required /></li>"""
         p = UserRegistration(initial={'username': 'babik'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="babik" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>"""
+            """<li>Username: <input type="text" name="username" value="babik" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>"""
         )
 
     def test_callable_initial_data(self):
@@ -1863,11 +1863,11 @@ Password: <input type="password" name="password" required /></li>"""
         p = UserRegistration(initial={'username': initial_django, 'options': initial_options}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>
-<li>Options: <select multiple name="options" required>
-<option value="f" selected>foo</option>
-<option value="b" selected>bar</option>
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>
+<li>Options: <select multiple="multiple" name="options" required="required">
+<option value="f" selected="selected">foo</option>
+<option value="b" selected="selected">bar</option>
 <option value="w">whiz</option>
 </select></li>"""
         )
@@ -1877,11 +1877,11 @@ Password: <input type="password" name="password" required /></li>"""
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-Username: <input type="text" name="username" maxlength="10" required /></li>
+Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>
+Password: <input type="password" name="password" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select multiple name="options" required>
+Options: <select multiple="multiple" name="options" required="required">
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -1891,11 +1891,11 @@ Options: <select multiple name="options" required>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><ul class="errorlist"><li>This field is required.</li></ul>
-            Username: <input type="text" name="username" maxlength="10" required /></li>
+            Username: <input type="text" name="username" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>
+Password: <input type="password" name="password" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Options: <select multiple name="options" required>
+Options: <select multiple="multiple" name="options" required="required">
 <option value="f">foo</option>
 <option value="b">bar</option>
 <option value="w">whiz</option>
@@ -1906,12 +1906,12 @@ Options: <select multiple name="options" required>
         )
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required /></li>
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required="required" /></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required /></li>
-<li>Options: <select multiple name="options" required>
-<option value="f" selected>foo</option>
-<option value="b" selected>bar</option>
+Password: <input type="password" name="password" required="required" /></li>
+<li>Options: <select multiple="multiple" name="options" required="required">
+<option value="f" selected="selected">foo</option>
+<option value="b" selected="selected">bar</option>
 <option value="w">whiz</option>
 </select></li>"""
         )
@@ -1936,22 +1936,22 @@ Password: <input type="password" name="password" required /></li>
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>
-<li>Options: <select multiple name="options" required>
+            """<li>Username: <input type="text" name="username" value="django" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>
+<li>Options: <select multiple="multiple" name="options" required="required">
 <option value="f">foo</option>
-<option value="b" selected>bar</option>
-<option value="w" selected>whiz</option>
+<option value="b" selected="selected">bar</option>
+<option value="w" selected="selected">whiz</option>
 </select></li>"""
         )
         p = UserRegistration(initial={'username': initial_stephane, 'options': initial_options}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required /></li>
-<li>Password: <input type="password" name="password" required /></li>
-<li>Options: <select multiple name="options" required>
-<option value="f" selected>foo</option>
-<option value="b" selected>bar</option>
+            """<li>Username: <input type="text" name="username" value="stephane" maxlength="10" required="required" /></li>
+<li>Password: <input type="password" name="password" required="required" /></li>
+<li>Options: <select multiple="multiple" name="options" required="required">
+<option value="f" selected="selected">foo</option>
+<option value="b" selected="selected">bar</option>
 <option value="w">whiz</option>
 </select></li>"""
         )
@@ -2112,23 +2112,23 @@ Password: <input type="password" name="password" required /></li>
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required />
+            """<li>Username: <input type="text" name="username" maxlength="10" required="required" />
 <span class="helptext">e.g., user@example.com</span></li>
-<li>Password: <input type="password" name="password" required />
+<li>Password: <input type="password" name="password" required="required" />
 <span class="helptext">Wählen Sie mit Bedacht.</span></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
-            """<p>Username: <input type="text" name="username" maxlength="10" required />
+            """<p>Username: <input type="text" name="username" maxlength="10" required="required" />
 <span class="helptext">e.g., user@example.com</span></p>
-<p>Password: <input type="password" name="password" required />
+<p>Password: <input type="password" name="password" required="required" />
 <span class="helptext">Wählen Sie mit Bedacht.</span></p>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
-            """<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required /><br />
+            """<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required="required" /><br />
 <span class="helptext">e.g., user@example.com</span></td></tr>
-<tr><th>Password:</th><td><input type="password" name="password" required /><br />
+<tr><th>Password:</th><td><input type="password" name="password" required="required" /><br />
 <span class="helptext">Wählen Sie mit Bedacht.</span></td></tr>"""
         )
 
@@ -2136,10 +2136,10 @@ Password: <input type="password" name="password" required /></li>
         p = UserRegistration({'username': 'foo'}, auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required />
+            """<li>Username: <input type="text" name="username" value="foo" maxlength="10" required="required" />
 <span class="helptext">e.g., user@example.com</span></li>
 <li><ul class="errorlist"><li>This field is required.</li></ul>
-Password: <input type="password" name="password" required />
+Password: <input type="password" name="password" required="required" />
 <span class="helptext">Wählen Sie mit Bedacht.</span></li>"""
         )
 
@@ -2153,9 +2153,9 @@ Password: <input type="password" name="password" required />
         p = UserRegistration(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>Username: <input type="text" name="username" maxlength="10" required />
+            """<li>Username: <input type="text" name="username" maxlength="10" required="required" />
 <span class="helptext">e.g., user@example.com</span></li>
-<li>Password: <input type="password" name="password" required />
+<li>Password: <input type="password" name="password" required="required" />
 <input type="hidden" name="next" value="/" /></li>"""
         )
 
@@ -2174,17 +2174,17 @@ Password: <input type="password" name="password" required />
         p = Person(auto_id=False)
         self.assertHTMLEqual(
             p.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /></li>"""
+            """<li>First name: <input type="text" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /></li>"""
         )
         m = Musician(auto_id=False)
         self.assertHTMLEqual(
             m.as_ul(),
-            """<li>First name: <input type="text" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /></li>
-<li>Instrument: <input type="text" name="instrument" required /></li>"""
+            """<li>First name: <input type="text" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /></li>
+<li>Instrument: <input type="text" name="instrument" required="required" /></li>"""
         )
 
         # Yes, you can subclass multiple forms. The fields are added in the order in
@@ -2201,11 +2201,11 @@ Password: <input type="password" name="password" required />
             haircut_type = CharField()
 
         b = Beatle(auto_id=False)
-        self.assertHTMLEqual(b.as_ul(), """<li>Instrument: <input type="text" name="instrument" required /></li>
-<li>First name: <input type="text" name="first_name" required /></li>
-<li>Last name: <input type="text" name="last_name" required /></li>
-<li>Birthday: <input type="text" name="birthday" required /></li>
-<li>Haircut type: <input type="text" name="haircut_type" required /></li>""")
+        self.assertHTMLEqual(b.as_ul(), """<li>Instrument: <input type="text" name="instrument" required="required" /></li>
+<li>First name: <input type="text" name="first_name" required="required" /></li>
+<li>Last name: <input type="text" name="last_name" required="required" /></li>
+<li>Birthday: <input type="text" name="birthday" required="required" /></li>
+<li>Haircut type: <input type="text" name="haircut_type" required="required" /></li>""")
 
     def test_forms_with_prefixes(self):
         # Sometimes it's necessary to have multiple forms display on the same HTML page,
@@ -2229,23 +2229,23 @@ Password: <input type="password" name="password" required />
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_person1-first_name">First name:</label>
-<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required /></li>
+<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required="required" /></li>
 <li><label for="id_person1-last_name">Last name:</label>
-<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required /></li>
+<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required="required" /></li>
 <li><label for="id_person1-birthday">Birthday:</label>
-<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required /></li>"""
+<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required="required" /></li>"""
         )
         self.assertHTMLEqual(
             str(p['first_name']),
-            '<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required />'
+            '<input type="text" name="person1-first_name" value="John" id="id_person1-first_name" required="required" />'
         )
         self.assertHTMLEqual(
             str(p['last_name']),
-            '<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required />'
+            '<input type="text" name="person1-last_name" value="Lennon" id="id_person1-last_name" required="required" />'
         )
         self.assertHTMLEqual(
             str(p['birthday']),
-            '<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required />'
+            '<input type="text" name="person1-birthday" value="1940-10-9" id="id_person1-birthday" required="required" />'
         )
         self.assertEqual(p.errors, {})
         self.assertTrue(p.is_valid())
@@ -2318,11 +2318,11 @@ Password: <input type="password" name="password" required />
         self.assertHTMLEqual(
             p.as_ul(),
             """<li><label for="id_foo-prefix-first_name">First name:</label>
-<input type="text" name="foo-prefix-first_name" id="id_foo-prefix-first_name" required /></li>
+<input type="text" name="foo-prefix-first_name" id="id_foo-prefix-first_name" required="required" /></li>
 <li><label for="id_foo-prefix-last_name">Last name:</label>
-<input type="text" name="foo-prefix-last_name" id="id_foo-prefix-last_name" required /></li>
+<input type="text" name="foo-prefix-last_name" id="id_foo-prefix-last_name" required="required" /></li>
 <li><label for="id_foo-prefix-birthday">Birthday:</label>
-<input type="text" name="foo-prefix-birthday" id="id_foo-prefix-birthday" required /></li>"""
+<input type="text" name="foo-prefix-birthday" id="id_foo-prefix-birthday" required="required" /></li>"""
         )
         data = {
             'foo-prefix-first_name': 'John',
@@ -2356,39 +2356,39 @@ Password: <input type="password" name="password" required />
 
         p = Person({'name': 'Joe'}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
-<option value="1" selected>Unknown</option>
+<option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select>""")
         p = Person({'name': 'Joe', 'is_cool': '1'}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
-<option value="1" selected>Unknown</option>
+<option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select>""")
         p = Person({'name': 'Joe', 'is_cool': '2'}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
 <option value="1">Unknown</option>
-<option value="2" selected>Yes</option>
+<option value="2" selected="selected">Yes</option>
 <option value="3">No</option>
 </select>""")
         p = Person({'name': 'Joe', 'is_cool': '3'}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
 <option value="1">Unknown</option>
 <option value="2">Yes</option>
-<option value="3" selected>No</option>
+<option value="3" selected="selected">No</option>
 </select>""")
         p = Person({'name': 'Joe', 'is_cool': True}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
 <option value="1">Unknown</option>
-<option value="2" selected>Yes</option>
+<option value="2" selected="selected">Yes</option>
 <option value="3">No</option>
 </select>""")
         p = Person({'name': 'Joe', 'is_cool': False}, auto_id=False)
         self.assertHTMLEqual(str(p['is_cool']), """<select name="is_cool">
 <option value="1">Unknown</option>
 <option value="2">Yes</option>
-<option value="3" selected>No</option>
+<option value="3" selected="selected">No</option>
 </select>""")
 
     def test_forms_with_file_fields(self):
@@ -2400,7 +2400,7 @@ Password: <input type="password" name="password" required />
         f = FileForm(auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required="required" /></td></tr>',
         )
 
         f = FileForm(data={}, files={}, auto_id=False)
@@ -2408,7 +2408,7 @@ Password: <input type="password" name="password" required />
             f.as_table(),
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>This field is required.</li></ul>'
-            '<input type="file" name="file1" required /></td></tr>'
+            '<input type="file" name="file1" required="required" /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': SimpleUploadedFile('name', b'')}, auto_id=False)
@@ -2416,7 +2416,7 @@ Password: <input type="password" name="password" required />
             f.as_table(),
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>The submitted file is empty.</li></ul>'
-            '<input type="file" name="file1" required /></td></tr>'
+            '<input type="file" name="file1" required="required" /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': 'something that is not a file'}, auto_id=False)
@@ -2425,13 +2425,13 @@ Password: <input type="password" name="password" required />
             '<tr><th>File1:</th><td>'
             '<ul class="errorlist"><li>No file was submitted. Check the '
             'encoding type on the form.</li></ul>'
-            '<input type="file" name="file1" required /></td></tr>'
+            '<input type="file" name="file1" required="required" /></td></tr>'
         )
 
         f = FileForm(data={}, files={'file1': SimpleUploadedFile('name', b'some content')}, auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required="required" /></td></tr>',
         )
         self.assertTrue(f.is_valid())
 
@@ -2439,7 +2439,7 @@ Password: <input type="password" name="password" required />
         f = FileForm(data={}, files={'file1': file1}, auto_id=False)
         self.assertHTMLEqual(
             f.as_table(),
-            '<tr><th>File1:</th><td><input type="file" name="file1" required /></td></tr>',
+            '<tr><th>File1:</th><td><input type="file" name="file1" required="required" /></td></tr>',
         )
 
         # A required file field with initial data should not contain the
@@ -2483,18 +2483,18 @@ Password: <input type="password" name="password" required />
 
             t = Template(\
                 '<form method="post">\n'
-                '<table>\n{{ form }}\n</table>\n<input type="submit" required />\n</form>'
+                '<table>\n{{ form }}\n</table>\n<input type="submit" required="required" />\n</form>'
             )
             return t.render(Context({'form': form}))
 
         # Case 1: GET (an empty form, with no errors).)
         self.assertHTMLEqual(my_function('GET', {}), """<form method="post">
 <table>
-<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required /></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>
+<tr><th>Username:</th><td><input type="text" name="username" maxlength="10" required="required" /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required="required" /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required="required" /></td></tr>
 </table>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>""")
         # Case 2: POST with erroneous data (a redisplayed form, with errors).)
         self.assertHTMLEqual(
@@ -2504,11 +2504,11 @@ Password: <input type="password" name="password" required />
 <tr><td colspan="2"><ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul></td></tr>
 <tr><th>Username:</th><td><ul class="errorlist">
 <li>Ensure this value has at most 10 characters (it has 23).</li></ul>
-<input type="text" name="username" value="this-is-a-long-username" maxlength="10" required /></td></tr>
-<tr><th>Password1:</th><td><input type="password" name="password1" required /></td></tr>
-<tr><th>Password2:</th><td><input type="password" name="password2" required /></td></tr>
+<input type="text" name="username" value="this-is-a-long-username" maxlength="10" required="required" /></td></tr>
+<tr><th>Password1:</th><td><input type="password" name="password1" required="required" /></td></tr>
+<tr><th>Password2:</th><td><input type="password" name="password2" required="required" /></td></tr>
 </table>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>"""
         )
         # Case 3: POST with valid data (the success message).)
@@ -2539,23 +2539,23 @@ Password: <input type="password" name="password" required />
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p><label>Your username: <input type="text" name="username" maxlength="10" required /></label></p>
-<p><label>Password: <input type="password" name="password1" required /></label></p>
-<p><label>Password (again): <input type="password" name="password2" required /></label></p>
-<input type="submit" required />
+<p><label>Your username: <input type="text" name="username" maxlength="10" required="required" /></label></p>
+<p><label>Password: <input type="password" name="password1" required="required" /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required="required" /></label></p>
+<input type="submit" required="required" />
 </form>""")
         self.assertHTMLEqual(
             t.render(Context({'form': UserRegistration({'username': 'django'}, auto_id=False)})),
             """<form>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required="required" /></label></p>
 <ul class="errorlist"><li>This field is required.</li></ul><p>
-<label>Password: <input type="password" name="password1" required /></label></p>
+<label>Password: <input type="password" name="password1" required="required" /></label></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
-<p><label>Password (again): <input type="password" name="password2" required /></label></p>
-<input type="submit" required />
+<p><label>Password (again): <input type="password" name="password2" required="required" /></label></p>
+<input type="submit" required="required" />
 </form>"""
         )
 
@@ -2567,13 +2567,13 @@ Password: <input type="password" name="password" required />
 <p><label>{{ form.username.label }}: {{ form.username }}</label></p>
 <p><label>{{ form.password1.label }}: {{ form.password1 }}</label></p>
 <p><label>{{ form.password2.label }}: {{ form.password2 }}</label></p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p><label>Username: <input type="text" name="username" maxlength="10" required /></label></p>
-<p><label>Password1: <input type="password" name="password1" required /></label></p>
-<p><label>Password2: <input type="password" name="password2" required /></label></p>
-<input type="submit" required />
+<p><label>Username: <input type="text" name="username" maxlength="10" required="required" /></label></p>
+<p><label>Password1: <input type="password" name="password1" required="required" /></label></p>
+<p><label>Password2: <input type="password" name="password2" required="required" /></label></p>
+<input type="submit" required="required" />
 </form>""")
 
         # User form.[field].label_tag to output a field's label with a <label> tag
@@ -2584,22 +2584,22 @@ Password: <input type="password" name="password" required />
 <p>{{ form.username.label_tag }} {{ form.username }}</p>
 <p>{{ form.password1.label_tag }} {{ form.password1 }}</p>
 <p>{{ form.password2.label_tag }} {{ form.password2 }}</p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id=False)})), """<form>
-<p>Username: <input type="text" name="username" maxlength="10" required /></p>
-<p>Password1: <input type="password" name="password1" required /></p>
-<p>Password2: <input type="password" name="password2" required /></p>
-<input type="submit" required />
+<p>Username: <input type="text" name="username" maxlength="10" required="required" /></p>
+<p>Password1: <input type="password" name="password1" required="required" /></p>
+<p>Password2: <input type="password" name="password2" required="required" /></p>
+<input type="submit" required="required" />
 </form>""")
         self.assertHTMLEqual(t.render(Context({'form': UserRegistration(auto_id='id_%s')})), """<form>
 <p><label for="id_username">Username:</label>
-<input id="id_username" type="text" name="username" maxlength="10" required /></p>
+<input id="id_username" type="text" name="username" maxlength="10" required="required" /></p>
 <p><label for="id_password1">Password1:</label>
-<input type="password" name="password1" id="id_password1" required /></p>
+<input type="password" name="password1" id="id_password1" required="required" /></p>
 <p><label for="id_password2">Password2:</label>
-<input type="password" name="password2" id="id_password2" required /></p>
-<input type="submit" required />
+<input type="password" name="password2" id="id_password2" required="required" /></p>
+<input type="submit" required="required" />
 </form>""")
 
         # User form.[field].help_text to output a field's help text. If the given field
@@ -2608,16 +2608,16 @@ Password: <input type="password" name="password" required />
 <p>{{ form.username.label_tag }} {{ form.username }}<br />{{ form.username.help_text }}</p>
 <p>{{ form.password1.label_tag }} {{ form.password1 }}</p>
 <p>{{ form.password2.label_tag }} {{ form.password2 }}</p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({'form': UserRegistration(auto_id=False)})),
             """<form>
-<p>Username: <input type="text" name="username" maxlength="10" required /><br />
+<p>Username: <input type="text" name="username" maxlength="10" required="required" /><br />
 Good luck picking a username that doesn&#39;t already exist.</p>
-<p>Password1: <input type="password" name="password1" required /></p>
-<p>Password2: <input type="password" name="password2" required /></p>
-<input type="submit" required />
+<p>Password1: <input type="password" name="password1" required="required" /></p>
+<p>Password2: <input type="password" name="password2" required="required" /></p>
+<input type="submit" required="required" />
 </form>"""
         )
         self.assertEqual(
@@ -2633,17 +2633,17 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({
                 'form': UserRegistration({'username': 'django', 'password1': 'foo', 'password2': 'bar'}, auto_id=False)
             })),
             """<form>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
-<p><label>Password: <input type="password" name="password1" required /></label></p>
-<p><label>Password (again): <input type="password" name="password2" required /></label></p>
-<input type="submit" required />
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required="required" /></label></p>
+<p><label>Password: <input type="password" name="password1" required="required" /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required="required" /></label></p>
+<input type="submit" required="required" />
 </form>"""
         )
         t = Template('''<form>
@@ -2651,7 +2651,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 {{ form.username.errors.as_ul }}<p><label>Your username: {{ form.username }}</label></p>
 {{ form.password1.errors.as_ul }}<p><label>Password: {{ form.password1 }}</label></p>
 {{ form.password2.errors.as_ul }}<p><label>Password (again): {{ form.password2 }}</label></p>
-<input type="submit" required />
+<input type="submit" required="required" />
 </form>''')
         self.assertHTMLEqual(
             t.render(Context({
@@ -2659,10 +2659,10 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             })),
             """<form>
 <ul class="errorlist nonfield"><li>Please make sure your passwords match.</li></ul>
-<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required /></label></p>
-<p><label>Password: <input type="password" name="password1" required /></label></p>
-<p><label>Password (again): <input type="password" name="password2" required /></label></p>
-<input type="submit" required />
+<p><label>Your username: <input type="text" name="username" value="django" maxlength="10" required="required" /></label></p>
+<p><label>Password: <input type="password" name="password1" required="required" /></label></p>
+<p><label>Password (again): <input type="password" name="password2" required="required" /></label></p>
+<input type="submit" required="required" />
 </form>"""
         )
 
@@ -2737,7 +2737,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             MyForm().as_table(),
             '<tr><th><label for="id_field1">Field1:</label></th>'
-            '<td><input id="id_field1" type="text" name="field1" maxlength="50" required />'
+            '<td><input id="id_field1" type="text" name="field1" maxlength="50" required="required" />'
             '<input type="hidden" name="initial-field1" id="initial-id_field1" /></td></tr>'
         )
 
@@ -2755,33 +2755,33 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             p.as_ul(),
             """<li class="required error"><ul class="errorlist"><li>This field is required.</li></ul>
-<label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" required /></li>
+<label class="required" for="id_name">Name:</label> <input type="text" name="name" id="id_name" required="required" /></li>
 <li class="required"><label class="required" for="id_is_cool">Is cool:</label>
 <select name="is_cool" id="id_is_cool">
-<option value="1" selected>Unknown</option>
+<option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select></li>
 <li><label for="id_email">Email:</label> <input type="email" name="email" id="id_email" /></li>
 <li class="required error"><ul class="errorlist"><li>This field is required.</li></ul>
-<label class="required" for="id_age">Age:</label> <input type="number" name="age" id="id_age" required /></li>"""
+<label class="required" for="id_age">Age:</label> <input type="number" name="age" id="id_age" required="required" /></li>"""
         )
 
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist"><li>This field is required.</li></ul>
 <p class="required error"><label class="required" for="id_name">Name:</label>
-<input type="text" name="name" id="id_name" required /></p>
+<input type="text" name="name" id="id_name" required="required" /></p>
 <p class="required"><label class="required" for="id_is_cool">Is cool:</label>
 <select name="is_cool" id="id_is_cool">
-<option value="1" selected>Unknown</option>
+<option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select></p>
 <p><label for="id_email">Email:</label> <input type="email" name="email" id="id_email" /></p>
 <ul class="errorlist"><li>This field is required.</li></ul>
 <p class="required error"><label class="required" for="id_age">Age:</label>
-<input type="number" name="age" id="id_age" required /></p>"""
+<input type="number" name="age" id="id_age" required="required" /></p>"""
         )
 
         self.assertHTMLEqual(
@@ -2789,10 +2789,10 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<tr class="required error">
 <th><label class="required" for="id_name">Name:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="text" name="name" id="id_name" required /></td></tr>
+<input type="text" name="name" id="id_name" required="required" /></td></tr>
 <tr class="required"><th><label class="required" for="id_is_cool">Is cool:</label></th>
 <td><select name="is_cool" id="id_is_cool">
-<option value="1" selected>Unknown</option>
+<option value="1" selected="selected">Unknown</option>
 <option value="2">Yes</option>
 <option value="3">No</option>
 </select></td></tr>
@@ -2800,7 +2800,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
 <input type="email" name="email" id="id_email" /></td></tr>
 <tr class="required error"><th><label class="required" for="id_age">Age:</label></th>
 <td><ul class="errorlist"><li>This field is required.</li></ul>
-<input type="number" name="age" id="id_age" required /></td></tr>"""
+<input type="number" name="age" id="id_age" required="required" /></td></tr>"""
         )
 
     def test_label_has_required_css_class(self):
@@ -3163,7 +3163,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><input id="id_custom" name="custom" type="text" required /> custom'
+            '<p><input id="id_custom" name="custom" type="text" required="required" /> custom'
             '<input id="id_hidden1" name="hidden1" type="hidden" />'
             '<input id="id_hidden2" name="hidden2" type="hidden" /></p>'
         )
@@ -3190,7 +3190,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = SomeForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><input id="id_custom" name="custom" type="text" required /> custom</p>\n'
+            '<p><input id="id_custom" name="custom" type="text" required="required" /> custom</p>\n'
             '<input id="id_hidden1" name="hidden1" type="hidden" />'
             '<input id="id_hidden2" name="hidden2" type="hidden" /><hr /><hr />'
         )
@@ -3322,14 +3322,14 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<li><ul class="errorlist nonfield">
 <li>(Hidden field last_name) This field is required.</li></ul></li><li>
 <label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" />
 <input id="id_last_name" name="last_name" type="hidden" /></li>"""
         )
         self.assertHTMLEqual(
             p.as_p(),
             """<ul class="errorlist nonfield"><li>(Hidden field last_name) This field is required.</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" />
 <input id="id_last_name" name="last_name" type="hidden" /></p>"""
         )
         self.assertHTMLEqual(
@@ -3337,7 +3337,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<tr><td colspan="2"><ul class="errorlist nonfield">
 <li>(Hidden field last_name) This field is required.</li></ul></td></tr>
 <tr><th><label for="id_first_name">First name:</label></th><td>
-<input id="id_first_name" name="first_name" type="text" value="John" required />
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" />
 <input id="id_last_name" name="last_name" type="hidden" /></td></tr>"""
         )
 
@@ -3359,9 +3359,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             """<li>
 <ul class="errorlist nonfield"><li>Generic validation error</li></ul></li>
 <li><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required /></li>
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" /></li>
 <li><label for="id_last_name">Last name:</label>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></li>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required="required" /></li>"""
         )
         self.assertHTMLEqual(
             p.non_field_errors().as_text(),
@@ -3371,17 +3371,17 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             p.as_p(),
             """<ul class="errorlist nonfield"><li>Generic validation error</li></ul>
 <p><label for="id_first_name">First name:</label>
-<input id="id_first_name" name="first_name" type="text" value="John" required /></p>
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" /></p>
 <p><label for="id_last_name">Last name:</label>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></p>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required="required" /></p>"""
         )
         self.assertHTMLEqual(
             p.as_table(),
             """<tr><td colspan="2"><ul class="errorlist nonfield"><li>Generic validation error</li></ul></td></tr>
 <tr><th><label for="id_first_name">First name:</label></th><td>
-<input id="id_first_name" name="first_name" type="text" value="John" required /></td></tr>
+<input id="id_first_name" name="first_name" type="text" value="John" required="required" /></td></tr>
 <tr><th><label for="id_last_name">Last name:</label></th><td>
-<input id="id_last_name" name="last_name" type="text" value="Lennon" required /></td></tr>"""
+<input id="id_last_name" name="last_name" type="text" value="Lennon" required="required" /></td></tr>"""
         )
 
     def test_errorlist_override(self):
@@ -3404,9 +3404,9 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         f = CommentForm(data, auto_id=False, error_class=DivErrorList)
         self.assertHTMLEqual(f.as_p(), """<p>Name: <input type="text" name="name" maxlength="50" /></p>
 <div class="errorlist"><div class="error">Enter a valid email address.</div></div>
-<p>Email: <input type="email" name="email" value="invalid" required /></p>
+<p>Email: <input type="email" name="email" value="invalid" required="required" /></p>
 <div class="errorlist"><div class="error">This field is required.</div></div>
-<p>Comment: <input type="text" name="comment" required /></p>""")
+<p>Comment: <input type="text" name="comment" required="required" /></p>""")
 
     def test_error_escaping(self):
         class TestForm(Form):
@@ -3425,7 +3425,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
             '<li><ul class="errorlist nonfield"><li>(Hidden field hidden) Foo &amp; &quot;bar&quot;!</li></ul></li>'
             '<li><ul class="errorlist"><li>Foo &amp; &quot;bar&quot;!</li></ul>'
             '<label for="id_visible">Visible:</label> '
-            '<input type="text" name="visible" value="b" id="id_visible" required />'
+            '<input type="text" name="visible" value="b" id="id_visible" required="required" />'
             '<input type="hidden" name="hidden" value="a" id="id_hidden" /></li>'
         )
 
@@ -3539,7 +3539,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         form = MyForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" required /></p>'
+            '<p><label for="id_f1">F1:</label> <input id="id_f1" maxlength="30" name="f1" type="text" required="required" /></p>'
             '<p><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></p>'
             '<p><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10" required>'
             '</textarea></p>'
@@ -3551,7 +3551,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             form.as_ul(),
             '<li><label for="id_f1">F1:</label> '
-            '<input id="id_f1" maxlength="30" name="f1" type="text" required /></li>'
+            '<input id="id_f1" maxlength="30" name="f1" type="text" required="required" /></li>'
             '<li><label for="id_f2">F2:</label> <input id="id_f2" maxlength="30" name="f2" type="text" /></li>'
             '<li><label for="id_f3">F3:</label> <textarea cols="40" id="id_f3" name="f3" rows="10" required>'
             '</textarea></li>'
@@ -3563,7 +3563,7 @@ Good luck picking a username that doesn&#39;t already exist.</p>
         self.assertHTMLEqual(
             form.as_table(),
             '<tr><th><label for="id_f1">F1:</label></th>'
-            '<td><input id="id_f1" maxlength="30" name="f1" type="text" required /></td></tr>'
+            '<td><input id="id_f1" maxlength="30" name="f1" type="text" required="required" /></td></tr>'
             '<tr><th><label for="id_f2">F2:</label></th>'
             '<td><input id="id_f2" maxlength="30" name="f2" type="text" /></td></tr>'
             '<tr><th><label for="id_f3">F3:</label></th>'

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -87,12 +87,12 @@ class FormsFormsetTestCase(SimpleTestCase):
         formset = self.make_choiceformset()
         self.assertHTMLEqual(
             str(formset),
-            """<input type="hidden" name="choices-TOTAL_FORMS" value="1">
-<input type="hidden" name="choices-INITIAL_FORMS" value="0">
-<input type="hidden" name="choices-MIN_NUM_FORMS" value="0">
-<input type="hidden" name="choices-MAX_NUM_FORMS" value="1000">
-<tr><th>Choice:</th><td><input type="text" name="choices-0-choice"></td></tr>
-<tr><th>Votes:</th><td><input type="number" name="choices-0-votes"></td></tr>"""
+            """<input type="hidden" name="choices-TOTAL_FORMS" value="1" />
+<input type="hidden" name="choices-INITIAL_FORMS" value="0" />
+<input type="hidden" name="choices-MIN_NUM_FORMS" value="0" />
+<input type="hidden" name="choices-MAX_NUM_FORMS" value="1000" />
+<tr><th>Choice:</th><td><input type="text" name="choices-0-choice" /></td></tr>
+<tr><th>Votes:</th><td><input type="number" name="choices-0-votes" /></td></tr>"""
         )
         # FormSet are treated similarly to Forms. FormSet has an is_valid()
         # method, and a cleaned_data or errors attribute depending on whether
@@ -199,10 +199,10 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>
-<li>Choice: <input type="text" name="choices-1-choice"></li>
-<li>Votes: <input type="number" name="choices-1-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" /></li>"""
         )
 
     def test_blank_form_unfilled(self):
@@ -244,12 +244,12 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice"></li>
-<li>Votes: <input type="number" name="choices-0-votes"></li>
-<li>Choice: <input type="text" name="choices-1-choice"></li>
-<li>Votes: <input type="number" name="choices-1-votes"></li>
-<li>Choice: <input type="text" name="choices-2-choice"></li>
-<li>Votes: <input type="number" name="choices-2-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" /></li>"""
         )
         # Since every form was displayed as blank, they are also accepted as
         # blank. This may seem a little strange, but min_num is used to require
@@ -285,10 +285,10 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertTrue(formset.forms[1].empty_permitted)
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice"></li>
-<li>Votes: <input type="number" name="choices-0-votes"></li>
-<li>Choice: <input type="text" name="choices-1-choice"></li>
-<li>Votes: <input type="number" name="choices-1-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" /></li>"""
         )
 
     def test_min_num_displaying_more_than_one_blank_form_with_zero_extra(self):
@@ -300,12 +300,12 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice"></li>
-<li>Votes: <input type="number" name="choices-0-votes"></li>
-<li>Choice: <input type="text" name="choices-1-choice"></li>
-<li>Votes: <input type="number" name="choices-1-votes"></li>
-<li>Choice: <input type="text" name="choices-2-choice"></li>
-<li>Votes: <input type="number" name="choices-2-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" /></li>"""
         )
 
     def test_single_form_completed(self):
@@ -439,21 +439,21 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>
-<li>Choice: <input type="text" name="choices-1-choice"></li>
-<li>Votes: <input type="number" name="choices-1-votes"></li>
-<li>Choice: <input type="text" name="choices-2-choice"></li>
-<li>Votes: <input type="number" name="choices-2-votes"></li>
-<li>Choice: <input type="text" name="choices-3-choice"></li>
-<li>Votes: <input type="number" name="choices-3-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" /></li>
+<li>Choice: <input type="text" name="choices-3-choice" /></li>
+<li>Votes: <input type="number" name="choices-3-votes" /></li>"""
         )
         # Retrieving an empty form works. Tt shows up in the form list.
         self.assertTrue(formset.empty_form.empty_permitted)
         self.assertHTMLEqual(
             formset.empty_form.as_ul(),
-            """<li>Choice: <input type="text" name="choices-__prefix__-choice"></li>
-<li>Votes: <input type="number" name="choices-__prefix__-votes"></li>"""
+            """<li>Choice: <input type="text" name="choices-__prefix__-choice" /></li>
+<li>Votes: <input type="number" name="choices-__prefix__-votes" /></li>"""
         )
 
     def test_formset_with_deletion(self):
@@ -470,15 +470,15 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>
-<li>Delete: <input type="checkbox" name="choices-0-DELETE"></li>
-<li>Choice: <input type="text" name="choices-1-choice" value="Fergie"></li>
-<li>Votes: <input type="number" name="choices-1-votes" value="900"></li>
-<li>Delete: <input type="checkbox" name="choices-1-DELETE"></li>
-<li>Choice: <input type="text" name="choices-2-choice"></li>
-<li>Votes: <input type="number" name="choices-2-votes"></li>
-<li>Delete: <input type="checkbox" name="choices-2-DELETE"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>
+<li>Delete: <input type="checkbox" name="choices-0-DELETE" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" value="Fergie" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" value="900" /></li>
+<li>Delete: <input type="checkbox" name="choices-1-DELETE" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" /></li>
+<li>Delete: <input type="checkbox" name="choices-2-DELETE" /></li>"""
         )
         # To delete something, set that form's special delete field to 'on'.
         # Let's go ahead and delete Fergie.
@@ -580,15 +580,15 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>
-<li>Order: <input type="number" name="choices-0-ORDER" value="1"></li>
-<li>Choice: <input type="text" name="choices-1-choice" value="Fergie"></li>
-<li>Votes: <input type="number" name="choices-1-votes" value="900"></li>
-<li>Order: <input type="number" name="choices-1-ORDER" value="2"></li>
-<li>Choice: <input type="text" name="choices-2-choice"></li>
-<li>Votes: <input type="number" name="choices-2-votes"></li>
-<li>Order: <input type="number" name="choices-2-ORDER"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>
+<li>Order: <input type="number" name="choices-0-ORDER" value="1" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" value="Fergie" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" value="900" /></li>
+<li>Order: <input type="number" name="choices-1-ORDER" value="2" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" /></li>
+<li>Order: <input type="number" name="choices-2-ORDER" /></li>"""
         )
         data = {
             'choices-TOTAL_FORMS': '3',  # the number of forms rendered
@@ -684,22 +684,22 @@ class FormsFormsetTestCase(SimpleTestCase):
             form_output.append(form.as_ul())
         self.assertHTMLEqual(
             '\n'.join(form_output),
-            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>
-<li>Order: <input type="number" name="choices-0-ORDER" value="1"></li>
-<li>Delete: <input type="checkbox" name="choices-0-DELETE"></li>
-<li>Choice: <input type="text" name="choices-1-choice" value="Fergie"></li>
-<li>Votes: <input type="number" name="choices-1-votes" value="900"></li>
-<li>Order: <input type="number" name="choices-1-ORDER" value="2"></li>
-<li>Delete: <input type="checkbox" name="choices-1-DELETE"></li>
-<li>Choice: <input type="text" name="choices-2-choice" value="The Decemberists"></li>
-<li>Votes: <input type="number" name="choices-2-votes" value="500"></li>
-<li>Order: <input type="number" name="choices-2-ORDER" value="3"></li>
-<li>Delete: <input type="checkbox" name="choices-2-DELETE"></li>
-<li>Choice: <input type="text" name="choices-3-choice"></li>
-<li>Votes: <input type="number" name="choices-3-votes"></li>
-<li>Order: <input type="number" name="choices-3-ORDER"></li>
-<li>Delete: <input type="checkbox" name="choices-3-DELETE"></li>"""
+            """<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>
+<li>Order: <input type="number" name="choices-0-ORDER" value="1" /></li>
+<li>Delete: <input type="checkbox" name="choices-0-DELETE" /></li>
+<li>Choice: <input type="text" name="choices-1-choice" value="Fergie" /></li>
+<li>Votes: <input type="number" name="choices-1-votes" value="900" /></li>
+<li>Order: <input type="number" name="choices-1-ORDER" value="2" /></li>
+<li>Delete: <input type="checkbox" name="choices-1-DELETE" /></li>
+<li>Choice: <input type="text" name="choices-2-choice" value="The Decemberists" /></li>
+<li>Votes: <input type="number" name="choices-2-votes" value="500" /></li>
+<li>Order: <input type="number" name="choices-2-ORDER" value="3" /></li>
+<li>Delete: <input type="checkbox" name="choices-2-DELETE" /></li>
+<li>Choice: <input type="text" name="choices-3-choice" /></li>
+<li>Votes: <input type="number" name="choices-3-votes" /></li>
+<li>Order: <input type="number" name="choices-3-ORDER" /></li>
+<li>Delete: <input type="checkbox" name="choices-3-DELETE" /></li>"""
         )
         # Let's delete Fergie, and put The Decemberists ahead of Calexico.
         data = {
@@ -803,11 +803,11 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input type="text" name="form-0-name" id="id_form-0-name"></td></tr>
+<td><input type="text" name="form-0-name" id="id_form-0-name" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input type="text" name="form-1-name" id="id_form-1-name"></td></tr>
+<td><input type="text" name="form-1-name" id="id_form-1-name" /></td></tr>
 <tr><th><label for="id_form-2-name">Name:</label></th>
-<td><input type="text" name="form-2-name" id="id_form-2-name"></td></tr>"""
+<td><input type="text" name="form-2-name" id="id_form-2-name" /></td></tr>"""
         )
         # If max_num is 0 then no form is rendered at all.
         LimitedFavoriteDrinkFormSet = formset_factory(FavoriteDrinkForm, extra=3, max_num=0)
@@ -826,9 +826,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th><td>
-<input type="text" name="form-0-name" id="id_form-0-name"></td></tr>
+<input type="text" name="form-0-name" id="id_form-0-name" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input type="text" name="form-1-name" id="id_form-1-name"></td></tr>"""
+<td><input type="text" name="form-1-name" id="id_form-1-name" /></td></tr>"""
         )
 
     def test_limiting_extra_lest_than_max_num(self):
@@ -841,7 +841,7 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input type="text" name="form-0-name" id="id_form-0-name"></td></tr>"""
+<td><input type="text" name="form-0-name" id="id_form-0-name" /></td></tr>"""
         )
 
     def test_max_num_with_initial_data(self):
@@ -860,9 +860,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input type="text" name="form-0-name" value="Fernet and Coke" id="id_form-0-name"></td></tr>
+<td><input type="text" name="form-0-name" value="Fernet and Coke" id="id_form-0-name" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input type="text" name="form-1-name" id="id_form-1-name"></td></tr>"""
+<td><input type="text" name="form-1-name" id="id_form-1-name" /></td></tr>"""
         )
 
     def test_max_num_zero(self):
@@ -891,9 +891,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input id="id_form-0-name" name="form-0-name" type="text" value="Fernet and Coke"></td></tr>
+<td><input id="id_form-0-name" name="form-0-name" type="text" value="Fernet and Coke" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input id="id_form-1-name" name="form-1-name" type="text" value="Bloody Mary"></td></tr>"""
+<td><input id="id_form-1-name" name="form-1-name" type="text" value="Bloody Mary" /></td></tr>"""
         )
 
     def test_more_initial_than_max_num(self):
@@ -914,11 +914,11 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input id="id_form-0-name" name="form-0-name" type="text" value="Gin Tonic"></td></tr>
+<td><input id="id_form-0-name" name="form-0-name" type="text" value="Gin Tonic" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input id="id_form-1-name" name="form-1-name" type="text" value="Bloody Mary"></td></tr>
+<td><input id="id_form-1-name" name="form-1-name" type="text" value="Bloody Mary" /></td></tr>
 <tr><th><label for="id_form-2-name">Name:</label></th>
-<td><input id="id_form-2-name" name="form-2-name" type="text" value="Jack and Coke"></td></tr>"""
+<td><input id="id_form-2-name" name="form-2-name" type="text" value="Jack and Coke" /></td></tr>"""
         )
 
     def test_more_initial_form_result_in_one(self):
@@ -937,9 +937,9 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertHTMLEqual(
             '\n'.join(form_output),
             """<tr><th><label for="id_form-0-name">Name:</label></th>
-<td><input type="text" name="form-0-name" value="Gin Tonic" id="id_form-0-name"></td></tr>
+<td><input type="text" name="form-0-name" value="Gin Tonic" id="id_form-0-name" /></td></tr>
 <tr><th><label for="id_form-1-name">Name:</label></th>
-<td><input type="text" name="form-1-name" id="id_form-1-name"></td></tr>"""
+<td><input type="text" name="form-1-name" id="id_form-1-name" /></td></tr>"""
         )
 
     def test_management_form_prefix(self):
@@ -1195,36 +1195,36 @@ class FormsetAsFooTests(SimpleTestCase):
         formset = ChoiceFormSet(data, auto_id=False, prefix='choices')
         self.assertHTMLEqual(
             formset.as_table(),
-            """<input type="hidden" name="choices-TOTAL_FORMS" value="1">
-<input type="hidden" name="choices-INITIAL_FORMS" value="0">
-<input type="hidden" name="choices-MIN_NUM_FORMS" value="0">
-<input type="hidden" name="choices-MAX_NUM_FORMS" value="0">
-<tr><th>Choice:</th><td><input type="text" name="choices-0-choice" value="Calexico"></td></tr>
-<tr><th>Votes:</th><td><input type="number" name="choices-0-votes" value="100"></td></tr>"""
+            """<input type="hidden" name="choices-TOTAL_FORMS" value="1" />
+<input type="hidden" name="choices-INITIAL_FORMS" value="0" />
+<input type="hidden" name="choices-MIN_NUM_FORMS" value="0" />
+<input type="hidden" name="choices-MAX_NUM_FORMS" value="0" />
+<tr><th>Choice:</th><td><input type="text" name="choices-0-choice" value="Calexico" /></td></tr>
+<tr><th>Votes:</th><td><input type="number" name="choices-0-votes" value="100" /></td></tr>"""
         )
 
     def test_as_p(self):
         formset = ChoiceFormSet(data, auto_id=False, prefix='choices')
         self.assertHTMLEqual(
             formset.as_p(),
-            """<input type="hidden" name="choices-TOTAL_FORMS" value="1">
-<input type="hidden" name="choices-INITIAL_FORMS" value="0">
-<input type="hidden" name="choices-MIN_NUM_FORMS" value="0">
-<input type="hidden" name="choices-MAX_NUM_FORMS" value="0">
-<p>Choice: <input type="text" name="choices-0-choice" value="Calexico"></p>
-<p>Votes: <input type="number" name="choices-0-votes" value="100"></p>"""
+            """<input type="hidden" name="choices-TOTAL_FORMS" value="1" />
+<input type="hidden" name="choices-INITIAL_FORMS" value="0" />
+<input type="hidden" name="choices-MIN_NUM_FORMS" value="0" />
+<input type="hidden" name="choices-MAX_NUM_FORMS" value="0" />
+<p>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></p>
+<p>Votes: <input type="number" name="choices-0-votes" value="100" /></p>"""
         )
 
     def test_as_ul(self):
         formset = ChoiceFormSet(data, auto_id=False, prefix='choices')
         self.assertHTMLEqual(
             formset.as_ul(),
-            """<input type="hidden" name="choices-TOTAL_FORMS" value="1">
-<input type="hidden" name="choices-INITIAL_FORMS" value="0">
-<input type="hidden" name="choices-MIN_NUM_FORMS" value="0">
-<input type="hidden" name="choices-MAX_NUM_FORMS" value="0">
-<li>Choice: <input type="text" name="choices-0-choice" value="Calexico"></li>
-<li>Votes: <input type="number" name="choices-0-votes" value="100"></li>"""
+            """<input type="hidden" name="choices-TOTAL_FORMS" value="1" />
+<input type="hidden" name="choices-INITIAL_FORMS" value="0" />
+<input type="hidden" name="choices-MIN_NUM_FORMS" value="0" />
+<input type="hidden" name="choices-MAX_NUM_FORMS" value="0" />
+<li>Choice: <input type="text" name="choices-0-choice" value="Calexico" /></li>
+<li>Votes: <input type="number" name="choices-0-votes" value="100" /></li>"""
         )
 
 

--- a/tests/forms_tests/tests/test_i18n.py
+++ b/tests/forms_tests/tests/test_i18n.py
@@ -15,7 +15,7 @@ class FormsI18nTests(SimpleTestCase):
         self.assertHTMLEqual(
             f.as_p(),
             '<p><label for="id_username">username:</label>'
-            '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
+            '<input id="id_username" type="text" name="username" maxlength="10" required="required"  /></p>'
         )
 
         # Translations are done at rendering time, so multi-lingual apps can define forms)
@@ -23,13 +23,13 @@ class FormsI18nTests(SimpleTestCase):
             self.assertHTMLEqual(
                 f.as_p(),
                 '<p><label for="id_username">Benutzername:</label>'
-                '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
+                '<input id="id_username" type="text" name="username" maxlength="10" required="required"  /></p>'
             )
         with translation.override('pl'):
             self.assertHTMLEqual(
                 f.as_p(),
                 '<p><label for="id_username">u\u017cytkownik:</label>'
-                '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
+                '<input id="id_username" type="text" name="username" maxlength="10" required="required"  /></p>'
             )
 
     def test_non_ascii_label(self):
@@ -59,12 +59,12 @@ class FormsI18nTests(SimpleTestCase):
             '<p><label for="id_somechoice_0">\xc5\xf8\xdf:</label>'
             '<ul id="id_somechoice">\n'
             '<li><label for="id_somechoice_0">'
-            '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required /> '
+            '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required="required"  /> '
             'En tied\xe4</label></li>\n'
             '<li><label for="id_somechoice_1">'
-            '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required /> '
+            '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required="required"  /> '
             'Mies</label></li>\n<li><label for="id_somechoice_2">'
-            '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required /> '
+            '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required="required"  /> '
             'Nainen</label></li>\n</ul></p>'
         )
 
@@ -78,12 +78,12 @@ class FormsI18nTests(SimpleTestCase):
                 '\u043d\u043e\u0435 \u043f\u043e\u043b\u0435.</li></ul>\n'
                 '<p><label for="id_somechoice_0">\xc5\xf8\xdf:</label>'
                 ' <ul id="id_somechoice">\n<li><label for="id_somechoice_0">'
-                '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required /> '
+                '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required="required"  /> '
                 'En tied\xe4</label></li>\n'
                 '<li><label for="id_somechoice_1">'
-                '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required /> '
+                '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required="required"  /> '
                 'Mies</label></li>\n<li><label for="id_somechoice_2">'
-                '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required /> '
+                '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required="required"  /> '
                 'Nainen</label></li>\n</ul></p>'
             )
 

--- a/tests/forms_tests/tests/test_i18n.py
+++ b/tests/forms_tests/tests/test_i18n.py
@@ -15,7 +15,7 @@ class FormsI18nTests(SimpleTestCase):
         self.assertHTMLEqual(
             f.as_p(),
             '<p><label for="id_username">username:</label>'
-            '<input id="id_username" type="text" name="username" maxlength="10" required></p>'
+            '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
         )
 
         # Translations are done at rendering time, so multi-lingual apps can define forms)
@@ -23,13 +23,13 @@ class FormsI18nTests(SimpleTestCase):
             self.assertHTMLEqual(
                 f.as_p(),
                 '<p><label for="id_username">Benutzername:</label>'
-                '<input id="id_username" type="text" name="username" maxlength="10" required></p>'
+                '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
             )
         with translation.override('pl'):
             self.assertHTMLEqual(
                 f.as_p(),
                 '<p><label for="id_username">u\u017cytkownik:</label>'
-                '<input id="id_username" type="text" name="username" maxlength="10" required></p>'
+                '<input id="id_username" type="text" name="username" maxlength="10" required /></p>'
             )
 
     def test_non_ascii_label(self):
@@ -59,12 +59,12 @@ class FormsI18nTests(SimpleTestCase):
             '<p><label for="id_somechoice_0">\xc5\xf8\xdf:</label>'
             '<ul id="id_somechoice">\n'
             '<li><label for="id_somechoice_0">'
-            '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required> '
+            '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required /> '
             'En tied\xe4</label></li>\n'
             '<li><label for="id_somechoice_1">'
-            '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required> '
+            '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required /> '
             'Mies</label></li>\n<li><label for="id_somechoice_2">'
-            '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required> '
+            '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required /> '
             'Nainen</label></li>\n</ul></p>'
         )
 
@@ -78,12 +78,12 @@ class FormsI18nTests(SimpleTestCase):
                 '\u043d\u043e\u0435 \u043f\u043e\u043b\u0435.</li></ul>\n'
                 '<p><label for="id_somechoice_0">\xc5\xf8\xdf:</label>'
                 ' <ul id="id_somechoice">\n<li><label for="id_somechoice_0">'
-                '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required> '
+                '<input type="radio" id="id_somechoice_0" value="\xc5" name="somechoice" required /> '
                 'En tied\xe4</label></li>\n'
                 '<li><label for="id_somechoice_1">'
-                '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required> '
+                '<input type="radio" id="id_somechoice_1" value="\xf8" name="somechoice" required /> '
                 'Mies</label></li>\n<li><label for="id_somechoice_2">'
-                '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required> '
+                '<input type="radio" id="id_somechoice_2" value="\xdf" name="somechoice" required /> '
                 'Nainen</label></li>\n</ul></p>'
             )
 

--- a/tests/forms_tests/tests/test_media.py
+++ b/tests/forms_tests/tests/test_media.py
@@ -17,8 +17,8 @@ class FormsMediaTestCase(SimpleTestCase):
         )
         self.assertEqual(
             str(m),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
@@ -38,8 +38,8 @@ class FormsMediaTestCase(SimpleTestCase):
         m3 = Media(Foo)
         self.assertEqual(
             str(m3),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
@@ -70,8 +70,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w1 = MyWidget1()
         self.assertEqual(
             str(w1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
@@ -80,8 +80,8 @@ class FormsMediaTestCase(SimpleTestCase):
         # Media objects can be interrogated by media type
         self.assertEqual(
             str(w1.media['css']),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">"""
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />"""
         )
 
         self.assertEqual(
@@ -120,9 +120,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w3 = MyWidget3()
         self.assertEqual(
             str(w1.media + w2.media + w3.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -132,8 +132,8 @@ class FormsMediaTestCase(SimpleTestCase):
         # media addition hasn't affected the original objects
         self.assertEqual(
             str(w1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
@@ -148,7 +148,7 @@ class FormsMediaTestCase(SimpleTestCase):
                 js = ('/path/to/js1', '/path/to/js1')
 
         w4 = MyWidget4()
-        self.assertEqual(str(w4.media), """<link href="/path/to/css1" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w4.media), """<link href="/path/to/css1" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>""")
 
     def test_media_property(self):
@@ -163,7 +163,7 @@ class FormsMediaTestCase(SimpleTestCase):
             media = property(_media)
 
         w4 = MyWidget4()
-        self.assertEqual(str(w4.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w4.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/some/js"></script>""")
 
         # Media properties can reference the media of their parents
@@ -173,8 +173,8 @@ class FormsMediaTestCase(SimpleTestCase):
             media = property(_media)
 
         w5 = MyWidget5()
-        self.assertEqual(str(w5.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w5.media), """<link href="/some/path" type="text/css" media="all" rel="stylesheet" />
+<link href="/other/path" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/some/js"></script>
 <script type="text/javascript" src="/other/js"></script>""")
 
@@ -196,9 +196,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w6 = MyWidget6()
         self.assertEqual(
             str(w6.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/other/path" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -224,8 +224,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w7 = MyWidget7()
         self.assertEqual(
             str(w7.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>"""
@@ -242,9 +242,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w8 = MyWidget8()
         self.assertEqual(
             str(w8.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -276,8 +276,8 @@ class FormsMediaTestCase(SimpleTestCase):
         w9 = MyWidget9()
         self.assertEqual(
             str(w9.media),
-            """<link href="/some/path" type="text/css" media="all" rel="stylesheet">
-<link href="/other/path" type="text/css" media="all" rel="stylesheet">
+            """<link href="/some/path" type="text/css" media="all" rel="stylesheet" />
+<link href="/other/path" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/some/js"></script>
 <script type="text/javascript" src="/other/js"></script>"""
         )
@@ -292,8 +292,8 @@ class FormsMediaTestCase(SimpleTestCase):
                 js = ('/path/to/js1', '/path/to/js4')
 
         w10 = MyWidget10()
-        self.assertEqual(str(w10.media), """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
+        self.assertEqual(str(w10.media), """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="/path/to/js4"></script>""")
 
@@ -317,9 +317,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w11 = MyWidget11()
         self.assertEqual(
             str(w11.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -346,9 +346,9 @@ class FormsMediaTestCase(SimpleTestCase):
         w12 = MyWidget12()
         self.assertEqual(
             str(w12.media),
-            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="/path/to/js4"></script>"""
         )
@@ -371,10 +371,10 @@ class FormsMediaTestCase(SimpleTestCase):
         multimedia = MultimediaWidget()
         self.assertEqual(
             str(multimedia.media),
-            """<link href="/file4" type="text/css" media="print" rel="stylesheet">
-<link href="/file3" type="text/css" media="screen" rel="stylesheet">
-<link href="/file1" type="text/css" media="screen, print" rel="stylesheet">
-<link href="/file2" type="text/css" media="screen, print" rel="stylesheet">
+            """<link href="/file4" type="text/css" media="print" rel="stylesheet" />
+<link href="/file3" type="text/css" media="screen" rel="stylesheet" />
+<link href="/file1" type="text/css" media="screen, print" rel="stylesheet" />
+<link href="/file2" type="text/css" media="screen, print" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="/path/to/js4"></script>"""
         )
@@ -415,9 +415,9 @@ class FormsMediaTestCase(SimpleTestCase):
         mymulti = MyMultiWidget()
         self.assertEqual(
             str(mymulti.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -457,9 +457,9 @@ class FormsMediaTestCase(SimpleTestCase):
         f1 = MyForm()
         self.assertEqual(
             str(f1.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -472,9 +472,9 @@ class FormsMediaTestCase(SimpleTestCase):
         f2 = AnotherForm()
         self.assertEqual(
             str(f1.media + f2.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -494,10 +494,10 @@ class FormsMediaTestCase(SimpleTestCase):
         f3 = FormWithMedia()
         self.assertEqual(
             str(f3.media),
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="/some/form/css" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
@@ -513,10 +513,10 @@ class FormsMediaTestCase(SimpleTestCase):
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>
 <script type="text/javascript" src="/path/to/js4"></script>
 <script type="text/javascript" src="/some/form/javascript"></script>"""
-            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet">
-<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">"""
+            """<link href="http://media.example.com/static/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css3" type="text/css" media="all" rel="stylesheet" />
+<link href="/some/form/css" type="text/css" media="all" rel="stylesheet" />"""
         )
 
     def test_html_safe(self):

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -86,24 +86,24 @@ class ModelFormCallableModelDefault(TestCase):
         self.assertHTMLEqual(
             ChoiceFieldForm().as_p(),
             """<p><label for="id_choice">Choice:</label> <select name="choice" id="id_choice">
-<option value="1" selected>ChoiceOption 1</option>
+<option value="1" selected="selected">ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-choice" value="1" id="initial-id_choice" /></p>
 <p><label for="id_choice_int">Choice int:</label> <select name="choice_int" id="id_choice_int">
-<option value="1" selected>ChoiceOption 1</option>
+<option value="1" selected="selected">ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-choice_int" value="1" id="initial-id_choice_int" /></p>
 <p><label for="id_multi_choice">Multi choice:</label>
-<select multiple name="multi_choice" id="id_multi_choice" required>
-<option value="1" selected>ChoiceOption 1</option>
+<select multiple="multiple" name="multi_choice" id="id_multi_choice" required="required">
+<option value="1" selected="selected">ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-multi_choice" value="1" id="initial-id_multi_choice_0" /></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
-<select multiple name="multi_choice_int" id="id_multi_choice_int" required>
-<option value="1" selected>ChoiceOption 1</option>
+<select multiple="multiple" name="multi_choice_int" id="id_multi_choice_int" required="required">
+<option value="1" selected="selected">ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0" /></p>"""
@@ -123,26 +123,26 @@ class ModelFormCallableModelDefault(TestCase):
             }).as_p(),
             """<p><label for="id_choice">Choice:</label> <select name="choice" id="id_choice">
 <option value="1">ChoiceOption 1</option>
-<option value="2" selected>ChoiceOption 2</option>
+<option value="2" selected="selected">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-choice" value="2" id="initial-id_choice" /></p>
 <p><label for="id_choice_int">Choice int:</label> <select name="choice_int" id="id_choice_int">
 <option value="1">ChoiceOption 1</option>
-<option value="2" selected>ChoiceOption 2</option>
+<option value="2" selected="selected">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-choice_int" value="2" id="initial-id_choice_int" /></p>
 <p><label for="id_multi_choice">Multi choice:</label>
-<select multiple name="multi_choice" id="id_multi_choice" required>
+<select multiple="multiple" name="multi_choice" id="id_multi_choice" required="required">
 <option value="1">ChoiceOption 1</option>
-<option value="2" selected>ChoiceOption 2</option>
-<option value="3" selected>ChoiceOption 3</option>
+<option value="2" selected="selected">ChoiceOption 2</option>
+<option value="3" selected="selected">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-multi_choice" value="2" id="initial-id_multi_choice_0" />
 <input type="hidden" name="initial-multi_choice" value="3" id="initial-id_multi_choice_1" /></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
-<select multiple name="multi_choice_int" id="id_multi_choice_int" required>
+<select multiple="multiple" name="multi_choice_int" id="id_multi_choice_int" required="required">
 <option value="1">ChoiceOption 1</option>
-<option value="2" selected>ChoiceOption 2</option>
-<option value="3" selected>ChoiceOption 3</option>
+<option value="2" selected="selected">ChoiceOption 2</option>
+<option value="3" selected="selected">ChoiceOption 3</option>
 </select><input type="hidden" name="initial-multi_choice_int" value="2" id="initial-id_multi_choice_int_0" />
 <input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1" /></p>"""
         )
@@ -288,9 +288,9 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyCharLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required="required"  /></p>
 <p><label for="id_choice">Choice:</label> <select id="id_choice" name="choice">
-<option value="" selected>No Preference</option>
+<option value="" selected="selected">No Preference</option>
 <option value="f">Foo</option>
 <option value="b">Bar</option>
 </select></p>"""
@@ -300,10 +300,10 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyCharLabelNoneChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required="required"  /></p>
 <p><label for="id_choice_string_w_none">Choice string w none:</label>
 <select id="id_choice_string_w_none" name="choice_string_w_none">
-<option value="" selected>No Preference</option>
+<option value="" selected="selected">No Preference</option>
 <option value="f">Foo</option>
 <option value="b">Bar</option>
 </select></p>"""
@@ -330,10 +330,10 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyIntegerLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required="required"  /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
-<option value="" selected>No Preference</option>
+<option value="" selected="selected">No Preference</option>
 <option value="1">Foo</option>
 <option value="2">Bar</option>
 </select></p>"""
@@ -350,10 +350,10 @@ class EmptyLabelTestCase(TestCase):
         self.assertHTMLEqual(
             f.as_p(),
             """<p><label for="id_name">Name:</label>
-<input id="id_name" maxlength="10" name="name" type="text" value="none-test" required /></p>
+<input id="id_name" maxlength="10" name="name" type="text" value="none-test" required="required"  /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
-<option value="" selected>No Preference</option>
+<option value="" selected="selected">No Preference</option>
 <option value="1">Foo</option>
 <option value="2">Bar</option>
 </select></p>"""
@@ -364,11 +364,11 @@ class EmptyLabelTestCase(TestCase):
         self.assertHTMLEqual(
             f.as_p(),
             """<p><label for="id_name">Name:</label>
-<input id="id_name" maxlength="10" name="name" type="text" value="foo-test" required /></p>
+<input id="id_name" maxlength="10" name="name" type="text" value="foo-test" required="required"  /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
 <option value="">No Preference</option>
-<option value="1" selected>Foo</option>
+<option value="1" selected="selected">Foo</option>
 <option value="2">Bar</option>
 </select></p>"""
         )

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -89,24 +89,24 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-choice" value="1" id="initial-id_choice"></p>
+</select><input type="hidden" name="initial-choice" value="1" id="initial-id_choice" /></p>
 <p><label for="id_choice_int">Choice int:</label> <select name="choice_int" id="id_choice_int">
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-choice_int" value="1" id="initial-id_choice_int"></p>
+</select><input type="hidden" name="initial-choice_int" value="1" id="initial-id_choice_int" /></p>
 <p><label for="id_multi_choice">Multi choice:</label>
 <select multiple name="multi_choice" id="id_multi_choice" required>
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice" value="1" id="initial-id_multi_choice_0"></p>
+</select><input type="hidden" name="initial-multi_choice" value="1" id="initial-id_multi_choice_0" /></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
 <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
 <option value="1" selected>ChoiceOption 1</option>
 <option value="2">ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0"></p>"""
+</select><input type="hidden" name="initial-multi_choice_int" value="1" id="initial-id_multi_choice_int_0" /></p>"""
         )
 
     def test_initial_instance_value(self):
@@ -125,26 +125,26 @@ class ModelFormCallableModelDefault(TestCase):
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-choice" value="2" id="initial-id_choice"></p>
+</select><input type="hidden" name="initial-choice" value="2" id="initial-id_choice" /></p>
 <p><label for="id_choice_int">Choice int:</label> <select name="choice_int" id="id_choice_int">
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3">ChoiceOption 3</option>
-</select><input type="hidden" name="initial-choice_int" value="2" id="initial-id_choice_int"></p>
+</select><input type="hidden" name="initial-choice_int" value="2" id="initial-id_choice_int" /></p>
 <p><label for="id_multi_choice">Multi choice:</label>
 <select multiple name="multi_choice" id="id_multi_choice" required>
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3" selected>ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice" value="2" id="initial-id_multi_choice_0">
-<input type="hidden" name="initial-multi_choice" value="3" id="initial-id_multi_choice_1"></p>
+</select><input type="hidden" name="initial-multi_choice" value="2" id="initial-id_multi_choice_0" />
+<input type="hidden" name="initial-multi_choice" value="3" id="initial-id_multi_choice_1" /></p>
 <p><label for="id_multi_choice_int">Multi choice int:</label>
 <select multiple name="multi_choice_int" id="id_multi_choice_int" required>
 <option value="1">ChoiceOption 1</option>
 <option value="2" selected>ChoiceOption 2</option>
 <option value="3" selected>ChoiceOption 3</option>
-</select><input type="hidden" name="initial-multi_choice_int" value="2" id="initial-id_multi_choice_int_0">
-<input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1"></p>"""
+</select><input type="hidden" name="initial-multi_choice_int" value="2" id="initial-id_multi_choice_int_0" />
+<input type="hidden" name="initial-multi_choice_int" value="3" id="initial-id_multi_choice_int_1" /></p>"""
         )
 
 
@@ -288,7 +288,7 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyCharLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
 <p><label for="id_choice">Choice:</label> <select id="id_choice" name="choice">
 <option value="" selected>No Preference</option>
 <option value="f">Foo</option>
@@ -300,7 +300,7 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyCharLabelNoneChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
 <p><label for="id_choice_string_w_none">Choice string w none:</label>
 <select id="id_choice_string_w_none" name="choice_string_w_none">
 <option value="" selected>No Preference</option>
@@ -330,7 +330,7 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyIntegerLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
 <option value="" selected>No Preference</option>
@@ -350,7 +350,7 @@ class EmptyLabelTestCase(TestCase):
         self.assertHTMLEqual(
             f.as_p(),
             """<p><label for="id_name">Name:</label>
-<input id="id_name" maxlength="10" name="name" type="text" value="none-test" required></p>
+<input id="id_name" maxlength="10" name="name" type="text" value="none-test" required /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
 <option value="" selected>No Preference</option>
@@ -364,7 +364,7 @@ class EmptyLabelTestCase(TestCase):
         self.assertHTMLEqual(
             f.as_p(),
             """<p><label for="id_name">Name:</label>
-<input id="id_name" maxlength="10" name="name" type="text" value="foo-test" required></p>
+<input id="id_name" maxlength="10" name="name" type="text" value="foo-test" required /></p>
 <p><label for="id_choice_integer">Choice integer:</label>
 <select id="id_choice_integer" name="choice_integer">
 <option value="">No Preference</option>

--- a/tests/forms_tests/widget_tests/test_checkboxinput.py
+++ b/tests/forms_tests/widget_tests/test_checkboxinput.py
@@ -7,18 +7,18 @@ class CheckboxInputTest(WidgetTest):
     widget = CheckboxInput()
 
     def test_render_empty(self):
-        self.check_html(self.widget, 'is_cool', '', html='<input type="checkbox" name="is_cool">')
+        self.check_html(self.widget, 'is_cool', '', html='<input type="checkbox" name="is_cool" />')
 
     def test_render_none(self):
-        self.check_html(self.widget, 'is_cool', None, html='<input type="checkbox" name="is_cool">')
+        self.check_html(self.widget, 'is_cool', None, html='<input type="checkbox" name="is_cool" />')
 
     def test_render_false(self):
-        self.check_html(self.widget, 'is_cool', False, html='<input type="checkbox" name="is_cool">')
+        self.check_html(self.widget, 'is_cool', False, html='<input type="checkbox" name="is_cool" />')
 
     def test_render_true(self):
         self.check_html(
             self.widget, 'is_cool', True,
-            html='<input checked type="checkbox" name="is_cool">'
+            html='<input checked type="checkbox" name="is_cool" />'
         )
 
     def test_render_value(self):
@@ -28,7 +28,7 @@ class CheckboxInputTest(WidgetTest):
         """
         self.check_html(
             self.widget, 'is_cool', 'foo',
-            html='<input checked type="checkbox" name="is_cool" value="foo">',
+            html='<input checked type="checkbox" name="is_cool" value="foo" />',
         )
 
     def test_render_int(self):
@@ -37,11 +37,11 @@ class CheckboxInputTest(WidgetTest):
         """
         self.check_html(
             self.widget, 'is_cool', 0,
-            html='<input checked type="checkbox" name="is_cool" value="0">',
+            html='<input checked type="checkbox" name="is_cool" value="0" />',
         )
         self.check_html(
             self.widget, 'is_cool', 1,
-            html='<input checked type="checkbox" name="is_cool" value="1">',
+            html='<input checked type="checkbox" name="is_cool" value="1" />',
         )
 
     def test_render_check_test(self):
@@ -51,16 +51,16 @@ class CheckboxInputTest(WidgetTest):
         """
         widget = CheckboxInput(check_test=lambda value: value.startswith('hello'))
         self.check_html(widget, 'greeting', '', html=(
-            '<input type="checkbox" name="greeting">'
+            '<input type="checkbox" name="greeting" />'
         ))
         self.check_html(widget, 'greeting', 'hello', html=(
-            '<input checked type="checkbox" name="greeting" value="hello">'
+            '<input checked type="checkbox" name="greeting" value="hello" />'
         ))
         self.check_html(widget, 'greeting', 'hello there', html=(
-            '<input checked type="checkbox" name="greeting" value="hello there">'
+            '<input checked type="checkbox" name="greeting" value="hello there" />'
         ))
         self.check_html(widget, 'greeting', 'hello & goodbye', html=(
-            '<input checked type="checkbox" name="greeting" value="hello &amp; goodbye">'
+            '<input checked type="checkbox" name="greeting" value="hello &amp; goodbye" />'
         ))
 
     def test_render_check_exception(self):

--- a/tests/forms_tests/widget_tests/test_checkboxinput.py
+++ b/tests/forms_tests/widget_tests/test_checkboxinput.py
@@ -18,7 +18,7 @@ class CheckboxInputTest(WidgetTest):
     def test_render_true(self):
         self.check_html(
             self.widget, 'is_cool', True,
-            html='<input checked type="checkbox" name="is_cool" />'
+            html='<input checked="checked" type="checkbox" name="is_cool" />'
         )
 
     def test_render_value(self):
@@ -28,7 +28,7 @@ class CheckboxInputTest(WidgetTest):
         """
         self.check_html(
             self.widget, 'is_cool', 'foo',
-            html='<input checked type="checkbox" name="is_cool" value="foo" />',
+            html='<input checked="checked" type="checkbox" name="is_cool" value="foo" />',
         )
 
     def test_render_int(self):
@@ -37,11 +37,11 @@ class CheckboxInputTest(WidgetTest):
         """
         self.check_html(
             self.widget, 'is_cool', 0,
-            html='<input checked type="checkbox" name="is_cool" value="0" />',
+            html='<input checked="checked" type="checkbox" name="is_cool" value="0" />',
         )
         self.check_html(
             self.widget, 'is_cool', 1,
-            html='<input checked type="checkbox" name="is_cool" value="1" />',
+            html='<input checked="checked" type="checkbox" name="is_cool" value="1" />',
         )
 
     def test_render_check_test(self):
@@ -54,13 +54,13 @@ class CheckboxInputTest(WidgetTest):
             '<input type="checkbox" name="greeting" />'
         ))
         self.check_html(widget, 'greeting', 'hello', html=(
-            '<input checked type="checkbox" name="greeting" value="hello" />'
+            '<input checked="checked" type="checkbox" name="greeting" value="hello" />'
         ))
         self.check_html(widget, 'greeting', 'hello there', html=(
-            '<input checked type="checkbox" name="greeting" value="hello there" />'
+            '<input checked="checked" type="checkbox" name="greeting" value="hello there" />'
         ))
         self.check_html(widget, 'greeting', 'hello & goodbye', html=(
-            '<input checked type="checkbox" name="greeting" value="hello &amp; goodbye" />'
+            '<input checked="checked" type="checkbox" name="greeting" value="hello &amp; goodbye" />'
         ))
 
     def test_render_check_exception(self):

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -13,20 +13,20 @@ class CheckboxSelectMultipleTest(WidgetTest):
     def test_render_value(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J'], html=(
             """<ul>
-            <li><label><input checked type="checkbox" name="beatles" value="J"> John</label></li>
-            <li><label><input type="checkbox" name="beatles" value="P"> Paul</label></li>
-            <li><label><input type="checkbox" name="beatles" value="G"> George</label></li>
-            <li><label><input type="checkbox" name="beatles" value="R"> Ringo</label></li>
+            <li><label><input checked type="checkbox" name="beatles" value="J" /> John</label></li>
+            <li><label><input type="checkbox" name="beatles" value="P" /> Paul</label></li>
+            <li><label><input type="checkbox" name="beatles" value="G" /> George</label></li>
+            <li><label><input type="checkbox" name="beatles" value="R" /> Ringo</label></li>
             </ul>"""
         ))
 
     def test_render_value_multiple(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J', 'P'], html=(
             """<ul>
-            <li><label><input checked type="checkbox" name="beatles" value="J"> John</label></li>
-            <li><label><input checked type="checkbox" name="beatles" value="P"> Paul</label></li>
-            <li><label><input type="checkbox" name="beatles" value="G"> George</label></li>
-            <li><label><input type="checkbox" name="beatles" value="R"> Ringo</label></li>
+            <li><label><input checked type="checkbox" name="beatles" value="J" /> John</label></li>
+            <li><label><input checked type="checkbox" name="beatles" value="P" /> Paul</label></li>
+            <li><label><input type="checkbox" name="beatles" value="G" /> George</label></li>
+            <li><label><input type="checkbox" name="beatles" value="R" /> Ringo</label></li>
             </ul>"""
         ))
 
@@ -37,11 +37,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         """
         self.check_html(self.widget(choices=(('', 'Unknown'),) + self.beatles), 'beatles', None, html=(
             """<ul>
-            <li><label><input type="checkbox" name="beatles" value=""> Unknown</label></li>
-            <li><label><input type="checkbox" name="beatles" value="J"> John</label></li>
-            <li><label><input type="checkbox" name="beatles" value="P"> Paul</label></li>
-            <li><label><input type="checkbox" name="beatles" value="G"> George</label></li>
-            <li><label><input type="checkbox" name="beatles" value="R"> Ringo</label></li>
+            <li><label><input type="checkbox" name="beatles" value="" /> Unknown</label></li>
+            <li><label><input type="checkbox" name="beatles" value="J" /> John</label></li>
+            <li><label><input type="checkbox" name="beatles" value="P" /> Paul</label></li>
+            <li><label><input type="checkbox" name="beatles" value="G" /> George</label></li>
+            <li><label><input type="checkbox" name="beatles" value="R" /> Ringo</label></li>
             </ul>"""
         ))
 
@@ -54,25 +54,25 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul id="media">
         <li>
-        <label for="media_0"><input id="media_0" name="nestchoice" type="checkbox" value="unknown"> Unknown</label>
+        <label for="media_0"><input id="media_0" name="nestchoice" type="checkbox" value="unknown" /> Unknown</label>
         </li>
         <li>Audio<ul id="media_1">
         <li>
         <label for="media_1_0">
-        <input checked id="media_1_0" name="nestchoice" type="checkbox" value="vinyl"> Vinyl
+        <input checked id="media_1_0" name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
         </label>
         </li>
         <li>
-        <label for="media_1_1"><input id="media_1_1" name="nestchoice" type="checkbox" value="cd"> CD</label>
+        <label for="media_1_1"><input id="media_1_1" name="nestchoice" type="checkbox" value="cd" /> CD</label>
         </li>
         </ul></li>
         <li>Video<ul id="media_2">
         <li>
-        <label for="media_2_0"><input id="media_2_0" name="nestchoice" type="checkbox" value="vhs"> VHS</label>
+        <label for="media_2_0"><input id="media_2_0" name="nestchoice" type="checkbox" value="vhs" /> VHS</label>
         </li>
         <li>
         <label for="media_2_1">
-        <input checked id="media_2_1" name="nestchoice" type="checkbox" value="dvd"> DVD
+        <input checked id="media_2_1" name="nestchoice" type="checkbox" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -92,25 +92,25 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul>
         <li>
-        <label><input name="nestchoice" type="checkbox" value="unknown"> Unknown</label>
+        <label><input name="nestchoice" type="checkbox" value="unknown" /> Unknown</label>
         </li>
         <li>Audio<ul>
         <li>
         <label>
-        <input checked name="nestchoice" type="checkbox" value="vinyl"> Vinyl
+        <input checked name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
         </label>
         </li>
         <li>
-        <label><input name="nestchoice" type="checkbox" value="cd"> CD</label>
+        <label><input name="nestchoice" type="checkbox" value="cd" /> CD</label>
         </li>
         </ul></li>
         <li>Video<ul>
         <li>
-        <label><input name="nestchoice" type="checkbox" value="vhs"> VHS</label>
+        <label><input name="nestchoice" type="checkbox" value="vhs" /> VHS</label>
         </li>
         <li>
         <label>
-        <input checked name="nestchoice" type="checkbox" value="dvd"> DVD
+        <input checked name="nestchoice" type="checkbox" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -126,11 +126,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul id="abc">
         <li>
-        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0"> A</label>
+        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
         </li>
-        <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1"> B</label></li>
+        <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1" /> B</label></li>
         <li>
-        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2"> C</label>
+        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
         </li>
         </ul>
         """
@@ -144,11 +144,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul id="abc">
         <li>
-        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0"> A</label>
+        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
         </li>
-        <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1"> B</label></li>
+        <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1" /> B</label></li>
         <li>
-        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2"> C</label>
+        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
         </li>
         </ul>
         """
@@ -163,9 +163,9 @@ class CheckboxSelectMultipleTest(WidgetTest):
         ]
         html = """
         <ul>
-        <li><label><input type="checkbox" name="numbers" value="1"> One</label></li>
-        <li><label><input type="checkbox" name="numbers" value="1000"> One thousand</label></li>
-        <li><label><input type="checkbox" name="numbers" value="1000000"> One million</label></li>
+        <li><label><input type="checkbox" name="numbers" value="1" /> One</label></li>
+        <li><label><input type="checkbox" name="numbers" value="1000" /> One thousand</label></li>
+        <li><label><input type="checkbox" name="numbers" value="1000000" /> One million</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=choices), 'numbers', None, html=html)
@@ -176,8 +176,8 @@ class CheckboxSelectMultipleTest(WidgetTest):
         ]
         html = """
         <ul>
-        <li><label><input type="checkbox" name="times" value="00:00:00"> midnight</label></li>
-        <li><label><input type="checkbox" name="times" value="12:00:00"> noon</label></li>
+        <li><label><input type="checkbox" name="times" value="00:00:00" /> midnight</label></li>
+        <li><label><input type="checkbox" name="times" value="12:00:00" /> noon</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=choices), 'times', None, html=html)

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -13,7 +13,7 @@ class CheckboxSelectMultipleTest(WidgetTest):
     def test_render_value(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J'], html=(
             """<ul>
-            <li><label><input checked type="checkbox" name="beatles" value="J" /> John</label></li>
+            <li><label><input checked="checked" type="checkbox" name="beatles" value="J" /> John</label></li>
             <li><label><input type="checkbox" name="beatles" value="P" /> Paul</label></li>
             <li><label><input type="checkbox" name="beatles" value="G" /> George</label></li>
             <li><label><input type="checkbox" name="beatles" value="R" /> Ringo</label></li>
@@ -23,8 +23,8 @@ class CheckboxSelectMultipleTest(WidgetTest):
     def test_render_value_multiple(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J', 'P'], html=(
             """<ul>
-            <li><label><input checked type="checkbox" name="beatles" value="J" /> John</label></li>
-            <li><label><input checked type="checkbox" name="beatles" value="P" /> Paul</label></li>
+            <li><label><input checked="checked" type="checkbox" name="beatles" value="J" /> John</label></li>
+            <li><label><input checked="checked" type="checkbox" name="beatles" value="P" /> Paul</label></li>
             <li><label><input type="checkbox" name="beatles" value="G" /> George</label></li>
             <li><label><input type="checkbox" name="beatles" value="R" /> Ringo</label></li>
             </ul>"""
@@ -59,7 +59,7 @@ class CheckboxSelectMultipleTest(WidgetTest):
         <li>Audio<ul id="media_1">
         <li>
         <label for="media_1_0">
-        <input checked id="media_1_0" name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
+        <input checked="checked" id="media_1_0" name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
         </label>
         </li>
         <li>
@@ -72,7 +72,7 @@ class CheckboxSelectMultipleTest(WidgetTest):
         </li>
         <li>
         <label for="media_2_1">
-        <input checked id="media_2_1" name="nestchoice" type="checkbox" value="dvd" /> DVD
+        <input checked="checked" id="media_2_1" name="nestchoice" type="checkbox" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -97,7 +97,7 @@ class CheckboxSelectMultipleTest(WidgetTest):
         <li>Audio<ul>
         <li>
         <label>
-        <input checked name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
+        <input checked="checked" name="nestchoice" type="checkbox" value="vinyl" /> Vinyl
         </label>
         </li>
         <li>
@@ -110,7 +110,7 @@ class CheckboxSelectMultipleTest(WidgetTest):
         </li>
         <li>
         <label>
-        <input checked name="nestchoice" type="checkbox" value="dvd" /> DVD
+        <input checked="checked" name="nestchoice" type="checkbox" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -126,11 +126,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul id="abc">
         <li>
-        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
+        <label for="abc_0"><input checked="checked" type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
         </li>
         <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1" /> B</label></li>
         <li>
-        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
+        <label for="abc_2"><input checked="checked" type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
         </li>
         </ul>
         """
@@ -144,11 +144,11 @@ class CheckboxSelectMultipleTest(WidgetTest):
         html = """
         <ul id="abc">
         <li>
-        <label for="abc_0"><input checked type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
+        <label for="abc_0"><input checked="checked" type="checkbox" name="letters" value="a" id="abc_0" /> A</label>
         </li>
         <li><label for="abc_1"><input type="checkbox" name="letters" value="b" id="abc_1" /> B</label></li>
         <li>
-        <label for="abc_2"><input checked type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
+        <label for="abc_2"><input checked="checked" type="checkbox" name="letters" value="c" id="abc_2" /> C</label>
         </li>
         </ul>
         """

--- a/tests/forms_tests/widget_tests/test_clearablefileinput.py
+++ b/tests/forms_tests/widget_tests/test_clearablefileinput.py
@@ -26,9 +26,9 @@ class ClearableFileInputTest(WidgetTest):
         self.check_html(self.widget, 'myfile', FakeFieldFile(), html=(
             """
             Currently: <a href="something">something</a>
-            <input type="checkbox" name="myfile-clear" id="myfile-clear_id">
-            <label for="myfile-clear_id">Clear</label><br>
-            Change: <input type="file" name="myfile">
+            <input type="checkbox" name="myfile-clear" id="myfile-clear_id" />
+            <label for="myfile-clear_id">Clear</label><br />
+            Change: <input type="file" name="myfile" />
             """
         ))
 
@@ -47,9 +47,9 @@ class ClearableFileInputTest(WidgetTest):
             """
             Currently: <a href="something?chapter=1&amp;sect=2&amp;copy=3&amp;lang=en">
             something&lt;div onclick=&quot;alert(&#39;oops&#39;)&quot;&gt;.jpg</a>
-            <input type="checkbox" name="my&lt;div&gt;file-clear" id="my&lt;div&gt;file-clear_id">
-            <label for="my&lt;div&gt;file-clear_id">Clear</label><br>
-            Change: <input type="file" name="my&lt;div&gt;file">
+            <input type="checkbox" name="my&lt;div&gt;file-clear" id="my&lt;div&gt;file-clear_id" />
+            <label for="my&lt;div&gt;file-clear_id">Clear</label><br />
+            Change: <input type="file" name="my&lt;div&gt;file" />
             """
         ))
 
@@ -62,8 +62,8 @@ class ClearableFileInputTest(WidgetTest):
         widget.is_required = True
         self.check_html(widget, 'myfile', FakeFieldFile(), html=(
             """
-            Currently: <a href="something">something</a> <br>
-            Change: <input type="file" name="myfile">
+            Currently: <a href="something">something</a> <br />
+            Change: <input type="file" name="myfile" />
             """
         ))
 
@@ -72,7 +72,7 @@ class ClearableFileInputTest(WidgetTest):
         A ClearableFileInput instantiated with no initial value does not render
         a clear checkbox.
         """
-        self.check_html(self.widget, 'myfile', None, html='<input type="file" name="myfile">')
+        self.check_html(self.widget, 'myfile', None, html='<input type="file" name="myfile" />')
 
     def test_render_as_subwidget(self):
         """A ClearableFileInput as a subwidget of MultiWidget."""
@@ -80,9 +80,9 @@ class ClearableFileInputTest(WidgetTest):
         self.check_html(widget, 'myfile', [FakeFieldFile()], html=(
             """
             Currently: <a href="something">something</a>
-            <input type="checkbox" name="myfile_0-clear" id="myfile_0-clear_id">
-            <label for="myfile_0-clear_id">Clear</label><br>
-            Change: <input type="file" name="myfile_0">
+            <input type="checkbox" name="myfile_0-clear" id="myfile_0-clear_id" />
+            <label for="myfile_0-clear_id">Clear</label><br />
+            Change: <input type="file" name="myfile_0" />
             """
         ))
 
@@ -148,7 +148,7 @@ class ClearableFileInputTest(WidgetTest):
                 return 'value'
 
         html = self.widget.render('myfile', NoURLFieldFile())
-        self.assertHTMLEqual(html, '<input name="myfile" type="file">')
+        self.assertHTMLEqual(html, '<input name="myfile" type="file" />')
 
     def test_use_required_attribute(self):
         # False when initial data exists. The file input is left blank by the

--- a/tests/forms_tests/widget_tests/test_dateinput.py
+++ b/tests/forms_tests/widget_tests/test_dateinput.py
@@ -11,15 +11,15 @@ class DateInputTest(WidgetTest):
     widget = DateInput()
 
     def test_render_none(self):
-        self.check_html(self.widget, 'date', None, html='<input type="text" name="date">')
+        self.check_html(self.widget, 'date', None, html='<input type="text" name="date" />')
 
     def test_render_value(self):
         d = date(2007, 9, 17)
         self.assertEqual(str(d), '2007-09-17')
 
-        self.check_html(self.widget, 'date', d, html='<input type="text" name="date" value="2007-09-17">')
+        self.check_html(self.widget, 'date', d, html='<input type="text" name="date" value="2007-09-17" />')
         self.check_html(self.widget, 'date', date(2007, 9, 17), html=(
-            '<input type="text" name="date" value="2007-09-17">'
+            '<input type="text" name="date" value="2007-09-17" />'
         ))
 
     def test_string(self):
@@ -27,7 +27,7 @@ class DateInputTest(WidgetTest):
         Should be able to initialize from a string value.
         """
         self.check_html(self.widget, 'date', '2007-09-17', html=(
-            '<input type="text" name="date" value="2007-09-17">'
+            '<input type="text" name="date" value="2007-09-17" />'
         ))
 
     def test_format(self):
@@ -36,12 +36,12 @@ class DateInputTest(WidgetTest):
         """
         d = date(2007, 9, 17)
         widget = DateInput(format='%d/%m/%Y', attrs={'type': 'date'})
-        self.check_html(widget, 'date', d, html='<input type="date" name="date" value="17/09/2007">')
+        self.check_html(widget, 'date', d, html='<input type="date" name="date" value="17/09/2007" />')
 
     @override_settings(USE_L10N=True)
     @translation.override('de-at')
     def test_l10n(self):
         self.check_html(
             self.widget, 'date', date(2007, 9, 17),
-            html='<input type="text" name="date" value="17.09.2007">',
+            html='<input type="text" name="date" value="17.09.2007" />',
         )

--- a/tests/forms_tests/widget_tests/test_datetimeinput.py
+++ b/tests/forms_tests/widget_tests/test_datetimeinput.py
@@ -11,7 +11,7 @@ class DateTimeInputTest(WidgetTest):
     widget = DateTimeInput()
 
     def test_render_none(self):
-        self.check_html(self.widget, 'date', None, '<input type="text" name="date">')
+        self.check_html(self.widget, 'date', None, '<input type="text" name="date" />')
 
     def test_render_value(self):
         """
@@ -20,13 +20,13 @@ class DateTimeInputTest(WidgetTest):
         d = datetime(2007, 9, 17, 12, 51, 34, 482548)
         self.assertEqual(str(d), '2007-09-17 12:51:34.482548')
         self.check_html(self.widget, 'date', d, html=(
-            '<input type="text" name="date" value="2007-09-17 12:51:34">'
+            '<input type="text" name="date" value="2007-09-17 12:51:34" />'
         ))
         self.check_html(self.widget, 'date', datetime(2007, 9, 17, 12, 51, 34), html=(
-            '<input type="text" name="date" value="2007-09-17 12:51:34">'
+            '<input type="text" name="date" value="2007-09-17 12:51:34" />'
         ))
         self.check_html(self.widget, 'date', datetime(2007, 9, 17, 12, 51), html=(
-            '<input type="text" name="date" value="2007-09-17 12:51:00">'
+            '<input type="text" name="date" value="2007-09-17 12:51:00" />'
         ))
 
     def test_render_formatted(self):
@@ -37,14 +37,14 @@ class DateTimeInputTest(WidgetTest):
             format='%d/%m/%Y %H:%M', attrs={'type': 'datetime'},
         )
         d = datetime(2007, 9, 17, 12, 51, 34, 482548)
-        self.check_html(widget, 'date', d, html='<input type="datetime" name="date" value="17/09/2007 12:51">')
+        self.check_html(widget, 'date', d, html='<input type="datetime" name="date" value="17/09/2007 12:51" />')
 
     @override_settings(USE_L10N=True)
     @translation.override('de-at')
     def test_l10n(self):
         d = datetime(2007, 9, 17, 12, 51, 34, 482548)
         self.check_html(self.widget, 'date', d, html=(
-            '<input type="text" name="date" value="17.09.2007 12:51:34">'
+            '<input type="text" name="date" value="17.09.2007 12:51:34" />'
         ))
 
     @override_settings(USE_L10N=True)
@@ -54,10 +54,10 @@ class DateTimeInputTest(WidgetTest):
         with self.settings(USE_L10N=False):
             self.check_html(
                 self.widget, 'date', d,
-                html='<input type="text" name="date" value="2007-09-17 12:51:34">',
+                html='<input type="text" name="date" value="2007-09-17 12:51:34" />',
             )
         with translation.override('es'):
             self.check_html(
                 self.widget, 'date', d,
-                html='<input type="text" name="date" value="17/09/2007 12:51:34">',
+                html='<input type="text" name="date" value="17/09/2007 12:51:34" />',
             )

--- a/tests/forms_tests/widget_tests/test_fileinput.py
+++ b/tests/forms_tests/widget_tests/test_fileinput.py
@@ -11,9 +11,9 @@ class FileInputTest(WidgetTest):
         FileInput widgets never render the value attribute. The old value
         isn't useful if a form is updated or an error occurred.
         """
-        self.check_html(self.widget, 'email', 'test@example.com', html='<input type="file" name="email">')
-        self.check_html(self.widget, 'email', '', html='<input type="file" name="email">')
-        self.check_html(self.widget, 'email', None, html='<input type="file" name="email">')
+        self.check_html(self.widget, 'email', 'test@example.com', html='<input type="file" name="email" />')
+        self.check_html(self.widget, 'email', '', html='<input type="file" name="email" />')
+        self.check_html(self.widget, 'email', None, html='<input type="file" name="email" />')
 
     def test_value_omitted_from_data(self):
         self.assertIs(self.widget.value_omitted_from_data({}, {}, 'field'), True)

--- a/tests/forms_tests/widget_tests/test_hiddeninput.py
+++ b/tests/forms_tests/widget_tests/test_hiddeninput.py
@@ -7,7 +7,7 @@ class HiddenInputTest(WidgetTest):
     widget = HiddenInput()
 
     def test_render(self):
-        self.check_html(self.widget, 'email', '', html='<input type="hidden" name="email">')
+        self.check_html(self.widget, 'email', '', html='<input type="hidden" name="email" />')
 
     def test_use_required_attribute(self):
         # Always False to avoid browser validation on inputs hidden from the

--- a/tests/forms_tests/widget_tests/test_input.py
+++ b/tests/forms_tests/widget_tests/test_input.py
@@ -8,8 +8,8 @@ class InputTests(WidgetTest):
     def test_attrs_with_type(self):
         attrs = {'type': 'date'}
         widget = Input(attrs)
-        self.check_html(widget, 'name', 'value', '<input type="date" name="name" value="value">')
+        self.check_html(widget, 'name', 'value', '<input type="date" name="name" value="value" />')
         # reuse the same attrs for another widget
-        self.check_html(Input(attrs), 'name', 'value', '<input type="date" name="name" value="value">')
+        self.check_html(Input(attrs), 'name', 'value', '<input type="date" name="name" value="value" />')
         attrs['type'] = 'number'  # shouldn't change the widget type
-        self.check_html(widget, 'name', 'value', '<input type="date" name="name" value="value">')
+        self.check_html(widget, 'name', 'value', '<input type="date" name="name" value="value" />')

--- a/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
+++ b/tests/forms_tests/widget_tests/test_multiplehiddeninput.py
@@ -9,30 +9,30 @@ class MultipleHiddenInputTest(WidgetTest):
     def test_render_single(self):
         self.check_html(
             self.widget, 'email', ['test@example.com'],
-            html='<input type="hidden" name="email" value="test@example.com">',
+            html='<input type="hidden" name="email" value="test@example.com" />',
         )
 
     def test_render_multiple(self):
         self.check_html(
             self.widget, 'email', ['test@example.com', 'foo@example.com'],
             html=(
-                '<input type="hidden" name="email" value="test@example.com">\n'
-                '<input type="hidden" name="email" value="foo@example.com">'
+                '<input type="hidden" name="email" value="test@example.com" />\n'
+                '<input type="hidden" name="email" value="foo@example.com" />'
             ),
         )
 
     def test_render_attrs(self):
         self.check_html(
             self.widget, 'email', ['test@example.com'], attrs={'class': 'fun'},
-            html='<input type="hidden" name="email" value="test@example.com" class="fun">',
+            html='<input type="hidden" name="email" value="test@example.com" class="fun" />',
         )
 
     def test_render_attrs_multiple(self):
         self.check_html(
             self.widget, 'email', ['test@example.com', 'foo@example.com'], attrs={'class': 'fun'},
             html=(
-                '<input type="hidden" name="email" value="test@example.com" class="fun">\n'
-                '<input type="hidden" name="email" value="foo@example.com" class="fun">'
+                '<input type="hidden" name="email" value="test@example.com" class="fun" />\n'
+                '<input type="hidden" name="email" value="foo@example.com" class="fun" />'
             ),
         )
 
@@ -41,18 +41,18 @@ class MultipleHiddenInputTest(WidgetTest):
         self.check_html(widget, 'email', [], '')
         self.check_html(
             widget, 'email', ['foo@example.com'],
-            html='<input type="hidden" class="fun" value="foo@example.com" name="email">',
+            html='<input type="hidden" class="fun" value="foo@example.com" name="email" />',
         )
         self.check_html(
             widget, 'email', ['foo@example.com', 'test@example.com'],
             html=(
-                '<input type="hidden" class="fun" value="foo@example.com" name="email">\n'
-                '<input type="hidden" class="fun" value="test@example.com" name="email">'
+                '<input type="hidden" class="fun" value="foo@example.com" name="email" />\n'
+                '<input type="hidden" class="fun" value="test@example.com" name="email" />'
             ),
         )
         self.check_html(
             widget, 'email', ['foo@example.com'], attrs={'class': 'special'},
-            html='<input type="hidden" class="special" value="foo@example.com" name="email">',
+            html='<input type="hidden" class="special" value="foo@example.com" name="email" />',
         )
 
     def test_render_empty(self):
@@ -68,8 +68,8 @@ class MultipleHiddenInputTest(WidgetTest):
         self.check_html(
             self.widget, 'letters', ['a', 'b', 'c'], attrs={'id': 'hideme'},
             html=(
-                '<input type="hidden" name="letters" value="a" id="hideme_0">\n'
-                '<input type="hidden" name="letters" value="b" id="hideme_1">\n'
-                '<input type="hidden" name="letters" value="c" id="hideme_2">'
+                '<input type="hidden" name="letters" value="a" id="hideme_0" />\n'
+                '<input type="hidden" name="letters" value="b" id="hideme_1" />\n'
+                '<input type="hidden" name="letters" value="c" id="hideme_2" />'
             ),
         )

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -155,9 +155,9 @@ class MultiWidgetTest(WidgetTest):
         self.check_html(widget, 'name', 'some text,JP,2007-04-25 06:24:00', html=(
             """
             <input type="text" name="name_0" value="some text" />
-            <select multiple name="name_1">
-                <option value="J" selected>John</option>
-                <option value="P" selected>Paul</option>
+            <select multiple="multiple" name="name_1">
+                <option value="J" selected="selected">John</option>
+                <option value="P" selected="selected">Paul</option>
                 <option value="G">George</option>
                 <option value="R">Ringo</option>
             </select>

--- a/tests/forms_tests/widget_tests/test_multiwidget.py
+++ b/tests/forms_tests/widget_tests/test_multiwidget.py
@@ -88,16 +88,16 @@ class MultiWidgetTest(WidgetTest):
             )
         )
         self.check_html(widget, 'name', ['john', 'lennon'], html=(
-            '<input type="text" class="big" value="john" name="name_0">'
-            '<input type="text" class="small" value="lennon" name="name_1">'
+            '<input type="text" class="big" value="john" name="name_0" />'
+            '<input type="text" class="small" value="lennon" name="name_1" />'
         ))
         self.check_html(widget, 'name', 'john__lennon', html=(
-            '<input type="text" class="big" value="john" name="name_0">'
-            '<input type="text" class="small" value="lennon" name="name_1">'
+            '<input type="text" class="big" value="john" name="name_0" />'
+            '<input type="text" class="small" value="lennon" name="name_1" />'
         ))
         self.check_html(widget, 'name', 'john__lennon', attrs={'id': 'foo'}, html=(
-            '<input id="foo_0" type="text" class="big" value="john" name="name_0">'
-            '<input id="foo_1" type="text" class="small" value="lennon" name="name_1">'
+            '<input id="foo_0" type="text" class="big" value="john" name="name_0" />'
+            '<input id="foo_1" type="text" class="small" value="lennon" name="name_1" />'
         ))
 
     def test_constructor_attrs(self):
@@ -109,21 +109,21 @@ class MultiWidgetTest(WidgetTest):
             attrs={'id': 'bar'},
         )
         self.check_html(widget, 'name', ['john', 'lennon'], html=(
-            '<input id="bar_0" type="text" class="big" value="john" name="name_0">'
-            '<input id="bar_1" type="text" class="small" value="lennon" name="name_1">'
+            '<input id="bar_0" type="text" class="big" value="john" name="name_0" />'
+            '<input id="bar_1" type="text" class="small" value="lennon" name="name_1" />'
         ))
 
     def test_constructor_attrs_with_type(self):
         attrs = {'type': 'number'}
         widget = MyMultiWidget(widgets=(TextInput, TextInput()), attrs=attrs)
         self.check_html(widget, 'code', ['1', '2'], html=(
-            '<input type="number" value="1" name="code_0">'
-            '<input type="number" value="2" name="code_1">'
+            '<input type="number" value="1" name="code_0" />'
+            '<input type="number" value="2" name="code_1" />'
         ))
         widget = MyMultiWidget(widgets=(TextInput(attrs), TextInput(attrs)), attrs={'class': 'bar'})
         self.check_html(widget, 'code', ['1', '2'], html=(
-            '<input type="number" value="1" name="code_0" class="bar">'
-            '<input type="number" value="2" name="code_1" class="bar">'
+            '<input type="number" value="1" name="code_0" class="bar" />'
+            '<input type="number" value="2" name="code_1" class="bar" />'
         ))
 
     def test_value_omitted_from_data(self):
@@ -154,23 +154,23 @@ class MultiWidgetTest(WidgetTest):
         widget = ComplexMultiWidget()
         self.check_html(widget, 'name', 'some text,JP,2007-04-25 06:24:00', html=(
             """
-            <input type="text" name="name_0" value="some text">
+            <input type="text" name="name_0" value="some text" />
             <select multiple name="name_1">
                 <option value="J" selected>John</option>
                 <option value="P" selected>Paul</option>
                 <option value="G">George</option>
                 <option value="R">Ringo</option>
             </select>
-            <input type="text" name="name_2_0" value="2007-04-25">
-            <input type="text" name="name_2_1" value="06:24:00">
+            <input type="text" name="name_2_0" value="2007-04-25" />
+            <input type="text" name="name_2_1" value="06:24:00" />
             """
         ))
 
     def test_no_whitespace_between_widgets(self):
         widget = MyMultiWidget(widgets=(TextInput, TextInput()))
         self.check_html(widget, 'code', None, html=(
-            '<input type="text" name="code_0">'
-            '<input type="text" name="code_1">'
+            '<input type="text" name="code_0" />'
+            '<input type="text" name="code_1" />'
         ), strict=True)
 
     def test_deepcopy(self):

--- a/tests/forms_tests/widget_tests/test_nullbooleanselect.py
+++ b/tests/forms_tests/widget_tests/test_nullbooleanselect.py
@@ -12,7 +12,7 @@ class NullBooleanSelectTest(WidgetTest):
         self.check_html(self.widget, 'is_cool', True, html=(
             """<select name="is_cool">
             <option value="1">Unknown</option>
-            <option value="2" selected>Yes</option>
+            <option value="2" selected="selected">Yes</option>
             <option value="3">No</option>
             </select>"""
         ))
@@ -22,14 +22,14 @@ class NullBooleanSelectTest(WidgetTest):
             """<select name="is_cool">
             <option value="1">Unknown</option>
             <option value="2">Yes</option>
-            <option value="3" selected>No</option>
+            <option value="3" selected="selected">No</option>
             </select>"""
         ))
 
     def test_render_none(self):
         self.check_html(self.widget, 'is_cool', None, html=(
             """<select name="is_cool">
-            <option value="1" selected>Unknown</option>
+            <option value="1" selected="selected">Unknown</option>
             <option value="2">Yes</option>
             <option value="3">No</option>
             </select>"""
@@ -39,7 +39,7 @@ class NullBooleanSelectTest(WidgetTest):
         self.check_html(self.widget, 'is_cool', '2', html=(
             """<select name="is_cool">
             <option value="1">Unknown</option>
-            <option value="2" selected>Yes</option>
+            <option value="2" selected="selected">Yes</option>
             <option value="3">No</option>
             </select>"""
         ))
@@ -56,7 +56,7 @@ class NullBooleanSelectTest(WidgetTest):
                 """
                 <select name="id_bool">
                     <option value="1">Unbekannt</option>
-                    <option value="2" selected>Ja</option>
+                    <option value="2" selected="selected">Ja</option>
                     <option value="3">Nein</option>
                 </select>
                 """

--- a/tests/forms_tests/widget_tests/test_numberinput.py
+++ b/tests/forms_tests/widget_tests/test_numberinput.py
@@ -11,5 +11,5 @@ class NumberInputTests(WidgetTest):
         widget = NumberInput(attrs={'max': 12345, 'min': 1234, 'step': 9999})
         self.check_html(
             widget, 'name', 'value',
-            '<input type="number" name="name" value="value" max="12345" min="1234" step="9999">'
+            '<input type="number" name="name" value="value" max="12345" min="1234" step="9999" />'
         )

--- a/tests/forms_tests/widget_tests/test_passwordinput.py
+++ b/tests/forms_tests/widget_tests/test_passwordinput.py
@@ -7,10 +7,10 @@ class PasswordInputTest(WidgetTest):
     widget = PasswordInput()
 
     def test_render(self):
-        self.check_html(self.widget, 'password', '', html='<input type="password" name="password">')
+        self.check_html(self.widget, 'password', '', html='<input type="password" name="password" />')
 
     def test_render_ignore_value(self):
-        self.check_html(self.widget, 'password', 'secret', html='<input type="password" name="password">')
+        self.check_html(self.widget, 'password', 'secret', html='<input type="password" name="password" />')
 
     def test_render_value_true(self):
         """
@@ -18,9 +18,9 @@ class PasswordInputTest(WidgetTest):
         render its value. For security reasons, this is off by default.
         """
         widget = PasswordInput(render_value=True)
-        self.check_html(widget, 'password', '', html='<input type="password" name="password">')
-        self.check_html(widget, 'password', None, html='<input type="password" name="password">')
+        self.check_html(widget, 'password', '', html='<input type="password" name="password" />')
+        self.check_html(widget, 'password', None, html='<input type="password" name="password" />')
         self.check_html(
             widget, 'password', 'test@example.com',
-            html='<input type="password" name="password" value="test@example.com">',
+            html='<input type="password" name="password" value="test@example.com" />',
         )

--- a/tests/forms_tests/widget_tests/test_radioselect.py
+++ b/tests/forms_tests/widget_tests/test_radioselect.py
@@ -13,11 +13,11 @@ class RadioSelectTest(WidgetTest):
         choices = (('', '------'),) + self.beatles
         self.check_html(self.widget(choices=choices), 'beatle', 'J', html=(
             """<ul>
-            <li><label><input type="radio" name="beatle" value=""> ------</label></li>
-            <li><label><input checked type="radio" name="beatle" value="J"> John</label></li>
-            <li><label><input type="radio" name="beatle" value="P"> Paul</label></li>
-            <li><label><input type="radio" name="beatle" value="G"> George</label></li>
-            <li><label><input type="radio" name="beatle" value="R"> Ringo</label></li>
+            <li><label><input type="radio" name="beatle" value="" /> ------</label></li>
+            <li><label><input checked type="radio" name="beatle" value="J" /> John</label></li>
+            <li><label><input type="radio" name="beatle" value="P" /> Paul</label></li>
+            <li><label><input type="radio" name="beatle" value="G" /> George</label></li>
+            <li><label><input type="radio" name="beatle" value="R" /> Ringo</label></li>
             </ul>"""
         ))
 
@@ -30,19 +30,19 @@ class RadioSelectTest(WidgetTest):
         html = """
         <ul id="media">
         <li>
-        <label for="media_0"><input id="media_0" name="nestchoice" type="radio" value="unknown"> Unknown</label>
+        <label for="media_0"><input id="media_0" name="nestchoice" type="radio" value="unknown" /> Unknown</label>
         </li>
         <li>Audio<ul id="media_1">
         <li>
-        <label for="media_1_0"><input id="media_1_0" name="nestchoice" type="radio" value="vinyl"> Vinyl</label>
+        <label for="media_1_0"><input id="media_1_0" name="nestchoice" type="radio" value="vinyl" /> Vinyl</label>
         </li>
-        <li><label for="media_1_1"><input id="media_1_1" name="nestchoice" type="radio" value="cd"> CD</label></li>
+        <li><label for="media_1_1"><input id="media_1_1" name="nestchoice" type="radio" value="cd" /> CD</label></li>
         </ul></li>
         <li>Video<ul id="media_2">
-        <li><label for="media_2_0"><input id="media_2_0" name="nestchoice" type="radio" value="vhs"> VHS</label></li>
+        <li><label for="media_2_0"><input id="media_2_0" name="nestchoice" type="radio" value="vhs" /> VHS</label></li>
         <li>
         <label for="media_2_1">
-        <input checked id="media_2_1" name="nestchoice" type="radio" value="dvd"> DVD
+        <input checked id="media_2_1" name="nestchoice" type="radio" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -62,11 +62,11 @@ class RadioSelectTest(WidgetTest):
         html = """
         <ul id="foo">
         <li>
-        <label for="foo_0"><input checked type="radio" id="foo_0" value="J" name="beatle"> John</label>
+        <label for="foo_0"><input checked type="radio" id="foo_0" value="J" name="beatle" /> John</label>
         </li>
-        <li><label for="foo_1"><input type="radio" id="foo_1" value="P" name="beatle"> Paul</label></li>
-        <li><label for="foo_2"><input type="radio" id="foo_2" value="G" name="beatle"> George</label></li>
-        <li><label for="foo_3"><input type="radio" id="foo_3" value="R" name="beatle"> Ringo</label></li>
+        <li><label for="foo_1"><input type="radio" id="foo_1" value="P" name="beatle" /> Paul</label></li>
+        <li><label for="foo_2"><input type="radio" id="foo_2" value="G" name="beatle" /> George</label></li>
+        <li><label for="foo_3"><input type="radio" id="foo_3" value="R" name="beatle" /> Ringo</label></li>
         </ul>
         """
         self.check_html(widget, 'beatle', 'J', html=html)
@@ -79,11 +79,11 @@ class RadioSelectTest(WidgetTest):
         html = """
         <ul id="bar">
         <li>
-        <label for="bar_0"><input checked type="radio" id="bar_0" value="J" name="beatle"> John</label>
+        <label for="bar_0"><input checked type="radio" id="bar_0" value="J" name="beatle" /> John</label>
         </li>
-        <li><label for="bar_1"><input type="radio" id="bar_1" value="P" name="beatle"> Paul</label></li>
-        <li><label for="bar_2"><input type="radio" id="bar_2" value="G" name="beatle"> George</label></li>
-        <li><label for="bar_3"><input type="radio" id="bar_3" value="R" name="beatle"> Ringo</label></li>
+        <li><label for="bar_1"><input type="radio" id="bar_1" value="P" name="beatle" /> Paul</label></li>
+        <li><label for="bar_2"><input type="radio" id="bar_2" value="G" name="beatle" /> George</label></li>
+        <li><label for="bar_3"><input type="radio" id="bar_3" value="R" name="beatle" /> Ringo</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=self.beatles), 'beatle', 'J', attrs={'id': 'bar'}, html=html)
@@ -95,10 +95,10 @@ class RadioSelectTest(WidgetTest):
         """
         html = """
         <ul class="bar">
-        <li><label><input checked type="radio" class="bar" value="J" name="beatle"> John</label></li>
-        <li><label><input type="radio" class="bar" value="P" name="beatle"> Paul</label></li>
-        <li><label><input type="radio" class="bar" value="G" name="beatle"> George</label></li>
-        <li><label><input type="radio" class="bar" value="R" name="beatle"> Ringo</label></li>
+        <li><label><input checked type="radio" class="bar" value="J" name="beatle" /> John</label></li>
+        <li><label><input type="radio" class="bar" value="P" name="beatle" /> Paul</label></li>
+        <li><label><input type="radio" class="bar" value="G" name="beatle" /> George</label></li>
+        <li><label><input type="radio" class="bar" value="R" name="beatle" /> Ringo</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=self.beatles), 'beatle', 'J', attrs={'class': 'bar'}, html=html)
@@ -112,9 +112,9 @@ class RadioSelectTest(WidgetTest):
         ]
         html = """
         <ul>
-        <li><label><input type="radio" name="number" value="1"> One</label></li>
-        <li><label><input type="radio" name="number" value="1000"> One thousand</label></li>
-        <li><label><input type="radio" name="number" value="1000000"> One million</label></li>
+        <li><label><input type="radio" name="number" value="1" /> One</label></li>
+        <li><label><input type="radio" name="number" value="1000" /> One thousand</label></li>
+        <li><label><input type="radio" name="number" value="1000000" /> One million</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=choices), 'number', None, html=html)
@@ -125,8 +125,8 @@ class RadioSelectTest(WidgetTest):
         ]
         html = """
         <ul>
-        <li><label><input type="radio" name="time" value="00:00:00"> midnight</label></li>
-        <li><label><input type="radio" name="time" value="12:00:00"> noon</label></li>
+        <li><label><input type="radio" name="time" value="00:00:00" /> midnight</label></li>
+        <li><label><input type="radio" name="time" value="12:00:00" /> noon</label></li>
         </ul>
         """
         self.check_html(self.widget(choices=choices), 'time', None, html=html)
@@ -136,10 +136,10 @@ class RadioSelectTest(WidgetTest):
         choices = (('', '------'),) + self.beatles
         self.check_html(MultiWidget([self.widget(choices=choices)]), 'beatle', ['J'], html=(
             """<ul>
-            <li><label><input type="radio" name="beatle_0" value=""> ------</label></li>
-            <li><label><input checked type="radio" name="beatle_0" value="J"> John</label></li>
-            <li><label><input type="radio" name="beatle_0" value="P"> Paul</label></li>
-            <li><label><input type="radio" name="beatle_0" value="G"> George</label></li>
-            <li><label><input type="radio" name="beatle_0" value="R"> Ringo</label></li>
+            <li><label><input type="radio" name="beatle_0" value="" /> ------</label></li>
+            <li><label><input checked type="radio" name="beatle_0" value="J" /> John</label></li>
+            <li><label><input type="radio" name="beatle_0" value="P" /> Paul</label></li>
+            <li><label><input type="radio" name="beatle_0" value="G" /> George</label></li>
+            <li><label><input type="radio" name="beatle_0" value="R" /> Ringo</label></li>
             </ul>"""
         ))

--- a/tests/forms_tests/widget_tests/test_radioselect.py
+++ b/tests/forms_tests/widget_tests/test_radioselect.py
@@ -14,7 +14,7 @@ class RadioSelectTest(WidgetTest):
         self.check_html(self.widget(choices=choices), 'beatle', 'J', html=(
             """<ul>
             <li><label><input type="radio" name="beatle" value="" /> ------</label></li>
-            <li><label><input checked type="radio" name="beatle" value="J" /> John</label></li>
+            <li><label><input checked="checked" type="radio" name="beatle" value="J" /> John</label></li>
             <li><label><input type="radio" name="beatle" value="P" /> Paul</label></li>
             <li><label><input type="radio" name="beatle" value="G" /> George</label></li>
             <li><label><input type="radio" name="beatle" value="R" /> Ringo</label></li>
@@ -42,7 +42,7 @@ class RadioSelectTest(WidgetTest):
         <li><label for="media_2_0"><input id="media_2_0" name="nestchoice" type="radio" value="vhs" /> VHS</label></li>
         <li>
         <label for="media_2_1">
-        <input checked id="media_2_1" name="nestchoice" type="radio" value="dvd" /> DVD
+        <input checked="checked" id="media_2_1" name="nestchoice" type="radio" value="dvd" /> DVD
         </label>
         </li>
         </ul></li>
@@ -62,7 +62,7 @@ class RadioSelectTest(WidgetTest):
         html = """
         <ul id="foo">
         <li>
-        <label for="foo_0"><input checked type="radio" id="foo_0" value="J" name="beatle" /> John</label>
+        <label for="foo_0"><input checked="checked" type="radio" id="foo_0" value="J" name="beatle" /> John</label>
         </li>
         <li><label for="foo_1"><input type="radio" id="foo_1" value="P" name="beatle" /> Paul</label></li>
         <li><label for="foo_2"><input type="radio" id="foo_2" value="G" name="beatle" /> George</label></li>
@@ -79,7 +79,7 @@ class RadioSelectTest(WidgetTest):
         html = """
         <ul id="bar">
         <li>
-        <label for="bar_0"><input checked type="radio" id="bar_0" value="J" name="beatle" /> John</label>
+        <label for="bar_0"><input checked="checked" type="radio" id="bar_0" value="J" name="beatle" /> John</label>
         </li>
         <li><label for="bar_1"><input type="radio" id="bar_1" value="P" name="beatle" /> Paul</label></li>
         <li><label for="bar_2"><input type="radio" id="bar_2" value="G" name="beatle" /> George</label></li>
@@ -95,7 +95,7 @@ class RadioSelectTest(WidgetTest):
         """
         html = """
         <ul class="bar">
-        <li><label><input checked type="radio" class="bar" value="J" name="beatle" /> John</label></li>
+        <li><label><input checked="checked" type="radio" class="bar" value="J" name="beatle" /> John</label></li>
         <li><label><input type="radio" class="bar" value="P" name="beatle" /> Paul</label></li>
         <li><label><input type="radio" class="bar" value="G" name="beatle" /> George</label></li>
         <li><label><input type="radio" class="bar" value="R" name="beatle" /> Ringo</label></li>
@@ -137,7 +137,7 @@ class RadioSelectTest(WidgetTest):
         self.check_html(MultiWidget([self.widget(choices=choices)]), 'beatle', ['J'], html=(
             """<ul>
             <li><label><input type="radio" name="beatle_0" value="" /> ------</label></li>
-            <li><label><input checked type="radio" name="beatle_0" value="J" /> John</label></li>
+            <li><label><input checked="checked" type="radio" name="beatle_0" value="J" /> John</label></li>
             <li><label><input type="radio" name="beatle_0" value="P" /> Paul</label></li>
             <li><label><input type="radio" name="beatle_0" value="G" /> George</label></li>
             <li><label><input type="radio" name="beatle_0" value="R" /> Ringo</label></li>

--- a/tests/forms_tests/widget_tests/test_select.py
+++ b/tests/forms_tests/widget_tests/test_select.py
@@ -18,7 +18,7 @@ class SelectTest(WidgetTest):
     def test_render(self):
         self.check_html(self.widget(choices=self.beatles), 'beatle', 'J', html=(
             """<select name="beatle">
-            <option value="J" selected>John</option>
+            <option value="J" selected="selected">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
@@ -60,7 +60,7 @@ class SelectTest(WidgetTest):
 
         self.check_html(self.widget(choices=choices), 'choices', '0', html=(
             """<select name="choices">
-            <option value="0" selected>0</option>
+            <option value="0" selected="selected">0</option>
             <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
@@ -79,7 +79,7 @@ class SelectTest(WidgetTest):
         self.check_html(widget, 'num', 2, html=(
             """<select name="num" class="super" id="super">
               <option value="1">1</option>
-              <option value="2" selected>2</option>
+              <option value="2" selected="selected">2</option>
               <option value="3">3</option>
             </select>"""
         ))
@@ -94,7 +94,7 @@ class SelectTest(WidgetTest):
             html=(
                 """<select name="num">
                 <option value="1">1</option>
-                <option value="2" selected>2</option>
+                <option value="2" selected="selected">2</option>
                 <option value="3">3</option>
                 </select>"""
             ),
@@ -105,7 +105,7 @@ class SelectTest(WidgetTest):
             html=(
                 """<select name="num">
                 <option value="1">1</option>
-                <option value="2" selected>2</option>
+                <option value="2" selected="selected">2</option>
                 <option value="3">3</option>
                 </select>"""
             ),
@@ -116,7 +116,7 @@ class SelectTest(WidgetTest):
             html=(
                 """<select name="num">
                 <option value="1">1</option>
-                <option value="2" selected>2</option>
+                <option value="2" selected="selected">2</option>
                 <option value="3">3</option>
                 </select>"""
             ),
@@ -127,7 +127,7 @@ class SelectTest(WidgetTest):
         self.check_html(widget, 'num', 2, html=(
             """<select name="num">
             <option value="1">1</option>
-            <option value="2" selected>2</option>
+            <option value="2" selected="selected">2</option>
             <option value="3">3</option>
             </select>"""
         ))
@@ -146,7 +146,7 @@ class SelectTest(WidgetTest):
             """<select name="num">
             <option value="0">0</option>
             <option value="1">1</option>
-            <option value="2" selected>2</option>
+            <option value="2" selected="selected">2</option>
             <option value="3">3</option>
             <option value="4">4</option>
             </select>"""
@@ -156,7 +156,7 @@ class SelectTest(WidgetTest):
             <option value="0">0</option>
             <option value="1">1</option>
             <option value="2">2</option>
-            <option value="3" selected>3</option>
+            <option value="3" selected="selected">3</option>
             <option value="4">4</option>
             </select>"""
         ))
@@ -176,7 +176,7 @@ class SelectTest(WidgetTest):
             'email', 'ŠĐĆŽćžšđ',
             html=(
                 """<select name="email">
-                <option value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" selected>
+                <option value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" selected="selected">
                     \u0160\u0110abc\u0106\u017d\u0107\u017e\u0161\u0111
                 </option>
                 <option value="\u0107\u017e\u0161\u0111">abc\u0107\u017e\u0161\u0111</option>
@@ -201,7 +201,7 @@ class SelectTest(WidgetTest):
     def test_choices_select_outer(self):
         self.check_html(self.nested_widget, 'nestchoice', 'outer1', html=(
             """<select name="nestchoice">
-            <option value="outer1" selected>Outer 1</option>
+            <option value="outer1" selected="selected">Outer 1</option>
             <optgroup label="Group &quot;1&quot;">
             <option value="inner1">Inner 1</option>
             <option value="inner2">Inner 2</option>
@@ -214,7 +214,7 @@ class SelectTest(WidgetTest):
             """<select name="nestchoice">
             <option value="outer1">Outer 1</option>
             <optgroup label="Group &quot;1&quot;">
-            <option value="inner1" selected>Inner 1</option>
+            <option value="inner1" selected="selected">Inner 1</option>
             <option value="inner2">Inner 2</option>
             </optgroup>
             </select>"""

--- a/tests/forms_tests/widget_tests/test_selectdatewidget.py
+++ b/tests/forms_tests/widget_tests/test_selectdatewidget.py
@@ -18,7 +18,7 @@ class SelectDateWidgetTest(WidgetTest):
         self.check_html(self.widget, 'mydate', '', html=(
             """
             <select name="mydate_month" id="id_mydate_month">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3">March</option>
@@ -34,7 +34,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_day" id="id_mydate_day">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -69,7 +69,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_year" id="id_mydate_year">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="2007">2007</option>
                 <option value="2008">2008</option>
                 <option value="2009">2009</option>
@@ -101,7 +101,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3">March</option>
-                <option value="4" selected>April</option>
+                <option value="4" selected="selected">April</option>
                 <option value="5">May</option>
                 <option value="6">June</option>
                 <option value="7">July</option>
@@ -128,7 +128,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="12">12</option>
                 <option value="13">13</option>
                 <option value="14">14</option>
-                <option value="15" selected>15</option>
+                <option value="15" selected="selected">15</option>
                 <option value="16">16</option>
                 <option value="17">17</option>
                 <option value="18">18</option>
@@ -152,7 +152,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="2007">2007</option>
                 <option value="2008">2008</option>
                 <option value="2009">2009</option>
-                <option value="2010" selected>2010</option>
+                <option value="2010" selected="selected">2010</option>
                 <option value="2011">2011</option>
                 <option value="2012">2012</option>
                 <option value="2013">2013</option>
@@ -178,7 +178,7 @@ class SelectDateWidgetTest(WidgetTest):
             <select name="mydate_month" id="id_mydate_month">
                 <option value="">---</option>
                 <option value="1">January</option>
-                <option value="2" selected>February</option>
+                <option value="2" selected="selected">February</option>
                 <option value="3">March</option>
                 <option value="4">April</option>
                 <option value="5">May</option>
@@ -223,7 +223,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="28">28</option>
                 <option value="29">29</option>
                 <option value="30">30</option>
-                <option value="31" selected>31</option>
+                <option value="31" selected="selected">31</option>
             </select>
 
             <select name="mydate_year" id="id_mydate_year">
@@ -231,7 +231,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="2007">2007</option>
                 <option value="2008">2008</option>
                 <option value="2009">2009</option>
-                <option value="2010" selected>2010</option>
+                <option value="2010" selected="selected">2010</option>
                 <option value="2011">2011</option>
                 <option value="2012">2012</option>
                 <option value="2013">2013</option>
@@ -247,7 +247,7 @@ class SelectDateWidgetTest(WidgetTest):
         self.check_html(widget, 'mydate', '', html=(
             """
             <select name="mydate_month" id="id_mydate_month">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">Jan.</option>
                 <option value="2">Feb.</option>
                 <option value="3">March</option>
@@ -263,7 +263,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_day" id="id_mydate_day">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -298,7 +298,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_year" id="id_mydate_year">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="2013">2013</option>
             </select>
             """
@@ -318,7 +318,7 @@ class SelectDateWidgetTest(WidgetTest):
         w = SelectDateWidget(years=('2014',), empty_label='empty_label')
 
         # Rendering the default state with empty_label set as string.
-        self.assertInHTML('<option selected value="">empty_label</option>', w.render('mydate', ''), count=3)
+        self.assertInHTML('<option selected="selected" value="">empty_label</option>', w.render('mydate', ''), count=3)
 
         w = SelectDateWidget(years=('2014',), empty_label=('empty_year', 'empty_month', 'empty_day'))
 
@@ -327,7 +327,7 @@ class SelectDateWidgetTest(WidgetTest):
             w.render('mydate', ''),
             """
             <select name="mydate_month" id="id_mydate_month">
-                <option selected value="">empty_month</option>
+                <option selected="selected" value="">empty_month</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3">March</option>
@@ -343,7 +343,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_day" id="id_mydate_day">
-                <option selected value="">empty_day</option>
+                <option selected="selected" value="">empty_day</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -378,7 +378,7 @@ class SelectDateWidgetTest(WidgetTest):
             </select>
 
             <select name="mydate_year" id="id_mydate_year">
-                <option selected value="">empty_year</option>
+                <option selected="selected" value="">empty_year</option>
                 <option value="2014">2014</option>
             </select>
             """,
@@ -415,7 +415,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="10">10</option>
                 <option value="11">11</option>
                 <option value="12">12</option>
-                <option value="13" selected>13</option>
+                <option value="13" selected="selected">13</option>
                 <option value="14">14</option>
                 <option value="15">15</option>
                 <option value="16">16</option>
@@ -445,7 +445,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="5">mei</option>
                 <option value="6">juni</option>
                 <option value="7">juli</option>
-                <option value="8" selected>augustus</option>
+                <option value="8" selected="selected">augustus</option>
                 <option value="9">september</option>
                 <option value="10">oktober</option>
                 <option value="11">november</option>
@@ -457,7 +457,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="2007">2007</option>
                 <option value="2008">2008</option>
                 <option value="2009">2009</option>
-                <option value="2010" selected>2010</option>
+                <option value="2010" selected="selected">2010</option>
                 <option value="2011">2011</option>
                 <option value="2012">2012</option>
                 <option value="2013">2013</option>
@@ -469,7 +469,7 @@ class SelectDateWidgetTest(WidgetTest):
         )
 
         # Even with an invalid date, the widget should reflect the entered value (#17401).
-        self.assertEqual(w.render('mydate', '2010-02-30').count('selected'), 3)
+        self.assertEqual(w.render('mydate', '2010-02-30').count('selected="selected"'), 3)
 
         # Years before 1900 should work.
         w = SelectDateWidget(years=('1899',))
@@ -530,7 +530,7 @@ class SelectDateWidgetTest(WidgetTest):
         self.check_html(widget, 'mydate', '', html=(
             """
             <select name="mydate_month" id="id_mydate_month">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3">March</option>
@@ -545,7 +545,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="12">December</option>
             </select>
             <select name="mydate_day" id="id_mydate_day">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -579,7 +579,7 @@ class SelectDateWidgetTest(WidgetTest):
                 <option value="31">31</option>
             </select>
             <select name="mydate_year" id="id_mydate_year">
-                <option selected value="">---</option>
+                <option selected="selected" value="">---</option>
                 <option value="2007">2007</option>
             </select>
             """

--- a/tests/forms_tests/widget_tests/test_selectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_selectmultiple.py
@@ -15,8 +15,8 @@ class SelectMultipleTest(WidgetTest):
 
     def test_render_selected(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J'], html=(
-            """<select multiple name="beatles">
-            <option value="J" selected>John</option>
+            """<select multiple="multiple" name="beatles">
+            <option value="J" selected="selected">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
@@ -25,9 +25,9 @@ class SelectMultipleTest(WidgetTest):
 
     def test_render_multiple_selected(self):
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J', 'P'], html=(
-            """<select multiple name="beatles">
-            <option value="J" selected>John</option>
-            <option value="P" selected>Paul</option>
+            """<select multiple="multiple" name="beatles">
+            <option value="J" selected="selected">John</option>
+            <option value="P" selected="selected">Paul</option>
             <option value="G">George</option>
             <option value="R">Ringo</option>
             </select>"""
@@ -39,7 +39,7 @@ class SelectMultipleTest(WidgetTest):
         choices have an empty option.
         """
         self.check_html(self.widget(choices=(('', 'Unknown'),) + self.beatles), 'beatles', None, html=(
-            """<select multiple name="beatles">
+            """<select multiple="multiple" name="beatles">
             <option value="">Unknown</option>
             <option value="J">John</option>
             <option value="P">Paul</option>
@@ -54,7 +54,7 @@ class SelectMultipleTest(WidgetTest):
         of the options are selected.
         """
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['John'], html=(
-            """<select multiple name="beatles">
+            """<select multiple="multiple" name="beatles">
             <option value="J">John</option>
             <option value="P">Paul</option>
             <option value="G">George</option>
@@ -67,12 +67,12 @@ class SelectMultipleTest(WidgetTest):
         Multiple options with the same value can be selected (#8103).
         """
         self.check_html(self.widget(choices=self.numeric_choices), 'choices', ['0'], html=(
-            """<select multiple name="choices">
-            <option value="0" selected>0</option>
+            """<select multiple="multiple" name="choices">
+            <option value="0" selected="selected">0</option>
             <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
-            <option value="0" selected>extra</option>
+            <option value="0" selected="selected">extra</option>
             </select>"""
         ))
 
@@ -82,10 +82,10 @@ class SelectMultipleTest(WidgetTest):
         ones are selected.
         """
         self.check_html(self.widget(choices=self.beatles), 'beatles', ['J', 'G', 'foo'], html=(
-            """<select multiple name="beatles">
-            <option value="J" selected>John</option>
+            """<select multiple="multiple" name="beatles">
+            <option value="J" selected="selected">John</option>
             <option value="P">Paul</option>
-            <option value="G" selected>George</option>
+            <option value="G" selected="selected">George</option>
             <option value="R">Ringo</option>
             </select>"""
         ))
@@ -94,25 +94,25 @@ class SelectMultipleTest(WidgetTest):
         choices = [('1', '1'), ('2', '2'), ('3', '3')]
 
         self.check_html(self.widget(choices=choices), 'nums', [2], html=(
-            """<select multiple name="nums">
+            """<select multiple="multiple" name="nums">
             <option value="1">1</option>
-            <option value="2" selected>2</option>
+            <option value="2" selected="selected">2</option>
             <option value="3">3</option>
             </select>"""
         ))
 
         self.check_html(self.widget(choices=choices), 'nums', ['2'], html=(
-            """<select multiple name="nums">
+            """<select multiple="multiple" name="nums">
             <option value="1">1</option>
-            <option value="2" selected>2</option>
+            <option value="2" selected="selected">2</option>
             <option value="3">3</option>
             </select>"""
         ))
 
         self.check_html(self.widget(choices=choices), 'nums', [2], html=(
-            """<select multiple name="nums">
+            """<select multiple="multiple" name="nums">
             <option value="1">1</option>
-            <option value="2" selected>2</option>
+            <option value="2" selected="selected">2</option>
             <option value="3">3</option>
             </select>"""
         ))
@@ -123,11 +123,11 @@ class SelectMultipleTest(WidgetTest):
             ('Group "1"', (('inner1', 'Inner 1'), ('inner2', 'Inner 2'))),
         ))
         self.check_html(widget, 'nestchoice', ['outer1', 'inner2'], html=(
-            """<select multiple name="nestchoice">
-            <option value="outer1" selected>Outer 1</option>
+            """<select multiple="multiple" name="nestchoice">
+            <option value="outer1" selected="selected">Outer 1</option>
             <optgroup label="Group &quot;1&quot;">
             <option value="inner1">Inner 1</option>
-            <option value="inner2" selected>Inner 2</option>
+            <option value="inner2" selected="selected">Inner 2</option>
             </optgroup>
             </select>"""
         ))

--- a/tests/forms_tests/widget_tests/test_splitdatetimewidget.py
+++ b/tests/forms_tests/widget_tests/test_splitdatetimewidget.py
@@ -10,37 +10,37 @@ class SplitDateTimeWidgetTest(WidgetTest):
 
     def test_render_empty(self):
         self.check_html(self.widget, 'date', '', html=(
-            '<input type="text" name="date_0"><input type="text" name="date_1">'
+            '<input type="text" name="date_0" /><input type="text" name="date_1" />'
         ))
 
     def test_render_none(self):
         self.check_html(self.widget, 'date', None, html=(
-            '<input type="text" name="date_0"><input type="text" name="date_1">'
+            '<input type="text" name="date_0" /><input type="text" name="date_1" />'
         ))
 
     def test_render_datetime(self):
         self.check_html(self.widget, 'date', datetime(2006, 1, 10, 7, 30), html=(
-            '<input type="text" name="date_0" value="2006-01-10">'
-            '<input type="text" name="date_1" value="07:30:00">'
+            '<input type="text" name="date_0" value="2006-01-10" />'
+            '<input type="text" name="date_1" value="07:30:00" />'
         ))
 
     def test_render_date_and_time(self):
         self.check_html(self.widget, 'date', [date(2006, 1, 10), time(7, 30)], html=(
-            '<input type="text" name="date_0" value="2006-01-10">'
-            '<input type="text" name="date_1" value="07:30:00">'
+            '<input type="text" name="date_0" value="2006-01-10" />'
+            '<input type="text" name="date_1" value="07:30:00" />'
         ))
 
     def test_constructor_attrs(self):
         widget = SplitDateTimeWidget(attrs={'class': 'pretty'})
         self.check_html(widget, 'date', datetime(2006, 1, 10, 7, 30), html=(
-            '<input type="text" class="pretty" value="2006-01-10" name="date_0">'
-            '<input type="text" class="pretty" value="07:30:00" name="date_1">'
+            '<input type="text" class="pretty" value="2006-01-10" name="date_0" />'
+            '<input type="text" class="pretty" value="07:30:00" name="date_1" />'
         ))
 
     def test_constructor_different_attrs(self):
         html = (
-            '<input type="text" class="foo" value="2006-01-10" name="date_0">'
-            '<input type="text" class="bar" value="07:30:00" name="date_1">'
+            '<input type="text" class="foo" value="2006-01-10" name="date_0" />'
+            '<input type="text" class="bar" value="07:30:00" name="date_1" />'
         )
         widget = SplitDateTimeWidget(date_attrs={'class': 'foo'}, time_attrs={'class': 'bar'})
         self.check_html(widget, 'date', datetime(2006, 1, 10, 7, 30), html=html)
@@ -58,6 +58,6 @@ class SplitDateTimeWidgetTest(WidgetTest):
             date_format='%d/%m/%Y', time_format='%H:%M',
         )
         self.check_html(widget, 'date', datetime(2006, 1, 10, 7, 30), html=(
-            '<input type="text" name="date_0" value="10/01/2006">'
-            '<input type="text" name="date_1" value="07:30">'
+            '<input type="text" name="date_0" value="10/01/2006" />'
+            '<input type="text" name="date_1" value="07:30" />'
         ))

--- a/tests/forms_tests/widget_tests/test_splithiddendatetimewidget.py
+++ b/tests/forms_tests/widget_tests/test_splithiddendatetimewidget.py
@@ -12,22 +12,22 @@ class SplitHiddenDateTimeWidgetTest(WidgetTest):
 
     def test_render_empty(self):
         self.check_html(self.widget, 'date', '', html=(
-            '<input type="hidden" name="date_0"><input type="hidden" name="date_1">'
+            '<input type="hidden" name="date_0" /><input type="hidden" name="date_1" />'
         ))
 
     def test_render_value(self):
         d = datetime(2007, 9, 17, 12, 51, 34, 482548)
         self.check_html(self.widget, 'date', d, html=(
-            '<input type="hidden" name="date_0" value="2007-09-17">'
-            '<input type="hidden" name="date_1" value="12:51:34">'
+            '<input type="hidden" name="date_0" value="2007-09-17" />'
+            '<input type="hidden" name="date_1" value="12:51:34" />'
         ))
         self.check_html(self.widget, 'date', datetime(2007, 9, 17, 12, 51, 34), html=(
-            '<input type="hidden" name="date_0" value="2007-09-17">'
-            '<input type="hidden" name="date_1" value="12:51:34">'
+            '<input type="hidden" name="date_0" value="2007-09-17" />'
+            '<input type="hidden" name="date_1" value="12:51:34" />'
         ))
         self.check_html(self.widget, 'date', datetime(2007, 9, 17, 12, 51), html=(
-            '<input type="hidden" name="date_0" value="2007-09-17">'
-            '<input type="hidden" name="date_1" value="12:51:00">'
+            '<input type="hidden" name="date_0" value="2007-09-17" />'
+            '<input type="hidden" name="date_1" value="12:51:00" />'
         ))
 
     @override_settings(USE_L10N=True)
@@ -36,15 +36,15 @@ class SplitHiddenDateTimeWidgetTest(WidgetTest):
         d = datetime(2007, 9, 17, 12, 51)
         self.check_html(self.widget, 'date', d, html=(
             """
-            <input type="hidden" name="date_0" value="17.09.2007">
-            <input type="hidden" name="date_1" value="12:51:00">
+            <input type="hidden" name="date_0" value="17.09.2007" />
+            <input type="hidden" name="date_1" value="12:51:00" />
             """
         ))
 
     def test_constructor_different_attrs(self):
         html = (
-            '<input type="hidden" class="foo" value="2006-01-10" name="date_0">'
-            '<input type="hidden" class="bar" value="07:30:00" name="date_1">'
+            '<input type="hidden" class="foo" value="2006-01-10" name="date_0" />'
+            '<input type="hidden" class="bar" value="07:30:00" name="date_1" />'
         )
         widget = SplitHiddenDateTimeWidget(date_attrs={'class': 'foo'}, time_attrs={'class': 'bar'})
         self.check_html(widget, 'date', datetime(2006, 1, 10, 7, 30), html=html)

--- a/tests/forms_tests/widget_tests/test_textinput.py
+++ b/tests/forms_tests/widget_tests/test_textinput.py
@@ -8,14 +8,14 @@ class TextInputTest(WidgetTest):
     widget = TextInput()
 
     def test_render(self):
-        self.check_html(self.widget, 'email', '', html='<input type="text" name="email">')
+        self.check_html(self.widget, 'email', '', html='<input type="text" name="email" />')
 
     def test_render_none(self):
-        self.check_html(self.widget, 'email', None, html='<input type="text" name="email">')
+        self.check_html(self.widget, 'email', None, html='<input type="text" name="email" />')
 
     def test_render_value(self):
         self.check_html(self.widget, 'email', 'test@example.com', html=(
-            '<input type="text" name="email" value="test@example.com">'
+            '<input type="text" name="email" value="test@example.com" />'
         ))
 
     def test_render_boolean(self):
@@ -24,22 +24,22 @@ class TextInputTest(WidgetTest):
         "False").
         """
         self.check_html(self.widget, 'get_spam', False, html=(
-            '<input type="text" name="get_spam" value="False">'
+            '<input type="text" name="get_spam" value="False" />'
         ))
         self.check_html(self.widget, 'get_spam', True, html=(
-            '<input type="text" name="get_spam" value="True">'
+            '<input type="text" name="get_spam" value="True" />'
         ))
 
     def test_render_quoted(self):
         self.check_html(
             self.widget, 'email', 'some "quoted" & ampersanded value',
-            html='<input type="text" name="email" value="some &quot;quoted&quot; &amp; ampersanded value">',
+            html='<input type="text" name="email" value="some &quot;quoted&quot; &amp; ampersanded value" />',
         )
 
     def test_render_custom_attrs(self):
         self.check_html(
             self.widget, 'email', 'test@example.com', attrs={'class': 'fun'},
-            html='<input type="text" name="email" value="test@example.com" class="fun">',
+            html='<input type="text" name="email" value="test@example.com" class="fun" />',
         )
 
     def test_render_unicode(self):
@@ -47,16 +47,16 @@ class TextInputTest(WidgetTest):
             self.widget, 'email', 'ŠĐĆŽćžšđ', attrs={'class': 'fun'},
             html=(
                 '<input type="text" name="email" '
-                'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" class="fun">'
+                'value="\u0160\u0110\u0106\u017d\u0107\u017e\u0161\u0111" class="fun" />'
             ),
         )
 
     def test_constructor_attrs(self):
         widget = TextInput(attrs={'class': 'fun', 'type': 'email'})
-        self.check_html(widget, 'email', '', html='<input type="email" class="fun" name="email">')
+        self.check_html(widget, 'email', '', html='<input type="email" class="fun" name="email" />')
         self.check_html(
             widget, 'email', 'foo@example.com',
-            html='<input type="email" class="fun" value="foo@example.com" name="email">',
+            html='<input type="email" class="fun" value="foo@example.com" name="email" />',
         )
 
     def test_attrs_precedence(self):
@@ -67,12 +67,12 @@ class TextInputTest(WidgetTest):
         widget = TextInput(attrs={'class': 'pretty'})
         self.check_html(
             widget, 'email', '', attrs={'class': 'special'},
-            html='<input type="text" class="special" name="email">',
+            html='<input type="text" class="special" name="email" />',
         )
 
     def test_attrs_safestring(self):
         widget = TextInput(attrs={'onBlur': mark_safe("function('foo')")})
-        self.check_html(widget, 'email', '', html='<input onBlur="function(\'foo\')" type="text" name="email">')
+        self.check_html(widget, 'email', '', html='<input onBlur="function(\'foo\')" type="text" name="email" />')
 
     def test_use_required_attribute(self):
         # Text inputs can safely trigger the browser validation.

--- a/tests/forms_tests/widget_tests/test_timeinput.py
+++ b/tests/forms_tests/widget_tests/test_timeinput.py
@@ -11,7 +11,7 @@ class TimeInputTest(WidgetTest):
     widget = TimeInput()
 
     def test_render_none(self):
-        self.check_html(self.widget, 'time', None, html='<input type="text" name="time">')
+        self.check_html(self.widget, 'time', None, html='<input type="text" name="time" />')
 
     def test_render_value(self):
         """
@@ -19,18 +19,18 @@ class TimeInputTest(WidgetTest):
         """
         t = time(12, 51, 34, 482548)
         self.assertEqual(str(t), '12:51:34.482548')
-        self.check_html(self.widget, 'time', t, html='<input type="text" name="time" value="12:51:34">')
+        self.check_html(self.widget, 'time', t, html='<input type="text" name="time" value="12:51:34" />')
         self.check_html(self.widget, 'time', time(12, 51, 34), html=(
-            '<input type="text" name="time" value="12:51:34">'
+            '<input type="text" name="time" value="12:51:34" />'
         ))
         self.check_html(self.widget, 'time', time(12, 51), html=(
-            '<input type="text" name="time" value="12:51:00">'
+            '<input type="text" name="time" value="12:51:00" />'
         ))
 
     def test_string(self):
         """Initializing from a string value."""
         self.check_html(self.widget, 'time', '13:12:11', html=(
-            '<input type="text" name="time" value="13:12:11">'
+            '<input type="text" name="time" value="13:12:11" />'
         ))
 
     def test_format(self):
@@ -39,10 +39,10 @@ class TimeInputTest(WidgetTest):
         """
         t = time(12, 51, 34, 482548)
         widget = TimeInput(format='%H:%M', attrs={'type': 'time'})
-        self.check_html(widget, 'time', t, html='<input type="time" name="time" value="12:51">')
+        self.check_html(widget, 'time', t, html='<input type="time" name="time" value="12:51" />')
 
     @override_settings(USE_L10N=True)
     @translation.override('de-at')
     def test_l10n(self):
         t = time(12, 51, 34, 482548)
-        self.check_html(self.widget, 'time', t, html='<input type="text" name="time" value="12:51:34">')
+        self.check_html(self.widget, 'time', t, html='<input type="text" name="time" value="12:51:34" />')

--- a/tests/forms_tests/widget_tests/test_widget.py
+++ b/tests/forms_tests/widget_tests/test_widget.py
@@ -19,8 +19,8 @@ class WidgetTests(WidgetTest):
         self.assertIs(widget.value_omitted_from_data({'field': 'value'}, {}, 'field'), False)
 
     def test_no_trailing_newline_in_attrs(self):
-        self.check_html(Input(), 'name', 'value', strict=True, html='<input type="None" name="name" value="value">')
+        self.check_html(Input(), 'name', 'value', strict=True, html='<input type="None" name="name" value="value" />')
 
     def test_attr_false_not_rendered(self):
-        html = '<input type="None" name="name" value="value">'
+        html = '<input type="None" name="name" value="value" />'
         self.check_html(Input(), 'name', 'value', html=html, attrs={'readonly': False})

--- a/tests/generic_relations/test_forms.py
+++ b/tests/generic_relations/test_forms.py
@@ -30,24 +30,24 @@ class GenericInlineFormsetTests(TestCase):
             ''.join(form.as_p() for form in formset.forms),
             """<p><label for="id_generic_relations-taggeditem-content_type-object_id-0-tag">
 Tag:</label> <input id="id_generic_relations-taggeditem-content_type-object_id-0-tag" type="text"
-name="generic_relations-taggeditem-content_type-object_id-0-tag" maxlength="50"></p>
+name="generic_relations-taggeditem-content_type-object_id-0-tag" maxlength="50" /></p>
 <p><label for="id_generic_relations-taggeditem-content_type-object_id-0-DELETE">Delete:</label>
 <input type="checkbox" name="generic_relations-taggeditem-content_type-object_id-0-DELETE"
-id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE">
+id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE" />
 <input type="hidden" name="generic_relations-taggeditem-content_type-object_id-0-id"
-id="id_generic_relations-taggeditem-content_type-object_id-0-id"></p>"""
+id="id_generic_relations-taggeditem-content_type-object_id-0-id" /></p>"""
         )
         formset = GenericFormSet(instance=Animal())
         self.assertHTMLEqual(
             ''.join(form.as_p() for form in formset.forms),
             """<p><label for="id_generic_relations-taggeditem-content_type-object_id-0-tag">
 Tag:</label> <input id="id_generic_relations-taggeditem-content_type-object_id-0-tag"
-type="text" name="generic_relations-taggeditem-content_type-object_id-0-tag" maxlength="50"></p>
+type="text" name="generic_relations-taggeditem-content_type-object_id-0-tag" maxlength="50" /></p>
 <p><label for="id_generic_relations-taggeditem-content_type-object_id-0-DELETE">Delete:</label>
 <input type="checkbox" name="generic_relations-taggeditem-content_type-object_id-0-DELETE"
-id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE"><input type="hidden"
+id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE" /><input type="hidden"
 name="generic_relations-taggeditem-content_type-object_id-0-id"
-id="id_generic_relations-taggeditem-content_type-object_id-0-id"></p>"""
+id="id_generic_relations-taggeditem-content_type-object_id-0-id" /></p>"""
         )
         platypus = Animal.objects.create(
             common_name='Platypus', latin_name='Ornithorhynchus anatinus',
@@ -60,29 +60,29 @@ id="id_generic_relations-taggeditem-content_type-object_id-0-id"></p>"""
             ''.join(form.as_p() for form in formset.forms),
             """<p><label for="id_generic_relations-taggeditem-content_type-object_id-0-tag">Tag:</label>
 <input id="id_generic_relations-taggeditem-content_type-object_id-0-tag" type="text"
-name="generic_relations-taggeditem-content_type-object_id-0-tag" value="shiny" maxlength="50"></p>
+name="generic_relations-taggeditem-content_type-object_id-0-tag" value="shiny" maxlength="50" /></p>
 <p><label for="id_generic_relations-taggeditem-content_type-object_id-0-DELETE">Delete:</label>
 <input type="checkbox" name="generic_relations-taggeditem-content_type-object_id-0-DELETE"
-id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE">
+id="id_generic_relations-taggeditem-content_type-object_id-0-DELETE" />
 <input type="hidden" name="generic_relations-taggeditem-content_type-object_id-0-id"
-value="%s" id="id_generic_relations-taggeditem-content_type-object_id-0-id"></p>
+value="%s" id="id_generic_relations-taggeditem-content_type-object_id-0-id" /></p>
 <p><label for="id_generic_relations-taggeditem-content_type-object_id-1-tag">Tag:</label>
 <input id="id_generic_relations-taggeditem-content_type-object_id-1-tag" type="text"
-name="generic_relations-taggeditem-content_type-object_id-1-tag" maxlength="50"></p>
+name="generic_relations-taggeditem-content_type-object_id-1-tag" maxlength="50" /></p>
 <p><label for="id_generic_relations-taggeditem-content_type-object_id-1-DELETE">Delete:</label>
 <input type="checkbox" name="generic_relations-taggeditem-content_type-object_id-1-DELETE"
-id="id_generic_relations-taggeditem-content_type-object_id-1-DELETE">
+id="id_generic_relations-taggeditem-content_type-object_id-1-DELETE" />
 <input type="hidden" name="generic_relations-taggeditem-content_type-object_id-1-id"
-id="id_generic_relations-taggeditem-content_type-object_id-1-id"></p>""" % tagged_item_id
+id="id_generic_relations-taggeditem-content_type-object_id-1-id" /></p>""" % tagged_item_id
         )
         lion = Animal.objects.create(common_name='Lion', latin_name='Panthera leo')
         formset = GenericFormSet(instance=lion, prefix='x')
         self.assertHTMLEqual(
             ''.join(form.as_p() for form in formset.forms),
             """<p><label for="id_x-0-tag">Tag:</label>
-<input id="id_x-0-tag" type="text" name="x-0-tag" maxlength="50"></p>
-<p><label for="id_x-0-DELETE">Delete:</label> <input type="checkbox" name="x-0-DELETE" id="id_x-0-DELETE">
-<input type="hidden" name="x-0-id" id="id_x-0-id"></p>"""
+<input id="id_x-0-tag" type="text" name="x-0-tag" maxlength="50" /></p>
+<p><label for="id_x-0-DELETE">Delete:</label> <input type="checkbox" name="x-0-DELETE" id="id_x-0-DELETE" />
+<input type="hidden" name="x-0-id" id="id_x-0-id" /></p>"""
         )
 
     def test_options(self):
@@ -101,7 +101,7 @@ id="id_generic_relations-taggeditem-content_type-object_id-1-id"></p>""" % tagge
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<input type="hidden" name="generic_relations-taggeditem-content_type-object_id-0-id" value="%s" '
-            'id="id_generic_relations-taggeditem-content_type-object_id-0-id">' % harmless.pk
+            'id="id_generic_relations-taggeditem-content_type-object_id-0-id" />' % harmless.pk
         )
         self.assertEqual(formset.forms[0].instance, harmless)
         self.assertEqual(formset.forms[1].instance, mammal)

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -475,7 +475,7 @@ class FormattingTests(SimpleTestCase):
                 '<option value="9">setembre</option>'
                 '<option value="10">octubre</option>'
                 '<option value="11">novembre</option>'
-                '<option value="12" selected>desembre</option>'
+                '<option value="12" selected="selected">desembre</option>'
                 '</select>'
                 '<select name="mydate_day" id="id_mydate_day">'
                 '<option value="">---</option>'
@@ -509,11 +509,11 @@ class FormattingTests(SimpleTestCase):
                 '<option value="28">28</option>'
                 '<option value="29">29</option>'
                 '<option value="30">30</option>'
-                '<option value="31" selected>31</option>'
+                '<option value="31" selected="selected">31</option>'
                 '</select>'
                 '<select name="mydate_year" id="id_mydate_year">'
                 '<option value="">---</option>'
-                '<option value="2009" selected>2009</option>'
+                '<option value="2009" selected="selected">2009</option>'
                 '<option value="2010">2010</option>'
                 '<option value="2011">2011</option>'
                 '<option value="2012">2012</option>'
@@ -673,7 +673,7 @@ class FormattingTests(SimpleTestCase):
                 '<option value="28">28</option>'
                 '<option value="29">29</option>'
                 '<option value="30">30</option>'
-                '<option value="31" selected>31</option>'
+                '<option value="31" selected="selected">31</option>'
                 '</select>'
                 '<select name="mydate_month" id="id_mydate_month">'
                 '<option value="">---</option>'
@@ -688,11 +688,11 @@ class FormattingTests(SimpleTestCase):
                 '<option value="9">setembre</option>'
                 '<option value="10">octubre</option>'
                 '<option value="11">novembre</option>'
-                '<option value="12" selected>desembre</option>'
+                '<option value="12" selected="selected">desembre</option>'
                 '</select>'
                 '<select name="mydate_year" id="id_mydate_year">'
                 '<option value="">---</option>'
-                '<option value="2009" selected>2009</option>'
+                '<option value="2009" selected="selected">2009</option>'
                 '<option value="2010">2010</option>'
                 '<option value="2011">2011</option>'
                 '<option value="2012">2012</option>'
@@ -741,7 +741,7 @@ class FormattingTests(SimpleTestCase):
                 '<option value="28">28</option>'
                 '<option value="29">29</option>'
                 '<option value="30">30</option>'
-                '<option value="31" selected>31</option>'
+                '<option value="31" selected="selected">31</option>'
                 '</select>'
                 '<select name="mydate_month" id="id_mydate_month">'
                 '<option value="">---</option>'
@@ -756,11 +756,11 @@ class FormattingTests(SimpleTestCase):
                 '<option value="9">\u0421\u0435\u043d\u0442\u044f\u0431\u0440\u044c</option>'
                 '<option value="10">\u041e\u043a\u0442\u044f\u0431\u0440\u044c</option>'
                 '<option value="11">\u041d\u043e\u044f\u0431\u0440\u044c</option>'
-                '<option value="12" selected>\u0414\u0435\u043a\u0430\u0431\u0440\u044c</option>'
+                '<option value="12" selected="selected">\u0414\u0435\u043a\u0430\u0431\u0440\u044c</option>'
                 '</select>'
                 '<select name="mydate_year" id="id_mydate_year">'
                 '<option value="">---</option>'
-                '<option value="2009" selected>2009</option>'
+                '<option value="2009" selected="selected">2009</option>'
                 '<option value="2010">2010</option>'
                 '<option value="2011">2011</option>'
                 '<option value="2012">2012</option>'
@@ -851,7 +851,7 @@ class FormattingTests(SimpleTestCase):
                 '<option value="9">September</option>'
                 '<option value="10">October</option>'
                 '<option value="11">November</option>'
-                '<option value="12" selected>December</option>'
+                '<option value="12" selected="selected">December</option>'
                 '</select>'
                 '<select name="mydate_day" id="id_mydate_day">'
                 '<option value="">---</option>'
@@ -885,11 +885,11 @@ class FormattingTests(SimpleTestCase):
                 '<option value="28">28</option>'
                 '<option value="29">29</option>'
                 '<option value="30">30</option>'
-                '<option value="31" selected>31</option>'
+                '<option value="31" selected="selected">31</option>'
                 '</select>'
                 '<select name="mydate_year" id="id_mydate_year">'
                 '<option value="">---</option>'
-                '<option value="2009" selected>2009</option>'
+                '<option value="2009" selected="selected">2009</option>'
                 '<option value="2010">2010</option>'
                 '<option value="2011">2011</option>'
                 '<option value="2012">2012</option>'
@@ -929,13 +929,13 @@ class FormattingTests(SimpleTestCase):
             self.assertHTMLEqual(
                 form6.as_ul(),
                 '<li><label for="id_name">Name:</label>'
-                '<input id="id_name" type="text" name="name" value="acme" maxlength="50" required /></li>'
+                '<input id="id_name" type="text" name="name" value="acme" maxlength="50" required="required"  /></li>'
                 '<li><label for="id_date_added">Date added:</label>'
-                '<input type="text" name="date_added" value="31.12.2009 06:00:00" id="id_date_added" required /></li>'
+                '<input type="text" name="date_added" value="31.12.2009 06:00:00" id="id_date_added" required="required"  /></li>'
                 '<li><label for="id_cents_paid">Cents paid:</label>'
-                '<input type="text" name="cents_paid" value="59,47" id="id_cents_paid" required /></li>'
+                '<input type="text" name="cents_paid" value="59,47" id="id_cents_paid" required="required"  /></li>'
                 '<li><label for="id_products_delivered">Products delivered:</label>'
-                '<input type="text" name="products_delivered" value="12000" id="id_products_delivered" required />'
+                '<input type="text" name="products_delivered" value="12000" id="id_products_delivered" required="required"  />'
                 '</li>'
             )
             self.assertEqual(localize_input(datetime.datetime(2009, 12, 31, 6, 0, 0)), '31.12.2009 06:00:00')
@@ -944,7 +944,7 @@ class FormattingTests(SimpleTestCase):
                 # Checking for the localized "products_delivered" field
                 self.assertInHTML(
                     '<input type="text" name="products_delivered" '
-                    'value="12.000" id="id_products_delivered" required />',
+                    'value="12.000" id="id_products_delivered" required="required"  />',
                     form6.as_ul()
                 )
 
@@ -1095,13 +1095,13 @@ class FormattingTests(SimpleTestCase):
 
             self.assertHTMLEqual(
                 template.render(context),
-                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required />;'
-                '<input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required />'
+                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required="required"  />;'
+                '<input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required="required"  />'
             )
             self.assertHTMLEqual(
                 template_as_text.render(context),
-                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required />;'
-                ' <input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required />'
+                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required="required"  />;'
+                ' <input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required="required"  />'
             )
             self.assertHTMLEqual(
                 template_as_hidden.render(context),

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -929,13 +929,13 @@ class FormattingTests(SimpleTestCase):
             self.assertHTMLEqual(
                 form6.as_ul(),
                 '<li><label for="id_name">Name:</label>'
-                '<input id="id_name" type="text" name="name" value="acme" maxlength="50" required></li>'
+                '<input id="id_name" type="text" name="name" value="acme" maxlength="50" required /></li>'
                 '<li><label for="id_date_added">Date added:</label>'
-                '<input type="text" name="date_added" value="31.12.2009 06:00:00" id="id_date_added" required></li>'
+                '<input type="text" name="date_added" value="31.12.2009 06:00:00" id="id_date_added" required /></li>'
                 '<li><label for="id_cents_paid">Cents paid:</label>'
-                '<input type="text" name="cents_paid" value="59,47" id="id_cents_paid" required></li>'
+                '<input type="text" name="cents_paid" value="59,47" id="id_cents_paid" required /></li>'
                 '<li><label for="id_products_delivered">Products delivered:</label>'
-                '<input type="text" name="products_delivered" value="12000" id="id_products_delivered" required>'
+                '<input type="text" name="products_delivered" value="12000" id="id_products_delivered" required />'
                 '</li>'
             )
             self.assertEqual(localize_input(datetime.datetime(2009, 12, 31, 6, 0, 0)), '31.12.2009 06:00:00')
@@ -944,7 +944,7 @@ class FormattingTests(SimpleTestCase):
                 # Checking for the localized "products_delivered" field
                 self.assertInHTML(
                     '<input type="text" name="products_delivered" '
-                    'value="12.000" id="id_products_delivered" required>',
+                    'value="12.000" id="id_products_delivered" required />',
                     form6.as_ul()
                 )
 
@@ -1095,18 +1095,18 @@ class FormattingTests(SimpleTestCase):
 
             self.assertHTMLEqual(
                 template.render(context),
-                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required>;'
-                '<input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required>'
+                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required />;'
+                '<input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required />'
             )
             self.assertHTMLEqual(
                 template_as_text.render(context),
-                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required>;'
-                ' <input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required>'
+                '<input id="id_date_added" name="date_added" type="text" value="31.12.2009 06:00:00" required />;'
+                ' <input id="id_cents_paid" name="cents_paid" type="text" value="59,47" required />'
             )
             self.assertHTMLEqual(
                 template_as_hidden.render(context),
-                '<input id="id_date_added" name="date_added" type="hidden" value="31.12.2009 06:00:00">;'
-                '<input id="id_cents_paid" name="cents_paid" type="hidden" value="59,47">'
+                '<input id="id_date_added" name="date_added" type="hidden" value="31.12.2009 06:00:00" />;'
+                '<input id="id_cents_paid" name="cents_paid" type="hidden" value="59,47" />'
             )
 
     def test_format_arbitrary_settings(self):

--- a/tests/mail/attachments/file.eml
+++ b/tests/mail/attachments/file.eml
@@ -20,7 +20,7 @@ Bill Jncjkq
 --bcaec54eecc63acce604a3050f77
 Content-Type: text/html; charset=ISO-8859-1
 
-<br clear="all">--<br>Bill Jncjkq<br>
+<br clear="all">--<br/>Bill Jncjkq<br/>
 
 --bcaec54eecc63acce604a3050f77--
 --bcaec54eecc63acce904a3050f79

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -266,9 +266,9 @@ class ModelChoiceFieldTests(TestCase):
         self.assertHTMLEqual(
             field.widget.render('name', []),
             '''<ul>
-<li><label><input type="checkbox" name="name" value="%d" data-slug="entertainment">Entertainment</label></li>
-<li><label><input type="checkbox" name="name" value="%d" data-slug="test">A test</label></li>
-<li><label><input type="checkbox" name="name" value="%d" data-slug="third-test">Third</label></li>
+<li><label><input type="checkbox" name="name" value="%d" data-slug="entertainment" />Entertainment</label></li>
+<li><label><input type="checkbox" name="name" value="%d" data-slug="test" />A test</label></li>
+<li><label><input type="checkbox" name="name" value="%d" data-slug="third-test" />Third</label></li>
 </ul>''' % (self.c1.pk, self.c2.pk, self.c3.pk),
         )
 

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -532,11 +532,11 @@ class ModelFormBaseTest(TestCase):
         self.assertHTMLEqual(
             str(SubclassMeta()),
             """<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required></td></tr>
+<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>
 <tr><th><label for="id_slug">Slug:</label></th>
-<td><input id="id_slug" type="text" name="slug" maxlength="20" required></td></tr>
+<td><input id="id_slug" type="text" name="slug" maxlength="20" required /></td></tr>
 <tr><th><label for="id_checkbox">Checkbox:</label></th>
-<td><input type="checkbox" name="checkbox" id="id_checkbox" required></td></tr>"""
+<td><input type="checkbox" name="checkbox" id="id_checkbox" required /></td></tr>"""
         )
 
     def test_orderfields_form(self):
@@ -550,9 +550,9 @@ class ModelFormBaseTest(TestCase):
         self.assertHTMLEqual(
             str(OrderFields()),
             """<tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required></td></tr>
+<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>
 <tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required></td></tr>"""
+<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>"""
         )
 
     def test_orderfields2_form(self):
@@ -741,11 +741,11 @@ class TestFieldOverridesByFormMeta(SimpleTestCase):
         )
         self.assertHTMLEqual(
             str(form['url']),
-            '<input id="id_url" type="text" class="url" name="url" maxlength="40" required>',
+            '<input id="id_url" type="text" class="url" name="url" maxlength="40" required />',
         )
         self.assertHTMLEqual(
             str(form['slug']),
-            '<input id="id_slug" type="text" name="slug" maxlength="20" required>',
+            '<input id="id_slug" type="text" name="slug" maxlength="20" required />',
         )
 
     def test_label_overrides(self):
@@ -1121,29 +1121,29 @@ class ModelFormBasicTests(TestCase):
         self.assertHTMLEqual(
             str(f),
             """<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required></td></tr>
+<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>
 <tr><th><label for="id_slug">Slug:</label></th>
-<td><input id="id_slug" type="text" name="slug" maxlength="20" required></td></tr>
+<td><input id="id_slug" type="text" name="slug" maxlength="20" required /></td></tr>
 <tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required></td></tr>"""
+<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>"""
         )
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="20" required></li>
-<li><label for="id_slug">Slug:</label> <input id="id_slug" type="text" name="slug" maxlength="20" required></li>
-<li><label for="id_url">The URL:</label> <input id="id_url" type="text" name="url" maxlength="40" required></li>"""
+            """<li><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="20" required /></li>
+<li><label for="id_slug">Slug:</label> <input id="id_slug" type="text" name="slug" maxlength="20" required /></li>
+<li><label for="id_url">The URL:</label> <input id="id_url" type="text" name="url" maxlength="40" required /></li>"""
         )
         self.assertHTMLEqual(
             str(f["name"]),
-            """<input id="id_name" type="text" name="name" maxlength="20" required>""")
+            """<input id="id_name" type="text" name="name" maxlength="20" required />""")
 
     def test_auto_id(self):
         f = BaseCategoryForm(auto_id=False)
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li>Name: <input type="text" name="name" maxlength="20" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="20" required></li>
-<li>The URL: <input type="text" name="url" maxlength="40" required></li>"""
+            """<li>Name: <input type="text" name="name" maxlength="20" required /></li>
+<li>Slug: <input type="text" name="slug" maxlength="20" required /></li>
+<li>The URL: <input type="text" name="url" maxlength="40" required /></li>"""
         )
 
     def test_initial_values(self):
@@ -1157,9 +1157,9 @@ class ModelFormBasicTests(TestCase):
             })
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="Your headline here" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
+            '''<li>Headline: <input type="text" name="headline" value="Your headline here" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" required /></li>
 <li>Writer: <select name="writer" required>
 <option value="" selected>---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1183,7 +1183,7 @@ class ModelFormBasicTests(TestCase):
         f = RoykoForm(auto_id=False, instance=self.w_royko)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Name:</th><td><input type="text" name="name" value="Mike Royko" maxlength="50" required><br>
+            '''<tr><th>Name:</th><td><input type="text" name="name" value="Mike Royko" maxlength="50" required /><br />
             <span class="helptext">Use both first and last names.</span></td></tr>'''
         )
 
@@ -1199,9 +1199,9 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False, instance=art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="Test article" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" value="test-article" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required></li>
+            '''<li>Headline: <input type="text" name="headline" value="Test article" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" value="test-article" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>
 <li>Writer: <select name="writer" required>
 <option value="">---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1257,7 +1257,7 @@ class ModelFormBasicTests(TestCase):
         self.assertHTMLEqual(
             form.as_ul(),
             """<li><label for="id_headline">Headline:</label>
-<input id="id_headline" type="text" name="headline" maxlength="50" required></li>
+<input id="id_headline" type="text" name="headline" maxlength="50" required /></li>
 <li><label for="id_categories">Categories:</label>
 <select multiple name="categories" id="id_categories">
 <option value="%d" selected>Entertainment</option>
@@ -1319,9 +1319,9 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required></td></tr>
-<tr><th>Slug:</th><td><input type="text" name="slug" maxlength="50" required></td></tr>
-<tr><th>Pub date:</th><td><input type="text" name="pub_date" required></td></tr>
+            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required /></td></tr>
+<tr><th>Slug:</th><td><input type="text" name="slug" maxlength="50" required /></td></tr>
+<tr><th>Pub date:</th><td><input type="text" name="pub_date" required /></td></tr>
 <tr><th>Writer:</th><td><select name="writer" required>
 <option value="" selected>---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1349,9 +1349,9 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False, instance=new_art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required></li>
+            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>
 <li>Writer: <select name="writer" required>
 <option value="">---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1385,8 +1385,8 @@ class ModelFormBasicTests(TestCase):
         f = PartialArticleForm(auto_id=False)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required></td></tr>
-<tr><th>Pub date:</th><td><input type="text" name="pub_date" required></td></tr>''')
+            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required /></td></tr>
+<tr><th>Pub date:</th><td><input type="text" name="pub_date" required /></td></tr>''')
 
         class PartialArticleFormWithSlug(forms.ModelForm):
             class Meta:
@@ -1404,9 +1404,9 @@ class ModelFormBasicTests(TestCase):
         }, auto_id=False, instance=art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required></li>'''
+            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>'''
         )
         self.assertTrue(f.is_valid())
         new_art = f.save()
@@ -1493,9 +1493,9 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
+            '''<li>Headline: <input type="text" name="headline" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" required /></li>
 <li>Writer: <select name="writer" required>
 <option value="" selected>---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1518,9 +1518,9 @@ class ModelFormBasicTests(TestCase):
         w_bernstein = Writer.objects.create(name='Carl Bernstein')
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
+            '''<li>Headline: <input type="text" name="headline" maxlength="50" required /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
+<li>Pub date: <input type="text" name="pub_date" required /></li>
 <li>Writer: <select name="writer" required>
 <option value="" selected>---------</option>
 <option value="%s">Bob Woodward</option>
@@ -1798,7 +1798,7 @@ class ModelOneToOneFieldTests(TestCase):
 <option value="%s">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></p>
-<p><label for="id_age">Age:</label> <input type="number" name="age" id="id_age" min="0" required></p>''' % (
+<p><label for="id_age">Age:</label> <input type="number" name="age" id="id_age" min="0" required /></p>''' % (
                 self.w_woodward.pk, self.w_royko.pk,
             )
         )
@@ -1820,7 +1820,7 @@ class ModelOneToOneFieldTests(TestCase):
 <option value="%s">Mike Royko</option>
 </select></p>
 <p><label for="id_age">Age:</label>
-<input type="number" name="age" value="65" id="id_age" min="0" required></p>''' % (
+<input type="number" name="age" value="65" id="id_age" min="0" required /></p>''' % (
                 self.w_woodward.pk, self.w_royko.pk,
             )
         )
@@ -1935,7 +1935,7 @@ class FileAndImageFieldTests(TestCase):
         form = DocumentForm(instance=doc)
         self.assertHTMLEqual(
             str(form['myfile']),
-            '<input id="id_myfile" name="myfile" type="file">'
+            '<input id="id_myfile" name="myfile" type="file" />'
         )
 
     def test_file_field_data(self):
@@ -2315,7 +2315,7 @@ class OtherModelFormTests(TestCase):
         f = ModelFormWithMedia()
         self.assertHTMLEqual(
             str(f.media),
-            '''<link href="/some/form/css" type="text/css" media="all" rel="stylesheet">
+            '''<link href="/some/form/css" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/some/form/javascript"></script>'''
         )
 
@@ -2389,9 +2389,9 @@ class OtherModelFormTests(TestCase):
         self.assertHTMLEqual(
             str(CategoryForm()),
             '''<tr><th><label for="id_description">Description:</label></th>
-<td><input type="text" name="description" id="id_description" required></td></tr>
+<td><input type="text" name="description" id="id_description" required /></td></tr>
 <tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required></td></tr>'''
+<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>'''
         )
         # to_field_name should also work on ModelMultipleChoiceField ##################
 
@@ -2409,7 +2409,7 @@ class OtherModelFormTests(TestCase):
         self.assertHTMLEqual(
             str(CustomFieldForExclusionForm()),
             '''<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="10" required></td></tr>'''
+<td><input id="id_name" type="text" name="name" maxlength="10" required /></td></tr>'''
         )
 
     def test_iterable_model_m2m(self):
@@ -2423,7 +2423,7 @@ class OtherModelFormTests(TestCase):
         self.maxDiff = 1024
         self.assertHTMLEqual(
             form.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="50" required></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="50" required /></p>
         <p><label for="id_colours">Colours:</label>
         <select multiple name="colours" id="id_colours" required>
         <option value="%(blue_pk)s">Blue</option>
@@ -2443,19 +2443,19 @@ class OtherModelFormTests(TestCase):
             form.as_p(),
             """
             <p><label for="id_title">Title:</label>
-                <input id="id_title" maxlength="30" name="title" type="text" required></p>
+                <input id="id_title" maxlength="30" name="title" type="text" required /></p>
             <p><label for="id_date_published">Date published:</label>
-                <input id="id_date_published" name="date_published" type="text" value="{0}" required>
-                <input id="initial-id_date_published" name="initial-date_published" type="hidden" value="{0}"></p>
+                <input id="id_date_published" name="date_published" type="text" value="{0}" required />
+                <input id="initial-id_date_published" name="initial-date_published" type="hidden" value="{0}" /></p>
             <p><label for="id_mode">Mode:</label> <select id="id_mode" name="mode">
                 <option value="di" selected>direct</option>
                 <option value="de">delayed</option></select>
-                <input id="initial-id_mode" name="initial-mode" type="hidden" value="di"></p>
+                <input id="initial-id_mode" name="initial-mode" type="hidden" value="di" /></p>
            <p><label for="id_category">Category:</label> <select id="id_category" name="category">
                 <option value="1">Games</option>
                 <option value="2">Comics</option>
                 <option value="3" selected>Novel</option></select>
-                <input id="initial-id_category" name="initial-category" type="hidden" value="3">
+                <input id="initial-id_category" name="initial-category" type="hidden" value="3" />
             """.format(today_str)
         )
         empty_data = {

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -532,11 +532,11 @@ class ModelFormBaseTest(TestCase):
         self.assertHTMLEqual(
             str(SubclassMeta()),
             """<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>
+<td><input id="id_name" type="text" name="name" maxlength="20" required="required" /></td></tr>
 <tr><th><label for="id_slug">Slug:</label></th>
-<td><input id="id_slug" type="text" name="slug" maxlength="20" required /></td></tr>
+<td><input id="id_slug" type="text" name="slug" maxlength="20" required="required" /></td></tr>
 <tr><th><label for="id_checkbox">Checkbox:</label></th>
-<td><input type="checkbox" name="checkbox" id="id_checkbox" required /></td></tr>"""
+<td><input type="checkbox" name="checkbox" id="id_checkbox" required="required" /></td></tr>"""
         )
 
     def test_orderfields_form(self):
@@ -550,9 +550,9 @@ class ModelFormBaseTest(TestCase):
         self.assertHTMLEqual(
             str(OrderFields()),
             """<tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>
+<td><input id="id_url" type="text" name="url" maxlength="40" required="required"  /></td></tr>
 <tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>"""
+<td><input id="id_name" type="text" name="name" maxlength="20" required="required"  /></td></tr>"""
         )
 
     def test_orderfields2_form(self):
@@ -741,11 +741,11 @@ class TestFieldOverridesByFormMeta(SimpleTestCase):
         )
         self.assertHTMLEqual(
             str(form['url']),
-            '<input id="id_url" type="text" class="url" name="url" maxlength="40" required />',
+            '<input id="id_url" type="text" class="url" name="url" maxlength="40" required="required"  />',
         )
         self.assertHTMLEqual(
             str(form['slug']),
-            '<input id="id_slug" type="text" name="slug" maxlength="20" required />',
+            '<input id="id_slug" type="text" name="slug" maxlength="20" required="required"  />',
         )
 
     def test_label_overrides(self):
@@ -1121,29 +1121,29 @@ class ModelFormBasicTests(TestCase):
         self.assertHTMLEqual(
             str(f),
             """<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required /></td></tr>
+<td><input id="id_name" type="text" name="name" maxlength="20" required="required"  /></td></tr>
 <tr><th><label for="id_slug">Slug:</label></th>
-<td><input id="id_slug" type="text" name="slug" maxlength="20" required /></td></tr>
+<td><input id="id_slug" type="text" name="slug" maxlength="20" required="required"  /></td></tr>
 <tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>"""
+<td><input id="id_url" type="text" name="url" maxlength="40" required="required"  /></td></tr>"""
         )
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="20" required /></li>
-<li><label for="id_slug">Slug:</label> <input id="id_slug" type="text" name="slug" maxlength="20" required /></li>
-<li><label for="id_url">The URL:</label> <input id="id_url" type="text" name="url" maxlength="40" required /></li>"""
+            """<li><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="20" required="required"  /></li>
+<li><label for="id_slug">Slug:</label> <input id="id_slug" type="text" name="slug" maxlength="20" required="required"  /></li>
+<li><label for="id_url">The URL:</label> <input id="id_url" type="text" name="url" maxlength="40" required="required"  /></li>"""
         )
         self.assertHTMLEqual(
             str(f["name"]),
-            """<input id="id_name" type="text" name="name" maxlength="20" required />""")
+            """<input id="id_name" type="text" name="name" maxlength="20" required="required"  />""")
 
     def test_auto_id(self):
         f = BaseCategoryForm(auto_id=False)
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li>Name: <input type="text" name="name" maxlength="20" required /></li>
-<li>Slug: <input type="text" name="slug" maxlength="20" required /></li>
-<li>The URL: <input type="text" name="url" maxlength="40" required /></li>"""
+            """<li>Name: <input type="text" name="name" maxlength="20" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" maxlength="20" required="required"  /></li>
+<li>The URL: <input type="text" name="url" maxlength="40" required="required"  /></li>"""
         )
 
     def test_initial_values(self):
@@ -1157,22 +1157,22 @@ class ModelFormBasicTests(TestCase):
             })
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="Your headline here" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" required /></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
+            '''<li>Headline: <input type="text" name="headline" value="Your headline here" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" required="required"  /></li>
+<li>Writer: <select name="writer" required="required">
+<option value="" selected="selected">---------</option>
 <option value="%s">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></li>
 <li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
-<option value="%s" selected>Entertainment</option>
-<option value="%s" selected>It&#39;s a test</option>
+<li>Categories: <select multiple="multiple" name="categories">
+<option value="%s" selected="selected">Entertainment</option>
+<option value="%s" selected="selected">It&#39;s a test</option>
 <option value="%s">Third test</option>
 </select></li>
 <li>Status: <select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1183,7 +1183,7 @@ class ModelFormBasicTests(TestCase):
         f = RoykoForm(auto_id=False, instance=self.w_royko)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Name:</th><td><input type="text" name="name" value="Mike Royko" maxlength="50" required /><br />
+            '''<tr><th>Name:</th><td><input type="text" name="name" value="Mike Royko" maxlength="50" required="required"  /><br />
             <span class="helptext">Use both first and last names.</span></td></tr>'''
         )
 
@@ -1199,22 +1199,22 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False, instance=art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="Test article" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" value="test-article" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>
-<li>Writer: <select name="writer" required>
+            '''<li>Headline: <input type="text" name="headline" value="Test article" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" value="test-article" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required="required"  /></li>
+<li>Writer: <select name="writer" required="required">
 <option value="">---------</option>
 <option value="%s">Bob Woodward</option>
-<option value="%s" selected>Mike Royko</option>
+<option value="%s" selected="selected">Mike Royko</option>
 </select></li>
 <li>Article: <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-<li>Categories: <select multiple name="categories">
+<li>Categories: <select multiple="multiple" name="categories">
 <option value="%s">Entertainment</option>
 <option value="%s">It&#39;s a test</option>
 <option value="%s">Third test</option>
 </select></li>
 <li>Status: <select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1257,11 +1257,11 @@ class ModelFormBasicTests(TestCase):
         self.assertHTMLEqual(
             form.as_ul(),
             """<li><label for="id_headline">Headline:</label>
-<input id="id_headline" type="text" name="headline" maxlength="50" required /></li>
+<input id="id_headline" type="text" name="headline" maxlength="50" required="required"  /></li>
 <li><label for="id_categories">Categories:</label>
-<select multiple name="categories" id="id_categories">
-<option value="%d" selected>Entertainment</option>
-<option value="%d" selected>It&39;s a test</option>
+<select multiple="multiple" name="categories" id="id_categories">
+<option value="%d" selected="selected">Entertainment</option>
+<option value="%d" selected="selected">It&39;s a test</option>
 <option value="%d">Third test</option>
 </select></li>"""
             % (self.c1.pk, self.c2.pk, self.c3.pk))
@@ -1319,22 +1319,22 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required /></td></tr>
-<tr><th>Slug:</th><td><input type="text" name="slug" maxlength="50" required /></td></tr>
-<tr><th>Pub date:</th><td><input type="text" name="pub_date" required /></td></tr>
-<tr><th>Writer:</th><td><select name="writer" required>
-<option value="" selected>---------</option>
+            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required="required"  /></td></tr>
+<tr><th>Slug:</th><td><input type="text" name="slug" maxlength="50" required="required"  /></td></tr>
+<tr><th>Pub date:</th><td><input type="text" name="pub_date" required="required"  /></td></tr>
+<tr><th>Writer:</th><td><select name="writer" required="required">
+<option value="" selected="selected">---------</option>
 <option value="%s">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></td></tr>
 <tr><th>Article:</th><td><textarea rows="10" cols="40" name="article" required></textarea></td></tr>
-<tr><th>Categories:</th><td><select multiple name="categories">
+<tr><th>Categories:</th><td><select multiple="multiple" name="categories">
 <option value="%s">Entertainment</option>
 <option value="%s">It&#39;s a test</option>
 <option value="%s">Third test</option>
 </select></td></tr>
 <tr><th>Status:</th><td><select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1349,22 +1349,22 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False, instance=new_art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>
-<li>Writer: <select name="writer" required>
+            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required="required"  /></li>
+<li>Writer: <select name="writer" required="required">
 <option value="">---------</option>
 <option value="%s">Bob Woodward</option>
-<option value="%s" selected>Mike Royko</option>
+<option value="%s" selected="selected">Mike Royko</option>
 </select></li>
 <li>Article: <textarea rows="10" cols="40" name="article" required>Hello.</textarea></li>
-<li>Categories: <select multiple name="categories">
-<option value="%s" selected>Entertainment</option>
+<li>Categories: <select multiple="multiple" name="categories">
+<option value="%s" selected="selected">Entertainment</option>
 <option value="%s">It&#39;s a test</option>
 <option value="%s">Third test</option>
 </select></li>
 <li>Status: <select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1385,8 +1385,8 @@ class ModelFormBasicTests(TestCase):
         f = PartialArticleForm(auto_id=False)
         self.assertHTMLEqual(
             str(f),
-            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required /></td></tr>
-<tr><th>Pub date:</th><td><input type="text" name="pub_date" required /></td></tr>''')
+            '''<tr><th>Headline:</th><td><input type="text" name="headline" maxlength="50" required="required"  /></td></tr>
+<tr><th>Pub date:</th><td><input type="text" name="pub_date" required="required"  /></td></tr>''')
 
         class PartialArticleFormWithSlug(forms.ModelForm):
             class Meta:
@@ -1404,9 +1404,9 @@ class ModelFormBasicTests(TestCase):
         }, auto_id=False, instance=art)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required /></li>'''
+            '''<li>Headline: <input type="text" name="headline" value="New headline" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" value="new-headline" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" value="1988-01-04" required="required"  /></li>'''
         )
         self.assertTrue(f.is_valid())
         new_art = f.save()
@@ -1493,22 +1493,22 @@ class ModelFormBasicTests(TestCase):
         f = ArticleForm(auto_id=False)
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" required /></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
+            '''<li>Headline: <input type="text" name="headline" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" required="required"  /></li>
+<li>Writer: <select name="writer" required="required">
+<option value="" selected="selected">---------</option>
 <option value="%s">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></li>
 <li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
+<li>Categories: <select multiple="multiple" name="categories">
 <option value="%s">Entertainment</option>
 <option value="%s">It&#39;s a test</option>
 <option value="%s">Third test</option>
 </select> </li>
 <li>Status: <select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1518,24 +1518,24 @@ class ModelFormBasicTests(TestCase):
         w_bernstein = Writer.objects.create(name='Carl Bernstein')
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" maxlength="50" required /></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required /></li>
-<li>Pub date: <input type="text" name="pub_date" required /></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
+            '''<li>Headline: <input type="text" name="headline" maxlength="50" required="required"  /></li>
+<li>Slug: <input type="text" name="slug" maxlength="50" required="required"  /></li>
+<li>Pub date: <input type="text" name="pub_date" required="required"  /></li>
+<li>Writer: <select name="writer" required="required">
+<option value="" selected="selected">---------</option>
 <option value="%s">Bob Woodward</option>
 <option value="%s">Carl Bernstein</option>
 <option value="%s">Mike Royko</option>
 </select></li>
 <li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
+<li>Categories: <select multiple="multiple" name="categories">
 <option value="%s">Entertainment</option>
 <option value="%s">It&#39;s a test</option>
 <option value="%s">Third test</option>
 <option value="%s">Fourth</option>
 </select></li>
 <li>Status: <select name="status">
-<option value="" selected>---------</option>
+<option value="" selected="selected">---------</option>
 <option value="1">Draft</option>
 <option value="2">Pending</option>
 <option value="3">Live</option>
@@ -1793,12 +1793,12 @@ class ModelOneToOneFieldTests(TestCase):
         form = WriterProfileForm()
         self.assertHTMLEqual(
             form.as_p(),
-            '''<p><label for="id_writer">Writer:</label> <select name="writer" id="id_writer" required>
-<option value="" selected>---------</option>
+            '''<p><label for="id_writer">Writer:</label> <select name="writer" id="id_writer" required="required">
+<option value="" selected="selected">---------</option>
 <option value="%s">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></p>
-<p><label for="id_age">Age:</label> <input type="number" name="age" id="id_age" min="0" required /></p>''' % (
+<p><label for="id_age">Age:</label> <input type="number" name="age" id="id_age" min="0" required="required"  /></p>''' % (
                 self.w_woodward.pk, self.w_royko.pk,
             )
         )
@@ -1814,13 +1814,13 @@ class ModelOneToOneFieldTests(TestCase):
         form = WriterProfileForm(instance=instance)
         self.assertHTMLEqual(
             form.as_p(),
-            '''<p><label for="id_writer">Writer:</label> <select name="writer" id="id_writer" required>
+            '''<p><label for="id_writer">Writer:</label> <select name="writer" id="id_writer" required="required">
 <option value="">---------</option>
-<option value="%s" selected>Bob Woodward</option>
+<option value="%s" selected="selected">Bob Woodward</option>
 <option value="%s">Mike Royko</option>
 </select></p>
 <p><label for="id_age">Age:</label>
-<input type="number" name="age" value="65" id="id_age" min="0" required /></p>''' % (
+<input type="number" name="age" value="65" id="id_age" min="0" required="required"  /></p>''' % (
                 self.w_woodward.pk, self.w_royko.pk,
             )
         )
@@ -2367,7 +2367,7 @@ class OtherModelFormTests(TestCase):
         form = InventoryForm(instance=core)
         self.assertHTMLEqual(str(form['parent']), '''<select name="parent" id="id_parent">
 <option value="">---------</option>
-<option value="86" selected>Apple</option>
+<option value="86" selected="selected">Apple</option>
 <option value="87">Core</option>
 <option value="22">Pear</option>
 </select>''')
@@ -2389,9 +2389,9 @@ class OtherModelFormTests(TestCase):
         self.assertHTMLEqual(
             str(CategoryForm()),
             '''<tr><th><label for="id_description">Description:</label></th>
-<td><input type="text" name="description" id="id_description" required /></td></tr>
+<td><input type="text" name="description" id="id_description" required="required"  /></td></tr>
 <tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required /></td></tr>'''
+<td><input id="id_url" type="text" name="url" maxlength="40" required="required"  /></td></tr>'''
         )
         # to_field_name should also work on ModelMultipleChoiceField ##################
 
@@ -2409,7 +2409,7 @@ class OtherModelFormTests(TestCase):
         self.assertHTMLEqual(
             str(CustomFieldForExclusionForm()),
             '''<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="10" required /></td></tr>'''
+<td><input id="id_name" type="text" name="name" maxlength="10" required="required"  /></td></tr>'''
         )
 
     def test_iterable_model_m2m(self):
@@ -2423,9 +2423,9 @@ class OtherModelFormTests(TestCase):
         self.maxDiff = 1024
         self.assertHTMLEqual(
             form.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="50" required /></p>
+            """<p><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="50" required="required"  /></p>
         <p><label for="id_colours">Colours:</label>
-        <select multiple name="colours" id="id_colours" required>
+        <select multiple="multiple" name="colours" id="id_colours" required="required">
         <option value="%(blue_pk)s">Blue</option>
         </select></p>"""
             % {'blue_pk': colour.pk})
@@ -2443,18 +2443,18 @@ class OtherModelFormTests(TestCase):
             form.as_p(),
             """
             <p><label for="id_title">Title:</label>
-                <input id="id_title" maxlength="30" name="title" type="text" required /></p>
+                <input id="id_title" maxlength="30" name="title" type="text" required="required"  /></p>
             <p><label for="id_date_published">Date published:</label>
-                <input id="id_date_published" name="date_published" type="text" value="{0}" required />
+                <input id="id_date_published" name="date_published" type="text" value="{0}" required="required"  />
                 <input id="initial-id_date_published" name="initial-date_published" type="hidden" value="{0}" /></p>
             <p><label for="id_mode">Mode:</label> <select id="id_mode" name="mode">
-                <option value="di" selected>direct</option>
+                <option value="di" selected="selected">direct</option>
                 <option value="de">delayed</option></select>
                 <input id="initial-id_mode" name="initial-mode" type="hidden" value="di" /></p>
            <p><label for="id_category">Category:</label> <select id="id_category" name="category">
                 <option value="1">Games</option>
                 <option value="2">Comics</option>
-                <option value="3" selected>Novel</option></select>
+                <option value="3" selected="selected">Novel</option></select>
                 <input id="initial-id_category" name="initial-category" type="hidden" value="3" />
             """.format(today_str)
         )

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1136,7 +1136,7 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-owner">Owner:</label>'
             '<select name="form-0-owner" id="id_form-0-owner">'
-            '<option value="" selected>---------</option>'
+            '<option value="" selected="selected">---------</option>'
             '<option value="%d">Joe Perry at Giordanos</option>'
             '<option value="%d">Jack Berry at Giordanos</option>'
             '</select></p>'
@@ -1724,7 +1724,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         form = PoetFormSet.form()
         self.assertHTMLEqual(
             "%s" % form['name'],
-            '<input id="id_name" maxlength="100" type="text" class="poet" name="name" required />'
+            '<input id="id_name" maxlength="100" type="text" class="poet" name="name" required="required"  />'
         )
 
     def test_inlineformset_factory_widgets(self):
@@ -1735,7 +1735,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         form = BookFormSet.form()
         self.assertHTMLEqual(
             "%s" % form['title'],
-            '<input class="book" id="id_title" maxlength="100" name="title" type="text" required />'
+            '<input class="book" id="id_title" maxlength="100" name="title" type="text" required="required"  />'
         )
 
     def test_modelformset_factory_labels_overrides(self):

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -152,20 +152,20 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-name">Name:</label>'
-            '<input id="id_form-0-name" type="text" name="form-0-name" maxlength="100">'
-            '<input type="hidden" name="form-0-id" id="id_form-0-id"></p>'
+            '<input id="id_form-0-name" type="text" name="form-0-name" maxlength="100" />'
+            '<input type="hidden" name="form-0-id" id="id_form-0-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_form-1-name">Name:</label>'
-            '<input id="id_form-1-name" type="text" name="form-1-name" maxlength="100">'
-            '<input type="hidden" name="form-1-id" id="id_form-1-id"></p>'
+            '<input id="id_form-1-name" type="text" name="form-1-name" maxlength="100" />'
+            '<input type="hidden" name="form-1-id" id="id_form-1-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_form-2-name">Name:</label>'
-            ' <input id="id_form-2-name" type="text" name="form-2-name" maxlength="100">'
-            '<input type="hidden" name="form-2-id" id="id_form-2-id"></p>'
+            ' <input id="id_form-2-name" type="text" name="form-2-name" maxlength="100" />'
+            '<input type="hidden" name="form-2-id" id="id_form-2-id" /></p>'
         )
 
         data = {
@@ -202,20 +202,20 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-name">Name:</label>'
-            '<input id="id_form-0-name" type="text" name="form-0-name" value="Arthur Rimbaud" maxlength="100">'
-            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id"></p>' % author2.id
+            '<input id="id_form-0-name" type="text" name="form-0-name" value="Arthur Rimbaud" maxlength="100" />'
+            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id" /></p>' % author2.id
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_form-1-name">Name:</label>'
-            '<input id="id_form-1-name" type="text" name="form-1-name" value="Charles Baudelaire" maxlength="100">'
-            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id"></p>' % author1.id
+            '<input id="id_form-1-name" type="text" name="form-1-name" value="Charles Baudelaire" maxlength="100" />'
+            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id" /></p>' % author1.id
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_form-2-name">Name:</label>'
-            '<input id="id_form-2-name" type="text" name="form-2-name" maxlength="100">'
-            '<input type="hidden" name="form-2-id" id="id_form-2-id"></p>'
+            '<input id="id_form-2-name" type="text" name="form-2-name" maxlength="100" />'
+            '<input type="hidden" name="form-2-id" id="id_form-2-id" /></p>'
         )
 
         data = {
@@ -253,36 +253,36 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-name">Name:</label>'
             '<input id="id_form-0-name" type="text" name="form-0-name" '
-            'value="Arthur Rimbaud" maxlength="100"></p>'
+            'value="Arthur Rimbaud" maxlength="100" /></p>'
             '<p><label for="id_form-0-DELETE">Delete:</label>'
-            '<input type="checkbox" name="form-0-DELETE" id="id_form-0-DELETE">'
-            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id"></p>' % author2.id
+            '<input type="checkbox" name="form-0-DELETE" id="id_form-0-DELETE" />'
+            '<input type="hidden" name="form-0-id" value="%d" id="id_form-0-id" /></p>' % author2.id
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_form-1-name">Name:</label>'
             '<input id="id_form-1-name" type="text" name="form-1-name" '
-            'value="Charles Baudelaire" maxlength="100"></p>'
+            'value="Charles Baudelaire" maxlength="100" /></p>'
             '<p><label for="id_form-1-DELETE">Delete:</label>'
-            '<input type="checkbox" name="form-1-DELETE" id="id_form-1-DELETE">'
-            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id"></p>' % author1.id
+            '<input type="checkbox" name="form-1-DELETE" id="id_form-1-DELETE" />'
+            '<input type="hidden" name="form-1-id" value="%d" id="id_form-1-id" /></p>' % author1.id
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_form-2-name">Name:</label>'
             '<input id="id_form-2-name" type="text" name="form-2-name" '
-            'value="Paul Verlaine" maxlength="100"></p>'
+            'value="Paul Verlaine" maxlength="100" /></p>'
             '<p><label for="id_form-2-DELETE">Delete:</label>'
-            '<input type="checkbox" name="form-2-DELETE" id="id_form-2-DELETE">'
-            '<input type="hidden" name="form-2-id" value="%d" id="id_form-2-id"></p>' % author3.id
+            '<input type="checkbox" name="form-2-DELETE" id="id_form-2-DELETE" />'
+            '<input type="hidden" name="form-2-id" value="%d" id="id_form-2-id" /></p>' % author3.id
         )
         self.assertHTMLEqual(
             formset.forms[3].as_p(),
             '<p><label for="id_form-3-name">Name:</label>'
-            '<input id="id_form-3-name" type="text" name="form-3-name" maxlength="100"></p>'
+            '<input id="id_form-3-name" type="text" name="form-3-name" maxlength="100" /></p>'
             '<p><label for="id_form-3-DELETE">Delete:</label>'
-            '<input type="checkbox" name="form-3-DELETE" id="id_form-3-DELETE">'
-            '<input type="hidden" name="form-3-id" id="id_form-3-id"></p>'
+            '<input type="checkbox" name="form-3-DELETE" id="id_form-3-DELETE" />'
+            '<input type="hidden" name="form-3-id" id="id_form-3-id" /></p>'
         )
 
         data = {
@@ -528,10 +528,10 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-name">Name:</label>'
-            '<input id="id_form-0-name" type="text" name="form-0-name" maxlength="100"></p>'
+            '<input id="id_form-0-name" type="text" name="form-0-name" maxlength="100" /></p>'
             '<p><label for="id_form-0-write_speed">Write speed:</label>'
-            '<input type="number" name="form-0-write_speed" id="id_form-0-write_speed">'
-            '<input type="hidden" name="form-0-author_ptr" id="id_form-0-author_ptr"></p>'
+            '<input type="number" name="form-0-write_speed" id="id_form-0-write_speed" />'
+            '<input type="hidden" name="form-0-author_ptr" id="id_form-0-author_ptr" /></p>'
         )
 
         data = {
@@ -556,18 +556,18 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-name">Name:</label>'
-            '<input id="id_form-0-name" type="text" name="form-0-name" value="Ernest Hemingway" maxlength="100"></p>'
+            '<input id="id_form-0-name" type="text" name="form-0-name" value="Ernest Hemingway" maxlength="100" /></p>'
             '<p><label for="id_form-0-write_speed">Write speed:</label>'
-            '<input type="number" name="form-0-write_speed" value="10" id="id_form-0-write_speed">'
-            '<input type="hidden" name="form-0-author_ptr" value="%d" id="id_form-0-author_ptr"></p>' % hemingway_id
+            '<input type="number" name="form-0-write_speed" value="10" id="id_form-0-write_speed" />'
+            '<input type="hidden" name="form-0-author_ptr" value="%d" id="id_form-0-author_ptr" /></p>' % hemingway_id
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_form-1-name">Name:</label>'
-            '<input id="id_form-1-name" type="text" name="form-1-name" maxlength="100"></p>'
+            '<input id="id_form-1-name" type="text" name="form-1-name" maxlength="100" /></p>'
             '<p><label for="id_form-1-write_speed">Write speed:</label>'
-            '<input type="number" name="form-1-write_speed" id="id_form-1-write_speed">'
-            '<input type="hidden" name="form-1-author_ptr" id="id_form-1-author_ptr"></p>'
+            '<input type="number" name="form-1-write_speed" id="id_form-1-write_speed" />'
+            '<input type="hidden" name="form-1-author_ptr" id="id_form-1-author_ptr" /></p>'
         )
 
         data = {
@@ -598,23 +598,23 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_book_set-0-title">Title:</label> <input id="id_book_set-0-title" type="text" '
-            'name="book_set-0-title" maxlength="100"><input type="hidden" name="book_set-0-author" value="%d" '
-            'id="id_book_set-0-author"><input type="hidden" name="book_set-0-id" id="id_book_set-0-id">'
+            'name="book_set-0-title" maxlength="100" /><input type="hidden" name="book_set-0-author" value="%d" '
+            'id="id_book_set-0-author" /><input type="hidden" name="book_set-0-id" id="id_book_set-0-id" />'
             '</p>' % author.id
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_book_set-1-title">Title:</label>'
-            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100">'
-            '<input type="hidden" name="book_set-1-author" value="%d" id="id_book_set-1-author">'
-            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id"></p>' % author.id
+            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-1-author" value="%d" id="id_book_set-1-author" />'
+            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id" /></p>' % author.id
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_book_set-2-title">Title:</label>'
-            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100">'
-            '<input type="hidden" name="book_set-2-author" value="%d" id="id_book_set-2-author">'
-            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id"></p>' % author.id
+            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-2-author" value="%d" id="id_book_set-2-author" />'
+            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id" /></p>' % author.id
         )
 
         data = {
@@ -648,25 +648,25 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_book_set-0-title">Title:</label>'
             '<input id="id_book_set-0-title" type="text" name="book_set-0-title" '
-            'value="Les Fleurs du Mal" maxlength="100">'
-            '<input type="hidden" name="book_set-0-author" value="%d" id="id_book_set-0-author">'
-            '<input type="hidden" name="book_set-0-id" value="%d" id="id_book_set-0-id"></p>' % (
+            'value="Les Fleurs du Mal" maxlength="100" />'
+            '<input type="hidden" name="book_set-0-author" value="%d" id="id_book_set-0-author" />'
+            '<input type="hidden" name="book_set-0-id" value="%d" id="id_book_set-0-id" /></p>' % (
                 author.id, book1.id,
             )
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_book_set-1-title">Title:</label>'
-            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100">'
-            '<input type="hidden" name="book_set-1-author" value="%d" id="id_book_set-1-author">'
-            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id"></p>' % author.id
+            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-1-author" value="%d" id="id_book_set-1-author" />'
+            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id" /></p>' % author.id
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_book_set-2-title">Title:</label>'
-            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100">'
-            '<input type="hidden" name="book_set-2-author" value="%d" id="id_book_set-2-author">'
-            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id"></p>' % author.id
+            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-2-author" value="%d" id="id_book_set-2-author" />'
+            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id" /></p>' % author.id
         )
 
         data = {
@@ -733,17 +733,17 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_test-0-title">Title:</label>'
-            '<input id="id_test-0-title" type="text" name="test-0-title" maxlength="100">'
-            '<input type="hidden" name="test-0-author" id="id_test-0-author">'
-            '<input type="hidden" name="test-0-id" id="id_test-0-id"></p>'
+            '<input id="id_test-0-title" type="text" name="test-0-title" maxlength="100" />'
+            '<input type="hidden" name="test-0-author" id="id_test-0-author" />'
+            '<input type="hidden" name="test-0-id" id="id_test-0-id" /></p>'
         )
 
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_test-1-title">Title:</label>'
-            '<input id="id_test-1-title" type="text" name="test-1-title" maxlength="100">'
-            '<input type="hidden" name="test-1-author" id="id_test-1-author">'
-            '<input type="hidden" name="test-1-id" id="id_test-1-id"></p>'
+            '<input id="id_test-1-title" type="text" name="test-1-title" maxlength="100" />'
+            '<input type="hidden" name="test-1-author" id="id_test-1-author" />'
+            '<input type="hidden" name="test-1-id" id="id_test-1-id" /></p>'
         )
 
     def test_inline_formsets_with_custom_pk(self):
@@ -762,12 +762,12 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_bookwithcustompk_set-0-my_pk">My pk:</label>'
             '<input id="id_bookwithcustompk_set-0-my_pk" type="number" '
-            'name="bookwithcustompk_set-0-my_pk" step="1"></p>'
+            'name="bookwithcustompk_set-0-my_pk" step="1" /></p>'
             '<p><label for="id_bookwithcustompk_set-0-title">Title:</label>'
             '<input id="id_bookwithcustompk_set-0-title" type="text" '
-            'name="bookwithcustompk_set-0-title" maxlength="100">'
+            'name="bookwithcustompk_set-0-title" maxlength="100" />'
             '<input type="hidden" name="bookwithcustompk_set-0-author" '
-            'value="1" id="id_bookwithcustompk_set-0-author"></p>'
+            'value="1" id="id_bookwithcustompk_set-0-author" /></p>'
         )
 
         data = {
@@ -802,14 +802,14 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_alternatebook_set-0-title">Title:</label>'
             '<input id="id_alternatebook_set-0-title" type="text" '
-            'name="alternatebook_set-0-title" maxlength="100"></p>'
+            'name="alternatebook_set-0-title" maxlength="100" /></p>'
             '<p><label for="id_alternatebook_set-0-notes">Notes:</label>'
             '<input id="id_alternatebook_set-0-notes" type="text" '
-            'name="alternatebook_set-0-notes" maxlength="100">'
+            'name="alternatebook_set-0-notes" maxlength="100" />'
             '<input type="hidden" name="alternatebook_set-0-author" value="1" '
-            'id="id_alternatebook_set-0-author">'
+            'id="id_alternatebook_set-0-author" />'
             '<input type="hidden" name="alternatebook_set-0-book_ptr" '
-            'id="id_alternatebook_set-0-book_ptr"></p>'
+            'id="id_alternatebook_set-0-book_ptr" /></p>'
         )
 
         data = {
@@ -905,39 +905,39 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_book_set-0-title">Title:</label>'
             '<input id="id_book_set-0-title" type="text" name="book_set-0-title" '
-            'value="Les Paradis Artificiels" maxlength="100">'
-            '<input type="hidden" name="book_set-0-author" value="1" id="id_book_set-0-author">'
-            '<input type="hidden" name="book_set-0-id" value="1" id="id_book_set-0-id"></p>'
+            'value="Les Paradis Artificiels" maxlength="100" />'
+            '<input type="hidden" name="book_set-0-author" value="1" id="id_book_set-0-author" />'
+            '<input type="hidden" name="book_set-0-id" value="1" id="id_book_set-0-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_book_set-1-title">Title:</label>'
             '<input id="id_book_set-1-title" type="text" name="book_set-1-title" '
-            'value="Les Fleurs du Mal" maxlength="100">'
-            '<input type="hidden" name="book_set-1-author" value="1" id="id_book_set-1-author">'
-            '<input type="hidden" name="book_set-1-id" value="2" id="id_book_set-1-id"></p>'
+            'value="Les Fleurs du Mal" maxlength="100" />'
+            '<input type="hidden" name="book_set-1-author" value="1" id="id_book_set-1-author" />'
+            '<input type="hidden" name="book_set-1-id" value="2" id="id_book_set-1-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_book_set-2-title">Title:</label>'
             '<input id="id_book_set-2-title" type="text" name="book_set-2-title" '
-            'value="Flowers of Evil" maxlength="100">'
-            '<input type="hidden" name="book_set-2-author" value="1" id="id_book_set-2-author">'
-            '<input type="hidden" name="book_set-2-id" value="3" id="id_book_set-2-id"></p>'
+            'value="Flowers of Evil" maxlength="100" />'
+            '<input type="hidden" name="book_set-2-author" value="1" id="id_book_set-2-author" />'
+            '<input type="hidden" name="book_set-2-id" value="3" id="id_book_set-2-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[3].as_p(),
             '<p><label for="id_book_set-3-title">Title:</label>'
-            '<input id="id_book_set-3-title" type="text" name="book_set-3-title" maxlength="100">'
-            '<input type="hidden" name="book_set-3-author" value="1" id="id_book_set-3-author">'
-            '<input type="hidden" name="book_set-3-id" id="id_book_set-3-id"></p>'
+            '<input id="id_book_set-3-title" type="text" name="book_set-3-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-3-author" value="1" id="id_book_set-3-author" />'
+            '<input type="hidden" name="book_set-3-id" id="id_book_set-3-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[4].as_p(),
             '<p><label for="id_book_set-4-title">Title:</label>'
-            '<input id="id_book_set-4-title" type="text" name="book_set-4-title" maxlength="100">'
-            '<input type="hidden" name="book_set-4-author" value="1" id="id_book_set-4-author">'
-            '<input type="hidden" name="book_set-4-id" id="id_book_set-4-id"></p>'
+            '<input id="id_book_set-4-title" type="text" name="book_set-4-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-4-author" value="1" id="id_book_set-4-author" />'
+            '<input type="hidden" name="book_set-4-id" id="id_book_set-4-id" /></p>'
         )
 
         data = {
@@ -962,23 +962,23 @@ class ModelFormsetTest(TestCase):
             formset.forms[0].as_p(),
             '<p><label for="id_book_set-0-title">Title:</label>'
             '<input id="id_book_set-0-title" type="text" name="book_set-0-title" '
-            'value="Flowers of Evil" maxlength="100">'
-            '<input type="hidden" name="book_set-0-author" value="1" id="id_book_set-0-author">'
-            '<input type="hidden" name="book_set-0-id" value="3" id="id_book_set-0-id"></p>'
+            'value="Flowers of Evil" maxlength="100" />'
+            '<input type="hidden" name="book_set-0-author" value="1" id="id_book_set-0-author" />'
+            '<input type="hidden" name="book_set-0-id" value="3" id="id_book_set-0-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_book_set-1-title">Title:</label>'
-            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100">'
-            '<input type="hidden" name="book_set-1-author" value="1" id="id_book_set-1-author">'
-            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id"></p>'
+            '<input id="id_book_set-1-title" type="text" name="book_set-1-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-1-author" value="1" id="id_book_set-1-author" />'
+            '<input type="hidden" name="book_set-1-id" id="id_book_set-1-id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_book_set-2-title">Title:</label>'
-            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100">'
-            '<input type="hidden" name="book_set-2-author" value="1" id="id_book_set-2-author">'
-            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id"></p>'
+            '<input id="id_book_set-2-title" type="text" name="book_set-2-title" maxlength="100" />'
+            '<input type="hidden" name="book_set-2-author" value="1" id="id_book_set-2-author" />'
+            '<input type="hidden" name="book_set-2-id" id="id_book_set-2-id" /></p>'
         )
 
         data = {
@@ -1040,9 +1040,9 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_form-0-my_pk">My pk:</label> <input id="id_form-0-my_pk" type="text" '
-            'name="form-0-my_pk" maxlength="10"></p>'
+            'name="form-0-my_pk" maxlength="10" /></p>'
             '<p><label for="id_form-0-some_field">Some field:</label>'
-            '<input id="id_form-0-some_field" type="text" name="form-0-some_field" maxlength="100"></p>'
+            '<input id="id_form-0-some_field" type="text" name="form-0-some_field" maxlength="100" /></p>'
         )
 
         # Custom primary keys with ForeignKey, OneToOneField and AutoField ############
@@ -1055,16 +1055,16 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_owner_set-0-name">Name:</label>'
-            '<input id="id_owner_set-0-name" type="text" name="owner_set-0-name" maxlength="100">'
-            '<input type="hidden" name="owner_set-0-place" value="1" id="id_owner_set-0-place">'
-            '<input type="hidden" name="owner_set-0-auto_id" id="id_owner_set-0-auto_id"></p>'
+            '<input id="id_owner_set-0-name" type="text" name="owner_set-0-name" maxlength="100" />'
+            '<input type="hidden" name="owner_set-0-place" value="1" id="id_owner_set-0-place" />'
+            '<input type="hidden" name="owner_set-0-auto_id" id="id_owner_set-0-auto_id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_owner_set-1-name">Name:</label>'
-            '<input id="id_owner_set-1-name" type="text" name="owner_set-1-name" maxlength="100">'
-            '<input type="hidden" name="owner_set-1-place" value="1" id="id_owner_set-1-place">'
-            '<input type="hidden" name="owner_set-1-auto_id" id="id_owner_set-1-auto_id"></p>'
+            '<input id="id_owner_set-1-name" type="text" name="owner_set-1-name" maxlength="100" />'
+            '<input type="hidden" name="owner_set-1-place" value="1" id="id_owner_set-1-place" />'
+            '<input type="hidden" name="owner_set-1-auto_id" id="id_owner_set-1-auto_id" /></p>'
         )
 
         data = {
@@ -1089,24 +1089,24 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_owner_set-0-name">Name:</label>'
-            '<input id="id_owner_set-0-name" type="text" name="owner_set-0-name" value="Joe Perry" maxlength="100">'
-            '<input type="hidden" name="owner_set-0-place" value="1" id="id_owner_set-0-place">'
-            '<input type="hidden" name="owner_set-0-auto_id" value="%d" id="id_owner_set-0-auto_id"></p>'
+            '<input id="id_owner_set-0-name" type="text" name="owner_set-0-name" value="Joe Perry" maxlength="100" />'
+            '<input type="hidden" name="owner_set-0-place" value="1" id="id_owner_set-0-place" />'
+            '<input type="hidden" name="owner_set-0-auto_id" value="%d" id="id_owner_set-0-auto_id" /></p>'
             % owner1.auto_id
         )
         self.assertHTMLEqual(
             formset.forms[1].as_p(),
             '<p><label for="id_owner_set-1-name">Name:</label>'
-            '<input id="id_owner_set-1-name" type="text" name="owner_set-1-name" maxlength="100">'
-            '<input type="hidden" name="owner_set-1-place" value="1" id="id_owner_set-1-place">'
-            '<input type="hidden" name="owner_set-1-auto_id" id="id_owner_set-1-auto_id"></p>'
+            '<input id="id_owner_set-1-name" type="text" name="owner_set-1-name" maxlength="100" />'
+            '<input type="hidden" name="owner_set-1-place" value="1" id="id_owner_set-1-place" />'
+            '<input type="hidden" name="owner_set-1-auto_id" id="id_owner_set-1-auto_id" /></p>'
         )
         self.assertHTMLEqual(
             formset.forms[2].as_p(),
             '<p><label for="id_owner_set-2-name">Name:</label>'
-            '<input id="id_owner_set-2-name" type="text" name="owner_set-2-name" maxlength="100">'
-            '<input type="hidden" name="owner_set-2-place" value="1" id="id_owner_set-2-place">'
-            '<input type="hidden" name="owner_set-2-auto_id" id="id_owner_set-2-auto_id"></p>'
+            '<input id="id_owner_set-2-name" type="text" name="owner_set-2-name" maxlength="100" />'
+            '<input type="hidden" name="owner_set-2-place" value="1" id="id_owner_set-2-place" />'
+            '<input type="hidden" name="owner_set-2-auto_id" id="id_owner_set-2-auto_id" /></p>'
         )
 
         data = {
@@ -1141,7 +1141,7 @@ class ModelFormsetTest(TestCase):
             '<option value="%d">Jack Berry at Giordanos</option>'
             '</select></p>'
             '<p><label for="id_form-0-age">Age:</label>'
-            '<input type="number" name="form-0-age" id="id_form-0-age" min="0"></p>'
+            '<input type="number" name="form-0-age" id="id_form-0-age" min="0" /></p>'
             % (owner1.auto_id, owner2.auto_id)
         )
 
@@ -1154,8 +1154,8 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_ownerprofile-0-age">Age:</label>'
-            '<input type="number" name="ownerprofile-0-age" id="id_ownerprofile-0-age" min="0">'
-            '<input type="hidden" name="ownerprofile-0-owner" value="%d" id="id_ownerprofile-0-owner"></p>'
+            '<input type="number" name="ownerprofile-0-age" id="id_ownerprofile-0-age" min="0" />'
+            '<input type="hidden" name="ownerprofile-0-owner" value="%d" id="id_ownerprofile-0-owner" /></p>'
             % owner1.auto_id
         )
 
@@ -1179,8 +1179,8 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_ownerprofile-0-age">Age:</label>'
-            '<input type="number" name="ownerprofile-0-age" value="54" id="id_ownerprofile-0-age" min="0">'
-            '<input type="hidden" name="ownerprofile-0-owner" value="%d" id="id_ownerprofile-0-owner"></p>'
+            '<input type="number" name="ownerprofile-0-age" value="54" id="id_ownerprofile-0-age" min="0" />'
+            '<input type="hidden" name="ownerprofile-0-owner" value="%d" id="id_ownerprofile-0-owner" /></p>'
             % owner1.auto_id
         )
 
@@ -1212,11 +1212,11 @@ class ModelFormsetTest(TestCase):
         self.assertHTMLEqual(
             formset.forms[0].as_p(),
             '<p><label for="id_location_set-0-lat">Lat:</label>'
-            '<input id="id_location_set-0-lat" type="text" name="location_set-0-lat" maxlength="100"></p>'
+            '<input id="id_location_set-0-lat" type="text" name="location_set-0-lat" maxlength="100" /></p>'
             '<p><label for="id_location_set-0-lon">Lon:</label> '
-            '<input id="id_location_set-0-lon" type="text" name="location_set-0-lon" maxlength="100">'
-            '<input type="hidden" name="location_set-0-place" value="1" id="id_location_set-0-place">'
-            '<input type="hidden" name="location_set-0-id" id="id_location_set-0-id"></p>'
+            '<input id="id_location_set-0-lon" type="text" name="location_set-0-lon" maxlength="100" />'
+            '<input type="hidden" name="location_set-0-place" value="1" id="id_location_set-0-place" />'
+            '<input type="hidden" name="location_set-0-id" id="id_location_set-0-id" /></p>'
         )
 
     def test_foreign_keys_in_parents(self):
@@ -1372,13 +1372,13 @@ class ModelFormsetTest(TestCase):
             result,
             '<p><label for="id_membership_set-0-date_joined">Date joined:</label>'
             '<input type="text" name="membership_set-0-date_joined" '
-            'value="__DATETIME__" id="id_membership_set-0-date_joined">'
+            'value="__DATETIME__" id="id_membership_set-0-date_joined" />'
             '<input type="hidden" name="initial-membership_set-0-date_joined" value="__DATETIME__" '
-            'id="initial-membership_set-0-id_membership_set-0-date_joined"></p>'
+            'id="initial-membership_set-0-id_membership_set-0-date_joined" /></p>'
             '<p><label for="id_membership_set-0-karma">Karma:</label>'
-            '<input type="number" name="membership_set-0-karma" id="id_membership_set-0-karma">'
-            '<input type="hidden" name="membership_set-0-person" value="%d" id="id_membership_set-0-person">'
-            '<input type="hidden" name="membership_set-0-id" id="id_membership_set-0-id"></p>'
+            '<input type="number" name="membership_set-0-karma" id="id_membership_set-0-karma" />'
+            '<input type="hidden" name="membership_set-0-person" value="%d" id="id_membership_set-0-person" />'
+            '<input type="hidden" name="membership_set-0-id" id="id_membership_set-0-id" /></p>'
             % person.id)
 
         # test for validation with callable defaults. Validations rely on hidden fields
@@ -1724,7 +1724,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         form = PoetFormSet.form()
         self.assertHTMLEqual(
             "%s" % form['name'],
-            '<input id="id_name" maxlength="100" type="text" class="poet" name="name" required>'
+            '<input id="id_name" maxlength="100" type="text" class="poet" name="name" required />'
         )
 
     def test_inlineformset_factory_widgets(self):
@@ -1735,7 +1735,7 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         form = BookFormSet.form()
         self.assertHTMLEqual(
             "%s" % form['title'],
-            '<input class="book" id="id_title" maxlength="100" name="title" type="text" required>'
+            '<input class="book" id="id_title" maxlength="100" name="title" type="text" required />'
         )
 
     def test_modelformset_factory_labels_overrides(self):

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -448,8 +448,8 @@ class ModelAdminTests(TestCase):
         self.assertHTMLEqual(
             str(form["main_band"]),
             '<div class="related-widget-wrapper">'
-            '<select name="main_band" id="id_main_band" required>'
-            '<option value="" selected>---------</option>'
+            '<select name="main_band" id="id_main_band" required="required">'
+            '<option value="" selected="selected">---------</option>'
             '<option value="%d">The Beatles</option>'
             '<option value="%d">The Doors</option>'
             '</select></div>' % (band2.id, self.band.id)
@@ -469,8 +469,8 @@ class ModelAdminTests(TestCase):
         self.assertHTMLEqual(
             str(form["main_band"]),
             '<div class="related-widget-wrapper">'
-            '<select name="main_band" id="id_main_band" required>'
-            '<option value="" selected>---------</option>'
+            '<select name="main_band" id="id_main_band" required="required">'
+            '<option value="" selected="selected">---------</option>'
             '<option value="%d">The Doors</option>'
             '</select></div>' % self.band.id
         )

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -836,9 +836,9 @@ class TestSplitFormField(PostgreSQLTestCase):
             <tr>
                 <th><label for="id_array_0">Array:</label></th>
                 <td>
-                    <input id="id_array_0" name="array_0" type="text" required />
-                    <input id="id_array_1" name="array_1" type="text" required />
-                    <input id="id_array_2" name="array_2" type="text" required />
+                    <input id="id_array_0" name="array_0" type="text" required="required"  />
+                    <input id="id_array_1" name="array_1" type="text" required="required"  />
+                    <input id="id_array_2" name="array_2" type="text" required="required"  />
                 </td>
             </tr>
         ''')

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -836,9 +836,9 @@ class TestSplitFormField(PostgreSQLTestCase):
             <tr>
                 <th><label for="id_array_0">Array:</label></th>
                 <td>
-                    <input id="id_array_0" name="array_0" type="text" required>
-                    <input id="id_array_1" name="array_1" type="text" required>
-                    <input id="id_array_2" name="array_2" type="text" required>
+                    <input id="id_array_0" name="array_0" type="text" required />
+                    <input id="id_array_1" name="array_1" type="text" required />
+                    <input id="id_array_2" name="array_2" type="text" required />
                 </td>
             </tr>
         ''')
@@ -907,8 +907,8 @@ class TestSplitFormWidget(PostgreSQLWidgetTestCase):
         self.check_html(
             SplitArrayWidget(forms.TextInput(), size=2), 'array', None,
             """
-            <input name="array_0" type="text">
-            <input name="array_1" type="text">
+            <input name="array_0" type="text" />
+            <input name="array_1" type="text" />
             """
         )
 
@@ -918,8 +918,8 @@ class TestSplitFormWidget(PostgreSQLWidgetTestCase):
             'array', ['val1', 'val2'], attrs={'id': 'foo'},
             html=(
                 """
-                <input id="foo_0" name="array_0" type="text" value="val1">
-                <input id="foo_1" name="array_1" type="text" value="val2">
+                <input id="foo_0" name="array_0" type="text" value="val1" />
+                <input id="foo_1" name="array_1" type="text" value="val2" />
                 """
             )
         )

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -468,10 +468,10 @@ class TestFormField(PostgreSQLTestCase):
                 <label for="id_field_0">Field:</label>
                 </th>
                 <td>
-                    <input id="id_field_0_0" name="field_0_0" type="text">
-                    <input id="id_field_0_1" name="field_0_1" type="text">
-                    <input id="id_field_1_0" name="field_1_0" type="text">
-                    <input id="id_field_1_1" name="field_1_1" type="text">
+                    <input id="id_field_0_0" name="field_0_0" type="text" />
+                    <input id="id_field_0_1" name="field_0_1" type="text" />
+                    <input id="id_field_1_0" name="field_1_0" type="text" />
+                    <input id="id_field_1_1" name="field_1_1" type="text" />
                 </td>
             </tr>
         ''')
@@ -499,8 +499,8 @@ class TestFormField(PostgreSQLTestCase):
         <tr>
             <th><label for="id_ints_0">Ints:</label></th>
             <td>
-                <input id="id_ints_0" name="ints_0" type="number">
-                <input id="id_ints_1" name="ints_1" type="number">
+                <input id="id_ints_0" name="ints_0" type="number" />
+                <input id="id_ints_1" name="ints_1" type="number" />
             </td>
         </tr>
         ''')
@@ -700,11 +700,11 @@ class TestWidget(PostgreSQLTestCase):
         f = pg_forms.ranges.DateTimeRangeField()
         self.assertHTMLEqual(
             f.widget.render('datetimerange', ''),
-            '<input type="text" name="datetimerange_0"><input type="text" name="datetimerange_1">'
+            '<input type="text" name="datetimerange_0" /><input type="text" name="datetimerange_1" />'
         )
         self.assertHTMLEqual(
             f.widget.render('datetimerange', None),
-            '<input type="text" name="datetimerange_0"><input type="text" name="datetimerange_1">'
+            '<input type="text" name="datetimerange_0" /><input type="text" name="datetimerange_1" />'
         )
         dt_range = DateTimeTZRange(
             datetime.datetime(2006, 1, 10, 7, 30),
@@ -712,6 +712,6 @@ class TestWidget(PostgreSQLTestCase):
         )
         self.assertHTMLEqual(
             f.widget.render('datetimerange', dt_range),
-            '<input type="text" name="datetimerange_0" value="2006-01-10 07:30:00">'
-            '<input type="text" name="datetimerange_1" value="2006-02-12 09:50:00">'
+            '<input type="text" name="datetimerange_0" value="2006-01-10 07:30:00" />'
+            '<input type="text" name="datetimerange_1" value="2006-02-12 09:50:00" />'
         )

--- a/tests/staticfiles_tests/test_forms.py
+++ b/tests/staticfiles_tests/test_forms.py
@@ -29,8 +29,8 @@ class StaticFilesFormsMediaTestCase(SimpleTestCase):
         )
         self.assertEqual(
             str(m),
-            """<link href="https://example.com/assets/path/to/css1" type="text/css" media="all" rel="stylesheet">
-<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet">
+            """<link href="https://example.com/assets/path/to/css1" type="text/css" media="all" rel="stylesheet" />
+<link href="/path/to/css2" type="text/css" media="all" rel="stylesheet" />
 <script type="text/javascript" src="/path/to/js1"></script>
 <script type="text/javascript" src="http://media.other.com/path/to/js2"></script>
 <script type="text/javascript" src="https://secure.other.com/path/to/js3"></script>

--- a/tests/template_backends/test_dummy.py
+++ b/tests/template_backends/test_dummy.py
@@ -81,7 +81,7 @@ class TemplateStringsTests(SimpleTestCase):
         template = self.engine.get_template('template_backends/csrf.html')
         content = template.render(request=request)
 
-        expected = '<input type="hidden" name="csrfmiddlewaretoken" value="([^"]+)">'
+        expected = '<input type="hidden" name="csrfmiddlewaretoken" value="([^"]+)" />'
         match = re.match(expected, content) or re.match(expected.replace('"', "'"), content)
         self.assertTrue(match, "hidden csrftoken field not found in output")
         self.assertTrue(equivalent_tokens(match.group(1), get_token(request)))

--- a/tests/template_tests/filter_tests/test_join.py
+++ b/tests/template_tests/filter_tests/test_join.py
@@ -56,20 +56,20 @@ class FunctionTests(SimpleTestCase):
 
     def test_autoescape(self):
         self.assertEqual(
-            join(['<a>', '<img>', '</a>'], '<br>'),
-            '&lt;a&gt;&lt;br&gt;&lt;img&gt;&lt;br&gt;&lt;/a&gt;',
+            join(['<a>', '<img/>', '</a>'], '<br/>'),
+            '&lt;a&gt;&lt;br/&gt;&lt;img/&gt;&lt;br/&gt;&lt;/a&gt;',
         )
 
     def test_autoescape_off(self):
         self.assertEqual(
-            join(['<a>', '<img>', '</a>'], '<br>', autoescape=False),
-            '<a>&lt;br&gt;<img>&lt;br&gt;</a>',
+            join(['<a>', '<img/>', '</a>'], '<br/>', autoescape=False),
+            '<a>&lt;br/&gt;<img/>&lt;br/&gt;</a>',
         )
 
     def test_noniterable_arg(self):
         obj = object()
-        self.assertEqual(join(obj, '<br>'), obj)
+        self.assertEqual(join(obj, '<br/>'), obj)
 
     def test_noniterable_arg_autoescape_off(self):
         obj = object()
-        self.assertEqual(join(obj, '<br>', autoescape=False), obj)
+        self.assertEqual(join(obj, '<br/>', autoescape=False), obj)

--- a/tests/template_tests/filter_tests/test_linebreaks.py
+++ b/tests/template_tests/filter_tests/test_linebreaks.py
@@ -15,12 +15,12 @@ class LinebreaksTests(SimpleTestCase):
     @setup({'linebreaks01': '{{ a|linebreaks }} {{ b|linebreaks }}'})
     def test_linebreaks01(self):
         output = self.engine.render_to_string('linebreaks01', {"a": "x&\ny", "b": mark_safe("x&\ny")})
-        self.assertEqual(output, "<p>x&amp;<br>y</p> <p>x&<br>y</p>")
+        self.assertEqual(output, "<p>x&amp;<br />y</p> <p>x&<br />y</p>")
 
     @setup({'linebreaks02': '{% autoescape off %}{{ a|linebreaks }} {{ b|linebreaks }}{% endautoescape %}'})
     def test_linebreaks02(self):
         output = self.engine.render_to_string('linebreaks02', {"a": "x&\ny", "b": mark_safe("x&\ny")})
-        self.assertEqual(output, "<p>x&<br>y</p> <p>x&<br>y</p>")
+        self.assertEqual(output, "<p>x&<br />y</p> <p>x&<br />y</p>")
 
 
 class FunctionTests(SimpleTestCase):
@@ -29,13 +29,13 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(linebreaks_filter('line 1'), '<p>line 1</p>')
 
     def test_newline(self):
-        self.assertEqual(linebreaks_filter('line 1\nline 2'), '<p>line 1<br>line 2</p>')
+        self.assertEqual(linebreaks_filter('line 1\nline 2'), '<p>line 1<br />line 2</p>')
 
     def test_carriage(self):
-        self.assertEqual(linebreaks_filter('line 1\rline 2'), '<p>line 1<br>line 2</p>')
+        self.assertEqual(linebreaks_filter('line 1\rline 2'), '<p>line 1<br />line 2</p>')
 
     def test_carriage_newline(self):
-        self.assertEqual(linebreaks_filter('line 1\r\nline 2'), '<p>line 1<br>line 2</p>')
+        self.assertEqual(linebreaks_filter('line 1\r\nline 2'), '<p>line 1<br />line 2</p>')
 
     def test_non_string_input(self):
         self.assertEqual(linebreaks_filter(123), '<p>123</p>')
@@ -43,18 +43,18 @@ class FunctionTests(SimpleTestCase):
     def test_autoescape(self):
         self.assertEqual(
             linebreaks_filter('foo\n<a>bar</a>\nbuz'),
-            '<p>foo<br>&lt;a&gt;bar&lt;/a&gt;<br>buz</p>',
+            '<p>foo<br />&lt;a&gt;bar&lt;/a&gt;<br />buz</p>',
         )
 
     def test_autoescape_off(self):
         self.assertEqual(
             linebreaks_filter('foo\n<a>bar</a>\nbuz', autoescape=False),
-            '<p>foo<br><a>bar</a><br>buz</p>',
+            '<p>foo<br /><a>bar</a><br />buz</p>',
         )
 
     def test_lazy_string_input(self):
         add_header = lazy(lambda string: 'Header\n\n' + string, str)
         self.assertEqual(
             linebreaks_filter(add_header('line 1\r\nline2')),
-            '<p>Header</p>\n\n<p>line 1<br>line2</p>'
+            '<p>Header</p>\n\n<p>line 1<br />line2</p>'
         )

--- a/tests/template_tests/filter_tests/test_linebreaksbr.py
+++ b/tests/template_tests/filter_tests/test_linebreaksbr.py
@@ -14,24 +14,24 @@ class LinebreaksbrTests(SimpleTestCase):
     @setup({'linebreaksbr01': '{{ a|linebreaksbr }} {{ b|linebreaksbr }}'})
     def test_linebreaksbr01(self):
         output = self.engine.render_to_string('linebreaksbr01', {"a": "x&\ny", "b": mark_safe("x&\ny")})
-        self.assertEqual(output, "x&amp;<br>y x&<br>y")
+        self.assertEqual(output, "x&amp;<br />y x&<br />y")
 
     @setup({'linebreaksbr02': '{% autoescape off %}{{ a|linebreaksbr }} {{ b|linebreaksbr }}{% endautoescape %}'})
     def test_linebreaksbr02(self):
         output = self.engine.render_to_string('linebreaksbr02', {"a": "x&\ny", "b": mark_safe("x&\ny")})
-        self.assertEqual(output, "x&<br>y x&<br>y")
+        self.assertEqual(output, "x&<br />y x&<br />y")
 
 
 class FunctionTests(SimpleTestCase):
 
     def test_newline(self):
-        self.assertEqual(linebreaksbr('line 1\nline 2'), 'line 1<br>line 2')
+        self.assertEqual(linebreaksbr('line 1\nline 2'), 'line 1<br />line 2')
 
     def test_carriage(self):
-        self.assertEqual(linebreaksbr('line 1\rline 2'), 'line 1<br>line 2')
+        self.assertEqual(linebreaksbr('line 1\rline 2'), 'line 1<br />line 2')
 
     def test_carriage_newline(self):
-        self.assertEqual(linebreaksbr('line 1\r\nline 2'), 'line 1<br>line 2')
+        self.assertEqual(linebreaksbr('line 1\r\nline 2'), 'line 1<br />line 2')
 
     def test_non_string_input(self):
         self.assertEqual(linebreaksbr(123), '123')
@@ -39,11 +39,11 @@ class FunctionTests(SimpleTestCase):
     def test_autoescape(self):
         self.assertEqual(
             linebreaksbr('foo\n<a>bar</a>\nbuz'),
-            'foo<br>&lt;a&gt;bar&lt;/a&gt;<br>buz',
+            'foo<br />&lt;a&gt;bar&lt;/a&gt;<br />buz',
         )
 
     def test_autoescape_off(self):
         self.assertEqual(
             linebreaksbr('foo\n<a>bar</a>\nbuz', autoescape=False),
-            'foo<br><a>bar</a><br>buz',
+            'foo<br /><a>bar</a><br />buz',
         )

--- a/tests/template_tests/filter_tests/test_truncatechars_html.py
+++ b/tests/template_tests/filter_tests/test_truncatechars_html.py
@@ -5,24 +5,24 @@ from django.test import SimpleTestCase
 class FunctionTests(SimpleTestCase):
 
     def test_truncate_zero(self):
-        self.assertEqual(truncatechars_html('<p>one <a href="#">two - three <br>four</a> five</p>', 0), '...')
+        self.assertEqual(truncatechars_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 0), '...')
 
     def test_truncate(self):
         self.assertEqual(
-            truncatechars_html('<p>one <a href="#">two - three <br>four</a> five</p>', 6),
+            truncatechars_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 6),
             '<p>one...</p>',
         )
 
     def test_truncate2(self):
         self.assertEqual(
-            truncatechars_html('<p>one <a href="#">two - three <br>four</a> five</p>', 11),
+            truncatechars_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 11),
             '<p>one <a href="#">two ...</a></p>',
         )
 
     def test_truncate3(self):
         self.assertEqual(
-            truncatechars_html('<p>one <a href="#">two - three <br>four</a> five</p>', 100),
-            '<p>one <a href="#">two - three <br>four</a> five</p>',
+            truncatechars_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 100),
+            '<p>one <a href="#">two - three <br/>four</a> five</p>',
         )
 
     def test_truncate_unicode(self):
@@ -32,5 +32,5 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(truncatechars_html('a<b>b</b>c', 3), 'a<b>b</b>c')
 
     def test_invalid_arg(self):
-        html = '<p>one <a href="#">two - three <br>four</a> five</p>'
+        html = '<p>one <a href="#">two - three <br/>four</a> five</p>'
         self.assertEqual(truncatechars_html(html, 'a'), html)

--- a/tests/template_tests/filter_tests/test_truncatewords_html.py
+++ b/tests/template_tests/filter_tests/test_truncatewords_html.py
@@ -5,30 +5,30 @@ from django.test import SimpleTestCase
 class FunctionTests(SimpleTestCase):
 
     def test_truncate_zero(self):
-        self.assertEqual(truncatewords_html('<p>one <a href="#">two - three <br>four</a> five</p>', 0), '')
+        self.assertEqual(truncatewords_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 0), '')
 
     def test_truncate(self):
         self.assertEqual(
-            truncatewords_html('<p>one <a href="#">two - three <br>four</a> five</p>', 2),
+            truncatewords_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 2),
             '<p>one <a href="#">two ...</a></p>',
         )
 
     def test_truncate2(self):
         self.assertEqual(
-            truncatewords_html('<p>one <a href="#">two - three <br>four</a> five</p>', 4),
-            '<p>one <a href="#">two - three <br>four ...</a></p>',
+            truncatewords_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 4),
+            '<p>one <a href="#">two - three <br/>four ...</a></p>',
         )
 
     def test_truncate3(self):
         self.assertEqual(
-            truncatewords_html('<p>one <a href="#">two - three <br>four</a> five</p>', 5),
-            '<p>one <a href="#">two - three <br>four</a> five</p>',
+            truncatewords_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 5),
+            '<p>one <a href="#">two - three <br/>four</a> five</p>',
         )
 
     def test_truncate4(self):
         self.assertEqual(
-            truncatewords_html('<p>one <a href="#">two - three <br>four</a> five</p>', 100),
-            '<p>one <a href="#">two - three <br>four</a> five</p>',
+            truncatewords_html('<p>one <a href="#">two - three <br/>four</a> five</p>', 100),
+            '<p>one <a href="#">two - three <br/>four</a> five</p>',
         )
 
     def test_truncate_unicode(self):

--- a/tests/templates/form_view.html
+++ b/tests/templates/form_view.html
@@ -8,7 +8,7 @@
 {% endif %}
 <ul class='form'>
 {{ form }}
-<li><input type='submit' value='Submit'></li>
+<li><input type='submit' value='Submit' /></li>
 </ul>
 </form>
 

--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -11,7 +11,7 @@
 <tr><td><label for="id_password">Password:</label></td><td>{{ form.password }}</td></tr>
 </table>
 
-<input type="submit" value="login">
-<input type="hidden" name="next" value="{{ next }}">
+<input type="submit" value="login" />
+<input type="hidden" name="next" value="{{ next }}" />
 </form>
 {% endblock %}

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -463,7 +463,7 @@ class HTMLEqualTests(SimpleTestCase):
         self.assertEqual(element.children[0].children[0], 'Hello')
 
         parse_html('<p>')
-        parse_html('<p attr>')
+        parse_html('<p attr="attr">')
         dom = parse_html('<p>foo')
         self.assertEqual(len(dom.children), 1)
         self.assertEqual(dom.name, 'p')
@@ -527,7 +527,7 @@ class HTMLEqualTests(SimpleTestCase):
         self.assertHTMLEqual('<p> </p>', '<p></p>')
         self.assertHTMLEqual('<p/>', '<p></p>')
         self.assertHTMLEqual('<p />', '<p></p>')
-        self.assertHTMLEqual('<input checked />', '<input checked="checked" />')
+        self.assertHTMLEqual('<input checked="checked" />', '<input checked="checked" />')
         self.assertHTMLEqual('<p>Hello', '<p> Hello')
         self.assertHTMLEqual('<p>Hello</p>World', '<p>Hello</p> World')
 

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -527,7 +527,7 @@ class HTMLEqualTests(SimpleTestCase):
         self.assertHTMLEqual('<p> </p>', '<p></p>')
         self.assertHTMLEqual('<p/>', '<p></p>')
         self.assertHTMLEqual('<p />', '<p></p>')
-        self.assertHTMLEqual('<input checked>', '<input checked="checked">')
+        self.assertHTMLEqual('<input checked />', '<input checked="checked" />')
         self.assertHTMLEqual('<p>Hello', '<p> Hello')
         self.assertHTMLEqual('<p>Hello</p>World', '<p>Hello</p> World')
 
@@ -587,9 +587,9 @@ class HTMLEqualTests(SimpleTestCase):
             """<!DOCTYPE html>
         <html>
         <head>
-            <link rel="stylesheet">
+            <link rel="stylesheet" />
             <title>Document</title>
-            <meta attribute="value">
+            <meta attribute="value" />
         </head>
         <body>
             <p>
@@ -599,9 +599,9 @@ class HTMLEqualTests(SimpleTestCase):
         </html>""", """
         <html>
         <head>
-            <link rel="stylesheet">
+            <link rel="stylesheet" />
             <title>Document</title>
-            <meta attribute="value">
+            <meta attribute="value" />
         </head>
         <body>
             <p> This is a valid paragraph
@@ -659,7 +659,7 @@ class HTMLEqualTests(SimpleTestCase):
         dom2 = parse_html('<p>foo</p><p>foo</p>')
         self.assertEqual(dom2.count(dom1), 2)
 
-        dom2 = parse_html('<div><p>foo<input type=""></p><p>foo</p></div>')
+        dom2 = parse_html('<div><p>foo<input type="" /></p><p>foo</p></div>')
         self.assertEqual(dom2.count(dom1), 1)
 
         dom2 = parse_html('<div><div><p>foo</p></div></div>')
@@ -696,10 +696,10 @@ class HTMLEqualTests(SimpleTestCase):
             <input type="text" name="Hello" />
         </form></body>''')
 
-        self.assertNotContains(response, "<input name='Hello' type='text'>")
+        self.assertNotContains(response, "<input name='Hello' type='text' />")
         self.assertContains(response, '<form method="get">')
 
-        self.assertContains(response, "<input name='Hello' type='text'>", html=True)
+        self.assertContains(response, "<input name='Hello' type='text' />", html=True)
         self.assertNotContains(response, '<form method="get">', html=True)
 
         invalid_response = HttpResponse('''<body <bad>>''')

--- a/tests/utils_tests/files/strip_tags1.html
+++ b/tests/utils_tests/files/strip_tags1.html
@@ -229,7 +229,7 @@
 
 </ul>
 
-              <h1 itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title public">
+              <h1 itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title public">
                 <span class="repo-label"><span>public</span></span>
                 <span class="mega-icon mega-icon-public-repo"></span>
                 <span class="author vcard">

--- a/tests/utils_tests/files/strip_tags1.html
+++ b/tests/utils_tests/files/strip_tags1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# githubog: http://ogp.me/ns/fb/githubog#">
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset='utf-8' />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>Improved regex in strip_tags ·  d7504a3 · django/django</title>
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub" />
     <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub" />
@@ -11,8 +11,8 @@
     <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-144.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144.png" />
     <link rel="logo" type="image/svg" href="http://github-media-downloads.s3.amazonaws.com/github-logo.svg" />
-    <meta name="msapplication-TileImage" content="/windows-tile.png">
-    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="/windows-tile.png" />
+    <meta name="msapplication-TileColor" content="#ffffff" />
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
@@ -27,11 +27,11 @@
       <script src="https://a248.e.akamai.net/assets.github.com/assets/frameworks-d76b58e749b52bc47a4c46620bf2c320fabe5248.js" type="text/javascript"></script>
       <script src="https://a248.e.akamai.net/assets.github.com/assets/github-67b55380cff8d6766b298e6935a3c1db7d5c6d5d.js" type="text/javascript"></script>
 
-      <meta http-equiv="x-pjax-version" content="1212ad79754350a805cefbcd08a3dadf">
+      <meta http-equiv="x-pjax-version" content="1212ad79754350a805cefbcd08a3dadf" />
 
-        <link data-pjax-transient rel='alternate' type='text/plain+diff' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e.diff">
-  <link data-pjax-transient rel='alternate' type='text/plain+patch' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e.patch">
-  <link data-pjax-transient rel='permalink' type='text/html' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e">
+        <link data-pjax-transient rel='alternate' type='text/plain+diff' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e.diff" />
+  <link data-pjax-transient rel='alternate' type='text/plain+patch' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e.patch" />
+  <link data-pjax-transient rel='permalink' type='text/html' href="&#x2F;django&#x2F;django&#x2F;commit&#x2F;d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e" />
     <meta property="og:title" content="django"/>
     <meta property="og:type" content="githubog:gitrepository"/>
     <meta property="og:url" content="https://github.com/django/django"/>
@@ -39,7 +39,7 @@
     <meta property="og:site_name" content="GitHub"/>
     <meta property="og:description" content="django - The Web framework for perfectionists with deadlines."/>
     <meta property="twitter:card" content="summary"/>
-    <meta property="twitter:site" content="@GitHub">
+    <meta property="twitter:site" content="@GitHub" />
     <meta property="twitter:title" content="django/django"/>
 
     <meta name="description" content="django - The Web framework for perfectionists with deadlines." />
@@ -71,13 +71,13 @@
             <form accept-charset="UTF-8" action="/search" class="command-bar-form" id="top_search_form" method="get">
   <a href="/search/advanced" class="advanced-search-icon tooltipped downwards command-bar-search" id="advanced_search" title="Advanced search"><span class="mini-icon mini-icon-advanced-search "></span></a>
 
-  <input type="text" name="q" id="js-command-bar-field" placeholder="Search or type a command" tabindex="1" data-username="claudep" autocapitalize="off">
+  <input type="text" name="q" id="js-command-bar-field" placeholder="Search or type a command" tabindex="1" data-username="claudep" autocapitalize="off" />
 
   <span class="mini-icon help tooltipped downwards" title="Show command bar help">
     <span class="mini-icon mini-icon-help"></span>
   </span>
 
-  <input type="hidden" name="ref" value="commandbar">
+  <input type="hidden" name="ref" value="commandbar" />
 
   <div class="divider-vertical"></div>
 </form>
@@ -286,7 +286,7 @@
 
           <div class="select-menu-filters">
             <div class="select-menu-text-filter">
-              <input type="text" id="commitish-filter-field" class="js-filterable-field js-navigation-enable" placeholder="Find or create a branch…">
+              <input type="text" id="commitish-filter-field" class="js-filterable-field js-navigation-enable" placeholder="Find or create a branch…" />
             </div>
             <div class="select-menu-tabs">
               <ul>
@@ -735,7 +735,7 @@
         <div class="actions">
           <span class="show-inline-notes">
             <label>
-              <input type="checkbox" checked="checked" class="js-show-inline-comments-toggle">
+              <input type="checkbox" checked="checked" class="js-show-inline-comments-toggle" />
               show inline notes
             </label>
           </span>
@@ -873,7 +873,7 @@
         <div class="actions">
           <span class="show-inline-notes">
             <label>
-              <input type="checkbox" checked="checked" class="js-show-inline-comments-toggle">
+              <input type="checkbox" checked="checked" class="js-show-inline-comments-toggle" />
               show inline notes
             </label>
           </span>
@@ -995,7 +995,7 @@
   <h2 class="commit-comments-header">
     0 notes
     on commit <code class="commit-comments-header-sha">d7504a3</code>
-    <span class="commit-comments-toggle-line-notes-wrapper"><label><input id="js-inline-comments-toggle" class="commit-comments-toggle-line-notes" type="checkbox">Show line notes below</label></span>
+    <span class="commit-comments-toggle-line-notes-wrapper"><label><input id="js-inline-comments-toggle" class="commit-comments-toggle-line-notes" type="checkbox" />Show line notes below</label></span>
   </h2>
   <div id="comments" class="only-commit-comments comment-holder commit-comments">
   </div>
@@ -1006,7 +1006,7 @@
       <form accept-charset="UTF-8" action="/django/django/commit_comment/create" method="post"><div style="margin:0;padding:0;display:inline"><input name="authenticity_token" type="hidden" value="Vbmuc30dLLFdm7POIe3xfTa4nODYc/la/wLrI1OLEOI=" /></div>
         <div class="discussion-bubble-content bubble">
           <div class="discussion-bubble-inner">
-            <input type='hidden' name='commit_id' value='d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e'>
+            <input type='hidden' name='commit_id' value='d7504a3d7b8645bdb979bab7ded0e9a9b6dccd0e' />
 
 
 <div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/preview?repository=4164482">
@@ -1040,7 +1040,7 @@
   <p class="drag-and-drop">
     <span class="default">
       Attach images by dragging &amp; dropping them or
-      <input type="file" multiple="multiple" class="manual-file-chooser js-manual-file-chooser">
+      <input type="file" multiple="multiple" class="manual-file-chooser js-manual-file-chooser" />
       <a class="manual-file-chooser-text" href="#">choose an image</a>
     </span>
     <span class="loading">
@@ -1245,7 +1245,7 @@
         <dd><a href="http://octodex.github.com/">The Octodex</a></dd>
       </dl>
 
-      <hr class="footer-divider">
+      <hr class="footer-divider" />
 
 
     <p class="right">&copy; 2013 <span title="0.09734s from fe2.rs.github.com">GitHub</span>, Inc. All rights reserved.</p>

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -57,8 +57,8 @@ class TestUtilsHtml(SimpleTestCase):
     def test_linebreaks(self):
         items = (
             ("para1\n\npara2\r\rpara3", "<p>para1</p>\n\n<p>para2</p>\n\n<p>para3</p>"),
-            ("para1\nsub1\rsub2\n\npara2", "<p>para1<br>sub1<br>sub2</p>\n\n<p>para2</p>"),
-            ("para1\r\n\r\npara2\rsub1\r\rpara4", "<p>para1</p>\n\n<p>para2<br>sub1</p>\n\n<p>para4</p>"),
+            ("para1\nsub1\rsub2\n\npara2", "<p>para1<br />sub1<br />sub2</p>\n\n<p>para2</p>"),
+            ("para1\r\n\r\npara2\rsub1\r\rpara4", "<p>para1</p>\n\n<p>para2<br />sub1</p>\n\n<p>para4</p>"),
             ("para1\tmore\n\npara2", "<p>para1\tmore</p>\n\n<p>para2</p>"),
         )
         for value, output in items:

--- a/tests/utils_tests/test_text.py
+++ b/tests/utils_tests/test_text.py
@@ -127,8 +127,8 @@ class TestUtilsText(SimpleTestCase):
         # Test self-closing tags
         truncator = text.Truncator('<br/>The <hr />quick brown fox jumped over the lazy dog.')
         self.assertEqual('<br/>The <hr />quick brown...', truncator.words(3, '...', html=True))
-        truncator = text.Truncator('<br>The <hr/>quick <em>brown fox</em> jumped over the lazy dog.')
-        self.assertEqual('<br>The <hr/>quick <em>brown...</em>', truncator.words(3, '...', html=True))
+        truncator = text.Truncator('<br/>The <hr/>quick <em>brown fox</em> jumped over the lazy dog.')
+        self.assertEqual('<br/>The <hr/>quick <em>brown...</em>', truncator.words(3, '...', html=True))
 
         # Test html entities
         truncator = text.Truncator('<i>Buenos d&iacute;as! &#x00bf;C&oacute;mo est&aacute;?</i>')

--- a/tests/view_tests/tests/test_csrf.py
+++ b/tests/view_tests/tests/test_csrf.py
@@ -58,7 +58,7 @@ class CsrfViewTests(SimpleTestCase):
         self.assertContains(
             response,
             'If you are using the &lt;meta name=&quot;referrer&quot; '
-            'content=&quot;no-referrer&quot;&gt; tag or including the '
+            'content=&quot;no-referrer&quot; /&gt; tag or including the '
             '&#39;Referrer-Policy: no-referrer&#39; header, please remove them.',
             status_code=403,
         )


### PR DESCRIPTION
Frameworks and libraries that generate html should output well-formed html that can be used for both HTML serialization (text/html) and XML serialization (application/xhtml+xml). This implies that Django should continue to output XML compatible markup even for HTML5.

This do not mean that Django need to be restricted by the XHTML-Transitional and XHTML-Strict standard. It only means that HTML5 needs to be written in a XML compatible style.