### PR TITLE
Refs #29015 -- Added database name to PostgreSQL database name too long exception.

### DIFF
--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -151,9 +151,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 "Please supply the NAME value.")
         if len(settings_dict['NAME'] or '') > self.ops.max_name_length():
             raise ImproperlyConfigured(
-                'Database names longer than %d characters are not supported by '
-                'PostgreSQL. Supply a shorter NAME in settings.DATABASES.'
-                % self.ops.max_name_length()
+                "The database name '%s' (%d characters) is longer than "
+                "PostgreSQL's limit of %d characters. Supply a shorter NAME "
+                "in settings.DATABASES." % (
+                    settings_dict['NAME'],
+                    len(settings_dict['NAME']),
+                    self.ops.max_name_length(),
+                )
             )
         conn_params = {
             'database': settings_dict['NAME'] or 'postgres',

--- a/tests/backends/postgresql/tests.py
+++ b/tests/backends/postgresql/tests.py
@@ -48,9 +48,10 @@ class Tests(TestCase):
         max_name_length = connection.ops.max_name_length()
         settings['NAME'] = 'a' + (max_name_length * 'a')
         msg = (
-            'Database names longer than %d characters are not supported by '
-            'PostgreSQL. Supply a shorter NAME in settings.DATABASES.'
-        ) % max_name_length
+            "The database name '%s' (%d characters) is longer than "
+            "PostgreSQL's limit of %s characters. Supply a shorter NAME in "
+            "settings.DATABASES."
+        ) % (settings['NAME'], max_name_length + 1, max_name_length)
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             DatabaseWrapper(settings).get_connection_params()
 


### PR DESCRIPTION
I bumped into this error a few times while upgrading a project to Django 2.1. In my case, the long database name was generated dynamically by a test. If the name had been presented, I think it would have been slightly easier to track down.