### PR TITLE
Refs #29426 -- Made UUIDField render values with dashes.

### DIFF
--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1187,7 +1187,7 @@ class UUIDField(CharField):
 
     def prepare_value(self, value):
         if isinstance(value, uuid.UUID):
-            return value.hex
+            return str(value)
         return value
 
     def to_python(self, value):

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -250,6 +250,10 @@ Database backend API
 
 * Support for GDAL 1.9 and 1.10 is dropped.
 
+* To improve readability, the ``UUIDField`` form field now displays values with
+  dashes, e.g. ``550e8400-e29b-41d4-a716-446655440000`` instead of
+  ``550e8400e29b41d4a716446655440000``.
+
 Miscellaneous
 -------------
 

--- a/tests/forms_tests/field_tests/test_uuidfield.py
+++ b/tests/forms_tests/field_tests/test_uuidfield.py
@@ -11,6 +11,11 @@ class UUIDFieldTest(SimpleTestCase):
         value = field.clean('550e8400e29b41d4a716446655440000')
         self.assertEqual(value, uuid.UUID('550e8400e29b41d4a716446655440000'))
 
+    def test_clean_value_with_dashes(self):
+        field = UUIDField()
+        value = field.clean('550e8400-e29b-41d4-a716-446655440000')
+        self.assertEqual(value, uuid.UUID('550e8400e29b41d4a716446655440000'))
+
     def test_uuidfield_2(self):
         field = UUIDField(required=False)
         value = field.clean('')
@@ -24,4 +29,4 @@ class UUIDFieldTest(SimpleTestCase):
     def test_uuidfield_4(self):
         field = UUIDField()
         value = field.prepare_value(uuid.UUID('550e8400e29b41d4a716446655440000'))
-        self.assertEqual(value, '550e8400e29b41d4a716446655440000')
+        self.assertEqual(value, '550e8400-e29b-41d4-a716-446655440000')


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29426 

Alternative to the approach in https://github.com/django/django/pull/9972 which adds an option to enable the behavior. I don't see a need for the toggle.