### PR TITLE
Fixed #29236 -- Fixed diffsettings crash if using settings.configure().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -319,6 +319,7 @@ answer newbie questions, and generally made Django that much better:
     Gustavo Picon
     hambaloney
     Hannes Struß <x@hannesstruss.de>
+    Hasan Ramezani <hasan.r67@gmail.com>
     Hawkeye
     Helen Sherwood-Taylor <helen@rrdlabs.co.uk>
     Henrique Romano <onaiort@gmail.com>

--- a/django/core/management/commands/diffsettings.py
+++ b/django/core/management/commands/diffsettings.py
@@ -42,7 +42,8 @@ class Command(BaseCommand):
         from django.conf import settings, Settings, global_settings
 
         # Because settings are imported lazily, we need to explicitly load them.
-        settings._setup()
+        if not settings.configured:
+            settings._setup()
 
         user_settings = module_to_dict(settings._wrapped)
         default = options['default']

--- a/tests/admin_scripts/configured_settings_manage.py
+++ b/tests/admin_scripts/configured_settings_manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import sys
+
+from django.conf import settings
+from django.core.management import execute_from_command_line
+
+if __name__ == '__main__':
+    settings.configure(DEBUG=True)
+    execute_from_command_line(sys.argv)

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -159,16 +159,18 @@ class AdminScriptTestCase(unittest.TestCase):
         script_dir = os.path.abspath(os.path.join(os.path.dirname(django.__file__), 'bin'))
         return self.run_test(os.path.join(script_dir, 'django-admin.py'), args, settings_file)
 
-    def run_manage(self, args, settings_file=None):
+    def run_manage(self, args, settings_file=None, configured_settings=False):
         def safe_remove(path):
             try:
                 os.remove(path)
             except OSError:
                 pass
 
-        conf_dir = os.path.dirname(conf.__file__)
-        template_manage_py = os.path.join(conf_dir, 'project_template', 'manage.py-tpl')
-
+        template_manage_py = (
+            os.path.join(os.path.dirname(__file__), 'configured_settings_manage.py')
+            if configured_settings else
+            os.path.join(os.path.dirname(conf.__file__), 'project_template', 'manage.py-tpl')
+        )
         test_manage_py = os.path.join(self.test_dir, 'manage.py')
         shutil.copyfile(template_manage_py, test_manage_py)
 
@@ -2181,6 +2183,11 @@ class DiffSettings(AdminScriptTestCase):
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
         self.assertOutput(out, "FOO = 'bar'  ###")
+
+    def test_settings_configured(self):
+        out, err = self.run_manage(['diffsettings'], configured_settings=True)
+        self.assertNoOutput(err)
+        self.assertOutput(out, 'DEBUG = True')
 
     def test_all(self):
         """The all option also shows settings with the default value."""


### PR DESCRIPTION
[ticket 29236](https://code.djangoproject.com/ticket/29236)