### PR TITLE
Fixed #29688 -- Added ModelAdmin.manager_name attribute.

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -101,6 +101,7 @@ csrf_protect_m = method_decorator(csrf_protect)
 class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
     """Functionality common to both ModelAdmin and InlineAdmin."""
 
+    manager_name = '_default_manager'
     autocomplete_fields = ()
     raw_id_fields = ()
     fields = None
@@ -351,7 +352,7 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         Return a QuerySet of all model instances that can be edited by the
         admin site. This is used by changelist_view.
         """
-        qs = self.model._default_manager.get_queryset()
+        qs = getattr(self.model, self.manager_name).get_queryset()
         # TODO: this should be handled by some parameter to the ChangeList.
         ordering = self.get_ordering(request)
         if ordering:

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -582,6 +582,11 @@ with the admin site:
   ``DateTimeField``.
 * **admin.E129**: ``<modeladmin>`` must define a ``has_<foo>_permission()``
   method for the ``<action>`` action.
+* **admin.E130**: The value of ``manager_name`` must be a string.
+* **admin.E131**: The value of ``manager_name`` refers to ``<field name>``,
+  which is not an attribute of ``<model>``.
+* **admin.E132**: The value of ``manager_name`` must be an attribute of
+  ``<model>`` that inherits from ``Manager``.
 
 ``InlineModelAdmin``
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -258,6 +258,12 @@ subclass::
 
             view_birth_date.empty_value_display = '???'
 
+.. attribute:: ModelAdmin.manager_name
+
+     Default, ``'_default_manager'``. Set this to the name of the model's
+     manager to be used by :meth:`.ModelAdmin.get_queryset()` if the default
+     manager is not appropriate for your needs.
+
 .. attribute:: ModelAdmin.exclude
 
     This attribute, if given, should be a list of field names to exclude from

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -43,7 +43,8 @@ Minor features
 :mod:`django.contrib.admin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ...
+* The new :attr:`.ModelAdmin.manager_name` attribute allows customizing the
+  model's manager used by :meth:`.ModelAdmin.get_queryset()`.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/admin_changelist/admin.py
+++ b/tests/admin_changelist/admin.py
@@ -147,3 +147,7 @@ class EmptyValueChildAdmin(admin.ModelAdmin):
     def age_display(self, obj):
         return obj.age
     age_display.empty_value_display = '&dagger;'
+
+
+class SoftDeletableObjectAdmin(admin.ModelAdmin):
+    manager_name = '_base_manager'

--- a/tests/admin_changelist/models.py
+++ b/tests/admin_changelist/models.py
@@ -119,3 +119,13 @@ class CustomIdUser(models.Model):
 
 class CharPK(models.Model):
     char_pk = models.CharField(max_length=100, primary_key=True)
+
+
+class SoftDeletableManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(deleted=False)
+
+
+class SoftDeletableObject(models.Model):
+    deleted = models.BooleanField(default=False)
+    objects = SoftDeletableManager()

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -26,13 +26,14 @@ from .admin import (
     DynamicListDisplayLinksChildAdmin, DynamicListFilterChildAdmin,
     DynamicSearchFieldsChildAdmin, EmptyValueChildAdmin, EventAdmin,
     FilteredChildAdmin, GroupAdmin, InvitationAdmin,
-    NoListDisplayLinksParentAdmin, ParentAdmin, QuartetAdmin, SwallowAdmin,
-    site as custom_site,
+    NoListDisplayLinksParentAdmin, ParentAdmin, QuartetAdmin,
+    SoftDeletableObjectAdmin, SwallowAdmin, site as custom_site,
 )
 from .models import (
     Band, CharPK, Child, ChordsBand, ChordsMusician, Concert, CustomIdUser,
     Event, Genre, Group, Invitation, Membership, Musician, OrderedObject,
-    Parent, Quartet, Swallow, SwallowOneToOne, UnorderedObject,
+    Parent, Quartet, SoftDeletableObject, Swallow, SwallowOneToOne,
+    UnorderedObject,
 )
 
 
@@ -1010,6 +1011,15 @@ class ChangeListTests(TestCase):
         self.assertIn('<ul class="object-tools">', response.rendered_content)
         # The "Add" button inside the object-tools shouldn't appear.
         self.assertNotIn('Add ', response.rendered_content)
+
+    def test_manager_name(self):
+        obj = SoftDeletableObject.objects.create()
+        deleted_obj = SoftDeletableObject.objects.create(deleted=True)
+        self.assertSequenceEqual(SoftDeletableObject._default_manager.get_queryset(), [obj])
+        superuser = self._create_superuser('superuser')
+        ma = SoftDeletableObjectAdmin(SoftDeletableObject, custom_site)
+        request = self._mocked_authenticated_request('/event/', superuser)
+        self.assertCountEqual(ma.get_queryset(request), [obj, deleted_obj])
 
 
 class GetAdminLogTests(TestCase):

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -856,3 +856,60 @@ class SystemChecksTestCase(SimpleTestCase):
             self.assertEqual(errors, [])
         finally:
             Book._meta.apps.ready = True
+
+    def test_check_manager_name_must_be_string(self):
+        class MyModelAdmin(admin.ModelAdmin):
+            manager_name = None
+
+        errors = MyModelAdmin(Album, AdminSite()).check()
+        self.assertEqual(
+            errors,
+            [
+                checks.Error(
+                    "The value of 'manager_name' must be a string.",
+                    obj=MyModelAdmin,
+                    id='admin.E130',
+                ),
+            ],
+        )
+
+    def test_check_manager_name_must_be_an_attribute(self):
+        class MyModelAdmin(admin.ModelAdmin):
+            manager_name = 'missing'
+
+        errors = MyModelAdmin(Album, AdminSite()).check()
+        self.assertEqual(
+            errors,
+            [
+                checks.Error(
+                    "The value of 'manager_name' refers to 'missing', which is "
+                    "not an attribute of 'admin_checks.Album'.",
+                    obj=MyModelAdmin,
+                    id='admin.E131',
+                ),
+            ],
+        )
+
+    def test_check_manager_name_must_reference_a_manager(self):
+        class MyModelAdmin(admin.ModelAdmin):
+            manager_name = 'title'
+
+        errors = MyModelAdmin(Album, AdminSite()).check()
+        self.assertEqual(
+            errors,
+            [
+                checks.Error(
+                    "The value of 'manager_name' must be an attribute of "
+                    "'admin_checks.Album' that inherits from 'Manager'.",
+                    obj=MyModelAdmin,
+                    id='admin.E132',
+                ),
+            ],
+        )
+
+    def test_check_manager_name_valid(self):
+        class MyModelAdmin(admin.ModelAdmin):
+            manager_name = '_base_manager'
+
+        errors = MyModelAdmin(Album, AdminSite()).check()
+        self.assertEqual(errors, [])


### PR DESCRIPTION
Allows customizing the manager used by `ModelAdmin.get_queryset()`.

https://code.djangoproject.com/ticket/29688