### PR TITLE
Fixed admin_checks tests to run in isolation.

### DIFF
--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -39,7 +39,12 @@ class MyAdmin(admin.ModelAdmin):
 
 @override_settings(
     SILENCED_SYSTEM_CHECKS=['fields.W342'],  # ForeignKey(unique=True)
-    INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'admin_checks']
+    INSTALLED_APPS=[
+        'django.contrib.admin',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'admin_checks',
+    ],
 )
 class SystemChecksTestCase(SimpleTestCase):
 
@@ -69,11 +74,6 @@ class SystemChecksTestCase(SimpleTestCase):
         self.assertEqual(admin.checks.check_dependencies(), [])
 
     @override_settings(
-        INSTALLED_APPS=[
-            'django.contrib.admin',
-            'django.contrib.auth',
-            'django.contrib.contenttypes',
-        ],
         TEMPLATES=[{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'DIRS': [],


### PR DESCRIPTION
Running only the `admin_checks` on master results in the exception below.

Should `admin` be included in the class level `INSTALLED_APPS` instead?

```
======================================================================
ERROR: test_allows_checks_relying_on_other_modeladmins (admin_checks.tests.SystemChecksTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jon/devel/django/django/apps/registry.py", line 152, in get_app_config
    return self.app_configs[app_label]
KeyError: 'admin'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jon/devel/django/tests/admin_checks/tests.py", line 122, in test_allows_checks_relying_on_other_modeladmins
    admin.site.register(Book, MyBookAdmin)
  File "/home/jon/devel/django/django/utils/functional.py", line 213, in inner
    self._setup()
  File "/home/jon/devel/django/django/contrib/admin/sites.py", line 529, in _setup
    AdminSiteClass = import_string(apps.get_app_config('admin').default_site)
  File "/home/jon/devel/django/django/apps/registry.py", line 159, in get_app_config
    raise LookupError(message)
LookupError: No installed app with label 'admin'.
```

