### PR TITLE
Removed unused function argument from Window.as_sql().

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1237,7 +1237,7 @@ class Window(Expression):
     def set_source_expressions(self, exprs):
         self.source_expression, self.partition_by, self.order_by, self.frame = exprs
 
-    def as_sql(self, compiler, connection, function=None, template=None):
+    def as_sql(self, compiler, connection, template=None):
         connection.ops.check_expression_support(self)
         expr_sql, params = compiler.compile(self.source_expression)
         window_sql, window_params = [], []


### PR DESCRIPTION
Unused since its introduction in d549b8805053d4b064bf492ba90e90db5d7e2a6b.