### PR TITLE
Fixed #29696 -- Prevented BaseModelFormSet.initial_form_count()'s from treating data={} as unbound.

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -570,7 +570,7 @@ class BaseModelFormSet(BaseFormSet):
 
     def initial_form_count(self):
         """Return the number of forms that are required in this FormSet."""
-        if not (self.data or self.files):
+        if not self.is_bound:
             return len(self.get_queryset())
         return super().initial_form_count()
 

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from django import forms
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.forms.models import (
     BaseModelFormSet, _get_foreign_key, inlineformset_factory,
@@ -1740,6 +1740,12 @@ class ModelFormsetTest(TestCase):
             formset.errors,
             [{'id': ['Select a valid choice. That choice is not one of the available choices.']}],
         )
+
+    def test_initial_form_count_empty_data_raises_validation_error(self):
+        AuthorFormSet = modelformset_factory(Author, fields='__all__')
+        msg = 'ManagementForm data is missing or has been tampered with'
+        with self.assertRaisesMessage(ValidationError, msg):
+            AuthorFormSet({}).initial_form_count()
 
 
 class TestModelFormsetOverridesTroughFormMeta(TestCase):


### PR DESCRIPTION
Avoids repeating logic for determining a bound formset. Makes the child class behavior more consistent with the parent class behavior.

Added test `test_initial_form_count_empty_data_raises_validation_error` to show that model formsets now correctly distinguishes between unbound and `data={}`.