### PR TITLE
Fixed #29698 -- Make Model Field _check_choices handle invalid type.

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -260,7 +260,7 @@ class Field(RegisterLookupMixin):
         for choices_group in self.choices:
             try:
                 group_name, group_choices = choices_group
-            except ValueError:
+            except (TypeError, ValueError):
                 # Containing non-pairs
                 break
             try:

--- a/tests/invalid_models_tests/test_ordinary_fields.py
+++ b/tests/invalid_models_tests/test_ordinary_fields.py
@@ -174,14 +174,20 @@ class CharFieldTests(TestCase):
         class Model(models.Model):
             field = models.CharField(max_length=10, choices=[(1, 2, 3), (1, 2, 3)])
 
-        field = Model._meta.get_field('field')
-        self.assertEqual(field.check(), [
-            Error(
-                "'choices' must be an iterable containing (actual value, human readable name) tuples.",
-                obj=field,
-                id='fields.E005',
-            ),
-        ])
+        class Model2(models.Model):
+            field = models.IntegerField(choices=[0])
+
+        for model in (Model, Model2):
+            with self.subTest(model.__name__):
+                field = model._meta.get_field('field')
+                self.assertEqual(field.check(), [
+                    Error(
+                        "'choices' must be an iterable containing (actual "
+                        "value, human readable name) tuples.",
+                        obj=field,
+                        id='fields.E005',
+                    ),
+                ])
 
     def test_choices_containing_lazy(self):
         class Model(models.Model):


### PR DESCRIPTION
Reference: https://code.djangoproject.com/ticket/29698#ticket