### PR TITLE
fix timestamp in response.delete_cookie()

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -216,7 +216,7 @@ class HttpResponseBase:
         secure = key.startswith(('__Secure-', '__Host-'))
         self.set_cookie(
             key, max_age=0, path=path, domain=domain, secure=secure,
-            expires='Thu, 01 Jan 1970 00:00:00 GMT',
+            expires='Thu, 01-Jan-1970 00:00:00 GMT',
         )
 
     # Common methods used by subclasses


### PR DESCRIPTION
RFC 2109 states: 
> 10.1.2  Expires and Max-Age
>   Netscape's original proposal defined an Expires header that took a
>   date value in a fixed-length variant format in place of Max-Age:
>   Wdy, DD-Mon-YY HH:MM:SS GMT

The Django documentation itself states:
> expires should either be a string in the format "Wdy, DD-Mon-YY HH:MM:SS GMT" or a datetime.datetime object in UTC.