### PR TITLE
Fixed #29703 -- Deprecated QuerySetPaginator alias.

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -3,6 +3,7 @@ import inspect
 import warnings
 from math import ceil
 
+from django.utils.deprecation import RemovedInDjango31Warning
 from django.utils.functional import cached_property
 from django.utils.inspect import method_has_no_args
 from django.utils.translation import gettext_lazy as _
@@ -125,7 +126,14 @@ class Paginator:
             )
 
 
-QuerySetPaginator = Paginator   # For backwards-compatibility.
+class QuerySetPaginator(Paginator):
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'The QuerySetPaginator alias of Paginator is deprecated.',
+            RemovedInDjango31Warning, stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class Page(collections.abc.Sequence):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -17,6 +17,8 @@ details on these changes.
 
 * ``django.utils.timezone.FixedOffset`` will be removed.
 
+* ``django.core.paginator.QuerySetPaginator`` will be removed.
+
 .. _deprecation-removed-in-3.0:
 
 3.0

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -293,3 +293,6 @@ Miscellaneous
 
 * ``django.utils.timezone.FixedOffset`` is deprecated in favor of
   :class:`datetime.timezone`.
+
+* The undocumented ``QuerySetPaginator`` alias of
+  ``django.core.paginator.Paginator`` is deprecated.

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -2,10 +2,11 @@ import warnings
 from datetime import datetime
 
 from django.core.paginator import (
-    EmptyPage, InvalidPage, PageNotAnInteger, Paginator,
+    EmptyPage, InvalidPage, PageNotAnInteger, Paginator, QuerySetPaginator,
     UnorderedObjectListWarning,
 )
 from django.test import SimpleTestCase, TestCase
+from django.utils.deprecation import RemovedInDjango31Warning
 
 from .custom import ValidAdjacentNumsPaginator
 from .models import Article
@@ -296,6 +297,12 @@ class PaginationTests(SimpleTestCase):
         paginator = Paginator([], 2, allow_empty_first_page=False)
         with self.assertRaises(EmptyPage):
             paginator.get_page(1)
+
+    def test_querysetpaginator_deprecation(self):
+        msg = 'The QuerySetPaginator alias of Paginator is deprecated.'
+        with self.assertWarnsMessage(RemovedInDjango31Warning, msg) as cm:
+            QuerySetPaginator([], 1)
+        self.assertEqual(cm.filename, __file__)
 
 
 class ModelPaginationTests(TestCase):


### PR DESCRIPTION
[Ticket #29703](https://code.djangoproject.com/ticket/29703). Unused since 4406d283e13819b04556df21044089b7d119edb0.