### PR TITLE
Fixed #29706 -- Missing using=db call in RenameContentType._rename

### DIFF
--- a/django/contrib/contenttypes/management/__init__.py
+++ b/django/contrib/contenttypes/management/__init__.py
@@ -24,7 +24,7 @@ class RenameContentType(migrations.RunPython):
             content_type.model = new_model
             try:
                 with transaction.atomic(using=db):
-                    content_type.save(update_fields={'model'})
+                    content_type.save(using=db, update_fields={'model'})
             except IntegrityError:
                 # Gracefully fallback if a stale content type causes a
                 # conflict as remove_stale_contenttypes will take care of


### PR DESCRIPTION
[Ticket #29706](https://code.djangoproject.com/ticket/29706)