### PR TITLE
Fixed #29694 -- Fixed column mismatch crash with QuerySet.values() or values_list() after combining querysets with extra() with union(), difference(), or intersection().

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -416,7 +416,11 @@ class SQLCompiler:
                 # must have the same columns list. Set the selects defined on
                 # the query on all combined queries, if not already set.
                 if not compiler.query.values_select and self.query.values_select:
-                    compiler.query.set_values((*self.query.values_select, *self.query.annotation_select))
+                    compiler.query.set_values((
+                        *self.query.extra_select,
+                        *self.query.values_select,
+                        *self.query.annotation_select,
+                    ))
                 parts += (compiler.as_sql(),)
             except EmptyResultSet:
                 # Omit the empty queryset with UNION and with DIFFERENCE if the

--- a/docs/releases/2.1.1.txt
+++ b/docs/releases/2.1.1.txt
@@ -41,3 +41,8 @@ Bugfixes
 
 * Fixed admin change view crash for view-only users if the form has an extra
   form field (:ticket:`29682`).
+
+* Fixed a regression in Django 2.0.5 where ``QuerySet.values()`` or
+  ``values_list()`` after combining querysets with ``extra()`` with
+  ``union()``, ``difference()``, or ``intersection()`` crashed due to
+  mismatching columns (:ticket:`29694`).

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -130,6 +130,13 @@ class QuerySetSetOperationTests(TestCase):
         ).values_list('num', 'count')
         self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
 
+    def test_union_with_extra_and_values_list(self):
+        qs1 = Number.objects.filter(num=1).extra(
+            select={'count': 0},
+        ).values_list('num', 'count')
+        qs2 = Number.objects.filter(num=2).extra(select={'count': 1})
+        self.assertCountEqual(qs1.union(qs2), [(1, 0), (2, 1)])
+
     def test_union_with_values_list_on_annotated_and_unannotated(self):
         ReservedName.objects.create(name='rn1', order=1)
         qs1 = Number.objects.annotate(


### PR DESCRIPTION
Regression in 0b66c3b442875627fa6daef4ac1e90900d74290b.
Ticket [29694](https://code.djangoproject.com/ticket/29694).