### PR TITLE
Fixed #29667 -- Handle spaces in path converter parameters

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -188,7 +188,7 @@ class RegexPattern(CheckURLMixin):
 
 
 _PATH_PARAMETER_COMPONENT_RE = re.compile(
-    r'<(?:(?P<converter>[^>:]+):)?(?P<parameter>\w+)>'
+    r'<(?:(?P<converter>[^>:]+):)?(\s+)?(?P<parameter>\w+)(\s+)?>'
 )
 
 

--- a/tests/urlpatterns/path_urls.py
+++ b/tests/urlpatterns/path_urls.py
@@ -12,4 +12,6 @@ urlpatterns = [
     path('users/<id>/', views.empty_view, name='user-with-id'),
     path('included_urls/', include('urlpatterns_reverse.included_urls')),
     path('<lang>/<path:url>/', views.empty_view, name='lang-and-path'),
+    path('prefix/<int: num>', views.empty_view, name='spaces-prefix-name'),
+    path('postfix/<int:num >', views.empty_view, name='spaces-postfix-name')
 ]

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -84,6 +84,26 @@ class SimplifiedURLTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             path('foo/<nonexistent:var>/', empty_view)
 
+    def test_prefix_spaces_in_name(self):
+        match = resolve('/prefix/1')
+        self.assertEqual(match.url_name, 'spaces-prefix-name')
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {'num': 1})
+
+    def test_reverse_prefix_spaces(self):
+        url = reverse('spaces-prefix-name', kwargs={'num': 1})
+        self.assertEqual(url, '/prefix/1')
+
+    def test_postfix_spaces_in_name(self):
+        match = resolve('/postfix/1')
+        self.assertEqual(match.url_name, 'spaces-postfix-name')
+        self.assertEqual(match.args, ())
+        self.assertEqual(match.kwargs, {'num': 1})
+
+    def test_reverse_postfix_spaces(self):
+        url = reverse('spaces-postfix-name', kwargs={'num': 1})
+        self.assertEqual(url, '/postfix/1')
+
 
 @override_settings(ROOT_URLCONF='urlpatterns.converter_urls')
 class ConverterTests(SimpleTestCase):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29667