### PR TITLE
Fixed #20581 -- Added support for deferrable unique constraints.

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -20,6 +20,8 @@ class BaseDatabaseFeatures:
     # Does the backend allow inserting duplicate rows when a unique_together
     # constraint exists and some fields are nullable but not all of them?
     supports_partially_nullable_unique_constraints = True
+    # Does the backend support initially deferrable unique constraints?
+    supports_deferrable_unique_constraints = False
 
     can_use_chunked_reads = True
     can_return_columns_from_insert = False

--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -71,9 +71,17 @@ def wrap_oracle_errors():
         #  message = 'ORA-02091: transaction rolled back
         #            'ORA-02291: integrity constraint (TEST_DJANGOTEST.SYS
         #               _C00102056) violated - parent key not found'
+        #            or:
+        #            'ORA-00001: unique constraint (DJANGOTEST.DEFERRABLE_
+        #               PINK_CONSTRAINT) violated
         # Convert that case to Django's IntegrityError exception.
         x = e.args[0]
-        if hasattr(x, 'code') and hasattr(x, 'message') and x.code == 2091 and 'ORA-02291' in x.message:
+        if (
+            hasattr(x, 'code') and
+            hasattr(x, 'message') and
+            x.code == 2091 and
+            ('ORA-02291' in x.message or 'ORA-00001' in x.message)
+        ):
             raise IntegrityError(*tuple(e.args))
         raise
 

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -17,6 +17,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_native_duration_field = True
     can_defer_constraint_checks = True
     supports_partially_nullable_unique_constraints = False
+    supports_deferrable_unique_constraints = True
     truncates_names = True
     supports_tablespaces = True
     supports_sequence_reset = False

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -56,6 +56,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_aggregate_filter_clause = True
     supported_explain_formats = {'JSON', 'TEXT', 'XML', 'YAML'}
     validates_explain_options = False  # A query will error on invalid options.
+    supports_deferrable_unique_constraints = True
 
     @cached_property
     def is_postgresql_9_6(self):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1904,6 +1904,25 @@ class Model(metaclass=ModelBase):
                         id='models.W036',
                     )
                 )
+            if not (
+                connection.features.supports_deferrable_unique_constraints or
+                'supports_deferrable_unique_constraints' in cls._meta.required_db_features
+            ) and any(
+                isinstance(constraint, UniqueConstraint) and constraint.deferrable is not None
+                for constraint in cls._meta.constraints
+            ):
+                errors.append(
+                    checks.Warning(
+                        '%s does not support deferrable unique constraints.'
+                        % connection.display_name,
+                        hint=(
+                            "A constraint won't be created. Silence this "
+                            "warning if you don't care about it."
+                        ),
+                        obj=cls,
+                        id='models.W038',
+                    )
+                )
         return errors
 
 

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -354,6 +354,8 @@ Models
 * **models.W036**: ``<database>`` does not support unique constraints with
   conditions.
 * **models.W037**: ``<database>`` does not support indexes with conditions.
+* **models.W038**: ``<database>`` does not support deferrable unique
+  constraints.
 
 Security
 --------

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -76,7 +76,7 @@ The name of the constraint.
 ``UniqueConstraint``
 ====================
 
-.. class:: UniqueConstraint(*, fields, name, condition=None)
+.. class:: UniqueConstraint(*, fields, name, condition=None, deferrable=None)
 
     Creates a unique constraint in the database.
 
@@ -119,3 +119,35 @@ ensures that each user only has one draft.
 
 These conditions have the same database restrictions as
 :attr:`Index.condition`.
+
+``deferrable``
+--------------
+
+.. attribute:: UniqueConstraint.deferrable
+
+.. versionadded:: 3.1
+
+Set this parameter to create a deferrable unique constraint. Accepted values
+are ``Deferrable.DEFERRED`` or ``Deferrable.IMMEDIATE``. For example::
+
+    from django.db.models import Deferrable, UniqueConstraint
+
+    UniqueConstraint(
+        name='unique_order',
+        fields=['order'],
+        deferrable=Deferrable.DEFERRED,
+    )
+
+By default constraints are not deferred. A deferred constraint will not be
+enforced until the end of the transaction. An immediate constraint will be
+enforced immediately after every command.
+
+.. admonition:: MySQL, MariaDB, and SQLite.
+
+    Deferrable unique constraints are ignored on MySQL, MariaDB, and SQLite as
+    neither supports them.
+
+.. warning::
+
+    Deferred unique constraints may lead to a `performance penalty
+    <https://www.postgresql.org/docs/current/sql-createtable.html#id-1.9.3.85.9.4>`_.

--- a/docs/releases/3.1.txt
+++ b/docs/releases/3.1.txt
@@ -381,6 +381,9 @@ Models
   <sqlite3.Connection.create_function>` on Python 3.8+. This allows using them
   in check constraints and partial indexes.
 
+* The new :attr:`.UniqueConstraint.deferrable` attribute allows creating
+  deferrable unique constraints.
+
 Pagination
 ~~~~~~~~~~
 

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -59,6 +59,28 @@ class UniqueConstraintConditionProduct(models.Model):
         ]
 
 
+class UniqueConstraintDeferrable(models.Model):
+    name = models.CharField(max_length=255)
+    shelf = models.CharField(max_length=31)
+
+    class Meta:
+        required_db_features = {
+            'supports_deferrable_unique_constraints',
+        }
+        constraints = [
+            models.UniqueConstraint(
+                fields=['name'],
+                name='name_init_deferred_uniq',
+                deferrable=models.Deferrable.DEFERRED,
+            ),
+            models.UniqueConstraint(
+                fields=['shelf'],
+                name='sheld_init_immediate_uniq',
+                deferrable=models.Deferrable.IMMEDIATE,
+            ),
+        ]
+
+
 class AbstractModel(models.Model):
     age = models.IntegerField()
 

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -1414,3 +1414,47 @@ class ConstraintsTests(TestCase):
                 ]
 
         self.assertEqual(Model.check(databases=self.databases), [])
+
+    def test_deferrable_unique_constraint(self):
+        class Model(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['age'],
+                        name='unique_age_deferrable',
+                        deferrable=models.Deferrable.DEFERRED,
+                    ),
+                ]
+
+        errors = Model.check(databases=self.databases)
+        expected = [] if connection.features.supports_deferrable_unique_constraints else [
+            Warning(
+                '%s does not support deferrable unique constraints.'
+                % connection.display_name,
+                hint=(
+                    "A constraint won't be created. Silence this warning if "
+                    "you don't care about it."
+                ),
+                obj=Model,
+                id='models.W038',
+            ),
+        ]
+        self.assertEqual(errors, expected)
+
+    def test_deferrable_unique_constraint_required_db_features(self):
+        class Model(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                required_db_features = {'supports_deferrable_unique_constraints'}
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['age'],
+                        name='unique_age_deferrable',
+                        deferrable=models.Deferrable.IMMEDIATE,
+                    ),
+                ]
+
+        self.assertEqual(Model.check(databases=self.databases), [])

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -393,6 +393,60 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[1], [])
         self.assertEqual(definition[2]['options']['constraints'], [partial_unique_constraint])
 
+    def test_create_model_with_deferred_unique_constraint(self):
+        deferred_unique_constraint = models.UniqueConstraint(
+            fields=['pink'],
+            name='deferrable_pink_constraint',
+            deferrable=models.Deferrable.DEFERRED,
+        )
+        operation = migrations.CreateModel(
+            'Pony',
+            [
+                ('id', models.AutoField(primary_key=True)),
+                ('pink', models.IntegerField(default=3)),
+            ],
+            options={'constraints': [deferred_unique_constraint]},
+        )
+        project_state = ProjectState()
+        new_state = project_state.clone()
+        operation.state_forwards('test_crmo', new_state)
+        self.assertEqual(len(new_state.models['test_crmo', 'pony'].options['constraints']), 1)
+        self.assertTableNotExists('test_crmo_pony')
+        # Create table.
+        with connection.schema_editor() as editor:
+            operation.database_forwards('test_crmo', editor, project_state, new_state)
+        self.assertTableExists('test_crmo_pony')
+        Pony = new_state.apps.get_model('test_crmo', 'Pony')
+        Pony.objects.create(pink=1)
+        if connection.features.supports_deferrable_unique_constraints:
+            # Unique constraint is deferred.
+            with transaction.atomic():
+                obj = Pony.objects.create(pink=1)
+                obj.pink = 2
+                obj.save()
+            # Constraint behavior can be changed with SET CONSTRAINTS.
+            with self.assertRaises(IntegrityError):
+                with transaction.atomic(), connection.cursor() as cursor:
+                    quoted_name = connection.ops.quote_name(deferred_unique_constraint.name)
+                    cursor.execute('SET CONSTRAINTS %s IMMEDIATE' % quoted_name)
+                    obj = Pony.objects.create(pink=1)
+                    obj.pink = 3
+                    obj.save()
+        else:
+            Pony.objects.create(pink=1)
+        # Reversal.
+        with connection.schema_editor() as editor:
+            operation.database_backwards('test_crmo', editor, new_state, project_state)
+        self.assertTableNotExists('test_crmo_pony')
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], 'CreateModel')
+        self.assertEqual(definition[1], [])
+        self.assertEqual(
+            definition[2]['options']['constraints'],
+            [deferred_unique_constraint],
+        )
+
     def test_create_model_managers(self):
         """
         The managers on a model are set.
@@ -2044,6 +2098,110 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[2], {
             'model_name': 'Pony',
             'name': 'test_constraint_pony_pink_for_weight_gt_5_uniq',
+        })
+
+    def test_add_deferred_unique_constraint(self):
+        app_label = 'test_adddeferred_uc'
+        project_state = self.set_up_test_model(app_label)
+        deferred_unique_constraint = models.UniqueConstraint(
+            fields=['pink'],
+            name='deferred_pink_constraint_add',
+            deferrable=models.Deferrable.DEFERRED,
+        )
+        operation = migrations.AddConstraint('Pony', deferred_unique_constraint)
+        self.assertEqual(
+            operation.describe(),
+            'Create constraint deferred_pink_constraint_add on model Pony',
+        )
+        # Add constraint.
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        self.assertEqual(len(new_state.models[app_label, 'pony'].options['constraints']), 1)
+        Pony = new_state.apps.get_model(app_label, 'Pony')
+        self.assertEqual(len(Pony._meta.constraints), 1)
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        Pony.objects.create(pink=1, weight=4.0)
+        if connection.features.supports_deferrable_unique_constraints:
+            # Unique constraint is deferred.
+            with transaction.atomic():
+                obj = Pony.objects.create(pink=1, weight=4.0)
+                obj.pink = 2
+                obj.save()
+            # Constraint behavior can be changed with SET CONSTRAINTS.
+            with self.assertRaises(IntegrityError):
+                with transaction.atomic(), connection.cursor() as cursor:
+                    quoted_name = connection.ops.quote_name(deferred_unique_constraint.name)
+                    cursor.execute('SET CONSTRAINTS %s IMMEDIATE' % quoted_name)
+                    obj = Pony.objects.create(pink=1, weight=4.0)
+                    obj.pink = 3
+                    obj.save()
+        else:
+            Pony.objects.create(pink=1, weight=4.0)
+        # Reversal.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        # Constraint doesn't work.
+        Pony.objects.create(pink=1, weight=4.0)
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], 'AddConstraint')
+        self.assertEqual(definition[1], [])
+        self.assertEqual(
+            definition[2],
+            {'model_name': 'Pony', 'constraint': deferred_unique_constraint},
+        )
+
+    def test_remove_deferred_unique_constraint(self):
+        app_label = 'test_removedeferred_uc'
+        deferred_unique_constraint = models.UniqueConstraint(
+            fields=['pink'],
+            name='deferred_pink_constraint_rm',
+            deferrable=models.Deferrable.DEFERRED,
+        )
+        project_state = self.set_up_test_model(app_label, constraints=[deferred_unique_constraint])
+        operation = migrations.RemoveConstraint('Pony', deferred_unique_constraint.name)
+        self.assertEqual(
+            operation.describe(),
+            'Remove constraint deferred_pink_constraint_rm from model Pony',
+        )
+        # Remove constraint.
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        self.assertEqual(len(new_state.models[app_label, 'pony'].options['constraints']), 0)
+        Pony = new_state.apps.get_model(app_label, 'Pony')
+        self.assertEqual(len(Pony._meta.constraints), 0)
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        # Constraint doesn't work.
+        Pony.objects.create(pink=1, weight=4.0)
+        Pony.objects.create(pink=1, weight=4.0).delete()
+        # Reversal.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        if connection.features.supports_deferrable_unique_constraints:
+            # Unique constraint is deferred.
+            with transaction.atomic():
+                obj = Pony.objects.create(pink=1, weight=4.0)
+                obj.pink = 2
+                obj.save()
+            # Constraint behavior can be changed with SET CONSTRAINTS.
+            with self.assertRaises(IntegrityError):
+                with transaction.atomic(), connection.cursor() as cursor:
+                    quoted_name = connection.ops.quote_name(deferred_unique_constraint.name)
+                    cursor.execute('SET CONSTRAINTS %s IMMEDIATE' % quoted_name)
+                    obj = Pony.objects.create(pink=1, weight=4.0)
+                    obj.pink = 3
+                    obj.save()
+        else:
+            Pony.objects.create(pink=1, weight=4.0)
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], 'RemoveConstraint')
+        self.assertEqual(definition[1], [])
+        self.assertEqual(definition[2], {
+            'model_name': 'Pony',
+            'name': 'deferred_pink_constraint_rm',
         })
 
     def test_alter_model_options(self):


### PR DESCRIPTION
This builds upon https://github.com/django/django/pull/10271, extending the `UniqueConstraint` class to support deferring constraint checks.
https://code.djangoproject.com/ticket/20581