### PR TITLE
Fixed LayerMapping encoding in geodjango tutorial.

### DIFF
--- a/docs/ref/contrib/gis/tutorial.txt
+++ b/docs/ref/contrib/gis/tutorial.txt
@@ -458,8 +458,7 @@ with the following code::
 
     def run(verbose=True):
         lm = LayerMapping(
-            WorldBorder, world_shp, world_mapping,
-            transform=False, encoding='iso-8859-1',
+            WorldBorder, world_shp, world_mapping, transform=False,
         )
         lm.save(strict=True, verbose=verbose)
 


### PR DESCRIPTION
GDAL >= 1.9 automatically converts latin-1-encoded strings from Shapefiles to
UTF-8.