### PR TITLE
Fixed #29712 -- Normalize locale input in 'makemessages' managment command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -551,6 +551,7 @@ answer newbie questions, and generally made Django that much better:
     Matt Dennenbaum
     Matthew Flanagan <http://wadofstuff.blogspot.com>
     Matthew Schinckel <matt@schinckel.net>
+    Matthew Segal <mattdsegal@gmail.com>
     Matthew Somerville <matthew-django@dracos.co.uk>
     Matthew Tretter <m@tthewwithanm.com>
     Matthew Wilkes <matt@matthewwilkes.name>

--- a/django/core/management/commands/makemessages.py
+++ b/django/core/management/commands/makemessages.py
@@ -18,7 +18,7 @@ from django.utils.encoding import DEFAULT_LOCALE_ENCODING
 from django.utils.functional import cached_property
 from django.utils.jslex import prepare_js_for_gettext
 from django.utils.text import get_text_list
-from django.utils.translation import templatize
+from django.utils.translation import templatize, to_locale
 
 plural_forms_re = re.compile(r'^(?P<value>"Plural-Forms.+?\\n")\s*$', re.MULTILINE | re.DOTALL)
 STATUS_OK = 0
@@ -166,6 +166,15 @@ def normalize_eols(raw_contents):
     if lines_list and lines_list[-1]:
         lines_list.append('')
     return '\n'.join(lines_list)
+
+
+def normalize_locale(locale_str):
+    """
+    Normalize locale string to use a single locale format.
+    Eg. (zh-cn, zh_cn, zh_CN, ZH-CN) all map to zh_CN
+    """
+    language = locale_str.lower().replace('_', '-')
+    return to_locale(language)
 
 
 def write_pot_file(potfile, msgs):
@@ -367,6 +376,9 @@ class Command(BaseCommand):
             lang_code for lang_code in map(os.path.basename, locale_dirs)
             if looks_like_locale.match(lang_code)
         ]
+
+        # Normalize user input locale(s)
+        locale = [normalize_locale(l) for l in locale]
 
         # Account for excluded locales
         if process_all:


### PR DESCRIPTION
Fixes issue [29712](https://code.djangoproject.com/ticket/29712)

A user running the `makemessages` managment command will not be able to use a translation locale if they do not use the exact right locale format.

Eg. Running the following command will create a locale folder `zh-cn` which will not create translations with `LANGUAGE_CODE` of `zh-cn`

```
./manage.py makemessages -l zh-cn
```

Whereas the following command will create a locale folder `zh_CN` which will create translations with `LANGUAGE_CODE` of `zh-cn`

```
./manage.py makemessages -l zh_CN
```

Rather than providing a warning message, I added some code to normalise the user's input to the expected format.

Tested the code as follows:

```
> ./manage.py makemessages -l zh-cn -l zh_cn -l ZH-CN -l ZH_CN -l zh_CN -l de
processing locale de
processing locale zh_CN
```

Note that all the permutations of `zh-cn` are normalized to `zh_CN`