### PR TITLE
Fixed #29717 -- Allowed tests to use an existing empty database.

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -136,6 +136,13 @@ Database backends
 
 * Added result streaming for :meth:`.QuerySet.iterator` on SQLite.
 
+* Postgres backend will now check if the test DB exists before trying to create
+  it. If it does exist, a `DROP OWNED BY CURRENT_USER;` statement will be
+  issued to clear the DB before starting tests.
+
+  This resolves the problem where the user used to connect to the DB does not
+  have permission to create a db.
+
 Email
 ~~~~~
 


### PR DESCRIPTION
When a user does not have permission to create a DB, creating a
TEST DB will fail, even if the DB already exists.

This patch will make the PG driver check if the DB exists, and if
it does, drop everything in it the connected user owns.

STILL REQUIRES TESTS.