### PR TITLE
Fixed #29735 -- Updated inheritance chain of the generic DeleteView.

### DIFF
--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -3,7 +3,7 @@ from django.forms import models as model_forms
 from django.http import HttpResponseRedirect
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 from django.views.generic.detail import (
-    BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin,
+    SingleObjectMixin, SingleObjectTemplateResponseMixin,
 )
 
 

--- a/django/views/generic/edit.py
+++ b/django/views/generic/edit.py
@@ -199,9 +199,31 @@ class UpdateView(SingleObjectTemplateResponseMixin, BaseUpdateView):
     template_name_suffix = '_form'
 
 
-class DeletionMixin:
+class DeletionMixin(SingleObjectMixin):
     """Provide the ability to delete objects."""
     success_url = None
+
+    def get_success_url(self):
+        if self.success_url:
+            return self.success_url.format(**self.object.__dict__)
+        else:
+            raise ImproperlyConfigured(
+                "No URL to redirect to. Provide a success_url.")
+
+
+class BaseDeleteView(DeletionMixin, View):
+    """
+    Base view for deleting an object.
+
+    Using this base class requires subclassing to provide a response mixin.
+    """
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        context = self.get_context_data(object=self.object)
+        return self.render_to_response(context)
+
+    def post(self, request, *args, **kwargs):
+        return self.delete(request, *args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
         """
@@ -212,25 +234,6 @@ class DeletionMixin:
         success_url = self.get_success_url()
         self.object.delete()
         return HttpResponseRedirect(success_url)
-
-    # Add support for browsers which only accept GET and POST for now.
-    def post(self, request, *args, **kwargs):
-        return self.delete(request, *args, **kwargs)
-
-    def get_success_url(self):
-        if self.success_url:
-            return self.success_url.format(**self.object.__dict__)
-        else:
-            raise ImproperlyConfigured(
-                "No URL to redirect to. Provide a success_url.")
-
-
-class BaseDeleteView(DeletionMixin, BaseDetailView):
-    """
-    Base view for deleting an object.
-
-    Using this base class requires subclassing to provide a response mixin.
-    """
 
 
 class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView):

--- a/docs/ref/class-based-views/generic-editing.txt
+++ b/docs/ref/class-based-views/generic-editing.txt
@@ -216,8 +216,8 @@ editing content:
     * :class:`django.views.generic.base.TemplateResponseMixin`
     * ``django.views.generic.edit.BaseDeleteView``
     * :class:`django.views.generic.edit.DeletionMixin`
-    * ``django.views.generic.detail.BaseDetailView``
     * :class:`django.views.generic.detail.SingleObjectMixin`
+    * :class:`django.views.generic.base.ContextMixin`
     * :class:`django.views.generic.base.View`
 
     **Attributes**

--- a/docs/ref/class-based-views/mixins-editing.txt
+++ b/docs/ref/class-based-views/mixins-editing.txt
@@ -220,6 +220,10 @@ The following mixins are used to construct Django's editing views:
 
     Enables handling of the ``DELETE`` http action.
 
+    **Mixins**
+
+    * :class:`django.views.generic.detail.SingleObjectMixin`
+
     **Methods and Attributes**
 
     .. attribute:: success_url
@@ -231,11 +235,6 @@ The following mixins are used to construct Django's editing views:
         interpolated against the object's field attributes. For example, you
         could use ``success_url="/parent/{parent_id}/"`` to redirect to a URL
         composed out of the ``parent_id`` field on a model.
-
-    .. method:: delete(request, *args, **kwargs)
-
-        Retrieves the target object and calls its ``delete()`` method, then
-        redirects to the success URL.
 
     .. method:: get_success_url()
 

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -160,7 +160,14 @@ Forms
 Generic Views
 ~~~~~~~~~~~~~
 
-* ...
+* MRO of :class:`~django.views.generic.edit.DeleteView` is changed in order to clarify the inheritance hierarchy.
+
+* :class:`~django.views.generic.detail.BaseDetailView` is not used in MRO of DeleteView, instead
+  :class:`~django.views.generic.detail.SingleObjectMixin` is used.
+
+* :class:`~django.views.generic.edit.DeletionMixin` inherits from :class:`~django.views.generic.detail.SingleObjectMixin`.
+
+* :class:`~django.views.generic.edit.BaseDeleteView` provides get(), post() and delete() methods
 
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -162,12 +162,11 @@ Generic Views
 
 * MRO of :class:`~django.views.generic.edit.DeleteView` is changed in order to clarify the inheritance hierarchy.
 
-* :class:`~django.views.generic.detail.BaseDetailView` is not used in MRO of DeleteView, instead
-  :class:`~django.views.generic.detail.SingleObjectMixin` is used.
+* ``BaseDetailView`` is not used in MRO of DeleteView, instead :class:`~django.views.generic.detail.SingleObjectMixin` is used.
 
 * :class:`~django.views.generic.edit.DeletionMixin` inherits from :class:`~django.views.generic.detail.SingleObjectMixin`.
 
-* :class:`~django.views.generic.edit.BaseDeleteView` provides get(), post() and delete() methods
+* ``BaseDeleteView`` provides get(), post() and delete() methods
 
 Internationalization
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refactored BaseDeleteView and DeleteMixin. Deleted BaseDetailView
in the MRO of DeleteView because SingleObjectMixin is sufficient.