### PR TITLE
Fixed #29725 -- Removed unnecessary join in QuerySet.count() and exists() on a many to many relation.

### DIFF
--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -912,6 +912,33 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
                 False,
             )
 
+        @property
+        def constrained_target(self):
+            # If the through relation's target field's foreign integrity is
+            # enforced, the query can be performed solely against the through
+            # table as the INNER JOIN'ing against target table is unnecessary.
+            if not self.target_field.db_constraint:
+                return None
+            db = router.db_for_read(self.through, instance=self.instance)
+            if not connections[db].features.supports_foreign_keys:
+                return None
+            hints = {'instance': self.instance}
+            manager = self.through._base_manager.db_manager(db, hints=hints)
+            filters = {self.source_field_name: self.instance.pk}
+            # Nullable target rows must be excluded as well as they would have
+            # been filtered out from an INNER JOIN.
+            if self.target_field.null:
+                filters['%s__isnull' % self.target_field_name] = False
+            return manager.filter(**filters)
+
+        def exists(self):
+            constrained_target = self.constrained_target
+            return constrained_target.exists() if constrained_target else super().exists()
+
+        def count(self):
+            constrained_target = self.constrained_target
+            return constrained_target.count() if constrained_target else super().count()
+
         def add(self, *objs):
             if not rel.through._meta.auto_created:
                 opts = self.through._meta

--- a/tests/many_to_many/models.py
+++ b/tests/many_to_many/models.py
@@ -55,3 +55,13 @@ class InheritedArticleA(AbstractArticle):
 
 class InheritedArticleB(AbstractArticle):
     pass
+
+
+class NullableTargetArticle(models.Model):
+    headline = models.CharField(max_length=100)
+    publications = models.ManyToManyField(Publication, through='NullablePublicationThrough')
+
+
+class NullablePublicationThrough(models.Model):
+    article = models.ForeignKey(NullableTargetArticle, models.CASCADE)
+    publication = models.ForeignKey(Publication, models.CASCADE, null=True)


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29725