### PR TITLE
Fixed #29573 -- Added link from per-item aggregation topic discussion to `annotate()` ref.

### DIFF
--- a/docs/topics/db/aggregation.txt
+++ b/docs/topics/db/aggregation.txt
@@ -149,19 +149,20 @@ Generating aggregates for each item in a ``QuerySet``
 =====================================================
 
 The second way to generate summary values is to generate an independent
-summary for each object in a ``QuerySet``. For example, if you are retrieving
-a list of books, you may want to know how many authors contributed to
-each book. Each Book has a many-to-many relationship with the Author; we
+summary for each object in a :class:`.QuerySet`. For example, if you are
+retrieving a list of books, you may want to know how many authors contributed
+to each book. Each Book has a many-to-many relationship with the Author; we
 want to summarize this relationship for each book in the ``QuerySet``.
 
-Per-object summaries can be generated using the ``annotate()`` clause.
-When an ``annotate()`` clause is specified, each object in the ``QuerySet``
-will be annotated with the specified values.
+Per-object summaries can be generated using the
+:meth:`~.QuerySet.annotate` clause. When an ``annotate()`` clause is
+specified, each object in the ``QuerySet`` will be annotated with the
+specified values.
 
 The syntax for these annotations is identical to that used for the
-``aggregate()`` clause. Each argument to ``annotate()`` describes an
-aggregate that is to be calculated. For example, to annotate books with
-the number of authors:
+:meth:`~.QuerySet.aggregate` clause. Each argument to ``annotate()`` describes
+an aggregate that is to be calculated. For example, to annotate books with the
+number of authors:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixed [29573](https://code.djangoproject.com/ticket/29573)

Links for `QuerySet`, `annotate`,  `aggregate` are added.