### PR TITLE
Fixed #29727 -- Made nonexistent joins in F() raise FieldError.

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1594,10 +1594,13 @@ class Query:
         else:
             field_list = name.split(LOOKUP_SEP)
             join_info = self.setup_joins(field_list, self.get_meta(), self.get_initial_alias(), can_reuse=reuse)
-            targets, _, join_list = self.trim_joins(join_info.targets, join_info.joins, join_info.path)
+            targets, final_alias, join_list = self.trim_joins(join_info.targets, join_info.joins, join_info.path)
             if len(targets) > 1:
                 raise FieldError("Referencing multicolumn fields with F() objects "
                                  "isn't supported")
+            # Verify that the last lookup in name is a field or a transform:
+            # transform_function() raises FieldError if not.
+            join_info.transform_function(targets[0], final_alias)
             if reuse is not None:
                 reuse.update(join_list)
             col = _get_col(targets[0], join_info.targets[0], join_list[-1], simple_col)

--- a/docs/releases/2.1.2.txt
+++ b/docs/releases/2.1.2.txt
@@ -9,4 +9,5 @@ Django 2.1.2 fixes several bugs in 2.1.1
 Bugfixes
 ========
 
-* ...
+* Fixed a regression where nonexistent joins in ``F()`` no longer raised
+  ``FieldError`` (:ticket:`29727`).

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -595,6 +595,10 @@ class BasicExpressionsTests(TestCase):
         with self.assertRaisesMessage(FieldError, "Cannot resolve keyword 'nope' into field."):
             list(Employee.objects.filter(firstname=F('nope')))
 
+    def test_incorrect_joined_field_in_F_expression(self):
+        with self.assertRaisesMessage(FieldError, "Cannot resolve keyword 'nope' into field."):
+            list(Company.objects.filter(ceo__pk=F('point_of_contact__nope')))
+
 
 class IterableLookupInnerExpressionsTests(TestCase):
     @classmethod


### PR DESCRIPTION
Fetching the value of a non-existing joined field on a model using ``F()`` does not raise an error. Instead, it is just giving the primary key of the fetched object.

This patch ensures a ``FieldError`` when last element in a name passed to ``F()`` is neither a field nor a transform.

[#29727](https://code.djangoproject.com/ticket/29727)
