### PR TITLE
Bugfix: Support Python 3.7 for 1.11

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -149,7 +149,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             params = self.url_parameters()
             if params:
                 related_url += '?' + '&amp;'.join(
-                    '%s=%s' % (k, v) for k, v in params.items(),
+                    '%s=%s' % [(k, v) for k, v in params.items()],
                 )
             context['related_url'] = mark_safe(related_url)
             context['link_title'] = _('Lookup')

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -149,7 +149,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             params = self.url_parameters()
             if params:
                 related_url += '?' + '&amp;'.join(
-                    '%s=%s' % [(k, v) for k, v in params.items()],
+                    ('%s=%s' % (k, v) for k, v in params.items()),
                 )
             context['related_url'] = mark_safe(related_url)
             context['link_title'] = _('Lookup')


### PR DESCRIPTION
I know that 1.11 should only get security bugfixes and does not officially support python 3.7, but please consider including this two character fix into the next patch release, it would make the work of many people easier.

Bug ticket: https://code.djangoproject.com/ticket/28814

Fix for:

```
  File ".../site-packages/django/contrib/admin/widgets.py", line 152
    '%s=%s' % (k, v) for k, v in params.items(),
    ^
SyntaxError: Generator expression must be parenthesized
```

And yes it's really only two square brackets missing!