### PR TITLE
Fixed #16995 -- Clarified interaction of initial and extra with model formsets.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -525,6 +525,7 @@ answer newbie questions, and generally made Django that much better:
     Mario Gonzalez <gonzalemario@gmail.com>
     Mariusz Felisiak <felisiak.mariusz@gmail.com>
     Mark Biggers <biggers@utsl.com>
+    Mark Gensler <mark.gensler@protonmail.com>
     mark@junklight.com
     Mark Lavin <markdlavin@gmail.com>
     Mark Sandstrom <mark@deliciouslynerdy.com>

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -877,8 +877,10 @@ As with regular formsets, it's possible to :ref:`specify initial data
 parameter when instantiating the model formset class returned by
 :func:`~django.forms.models.modelformset_factory`. However, with model
 formsets, the initial values only apply to extra forms, those that aren't
-attached to an existing model instance. If the extra forms with initial data
-aren't changed by the user, they won't be validated or saved.
+attached to an existing model instance. If the length of ``initial`` exceeds
+the number of extra forms, the excess initial data is ignored. If the extra
+forms with initial data aren't changed by the user, they won't be validated or
+saved.
 
 .. _saving-objects-in-the-formset:
 


### PR DESCRIPTION
Clarify that if initial is longer than the number of extra forms, any
additional data will not be used when rendering forms.