### PR TITLE
Fixed #29746 -- Fixed misleading FlatpageForm URL help text if APPEND_SLASH is disabled.

### DIFF
--- a/django/contrib/flatpages/forms.py
+++ b/django/contrib/flatpages/forms.py
@@ -22,6 +22,19 @@ class FlatpageForm(forms.ModelForm):
         model = FlatPage
         fields = '__all__'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self._trailing_slash_required():
+            self.fields['url'].help_text = _(
+                "Example: '/about/contact'. Make sure to have a leading slash."
+            )
+
+    def _trailing_slash_required(self):
+        return (
+            settings.APPEND_SLASH and
+            'django.middleware.common.CommonMiddleware' in settings.MIDDLEWARE
+        )
+
     def clean_url(self):
         url = self.cleaned_data['url']
         if not url.startswith('/'):
@@ -29,9 +42,7 @@ class FlatpageForm(forms.ModelForm):
                 gettext("URL is missing a leading slash."),
                 code='missing_leading_slash',
             )
-        if (settings.APPEND_SLASH and
-                'django.middleware.common.CommonMiddleware' in settings.MIDDLEWARE and
-                not url.endswith('/')):
+        if self._trailing_slash_required() and not url.endswith('/'):
             raise forms.ValidationError(
                 gettext("URL is missing a trailing slash."),
                 code='missing_trailing_slash',

--- a/tests/flatpages_tests/test_forms.py
+++ b/tests/flatpages_tests/test_forms.py
@@ -49,6 +49,11 @@ class FlatpageAdminFormTests(TestCase):
     def test_flatpage_requires_trailing_slash_with_append_slash(self):
         form = FlatpageForm(data=dict(url='/no_trailing_slash', **self.form_data))
         with translation.override('en'):
+            self.assertEqual(
+                form.fields['url'].help_text,
+                "Example: '/about/contact/'. Make sure to have leading and "
+                "trailing slashes."
+            )
             self.assertFalse(form.is_valid())
             self.assertEqual(form.errors['url'], ["URL is missing a trailing slash."])
 
@@ -56,6 +61,11 @@ class FlatpageAdminFormTests(TestCase):
     def test_flatpage_doesnt_requires_trailing_slash_without_append_slash(self):
         form = FlatpageForm(data=dict(url='/no_trailing_slash', **self.form_data))
         self.assertTrue(form.is_valid())
+        with translation.override('en'):
+            self.assertEqual(
+                form.fields['url'].help_text,
+                "Example: '/about/contact'. Make sure to have a leading slash."
+            )
 
     def test_flatpage_admin_form_url_uniqueness_validation(self):
         "The flatpage admin form correctly enforces url uniqueness among flatpages of the same site"


### PR DESCRIPTION
Hijacking some existing tests since they're very tightly related, but let me know if these should have new tests.

Also not 100% sure on the implementation, but couldn't immediately see a better way.