### PR TITLE
Fixed #29745 -- Based Expression equality on detailed initialization signature.

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import inspect
 from decimal import Decimal
 
 from django.core.exceptions import EmptyResultSet, FieldError
@@ -135,6 +136,16 @@ class Combinable:
         raise NotImplementedError(
             "Use .bitand() and .bitor() for bitwise logical operations."
         )
+
+
+def make_hashable(value):
+    if isinstance(value, list):
+        return tuple(map(make_hashable, value))
+    if isinstance(value, dict):
+        return tuple([
+            (key, make_hashable(nested_value)) for key, nested_value in value.items()
+        ])
+    return value
 
 
 @deconstructible
@@ -360,28 +371,27 @@ class BaseExpression:
             if expr:
                 yield from expr.flatten()
 
+    @cached_property
+    def identity(self):
+        constructor_signature = inspect.signature(self.__init__)
+        args, kwargs = self._constructor_args
+        signature = constructor_signature.bind_partial(*args, **kwargs)
+        signature.apply_defaults()
+        arguments = signature.arguments.items()
+        identity = [self.__class__]
+        for arg, value in arguments:
+            if isinstance(value, fields.Field):
+                value = type(value)
+            else:
+                value = make_hashable(value)
+            identity.append((arg, value))
+        return tuple(identity)
+
     def __eq__(self, other):
-        if self.__class__ != other.__class__:
-            return False
-        path, args, kwargs = self.deconstruct()
-        other_path, other_args, other_kwargs = other.deconstruct()
-        if (path, args) == (other_path, other_args):
-            kwargs = kwargs.copy()
-            other_kwargs = other_kwargs.copy()
-            output_field = type(kwargs.pop('output_field', None))
-            other_output_field = type(other_kwargs.pop('output_field', None))
-            if output_field == other_output_field:
-                return kwargs == other_kwargs
-        return False
+        return isinstance(other, BaseExpression) and other.identity == self.identity
 
     def __hash__(self):
-        path, args, kwargs = self.deconstruct()
-        kwargs = kwargs.copy()
-        output_field = type(kwargs.pop('output_field', None))
-        return hash((path, output_field) + args + tuple([
-            (key, tuple(value)) if isinstance(value, list) else (key, value)
-            for key, value in kwargs.items()
-        ]))
+        return hash(self.identity)
 
 
 class Expression(BaseExpression, Combinable):
@@ -694,9 +704,6 @@ class RawSQL(Expression):
 
     def get_group_by_cols(self):
         return [self]
-
-    def __hash__(self):
-        return hash((self.sql, self.output_field) + tuple(self.params))
 
 
 class Star(Expression):

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -11,8 +11,9 @@ from django.db.models.aggregates import (
     Avg, Count, Max, Min, StdDev, Sum, Variance,
 )
 from django.db.models.expressions import (
-    Case, Col, Combinable, Exists, ExpressionList, ExpressionWrapper, F, Func,
-    OrderBy, OuterRef, Random, RawSQL, Ref, Subquery, Value, When,
+    Case, Col, Combinable, Exists, Expression, ExpressionList,
+    ExpressionWrapper, F, Func, OrderBy, OuterRef, Random, RawSQL, Ref,
+    Subquery, Value, When,
 )
 from django.db.models.functions import (
     Coalesce, Concat, Length, Lower, Substr, Upper,
@@ -819,6 +820,31 @@ class ExpressionsTests(TestCase):
             Employee.objects.filter(firstname__iendswith=F('lastname')),
             ["<Employee: Jean-Claude claude>"],
             ordered=False,
+        )
+
+
+class SimpleExpressionTests(SimpleTestCase):
+
+    def test_equal(self):
+        self.assertEqual(Expression(), Expression())
+        self.assertEqual(
+            Expression(models.IntegerField()),
+            Expression(output_field=models.IntegerField())
+        )
+        self.assertNotEqual(
+            Expression(models.IntegerField()),
+            Expression(models.CharField())
+        )
+
+    def test_hash(self):
+        self.assertEqual(hash(Expression()), hash(Expression()))
+        self.assertEqual(
+            hash(Expression(models.IntegerField())),
+            hash(Expression(output_field=models.IntegerField()))
+        )
+        self.assertNotEqual(
+            hash(Expression(models.IntegerField())),
+            hash(Expression(models.CharField())),
         )
 
 


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29745

It was breaking equality checks between expressions allowing arguments to be
provided using either positional or keyword arguments.

e.g. Expression(IntegerField()) != Expression(output_field=IntegerField()).

It was particularily problematic for expressions such as Cast() where the
output_field argument is likely to be passed as a positional argument while
BaseExpression.__eq__ was expecting it to be provided as a keyword argument.

This could likely have been solved with some per-subclass introspection logic
of __init__ but relying on simple tuple comparisons is likely to be easier to
grasp and maintain.

Refs #11964, #26167.

/cc @Ian-Foote since you worked on #7517.