### PR TITLE
Fixed #29724 -- Timezoned the date hierarchy tag

### DIFF
--- a/tests/admin_views/test_templatetags.py
+++ b/tests/admin_views/test_templatetags.py
@@ -75,7 +75,7 @@ class DateHierarchyTests(TestCase):
     def setUp(self):
         self.superuser = User.objects.create_superuser(username='super', password='secret', email='super@example.com')
 
-    def test_choice_links(self):
+    def test_choice_links_date(self):
         modeladmin = ModelAdmin(Question, site)
         modeladmin.date_hierarchy = 'posted'
 
@@ -106,6 +106,41 @@ class DateHierarchyTests(TestCase):
                 choices = [choice['link'] for choice in spec['choices']]
                 expected_choices = [
                     '&'.join('posted__%s' % c for c in choice) for choice in expected_choices
+                ]
+                expected_choices = [('?' + choice) if choice else '' for choice in expected_choices]
+                self.assertEqual(choices, expected_choices)
+
+    def test_choice_links_datetime(self):
+        modeladmin = ModelAdmin(Question, site)
+        modeladmin.date_hierarchy = 'expires'
+
+        expires_dates = (
+            datetime.datetime(2017, 10, 1),
+            datetime.datetime(2017, 10, 1),
+            datetime.datetime(2017, 12, 15),
+            datetime.datetime(2017, 12, 15),
+            datetime.datetime(2017, 12, 31),
+            datetime.datetime(2018, 2, 1),
+        )
+        Question.objects.bulk_create(Question(question='q', expires=expires) for expires in expires_dates)
+
+        tests = (
+            ({}, [['year=2017'], ['year=2018']]),
+            ({'year': 2016}, []),
+            ({'year': 2017}, [['month=10', 'year=2017'], ['month=12', 'year=2017']]),
+            ({'year': 2017, 'month': 9}, []),
+            ({'year': 2017, 'month': 12}, [['day=15', 'month=12', 'year=2017'], ['day=31', 'month=12', 'year=2017']]),
+        )
+        for query, expected_choices in tests:
+            with self.subTest(query=query):
+                query = {'expires__%s' % q: val for q, val in query.items()}
+                request = self.factory.get('/', query)
+                request.user = self.superuser
+                changelist = modeladmin.get_changelist_instance(request)
+                spec = date_hierarchy(changelist)
+                choices = [choice['link'] for choice in spec['choices']]
+                expected_choices = [
+                    '&'.join('expires__%s' % c for c in choice) for choice in expected_choices
                 ]
                 expected_choices = [('?' + choice) if choice else '' for choice in expected_choices]
                 self.assertEqual(choices, expected_choices)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -950,6 +950,18 @@ class AdminViewBasicTest(AdminViewBasicTestCase):
         self.assertContains(response, 'question__expires__month=10')
         self.assertContains(response, 'question__expires__year=2016')
 
+    @override_settings(TIME_ZONE='America/Los_Angeles', USE_TZ=True)
+    def test_date_hierarchy_local_date_differ_from_utc(self):
+        # This datetime is 2017-01-01 in UTC
+        date = pytz.timezone('America/Los_Angeles').localize(datetime.datetime(2016, 12, 31, 16))
+        q = Question.objects.create(question='Why?', expires=date)
+        Answer2.objects.create(question=q, answer='Because.')
+        response = self.client.get(reverse('admin:admin_views_answer2_changelist'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'question__expires__day=31')
+        self.assertContains(response, 'question__expires__month=12')
+        self.assertContains(response, 'question__expires__year=2016')
+
     def test_sortable_by_columns_subset(self):
         expected_sortable_fields = ('date', 'callable_year')
         expected_not_sortable_fields = (


### PR DESCRIPTION
The date hierarchy tag in django admin based its navigation on UTC instead of current timezone so models where ``date_hierarchy`` is a ``DateTimeField`` goes off sync with ``result_list`` (which uses current timezone).

This patch localizes navigation by instructing ``date_hierarchy`` to use ``queryset.datetimes()`` when ``date_hierarchy`` is a ``DateTimeField``.

[#29724](https://code.djangoproject.com/ticket/29724)