### PR TITLE
Fixed #11154, #22270 -- Made proxy model permissions use correct content type.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ answer newbie questions, and generally made Django that much better:
     Artem Gnilov <boobsd@gmail.com>
     Arthur <avandorp@gmail.com>
     Arthur Koziel <http://arthurkoziel.com>
+    Arthur Rio <arthur.rio44@gmail.com>
     Arvis Bickovskis <viestards.lists@gmail.com>
     Aryeh Leib Taurog <http://www.aryehleib.com/>
     A S Alam <aalam@users.sf.net>

--- a/django/contrib/auth/management/__init__.py
+++ b/django/contrib/auth/management/__init__.py
@@ -60,7 +60,7 @@ def create_permissions(app_config, verbosity=2, interactive=True, using=DEFAULT_
     for klass in app_config.get_models():
         # Force looking up the content types in the current database
         # before creating foreign keys to them.
-        ctype = ContentType.objects.db_manager(using).get_for_model(klass)
+        ctype = ContentType.objects.db_manager(using).get_for_model(klass, for_concrete_model=False)
 
         ctypes.add(ctype)
         for perm in _get_all_permissions(klass._meta):

--- a/django/contrib/auth/migrations/0011_update_proxy_permissions.py
+++ b/django/contrib/auth/migrations/0011_update_proxy_permissions.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+from django.db.models import Q
+
+
+def update_proxy_model_permissions(apps, schema_editor, reverse=False):
+    """
+    Update the content_type of proxy model permissions to use the ContentType
+    of the proxy model.
+    """
+    Permission = apps.get_model('auth', 'Permission')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    for Model in apps.get_models():
+        opts = Model._meta
+        if not opts.proxy:
+            continue
+        proxy_default_permissions_codenames = [
+            '%s_%s' % (action, opts.model_name)
+            for action in opts.default_permissions
+        ]
+        permissions_query = Q(codename__in=proxy_default_permissions_codenames)
+        for codename, name in opts.permissions:
+            permissions_query = permissions_query | Q(codename=codename, name=name)
+        concrete_content_type = ContentType.objects.get_for_model(Model, for_concrete_model=True)
+        proxy_content_type = ContentType.objects.get_for_model(Model, for_concrete_model=False)
+        old_content_type = proxy_content_type if reverse else concrete_content_type
+        new_content_type = concrete_content_type if reverse else proxy_content_type
+        Permission.objects.filter(
+            permissions_query,
+            content_type=old_content_type,
+        ).update(content_type=new_content_type)
+
+
+def revert_proxy_model_permissions(apps, schema_editor):
+    """
+    Update the content_type of proxy model permissions to use the ContentType
+    of the concrete model.
+    """
+    update_proxy_model_permissions(apps, schema_editor, reverse=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('auth', '0010_alter_group_name_max_length'),
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+    operations = [
+        migrations.RunPython(update_proxy_model_permissions, revert_proxy_model_permissions),
+    ]

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -439,6 +439,28 @@ Use this instead::
 
         alias = property(operator.attrgetter('base'))
 
+Permissions for proxy models
+----------------------------
+
+:ref:`Permissions for proxy models <proxy-models-permissions-topic>` are now
+created using the content type of the proxy model rather than the content type
+of the concrete model. A migration will update existing permissions when you
+run :djadmin:`migrate`.
+
+In the admin, the change is transparent for proxy models having the same
+``app_label`` as their concrete model. However, in older versions, users with
+permissions for a proxy model with a *different* ``app_label`` than its
+concrete model couldn't access the model in the admin. That's now fixed, but
+you might want to audit the permissions assignments for such proxy models
+(``[add|view|change|delete]_myproxy``) prior to upgrading to ensure the new
+access is appropriate.
+
+Finally, proxy model permission strings must be updated to use their own
+``app_label``. For example, for ``app.MyProxyModel`` inheriting from
+``other_app.ConcreteModel``, update
+``user.has_perm('other_app.add_myproxymodel')`` to
+``user.has_perm('app.add_myproxymodel')``.
+
 Miscellaneous
 -------------
 

--- a/docs/topics/auth/default.txt
+++ b/docs/topics/auth/default.txt
@@ -262,6 +262,20 @@ The permission can then be assigned to a
 attribute or to a :class:`~django.contrib.auth.models.Group` via its
 ``permissions`` attribute.
 
+.. admonition:: Proxy models need their own content type
+
+    If you want to create :ref:`permissions for a proxy model
+    <proxy-models-permissions-topic>`, pass ``for_concrete_model=False`` to
+    :meth:`.ContentTypeManager.get_for_model` to get the appropriate
+    ``ContentType``::
+
+        content_type = ContentType.objects.get_for_model(BlogPostProxy, for_concrete_model=False)
+
+    .. versionchanged:: 2.2
+
+        In older versions, proxy models use the content type of the concrete
+        model.
+
 Permission caching
 ------------------
 
@@ -302,6 +316,44 @@ the user from the database. For example::
         user.has_perm('myapp.change_blogpost')  # True
 
         ...
+
+.. _proxy-models-permissions-topic:
+
+Proxy models
+------------
+
+Proxy models work exactly the same way as concrete models. Permissions are
+created using the own content type of the proxy model. Proxy models don't
+inherit the permissions of the concrete model they subclass::
+
+    class Person(models.Model):
+        class Meta:
+            permissions = (('can_eat_pizzas', 'Can eat pizzas'),)
+
+    class Student(Person):
+        class Meta:
+            proxy = True
+            permissions = (('can_deliver_pizzas', 'Can deliver pizzas'),)
+
+    >>> # Fetch the content type for the proxy model.
+    >>> content_type = ContentType.objects.get_for_model(Student, for_concrete_model=False)
+    >>> student_permissions = Permission.objects.filter(content_type=content_type)
+    >>> [p.codename for p in student_permissions]
+    ['add_student', 'change_student', 'delete_student', 'view_student',
+    'can_deliver_pizzas']
+    >>> for permission in student_permissions:
+    ...     user.user_permissions.add(permission)
+    >>> user.has_perm('app.add_person')
+    False
+    >>> user.has_perm('app.can_eat_pizzas')
+    False
+    >>> user.has_perms(('app.add_student', 'app.can_deliver_pizzas'))
+    True
+
+.. versionchanged:: 2.2
+
+    In older versions, permissions for proxy models use the content type of
+    the concrete model rather than content type of the proxy model.
 
 .. _auth-web-requests:
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -43,7 +43,8 @@ from .models import (
     Restaurant, RowLevelChangePermissionModel, Section, ShortMessage, Simple,
     Sketch, State, Story, StumpJoke, Subscriber, SuperVillain, Telegram, Thing,
     Topping, UnchangeableObject, UndeletableObject, UnorderedObject,
-    UserMessenger, Villain, Vodcast, Whatsit, Widget, Worker, WorkHour,
+    UserMessenger, UserProxy, Villain, Vodcast, Whatsit, Widget, Worker,
+    WorkHour,
 )
 
 
@@ -1075,6 +1076,7 @@ site.register(Ingredient)
 site.register(NotReferenced)
 site.register(ExplicitlyProvidedPK, GetFormsetsArgumentCheckingAdmin)
 site.register(ImplicitlyGeneratedPK, GetFormsetsArgumentCheckingAdmin)
+site.register(UserProxy)
 
 # Register core models we need in our tests
 site.register(User, UserAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -976,3 +976,9 @@ class Author(models.Model):
 class Authorship(models.Model):
     book = models.ForeignKey(Book, models.CASCADE)
     author = models.ForeignKey(Author, models.CASCADE)
+
+
+class UserProxy(User):
+    """Proxy a model with a different app_label."""
+    class Meta:
+        proxy = True

--- a/tests/auth_tests/models/__init__.py
+++ b/tests/auth_tests/models/__init__.py
@@ -6,14 +6,16 @@ from .invalid_models import CustomUserNonUniqueUsername
 from .is_active import IsActiveTestUser1
 from .minimal import MinimalUser
 from .no_password import NoPasswordUser
+from .proxy import Proxy, UserProxy
 from .uuid_pk import UUIDUser
 from .with_foreign_key import CustomUserWithFK, Email
 from .with_integer_username import IntegerUsernameUser
 from .with_last_login_attr import UserWithDisabledLastLoginField
 
 __all__ = (
-    'CustomUser', 'CustomUserWithoutIsActiveField', 'CustomPermissionsUser',
-    'CustomUserWithFK', 'Email', 'ExtensionUser', 'IsActiveTestUser1',
-    'MinimalUser', 'NoPasswordUser', 'UUIDUser', 'CustomUserNonUniqueUsername',
-    'IntegerUsernameUser', 'UserWithDisabledLastLoginField',
+    'CustomPermissionsUser', 'CustomUser', 'CustomUserNonUniqueUsername',
+    'CustomUserWithFK', 'CustomUserWithoutIsActiveField', 'Email',
+    'ExtensionUser', 'IntegerUsernameUser', 'IsActiveTestUser1', 'MinimalUser',
+    'NoPasswordUser', 'Proxy', 'UUIDUser', 'UserProxy',
+    'UserWithDisabledLastLoginField',
 )

--- a/tests/auth_tests/models/proxy.py
+++ b/tests/auth_tests/models/proxy.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import User
+from django.db import models
+
+
+class Concrete(models.Model):
+    pass
+
+
+class Proxy(Concrete):
+    class Meta:
+        proxy = True
+        permissions = (
+            ('display_proxys', 'May display proxys information'),
+        )
+
+
+class UserProxy(User):
+    class Meta:
+        proxy = True
+        permissions = (
+            ('use_different_app_label', 'May use a different app label'),
+        )

--- a/tests/auth_tests/test_migrations.py
+++ b/tests/auth_tests/test_migrations.py
@@ -1,0 +1,154 @@
+from importlib import import_module
+
+from django.apps import apps
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from .models import Proxy, UserProxy
+
+update_proxy_permissions = import_module('django.contrib.auth.migrations.0011_update_proxy_permissions')
+
+
+class ProxyModelWithDifferentAppLabelTests(TestCase):
+    available_apps = [
+        'auth_tests',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+    ]
+
+    def setUp(self):
+        """
+        Create proxy permissions with content_type to the concrete model
+        rather than the proxy model (as they were before Django 2.2 and
+        migration 11).
+        """
+        Permission.objects.all().delete()
+        self.concrete_content_type = ContentType.objects.get_for_model(UserProxy)
+        self.default_permission = Permission.objects.create(
+            content_type=self.concrete_content_type,
+            codename='add_userproxy',
+            name='Can add userproxy',
+        )
+        self.custom_permission = Permission.objects.create(
+            content_type=self.concrete_content_type,
+            codename='use_different_app_label',
+            name='May use a different app label',
+        )
+
+    def test_proxy_model_permissions_contenttype(self):
+        proxy_model_content_type = ContentType.objects.get_for_model(UserProxy, for_concrete_model=False)
+        self.assertEqual(self.default_permission.content_type, self.concrete_content_type)
+        self.assertEqual(self.custom_permission.content_type, self.concrete_content_type)
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        self.default_permission.refresh_from_db()
+        self.assertEqual(self.default_permission.content_type, proxy_model_content_type)
+        self.custom_permission.refresh_from_db()
+        self.assertEqual(self.custom_permission.content_type, proxy_model_content_type)
+
+    def test_user_has_now_proxy_model_permissions(self):
+        user = User.objects.create()
+        user.user_permissions.add(self.default_permission)
+        user.user_permissions.add(self.custom_permission)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth.' + permission.codename))
+            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        # Reload user to purge the _perm_cache.
+        user = User._default_manager.get(pk=user.pk)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertFalse(user.has_perm('auth.' + permission.codename))
+            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+
+    def test_migrate_backwards(self):
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        update_proxy_permissions.revert_proxy_model_permissions(apps, None)
+        self.default_permission.refresh_from_db()
+        self.assertEqual(self.default_permission.content_type, self.concrete_content_type)
+        self.custom_permission.refresh_from_db()
+        self.assertEqual(self.custom_permission.content_type, self.concrete_content_type)
+
+    def test_user_keeps_same_permissions_after_migrating_backward(self):
+        user = User.objects.create()
+        user.user_permissions.add(self.default_permission)
+        user.user_permissions.add(self.custom_permission)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth.' + permission.codename))
+            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        update_proxy_permissions.revert_proxy_model_permissions(apps, None)
+        # Reload user to purge the _perm_cache.
+        user = User._default_manager.get(pk=user.pk)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth.' + permission.codename))
+            self.assertFalse(user.has_perm('auth_tests.' + permission.codename))
+
+
+class ProxyModelWithSameAppLabelTests(TestCase):
+    available_apps = [
+        'auth_tests',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+    ]
+
+    def setUp(self):
+        """
+        Create proxy permissions with content_type to the concrete model
+        rather than the proxy model (as they were before Django 2.2 and
+        migration 11).
+        """
+        Permission.objects.all().delete()
+        self.concrete_content_type = ContentType.objects.get_for_model(Proxy)
+        self.default_permission = Permission.objects.create(
+            content_type=self.concrete_content_type,
+            codename='add_proxy',
+            name='Can add proxy',
+        )
+        self.custom_permission = Permission.objects.create(
+            content_type=self.concrete_content_type,
+            codename='display_proxys',
+            name='May display proxys information',
+        )
+
+    def test_proxy_model_permissions_contenttype(self):
+        proxy_model_content_type = ContentType.objects.get_for_model(Proxy, for_concrete_model=False)
+        self.assertEqual(self.default_permission.content_type, self.concrete_content_type)
+        self.assertEqual(self.custom_permission.content_type, self.concrete_content_type)
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        self.default_permission.refresh_from_db()
+        self.custom_permission.refresh_from_db()
+        self.assertEqual(self.default_permission.content_type, proxy_model_content_type)
+        self.assertEqual(self.custom_permission.content_type, proxy_model_content_type)
+
+    def test_user_still_has_proxy_model_permissions(self):
+        user = User.objects.create()
+        user.user_permissions.add(self.default_permission)
+        user.user_permissions.add(self.custom_permission)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        # Reload user to purge the _perm_cache.
+        user = User._default_manager.get(pk=user.pk)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+
+    def test_migrate_backwards(self):
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        update_proxy_permissions.revert_proxy_model_permissions(apps, None)
+        self.default_permission.refresh_from_db()
+        self.assertEqual(self.default_permission.content_type, self.concrete_content_type)
+        self.custom_permission.refresh_from_db()
+        self.assertEqual(self.custom_permission.content_type, self.concrete_content_type)
+
+    def test_user_keeps_same_permissions_after_migrating_backward(self):
+        user = User.objects.create()
+        user.user_permissions.add(self.default_permission)
+        user.user_permissions.add(self.custom_permission)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))
+        update_proxy_permissions.update_proxy_model_permissions(apps, None)
+        update_proxy_permissions.revert_proxy_model_permissions(apps, None)
+        # Reload user to purge the _perm_cache.
+        user = User._default_manager.get(pk=user.pk)
+        for permission in [self.default_permission, self.custom_permission]:
+            self.assertTrue(user.has_perm('auth_tests.' + permission.codename))


### PR DESCRIPTION
# Context

Previous PR: #4681

**Ticket links**:
- Main bug: https://code.djangoproject.com/ticket/11154
- Maybe related bug: https://code.djangoproject.com/ticket/17904
- Docs: https://code.djangoproject.com/ticket/22270

# State of things before this patch

## Permissions for proxy models

They are created using the concrete model content type.

```python
# myapp/model.py
class User(models.Model):
    pass

class Student(models.Model):
    class Meta:
        proxy = True
        # Extra permissions
        permissions = (
            ('email_student', 'Can email students'),
        )

student_permission = Permission.objects.get(codename='email_student')
user_permission = Permission.objects.get(codename='add_user')

# The content type used for the permissions is the one of the concrete model
assert student_permission.content_type == user_permission.content_type

# Add the permissions to the user
user.user_permissions.add(student_permission)
user.user_permissions.add(user_permission)

# Then check if it worked as you would expect
assert user.has_perms('myapp.email_student', 'myapp.add_user') is True
```

So far everything works as expected... But now let's use a proxy model in a different app!

```python
# myotherapp/models.py
from myapp.models import User

class Teacher(User):
    class Meta:
        proxy = True

teacher_permission = Permission.objects.get(codename='add_teacher')
assert teacher_permission.content_type == user_permission.content_type

# Add the permission to the user
user.user_permissions.add(teacher_permission)

# And here is the catch...
assert user.has_perm('myotherapp.add_teacher') is True, 'Bad luck, you have to use the app_label of the concrete model'
# Instead
assert user.has_perm('myapp.add_teacher') is True
```
## Admin pages

For proxy models having a different `app_label` than the concrete model would, their admin page would not be accessible to users having the proxy model permissions because of how the permission lookup is done in `django.contrib.admin.options.py`. As mentioned in the previous example, you need to use the `app_label` of the concrete model to lookup the permission, but the admin was constructing the string with the model app_label whether or not that model was a proxy model.
```python
# myapp/admin.py
from myapp.models import Student

admin.site.register(Student)
```

```python
# myotherapp/admin.py
from myotherapp.models import Teacher


admin.site.register(Teacher)
```

```python
user.user_permissions.add(Permission.objects.get(codename='change_student'))
user.user_permissions.add(Permission.objects.get(codename='change_teacher'))
# Log the user in...
# ...
response = client.get('admin:myapp_student_changelist')
assert response.status_code == 200

response = client.get('admin:myotherapp_teacher_changelist')
assert response.status_code == 200, 'Nope, it returns 403 because of the bad permission lookup!'
```

## Existing workarounds (That I know of...)
So currently, to give users access to the `Teacher` admin page, there are 2 options:
- Create manually the permissions that will use the proxy model content type (The [gist](https://gist.github.com/magopian/7543724) mentioned in https://code.djangoproject.com/ticket/11154#comment:54)
- Make the user a superuser

# What will happen after this patch in terms of permissions?

- New permissions will be created for all the proxy models, using their own content type instead of the content type of the concrete model.
- Users with the new permissions will be able to access the admin pages of proxy models with an `app_label` different from the concrete model.

# What will stay the same?

- If you give a user the permissions of a concrete model, it doesn't give them any permission on an inheriting proxy model.

# Highlighted changes for review

- [x] Cherry-pick the changes of #4681
- [x] Describe with concrete examples how this page will affect permission creation
- [x] Update existing docs around proxy models and getting permissions by content type
- [x] Add the release notes
- [x] Write documentation to explain how the permissions are created for a model/proxy model
    - [x] Explain that permissions for a concrete model don't give permissions for a proxy model