### PR TITLE
Fixed typo in search docs

### DIFF
--- a/docs/ref/contrib/postgres/search.txt
+++ b/docs/ref/contrib/postgres/search.txt
@@ -116,7 +116,7 @@ Changing the search configuration
 
 You can specify the ``config`` attribute to a :class:`SearchVector` and
 :class:`SearchQuery` to use a different search configuration. This allows using
-a different language parsers and dictionaries as defined by the database::
+different language parsers and dictionaries as defined by the database::
 
     >>> from django.contrib.postgres.search import SearchQuery, SearchVector
     >>> Entry.objects.annotate(


### PR DESCRIPTION
Typo is live here: https://docs.djangoproject.com/en/dev/ref/contrib/postgres/search/#changing-the-search-configuration