### PR TITLE
Add a test for cast between datetime and date.

### DIFF
--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -10,7 +10,7 @@ from django.test import (
     TestCase, ignore_warnings, override_settings, skipUnlessDBFeature,
 )
 
-from ..models import Author
+from ..models import Author, Fan
 
 
 class CastTests(TestCase):
@@ -50,6 +50,11 @@ class CastTests(TestCase):
             with self.subTest(field_class=field_class):
                 numbers = Author.objects.annotate(cast_int=Cast('alias', field_class()))
                 self.assertEqual(numbers.get().cast_int, 1)
+
+    def test_case_from_db_datetime_to_date(self):
+        fan = Fan.objects.create()
+        fans = Fan.objects.filter(pk=fan.pk).annotate(fan_from_day=Cast("fan_since", models.DateField())).values()
+        self.assertTrue(isinstance(fans[0]['fan_from_day'], datetime.date))
 
     def test_cast_from_python_to_date(self):
         today = datetime.date.today()

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -52,9 +52,20 @@ class CastTests(TestCase):
                 self.assertEqual(numbers.get().cast_int, 1)
 
     def test_case_from_db_datetime_to_date(self):
-        fan = Fan.objects.create()
-        fans = Fan.objects.filter(pk=fan.pk).annotate(fan_from_day=Cast("fan_since", models.DateField())).values()
-        self.assertTrue(isinstance(fans[0]['fan_from_day'], datetime.date))
+        author = Author.objects.create(name='John Smith', age=45)
+        Fan.objects.create(name='Margaret', age=50, author=author)
+        fans = Fan.objects.annotate(fan_for_day=Cast("fan_since", models.DateField()))
+        self.assertTrue(isinstance(fans.get().fan_for_day, datetime.date))
+
+    def test_case_from_db_datetime_to_date_group_by(self):
+        # Create a fan
+        author = Author.objects.create(name='John Smith', age=45)
+        Fan.objects.create(name='Margaret', age=50, author=author)
+        fans = Fan.objects.values("author").annotate(
+            fan_for_day=Cast("fan_since", models.DateField()),
+            fans=models.Count("*")).values()
+        self.assertTrue(isinstance(fans[0]['fan_for_day'], datetime.date))
+        self.assertEqual(fans[0]['fans'], 1)
 
     def test_cast_from_python_to_date(self):
         today = datetime.date.today()


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29767#ticket

While using with Annotations and Cast I realized that the casting between datetime and date with SQLite3 was kinda broken.

`Cast("datetime_field", DateField())` is transformed into `CAST("datetime_field" AS TEXT)` rather than for instance `substr(CAST(datetime_field AS TEXT),0,11)`

I was able to use extra to fix that and run the query. However I would like to fix this.

This is especially useful for my usecase where I want to GROUP BY the annotated value.