### PR TITLE
Fixed #29755 -- Enabled default_related_name change detection.

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -638,6 +638,7 @@ class AlterModelOptions(ModelOptionOperation):
     ALTER_OPTION_KEYS = [
         "base_manager_name",
         "default_manager_name",
+        "default_related_name",
         "get_latest_by",
         "managed",
         "ordering",

--- a/docs/releases/2.1.2.txt
+++ b/docs/releases/2.1.2.txt
@@ -14,3 +14,6 @@ Bugfixes
 
 * Fixed a regression where files starting with a tilde or underscore weren't
   ignored by the migrations loader (:ticket:`29749`).
+
+* Made migrations detect changes to ``Meta.default_related_name``
+  (:ticket:`29755`).

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2104,6 +2104,25 @@ class AutodetectorTests(TestCase):
         self.assertOperationAttributes(changes, 'thirdapp', 0, 0, name="CustomUser")
         self.assertOperationAttributes(changes, 'thirdapp', 0, 1, name="Aardvark")
 
+    def test_default_related_name_option(self):
+        model_state = ModelState('app', 'model', [
+            ('id', models.AutoField(primary_key=True)),
+        ], options={'default_related_name': 'related_name'})
+        changes = self.get_changes([], [model_state])
+        self.assertNumberMigrations(changes, 'app', 1)
+        self.assertOperationTypes(changes, 'app', 0, ['CreateModel'])
+        self.assertOperationAttributes(
+            changes, 'app', 0, 0, name='model',
+            options={'default_related_name': 'related_name'},
+        )
+        altered_model_state = ModelState('app', 'Model', [
+            ('id', models.AutoField(primary_key=True)),
+        ])
+        changes = self.get_changes([model_state], [altered_model_state])
+        self.assertNumberMigrations(changes, 'app', 1)
+        self.assertOperationTypes(changes, 'app', 0, ['AlterModelOptions'])
+        self.assertOperationAttributes(changes, 'app', 0, 0, name='model', options={})
+
     @override_settings(AUTH_USER_MODEL="thirdapp.CustomUser")
     def test_swappable_first_setting(self):
         """Swappable models get their CreateModel first."""


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29755