### PR TITLE
Fixed #29759 -- Fixed crash on Oracle when fetching a returned insert id with cx_Oracle 7.

### DIFF
--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -226,7 +226,9 @@ END;
 
     def fetch_returned_insert_id(self, cursor):
         try:
-            return int(cursor._insert_id_var.getvalue())
+            value = cursor._insert_id_var.getvalue()
+            # cx_Oracle < 7 returns value, >= 7 returns list with single value.
+            return int(value[0] if isinstance(value, list) else value)
         except (IndexError, TypeError):
             # cx_Oracle < 6.3 returns None, >= 6.3 raises IndexError.
             raise DatabaseError(

--- a/docs/releases/2.1.2.txt
+++ b/docs/releases/2.1.2.txt
@@ -17,3 +17,5 @@ Bugfixes
 
 * Made migrations detect changes to ``Meta.default_related_name``
   (:ticket:`29755`).
+
+* Added compatibility for ``cx_Oracle`` 7 (:ticket:`29759`).


### PR DESCRIPTION
Ticket [29759](https://code.djangoproject.com/ticket/29759).