### PR TITLE
[2.0.x] Added words to docs/spelling_wordlist for Ubuntu 18.04.

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -69,6 +69,7 @@ blogs
 boilerplatish
 Bokmål
 bolded
+Bonham
 bookmarklet
 bookmarklets
 boolean
@@ -107,6 +108,7 @@ clickjacking
 cms
 codebase
 codec
+codenamed
 coercible
 collectstatic
 commenters
@@ -119,6 +121,7 @@ config
 ContentType
 contenttypes
 contrib
+covariance
 coveredby
 createcachetable
 createdb
@@ -157,11 +160,14 @@ decrement
 decrementing
 deduplicates
 deepcopy
+deferrable
+deprecations
 deserialization
 deserialize
 deserialized
 deserializer
 deserializing
+deterministically
 Deutsch
 dev
 dict
@@ -303,6 +309,7 @@ ifchanged
 iframe
 inbox
 incrementing
+indexable
 indices
 ing
 ini
@@ -332,6 +339,7 @@ iso
 istartswith
 iterable
 iterables
+iteratively
 itunes
 iTunes
 ize
@@ -360,6 +368,7 @@ linebreaksbr
 linenumbers
 linestring
 linework
+linter
 Livni
 ljust
 loaddata
@@ -375,6 +384,7 @@ lookup
 lookups
 loopback
 lorem
+lossy
 lowercased
 lowercasing
 lt
@@ -424,6 +434,7 @@ multipolygon
 multitenancy
 multithreaded
 multithreading
+multivalued
 Mumbai
 myapp
 myproject
@@ -446,6 +457,7 @@ newforms
 nginx
 noding
 nonspatial
+nows
 nullable
 OAuth
 offline
@@ -466,9 +478,13 @@ outbox
 Outdim
 outfile
 paginator
+parallelization
+parallelized
+parameterization
 parameterized
 params
 parens
+parsers
 Paweł
 pdf
 PEM
@@ -519,6 +535,7 @@ prepopulate
 prepopulated
 prepopulates
 preprocess
+preprocessed
 preprocesses
 preprocessing
 programmatically
@@ -544,6 +561,7 @@ QUnit
 quo
 quoteless
 Radziej
+rasters
 rc
 readded
 reallow
@@ -682,6 +700,7 @@ sublist
 submodule
 submodules
 subpath
+subprocesses
 subqueries
 subquery
 subselect
@@ -744,6 +763,8 @@ Tredinnick
 triager
 triagers
 triaging
+trigram
+trigrams
 truncatechars
 truncatewords
 tuple
@@ -755,6 +776,7 @@ ubuntu
 ul
 umask
 Unaccent
+unannotated
 unapplied
 unapply
 unapplying
@@ -782,6 +804,7 @@ unittest
 unittests
 unlocalize
 unlocalized
+unmaintained
 unmanaged
 unordered
 unparseable
@@ -801,6 +824,7 @@ unsquashed
 untar
 untrusted
 unvalidated
+uppercased
 uptime
 url
 urlencode


### PR DESCRIPTION
Backport of 8edb27b6c6d5d9e4f3ad95a91254588616854d16 from master