### PR TITLE
Refs #29641 -- Refactored database schema constraint creation code.

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -12,10 +12,10 @@ from django.db.utils import NotSupportedError
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     sql_delete_table = "DROP TABLE %(table)s"
-    sql_create_fk = None
     sql_create_inline_fk = "REFERENCES %(to_table)s (%(to_column)s) DEFERRABLE INITIALLY DEFERRED"
     sql_create_unique = "CREATE UNIQUE INDEX %(name)s ON %(table)s (%(columns)s)"
     sql_delete_unique = "DROP INDEX %(name)s"
+    sql_foreign_key_constraint = None
 
     def __enter__(self):
         # Some SQLite schema alterations need foreign key constraints to be

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -10,16 +10,22 @@ class BaseConstraint:
     def constraint_sql(self, model, schema_editor):
         raise NotImplementedError('This method must be implemented by a subclass.')
 
+    def full_constraint_sql(self, model, schema_editor):
+        return schema_editor.sql_constraint % {
+            'name': schema_editor.quote_name(self.name),
+            'constraint': self.constraint_sql(model, schema_editor),
+        }
+
     def create_sql(self, model, schema_editor):
-        sql = self.constraint_sql(model, schema_editor)
-        return schema_editor.sql_create_check % {
+        sql = self.full_constraint_sql(model, schema_editor)
+        return schema_editor.sql_create_constraint % {
             'table': schema_editor.quote_name(model._meta.db_table),
-            'check': sql,
+            'constraint': sql,
         }
 
     def remove_sql(self, model, schema_editor):
         quote_name = schema_editor.quote_name
-        return schema_editor.sql_delete_check % {
+        return schema_editor.sql_delete_constraint % {
             'table': quote_name(model._meta.db_table),
             'name': quote_name(self.name),
         }
@@ -46,10 +52,7 @@ class CheckConstraint(BaseConstraint):
         compiler = connection.ops.compiler('SQLCompiler')(query, connection, 'default')
         sql, params = where.as_sql(compiler, connection)
         params = tuple(schema_editor.quote_value(p) for p in params)
-        return schema_editor.sql_check % {
-            'name': schema_editor.quote_name(self.name),
-            'check': sql % params,
-        }
+        return schema_editor.sql_check_constraint % {'check': sql % params}
 
     def __repr__(self):
         return "<%s: check='%s' name=%r>" % (self.__class__.__name__, self.check, self.name)

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -293,6 +293,13 @@ Database backend API
 * Third party database backends must implement support for partial indexes or
   set ``DatabaseFeatures.supports_partial_indexes`` to ``False``.
 
+* Several ``SchemaEditor`` attributes are changed:
+
+  * ``sql_create_check`` is replaced with ``sql_create_constraint``.
+  * ``sql_delete_check`` is replaced with ``sql_delete_constraint``.
+  * ``sql_create_fk`` is replaced with ``sql_foreign_key_constraint``,
+    ``sql_constraint``, and ``sql_create_constraint``.
+
 Admin actions are no longer collected from base ``ModelAdmin`` classes
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
Add a test to ensure we set the constraint name correctly in the
database.

Update sqlite introspection to use sqlparse. This allows us to read the
actual constraint name for table check constraints and unique constraints.