### PR TITLE
Fixed #29598 -- Deprecated FloatRangeField in favor of DecimalRangeField.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -19,7 +19,7 @@ class PostgresConfig(AppConfig):
                 conn.introspection.data_types_reverse.update({
                     3802: 'django.contrib.postgres.fields.JSONField',
                     3904: 'django.contrib.postgres.fields.IntegerRangeField',
-                    3906: 'django.contrib.postgres.fields.FloatRangeField',
+                    3906: 'django.contrib.postgres.fields.DecimalRangeField',
                     3910: 'django.contrib.postgres.fields.DateTimeRangeField',
                     3912: 'django.contrib.postgres.fields.DateRangeField',
                     3926: 'django.contrib.postgres.fields.BigIntegerRangeField',

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -10,7 +10,8 @@ from .utils import AttributeSetter
 
 __all__ = [
     'RangeField', 'IntegerRangeField', 'BigIntegerRangeField',
-    'FloatRangeField', 'DateTimeRangeField', 'DateRangeField',
+    'DecimalRangeField', 'DateTimeRangeField', 'DateRangeField',
+    'FloatRangeField',
 ]
 
 
@@ -100,7 +101,23 @@ class BigIntegerRangeField(RangeField):
         return 'int8range'
 
 
+class DecimalRangeField(RangeField):
+    base_field = models.DecimalField
+    range_type = NumericRange
+    form_field = forms.DecimalRangeField
+
+    def db_type(self, connection):
+        return 'numrange'
+
+
 class FloatRangeField(RangeField):
+    system_check_deprecated_details = {
+        'msg': (
+            'FloatRangeField is deprecated and will be removed in Django 3.1.'
+        ),
+        'hint': 'Use DecimalRangeField instead.',
+        'id': 'fields.W902',
+    }
     base_field = models.FloatField
     range_type = NumericRange
     form_field = forms.FloatRangeField

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -1,13 +1,16 @@
+import warnings
+
 from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
 
 from django import forms
 from django.core import exceptions
 from django.forms.widgets import MultiWidget
+from django.utils.deprecation import RemovedInDjango31Warning
 from django.utils.translation import gettext_lazy as _
 
 __all__ = [
-    'BaseRangeField', 'IntegerRangeField', 'FloatRangeField',
-    'DateTimeRangeField', 'DateRangeField', 'RangeWidget',
+    'BaseRangeField', 'IntegerRangeField', 'DecimalRangeField',
+    'DateTimeRangeField', 'DateRangeField', 'FloatRangeField', 'RangeWidget',
 ]
 
 
@@ -66,10 +69,21 @@ class IntegerRangeField(BaseRangeField):
     range_type = NumericRange
 
 
-class FloatRangeField(BaseRangeField):
+class DecimalRangeField(BaseRangeField):
     default_error_messages = {'invalid': _('Enter two numbers.')}
-    base_field = forms.FloatField
+    base_field = forms.DecimalField
     range_type = NumericRange
+
+
+class FloatRangeField(DecimalRangeField):
+    base_field = forms.FloatField
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            'FloatRangeField is deprecated in favor of DecimalRangeField.',
+            RemovedInDjango31Warning, stacklevel=2,
+        )
+        super().__init__(**kwargs)
 
 
 class DateTimeRangeField(BaseRangeField):

--- a/docs/internals/deprecation.txt
+++ b/docs/internals/deprecation.txt
@@ -21,6 +21,9 @@ details on these changes.
 
 * A model's ``Meta.ordering`` will no longer affect ``GROUP BY`` queries.
 
+* ``django.contrib.postgres.fields.FloatRangeField`` and
+  ``django.contrib.postgres.forms.FloatRangeField`` will be removed.
+
 .. _deprecation-removed-in-3.0:
 
 3.0

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -168,6 +168,8 @@ Model fields
   check appeared in Django 1.10 and 1.11*.
 * **fields.E901**: ``CommaSeparatedIntegerField`` is removed except for support
   in historical migrations.
+* **fields.W902**: ``FloatRangeField`` is deprecated and will be removed in
+  Django 3.1.
 
 File fields
 ~~~~~~~~~~~

--- a/docs/ref/contrib/postgres/fields.txt
+++ b/docs/ref/contrib/postgres/fields.txt
@@ -653,6 +653,18 @@ excluded; that is, ``[)``.
     returns a range in a canonical form that includes the lower bound and
     excludes the upper bound; that is ``[)``.
 
+``DecimalRangeField``
+---------------------
+
+.. class:: DecimalRangeField(**options)
+
+    .. versionadded:: 2.2
+
+    Stores a range of floating point values. Based on a
+    :class:`~django.db.models.DecimalField`. Represented by a ``numrange`` in
+    the database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in
+    Python.
+
 ``FloatRangeField``
 -------------------
 
@@ -661,6 +673,10 @@ excluded; that is, ``[)``.
     Stores a range of floating point values. Based on a
     :class:`~django.db.models.FloatField`. Represented by a ``numrange`` in the
     database and a :class:`~psycopg2:psycopg2.extras.NumericRange` in Python.
+
+    .. deprecated:: 2.2
+
+        Use :class:`DecimalRangeField` instead.
 
 ``DateTimeRangeField``
 ----------------------

--- a/docs/ref/contrib/postgres/forms.txt
+++ b/docs/ref/contrib/postgres/forms.txt
@@ -193,6 +193,17 @@ not greater than the upper bound. All of these fields use
     :class:`~django.contrib.postgres.fields.IntegerRangeField` and
     :class:`~django.contrib.postgres.fields.BigIntegerRangeField`.
 
+``DecimalRangeField``
+~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: DecimalRangeField
+
+    .. versionadded:: 2.2
+
+    Based on :class:`~django.forms.DecimalField` and translates its input into
+    :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
+    :class:`~django.contrib.postgres.fields.DecimalRangeField`.
+
 ``FloatRangeField``
 ~~~~~~~~~~~~~~~~~~~
 
@@ -201,6 +212,10 @@ not greater than the upper bound. All of these fields use
     Based on :class:`~django.forms.FloatField` and translates its input into
     :class:`~psycopg2:psycopg2.extras.NumericRange`. Default for
     :class:`~django.contrib.postgres.fields.FloatRangeField`.
+
+    .. deprecated:: 2.2
+
+        Use :class:`DecimalRangeField` instead.
 
 ``DateTimeRangeField``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -315,3 +315,7 @@ Miscellaneous
 
 * The undocumented ``QuerySetPaginator`` alias of
   ``django.core.paginator.Paginator`` is deprecated.
+
+* The ``FloatRangeField`` model and form fields in ``django.contrib.postgres``
+  are deprecated in favor of a new name, ``DecimalRangeField``, to match the
+  underlying ``numrange`` data type used in the database.

--- a/tests/postgres_tests/fields.py
+++ b/tests/postgres_tests/fields.py
@@ -7,7 +7,7 @@ from django.db import models
 try:
     from django.contrib.postgres.fields import (
         ArrayField, BigIntegerRangeField, CICharField, CIEmailField,
-        CITextField, DateRangeField, DateTimeRangeField, FloatRangeField,
+        CITextField, DateRangeField, DateTimeRangeField, DecimalRangeField,
         HStoreField, IntegerRangeField, JSONField,
     )
     from django.contrib.postgres.search import SearchVectorField
@@ -35,7 +35,7 @@ except ImportError:
     CITextField = models.Field
     DateRangeField = models.Field
     DateTimeRangeField = models.Field
-    FloatRangeField = models.Field
+    DecimalRangeField = models.Field
     HStoreField = models.Field
     IntegerRangeField = models.Field
     JSONField = DummyJSONField

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -3,7 +3,7 @@ from django.db import migrations, models
 
 from ..fields import (
     ArrayField, BigIntegerRangeField, CICharField, CIEmailField, CITextField,
-    DateRangeField, DateTimeRangeField, FloatRangeField, HStoreField,
+    DateRangeField, DateTimeRangeField, DecimalRangeField, HStoreField,
     IntegerRangeField, JSONField, SearchVectorField,
 )
 from ..models import TagField
@@ -209,7 +209,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('ints', IntegerRangeField(null=True, blank=True)),
                 ('bigints', BigIntegerRangeField(null=True, blank=True)),
-                ('floats', FloatRangeField(null=True, blank=True)),
+                ('decimals', DecimalRangeField(null=True, blank=True)),
                 ('timestamps', DateTimeRangeField(null=True, blank=True)),
                 ('dates', DateRangeField(null=True, blank=True)),
             ],

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 from .fields import (
     ArrayField, BigIntegerRangeField, CICharField, CIEmailField, CITextField,
-    DateRangeField, DateTimeRangeField, FloatRangeField, HStoreField,
+    DateRangeField, DateTimeRangeField, DecimalRangeField, HStoreField,
     IntegerRangeField, JSONField, SearchVectorField,
 )
 
@@ -129,7 +129,7 @@ class Line(PostgreSQLModel):
 class RangesModel(PostgreSQLModel):
     ints = IntegerRangeField(blank=True, null=True)
     bigints = BigIntegerRangeField(blank=True, null=True)
-    floats = FloatRangeField(blank=True, null=True)
+    decimals = DecimalRangeField(blank=True, null=True)
     timestamps = DateTimeRangeField(blank=True, null=True)
     dates = DateRangeField(blank=True, null=True)
 

--- a/tests/postgres_tests/test_introspection.py
+++ b/tests/postgres_tests/test_introspection.py
@@ -31,7 +31,7 @@ class InspectDBTests(PostgreSQLTestCase):
             [
                 'ints = django.contrib.postgres.fields.IntegerRangeField(blank=True, null=True)',
                 'bigints = django.contrib.postgres.fields.BigIntegerRangeField(blank=True, null=True)',
-                'floats = django.contrib.postgres.fields.FloatRangeField(blank=True, null=True)',
+                'decimals = django.contrib.postgres.fields.DecimalRangeField(blank=True, null=True)',
                 'timestamps = django.contrib.postgres.fields.DateTimeRangeField(blank=True, null=True)',
                 'dates = django.contrib.postgres.fields.DateRangeField(blank=True, null=True)',
             ],


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29598