### PR TITLE
Fixed #29673 -- Reset URLconf at the end of request processing

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -3,6 +3,7 @@ import types
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
+from django.core.signals import request_finished
 from django.db import connections, transaction
 from django.urls import get_resolver, set_urlconf
 from django.utils.log import log_response
@@ -167,3 +168,11 @@ class BaseHandler:
             if response:
                 return response
         raise
+
+
+def reset_urlconf(sender, **kwargs):
+    """Reset the URLconf after each request is finished."""
+    set_urlconf(None)
+
+
+request_finished.connect(reset_urlconf)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -18,7 +18,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import override_script_prefix
 from django.urls import (
     NoReverseMatch, Resolver404, ResolverMatch, URLPattern, URLResolver,
-    get_callable, get_resolver, resolve, reverse, reverse_lazy,
+    get_callable, get_resolver, get_urlconf, resolve, reverse, reverse_lazy,
 )
 from django.urls.resolvers import RegexPattern
 
@@ -1033,6 +1033,13 @@ class RequestURLconfTests(SimpleTestCase):
         with self.assertRaisesMessage(NoReverseMatch, message):
             self.client.get('/second_test/')
             b''.join(self.client.get('/second_test/'))
+
+    def test_urlconf_is_reset_after_request(self):
+        """The URLconf is reset after each request."""
+        self.assertIsNone(get_urlconf())
+        with override_settings(MIDDLEWARE=['%s.ChangeURLconfMiddleware' % middleware.__name__]):
+            self.client.get(reverse('inner'))
+        self.assertIsNone(get_urlconf())
 
 
 class ErrorHandlerResolutionTests(SimpleTestCase):


### PR DESCRIPTION
Fixes [ticket 29673](https://code.djangoproject.com/ticket/29673)

We attach a signal handler to request_finished, and reset the URLconf. Before this change, the URLconf is not reset until the start of the next request.