### PR TITLE
Fixed #29778 -- Fixed quoting of unique index names.

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1013,11 +1013,13 @@ class BaseDatabaseSchemaEditor:
         )
 
     def _create_unique_sql(self, model, columns):
+        def create_unique_name(*args, **kwargs):
+            return self.quote_name(self._create_index_name(*args, **kwargs))
         table = model._meta.db_table
         return Statement(
             self.sql_create_unique,
             table=Table(table, self.quote_name),
-            name=IndexName(table, columns, '_uniq', self._create_index_name),
+            name=IndexName(table, columns, '_uniq', create_unique_name),
             columns=Columns(table, columns, self.quote_name),
         )
 

--- a/docs/releases/2.1.2.txt
+++ b/docs/releases/2.1.2.txt
@@ -19,3 +19,6 @@ Bugfixes
   (:ticket:`29755`).
 
 * Added compatibility for ``cx_Oracle`` 7 (:ticket:`29759`).
+
+* Fixed a regression in Django 2.0 where unique index names weren't quoted
+  (:ticket:`29778`).


### PR DESCRIPTION
This change fixes regression introduced in PR #6643 - commit 3b429c96736b8328c40e5d77282b0d30de563c3c.
Now it is possible to create unqiue indexes for tables, whose names should be quoted.
This was supported in version 1.11 and should work according to documentation:
> If your database table name is an SQL reserved word, or contains characters that aren’t allowed in Python variable names – notably, the hyphen – that’s OK. Django quotes column and table names behind the scenes.

Regression test included.
