### PR TITLE
Refs #29198 -- Fixed migrate --plan crash if RunSQL uses a list or tuple.

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -344,7 +344,7 @@ class Command(BaseCommand):
             action = 'IRREVERSIBLE'
             is_error = True
         else:
-            action = action.replace('\n', '')
+            action = str(action).replace('\n', '')
             is_error = False
         if action:
             action = ' -> ' + action

--- a/tests/migrations/test_migrations_plan/0002_second.py
+++ b/tests/migrations/test_migrations_plan/0002_second.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True)),
             ],
         ),
-        migrations.RunSQL('SELECT * FROM migrations_book', 'SELECT * FROM migrations_salamander')
+        migrations.RunSQL(['SELECT * FROM migrations_book'], ['SELECT * FROM migrations_salamander'])
 
     ]

--- a/tests/migrations/test_migrations_plan/0003_third.py
+++ b/tests/migrations/test_migrations_plan/0003_third.py
@@ -15,5 +15,5 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True)),
             ],
         ),
-        migrations.RunSQL('SELECT * FROM migrations_author', 'SELECT * FROM migrations_book')
+        migrations.RunSQL(['SELECT * FROM migrations_author'], ['SELECT * FROM migrations_book'])
     ]


### PR DESCRIPTION
Also fixed test failures if sqlparse isn't installed.