### PR TITLE
Fixed #29630 -- Fixed crash of sliced queries with multiple columns with the same name on Oracle 12.1.

### DIFF
--- a/django/db/backends/oracle/compiler.py
+++ b/django/db/backends/oracle/compiler.py
@@ -1,0 +1,60 @@
+from django.db import NotSupportedError
+from django.db.models.sql import compiler
+
+
+class SQLCompiler(compiler.SQLCompiler):
+    def as_sql(self, with_limits=True, with_col_aliases=False):
+        """
+        Create the SQL for this query. Return the SQL string and list of
+        parameters. This is overridden from the original Query class to handle
+        the restriction in Oracle 12.1 and emulate LIMIT and OFFSET with
+        a subquery.
+
+        If 'with_limits' is False, any limit/offset information is not included
+        in the query.
+        """
+        # Whether the query must be constructed using limit/offset.
+        do_offset = with_limits and (self.query.high_mark is not None or self.query.low_mark)
+        if not do_offset:
+            sql, params = super().as_sql(with_limits=False, with_col_aliases=with_col_aliases)
+        elif not self.connection.features.supports_select_for_update_with_limit and self.query.select_for_update:
+            raise NotSupportedError(
+                'LIMIT/OFFSET is not supported with select_for_update on this '
+                'database backend.'
+            )
+        else:
+            sql, params = super().as_sql(with_limits=False, with_col_aliases=True)
+            # Wrap the base query in an outer SELECT * with boundaries on
+            # the "_RN" column. This is the canonical way to emulate LIMIT
+            # and OFFSET on Oracle.
+            high_where = ''
+            if self.query.high_mark is not None:
+                high_where = 'WHERE ROWNUM <= %d' % (self.query.high_mark,)
+
+            if self.query.low_mark:
+                sql = (
+                    'SELECT * FROM (SELECT "_SUB".*, ROWNUM AS "_RN" FROM (%s) '
+                    '"_SUB" %s) WHERE "_RN" > %d' % (sql, high_where, self.query.low_mark)
+                )
+            else:
+                # Simplify the query to support subqueries if there's no offset.
+                sql = (
+                    'SELECT * FROM (SELECT "_SUB".* FROM (%s) "_SUB" %s)' % (sql, high_where)
+                )
+        return sql, params
+
+
+class SQLInsertCompiler(compiler.SQLInsertCompiler, SQLCompiler):
+    pass
+
+
+class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
+    pass
+
+
+class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
+    pass
+
+
+class SQLAggregateCompiler(compiler.SQLAggregateCompiler, SQLCompiler):
+    pass

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -1,5 +1,6 @@
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.db.utils import InterfaceError
+from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
@@ -55,3 +56,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_over_clause = True
     supports_ignore_conflicts = False
     max_query_params = 2**16 - 1
+
+    @cached_property
+    def has_fetch_offset_support(self):
+        return self.connection.oracle_version >= (12, 2)
+
+    @cached_property
+    def allow_sliced_subqueries_with_in(self):
+        return self.has_fetch_offset_support

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -8,6 +8,7 @@ from django.db.backends.utils import strip_quotes, truncate_name
 from django.db.utils import DatabaseError
 from django.utils import timezone
 from django.utils.encoding import force_bytes
+from django.utils.functional import cached_property
 
 from .base import Database
 from .utils import BulkInsertMapper, InsertIdVar, Oracle_datetime
@@ -579,3 +580,9 @@ END;
         if fields:
             return self.connection.features.max_query_params // len(fields)
         return len(objs)
+
+    @cached_property
+    def compiler_module(self):
+        if self.connection.features.has_fetch_offset_support:
+            return super().compiler_module
+        return 'django.db.backends.oracle.compiler'

--- a/docs/releases/2.1.2.txt
+++ b/docs/releases/2.1.2.txt
@@ -22,3 +22,6 @@ Bugfixes
 
 * Fixed a regression in Django 2.0 where unique index names weren't quoted
   (:ticket:`29778`).
+
+* Fixed a regression where sliced queries with multiple columns with the same
+  name crashed on Oracle 12.1 (:ticket:`29630`).


### PR DESCRIPTION
Ticket [29630](https://code.djangoproject.com/ticket/29630).

Regression in 0899d583bdb140910698d00d17f5f1abc8774b07.