### PR TITLE
Refs #27795 -- Removed force_bytes() usage in utils/_os.py.

### DIFF
--- a/django/utils/_os.py
+++ b/django/utils/_os.py
@@ -3,7 +3,6 @@ import tempfile
 from os.path import abspath, dirname, join, normcase, sep
 
 from django.core.exceptions import SuspiciousFileOperation
-from django.utils.encoding import force_text
 
 # For backwards-compatibility in Django 2.0
 abspathu = abspath
@@ -30,8 +29,6 @@ def safe_join(base, *paths):
     Raise ValueError if the final path isn't located inside of the base path
     component.
     """
-    base = force_text(base)
-    paths = [force_text(p) for p in paths]
     final_path = abspath(join(base, *paths))
     base_path = abspath(base)
     # Ensure final_path starts with base_path (using normcase to ensure we

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -291,6 +291,8 @@ Miscellaneous
   is now the real ellipsis character (``…``) instead of 3 dots. You may have to
   adapt some test output comparisons.
 
+* Support for bytestring paths in the template filesystem loader is removed.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/template_tests/test_loaders.py
+++ b/tests/template_tests/test_loaders.py
@@ -156,24 +156,17 @@ class FileSystemLoaderTests(SimpleTestCase):
 
     def test_unicode_template_name(self):
         with self.source_checker(['/dir1', '/dir2']) as check_sources:
-            # UTF-8 bytestrings are permitted.
-            check_sources(b'\xc3\x85ngstr\xc3\xb6m', ['/dir1/Ångström', '/dir2/Ångström'])
-            # Strings are permitted.
             check_sources('Ångström', ['/dir1/Ångström', '/dir2/Ångström'])
 
-    def test_utf8_bytestring(self):
-        """
-        Invalid UTF-8 encoding in bytestrings should raise a useful error
-        """
-        engine = self.engine
-        loader = engine.template_loaders[0]
-        with self.assertRaises(UnicodeDecodeError):
-            list(loader.get_template_sources(b'\xc3\xc3'))
+    def test_bytestring(self):
+        loader = self.engine.template_loaders[0]
+        msg = "Can't mix strings and bytes in path components"
+        with self.assertRaisesMessage(TypeError, msg):
+            list(loader.get_template_sources(b'\xc3\x85ngstr\xc3\xb6m'))
 
     def test_unicode_dir_name(self):
-        with self.source_checker([b'/Stra\xc3\x9fe']) as check_sources:
+        with self.source_checker(['/Straße']) as check_sources:
             check_sources('Ångström', ['/Straße/Ångström'])
-            check_sources(b'\xc3\x85ngstr\xc3\xb6m', ['/Straße/Ångström'])
 
     @unittest.skipUnless(
         os.path.normcase('/TEST') == os.path.normpath('/test'),


### PR DESCRIPTION
Filesystem paths are expected to be passed as text strings.