### PR TITLE
Fixed #22125 - Don't create extraneous index on autocreated through models

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -269,6 +269,9 @@ class BaseDatabaseFeatures:
     # in UPDATE statements to ensure the expression has the correct type?
     requires_casted_case_in_updates = False
 
+    # Does this backend use composite index to search by any prefix of its key?
+    composite_index_supports_prefix_search = True
+
     def __init__(self, connection):
         self.connection = connection
 

--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -1061,6 +1061,7 @@ def create_many_to_many_intermediary_model(field, klass):
             related_name='%s+' % name,
             db_tablespace=field.db_tablespace,
             db_constraint=field.remote_field.db_constraint,
+            db_index=not connection.features.composite_index_supports_prefix_search,
             on_delete=CASCADE,
         ),
         to: models.ForeignKey(

--- a/tests/model_options/test_tablespaces.py
+++ b/tests/model_options/test_tablespaces.py
@@ -100,10 +100,11 @@ class TablespacesTests(TestCase):
         sql = sql_for_index(Authors).lower()
         # The ManyToManyField declares no db_tablespace, its indexes go to
         # the model's tablespace, unless DEFAULT_INDEX_TABLESPACE is set.
+        expected_through_indexes = 1 if connection.features.composite_index_supports_prefix_search else 2
         if settings.DEFAULT_INDEX_TABLESPACE:
-            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, 2)
+            self.assertNumContains(sql, settings.DEFAULT_INDEX_TABLESPACE, expected_through_indexes)
         else:
-            self.assertNumContains(sql, 'tbl_tbsp', 2)
+            self.assertNumContains(sql, 'tbl_tbsp', expected_through_indexes)
         self.assertNumContains(sql, 'idx_tbsp', 0)
 
         sql = sql_for_table(Reviewers).lower()
@@ -122,4 +123,4 @@ class TablespacesTests(TestCase):
         sql = sql_for_index(Reviewers).lower()
         # The ManyToManyField declares db_tablespace, its indexes go there.
         self.assertNumContains(sql, 'tbl_tbsp', 0)
-        self.assertNumContains(sql, 'idx_tbsp', 2)
+        self.assertNumContains(sql, 'idx_tbsp', expected_through_indexes)


### PR DESCRIPTION
This patch is based on all the suggestions in https://code.djangoproject.com/ticket/22125.