### PR TITLE
Extended a hook for adding extra fields to formset forms

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -367,11 +367,13 @@ class BaseFormSet:
         """A hook for adding extra fields on to each form instance."""
         if self.can_order:
             # Only pre-fill the ordering field for initial forms.
-            if index is not None and index < self.initial_form_count():
+            if index is not None and index < self.initial_form_count() and ORDERING_FIELD_NAME not in form.fields:
                 form.fields[ORDERING_FIELD_NAME] = IntegerField(label=_('Order'), initial=index + 1, required=False)
-            else:
+            elif index is not None and index < self.initial_form_count() and ORDERING_FIELD_NAME in form.fields:
+                form.fields[ORDERING_FIELD_NAME].initial = index + 1
+            elif ORDERING_FIELD_NAME not in form.fields:
                 form.fields[ORDERING_FIELD_NAME] = IntegerField(label=_('Order'), required=False)
-        if self.can_delete:
+        if self.can_delete and DELETION_FIELD_NAME not in form.fields:
             form.fields[DELETION_FIELD_NAME] = BooleanField(label=_('Delete'), required=False)
 
     def add_prefix(self, index):


### PR DESCRIPTION
Extended a hook for adding extra fields on to each form instance. Now it's possible to redefine extra fields within the form.