### PR TITLE
Fixed #29796 -- Added system check for STATICFILES_DIRS prefix ending with a slash.

### DIFF
--- a/django/contrib/staticfiles/finders.py
+++ b/django/contrib/staticfiles/finders.py
@@ -78,7 +78,13 @@ class FileSystemFinder(BaseFinder):
             ))
         for root in settings.STATICFILES_DIRS:
             if isinstance(root, (list, tuple)):
-                _, root = root
+                prefix, root = root
+                if prefix.endswith('/'):
+                    errors.append(Error(
+                        'The prefix %r in the STATICFILES_DIRS setting must '
+                        'not end with a slash.' % prefix,
+                        id='staticfiles.E003',
+                    ))
             if settings.STATIC_ROOT and os.path.abspath(settings.STATIC_ROOT) == os.path.abspath(root):
                 errors.append(Error(
                     'The STATICFILES_DIRS setting should not contain the '

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -731,3 +731,5 @@ configured:
   or list.
 * **staticfiles.E002**: The :setting:`STATICFILES_DIRS` setting should not
   contain the :setting:`STATIC_ROOT` setting.
+* **staticfiles.E003**: The prefix ``<prefix>`` in the
+  :setting:`STATICFILES_DIRS` setting must not end with a slash.

--- a/tests/staticfiles_tests/test_checks.py
+++ b/tests/staticfiles_tests/test_checks.py
@@ -75,3 +75,13 @@ class FindersCheckTests(SimpleTestCase):
                 id='staticfiles.E002',
             )
         ])
+
+    @override_settings(STATICFILES_DIRS=[('prefix/', '/fake/path')])
+    def test_prefix_contains_trailing_slash(self):
+        self.assertEqual(check_finders(None), [
+            Error(
+                "The prefix 'prefix/' in the STATICFILES_DIRS setting must "
+                "not end with a slash.",
+                id='staticfiles.E003',
+            )
+        ])


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29796