### PR TITLE
Refs #27795 -- Removed force_bytes() usage in contrib/auth/handlers/modwsgi.py.

### DIFF
--- a/django/contrib/auth/handlers/modwsgi.py
+++ b/django/contrib/auth/handlers/modwsgi.py
@@ -1,6 +1,5 @@
 from django import db
 from django.contrib import auth
-from django.utils.encoding import force_bytes
 
 UserModel = auth.get_user_model()
 
@@ -39,6 +38,6 @@ def groups_for_user(environ, username):
             return []
         if not user.is_active:
             return []
-        return [force_bytes(group.name) for group in user.groups.all()]
+        return [group.name.encode() for group in user.groups.all()]
     finally:
         db.close_old_connections()


### PR DESCRIPTION
`Group.name` is a `CharField`. Can safely assume it is a text string.