### PR TITLE
Fixed #21171 -- Avoided starting a transaction when a single (or atomic queries) are executed.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -7,6 +7,7 @@ import datetime
 import decimal
 import os
 import platform
+from contextlib import contextmanager
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -56,6 +57,24 @@ from .operations import DatabaseOperations                  # NOQA isort:skip
 from .schema import DatabaseSchemaEditor                    # NOQA isort:skip
 from .utils import Oracle_datetime                          # NOQA isort:skip
 from .validation import DatabaseValidation                  # NOQA isort:skip
+
+
+@contextmanager
+def wrap_oracle_errors():
+    try:
+        yield
+    except Database.DatabaseError as e:
+        # cx_Oracle raises a cx_Oracle.DatabaseError exception with the
+        # following attributes and values:
+        #  code = 2091
+        #  message = 'ORA-02091: transaction rolled back
+        #            'ORA-02291: integrity constraint (TEST_DJANGOTEST.SYS
+        #               _C00102056) violated - parent key not found'
+        # Convert that case to Django's IntegrityError exception.
+        x = e.args[0]
+        if hasattr(x, 'code') and hasattr(x, 'message') and x.code == 2091 and 'ORA-02291' in x.message:
+            raise utils.IntegrityError(*tuple(e.args))
+        raise
 
 
 class _UninitializedOperatorsDescriptor:
@@ -255,21 +274,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     def _commit(self):
         if self.connection is not None:
-            try:
+            with wrap_oracle_errors():
                 return self.connection.commit()
-            except Database.DatabaseError as e:
-                # cx_Oracle raises a cx_Oracle.DatabaseError exception
-                # with the following attributes and values:
-                #  code = 2091
-                #  message = 'ORA-02091: transaction rolled back
-                #            'ORA-02291: integrity constraint (TEST_DJANGOTEST.SYS
-                #               _C00102056) violated - parent key not found'
-                # We convert that particular case to our IntegrityError exception
-                x = e.args[0]
-                if hasattr(x, 'code') and hasattr(x, 'message') \
-                   and x.code == 2091 and 'ORA-02291' in x.message:
-                    raise utils.IntegrityError(*tuple(e.args))
-                raise
 
     # Oracle doesn't support releasing savepoints. But we fake them when query
     # logging is enabled to keep query counts consistent with other backends.
@@ -500,7 +506,8 @@ class FormatStylePlaceholderCursor:
     def execute(self, query, params=None):
         query, params = self._fix_for_params(query, params, unify_by_values=True)
         self._guess_input_sizes([params])
-        return self.cursor.execute(query, self._param_generator(params))
+        with wrap_oracle_errors():
+            return self.cursor.execute(query, self._param_generator(params))
 
     def executemany(self, query, params=None):
         if not params:
@@ -513,7 +520,8 @@ class FormatStylePlaceholderCursor:
         # more than once, we can't make it lazy by using a generator
         formatted = [firstparams] + [self._format_params(p) for p in params_iter]
         self._guess_input_sizes(formatted)
-        return self.cursor.executemany(query, [self._param_generator(p) for p in formatted])
+        with wrap_oracle_errors():
+            return self.cursor.executemany(query, [self._param_generator(p) for p in formatted])
 
     def close(self):
         try:

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -727,7 +727,7 @@ class QuerySet:
         query.add_update_values(kwargs)
         # Clear any annotations so that they won't be present in subqueries.
         query._annotations = None
-        with transaction.atomic(using=self.db, savepoint=False):
+        with transaction.mark_for_rollback_on_error(using=self.db):
             rows = query.get_compiler(self.db).execute_sql(CURSOR)
         self._result_cache = None
         return rows

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -209,6 +209,11 @@ Models
 * The new :meth:`.QuerySet.bulk_update` method allows efficiently updating
   specific fields on multiple model instances.
 
+* Django no longer always starts a transaction when a single query is being
+  performed, such as ``Model.save()``, ``QuerySet.update()``, and
+  ``Model.delete()``. This improves the performance of autocommit by reducing
+  the number of database round trips.
+
 Requests and Responses
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Avoid starting a transaction when only a single (or atomic queries) are executed.

I have checked the following locations:

 * `Model.save`: If there are parents involved take the safe way and use
   transactions since this should be an all or nothing operation.

   If we have no parents:

    * Signals are executed before and after the previous existing
      transaction -- they have never been part of the transaction.

    * if `force_insert` is set then only one query is executed -> atomic
      by definition and no transaction needed.

    * same applies to `force_update`.

    * If a primary key is set and no `force_*` is set Django will try an
      UPDATE and if that returns zero rows it tries an INSERT. The first
      case is completly save (single query). In the second case a
      transaction should not produce different results since the update
      query is basically a no-op then (might miss something though).

 * `QuerySet.update`: no signals issued, single query -> no transaction
    needed.

 * `Model/Collector.delete`: This one is fun due to the fact that is
    does many things at once.

    Most importantly though: It does send signals as part of the
    transaction, so for maximum backwards compatibility we need to be
    conservative.

    To ensure maximum compatibility the transaction here is removed if
    and only if the following holds true:

     * We are deleting a single instance.
     * There are no signal handlers attached to that instance.
     * There are no deletions/updates to cascade.
     * There are no parents which also need deletion.