### PR TITLE
Fixed #29804 -- Added helpful 'did you mean' suggestions for FieldError

### DIFF
--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -293,6 +293,11 @@ Miscellaneous
 
 * Support for bytestring paths in the template filesystem loader is removed.
 
+* When :exc:`~django.core.exceptions.FieldError` is raised because of an unsupported
+  or invalid lookup field, the error message may suggest alternatives that are
+  typographically similar, e.g. it may suggest 'isnull' if a user incorrectly writes
+  'is_null'.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -572,9 +572,23 @@ class LookupTests(TestCase):
         with self.assertRaisesMessage(
             FieldError,
             "Unsupported lookup 'starts' for CharField or join on the field "
-            "not permitted."
+            "not permitted- perhaps you meant startswith or istartswith?"
         ):
             Article.objects.filter(headline__starts='Article')
+
+        with self.assertRaisesMessage(
+            FieldError,
+            "Unsupported lookup 'is_null' for DateTimeField or join on the field "
+            "not permitted- perhaps you meant isnull?"
+        ):
+            Article.objects.filter(pub_date__is_null=True)
+
+        with self.assertRaisesMessage(
+            FieldError,
+            "Unsupported lookup 'gobbledygook' for DateTimeField or join on the field "
+            "not permitted."
+        ):
+            Article.objects.filter(pub_date__gobbledygook='blahblah')
 
     def test_relation_nested_lookup_error(self):
         # An invalid nested lookup on a related field raises a useful error.


### PR DESCRIPTION
When FieldError is raised because of an unsupported lookup, the error
message may suggest possible typographically similar alternatives.