### PR TITLE
Fixed #29804 -- Added helpful 'did you mean' suggestions for FieldError

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ answer newbie questions, and generally made Django that much better:
     Aaron Swartz <http://www.aaronsw.com/>
     Aaron T. Myers <atmyers@gmail.com>
     Abeer Upadhyay <ab.esquarer@gmail.com>
+    Abhinav Patil <https://github.com/ubadub/>
     Abhishek Gautam <abhishekg1128@yahoo.com>
     Adam Bogdał <adam@bogdal.pl>
     Adam Donaghy

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -6,6 +6,7 @@ themselves do not have to (and could be backed by things other than SQL
 databases). The abstraction barrier only works one way: this module has to know
 all about the internals of models in order to get the information it needs.
 """
+import difflib
 import functools
 from collections import Counter, OrderedDict, namedtuple
 from collections.abc import Iterator, Mapping
@@ -1140,10 +1141,17 @@ class Query:
         if transform_class:
             return transform_class(lhs)
         else:
+            cls = lhs.output_field.__class__
+            # get a list of all valid lookups for this class
+            lookups = cls.get_lookups()
+            alternatives = difflib.get_close_matches(name, lookups)
+            suggestion = "."  # just punctuation, to be used if there are no "did you mean"s available
+            if alternatives:
+                suggestion = "- perhaps you meant %s?" % " or ".join(alternatives)
             raise FieldError(
                 "Unsupported lookup '%s' for %s or join on the field not "
-                "permitted." %
-                (name, lhs.output_field.__class__.__name__))
+                "permitted%s" %
+                (name, cls.__name__, suggestion))
 
     def build_filter(self, filter_expr, branch_negated=False, current_negated=False,
                      can_reuse=None, allow_joins=True, split_subq=True,

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -293,6 +293,11 @@ Miscellaneous
 
 * Support for bytestring paths in the template filesystem loader is removed.
 
+* When :exc:`~django.core.exceptions.FieldError` is raised because of an unsupported
+  or invalid lookup field, the error message may suggest alternatives that are
+  typographically similar, e.g. it may suggest `isnull` if a user incorrectly writes
+  `is_null`.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/lookup/tests.py
+++ b/tests/lookup/tests.py
@@ -572,9 +572,23 @@ class LookupTests(TestCase):
         with self.assertRaisesMessage(
             FieldError,
             "Unsupported lookup 'starts' for CharField or join on the field "
-            "not permitted."
+            "not permitted- perhaps you meant startswith or istartswith?"
         ):
             Article.objects.filter(headline__starts='Article')
+
+        with self.assertRaisesMessage(
+            FieldError,
+            "Unsupported lookup 'is_null' for DateTimeField or join on the field "
+            "not permitted- perhaps you meant isnull?"
+        ):
+            Article.objects.filter(pub_date__is_null=True)
+
+        with self.assertRaisesMessage(
+            FieldError,
+            "Unsupported lookup 'gobbledygook' for DateTimeField or join on the field "
+            "not permitted."
+        ):
+            Article.objects.filter(pub_date__gobbledygook='blahblah')
 
     def test_relation_nested_lookup_error(self):
         # An invalid nested lookup on a related field raises a useful error.


### PR DESCRIPTION
Modified the error message associated with FieldError so that when it
is raised because of an unsupported lookup, the error message may
suggest possible typographically similar alternatives.