### PR TITLE
Fixed ResourceWarning in MySQL's _clone_test_db().

### DIFF
--- a/django/db/backends/mysql/creation.py
+++ b/django/db/backends/mysql/creation.py
@@ -66,7 +66,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         load_cmd = DatabaseClient.settings_to_cmd_args(self.connection.settings_dict)
         load_cmd[-1] = target_database_name
 
-        dump_proc = subprocess.Popen(dump_cmd, stdout=subprocess.PIPE)
-        load_proc = subprocess.Popen(load_cmd, stdin=dump_proc.stdout, stdout=subprocess.PIPE)
-        dump_proc.stdout.close()    # allow dump_proc to receive a SIGPIPE if load_proc exits.
-        load_proc.communicate()
+        with subprocess.Popen(dump_cmd, stdout=subprocess.PIPE) as dump_proc:
+            with subprocess.Popen(load_cmd, stdin=dump_proc.stdout, stdout=subprocess.DEVNULL):
+                # Allow dump_proc to receive a SIGPIPE if the load process exits.
+                dump_proc.stdout.close()


### PR DESCRIPTION
Starting with Python 3.6, the Popen destructor emits a `ResourceWarning` warning if the child process is still running.

https://docs.python.org/library/subprocess.html#popen-constructor

> Changed in version 3.6: `Popen` destructor now emits a `ResourceWarning` warning if the child process is still running.

Use the `Popen` context manager (available since Python 3.2) to ensure the subprocess is waited for.

Fixes warning of the form:

  /usr/lib64/python3.7/subprocess.py:839: ResourceWarning: subprocess ... is still running