### PR TITLE
Corrected docs to say that all templates are text strings.

### DIFF
--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -270,11 +270,9 @@ querysets are identical::
 Templates
 =========
 
-You can use either strings or UTF-8 bytestrings when creating templates
-manually::
+Use strings when creating templates manually::
 
     from django.template import Template
-    t1 = Template(b'This is a bytestring template.')
     t2 = Template('This is a string template.')
 
 But the common case is to read templates from the filesystem, and this creates


### PR DESCRIPTION
Support for bytestring templates was removed in 3a148f958dddd97c1379081118c30fbede6b6bc4.