### PR TITLE
Fixed #29775 -- Fixed URL converters in a nested namespaced path.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,6 +255,7 @@ answer newbie questions, and generally made Django that much better:
     enlight
     Enrico <rico.bl@gmail.com>
     Eric Boersma <eric.boersma@gmail.com>
+    Eric Brandwein <brandweineric@gmail.com>
     Eric Floehr <eric@intellovations.com>
     Eric Florenzano <floguy@gmail.com>
     Eric Holscher <http://ericholscher.com>

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -469,6 +469,8 @@ class URLResolver:
                                     )
                                 )
                         for namespace, (prefix, sub_pattern) in url_pattern.namespace_dict.items():
+                            current_converters = url_pattern.pattern.converters
+                            sub_pattern.pattern.converters.update(current_converters)
                             namespaces[namespace] = (p_pattern + prefix, sub_pattern)
                         for app_name, namespace_list in url_pattern.app_dict.items():
                             apps.setdefault(app_name, []).extend(namespace_list)

--- a/tests/urlpatterns/path_base64_urls.py
+++ b/tests/urlpatterns/path_base64_urls.py
@@ -4,8 +4,16 @@ from . import converters, views
 
 register_converter(converters.Base64Converter, 'base64')
 
+subsubpatterns = [
+    path('<base64:last_value>/', views.empty_view, name='subsubpattern-base64'),
+]
+
 subpatterns = [
     path('<base64:value>/', views.empty_view, name='subpattern-base64'),
+    path(
+        '<base64:value>/',
+        include((subsubpatterns, 'second-layer-namespaced-base64'), 'instance-ns-base64')
+    ),
 ]
 
 urlpatterns = [

--- a/tests/urlpatterns/tests.py
+++ b/tests/urlpatterns/tests.py
@@ -70,6 +70,13 @@ class SimplifiedURLTests(SimpleTestCase):
                 url = reverse(url_name, kwargs=kwargs)
                 self.assertEqual(url, expected)
 
+    @override_settings(ROOT_URLCONF='urlpatterns.path_base64_urls')
+    def test_converter_reverse_with_second_layer_instance_namespace(self):
+        kwargs = included_kwargs.copy()
+        kwargs['last_value'] = b'world'
+        url = reverse('instance-ns-base64:subsubpattern-base64', kwargs=kwargs)
+        self.assertEqual(url, '/base64/aGVsbG8=/subpatterns/d29ybGQ=/d29ybGQ=/')
+
     def test_path_inclusion_is_matchable(self):
         match = resolve('/included_urls/extra/something/')
         self.assertEqual(match.url_name, 'inner-extra')


### PR DESCRIPTION
When using an include() without namespaces of some urlpatterns
that do have an include() with namespace, the converters of the
parent include() weren't being used to convert the arguments
of reverse(). 

https://code.djangoproject.com/ticket/29775