### PR TITLE
Refs #27778 -- Removed "The database API" section from "Unicode data" docs.

### DIFF
--- a/docs/ref/unicode.txt
+++ b/docs/ref/unicode.txt
@@ -257,16 +257,6 @@ non-ASCII characters would have been removed in quoting in the first line.)
 
 .. _above: `URI and IRI handling`_
 
-The database API
-================
-
-You can pass either strings or UTF-8 bytestrings as arguments to
-``filter()`` methods and the like in the database API. The following two
-querysets are identical::
-
-    qs = People.objects.filter(name__contains='Å')
-    qs = People.objects.filter(name__contains=b'\xc3\x85') # UTF-8 encoding of Å
-
 Templates
 =========
 


### PR DESCRIPTION
Support for passing bytestrings to the database API has been removed in: 301de774c21d055e9e5a7073e5bffdb52bc71079.