### PR TITLE
Emphasized that ForeignKey.on_delete doesn't create a SQL constraint.

### DIFF
--- a/docs/ref/models/fields.txt
+++ b/docs/ref/models/fields.txt
@@ -1271,6 +1271,9 @@ relation works.
             null=True,
         )
 
+    ``on_delete`` doesn't create a SQL constraint in the database. Support for
+    database-level cascade options :ticket:`may be implemented later <21961>`.
+
 The possible values for :attr:`~ForeignKey.on_delete` are found in
 :mod:`django.db.models`:
 


### PR DESCRIPTION
Update fields.txt to focus on behaviour of on_delete. It could pass unnoticed.