### PR TITLE
Fixed postgres_tests.test_signals.OIDTests to run in isolation.

### DIFF
--- a/tests/postgres_tests/test_signals.py
+++ b/tests/postgres_tests/test_signals.py
@@ -18,10 +18,12 @@ class OIDTests(PostgreSQLTestCase):
         self.assertTrue(all(isinstance(oid, int) for oid in oids))
 
     def test_hstore_cache(self):
+        get_hstore_oids(connection.alias)
         with self.assertNumQueries(0):
             get_hstore_oids(connection.alias)
 
     def test_citext_cache(self):
+        get_citext_oids(connection.alias)
         with self.assertNumQueries(0):
             get_citext_oids(connection.alias)
 


### PR DESCRIPTION
Fixes failures:

```
======================================================================
FAIL: test_citext_cache (postgres_tests.test_signals.OIDTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../django/tests/postgres_tests/test_signals.py", line 26, in test_citext_cache
    get_citext_oids(connection.alias)
  File ".../django/django/test/testcases.py", line 82, in __exit__
    '%d. %s' % (i, query['sql']) for i, query in enumerate(self.captured_queries, start=1)
AssertionError: 1 != 0 : 1 queries executed, 0 expected
Captured queries were:
1. SELECT typarray FROM pg_type WHERE typname = 'citext'

======================================================================
FAIL: test_hstore_cache (postgres_tests.test_signals.OIDTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../django/tests/postgres_tests/test_signals.py", line 22, in test_hstore_cache
    get_hstore_oids(connection.alias)
  File ".../django/django/test/testcases.py", line 82, in __exit__
    '%d. %s' % (i, query['sql']) for i, query in enumerate(self.captured_queries, start=1)
AssertionError: 1 != 0 : 1 queries executed, 0 expected
Captured queries were:
1. SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore'
```