### PR TITLE
Fixed #29138 -- Added ModelAdmin.autocomplete_fields support for ForeignKeys that use to_field.

### DIFF
--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -25,7 +25,7 @@ class AutocompleteJsonView(BaseListView):
             return JsonResponse({'error': '403 Forbidden'}, status=403)
 
         self.term = request.GET.get('term', '')
-        self.to_field = request.GET.get('to_field')
+        self.to_field = request.GET.get('to_field', None)
         if self.to_field:
             if not self.model_admin.to_field_allowed(request, self.to_field):
                 raise DisallowedModelAdminToField("The field %s cannot be referenced." % self.to_field)
@@ -33,7 +33,7 @@ class AutocompleteJsonView(BaseListView):
             self.to_field = 'pk'
 
         self.paginator_class = self.model_admin.paginator
-        self.object_list = self.get_queryset()
+        self.object_list = self.get_queryset().order_by(self.to_field)
         context = self.get_context_data()
         return JsonResponse({
             'results': [

--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -33,7 +33,7 @@ class AutocompleteJsonView(BaseListView):
             self.to_field = 'pk'
 
         self.paginator_class = self.model_admin.paginator
-        self.object_list = self.get_queryset().order_by(self.to_field)
+        self.object_list = self.get_queryset()
         context = self.get_context_data()
         return JsonResponse({
             'results': [

--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -384,12 +384,12 @@ class AutocompleteMixin:
         self.db = using
         self.choices = choices
         self.attrs = {} if attrs is None else attrs.copy()
-        self.to_field = self.rel.field.to_fields[0] if hasattr(self.rel.field, 'to_fields') else 'pk'
+        self.to_field = self.rel.field.to_fields[0] if hasattr(self.rel.field, 'to_fields') else None
 
     def get_url(self):
         model = self.rel.model
         url = reverse(self.url_name % (self.admin_site.name, model._meta.app_label, model._meta.model_name))
-        return url + '?to_field=' + self.to_field
+        return url if not self.to_field else url + '?to_field=' + self.to_field
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         """
@@ -424,8 +424,8 @@ class AutocompleteMixin:
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
         choices = (
-            (getattr(obj, self.to_field), self.choices.field.label_from_instance(obj))
-            for obj in self.choices.queryset.using(self.db).filter(**{ self.to_field + '__in':selected_choices})
+            (getattr(obj, self.to_field) if self.to_field else obj.pk, self.choices.field.label_from_instance(obj))
+            for obj in self.choices.queryset.using(self.db).filter(**{ (self.to_field if self.to_field else 'pk') + '__in':selected_choices})
         )
         for option_value, option_label in choices:
             selected = (

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -37,7 +37,7 @@ from .models import (
     Person, Persona, Picture, Pizza, Plot, PlotDetails, PlotProxy,
     PluggableSearchPerson, Podcast, Post, PrePopulatedPost,
     PrePopulatedPostLargeSlug, PrePopulatedSubPost, Promo, Question,
-    ReadablePizza, ReadOnlyPizza, Recipe, Recommendation, Recommender,
+    ReadablePizza, ReadOnlyPizza, Recipe, Recommendation, Recommender, ParentWithFK,
     ReferencedByGenRel, ReferencedByInline, ReferencedByParent,
     RelatedPrepopulated, RelatedWithUUIDPKModel, Report, Reservation,
     Restaurant, RowLevelChangePermissionModel, Section, ShortMessage, Simple,
@@ -644,12 +644,17 @@ class PluggableSearchPersonAdmin(admin.ModelAdmin):
 class AlbumAdmin(admin.ModelAdmin):
     list_filter = ['title']
 
-
 class QuestionAdmin(admin.ModelAdmin):
     ordering = ['-posted']
     search_fields = ['question']
     autocomplete_fields = ['related_questions']
 
+class ReferencedByParentAdmin(admin.ModelAdmin):
+    search_fields = ['name']
+
+class ParentWithFKAdmin(admin.ModelAdmin):
+    search_fields = ['fk__name']
+    autocomplete_fields = ['fk']
 
 class AnswerAdmin(admin.ModelAdmin):
     autocomplete_fields = ['question']
@@ -1012,7 +1017,6 @@ site.register(City, CityAdmin)
 site.register(Restaurant, RestaurantAdmin)
 site.register(Worker, WorkerAdmin)
 site.register(FunkyTag, FunkyTagAdmin)
-site.register(ReferencedByParent)
 site.register(ChildOfReferer)
 site.register(ReferencedByInline)
 site.register(InlineReferer, InlineRefererAdmin)
@@ -1039,6 +1043,8 @@ site.register(ReadablePizza)
 site.register(Topping, ToppingAdmin)
 site.register(Album, AlbumAdmin)
 site.register(Question, QuestionAdmin)
+site.register(ReferencedByParent, ReferencedByParentAdmin)
+site.register(ParentWithFK, ParentWithFKAdmin)
 site.register(Answer, AnswerAdmin, date_hierarchy='question__posted')
 site.register(Answer2, date_hierarchy='question__expires')
 site.register(PrePopulatedPost, PrePopulatedPostAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -890,6 +890,9 @@ class ReferencedByParent(models.Model):
     def __str__(self):
         return self.name
 
+    class Meta:
+        ordering = ['name']
+
 
 class ParentWithFK(models.Model):
     fk = models.ForeignKey(

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -887,6 +887,9 @@ class Worker(models.Model):
 class ReferencedByParent(models.Model):
     name = models.CharField(max_length=20, unique=True)
 
+    def __str__(self):
+        return self.name
+
 
 class ParentWithFK(models.Model):
     fk = models.ForeignKey(
@@ -895,6 +898,9 @@ class ParentWithFK(models.Model):
         to_field='name',
         related_name='hidden+',
     )
+
+    def __str__(self):
+        return str(self.fk)
 
 
 class ChildOfReferer(ParentWithFK):

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -25,6 +25,7 @@ class AuthorshipInline(admin.TabularInline):
     model = Authorship
     autocomplete_fields = ['author']
 
+
 class BookAdmin(admin.ModelAdmin):
     inlines = [AuthorshipInline]
 
@@ -40,10 +41,10 @@ site.register(Book, BookAdmin)
 
 class AutocompleteJsonViewTests(AdminViewBasicTestCase):
     as_view_args = {'model_admin': QuestionAdmin(Question, site)}
-    as_view_args_to_field = {'model_admin': ParentWithFKAdmin(ParentWithFK, site)}
+    as_view_args_to_field = {'model_admin': ReferencedByParentAdmin(ReferencedByParent, site)}
     factory = RequestFactory()
     url = reverse_lazy('autocomplete_admin:admin_views_question_autocomplete')
-    url_to_field = reverse_lazy('autocomplete_admin:admin_views_parentwithfk_autocomplete')
+    url_to_field = reverse_lazy('autocomplete_admin:admin_views_referencedbyparent_autocomplete')
 
     @classmethod
     def setUpTestData(cls):
@@ -55,7 +56,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
 
     def test_success(self):
         q = Question.objects.create(question='Is this a question?')
-        request = self.factory.get(self.url, {'term': 'is'}) # return_id defaults to 'pk'
+        request = self.factory.get(self.url, {'term': 'is'})
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args)(request)
         self.assertEqual(response.status_code, 200)
@@ -67,7 +68,7 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
         # test for `to_field`
         fk = ReferencedByParent.objects.create(name='ref by parent')
         p = ParentWithFK.objects.create(fk=fk)
-        request = self.factory.get(self.url_to_field, {'term': 'by', 'to_field': 'fk'})
+        request = self.factory.get(self.url_to_field, {'term': 'by', 'to_field': 'name'})
         request.user = self.superuser
         response = AutocompleteJsonView.as_view(**self.as_view_args_to_field)(request)
         self.assertEqual(response.status_code, 200)

--- a/tests/admin_widgets/test_autocomplete_widget.py
+++ b/tests/admin_widgets/test_autocomplete_widget.py
@@ -5,7 +5,7 @@ from django.forms import ModelChoiceField
 from django.test import TestCase, override_settings
 from django.utils import translation
 
-from .models import Album, Band
+from .models import Album, Band, Profile
 
 
 class AlbumForm(forms.ModelForm):
@@ -53,7 +53,7 @@ class AutocompleteMixinTests(TestCase):
             'class': 'my-class admin-autocomplete',
             'data-ajax--cache': 'true',
             'data-ajax--type': 'GET',
-            'data-ajax--url': '/admin_widgets/band/autocomplete/',
+            'data-ajax--url': '/admin_widgets/band/autocomplete/?to_field=id',
             'data-theme': 'admin-autocomplete',
             'data-allow-clear': 'false',
             'data-placeholder': ''
@@ -78,7 +78,13 @@ class AutocompleteMixinTests(TestCase):
         rel = Album._meta.get_field('band').remote_field
         w = AutocompleteSelect(rel, admin.site)
         url = w.get_url()
-        self.assertEqual(url, '/admin_widgets/band/autocomplete/')
+        self.assertEqual(url, '/admin_widgets/band/autocomplete/?to_field=id')
+
+    def test_get_url_to_field(self):
+        rel = Profile._meta.get_field('user').remote_field
+        w = AutocompleteSelect(rel, admin.site)
+        url = w.get_url()
+        self.assertEqual(url, '/auth/user/autocomplete/?to_field=username')
 
     def test_render_options(self):
         beatles = Band.objects.create(name='The Beatles', style='rock')


### PR DESCRIPTION
Bug fix for [29138](https://code.djangoproject.com/ticket/29138); creating [PR as requested](https://code.djangoproject.com/ticket/29138#comment:10).

> **Note** I've been able to update all unit tests and create some new ones, however I haven't been able to leverage `to_field_allowed` to prevent data leaks. I've tried to implement it (see ​here), however I can't get it to play nicely with the unit tests. When uncommented, the `id_field` isn't properly being considered as to_field_allowed. I'm not familiar with this function, so could use some help troubleshooting.