### PR TITLE
Change language style on 'Congrats' page for new installation.

### DIFF
--- a/django/views/templates/default_urlconf.html
+++ b/django/views/templates/default_urlconf.html
@@ -364,7 +364,7 @@
             <path class="flame" d="M 6.7 1.14 l 2.8 4.7 s 1.3 3 -1.82 3.22 l -5.4 0 s -3.28 -.14 -1.74 -3.26 l 2.76 -4.7 s 1.7 -2.3 3.4 0 z" fill="#AA2247"></path>
           </svg>
         </div>
-        <h2>{% trans "The install worked successfully! Congratulations!" %}</h2>
+        <h2>{% trans "The installation worked successfully! Congratulations!" %}</h2>
         <p>{% blocktrans %}You are seeing this page because <a href="https://docs.djangoproject.com/en/{{ version }}/ref/settings/#debug" target="_blank" rel="noopener">DEBUG=True</a> is in your settings file and you have not configured any URLs.{% endblocktrans %}</p>
       </main>
       <footer class="u-clearfix">


### PR DESCRIPTION
The new 'Congrats' page introduced in 2.0 uses the phrase "_The install worked successfully! Congratulations!_". This is a jargonistic use of the word _install_ to refer to the installation process. In most English contexts, _install_ is a verb, and the corresponding noun would be _installation_, but in the software industry the jargon of install-as-a-noun does seem to be widespread.

Dictionaries reflect this usage (e.g. [Wiktionary](https://en.wiktionary.org/wiki/install#Noun), adding the context label 'computing'), but dictionaries are just a record of how words are used, not how we would like our use of language to reflect on us. For this we need a style guide. Django doesn't have a language style guide, just one for coding style. The Guardian (I'm UK-based) Style Guide doesn't have a relevant entry for _install_ vs _installation_. I turned to manuals of style for the software industry:

> **install** You install items on a disk, not onto a disk. Don’t use install as a noun.
> — Apple Style Guide, https://help.apple.com/applestyleguide/#/apsg346ef241?sub=apdcec819bd1bd14

> Don't use install as a noun. Use installation instead.
> — Microsoft Writing Style Guide https://docs.microsoft.com/en-gb/style-guide/a-z-word-list-term-collections/i/install

There's even inconsistency in the PR that updated the 'Congrats' page. The [first commit](https://github.com/django/django/pull/8823/commits/ca0ad2f457c3a2b56ed189e1f923c7c166842e1e) in PR #8823 adds the lines

>     <meta name="description" content="Congratulations! Your Django installation worked! Django is the web framework for perfectionists with deadlines.">
> — line 7

>     <h2>The install worked successfully! Congratulations!</h2>
> —line 43

The PR is titled:

> Updated the design of the 'Congrats' page for first time Django _installs_.
> — PR #8823 message

but the first commit in it has a message beginning

> A new 'Congrats' page for first time Django _installation_…
> — https://github.com/django/django/pull/8823/commits/ca0ad2f457c3a2b56ed189e1f923c7c166842e1e

Which is preferred in Django's case is probably not up to me to decide, but since this is the first thing many users will see, it's important that the way the project presents itself is considered and reasoned, rather than down to the circumstance of whichever variant was used for that particular line. I.e. use the jargon if you like, but be prepared to justify it, and if we can't, then use the more appropriate common English word.

(My own point of view is that using _install_ instead of the existing word _installation_, and the similarly-strange _amends_ (which is a noun, but has its own, quite different, meaning) instead of _amendments_ are lazy slang terms, and do not reflect well upon the user. I admit that my position is strongly opinionated.)