### PR TITLE
Fixed "SyntaxError: Generator expression must be parenthesized" on Python 3.7

### DIFF
--- a/django/contrib/admin/widgets.py
+++ b/django/contrib/admin/widgets.py
@@ -149,7 +149,7 @@ class ForeignKeyRawIdWidget(forms.TextInput):
             params = self.url_parameters()
             if params:
                 related_url += '?' + '&amp;'.join(
-                    '%s=%s' % (k, v) for k, v in params.items(),
+                    '%s=%s' % (k, v) for k, v in params.items()
                 )
             context['related_url'] = mark_safe(related_url)
             context['link_title'] = _('Lookup')


### PR DESCRIPTION
Fixed "SyntaxError: Generator expression must be parenthesized" on Python 3.7