### PR TITLE
Fixed #29836 -- Bumped required cx_Oracle to 6.0.

### DIFF
--- a/django/db/backends/oracle/base.py
+++ b/django/db/backends/oracle/base.py
@@ -390,8 +390,6 @@ class FormatStylePlaceholderCursor:
     def __init__(self, connection):
         self.cursor = connection.cursor()
         self.cursor.outputtypehandler = self._output_type_handler
-        # The default for cx_Oracle < 5.3 is 50.
-        self.cursor.arraysize = 100
 
     @staticmethod
     def _output_number_converter(value):

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -731,7 +731,7 @@ Oracle notes
 ============
 
 Django supports `Oracle Database Server`_ versions 12.1 and higher. Version
-5.2 or higher of the `cx_Oracle`_ Python driver is required.
+6.0 or higher of the `cx_Oracle`_ Python driver is required.
 
 .. _`Oracle Database Server`: https://www.oracle.com/
 .. _`cx_Oracle`: https://oracle.github.io/python-cx_Oracle/

--- a/docs/releases/2.2.txt
+++ b/docs/releases/2.2.txt
@@ -302,6 +302,8 @@ Miscellaneous
   of a bytestring, and :func:`django.utils.http.urlsafe_base64_decode` may no
   longer be passed a bytestring.
 
+* Support for ``cx_Oracle`` < 6.0 is removed.
+
 .. _deprecated-features-2.2:
 
 Features deprecated in 2.2

--- a/tests/requirements/oracle.txt
+++ b/tests/requirements/oracle.txt
@@ -1,1 +1,1 @@
-cx_oracle
+cx_oracle >= 6.0


### PR DESCRIPTION
Ticket [29836](https://code.djangoproject.com/ticket/29836).