### PR TITLE
Add a gc.collect() to make GDALBandTests.test_band_data more deterministic

### DIFF
--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -582,7 +582,8 @@ class GDALBandTests(SimpleTestCase):
             self.assertAlmostEqual(self.band.mean, 2.828326634228898)
             self.assertAlmostEqual(self.band.std, 2.4260526986669095)
 
-            # Statistics are persisted into PAM file on band close when the object is deleted.
+            # Statistics are persisted into PAM file on band close when the object 
+            # is garbage collected or reclaimed from memory.
             self.band = None
             gc.collect()
             self.assertTrue(os.path.isfile(pam_file))

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import struct
 import tempfile
@@ -581,8 +582,9 @@ class GDALBandTests(SimpleTestCase):
             self.assertAlmostEqual(self.band.mean, 2.828326634228898)
             self.assertAlmostEqual(self.band.std, 2.4260526986669095)
 
-            # Statistics are persisted into PAM file on band close
+            # Statistics are persisted into PAM file on band close when the object is deleted.
             self.band = None
+            gc.collect()
             self.assertTrue(os.path.isfile(pam_file))
         finally:
             # Close band and remove file if created

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -582,7 +582,7 @@ class GDALBandTests(SimpleTestCase):
             self.assertAlmostEqual(self.band.mean, 2.828326634228898)
             self.assertAlmostEqual(self.band.std, 2.4260526986669095)
 
-            # Statistics are persisted into PAM file on band close when the object 
+            # Statistics are persisted into PAM file on band close when the object
             # is garbage collected or reclaimed from memory.
             self.band = None
             gc.collect()

--- a/tests/gis_tests/gdal_tests/test_raster.py
+++ b/tests/gis_tests/gdal_tests/test_raster.py
@@ -582,8 +582,7 @@ class GDALBandTests(SimpleTestCase):
             self.assertAlmostEqual(self.band.mean, 2.828326634228898)
             self.assertAlmostEqual(self.band.std, 2.4260526986669095)
 
-            # Statistics are persisted into PAM file on band close when the object
-            # is garbage collected or reclaimed from memory.
+            # Statistics are persisted into PAM file on band close when the object is garbage collected.
             self.band = None
             gc.collect()
             self.assertTrue(os.path.isfile(pam_file))


### PR DESCRIPTION
I noticed some failures here as it relies on the garbage collector triggering and collecting `self.band` before the `self.assertTrue()` is ran. (At least, that's what I *think* is happening?)

I'm not sure the best way to work around this, so I added a `gc.collect()` to ensure that a garbage collection is ran (and the objects `__del__` is called).