### PR TITLE
Refs #29826 -- Removed unused characters from urlize configuration.

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -14,7 +14,7 @@ from django.utils.text import normalize_newlines
 
 # Configuration for urlize() function.
 TRAILING_PUNCTUATION_CHARS = '.,:;!'
-WRAPPING_PUNCTUATION = [('(', ')'), ('<', '>'), ('[', ']'), ('&lt;', '&gt;'), ('"', '"'), ('\'', '\'')]
+WRAPPING_PUNCTUATION = [('(', ')'), ('[', ']')]
 
 # List of possible strings used for bullets in bulleted lists.
 DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -278,6 +278,24 @@ class FunctionTests(SimpleTestCase):
             'http://168.192.0.1](http://168.192.0.1)</a>',
         )
 
+    def test_wrapping_characters(self):
+        wrapping_chars = (
+            ('()', ('(', ')')),
+            ('<>', ('&lt;', '&gt;')),
+            ('[]', ('[', ']')),
+            ('""', ('&quot;', '&quot;')),
+            ("''", ('&#39;', '&#39;')),
+        )
+        for wrapping_in, (start_out, end_out) in wrapping_chars:
+            with self.subTest(wrapping_in=wrapping_in):
+                start_in, end_in = wrapping_in
+                self.assertEqual(
+                    urlize(start_in + 'https://www.example.org/' + end_in),
+                    start_out +
+                    '<a href="https://www.example.org/" rel="nofollow">https://www.example.org/</a>' +
+                    end_out,
+                )
+
     def test_ipv4(self):
         self.assertEqual(
             urlize('http://192.168.0.15/api/9'),


### PR DESCRIPTION
The HTML characters are unused because urlize is meant to be applied to
plain text and these characters aren't properly detected (refs [#29826](https://code.djangoproject.com/ticket/29826)).
Angle brackets and quotes are present in word_split_re and therefore
won't be used in WRAPPING_PUNCTUATION.

Regression test in a separate commit shows existing behavior remains unchanged.