### PR TITLE
Fixed #29845 -- Fixed Cast crash on MySQL when casting to DecimalField.

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -19,6 +19,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         'AutoField': 'signed integer',
         'BigAutoField': 'signed integer',
         'CharField': 'char(%(max_length)s)',
+        'DecimalField': 'decimal(%(max_digits)s, %(decimal_places)s)',
         'TextField': 'char',
         'IntegerField': 'signed integer',
         'BigIntegerField': 'signed integer',

--- a/tests/db_functions/comparison/test_cast.py
+++ b/tests/db_functions/comparison/test_cast.py
@@ -10,7 +10,7 @@ from django.test import (
     TestCase, ignore_warnings, override_settings, skipUnlessDBFeature,
 )
 
-from ..models import Author, DTModel, Fan
+from ..models import Author, DTModel, Fan, FloatModel
 
 
 class CastTests(TestCase):
@@ -36,6 +36,20 @@ class CastTests(TestCase):
     def test_cast_to_char_field_with_max_length(self):
         names = Author.objects.annotate(cast_string=Cast('name', models.CharField(max_length=1)))
         self.assertEqual(names.get().cast_string, 'B')
+
+    @skipUnlessDBFeature('supports_cast_with_precision')
+    def test_cast_to_decimal_field(self):
+        FloatModel.objects.create(f1=-1.934, f2=3.467)
+        float_obj = FloatModel.objects.annotate(
+            cast_f1_decimal=Cast('f1', models.DecimalField(max_digits=8, decimal_places=2)),
+            cast_f2_decimal=Cast('f2', models.DecimalField(max_digits=8, decimal_places=1)),
+        ).get()
+        self.assertEqual(float_obj.cast_f1_decimal, decimal.Decimal('-1.93'))
+        self.assertEqual(float_obj.cast_f2_decimal, decimal.Decimal('3.5'))
+        author_obj = Author.objects.annotate(
+            cast_alias_decimal=Cast('alias', models.DecimalField(max_digits=8, decimal_places=2)),
+        ).get()
+        self.assertEqual(author_obj.cast_alias_decimal, decimal.Decimal('1'))
 
     def test_cast_to_integer(self):
         for field_class in (


### PR DESCRIPTION
Ticket [29845](https://code.djangoproject.com/ticket/).