### PR TITLE
Fixed #29324 -- Made Settings raise ImproperlyConfigured if SECRET_KEY is accessed but not set.

### DIFF
--- a/django/conf/__init__.py
+++ b/django/conf/__init__.py
@@ -160,9 +160,6 @@ class Settings:
                 setattr(self, setting, setting_value)
                 self._explicit_settings.add(setting)
 
-        if not self.SECRET_KEY:
-            raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
-
         if self.is_overridden('DEFAULT_CONTENT_TYPE'):
             warnings.warn(DEFAULT_CONTENT_TYPE_DEPRECATED_MSG, RemovedInDjango30Warning)
         if self.is_overridden('FILE_CHARSET'):
@@ -188,6 +185,23 @@ class Settings:
             'cls': self.__class__.__name__,
             'settings_module': self.SETTINGS_MODULE,
         }
+
+    @property
+    def SECRET_KEY(self):
+        try:
+            return self.__dict__['SECRET_KEY']
+        except KeyError:
+            raise ImproperlyConfigured("The SECRET_KEY setting must be set.")
+
+    @SECRET_KEY.setter
+    def SECRET_KEY(self, value):
+        if not value:
+            raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
+        self.__dict__['SECRET_KEY'] = value
+
+    @SECRET_KEY.deleter
+    def SECRET_KEY(self):
+        del self.__dict__['SECRET_KEY']
 
 
 class UserSettingsHolder:
@@ -238,6 +252,26 @@ class UserSettingsHolder:
         return '<%(cls)s>' % {
             'cls': self.__class__.__name__,
         }
+
+    @property
+    def SECRET_KEY(self):
+        try:
+            return self.__dict__['SECRET_KEY']
+        except KeyError:
+            try:
+                return getattr(self.default_settings, 'SECRET_KEY')
+            except AttributeError:
+                raise ImproperlyConfigured("The SECRET_KEY setting must be set.")
+
+    @SECRET_KEY.setter
+    def SECRET_KEY(self, value):
+        if not value:
+            raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
+        self.__dict__['SECRET_KEY'] = value
+
+    @SECRET_KEY.deleter
+    def SECRET_KEY(self):
+        del self.__dict__['SECRET_KEY']
 
 
 settings = LazySettings()

--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -256,11 +256,6 @@ ABSOLUTE_URL_OVERRIDES = {}
 #    ]
 IGNORABLE_404_URLS = []
 
-# A secret key for this particular Django installation. Used in secret-key
-# hashing algorithms. Set this in your settings, or Django will complain
-# loudly.
-SECRET_KEY = ''
-
 # Default file storage mechanism that holds media.
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 

--- a/django/core/checks/security/base.py
+++ b/django/core/checks/security/base.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from .. import Tags, Warning, register
 
@@ -182,11 +183,16 @@ def check_ssl_redirect(app_configs, **kwargs):
 
 @register(Tags.security, deploy=True)
 def check_secret_key(app_configs, **kwargs):
-    passed_check = (
-        getattr(settings, 'SECRET_KEY', None) and
-        len(set(settings.SECRET_KEY)) >= SECRET_KEY_MIN_UNIQUE_CHARACTERS and
-        len(settings.SECRET_KEY) >= SECRET_KEY_MIN_LENGTH
-    )
+    try:
+        secret_key = settings.SECRET_KEY
+    except ImproperlyConfigured:
+        # SECRET_KEY is not set.
+        passed_check = True
+    else:
+        passed_check = (
+            len(set(secret_key)) >= SECRET_KEY_MIN_UNIQUE_CHARACTERS and
+            len(secret_key) >= SECRET_KEY_MIN_LENGTH
+        )
     return [] if passed_check else [W009]
 
 

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -2068,7 +2068,7 @@ object. See :ref:`how-django-processes-a-request` for details.
 ``SECRET_KEY``
 --------------
 
-Default: ``''`` (Empty string)
+Default: Not defined
 
 A secret key for a particular Django installation. This is used to provide
 :doc:`cryptographic signing </topics/signing>`, and should be set to a unique,
@@ -2081,7 +2081,9 @@ Uses of the key shouldn't assume that it's text or bytes. Every use should go
 through :func:`~django.utils.encoding.force_text` or
 :func:`~django.utils.encoding.force_bytes` to convert it to the desired type.
 
-Django will refuse to start if :setting:`SECRET_KEY` is not set.
+Django will refuse to start if :setting:`SECRET_KEY` is set to an empty value.
+:class:`~django.core.exceptions.ImproperlyConfigured` is raised if
+``SECRET_KEY`` is accessed but not set.
 
 .. warning::
 
@@ -2113,6 +2115,10 @@ affect them.
     The default :file:`settings.py` file created by :djadmin:`django-admin
     startproject <startproject>` creates a unique ``SECRET_KEY`` for
     convenience.
+
+.. versionchanged:: 2.2
+
+    In older versions, ``SECRET_KEY`` defaults to an empty string.
 
 .. setting:: SECURE_BROWSER_XSS_FILTER
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -2269,7 +2269,11 @@ class DiffSettings(AdminScriptTestCase):
         out, err = self.run_manage(args)
         self.assertNoOutput(err)
         self.assertOutput(out, "+ FOO = 'bar'")
-        self.assertOutput(out, "- SECRET_KEY = ''")
+        self.assertOutput(out, "- INSTALLED_APPS = []")
+        self.assertOutput(
+            out,
+            "+ INSTALLED_APPS = ['django.contrib.auth', 'django.contrib.contenttypes', 'admin_scripts']"
+        )
         self.assertOutput(out, "+ SECRET_KEY = 'django_tests_secret_key'")
         self.assertNotInOutput(out, "  APPEND_SLASH = True")
 
@@ -2285,7 +2289,12 @@ class DiffSettings(AdminScriptTestCase):
         self.assertNoOutput(err)
         self.assertOutput(out, "  APPEND_SLASH = True")
         self.assertOutput(out, "+ FOO = 'bar'")
-        self.assertOutput(out, "- SECRET_KEY = ''")
+        self.assertOutput(out, "- INSTALLED_APPS = []")
+        self.assertOutput(
+            out,
+            "+ INSTALLED_APPS = ['django.contrib.auth', 'django.contrib.contenttypes', 'admin_scripts']"
+        )
+        self.assertOutput(out, "+ SECRET_KEY = 'django_tests_secret_key'")
 
 
 class Dumpdata(AdminScriptTestCase):

--- a/tests/check_framework/test_security.py
+++ b/tests/check_framework/test_security.py
@@ -482,10 +482,10 @@ class CheckSecretKeyTest(SimpleTestCase):
     def test_empty_secret_key(self):
         self.assertEqual(self.func(None), [base.W009])
 
-    @override_settings(SECRET_KEY=None)
+    @override_settings()
     def test_missing_secret_key(self):
         del settings.SECRET_KEY
-        self.assertEqual(self.func(None), [base.W009])
+        self.assertEqual(self.func(None), [])
 
     @override_settings(SECRET_KEY=None)
     def test_none_secret_key(self):

--- a/tests/view_tests/tests/test_default_content_type.py
+++ b/tests/view_tests/tests/test_default_content_type.py
@@ -35,7 +35,6 @@ class DefaultContentTypeTests(SimpleTestCase):
     def test_settings_init_warning(self):
         settings_module = ModuleType('fake_settings_module')
         settings_module.DEFAULT_CONTENT_TYPE = 'text/xml'
-        settings_module.SECRET_KEY = 'abc'
         sys.modules['fake_settings_module'] = settings_module
         try:
             with self.assertRaisesMessage(RemovedInDjango30Warning, self.msg):


### PR DESCRIPTION
https://code.djangoproject.com/ticket/29324